### PR TITLE
Force Windows AI NuGet pipeline to use Windows SDK 19041

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
@@ -57,7 +57,7 @@ steps:
     displayName: 'Generate CMake Configuration'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags)' --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.19041.0
+      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags) --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.19041.0'
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1

--- a/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
@@ -57,7 +57,7 @@ steps:
     displayName: 'Generate CMake Configuration'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags)'
+      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags)' --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.19041.0
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1


### PR DESCRIPTION
Force Windows AI NuGet pipeline to use Windows SDK 19041

Issue: Build machines have 22000 installed, and will use that SDK version by default. However, this SDK is adding an import to LoadLibraryW which breaks downlevel.

Fix: Force Windows AI NuGet pipelines onto 19041.