### PR TITLE
Patching cuda profiler with enhancements

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_profiler.cc
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.cc
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING))
+#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING)) || defined(CUDA_VERSION) && CUDA_VERSION < 11000
 
 #include "cuda_profiler.h"
 #include <map>

--- a/onnxruntime/core/providers/cuda/cuda_profiler.cc
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.cc
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING)) || defined(CUDA_VERSION) && CUDA_VERSION < 11000
+#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING)) && defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 
 #include "cuda_profiler.h"
 #include <map>

--- a/onnxruntime/core/providers/cuda/cuda_profiler.cc
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.cc
@@ -62,7 +62,7 @@ void CUPTIAPI CudaProfiler::BufferCompleted(CUcontext, uint32_t, uint8_t* buffer
     do {
       status = cuptiActivityGetNextRecord(buffer, validSize, &record);
       if (status == CUPTI_SUCCESS) {
-        if (CUPTI_ACTIVITY_KIND_KERNEL == record->kind) {
+        if (CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL == record->kind) {
           CUpti_ActivityKernel3* kernel = (CUpti_ActivityKernel3*)record;
           stats.push_back({kernel->name, kernel->streamId,
                            kernel->gridX, kernel->gridY, kernel->gridZ,
@@ -93,7 +93,7 @@ bool CudaProfiler::StartProfiling() {
   if (!enabled.test_and_set()) {
     if (cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME) == CUPTI_SUCCESS &&
         cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER) == CUPTI_SUCCESS &&
-        cuptiActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL) == CUPTI_SUCCESS &&
+        cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL) == CUPTI_SUCCESS &&
         cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY) == CUPTI_SUCCESS &&
         cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION) == CUPTI_SUCCESS &&
         cuptiActivityRegisterCallbacks(BufferRequested, BufferCompleted) == CUPTI_SUCCESS) {
@@ -179,7 +179,7 @@ void CudaProfiler::Stop(uint64_t) {
 
 void CudaProfiler::DisableEvents() {
   cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
-  cuptiActivityDisable(CUPTI_ACTIVITY_KIND_KERNEL);
+  cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
   cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY);
   cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER);
   cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME);

--- a/onnxruntime/core/providers/cuda/cuda_profiler.h
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #include "core/common/profiler_common.h"
 
-#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING)) && defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING))
 
 #include "core/platform/ort_mutex.h"
 #include <cupti.h>

--- a/onnxruntime/core/providers/cuda/cuda_profiler.h
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #include "core/common/profiler_common.h"
 
-#if defined(USE_ROCM) || defined(ENABLE_TRAINING)
+#if defined(USE_ROCM) || defined(ENABLE_TRAINING) || defined(CUDA_VERSION) && CUDA_VERSION < 11000
 namespace onnxruntime {
 
 namespace profiling {

--- a/onnxruntime/core/providers/cuda/cuda_profiler.h
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #include "core/common/profiler_common.h"
 
-#if defined(USE_ROCM) || defined(ENABLE_TRAINING) || defined(CUDA_VERSION) && CUDA_VERSION < 11000
+#if defined(USE_ROCM) || defined(ENABLE_TRAINING) || (defined(CUDA_VERSION) && CUDA_VERSION < 11000)
 namespace onnxruntime {
 
 namespace profiling {

--- a/onnxruntime/core/providers/cuda/cuda_profiler.h
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.h
@@ -2,23 +2,7 @@
 // Licensed under the MIT License.
 #include "core/common/profiler_common.h"
 
-#if defined(USE_ROCM) || defined(ENABLE_TRAINING) || (defined(CUDA_VERSION) && CUDA_VERSION < 11000)
-namespace onnxruntime {
-
-namespace profiling {
-
-class CudaProfiler final : public EpProfiler {
- public:
-  bool StartProfiling() override { return true; }
-  void EndProfiling(TimePoint, Events&) override{};
-  void Start(uint64_t) override{};
-  void Stop(uint64_t) override{};
-};
-
-}
-}
-
-#else
+#if !(defined(USE_ROCM) || defined(ENABLE_TRAINING)) && defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 
 #include "core/platform/ort_mutex.h"
 #include <cupti.h>
@@ -78,4 +62,22 @@ class CudaProfiler final : public EpProfiler {
 
 }  // namespace profiling
 }  // namespace onnxruntime
+
+#else
+
+namespace onnxruntime {
+
+namespace profiling {
+
+class CudaProfiler final : public EpProfiler {
+ public:
+  bool StartProfiling() override { return true; }
+  void EndProfiling(TimePoint, Events&) override{};
+  void Start(uint64_t) override{};
+  void Stop(uint64_t) override{};
+};
+
+}
+}
+
 #endif

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -653,7 +653,7 @@ TEST(InferenceSessionTests, CheckRunProfilerWithSessionOptions) {
     }
   }
 
-#if defined(USE_CUDA) && !defined(ENABLE_TRAINING)
+#if defined(USE_CUDA) && !defined(ENABLE_TRAINING) && defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   ASSERT_TRUE(has_kernel_info);
 #endif
 }


### PR DESCRIPTION
1. Switch to concurrent kernel profiling in case cupti prevent kernels from running in parallel on multiple streams, despite that ort cuda EP for now only occupies a single stream;
2. Exclude the profiler from cuda 10.x
