### PR TITLE
Decouple GraphExecutionManager and accept extra exporter options

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -125,6 +125,10 @@ class GraphExecutionManager(GraphExecutionInterface):
         # To be instantiated in the concrete implementation of GraphExecutionManager
         self._export_mode = None
 
+        # Exporter can take extra arguments for ORTModule extensions
+        # It cannot overlap with required/immutable arguments (validated in runtime)
+        self._export_extra_kwargs = {}
+
         # Related to training graph shape inference
         self._current_input_shape = None
         # default execution order is priority-based for both dynamic/static shape input for now
@@ -354,18 +358,24 @@ class GraphExecutionManager(GraphExecutionInterface):
         try:
             with torch.set_grad_enabled(self._enable_custom_autograd_function), \
                     _logger.suppress_os_stream_output(log_level=self._debug_options.logging.log_level):
+
+                required_export_kwargs = {'input_names': self._input_info.names,
+                                          'output_names': output_names,
+                                          'opset_version': ONNX_OPSET_VERSION,
+                                          'do_constant_folding': False,
+                                          'training': self._export_mode,
+                                          'dynamic_axes': self._input_info.dynamic_axes,
+                                          'verbose': self._debug_options.logging.log_level < LogLevel.WARNING,
+                                          'export_params': False,
+                                          'keep_initializers_as_inputs': True}
+                invalid_args = self._export_extra_kwargs.keys() & required_export_kwargs.keys()
+                assert len(invalid_args) == 0,\
+                    f"The following PyTorch exporter arguments cannot be specified: '{invalid_args}'."
                 torch.onnx.export(self._flattened_module,
                                   sample_inputs_as_tuple,
                                   f,
-                                  input_names=self._input_info.names,
-                                  output_names=output_names,
-                                  opset_version=ONNX_OPSET_VERSION,
-                                  do_constant_folding=False,
-                                  training=self._export_mode,
-                                  dynamic_axes=self._input_info.dynamic_axes,
-                                  verbose=self._debug_options.logging.log_level < LogLevel.WARNING,
-                                  export_params=False,
-                                  keep_initializers_as_inputs=True)
+                                  **required_export_kwargs,
+                                  **self._export_extra_kwargs)
         except Exception as e:
             raise wrap_exception(ORTModuleONNXModelException,
                                  RuntimeError(f'There was an error while exporting the PyTorch model to ONNX: '

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager_factory.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager_factory.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+from ._io import _FlattenedModule
 from ._training_manager import TrainingManager
 from ._inference_manager import InferenceManager
 from .debug_options import DebugOptions
@@ -10,9 +11,12 @@ from ._fallback import _FallbackManager
 
 
 class GraphExecutionManagerFactory(object):
-    def __init__(self, module, debug_options: DebugOptions, fallback_manager: _FallbackManager):
-        self._training_manager = TrainingManager(module, debug_options, fallback_manager)
-        self._inference_manager = InferenceManager(module, debug_options, fallback_manager)
+    def __init__(self,
+                 flattened_module: _FlattenedModule,
+                 debug_options: DebugOptions,
+                 fallback_manager: _FallbackManager):
+        self._training_manager = TrainingManager(flattened_module, debug_options, fallback_manager)
+        self._inference_manager = InferenceManager(flattened_module, debug_options, fallback_manager)
 
     def __call__(self, is_training):
         if is_training:

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -10,7 +10,9 @@ import torch
 import warnings
 import gc
 
-from ._fallback import _FallbackManager, ORTModuleIOError, ORTModuleONNXModelException, wrap_exception
+from ._fallback import (ORTModuleIOError,
+                        ORTModuleONNXModelException,
+                        wrap_exception)
 
 
 class _OutputIdentityOp(torch.autograd.Function):

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_factory.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_factory.py
@@ -2,13 +2,18 @@
 # Licensed under the MIT License.
 # _torch_module_factory.py
 
+from ._io import _FlattenedModule
 from ._torch_module_ort import TorchModuleORT
-from .debug_options import DebugOptions
-from ._fallback import _FallbackManager
+from ._graph_execution_manager import GraphExecutionManager
+
+import torch
 
 
 class TorchModuleFactory:
-    def __call__(self, module, debug_options: DebugOptions, fallback_manager: _FallbackManager):
+    def __call__(self,
+                 module: torch.nn.Module,
+                 flattened_module: _FlattenedModule,
+                 execution_manager: GraphExecutionManager):
         """Creates a TorchModule instance based on the input module."""
 
-        return TorchModuleORT(module, debug_options, fallback_manager)
+        return TorchModuleORT(module, flattened_module, execution_manager)

--- a/orttraining/orttraining/python/training/ortmodule/experimental/json_config/_load_config_from_json.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/json_config/_load_config_from_json.py
@@ -286,7 +286,7 @@ def load_from_json(ortmodule, path=None):
 
     for training_mode in [True, False]:
         # update the debug config for both train and eval modes
-        ortmodule_config_accessor = ortmodule._torch_module._execution_manager(training_mode)
+        ortmodule_config_accessor = ortmodule._execution_manager(training_mode)
         # iterate over the json data instead of checking for keys in json to catch key errors
         for key, _ in data.__dict__.items():
             load_functions[key](ortmodule_config_accessor, data)

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -333,7 +333,7 @@ class ORTModule(torch.nn.Module):
             # Re-export will be avoided if _skip_check is enabled.
             if isinstance(self._torch_module, TorchModuleORT):
                 for training_mode in [False, True]:
-                    self._torch_module._execution_manager(training_mode).signal_model_changed()
+                    self._execution_manager(training_mode).signal_model_changed()
 
         else:
             # Setting any new attributes should be done on ORTModule only when 'torch_module' is not defined


### PR DESCRIPTION
Current ORTModule class has a TorchModuleInterface which was meant to wrap PyTorch API's only. However, TorchModuleInterface also defines and store GraphExecutionManager, which is responsible for executing ONNX graphs using ORT.

This PR moves GraphExecutionManager from within TorchModuleInterface to ORTModule, which is the main class and responsible for orchestrating the graph. It also allows extra exporter arguments to be specified using internal APIs.

The main benefit of such change is easier ORTModule extensions, as the new version has a lower coupling and higher cohesion.