### PR TITLE
Move from eigen to eigen-backup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/google/re2.git
 [submodule "cmake/external/eigen"]
 	path = cmake/external/eigen
-	url = https://gitlab.com/libeigen/eigen.git
+	url = https://gitlab.com/libeigen/eigen-backup.git
 [submodule "cmake/external/cxxopts"]
 	path = cmake/external/cxxopts
 	url = https://github.com/jarro2783/cxxopts.git


### PR DESCRIPTION
Issue: All pipelines are failing because Eigen has been deleted from gitlab due to user error. The recommendation is to use eigen-backup while the outage is addressed.

Error: fatal: repository 'https://gitlab.com/libeigen/eigen.git/' not found

Fix: Per this issue, the request is to use the backup repo in the meanwhile: https://gitlab.com/libeigen/eigen/-/issues/2336#note_693188875