### PR TITLE
resolve the provider options before create training session in orttrainer

### DIFF
--- a/orttraining/orttraining/python/orttraining_pybind_common.h
+++ b/orttraining/orttraining/python/orttraining_pybind_common.h
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "python/onnxruntime_pybind_exceptions.h"
+#include "python/onnxruntime_pybind_mlvalue.h"
+#include "python/onnxruntime_pybind_state_common.h"
+
+#include "core/platform/env.h"
+#include <unordered_map>
+#include <cstdlib>
+
+namespace onnxruntime {
+namespace python {
+namespace py = pybind11;
+
+using namespace onnxruntime::logging;
+
+using ExecutionProviderMap = std::unordered_map<std::string, std::shared_ptr<IExecutionProvider> >;
+using ExecutionProviderLibInfoMap = std::unordered_map<std::string, std::pair<std::string, ProviderOptions> > ;
+
+
+class ORTTrainingPythonEnv{
+public:
+  ORTTrainingPythonEnv();
+
+  Environment& GetORTEnv();
+
+  std::shared_ptr<IExecutionProvider> GetExecutionProviderInstance(const std::string& provider_type,
+                                                                 size_t hash);
+
+  void AddExecutionProvider(const std::string& provider_type,
+                            size_t hash,
+                            std::unique_ptr<IExecutionProvider> execution_provider);
+
+  void RegisterExtExecutionProviderInfo(const std::string& provider_type, 
+                                        const std::string& provider_lib_path,
+                                        const ProviderOptions& default_options);
+
+  const std::vector<std::string>& GetAvailableTrainingExecutionProviderTypes();
+
+  ExecutionProviderLibInfoMap ext_execution_provider_info_map_;
+
+private:
+  std::string GetExecutionProviderMapKey(const std::string& provider_type,
+                                         size_t hash);
+
+  std::unique_ptr<Environment> ort_env_;
+  ExecutionProviderMap execution_provider_instances_map_;
+  std::vector<std::string> available_training_eps_;
+};
+
+}
+}

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -20,6 +20,8 @@
 
 #include "orttraining/training_ops/cpu/aten_ops/aten_op_executor.h"
 
+#include "orttraining/python/orttraining_pybind_common.h"
+
 #ifdef ENABLE_TRAINING_TORCH_INTEROP
 #include "orttraining/core/framework/torch/custom_function_register.h"
 #endif
@@ -35,6 +37,33 @@ using namespace onnxruntime::logging;
 using namespace onnxruntime::training;
 
 Environment& GetTrainingORTEnv();
+ORTTrainingPythonEnv& GetTrainingEnv();
+
+void ResolveExtraProviderOptions(const std::vector<std::string>& provider_types,
+                                 const ProviderOptionsVector& original_provider_options_vector,
+                                 ProviderOptionsVector& merged_options){
+  auto& training_env = GetTrainingEnv();
+  std::size_t j = 0;  // index for provider_options_vector
+  for (const std::string& type : provider_types) {
+    auto it = training_env.ext_execution_provider_info_map_.find(type);
+    if (it == training_env.ext_execution_provider_info_map_.end()){
+      if (j < original_provider_options_vector.size() && !original_provider_options_vector[j].empty()) {
+        merged_options.push_back(original_provider_options_vector[j]);
+      }
+    }else{
+      ProviderOptions options = it->second.second;
+      options.insert({kExecutionProviderSharedLibraryPath, it->second.first});
+      if (j < original_provider_options_vector.size() && !original_provider_options_vector[j].empty()) {
+        for (auto [k, v] : original_provider_options_vector[j]){
+          options.insert({k, v});
+        }
+      }
+      merged_options.push_back(options);
+    }
+
+    j += 1;
+  }
+}
 
 struct TrainingParameters {
   std::string loss_output_name;
@@ -521,7 +550,10 @@ void addObjectMethodsForTraining(py::module& m, ExecutionProviderRegistrationFn 
 #endif
         const auto config_result = ConfigureSessionForTraining(static_cast<PipelineTrainingSession*>(sess->GetSessionHandle()), parameters);
 
-        InitializeSession(sess->GetSessionHandle(), ep_registration_fn, provider_types, provider_options);
+        ProviderOptionsVector merged_options;
+        ResolveExtraProviderOptions(provider_types, provider_options, merged_options);
+
+        InitializeSession(sess->GetSessionHandle(), ep_registration_fn, provider_types, merged_options);
 
         return config_result;
       })
