### PR TITLE
UWP Apps are broken in 1.9 due to Store compliant builds referencing LoadPackagedLibrary

### DIFF
--- a/csharp/OnnxRuntime.CSharp.proj
+++ b/csharp/OnnxRuntime.CSharp.proj
@@ -18,7 +18,6 @@ CMake creates a target to this project
     <IsReleaseBuild Condition=" '$(IsReleaseBuild)' == '' ">false</IsReleaseBuild>
     <IsLinuxBuild Condition=" '$(IsLinuxBuild)' == '' ">false</IsLinuxBuild>
     <ExecutionProvider Condition=" '$(ExecutionProvider)' == '' ">None</ExecutionProvider>
-    <IsStoreBuild Condition=" '$(IsStoreBuild)' == '' ">false</IsStoreBuild>
 
     <!--internal build related properties-->
     <OnnxRuntimeSourceDirectory Condition="'$(OnnxRuntimeSourceDirectory)'==''">..</OnnxRuntimeSourceDirectory>
@@ -153,7 +152,7 @@ CMake creates a target to this project
     <Copy SourceFiles="@(LicenseFile)" DestinationFiles="@(LicenseFile->'$(OnnxRuntimeSourceDirectory)\%(Filename).txt')"/>
 
     <Message Importance="High" Text="Generating nuspec for the Microsoft.AI.MachineLearning Nuget package ..." />
-    <Exec ContinueOnError="False" Command="python ..\tools\nuget\generate_nuspec_for_native_nuget.py --package_version $(PackageVersion) --package_name Microsoft.AI.MachineLearning --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild) --is_store_build $(IsStoreBuild)" ConsoleToMSBuild="true">
+    <Exec ContinueOnError="False" Command="python ..\tools\nuget\generate_nuspec_for_native_nuget.py --package_version $(PackageVersion) --package_name Microsoft.AI.MachineLearning --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GenerateNuspecOutput" />
     </Exec>
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/windowsai.yml
@@ -99,58 +99,6 @@ jobs:
         BuildArch: 'arm'
         Runtime: 'static'
 
-- job: WindowsAI_CPU_X64_Store
-  timeoutInMinutes: 120
-  workspace:
-    clean: all
-  pool:
-    name: 'Win-CPU-2021'
-    demands: []
-  steps:
-  - template: ../../templates/windowsai-nuget-build.yml
-    parameters:
-      BuildArch: 'x64'
-      BuildForStore: 'true'
-  
-- job: WindowsAI_CPU_X86_Store
-  timeoutInMinutes: 120
-  workspace:
-    clean: all
-  pool:
-    name: 'Win-CPU-2021'
-    demands: []
-  steps:
-  - template: ../../templates/windowsai-nuget-build.yml
-    parameters:
-      BuildArch: 'x86'
-      BuildForStore: 'true'
-  
-- job: WindowsAI_CPU_ARM64_Store
-  timeoutInMinutes: 120
-  workspace:
-    clean: all
-  pool:
-    name: 'Win-CPU-2021'
-    demands: []
-  steps:
-  - template: ../../templates/windowsai-nuget-build.yml
-    parameters:
-      BuildArch: 'arm64'
-      BuildForStore: 'true'
-
-- job: WindowsAI_CPU_ARM_Store
-  timeoutInMinutes: 120
-  workspace:
-    clean: all
-  pool:
-    name: 'Win-CPU-2021'
-    demands: []
-  steps:
-  - template: ../../templates/windowsai-nuget-build.yml
-    parameters:
-      BuildArch: 'arm'
-      BuildForStore: 'true'
-
 - job: NuGet_Packaging
   workspace:
     clean: all
@@ -160,10 +108,6 @@ jobs:
   - WindowsAI_DirectML_X86
   - WindowsAI_DirectML_ARM64
   - WindowsAI_DirectML_ARM
-  - WindowsAI_CPU_X64_Store
-  - WindowsAI_CPU_X86_Store
-  - WindowsAI_CPU_ARM64_Store
-  - WindowsAI_CPU_ARM_Store
   - WindowsAI_DirectML_X64_StaticRuntime
   - WindowsAI_DirectML_X86_StaticRuntime
   - WindowsAI_DirectML_ARM64_StaticRuntime
@@ -193,30 +137,6 @@ jobs:
     inputs:
       artifactName: 'Microsoft.AI.MachineLearning.arm'
       targetPath: '$(Build.BinariesDirectory)/nuget-artifact-arm'
