### PR TITLE
Add  Transpose, Reshape, Pow and  LeakyRelu ops to DNNL  execution provider

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
@@ -62,7 +62,7 @@ std::vector<std::vector<NodeIndex>> DNNLExecutionProvider::GetSupportedNodes(con
     auto node_idx = node_indices[i];
     const auto* node(graph_viewer.GetNode(node_idx));
 
-    bool supported = opManager_.IsNodeSupported(node);
+    bool supported = opManager_.IsNodeSupported(node, graph_viewer);
 
     if (debug_log_) {
       LOGS_DEFAULT(ERROR) << "Operator type: [" << node->OpType()

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -405,4 +405,22 @@ bool DnnlGemmNodeCapability::Supported(const Node* node) const {
   return true;
 }
 
+// DnnlReshapeNodeCapability class
+//-------------------------------------
+bool DnnlReshapeNodeCapability::Supported(const Node* node) const {
+  if (!IsTypeSupported(node)) return false;
+  if (!IsDimensionSupported(node)) return false;
+  return true;
+}
+bool DnnlReshapeNodeCapability::IsDimensionSupported(const Node* node) const {
+  auto node_inputs = node->InputDefs();
+  // We can not reshape a one dimentional tensor to a scalar output
+  if (node_inputs[1]->Shape() != nullptr &&
+      node_inputs[1]->Shape()->dim_size() == 1 &&
+      node_inputs[1]->Shape()->dim(0).dim_value() == 0) {
+      return false;
+  }
+
+  return true;
+}
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -231,4 +231,19 @@ class DnnlGemmNodeCapability : public DnnlDefaultNodeCapability {
   DnnlBinaryNodeCapability _binary;
 };
 
+class DnnlReshapeNodeCapability : public DnnlDefaultNodeCapability {
+ public:
+  DnnlReshapeNodeCapability() : DnnlDefaultNodeCapability({"float",
+                                                           "float16",
+                                                           "bfloat16",
+                                                           "int32",
+                                                           "int8",
+                                                           "uint8"}) {}
+
+  bool Supported(const Node* node) const override;
+
+ private:
+  bool IsDimensionSupported(const Node* node) const;
+};
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -4,9 +4,30 @@
 #pragma once
 
 #include "core/providers/shared_library/provider_api.h"
+#include <unordered_set>
 
 namespace onnxruntime {
 
+// redefinition of `enum TensorProto_DataType : int` to help code readability by using shorter names.
+enum ORT_DataType : int {
+  type_undefined = ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED,
+  type_float32 = ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+  type_uint8 = ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+  type_int8 = ONNX_NAMESPACE::TensorProto_DataType_INT8,
+  type_uint16 = ONNX_NAMESPACE::TensorProto_DataType_UINT16,
+  type_int16 = ONNX_NAMESPACE::TensorProto_DataType_INT16,
+  type_int32 = ONNX_NAMESPACE::TensorProto_DataType_INT32,
+  type_int64 = ONNX_NAMESPACE::TensorProto_DataType_INT64,
+  type_string = ONNX_NAMESPACE::TensorProto_DataType_STRING,
+  type_bool = ONNX_NAMESPACE::TensorProto_DataType_BOOL,
+  type_float16 = ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+  type_double = ONNX_NAMESPACE::TensorProto_DataType_DOUBLE,
+  type_uint32 = ONNX_NAMESPACE::TensorProto_DataType_UINT32,
+  type_uint64 = ONNX_NAMESPACE::TensorProto_DataType_UINT64,
+  type_complex64 = ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64,
+  type_complex128 = ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128,
+  type_bfloat16 = ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16
+};
 /**
  * Pure virtual base class
  *
@@ -34,39 +55,16 @@ class DnnlNodeCapability {
 /**
  * Default impelementation of the DnnlNodeCapability interface
  * This class can be used if the only thing needed to
- * decided if the we are capable of running the node using
- * the DnnlExecutionProvider is the input data type.
+ * decided if the we are capable of running the node
+ * is the input data type.
  *
- * The default constructor assumes that "float" data
+ * The default constructor assumes that type_float32 data
  * type is supported and no other data types.
  *
- * To add additional data types an array of data types
- * can be passed as strings i.e.
- * `DnnlDefaultNodeCapability({"float", "int8"})`
+ * To add additional data types an array of ORT_DataTypes
+ * can be passed into the custructor i.e.
+ * `DnnlDefaultNodeCapability({type_float32, type_int8})`
  * Would indicate that "float" and "int8" are supported.
- *
- * At this time the possible data types strings are:
- * - "float"
- * - "float16"
- * - "bfloat16"
- * - "double"
- * - "int8"
- * - "int16"
- * - "int32"
- * - "int64"
- * - "uint8"
- * - "uint16"
- * - "uint32"
- * - "uint64"
- * - "complex64"
- * - "complex128"
- * - "string"
- * - "bool"
- *
- * The strings are from the data_type_utils.cc
- * TypesWrapper::TypesWrapper() member function. If a type
- * is expected but not found in the above list see if it is
- * assigned in the data_type_utils.cc file.
  *
  * This currently only checks the data type of input[0]. If
  * this does not work for the Node then this class will need
@@ -76,7 +74,7 @@ class DnnlNodeCapability {
 class DnnlDefaultNodeCapability : public DnnlNodeCapability {
  public:
   DnnlDefaultNodeCapability();
-  DnnlDefaultNodeCapability(std::vector<std::string> inputTypes);
+  DnnlDefaultNodeCapability(std::vector<ORT_DataType> inputTypes);
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -84,7 +82,7 @@ class DnnlDefaultNodeCapability : public DnnlNodeCapability {
   bool IsTypeSupported(const Node* node) const;
 
  private:
-  std::vector<std::string> inputTypes_;
+  std::vector<ORT_DataType> inputTypes_;
 };
 
 /*
@@ -92,13 +90,19 @@ class DnnlDefaultNodeCapability : public DnnlNodeCapability {
 * will check the input of all input nodes.
 *
 * Example usage:
-* std::vector T1 = {"float"};
-* std::vector T2 = {"uint8", "int32", "float"};
+* std::unordered_set T1 = {type_float32};
+* std::unordered_set T2 = {type_uint8, type_int32, type_float32};
 * DnnlDefaultMultiInputNodeCapability({T1, T2});
+*
+* The number of inputs and the number of unordered_sets must match. For this reason
+* this capability class is not sutable for nodes that may have a varible number of
+* inputs.
+*
+* All types for all inputs must be specified.
 */
 class DnnlDefaultMultiInputNodeCapability : public DnnlNodeCapability {
  public:
-  DnnlDefaultMultiInputNodeCapability(std::vector<std::vector<std::string>> inputTypes);
+  DnnlDefaultMultiInputNodeCapability(std::vector<std::unordered_set<ORT_DataType>> inputTypes);
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -106,7 +110,7 @@ class DnnlDefaultMultiInputNodeCapability : public DnnlNodeCapability {
   bool IsTypeSupported(const Node* node) const;
 
  private:
-  std::vector<std::vector<std::string>> inputTypes_;
+  std::vector<std::unordered_set<ORT_DataType>> inputTypes_;
 };
 
 /**
@@ -118,7 +122,7 @@ class DnnlDefaultMultiInputNodeCapability : public DnnlNodeCapability {
  */
 class DnnlPoolNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlPoolNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlPoolNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -133,7 +137,7 @@ class DnnlPoolNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlBatchNormalizationNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlBatchNormalizationNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlBatchNormalizationNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -148,7 +152,7 @@ class DnnlBatchNormalizationNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlReduceMeanNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlReduceMeanNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlReduceMeanNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -164,7 +168,7 @@ class DnnlReduceMeanNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlSoftmaxNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlSoftmaxNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlSoftmaxNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -177,7 +181,7 @@ class DnnlSoftmaxNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlMatMulNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlMatMulNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlMatMulNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -190,7 +194,7 @@ class DnnlMatMulNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlMatMulIntegerNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlMatMulIntegerNodeCapability() : DnnlDefaultNodeCapability({"int8", "uint8"}) {}
+  DnnlMatMulIntegerNodeCapability() : DnnlDefaultNodeCapability({type_int8, type_uint8}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -208,7 +212,7 @@ class DnnlSumNodeCapability : public DnnlDefaultNodeCapability {
   // Onnx reports support for float, float16, bfloat16, and double
   // Onnxruntime only has unittests for float and double.
   // To enable float16 and bfloat16 we will should add tests to verify those data types.
-  DnnlSumNodeCapability() : DnnlDefaultNodeCapability({"float" /*, "float16", "bfloat16", "int8", "uint8"*/}) {}
+  DnnlSumNodeCapability() : DnnlDefaultNodeCapability({type_float32 /*, type_float16, type_bfloat16, type_int8, type_uint8*/}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -221,7 +225,7 @@ class DnnlSumNodeCapability : public DnnlDefaultNodeCapability {
  */
 class DnnlBinaryNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlBinaryNodeCapability() : DnnlDefaultNodeCapability({"int8", "uint8", "float"}) {}
+  DnnlBinaryNodeCapability() : DnnlDefaultNodeCapability({type_int8, type_uint8, type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -236,7 +240,7 @@ class DnnlBinaryNodeCapability : public DnnlDefaultNodeCapability {
 */
 class DnnlElementwiseCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlElementwiseCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlElementwiseCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -247,8 +251,8 @@ class DnnlElementwiseCapability : public DnnlDefaultNodeCapability {
 class DnnlPowNodeCapability : public DnnlDefaultMultiInputNodeCapability {
  public:
   DnnlPowNodeCapability()
-    : DnnlDefaultMultiInputNodeCapability({/*T */{"float"},
-                                           /*T1*/{"uint8", "int8", "int32", "float"}}) {}
+    : DnnlDefaultMultiInputNodeCapability({/*T */{type_float32},
+                                           /*T1*/{type_uint8, type_int8, type_int32, type_float32}}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -261,7 +265,7 @@ class DnnlPowNodeCapability : public DnnlDefaultMultiInputNodeCapability {
  */
 class DnnlGemmNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlGemmNodeCapability() : DnnlDefaultNodeCapability({"float"}) {}
+  DnnlGemmNodeCapability() : DnnlDefaultNodeCapability({type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
@@ -272,12 +276,12 @@ class DnnlGemmNodeCapability : public DnnlDefaultNodeCapability {
 
 class DnnlReshapeNodeCapability : public DnnlDefaultNodeCapability {
  public:
-  DnnlReshapeNodeCapability() : DnnlDefaultNodeCapability({"float",
-                                                           "float16",
-                                                           "bfloat16",
-                                                           "int32",
-                                                           "int8",
-                                                           "uint8"}) {}
+  DnnlReshapeNodeCapability() : DnnlDefaultNodeCapability({type_float32,
+                                                           type_float16,
+                                                           type_bfloat16,
+                                                           type_int32,
+                                                           type_int8,
+                                                           type_uint8}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -25,6 +25,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Mul", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ReduceMean", std::unique_ptr<DnnlNodeCapability>(new DnnlReduceMeanNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Relu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Reshape", std::unique_ptr<DnnlNodeCapability>(new DnnlReshapeNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Round", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sigmoid", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Softmax", std::unique_ptr<DnnlNodeCapability>(new DnnlSoftmaxNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -23,6 +23,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("MatMulInteger", std::unique_ptr<DnnlNodeCapability>(new DnnlMatMulIntegerNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("MaxPool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Mul", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Pow", std::unique_ptr<DnnlNodeCapability>(new DnnlPowNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ReduceMean", std::unique_ptr<DnnlNodeCapability>(new DnnlReduceMeanNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Relu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Reshape", std::unique_ptr<DnnlNodeCapability>(new DnnlReshapeNodeCapability())));
@@ -44,12 +45,12 @@ DnnlOpManager::DnnlOpManager() {
 #endif  // ENABLE_TRAINING
 }
 
-bool DnnlOpManager::IsNodeSupported(const Node* node) const {
+bool DnnlOpManager::IsNodeSupported(const Node* node, const GraphViewer& graph_viewer) const {
   auto it = dnnl_ops_map_.find(node->OpType());
   if (it == dnnl_ops_map_.end()) {
     return false;
   }
-  return it->second->Supported(node);
+  return it->second->Supported(node, graph_viewer);
 }
 
 bool DnnlOpManager::IsOpTypeAvalible(const std::string& opType) const {

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -33,6 +33,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Sub", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sum", std::unique_ptr<DnnlNodeCapability>(new DnnlSumNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Tanh", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Transpose", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
 #if defined(ENABLE_TRAINING)
   dnnl_ops_map_.emplace(std::make_pair("AveragePoolGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ConvGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -17,6 +17,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Gemm", std::unique_ptr<DnnlNodeCapability>(new DnnlGemmNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("GlobalAveragePool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("GlobalMaxPool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("LeakyRelu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Log", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("LRN", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("MatMul", std::unique_ptr<DnnlNodeCapability>(new DnnlMatMulNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.h
@@ -25,7 +25,7 @@ class DnnlOpManager {
   * @return true if the node is Supported by the DNNL execution provider
   *         false is returned otherwise.
   */
-  bool IsNodeSupported(const Node* node) const;
+  bool IsNodeSupported(const Node* node, const GraphViewer& graph_viewer) const;
 
   /**
   * Find out if the OpType is one of the OpTypes Supported by the DNNL execution provider

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_batchnorm.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_batchnorm.cc
@@ -21,20 +21,20 @@ void DnnlBatchNorm::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto epsilon = ReadEpsilon(node);
   
-  auto batchnorm_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto batchnorm_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = batchnorm_src_mem.get_desc();
 
-  auto batchnorm_scale_mem = sp.GetMemory(node.Input(IN_SCALE).Name());
+  auto batchnorm_scale_mem = sp.GetMemory(node.Input(IN_SCALE));
   auto scale_md = batchnorm_scale_mem.get_desc();
   auto scale_dims = scale_md.dims();
 
-  auto batchnorm_bias_mem = sp.GetMemory(node.Input(IN_B).Name());
+  auto batchnorm_bias_mem = sp.GetMemory(node.Input(IN_B));
   auto bias_md = batchnorm_bias_mem.get_desc();
 
-  auto batchnorm_mean_mem = sp.GetMemory(node.Input(IN_MEAN).Name());
+  auto batchnorm_mean_mem = sp.GetMemory(node.Input(IN_MEAN));
   auto mean_md = batchnorm_mean_mem.get_desc();
 
-  auto batchnorm_var_mem = sp.GetMemory(node.Input(IN_VAR).Name());
+  auto batchnorm_var_mem = sp.GetMemory(node.Input(IN_VAR));
   auto var_md = batchnorm_var_mem.get_desc();
 
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
@@ -23,8 +23,8 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
     ORT_THROW("op type not supported");
   }
 
-  auto src_0_ori_md = sp.GetMemory(node.Input(IN_A).Name()).get_desc();
-  auto src_1_ori_md = sp.GetMemory(node.Input(IN_B).Name()).get_desc();
+  auto src_0_ori_md = sp.GetMemory(node.Input(IN_A)).get_desc();
+  auto src_1_ori_md = sp.GetMemory(node.Input(IN_B)).get_desc();
 
   auto src_0_dims = src_0_ori_md.dims();
   auto src_1_dims = src_1_ori_md.dims();

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.cc
@@ -14,11 +14,11 @@ DnnlConv::DnnlConv() {}
 void DnnlConv::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto conv_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto conv_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = conv_src_mem.get_desc();
   auto src_dims = conv_src_mem.get_desc().dims();
 
-  auto conv_weights_mem = sp.GetMemory(node.Input(IN_W).Name());
+  auto conv_weights_mem = sp.GetMemory(node.Input(IN_W));
   auto weight_md = conv_weights_mem.get_desc();
   auto weight_dims_original = conv_weights_mem.get_desc().dims();
   dnnl::memory::dims weight_dims = weight_dims_original;
@@ -27,7 +27,7 @@ void DnnlConv::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   dnnl::memory conv_bias_mem;
   dnnl::memory::desc bias_md;
   if (bias_exists) {
-    conv_bias_mem = sp.GetMemory(node.Input(IN_B).Name());
+    conv_bias_mem = sp.GetMemory(node.Input(IN_B));
     bias_md = conv_bias_mem.get_desc();
   }
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_convgrad.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_convgrad.cc
@@ -47,15 +47,15 @@ To acheive Everything specified in the OnnxRuntime ConvGrad we must use both:
 void DnnlConvGrad::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto dy_mem = sp.GetMemory(node.Input(IN_DY).Name());
+  auto dy_mem = sp.GetMemory(node.Input(IN_DY));
   auto dy_md = dy_mem.get_desc();
   auto dy_dims = dy_mem.get_desc().dims();
 
-  auto x_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto x_mem = sp.GetMemory(node.Input(IN_X));
   auto x_md = x_mem.get_desc();
   auto x_dims = x_mem.get_desc().dims();
 
-  auto w_mem = sp.GetMemory(node.Input(IN_W).Name());
+  auto w_mem = sp.GetMemory(node.Input(IN_W));
   auto w_md = w_mem.get_desc();
   auto w_dims_original = w_mem.get_desc().dims();
   auto w_dims = w_dims_original;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
@@ -13,7 +13,7 @@ DnnlElementwise::DnnlElementwise() {}
 void DnnlElementwise::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto elementwise_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto elementwise_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = elementwise_src_mem.get_desc();
   dnnl::algorithm algo;
   bool requires_alpha = false;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
@@ -8,9 +8,7 @@
 namespace onnxruntime {
 namespace ort_dnnl {
 
-DnnlElementwise::DnnlElementwise() {
-  default_alpha_ = 1.0;
-}
+DnnlElementwise::DnnlElementwise() {}
 
 void DnnlElementwise::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
@@ -24,11 +22,14 @@ void DnnlElementwise::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node)
     algo = dnnl::algorithm::eltwise_abs;
   } else if (node.OpType() == "Elu") {
     requires_alpha = true;
-    default_alpha_ = 1.0;
-    alpha = GetAlpha(node);
+    alpha = GetAlpha(node, /*default_alpha*/1.0f);
     algo = dnnl::algorithm::eltwise_elu; 
   } else if (node.OpType() == "Exp") {
     algo = dnnl::algorithm::eltwise_exp;
+  } else if (node.OpType() == "LeakyRelu") {
+    requires_alpha = true;
+    alpha = GetAlpha(node, /*default_alpha*/ 0.01f);
+    algo = dnnl::algorithm::eltwise_relu;
   } else if (node.OpType() == "Log") {
     algo = dnnl::algorithm::eltwise_log;
   } else if (node.OpType() == "Relu") {
@@ -68,12 +69,12 @@ void DnnlElementwise::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node)
   sp.SetMemory(node.Output(OUT_Y), elementwise_dst_mem);
 }
 
-float DnnlElementwise::GetAlpha(DnnlNode& node) {
+float DnnlElementwise::GetAlpha(DnnlNode& node, float default_alpha) {
   auto attr = node.Attributes().find("alpha");
   if (attr != node.Attributes().end()) {
     return attr->second().f();
   }
-  return default_alpha_;
+  return default_alpha;
 }
 
 }  // namespace ort_dnnl

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.h
@@ -33,8 +33,7 @@ class DnnlElementwise {
   * Note: The number of operators that use the 'alpha' attribute is much smaller than
   * initially expected.
   */
-  float GetAlpha(DnnlNode& node);
-  float default_alpha_;
+  float GetAlpha(DnnlNode& node, float default_alpha);
 };
 
 }  // namespace ort_dnnl

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_gemm.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_gemm.cc
@@ -56,8 +56,8 @@ OneDNN algorithm:
 void DnnlGemm::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto eng = sp.GetEngine();
 
-  auto a_dims = sp.GetMemory(node.Input(IN_A).Name()).get_desc().dims();
-  auto b_dims = sp.GetMemory(node.Input(IN_B).Name()).get_desc().dims();
+  auto a_dims = sp.GetMemory(node.Input(IN_A)).get_desc().dims();
+  auto b_dims = sp.GetMemory(node.Input(IN_B)).get_desc().dims();
 
   bool input_c_exists = node.Input(IN_C).Exists();
 
@@ -115,7 +115,7 @@ void DnnlGemm::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   sp.AddPrimitive(matmul_op, args);
 
   if (input_c_exists) {
-    auto c_original_md = sp.GetMemory(node.Input(IN_C).Name()).get_desc();
+    auto c_original_md = sp.GetMemory(node.Input(IN_C)).get_desc();
     auto c_dims = c_original_md.dims();
     if (c_dims.size() != a_dims.size()) {
       while (c_dims.size() < a_dims.size()) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_lrn.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_lrn.cc
@@ -22,7 +22,7 @@ void DnnlLrn::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto bias = ReadBias(node);
   auto size = ReadSize(node);
 
-  auto lrn_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto lrn_src_mem = sp.GetMemory(node.Input(IN_X));
   auto lrn_src_md = lrn_src_mem.get_desc();
 
   auto lrn_desc = dnnl::lrn_forward::desc(dnnl::prop_kind::forward_scoring, dnnl::algorithm::lrn_across_channels, lrn_src_md, size, alpha, beta, bias);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_matmul.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_matmul.cc
@@ -13,8 +13,8 @@ DnnlMatMul::DnnlMatMul() {}
 void DnnlMatMul::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto eng = sp.GetEngine();
 
-  auto src_dims = sp.GetMemory(node.Input(IN_A).Name()).get_desc().dims();
-  auto weights_dims = sp.GetMemory(node.Input(IN_B).Name()).get_desc().dims();
+  auto src_dims = sp.GetMemory(node.Input(IN_A)).get_desc().dims();
+  auto weights_dims = sp.GetMemory(node.Input(IN_B)).get_desc().dims();
 
   if (src_dims.size() != weights_dims.size()) {
     while (src_dims.size() < weights_dims.size()) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_matmul_integer.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_matmul_integer.cc
@@ -13,8 +13,8 @@ DnnlMatMulInteger::DnnlMatMulInteger() {}
 void DnnlMatMulInteger::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto eng = sp.GetEngine();
 
-  auto src_dims = sp.GetMemory(node.Input(IN_A).Name()).get_desc().dims();
-  auto weights_dims = sp.GetMemory(node.Input(IN_B).Name()).get_desc().dims();
+  auto src_dims = sp.GetMemory(node.Input(IN_A)).get_desc().dims();
+  auto weights_dims = sp.GetMemory(node.Input(IN_B)).get_desc().dims();
 
   if (src_dims.size() != weights_dims.size()) {
     while (src_dims.size() < weights_dims.size()) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_pool.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_pool.cc
@@ -13,7 +13,7 @@ DnnlPool::DnnlPool() {}
 void DnnlPool::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto pool_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto pool_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = pool_src_mem.get_desc();
   auto src_dims = pool_src_mem.get_desc().dims();
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_poolgrad.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_poolgrad.cc
@@ -57,7 +57,7 @@ Attributes (auto_pad, ceil_mode, count_include_pad, kernel_shap, pads, and strid
 void DnnlPoolGrad::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto dy_mem = sp.GetMemory(node.Input(IN_DY).Name());
+  auto dy_mem = sp.GetMemory(node.Input(IN_DY));
   auto dy_md = dy_mem.get_desc();
   auto dy_dims = dy_mem.get_desc().dims();
 
@@ -67,7 +67,7 @@ void DnnlPoolGrad::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   bool maxpoolgrad_optype = (node.OpType() == "MaxPoolGrad");
 
   if (maxpoolgrad_optype) {
-    indices_mem = sp.GetMemory(node.Input(IN_INDICES).Name());
+    indices_mem = sp.GetMemory(node.Input(IN_INDICES));
     indices_md = indices_mem.get_desc();
     indices_dims = indices_mem.get_desc().dims();
   }

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
@@ -1,0 +1,59 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_pow.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+DnnlPow::DnnlPow() {}
+
+void DnnlPow::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto dnnl_engine = sp.GetEngine();
+
+  auto elementwise_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto src_md = elementwise_src_mem.get_desc();
+
+  auto exponent_src_mem = sp.GetMemory(node.Input(IN_Y).Name());
+
+  float beta = 1.0;
+  switch (node.Input(IN_Y).Type()) {
+    case dnnl::memory::data_type::f32: {
+      beta = static_cast<float>(*(float*)exponent_src_mem.get_data_handle());
+      break;
+    }
+    case dnnl::memory::data_type::s32: {
+      beta = static_cast<float>(*(int32_t*)exponent_src_mem.get_data_handle());
+      break;
+    }
+    case dnnl::memory::data_type::s8: {
+      beta = static_cast<float>(*(int8_t*)exponent_src_mem.get_data_handle());
+      break;
+    }
+    case dnnl::memory::data_type::u8: {
+      beta = static_cast<float>(*(uint8_t*)exponent_src_mem.get_data_handle());
+      break;
+    }
+    default:
+      ORT_THROW("Pow exponent data type not supported");
+  }
+
+  // DNNL eltwise_pow is defined as alpha*x^beta. We don't use alpha so it is hard coded to 1.0
+  dnnl::eltwise_forward::desc elementwise_desc(dnnl::prop_kind::forward_inference, dnnl::algorithm::eltwise_pow, src_md, 1.0, beta);
+  dnnl::eltwise_forward::primitive_desc elementwise_pd(elementwise_desc, dnnl_engine);
+
+  // If using GPU this will move the memory from the CPU to the GPU.
+  elementwise_src_mem = sp.GetMemoryAndReshape(node.Input(IN_X), elementwise_pd.src_desc(), dnnl_engine);
+  auto elementwise_dst_mem = dnnl::memory(elementwise_pd.dst_desc(), dnnl_engine);
+
+  auto elemenwise_primitive = dnnl::eltwise_forward(elementwise_pd);
+  sp.AddPrimitive(elemenwise_primitive, {{DNNL_ARG_SRC, elementwise_src_mem},
+                                         {DNNL_ARG_DST, elementwise_dst_mem}});
+
+  sp.SetMemory(node.Output(OUT_Z), elementwise_dst_mem);
+}
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
@@ -13,10 +13,10 @@ DnnlPow::DnnlPow() {}
 void DnnlPow::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto elementwise_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto elementwise_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = elementwise_src_mem.get_desc();
 
-  auto exponent_src_mem = sp.GetMemory(node.Input(IN_Y).Name());
+  auto exponent_src_mem = sp.GetMemory(node.Input(IN_Y));
 
   float beta = 1.0;
   switch (node.Input(IN_Y).Type()) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.h
@@ -1,0 +1,27 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlPow {
+ public:
+  enum InputTensors : int {
+    IN_X = 0,
+    IN_Y = 1
+  };
+
+  enum OutputTensors : int {
+    OUT_Z = 0
+  };
+
+  DnnlPow();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reducemean.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reducemean.cc
@@ -20,7 +20,7 @@ void DnnlReduceMean::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) 
 
   auto axes = ReadAxes(node);
   
-  auto reducemean_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto reducemean_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = reducemean_src_mem.get_desc();
 
   //We need to calculate output tensor shape

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_relugrad.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_relugrad.cc
@@ -11,8 +11,8 @@ void DnnlReluGrad::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto eng = sp.GetEngine();
 
   //get what's available as input
-  auto src_mem = sp.GetMemory(node.Input(IN_X).Name());
-  auto diff_dst_mem = sp.GetMemory(node.Input(IN_dY).Name());
+  auto src_mem = sp.GetMemory(node.Input(IN_X));
+  auto diff_dst_mem = sp.GetMemory(node.Input(IN_dY));
 
   //reorder if needed (gpu)
   auto relu_bwd_src_mem = sp.GetMemoryAndReshape(node.Input(IN_X), src_mem.get_desc(), eng);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.cc
@@ -13,7 +13,7 @@ DnnlReshape::DnnlReshape() { }
 void DnnlReshape::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto dnnl_engine = sp.GetEngine();
 
-  auto data_mem = sp.GetMemory(node.Input(IN_DATA).Name());
+  auto data_mem = sp.GetMemory(node.Input(IN_DATA));
   dnnl::memory::dims data_dims = data_mem.get_desc().dims();
   auto data_md = data_mem.get_desc();
 
@@ -29,7 +29,7 @@ void DnnlReshape::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
     data_mem = sp.GetMemoryAndReshape(node.Input(IN_DATA), data_md, dnnl_engine);
   }
 
-  auto shape_mem = sp.GetMemory(node.Input(IN_SHAPE).Name());
+  auto shape_mem = sp.GetMemory(node.Input(IN_SHAPE));
   dnnl::memory::dims shape_dims = shape_mem.get_desc().dims();
   int64_t* shape_data = (int64_t*)shape_mem.get_data_handle();
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.cc
@@ -1,0 +1,81 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_reshape.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+#include "core/providers/cpu/tensor/reshape_helper.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+DnnlReshape::DnnlReshape() { }
+
+void DnnlReshape::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto dnnl_engine = sp.GetEngine();
+
+  auto data_mem = sp.GetMemory(node.Input(IN_DATA).Name());
+  dnnl::memory::dims data_dims = data_mem.get_desc().dims();
+  auto data_md = data_mem.get_desc();
+
+
+  if (!IsMemoryInExpectedOrtFormat(data_md)) {
+    auto temp_md = dnnl::memory::desc(data_dims, node.Input(IN_DATA).Type(), sp.GetDnnlFormat(data_dims.size()));
+    dnnl::memory temp_mem = dnnl::memory(temp_md, dnnl_engine);
+    sp.AddPrimitive(dnnl::reorder(data_mem, temp_mem), {{DNNL_ARG_FROM, data_mem},
+                                                           {DNNL_ARG_TO, temp_mem}});
+    data_mem = temp_mem;
+  } else {
+    // If using GPU this will move the memory from the CPU to the GPU.
+    data_mem = sp.GetMemoryAndReshape(node.Input(IN_DATA), data_md, dnnl_engine);
+  }
+
+  auto shape_mem = sp.GetMemory(node.Input(IN_SHAPE).Name());
+  dnnl::memory::dims shape_dims = shape_mem.get_desc().dims();
+  int64_t* shape_data = (int64_t*)shape_mem.get_data_handle();
+
+  dnnl::memory::dims reshape_shape(shape_data, shape_data + shape_dims[0]);
+  // Reshape helper will take input data_dims shape and the reshape_shape and replace the -1 and 0s with the calculated
+  // Output values. The Reshape helper also does a lot of error checking to make sure the Reshape is possible.
+  ReshapeHelper helper(TensorShape(data_dims), reshape_shape, GetAllowZero(node));
+
+  //the dnnl::memory::desc.reshape(shape) failed on some models so we instead create a new dnnl:memory::desc
+  dnnl::memory::desc reshaped_md(reshape_shape, node.Input(IN_DATA).Type(), sp.GetDnnlFormat(reshape_shape.size()));
+
+  dnnl::memory reshaped_mem = dnnl::memory(reshaped_md, dnnl_engine, nullptr);
+  sp.AddReshape(data_mem, reshaped_mem);
+
+  sp.SetMemory(node.Output(OUT_RESHAPED), reshaped_mem, true);
+}
+
+bool DnnlReshape::IsMemoryInExpectedOrtFormat(const dnnl::memory::desc& desc) {
+  if (desc.data.format_kind != dnnl_blocked) {
+    return false;
+  }
+  if (desc.data.format_desc.blocking.inner_nblks != 0) {
+    return false;
+  }
+  auto strides = desc.data.format_desc.blocking.strides;
+  // if a data format is dnnl_format::abcd... the stride will go from largest to smallest
+  // if for example we have a shape {2,3,4} we expect a stride of {12, 4, 1} if it were
+  // of dnnl_format::abc if instead the stride were {12, 1, 4} that would be dnnl_format::acb
+  // which does not match what is expected from Onnxruntime.
+  for (size_t i = 1; i < desc.dims().size(); ++i) {
+    if (strides[i - 1] < strides[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DnnlReshape::GetAllowZero(DnnlNode& node) {
+  auto attr = node.Attributes().find("allowzero");
+  int64_t allowzero = 0;  //Default value according to ONNX spec
+  if (attr != node.Attributes().end() &&
+      attr->second().type() == ::ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT) {
+    allowzero = attr->second().i();
+  }
+  return !(allowzero == 0);
+}
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.h
@@ -1,0 +1,31 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlReshape{
+ public:
+  enum InputTensors : int {
+    IN_DATA = 0,
+    IN_SHAPE =1,
+  };
+
+  enum OutputTensors : int {
+    OUT_RESHAPED = 0
+  };
+
+  DnnlReshape();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+  private:
+  bool IsMemoryInExpectedOrtFormat(const dnnl::memory::desc& desc);
+  bool GetAllowZero(DnnlNode& node);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmax.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmax.cc
@@ -20,7 +20,7 @@ void DnnlSoftmax::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto axis = ReadAxis(node);
   
-  auto softmax_src_mem = sp.GetMemory(node.Input(IN_X).Name());
+  auto softmax_src_mem = sp.GetMemory(node.Input(IN_X));
   auto softmax_src_md = softmax_src_mem.get_desc();
 
   if (axis < 0)

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmaxgrad.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmaxgrad.cc
@@ -11,8 +11,8 @@ void DnnlSoftmaxGrad::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node)
   auto eng = sp.GetEngine();
 
   //get what's available as input
-  auto src_mem = sp.GetMemory(node.Input(IN_X).Name());
-  auto diff_dst_mem = sp.GetMemory(node.Input(IN_dY).Name());
+  auto src_mem = sp.GetMemory(node.Input(IN_X));
+  auto diff_dst_mem = sp.GetMemory(node.Input(IN_dY));
 
   //reorder if needed (gpu)
   auto softmax_bwd_src_mem = sp.GetMemoryAndReshape(node.Input(IN_X), src_mem.get_desc(), eng);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
@@ -15,7 +15,7 @@ DnnlTensor::DnnlTensor(std::string name) {
   tensor_name_ = name;
 }
 
-std::string DnnlTensor::Name() {
+std::string DnnlTensor::Name() const {
   return tensor_name_;
 }
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
@@ -56,6 +56,14 @@ dnnl::memory::data_type DnnlTensor::Type() {
       return dnnl::memory::data_type::bf16;
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
       return dnnl::memory::data_type::f32;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      // OneDNN does not have support for tensors of int64_t so we just say
+      // the tensor is int32_t and then use casting in the actual operator
+      // to convert the dnnl::memory::data_handle to an int64_t*.  Care
+      // must be taken that an int64_t tensor does not make it pass the
+      // node capability check unless the operator is explicitly expecting
+      // the int64_t
+      return dnnl::memory::data_type::s32;
     case ONNX_NAMESPACE::TensorProto_DataType_INT32:
       return dnnl::memory::data_type::s32;
     case ONNX_NAMESPACE::TensorProto_DataType_INT8:

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
@@ -16,7 +16,7 @@ class DnnlTensor {
  public:
   DnnlTensor(const NodeArg* arg);
   DnnlTensor(std::string name);
-  std::string Name();
+  std::string Name() const;
   dnnl::memory::dims Dim();
   dnnl::memory::data_type Type();
   dnnl::memory::format_tag Format();

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -12,6 +12,7 @@
 #include "dnnl_matmul.h"
 #include "dnnl_matmul_integer.h"
 #include "dnnl_pool.h"
+#include "dnnl_pow.h"
 #include "dnnl_reducemean.h"
 #include "dnnl_reshape.h"
 #include "dnnl_softmax.h"
@@ -63,6 +64,8 @@ void DnnlSubgraphPrimitive::AddKernels() {
       DnnlMatMulInteger().CreatePrimitive(*this, node);
     } else if (pool_ops.count(node.OpType())) {
       DnnlPool().CreatePrimitive(*this, node);
+    } else if (node.OpType() == "Pow") {
+      DnnlPow().CreatePrimitive(*this, node);
     } else if (node.OpType() == "ReduceMean") {
       DnnlReduceMean().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Reshape") {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -13,6 +13,7 @@
 #include "dnnl_matmul_integer.h"
 #include "dnnl_pool.h"
 #include "dnnl_reducemean.h"
+#include "dnnl_reshape.h"
 #include "dnnl_softmax.h"
 #include "dnnl_softmaxgrad.h"
 #include "dnnl_sum.h"
@@ -64,6 +65,8 @@ void DnnlSubgraphPrimitive::AddKernels() {
       DnnlPool().CreatePrimitive(*this, node);
     } else if (node.OpType() == "ReduceMean") {
       DnnlReduceMean().CreatePrimitive(*this, node);
+    } else if (node.OpType() == "Reshape") {
+      DnnlReshape().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Softmax") {
       DnnlSoftmax().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Sum") {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -43,7 +43,7 @@ int Product(dnnl::memory::dims d) {
 
 void DnnlSubgraphPrimitive::AddKernels() {
   std::unordered_set<std::string> binary_ops = {"Add", "Div", "Mul", "Sub"};
-  std::unordered_set<std::string> elementwise_ops = {"Abs", "Elu", "Exp","Log", "Relu", "Round", "Sigmoid", "Softplus", "Sqrt", "Tanh"};
+  std::unordered_set<std::string> elementwise_ops = {"Abs", "Elu", "Exp", "LeakyRelu", "Log", "Relu", "Round", "Sigmoid", "Softplus", "Sqrt", "Tanh"};
   std::unordered_set<std::string> pool_ops = {"AveragePool", "GlobalAveragePool", "GlobalMaxPool", "MaxPool"};
   for (auto& node : subgraph_->GetDnnlNodes()) {
     if (node.OpType() == "BatchNormalization") {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -46,14 +46,14 @@ class DnnlSubgraphPrimitive {
   dnnl::stream GetStream();
 
   //obtain a dnnl::memory with specified name, memory descriptor and engine, will perform extra reorder/reshape if necessary before returning
-  dnnl::memory GetMemoryAndReshape(ort_dnnl::DnnlTensor tensor, dnnl::memory::desc mem_desc, dnnl::engine eng, bool transpose = false);
+  dnnl::memory GetMemoryAndReshape(const DnnlTensor& tensor, dnnl::memory::desc mem_desc, dnnl::engine eng, bool transpose = false);
   //add dnnl primitive and memory map to subgraph primitive
   void AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map);
   //add a reshape (e.g. squeeze, unsqueeze) to subgraph primitive
   void AddReshape(dnnl::memory src, dnnl::memory dst);
   bool HasMemory(std::string memory_name, dnnl::memory::desc mem_desc, dnnl::engine eng);
-  dnnl::memory GetMemory(std::string memory_name);
-  dnnl::memory GetMemory(std::string memory_name, dnnl::memory::desc mem_desc, dnnl::engine eng);
+  dnnl::memory GetMemory(const DnnlTensor& tensor);
+  dnnl::memory GetMemory(const DnnlTensor& tensor, dnnl::memory::desc mem_desc, dnnl::engine eng);
   //set memory to a tensor (output)
   // if always_copy_output is true a copy of the memory will be made when the output is leaving the subgraph.
   void SetMemory(DnnlTensor tensor, dnnl::memory mem, bool always_copy_output = false);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -55,7 +55,8 @@ class DnnlSubgraphPrimitive {
   dnnl::memory GetMemory(std::string memory_name);
   dnnl::memory GetMemory(std::string memory_name, dnnl::memory::desc mem_desc, dnnl::engine eng);
   //set memory to a tensor (output)
-  void SetMemory(DnnlTensor tensor, dnnl::memory mem);
+  // if always_copy_output is true a copy of the memory will be made when the output is leaving the subgraph.
+  void SetMemory(DnnlTensor tensor, dnnl::memory mem, bool always_copy_output = false);
   void SetMemory(std::string memory_name, dnnl::memory mem);
   void SetInitializer(std::string memory_name, dnnl::memory mem);
   dnnl::memory::desc GetOutputInfo(std::string name);
@@ -72,6 +73,7 @@ class DnnlSubgraphPrimitive {
 
   std::unordered_map<std::string, dnnl::memory> outputs_;
   std::unordered_map<std::string, dnnl::memory::desc> outputs_md_;
+  std::unordered_set<std::string> outputs_are_always_copied_;
 
   //initializer should not be dynamic
   std::unordered_map<std::string, std::vector<dnnl::memory>> initializers_;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_sum.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_sum.cc
@@ -15,7 +15,7 @@ void DnnlSum::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   std::vector<dnnl::memory> src_mems;
   for (size_t i = IN_DATA_0; i < node.InputCount(); ++i) {
-    src_mems.push_back(sp.GetMemory(node.Input(static_cast<int>(IN_DATA_0 + i)).Name()));
+    src_mems.push_back(sp.GetMemory(node.Input(static_cast<int>(IN_DATA_0 + i))));
   }
 
   std::vector<float> scales;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.cc
@@ -30,7 +30,7 @@ void DnnlTranspose::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto dnnl_engine = sp.GetEngine();
 
-  auto data_mem = sp.GetMemory(node.Input(IN_DATA).Name());
+  auto data_mem = sp.GetMemory(node.Input(IN_DATA));
   auto data_dims = data_mem.get_desc().dims();
   auto ndata_dims = data_dims.size();
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.cc
@@ -1,0 +1,90 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_transpose.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+#include <iostream>
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+DnnlTranspose::DnnlTranspose() {}
+
+/*
+Transpose: 
+  Inputs:
+    0) DATA - Input Tensor
+  Outputs:
+    0) TRANSPOSED - Output Tensor
+
+    (DATA)     +-----------+ (TRANSPOSED)
+    ---------->+ Transpose +-------------->
+               +-----------+
+
+Attributes (perm) - A list of integers. By default, reverse the dimensions,
+                    otherwise permute the axes according to the values given.
+*/
+void DnnlTranspose::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+
+  auto dnnl_engine = sp.GetEngine();
+
+  auto data_mem = sp.GetMemory(node.Input(IN_DATA).Name());
+  auto data_dims = data_mem.get_desc().dims();
+  auto ndata_dims = data_dims.size();
+
+  auto perm = GetPerm(node);
+  if (perm.size() == 0) {
+    perm.reserve(ndata_dims);
+    for (size_t i = 0; i < ndata_dims; ++i) {
+      perm.push_back(static_cast<int64_t>(ndata_dims - i - 1));
+    }
+  }
+
+  dnnl::memory::dims transposed_dims(ndata_dims, 0);
+  dnnl::memory::dims strides(ndata_dims, 0);
+  dnnl::memory::dim total_stride = 1;
+  for (int i = (int)ndata_dims - 1 ; i >= 0; i--) {
+    transposed_dims[i] = data_dims[perm[i]];
+    strides[perm[i]] = total_stride;
+    total_stride *= data_dims[perm[i]];
+  }
+
+  dnnl::memory::dims strides_inverse;
+  strides_inverse.reserve(ndata_dims);
+  for (size_t i = 0; i < ndata_dims; ++i) {
+    strides_inverse.push_back(strides[ndata_dims - i - 1]);
+  }
+
+  // Memory descriptor describes the memory reorder but will not have the correct output dimentions or the correct dnnl::memory::format
+  dnnl::memory::desc intermediate_md = dnnl::memory::desc(data_dims, node.Input(IN_DATA).Type(), strides);
+  dnnl::memory intermediate_mem = dnnl::memory(intermediate_md, dnnl_engine);
+
+  auto traspose_primitive = dnnl::reorder(data_mem, intermediate_mem);
+  sp.AddPrimitive(traspose_primitive, {{DNNL_ARG_FROM, data_mem},
+                                       {DNNL_ARG_TO, intermediate_mem}});
+
+  // The reorder from above will get the memory in the right order. The next few lines will create a memory and memory descriptor
+  // that will have the correct dimentions and correct memory::format
+  dnnl::memory::desc transposed_md = dnnl::memory::desc(transposed_dims, node.Input(IN_DATA).Type(), sp.GetDnnlFormat(data_dims.size()));
+  dnnl::memory transposed_mem = dnnl::memory(transposed_md, dnnl_engine, nullptr);
+  void* handle = intermediate_mem.get_data_handle();
+  transposed_mem.set_data_handle(handle);
+
+  sp.SetMemory(node.Output(OUT_TRANSPOSED), transposed_mem, true);
+}
+
+std::vector<int64_t> DnnlTranspose::GetPerm(DnnlNode& node) {
+  auto attr = node.Attributes().find("perm");
+  std::vector<int64_t> perm;
+  if (attr != node.Attributes().end()) {
+    perm.reserve(attr->second().ints_size());
+    for (int i = 0; i < attr->second().ints_size(); ++i) {
+      perm.push_back(attr->second().ints(i));
+    }
+  }
+  return perm;
+}
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_transpose.h
@@ -1,0 +1,30 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlTranspose {
+ public:
+  enum InputTensors : int {
+    IN_DATA = 0,
+  };
+
+  enum OutputTensors : int {
+    OUT_TRANSPOSED = 0
+  };
+
+  DnnlTranspose();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+ private:
+  std::vector<int64_t> GetPerm(DnnlNode& node);
+};
+
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -738,6 +738,16 @@ TEST(MathOpTest, Pow_Broadcast_Scalar1_12) {
   test.Run();
 }
 
+TEST(MathOpTest, Pow_Broadcast_Scalar1_float_int32_12) {
+  OpTester test("Pow", 12);
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<int32_t>("Y", {}, {3});
+  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
+  test.Run();
+}
+
 TEST(MathOpTest, Pow_float_int64) {
   OpTester test("Pow", 12);
   std::vector<int64_t> dims{3};

--- a/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
@@ -1,0 +1,71 @@
+// Copyright (c)Intel. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+#include "core/util/math.h"
+#include <algorithm>
+#include <math.h>
+
+namespace onnxruntime {
+namespace test {
+
+#ifdef USE_DNNL
+// Many of the "Pow" tests are identical to the CPU element wise ops tests with the
+// exception the exponent for the "Pow" operator is setup as an initilizer value. Since
+// the DNNL execution provider will only accept exponents that are initializers. This matches
+// what is seen in many models that use "Pow"
+TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1) {
+  OpTester test("Pow");
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<float>("Y", {}, {2.0f}, true);
+  test.AddOutput<float>("Z", dims, {1.0f, 4.0f, 9.0f});
+  test.Run();
+}
+
+TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_12) {
+  OpTester test("Pow", 12);
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<float>("Y", {1}, {2.0f}, true);
+  test.AddOutput<float>("Z", dims, {1.0f, 4.0f, 9.0f});
+  test.Run();
+}
+
+TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int32_12) {
+  OpTester test("Pow", 12);
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<int32_t>("Y", {}, {3}, true);
+  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
+  test.Run();
+}
+
+TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int8_12) {
+  OpTester test("Pow", 12);
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<int8_t>("Y", {}, {3}, true);
+  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
+  test.Run();
+}
+
+TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_uint8_12) {
+  OpTester test("Pow", 12);
+
+  std::vector<int64_t> dims{3};
+  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
+  test.AddInput<uint8_t>("Y", {}, {3}, true);
+  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
+  test.Run();
+}
+#endif  // USE_DNNL
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Describe your changes.
This adds 4 additional operators to the DNNL execution provider
- Transpose
- Reshape
- Pow
- LeakyRelu

In addition to the Operators, this also contains two code improvement commits. 
One commit updates the dnnl_code_capability code to use enums instead of strings.
The other commit updates the DnnlSubgraphPrimitve.GetMemory function to more closely resemble the other member functions making the code more straightforward to use. 

Both of these changes really only affect the DNNL execution provider code and will not affect other execution providers.

**Motivation and Context**
- Why is this change required? What problem does it solve?
This increases the Operators supported by the DNNL execution provider.

