### PR TITLE
[wasm] remove deprecated prefix 'EXTRA_' in emcc flags

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -39,20 +39,20 @@ target_link_libraries(onnxruntime_webassembly PRIVATE
   re2::re2
 )
 
-set(EXTRA_EXPORTED_RUNTIME_METHODS "['stackAlloc','stackRestore','stackSave','UTF8ToString','stringToUTF8','lengthBytesUTF8']")
+set(EXPORTED_RUNTIME_METHODS "['stackAlloc','stackRestore','stackSave','UTF8ToString','stringToUTF8','lengthBytesUTF8']")
 
-set_target_properties(onnxruntime_webassembly PROPERTIES LINK_FLAGS "                         \
-                      -s \"EXTRA_EXPORTED_RUNTIME_METHODS=${EXTRA_EXPORTED_RUNTIME_METHODS}\" \
-                      -s WASM=1                                                               \
-                      -s NO_EXIT_RUNTIME=0                                                    \
-                      -s ALLOW_MEMORY_GROWTH=1                                                \
-                      -s MODULARIZE=1                                                         \
-                      -s EXPORT_ALL=0                                                         \
-                      -s LLD_REPORT_UNDEFINED                                                 \
-                      -s VERBOSE=0                                                            \
-                      -s NO_FILESYSTEM=1                                                      \
-                      -s MALLOC=${onnxruntime_WEBASSEMBLY_MALLOC}                             \
-                      --closure 1                                                             \
+set_target_properties(onnxruntime_webassembly PROPERTIES LINK_FLAGS "             \
+                      -s \"EXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}\" \
+                      -s WASM=1                                                   \
+                      -s NO_EXIT_RUNTIME=0                                        \
+                      -s ALLOW_MEMORY_GROWTH=1                                    \
+                      -s MODULARIZE=1                                             \
+                      -s EXPORT_ALL=0                                             \
+                      -s LLD_REPORT_UNDEFINED                                     \
+                      -s VERBOSE=0                                                \
+                      -s NO_FILESYSTEM=1                                          \
+                      -s MALLOC=${onnxruntime_WEBASSEMBLY_MALLOC}                 \
+                      --closure 1                                                 \
                       --no-entry")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
**Description**: This change renames deprecated flag 'EXTRA_EXPORTED_RUNTIME_METHODS' to 'EXPORTED_RUNTIME_METHODS'.