-
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact - NuGet CPU x64 Store'
-    inputs:
-      artifactName: 'Microsoft.AI.MachineLearning.x64.Store'
-      targetPath: '$(Build.BinariesDirectory)/nuget-artifact-x64-store'
-
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact - NuGet CPU x86 Store'
-    inputs:
-      artifactName: 'Microsoft.AI.MachineLearning.x86.Store'
-      targetPath: '$(Build.BinariesDirectory)/nuget-artifact-x86-store'
-
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact - NuGet CPU ARM64 Store'
-    inputs:
-      artifactName: 'Microsoft.AI.MachineLearning.arm64.Store'
-      targetPath: '$(Build.BinariesDirectory)/nuget-artifact-arm64-store'
-
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download Pipeline Artifact - NuGet CPU ARM Store'
-    inputs:
-      artifactName: 'Microsoft.AI.MachineLearning.arm.Store'
-      targetPath: '$(Build.BinariesDirectory)/nuget-artifact-arm-store'
 
   - task: DownloadPipelineArtifact@0
     displayName: 'Download Pipeline Artifact - NuGet DirectML x64 StaticRuntime'
@@ -256,12 +176,6 @@ jobs:
         $x64_nupkg_unzipped_directory = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($x64_nuget_package))
         [System.IO.Compression.ZipFile]::ExtractToDirectory($x64_nuget_package, $x64_nupkg_unzipped_directory)
 
