### PR TITLE
DirectML.dll load fails when executable path contains Non-English characters

### DIFF
--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -22,30 +22,25 @@ namespace winmla = Windows::AI::MachineLearning::Adapter;
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
-static std::string CurrentModulePath() {
-  char path[MAX_PATH];
-  FAIL_FAST_IF(0 == GetModuleFileNameA((HINSTANCE)&__ImageBase, path, _countof(path)));
+static std::wstring CurrentModulePath() {
+    WCHAR path[MAX_PATH];
+    GetModuleFileNameW((HINSTANCE)&__ImageBase, path, _countof(path));
 
-  char absolute_path[MAX_PATH];
-  char* name;
-  FAIL_FAST_IF(0 == GetFullPathNameA(path, _countof(path), absolute_path, &name));
+    WCHAR absolute_path[MAX_PATH];
+    WCHAR* name;
+    GetFullPathNameW(path, _countof(path), absolute_path, &name);
 
-  auto idx = std::distance(absolute_path, name);
-  auto out_path = std::string(absolute_path);
-  out_path.resize(idx);
+    auto idx = std::distance(absolute_path, name);
+    auto out_path = std::wstring(absolute_path);
+    out_path.resize(idx);
 
-  return out_path;
+    return out_path;
 }
 
 Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(ID3D12Device* d3d12Device) {
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   // Dynamically load DML to avoid WinML taking a static dependency on DirectML.dll
-  auto directml_dll = CurrentModulePath() + "\\DirectML.dll";
-  wil::unique_hmodule dmlDll(LoadLibraryExA(directml_dll.c_str(), nullptr, 0));
-#elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_PC_APP)
-  wil::unique_hmodule dmlDll(LoadPackagedLibrary(L"DirectML.dll", 0));
-#endif
-
+  auto directml_dll = CurrentModulePath() + "DirectML.dll";
+  wil::unique_hmodule dmlDll(LoadLibraryExW(directml_dll.c_str(), nullptr, 0));
   THROW_LAST_ERROR_IF(!dmlDll);
 
   auto dmlCreateDevice1Fn = reinterpret_cast<decltype(&DMLCreateDevice1)>(

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -24,11 +24,11 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 static std::wstring CurrentModulePath() {
     WCHAR path[MAX_PATH];
-    GetModuleFileNameW((HINSTANCE)&__ImageBase, path, _countof(path));
+    FAIL_FAST_IF(0 == GetModuleFileNameW((HINSTANCE)&__ImageBase, path, _countof(path)));
 
     WCHAR absolute_path[MAX_PATH];
     WCHAR* name;
-    GetFullPathNameW(path, _countof(path), absolute_path, &name);
+    FAIL_FAST_IF(0 == GetFullPathNameW(path, _countof(path), absolute_path, &name));
 
     auto idx = std::distance(absolute_path, name);
     auto out_path = std::wstring(absolute_path);

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -39,7 +39,7 @@ static std::wstring CurrentModulePath() {
 
 Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(ID3D12Device* d3d12Device) {
   // Dynamically load DML to avoid WinML taking a static dependency on DirectML.dll
-  auto directml_dll = CurrentModulePath() + "DirectML.dll";
+  auto directml_dll = CurrentModulePath() + L"DirectML.dll";
   wil::unique_hmodule dmlDll(LoadLibraryExW(directml_dll.c_str(), nullptr, 0));
   THROW_LAST_ERROR_IF(!dmlDll);
 


### PR DESCRIPTION
DirectML.dll load fails when executable path contains Non-English characters

Issue: DirectML.dll is loaded with LoadLibraryExA when it should be using LoadLibraryExW

Test: Windows AI builds correctly and loads correctly when built exes are run from paths containing unicode:
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=176800&view=results