@@ -535,8 +567,10 @@ void addObjectMethodsForTraining(py::module& m, ExecutionProviderRegistrationFn 
           CopyMPIContextToTrainingParameters(parameters, sess->GetSessionHandle()->GetLogger());
 #endif
         const auto config_result = ConfigureSessionForTraining(static_cast<PipelineTrainingSession*>(sess->GetSessionHandle()), parameters);
+        ProviderOptionsVector merged_options;
+        ResolveExtraProviderOptions(provider_types, provider_options, merged_options);
 
-        InitializeSession(sess->GetSessionHandle(), ep_registration_fn, provider_types, provider_options);
+        InitializeSession(sess->GetSessionHandle(), ep_registration_fn, provider_types, merged_options);
 
         return config_result;
       })

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -1,18 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "python/onnxruntime_pybind_exceptions.h"
-#include "python/onnxruntime_pybind_mlvalue.h"
-#include "python/onnxruntime_pybind_state_common.h"
+#include "orttraining/python/orttraining_pybind_common.h"
 
 #include "core/common/logging/logging.h"
 #include "core/common/logging/severity.h"
 #include "core/providers/get_execution_providers.h"
-
-#include "core/platform/env.h"
 #include "core/session/provider_bridge_ort.h"
-#include <unordered_map>
-#include <cstdlib>
 
 namespace onnxruntime {
 namespace python {
@@ -41,8 +35,6 @@ void addObjectMethodsForTraining(py::module& m, ExecutionProviderRegistrationFn 
 void addObjectMethodsForEager(py::module& m);
 void InitArray();
 
-using ExecutionProviderMap = std::unordered_map<std::string, std::shared_ptr<IExecutionProvider> >;
-using ExecutionProviderLibInfoMap = std::unordered_map<std::string, std::pair<std::string, ProviderOptions> > ;
 
 bool GetDyanmicExecutionProviderHash(
     const std::string& ep_shared_lib_path,
@@ -131,61 +123,51 @@ bool GetProviderInstanceHash(const std::string& type,
   return false;
 }
 
-class ORTTrainingPythonEnv{
-public:
-  ORTTrainingPythonEnv(){
-    OrtPybindThrowIfError(Environment::Create(std::make_unique<LoggingManager>(
-                                                  std::unique_ptr<ISink>{new CLogSink{}},
-                                                  Severity::kWARNING, false, LoggingManager::InstanceType::Default,
-                                                  &SessionObjectInitializer::default_logger_id),
-                                              ort_env_));
-    auto& builtinEPs = GetAvailableExecutionProviderNames();
-    available_training_eps_.assign(builtinEPs.begin(), builtinEPs.end());
-  }
+ORTTrainingPythonEnv::ORTTrainingPythonEnv(){
+  OrtPybindThrowIfError(Environment::Create(std::make_unique<LoggingManager>(
+                                                std::unique_ptr<ISink>{new CLogSink{}},
+                                                Severity::kWARNING, false, LoggingManager::InstanceType::Default,
+                                                &SessionObjectInitializer::default_logger_id),
+                                            ort_env_));
+  auto& builtinEPs = GetAvailableExecutionProviderNames();
+  available_training_eps_.assign(builtinEPs.begin(), builtinEPs.end());
+}
 
-  Environment& GetORTEnv(){
-    return *ort_env_;
-  }
+Environment& ORTTrainingPythonEnv::GetORTEnv(){
+  return *ort_env_;
+}
 
-  std::shared_ptr<IExecutionProvider> GetExecutionProviderInstance(const std::string& provider_type,
-                                                                   size_t hash){
-    auto it = execution_provider_instances_map_.find(GetExecutionProviderMapKey(provider_type, hash));
-    return it == execution_provider_instances_map_.end() ? nullptr : it->second;
-  }
+std::shared_ptr<IExecutionProvider> ORTTrainingPythonEnv::GetExecutionProviderInstance(const std::string& provider_type,
+                                                                 size_t hash){
+  auto it = execution_provider_instances_map_.find(GetExecutionProviderMapKey(provider_type, hash));
+  return it == execution_provider_instances_map_.end() ? nullptr : it->second;
+}
 
-  void AddExecutionProvider(const std::string& provider_type,
-                            size_t hash,
-                            std::unique_ptr<IExecutionProvider> execution_provider){
-    execution_provider_instances_map_.insert({GetExecutionProviderMapKey(provider_type, hash),
-                                          std::move(execution_provider)});
-  }
+void ORTTrainingPythonEnv::AddExecutionProvider(const std::string& provider_type,
+                          size_t hash,
+                          std::unique_ptr<IExecutionProvider> execution_provider){
+  execution_provider_instances_map_.insert({GetExecutionProviderMapKey(provider_type, hash),
+                                        std::move(execution_provider)});
+}
 
-  void RegisterExtExecutionProviderInfo(const std::string& provider_type, 
-                                        const std::string& provider_lib_path,
-                                        const ProviderOptions& default_options){
-    ext_execution_provider_info_map_.insert({provider_type, {provider_lib_path, default_options}});
-    if (std::find(available_training_eps_.begin(), available_training_eps_.end(), provider_type) == available_training_eps_.end())
-      available_training_eps_.push_back(provider_type);
-  }
+void ORTTrainingPythonEnv::RegisterExtExecutionProviderInfo(const std::string& provider_type, 
+                                      const std::string& provider_lib_path,
+                                      const ProviderOptions& default_options){
+  ext_execution_provider_info_map_.insert({provider_type, {provider_lib_path, default_options}});
+  if (std::find(available_training_eps_.begin(), available_training_eps_.end(), provider_type) == available_training_eps_.end())
+    available_training_eps_.push_back(provider_type);
+}
 
-  const std::vector<std::string>& GetAvailableTrainingExecutionProviderTypes(){
-    return available_training_eps_;
-  }
+const std::vector<std::string>& ORTTrainingPythonEnv::GetAvailableTrainingExecutionProviderTypes(){
+  return available_training_eps_;
+}
 
-  ExecutionProviderLibInfoMap ext_execution_provider_info_map_;
-
-private:
-  std::string GetExecutionProviderMapKey(const std::string& provider_type,
-                                         size_t hash){
-    std::string key(provider_type);
-    key.append(std::to_string(hash));
-    return key;
-  }
-
-  std::unique_ptr<Environment> ort_env_;
-  ExecutionProviderMap execution_provider_instances_map_;
-  std::vector<std::string> available_training_eps_;
-};
+std::string ORTTrainingPythonEnv::GetExecutionProviderMapKey(const std::string& provider_type,
+                                       size_t hash){
+  std::string key(provider_type);
+  key.append(std::to_string(hash));
+  return key;
+}
 
 static std::unique_ptr<ORTTrainingPythonEnv> ort_training_env;
 
@@ -218,24 +200,27 @@ Environment& GetTrainingORTEnv() {
   return ort_training_env->GetORTEnv();
 }
 
-void ResolveExtraProviderOptions(const std::string& provider_type,
+void ResolveExtraProviderOptions(const std::vector<std::string>& provider_types,
                                  const ProviderOptionsMap& original_provider_options_map,
                                  ProviderOptionsMap& merged_options){
   auto& training_env = GetTrainingEnv();
-  auto it = training_env.ext_execution_provider_info_map_.find(provider_type);
-  if (it == training_env.ext_execution_provider_info_map_.end()){
-    //nothing changed.
-    merged_options = original_provider_options_map;
-  }else{
-    ProviderOptions options = it->second.second;
-    options.insert({kExecutionProviderSharedLibraryPath, it->second.first});
-    auto original_map_it = original_provider_options_map.find(provider_type);
-    if (original_map_it != original_provider_options_map.end()){
-      for (auto [k, v] : original_map_it->second){
-        options.insert({k, v});
+  for (auto& provider_type : provider_types){
+    auto it = training_env.ext_execution_provider_info_map_.find(provider_type);
+    if (it == training_env.ext_execution_provider_info_map_.end()){
+      //nothing changed.
+      if (original_provider_options_map.find(provider_type) != original_provider_options_map.end())
+        merged_options.insert({provider_type, original_provider_options_map.at(provider_type)});
+    }else{
+      ProviderOptions options = it->second.second;
+      options.insert({kExecutionProviderSharedLibraryPath, it->second.first});
+      auto original_map_it = original_provider_options_map.find(provider_type);
+      if (original_map_it != original_provider_options_map.end()){
+        for (auto [k, v] : original_map_it->second){
+          options.insert({k, v});
+        }
       }
+      merged_options[provider_type] = options;
     }
-    merged_options[provider_type] = options;
   }
 }
 
@@ -247,7 +232,7 @@ std::unique_ptr<IExecutionProvider> CreateTrainingEP(
   if (training_env.ext_execution_provider_info_map_.find(provider_type) != 
       training_env.ext_execution_provider_info_map_.end()){
     ProviderOptionsMap merged_options;
-    ResolveExtraProviderOptions(provider_type, provider_options_map, merged_options);
+    ResolveExtraProviderOptions({provider_type}, provider_options_map, merged_options);
     return CreateExecutionProviderInstance(session_options, provider_type, merged_options);
   }else{
     return CreateExecutionProviderInstance(session_options, provider_type, provider_options_map);


### PR DESCRIPTION

**Description**: Previously when create orttrainer, it doesn't look at the registered external execution provider information. Resolve those information before init session.