### PR TITLE
1.9.1 Cherry-picks Round 2

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/windowsai-nuget-build.yml
@@ -57,7 +57,7 @@ steps:
     displayName: 'Generate CMake Configuration'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags)'
+      arguments: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests $(TelemetryOption) --ms_experimental --use_dml --use_winml --cmake_generator "Visual Studio 16 2019" --update --config RelWithDebInfo --enable_lto --disable_rtti $(BuildFlags) --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.19041.0'
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1


### PR DESCRIPTION
1.9.1 Cherry-picks Round 2

9255- Force Windows SDK to 19041 to prevent downlevel LoadLibraryW breaks with 22000
8f6fd014e461ec9096a537365099c508cd46aacf