-        $nupkgs = (Get-ChildItem ..\nuget-artifact-x64-store -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
-        $x64_store_nuget_package = $nupkgs[0].FullName
-        $x64_store_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
-        $x64_store_nupkg_unzipped_directory = [System.IO.Path]::Combine($x64_store_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($x64_store_nuget_package))
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($x64_store_nuget_package, $x64_store_nupkg_unzipped_directory)
-
         $nupkgs = (Get-ChildItem ..\nuget-artifact-x64-static-runtime -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
         $x64_static_runtime_nuget_package = $nupkgs[0].FullName
         $x64_static_runtime_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
@@ -273,12 +187,6 @@ jobs:
         $x86_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
         $x86_nupkg_unzipped_directory = [System.IO.Path]::Combine($x86_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($x86_nuget_package))
         [System.IO.Compression.ZipFile]::ExtractToDirectory($x86_nuget_package, $x86_nupkg_unzipped_directory)
-
-        $nupkgs = (Get-ChildItem ..\nuget-artifact-x86-store -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
-        $x86_store_nuget_package = $nupkgs[0].FullName
-        $x86_store_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
-        $x86_store_nupkg_unzipped_directory = [System.IO.Path]::Combine($x86_store_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($x86_store_nuget_package))
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($x86_store_nuget_package, $x86_store_nupkg_unzipped_directory)
 
         $nupkgs = (Get-ChildItem ..\nuget-artifact-x86-static-runtime -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
         $x86_static_runtime_nuget_package = $nupkgs[0].FullName
@@ -292,12 +200,6 @@ jobs:
         $arm64_nupkg_unzipped_directory = [System.IO.Path]::Combine($arm64_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($arm64_nuget_package))
         [System.IO.Compression.ZipFile]::ExtractToDirectory($arm64_nuget_package, $arm64_nupkg_unzipped_directory)
 
-        $nupkgs = (Get-ChildItem ..\nuget-artifact-arm64-store -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
-        $arm64_store_nuget_package = $nupkgs[0].FullName
-        $arm64_store_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
-        $arm64_store_nupkg_unzipped_directory = [System.IO.Path]::Combine($arm64_store_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($arm64_store_nuget_package))
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($arm64_store_nuget_package, $arm64_store_nupkg_unzipped_directory)
-
         $nupkgs = (Get-ChildItem ..\nuget-artifact-arm64-static-runtime -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
         $arm64_static_runtime_nuget_package = $nupkgs[0].FullName
         $arm64_static_runtime_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
@@ -310,41 +212,35 @@ jobs:
         $arm_nupkg_unzipped_directory = [System.IO.Path]::Combine($arm_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($arm_nuget_package))
         [System.IO.Compression.ZipFile]::ExtractToDirectory($arm_nuget_package, $arm_nupkg_unzipped_directory)
 
-        $nupkgs = (Get-ChildItem ..\nuget-artifact-arm-store -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
-        $arm_store_nuget_package = $nupkgs[0].FullName
-        $arm_store_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
-        $arm_store_nupkg_unzipped_directory = [System.IO.Path]::Combine($arm_store_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($arm_store_nuget_package))
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($arm_store_nuget_package, $arm_store_nupkg_unzipped_directory)
-
         $nupkgs = (Get-ChildItem ..\nuget-artifact-arm-static-runtime -Filter Microsoft.AI.MachineLearning*.nupkg -Recurse)
         $arm_static_runtime_nuget_package = $nupkgs[0].FullName
         $arm_static_runtime_nupkg_unzipped_directory_root = $nupkgs[0].Directory.FullName
         $arm_static_runtime_nupkg_unzipped_directory = [System.IO.Path]::Combine($arm_static_runtime_nupkg_unzipped_directory_root, 'binaries', [System.IO.Path]::GetFileNameWithoutExtension($arm_static_runtime_nuget_package))
         [System.IO.Compression.ZipFile]::ExtractToDirectory($arm_static_runtime_nuget_package, $arm_static_runtime_nupkg_unzipped_directory)
 
-        $x64_store_runtime_path_old = [System.IO.Path]::Combine($x64_store_nupkg_unzipped_directory, 'runtimes', 'win-x64', 'lib\\uap10.0')
+        $x64_store_runtime_path_old = [System.IO.Path]::Combine($x64_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-x64', '_native')
         $x64_store_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-x64', 'lib\\uap10.0')
         $x64_static_runtime_path_old = [System.IO.Path]::Combine($x64_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-x64', '_native')
         $x64_static_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-x64', '_native', 'static')
         $x86_runtime_path_old = [System.IO.Path]::Combine($x86_nupkg_unzipped_directory, 'runtimes', 'win-x86', '_native')
         $x86_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-x86', '_native')
-        $x86_store_runtime_path_old = [System.IO.Path]::Combine($x86_store_nupkg_unzipped_directory, 'runtimes', 'win-x86', 'lib\\uap10.0')
+        $x86_store_runtime_path_old = [System.IO.Path]::Combine($x86_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-x86', '_native')
         $x86_store_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-x86', 'lib\\uap10.0')
         $x86_static_runtime_path_old = [System.IO.Path]::Combine($x86_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-x86', '_native')
         $x86_static_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-x86', '_native', 'static')
         $arm64_runtime_path_old = [System.IO.Path]::Combine($arm64_nupkg_unzipped_directory, 'runtimes', 'win-arm64', '_native')
         $arm64_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm64', '_native')
-        $arm64_store_runtime_path_old = [System.IO.Path]::Combine($arm64_store_nupkg_unzipped_directory, 'runtimes', 'win-arm64', 'lib\\uap10.0')
+        $arm64_store_runtime_path_old = [System.IO.Path]::Combine($arm64_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-arm64', '_native')
         $arm64_store_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm64', 'lib\\uap10.0')
         $arm64_static_runtime_path_old = [System.IO.Path]::Combine($arm64_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-arm64', '_native')
         $arm64_static_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm64', '_native', 'static')
         $arm_runtime_path_old = [System.IO.Path]::Combine($arm_nupkg_unzipped_directory, 'runtimes', 'win-arm', '_native')
         $arm_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm', '_native')
-        $arm_store_runtime_path_old = [System.IO.Path]::Combine($arm_store_nupkg_unzipped_directory, 'runtimes', 'win-arm', 'lib\\uap10.0')
+        $arm_store_runtime_path_old = [System.IO.Path]::Combine($arm_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-arm', '_native')
         $arm_store_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm', 'lib\\uap10.0')
         $arm_static_runtime_path_old = [System.IO.Path]::Combine($arm_static_runtime_nupkg_unzipped_directory, 'runtimes', 'win-arm', '_native')
         $arm_static_runtime_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'runtimes', 'win-arm', '_native', 'static')
-        $uap_build_path_old = [System.IO.Path]::Combine($x64_store_nupkg_unzipped_directory, 'build', 'uap10.0')
+        $uap_build_path_old = [System.IO.Path]::Combine($x64_static_runtime_nupkg_unzipped_directory, 'build', 'native')
         $uap_build_path_new = [System.IO.Path]::Combine($x64_nupkg_unzipped_directory, 'build', 'uap10.0')
 
         New-Item -Path $x64_store_runtime_path_new -ItemType Directory

--- a/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
@@ -1,7 +1,6 @@
 parameters:
   BuildArch: 'x64'
   RunTests : 'true'
-  BuildForStore: 'false'
   Runtime: 'dynamic'
 
 steps:
@@ -47,13 +46,6 @@ steps:
   - powershell: |
      Write-Host "##vso[task.setvariable variable=BuildFlags]$(BuildFlags) --enable_wcos"
     displayName: Add OneCore flags
-    condition: eq('${{ parameters.BuildForStore }}', 'false')
-
-  - powershell: |
-     Write-Host "##vso[task.setvariable variable=BuildFlags]$(BuildFlags) --enable_windows_store"
-     Write-Host "##vso[task.setvariable variable=ArtifactName]$(ArtifactName).Store"
-    displayName: Add Microsoft Store flags
-    condition: eq('${{ parameters.BuildForStore }}', 'true')
 
   - powershell: |
      Write-Host "##vso[task.setvariable variable=BuildFlags]$(BuildFlags) --enable_msvc_static_runtime"
@@ -68,59 +60,22 @@ steps:
       arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags)'
       workingDirectory: '$(Build.BinariesDirectory)'
 
-  - ${{ if or(notIn(parameters['sln_platform'], 'Win32', 'x64'), eq(parameters.BuildForStore, 'true')) }}:
-    # Use cross-compiled protoc
-    - script: |
-       @echo ##vso[task.setvariable variable=ProtocDirectory]$(Build.BinariesDirectory)\host_protoc\Release
+  - task: VSBuild@1
+    displayName: 'Build'
+    inputs:
+      solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
+      ${{ if ne(parameters.BuildArch, 'x86') }}:
+        platform: ${{ parameters.BuildArch }}
+      ${{ if eq(parameters.BuildArch, 'x86') }}:
+        platform: 'Win32'
+      configuration: RelWithDebInfo
+      msbuildArchitecture: ${{ parameters.BuildArch }}
+      maximumCpuCount: true
+      logProjectEvents: true
+      workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
+      createLogFile: true
 
-  - ${{ if eq(parameters.BuildForStore, 'false') }}:
-    - task: VSBuild@1
-      displayName: 'Build'
-      inputs:
-        solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.sln'
-        ${{ if ne(parameters.BuildArch, 'x86') }}:
-          platform: ${{ parameters.BuildArch }}
-        ${{ if eq(parameters.BuildArch, 'x86') }}:
-          platform: 'Win32'
-        configuration: RelWithDebInfo
-        msbuildArchitecture: ${{ parameters.BuildArch }}
-        maximumCpuCount: true
-        logProjectEvents: true
-        workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-        createLogFile: true
-
-  - ${{ if eq(parameters.BuildForStore, 'true') }}:
-      - task: VSBuild@1
-        displayName: 'Build'
-        inputs:
-          solution: '$(Build.BinariesDirectory)\RelWithDebInfo\onnxruntime.vcxproj'
-          ${{ if ne(parameters.BuildArch, 'x86') }}:
-            platform: ${{ parameters.BuildArch }}
-          ${{ if eq(parameters.BuildArch, 'x86') }}:
-            platform: 'Win32'
-          configuration: RelWithDebInfo
-          msbuildArchitecture: ${{ parameters.BuildArch }}
-          maximumCpuCount: true
-          logProjectEvents: true
-          workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-          createLogFile: true
-
-      - task: VSBuild@1
-        displayName: 'Build'
-        inputs:
-          solution: '$(Build.BinariesDirectory)\RelWithDebInfo\winml_dll.vcxproj'
-          ${{ if ne(parameters.BuildArch, 'x86') }}:
-            platform: ${{ parameters.BuildArch }}
-          ${{ if eq(parameters.BuildArch, 'x86') }}:
-            platform: 'Win32'
-          configuration: RelWithDebInfo
-          msbuildArchitecture: ${{ parameters.BuildArch }}
-          maximumCpuCount: true
-          logProjectEvents: true
-          workingFolder: '$(Build.BinariesDirectory)\RelWithDebInfo'
-          createLogFile: true
-
-  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.BuildForStore, 'false'), eq(parameters.Runtime, 'dynamic')) }}:
+  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.Runtime, 'dynamic')) }}:
     - script: |
         mklink  /D /J $(Build.BinariesDirectory)\RelWithDebInfo\models $(Build.BinariesDirectory)\models
         DIR dist\ /S /B > wheel_filename_file
@@ -146,7 +101,7 @@ steps:
         testRunTitle: 'Unit Test Run'
       condition: succeededOrFailed()
   
-  - ${{ if and(eq(parameters.BuildForStore, 'false'), eq(parameters.Runtime, 'dynamic')) }}:
+  - ${{ if eq(parameters.Runtime, 'dynamic') }}:
     - script: |
        xcopy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\winml_test_api.exe $(Build.ArtifactStagingDirectory)\test_artifact\
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\winml_test_scenario.exe $(Build.ArtifactStagingDirectory)\test_artifact\
@@ -181,7 +136,7 @@ steps:
         arguments: 'x64'
       modifyEnvironment: true
    
-  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.BuildForStore, 'false')) }}:
+  - ${{ if eq(parameters.BuildArch, 'x64') }}:
     - script: msbuild Microsoft.AI.MachineLearning.Interop.csproj /p:Configuration=RelWithDebInfo /p:Platform="Any CPU" /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) -restore
       workingDirectory: '$(Build.SourcesDirectory)\csharp\src\Microsoft.AI.MachineLearning.Interop'
       displayName: 'Build Microsoft.AI.MachineLearning.Interop.dll'
