### PR TITLE
FP16_Optimizer wrapper

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -274,6 +274,9 @@ if (onnxruntime_ENABLE_TRAINING)
   file(GLOB onnxruntime_python_ortmodule_experimental_json_config_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/ortmodule/experimental/json_config/*.py"
   )
+  file(GLOB onnxruntime_python_ortmodule_optimizer_srcs CONFIGURE_DEPENDS
+    "${ORTTRAINING_SOURCE_DIR}/python/training/ortmodule/optimizer/*.py"
+  )
   file(GLOB onnxruntime_python_ortmodule_torch_cpp_ext_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/ortmodule/torch_cpp_extensions/*.py"
   )
@@ -517,6 +520,7 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/experimental
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/experimental/json_config
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/optimizer
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/aten_op_executor
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/torch_interop_utils
@@ -542,6 +546,9 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_ortmodule_experimental_json_config_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/experimental/json_config/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_ortmodule_optimizer_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/optimizer/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_ortmodule_torch_cpp_ext_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/

--- a/orttraining/orttraining/python/training/ortmodule/optimizer/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/optimizer/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py

--- a/orttraining/orttraining/python/training/ortmodule/optimizer/fp16_optimizer.py
+++ b/orttraining/orttraining/python/training/ortmodule/optimizer/fp16_optimizer.py
@@ -1,0 +1,181 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import functools
+import torch
+import types
+from numpy import inf
+import nvtx
+
+def megatron_lm_check(optimizer):
+    try:
+        from apex.multi_tensor_apply import multi_tensor_applier
+        import amp_C
+        _ = torch._amp_foreach_non_finite_check_and_unscale_
+    except Exception as error:
+        # Error handling
+        return False
+    _check_overflow_function = getattr(optimizer, "_check_overflow", None)
+    clip_master_grads_function = getattr(optimizer, "clip_master_grads", None)
+    if not _check_overflow_function or not callable(_check_overflow_function):
+        return False
+    if not clip_master_grads_function or not callable(clip_master_grads_function):
+        return False
+    return True
+
+
+def FP16_Optimizer(optimizer, get_tensor_model_parallel_rank=None, get_model_parallel_group=None):
+    """
+    Simple wrapper to replace inefficient FP16_Optimizer function calls implemented by library for example
+        Apex, DeepSpeed, Megatron-LM.
+
+    Args:
+        optimizer: the FP16_Optimizer instance
+        get_tensor_model_parallel_rank (optional): function to get model parallel rank
+        get_model_parallel_group (optional): function to get model parallel group.
+
+    Returns:
+        the FP16_Optimizer instance
+
+    """
+    def get_full_qualified_type_name(o):
+        klass = o.__class__
+        module = klass.__module__
+        if module == 'builtins':
+            return klass.__qualname__ # avoid outputs like 'builtins.str'
+        return module + '.' + klass.__qualname__
+
+    optimizer_full_name = get_full_qualified_type_name(optimizer)
+    if optimizer_full_name == "megatron.fp16.fp16.FP16_Optimizer":
+        if megatron_lm_check(optimizer):
+            optimizer._check_overflow = types.MethodType(_check_overflow, optimizer)
+            optimizer.clip_master_grads = types.MethodType(clip_master_grads, optimizer)
+        else:
+            raise RuntimeError("megatron.fp16.fp16.FP16_Optimizer wrapping failed.")
+
+    return optimizer
+
+@nvtx.annotate(message="_check_overflow", color="red")
+def _check_overflow(self):
+    params = []
+    for group in self.fp16_groups:
+        for param in group:
+            params.append(param)
+    for group in self.fp32_from_fp32_groups:
+        for param in group:
+            params.append(param)
+
+    found_inf = torch.cuda.FloatTensor([0.0])
+    scaler = torch.cuda.FloatTensor([1.0])
+    grad_data = [p.grad.data for p in params if p.grad is not None]
+    # Unscale and set found inf/nan
+    torch._amp_foreach_non_finite_check_and_unscale_(grad_data, found_inf, scaler)
+
+    # Check for nan.
+    self.overflow = (found_inf.item() > 0)
+    return self.overflow 
+
+
+def clip_grad_norm_fp32(parameters, max_norm, norm_type):
+    from apex.multi_tensor_apply import multi_tensor_applier
+    import amp_C
+    def param_is_not_shared(param):
+        not_shared = hasattr(param, 'model_parallel') and param.model_parallel
+        return not_shared
+
+    def param_is_not_tensor_parallel_duplicate(param):
+        is_mp_tensor = hasattr(param, 'model_parallel') and param.model_parallel
+        return is_mp_tensor or (get_tensor_model_parallel_rank() == 0)
+
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+
+    # Filter parameters based on:
+    #   - grad should not be none
+    #   - parameter should not be shared
+    #   - should not be a replica due to tensor model parallelism
+    grads = []
+    grads_for_norm = []
+    for param in parameters:
+        grad_not_none = param.grad is not None
+        is_not_shared = param_is_not_shared(param)
+        is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param)
+        grad = param.grad.detach()
+        if grad_not_none:
+            # Make sure the grads are in fp32
+            assert param.grad.type() == 'torch.cuda.FloatTensor'
+            grads.append(grad)
+        if grad_not_none and is_not_shared and is_not_tp_duplicate:
+            grads_for_norm.append(grad)
+
+    # Norm parameters.
+    max_norm = float(max_norm)
+    norm_type = float(norm_type)
+    total_norm = 0.0
+
+    # Calculate norm.
+    if norm_type == inf:
+        total_norm = max(grad.abs().max() for grad in grads_for_norm)
+        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        # Take max across all model-parallel GPUs.
+        torch.distributed.all_reduce(total_norm_cuda,
+                                    op=torch.distributed.ReduceOp.MAX,
+                                    group=get_model_parallel_group())
+        total_norm = total_norm_cuda[0].item()
+
+    else:
+        if norm_type == 2.0:
+            dummy_overflow_buf = torch.cuda.IntTensor([0])
+            # Use apex's multi-tensor applier for efficiency reasons.
+            # Multi-tensor applier takes a function and a list of list
+            # and performs the operation on that list all in one kernel.
+            grad_norm, _ = multi_tensor_applier(
+                amp_C.multi_tensor_l2norm,
+                dummy_overflow_buf,
+                [grads_for_norm],
+                False # no per-parameter norm
+            )
+            # Since we will be summing across data parallel groups,
+            # we need the pow(norm-type).
+            total_norm = grad_norm ** norm_type
+
+        else:
+            for grad in grads_for_norm:
+                grad_norm = torch.norm(grad, norm_type)
+                total_norm += grad_norm ** norm_type
+
+        # Sum across all model-parallel GPUs.
+        torch.distributed.all_reduce(total_norm,
+                                    op=torch.distributed.ReduceOp.SUM,
+                                    group=get_model_parallel_group())
+        total_norm = total_norm.item() ** (1.0 / norm_type)
+
+    return total_norm
+
+@nvtx.annotate(message="clip_grad_norm_fp32", color="red")
+def clip_master_grads(self, max_norm, norm_type=2):
+    """
+    Clips fp32 master gradients via ``torch.nn.utils.clip_grad_norm``.
+
+    Args:
+        max_norm (float or int): max norm of the gradients
+        norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for
+            infinity norm.
+
+    Returns:
+        Total norm of the current fp32 gradients (viewed as a single vector).
+
+    .. warning::
+        Returns -1 if the most recently computed fp16 gradients overflowed (that is, if ``self.overflow`` is ``True``).
+    """
+    if not self.overflow:
+        print("clip_grad_norm_fp32 called....................................")
+        fp32_params = []
+        for param_group in self.optimizer.param_groups:
+            for param in param_group['params']:
+                fp32_params.append(param)
+        return clip_grad_norm_fp32(fp32_params, max_norm, norm_type)
+    else:
+        return -1

--- a/setup.py
+++ b/setup.py
@@ -327,6 +327,7 @@ if enable_training:
                      'onnxruntime.training.ortmodule',
                      'onnxruntime.training.ortmodule.experimental',
                      'onnxruntime.training.ortmodule.experimental.json_config',
+                     'onnxruntime.training.ortmodule.optimizer',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.aten_op_executor',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.torch_interop_utils',


### PR DESCRIPTION
**Description**: FP16_Optimizer wrapper.

It is found, some version of APEX's FP16_Optimizer and DeepSpeed Optimizers 
1). are using serial overflow check, which introduces many GPU->CPU copy. 
2). are using serial gradient norm calculation, also having many GPU->CPU copy. 

Both can be addressed by simple calls, either into Torch, or Apex. This could significant decrease the latency of check overflow and clip gradient norm.  

24 layer of GPT2 Megatron-LM model, 

Without this change:

 iteration       98/     100 | elapsed time per iteration (ms): 186.1 | learning rate: 3.891E-06 | lm loss: 9.072313E+00 | loss scale: 262144.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms) | forward: 57.49 | backward: 119.91 | backward-backward: 59.34 | backward-allreduce: 11.33 | backward-master-grad: 30.21 | backward-clip-grad: 18.30 | optimizer: 6.96 | batch generator: 1.37
 iteration       99/     100 | elapsed time per iteration (ms): 192.1 | learning rate: 3.937E-06 | lm loss: 9.137538E+00 | loss scale: 262144.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms) | forward: 59.64 | backward: 123.78 | backward-backward: 59.00 | backward-allreduce: 13.23 | backward-master-grad: 32.41 | backward-clip-grad: 18.44 | optimizer: 6.94 | batch generator: 1.38

With this change:

iteration       98/     100 | elapsed time per iteration (ms): 144.2 | learning rate: 3.891E-06 | lm loss: 9.183796E+00 | loss scale: 262144.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms) | forward: 56.70 | backward: 79.34 | backward-backward: 58.12 | backward-allreduce: 11.99 | backward-master-grad: 5.98 | backward-clip-grad: 2.72 | optimizer: 6.88 | batch generator: 1.05
iteration       99/     100 | elapsed time per iteration (ms): 149.7 | learning rate: 3.937E-06 | lm loss: 9.250105E+00 | loss scale: 262144.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms) | forward: 56.72 | backward: 84.77 | backward-backward: 58.31 | backward-allreduce: 14.76 | backward-master-grad: 5.99 | backward-clip-grad: 5.09 | optimizer: 6.95 | batch generator: 1.16

elapsed time per iteration dropped ~22.38% 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
