### PR TITLE
[WIP] Replace eigen with eigen-backup for now because the original repo is missing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/google/re2.git
 [submodule "cmake/external/eigen"]
 	path = cmake/external/eigen
-	url = https://gitlab.com/libeigen/eigen.git
+	url = https://gitlab.com/libeigen/eigen-backup.git
 [submodule "cmake/external/cxxopts"]
 	path = cmake/external/cxxopts
 	url = https://github.com/jarro2783/cxxopts.git

--- a/cgmanifests/submodules/cgmanifest.json
+++ b/cgmanifests/submodules/cgmanifest.json
@@ -115,7 +115,7 @@
         "type": "git",
         "git": {
           "commitHash": "efd9867ff0e8df23016ac6c9828d0d7bf8bec1b1",
-          "repositoryUrl": "https://gitlab.com/libeigen/eigen.git"
+          "repositoryUrl": "https://gitlab.com/libeigen/eigen-backup.git"
         },
         "comments": "git submodule at cmake/external/FeaturizersLibrary/src/3rdParty/eigen"
       }
@@ -195,7 +195,7 @@
         "type": "git",
         "git": {
           "commitHash": "d10b27fe37736d2944630ecd7557cefa95cf87c9",
-          "repositoryUrl": "https://gitlab.com/libeigen/eigen.git"
+          "repositoryUrl": "https://gitlab.com/libeigen/eigen-backup.git"
         },
         "comments": "git submodule at cmake/external/eigen"
       }


### PR DESCRIPTION
**Description**
Not sure whether this PR is needed or they can fix the missing stuff in time, but at lease the provider just provided a backup repo for now. Let me try to propose the workaround PR and make the CI run first.

**Motivation and Context**
https://github.com/microsoft/onnxruntime/issues/9259, https://gitlab.com/libeigen/eigen/-/issues/2336