@@ -194,7 +149,7 @@ steps:
       DoEsrp: 'true'
 
 
-  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.BuildForStore, 'false')) }}:
+  - ${{ if eq(parameters.BuildArch, 'x64') }}:
     - script: |
        msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory)
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
@@ -202,7 +157,7 @@ steps:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
       displayName: 'Create NuGet Package'
 
-  - ${{ if and(eq(parameters.BuildArch, 'x86'), eq(parameters.BuildForStore, 'false')) }}:
+  - ${{ if eq(parameters.BuildArch, 'x86') }}:
     - script: |
        msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=x86
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
@@ -210,25 +165,9 @@ steps:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
       displayName: 'Create NuGet Package'
 
-  - ${{ if and(eq(parameters.BuildArch, 'x64'), eq(parameters.BuildForStore, 'true')) }}:
-    - script: |
-       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:IsStoreBuild=True /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
-       copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
-       copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.snupkg $(Build.ArtifactStagingDirectory)
-      workingDirectory: '$(Build.SourcesDirectory)\csharp'
-      displayName: 'Create NuGet Package'
-
-  - ${{ if and(eq(parameters.BuildArch, 'x86'), eq(parameters.BuildForStore, 'true')) }}:
-    - script: |
-       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=x86 /p:IsStoreBuild=True /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
-       copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
-       copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.snupkg $(Build.ArtifactStagingDirectory)
-      workingDirectory: '$(Build.SourcesDirectory)\csharp'
-      displayName: 'Create NuGet Package'
-
   - ${{ if eq(parameters.BuildArch, 'arm64') }}:
     - script: |
-       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=arm64 /p:IsStoreBuild=${{ parameters.BuildForStore }} /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
+       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=arm64 /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.snupkg $(Build.ArtifactStagingDirectory)
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
@@ -236,7 +175,7 @@ steps:
 
   - ${{ if eq(parameters.BuildArch, 'arm') }}:
     - script: |
-       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=arm /p:IsStoreBuild=${{ parameters.BuildForStore }} /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
+       msbuild $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.proj /p:Configuration=RelWithDebInfo /t:CreateWindowsAIPackage /p:OnnxRuntimeBuildDirectory=$(Build.BinariesDirectory) /p:OnnxRuntimeSourceDirectory=$(Build.SourcesDirectory) /p:TargetArchitecture=arm /p:ProtocDirectory=$(Build.BinariesDirectory)\host_protoc\Release
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.nupkg $(Build.ArtifactStagingDirectory)
        copy $(Build.BinariesDirectory)\RelWithDebInfo\RelWithDebInfo\*.snupkg $(Build.ArtifactStagingDirectory)
       workingDirectory: '$(Build.SourcesDirectory)\csharp'


### PR DESCRIPTION
UWP Apps are broken in 1.9 due to Store compliant builds referencing LoadPackagedLibrary

Issue: This change (https://github.com/microsoft/onnxruntime/pull/8753) forced the Microsoft.AI.MachineLearning WinRT Store builds to use LoadPackagedLibrary for StoreApps to make the binaries compliant with Store WACK Policies (this is now not needed). Because of this change all load library calls from inside the binaries were swapped to use LoadPackagedLibrary. However, LoadPackagedLibrary cannot find system32 dlls like combase, and other winrt types, and fails.

Fix: For UWP Store binaries use the statically linked desktop binaries. The desktop binaries are now compliant with Store WACK policies, as WACK certification from the latest Windows SDKs do not require Store only apis.