### PR TITLE
Fix all-or-nothing fallback for bad ORTModule init

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -26,8 +26,7 @@ _FALLBACK_INIT_EXCEPTION = None
 ORTMODULE_FALLBACK_POLICY = _FallbackPolicy.FALLBACK_UNSUPPORTED_DEVICE |\
                             _FallbackPolicy.FALLBACK_UNSUPPORTED_DATA |\
                             _FallbackPolicy.FALLBACK_UNSUPPORTED_TORCH_MODEL |\
-                            _FallbackPolicy.FALLBACK_UNSUPPORTED_ONNX_MODEL |\
-                            _FallbackPolicy.FALLBACK_BAD_INITIALIZATION
+                            _FallbackPolicy.FALLBACK_UNSUPPORTED_ONNX_MODEL
 ORTMODULE_FALLBACK_RETRY = False
 ORTMODULE_IS_DETERMINISTIC = torch.are_deterministic_algorithms_enabled()
 

--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -57,7 +57,7 @@ except ImportError as e:
 if not is_torch_cpp_extensions_installed(ORTMODULE_TORCH_CPP_DIR) and '-m' not in sys.argv:
     _FALLBACK_INIT_EXCEPTION = wrap_exception(
         ORTModuleInitException,
-        EnvironmentError(
+        RuntimeError(
             f"ORTModule's extensions were not detected at '{ORTMODULE_TORCH_CPP_DIR}' folder. "
             "Run `python -m torch_ort.configure` before using `ORTModule` frontend."))
 

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -68,7 +68,7 @@ class InferenceManager(GraphExecutionManager):
         # Fallback to PyTorch due to failures *external* to forward(),
         #  typically from initialization
         if self._fallback_manager.is_pending():
-            return self._fallback_manager.fallback(self._original_module, self._debug_options.logging.log_level, *inputs, **kwargs)
+            return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
         try:
             # Issue at most one warning message about fast path
@@ -146,7 +146,7 @@ class InferenceManager(GraphExecutionManager):
         # Fallback to PyTorch due to failures *during* forward(),
         #  (e.g. export, model/input post-processing, forward, output processing, etc)
         if self._fallback_manager.is_pending():
-            return self._fallback_manager.fallback(self._original_module, self._debug_options.logging.log_level, *inputs, **kwargs)
+            return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
     def _build_graph(self):
         """Build an optimized inference graph using the module_graph_builder"""

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_pytorch.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_pytorch.py
@@ -2,14 +2,9 @@
 # Licensed under the MIT License.
 # _torch_module_pytorch.py
 
-from . import _io
-from .debug_options import DebugOptions
-from ._graph_execution_manager_factory import GraphExecutionManagerFactory
 from ._torch_module_interface import TorchModuleInterface
-from ._fallback import _FallbackManager
 
 from collections import OrderedDict
-import functools
 import torch
 from typing import Iterator, Optional, Tuple, TypeVar, Callable
 

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -70,8 +70,7 @@ class TrainingManager(GraphExecutionManager):
         # Fallback to PyTorch due to failures *external* to forward(),
         #  typically from initialization
         if self._fallback_manager.is_pending():
-            return self._fallback_manager.fallback(self._original_module, self._debug_options.logging.log_level,
-                                                   *inputs, **kwargs)
+            return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
         try:
             if self._first_skip_check_warning is True and self._skip_check.is_disabled() is False \
@@ -282,10 +281,7 @@ class TrainingManager(GraphExecutionManager):
         # Fallback to PyTorch due to failures *during* forward(),
         #  (e.g. export, model/input post-processing, forward, output processing, etc)
         if self._fallback_manager.is_pending():
-            return self._fallback_manager.fallback(self._original_module,
-                                                   self._debug_options.logging.log_level,
-                                                   *inputs,
-                                                   **kwargs)
+            return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
     def _build_graph(self):
         """Build an optimized gradient graph using the module_graph_builder"""

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -6,6 +6,7 @@
 from onnxruntime.capi.onnxruntime_inference_collection import OrtValue
 from onnxruntime.capi import _pybind_state as C
 from ._fallback_exceptions import ORTModuleDeviceException, wrap_exception
+from ._torch_module_pytorch import TorchModulePytorch
 
 import os
 import copy
@@ -208,3 +209,20 @@ def get_exception_as_string(exception):
         raise exception
     except:
         return traceback.format_exc()
+
+def switch_backend_to_pytorch(ortmodule, pytorch_module):
+    ortmodule._torch_module = TorchModulePytorch(pytorch_module)
+
+    # TODO: Rework by implementing the "__getattribute__" method.
+    #       Assigning all default attributes from user's original torch.nn.Module into ORTModule
+    ortmodule._backward_hooks = pytorch_module._backward_hooks
+    ortmodule._forward_hooks = pytorch_module._forward_hooks
+    ortmodule._forward_pre_hooks = pytorch_module._forward_pre_hooks
+    ortmodule._parameters = pytorch_module._parameters
+    ortmodule._buffers = pytorch_module._buffers
+    ortmodule._non_persistent_buffers_set = pytorch_module._non_persistent_buffers_set
+    ortmodule._is_full_backward_hook = pytorch_module._is_full_backward_hook
+    ortmodule._state_dict_hooks = pytorch_module._state_dict_hooks
+    ortmodule._load_state_dict_pre_hooks = pytorch_module._load_state_dict_pre_hooks
+    ortmodule._modules = pytorch_module._modules
+    ortmodule.forward = pytorch_module.forward

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -59,7 +59,8 @@ class ORTModule(torch.nn.Module):
             debug_options = DebugOptions()
 
         # Fallback settings
-        self._fallback_manager = _FallbackManager(policy=ORTMODULE_FALLBACK_POLICY,
+        self._fallback_manager = _FallbackManager(pytorch_module=module,
+                                                  policy=ORTMODULE_FALLBACK_POLICY,
                                                   retry=ORTMODULE_FALLBACK_RETRY)
 
         try:
@@ -101,26 +102,18 @@ class ORTModule(torch.nn.Module):
             _utils.check_for_name_collisions_and_bind_methods_to_ortmodule(self, module)
 
         except ORTModuleFallbackException as e:
-            self._torch_module = TorchModulePytorch(module)
-            # TODO: Rework by implementing the "__getattribute__" method.
-            #       Assigning all default attributes from user's original torch.nn.Module into ORTModule
-            self._backward_hooks = module._backward_hooks
-            self._forward_hooks = module._forward_hooks
-            self._forward_pre_hooks = module._forward_pre_hooks
-            self._parameters = module._parameters
-            self._buffers = module._buffers
-            self._non_persistent_buffers_set = module._non_persistent_buffers_set
-            self._is_full_backward_hook = module._is_full_backward_hook
-            self._state_dict_hooks = module._state_dict_hooks
-            self._load_state_dict_pre_hooks = module._load_state_dict_pre_hooks
-            self._modules = module._modules
-            self.forward = module.forward
+            # Although backend is switched to PyTorch here,
+            # it is up to _FallbackManager to actually terminate execution or fallback
+            self._switch_backend_to_pytorch(module)
 
             # Exceptions subject to fallback are handled here
             self._fallback_manager.handle_exception(exception=e,
                                                     log_level=debug_options.logging.log_level)
         except Exception as e:
-            self._torch_module = TorchModulePytorch(module)
+            # Although backend is switched to PyTorch here,
+            # it is up to _FallbackManager to actually terminate execution or fallback
+            self._switch_backend_to_pytorch(module)
+
             # Catch-all FALLBACK_FORCE_TORCH_FORWARD fallback is handled here
             self._fallback_manager.handle_exception(exception=e,
                                                     log_level=debug_options.logging.log_level,
@@ -331,3 +324,20 @@ class ORTModule(torch.nn.Module):
         else:
             # Setting any new attributes should be done on ORTModule only when 'torch_module' is not defined
             self.__dict__[name] = value
+
+    def _switch_backend_to_pytorch(self, module):
+        self._torch_module = TorchModulePytorch(module)
+
+        # TODO: Rework by implementing the "__getattribute__" method.
+        #       Assigning all default attributes from user's original torch.nn.Module into ORTModule
+        self._backward_hooks = module._backward_hooks
+        self._forward_hooks = module._forward_hooks
+        self._forward_pre_hooks = module._forward_pre_hooks
+        self._parameters = module._parameters
+        self._buffers = module._buffers
+        self._non_persistent_buffers_set = module._non_persistent_buffers_set
+        self._is_full_backward_hook = module._is_full_backward_hook
+        self._state_dict_hooks = module._state_dict_hooks
+        self._load_state_dict_pre_hooks = module._load_state_dict_pre_hooks
+        self._modules = module._modules
+        self.forward = module.forward

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -104,7 +104,7 @@ class ORTModule(torch.nn.Module):
         except ORTModuleFallbackException as e:
             # Although backend is switched to PyTorch here,
             # it is up to _FallbackManager to actually terminate execution or fallback
-            self._switch_backend_to_pytorch(module)
+            _utils.switch_backend_to_pytorch(self, module)
 
             # Exceptions subject to fallback are handled here
             self._fallback_manager.handle_exception(exception=e,
@@ -112,7 +112,7 @@ class ORTModule(torch.nn.Module):
         except Exception as e:
             # Although backend is switched to PyTorch here,
             # it is up to _FallbackManager to actually terminate execution or fallback
-            self._switch_backend_to_pytorch(module)
+            _utils.switch_backend_to_pytorch(self, module)
 
             # Catch-all FALLBACK_FORCE_TORCH_FORWARD fallback is handled here
             self._fallback_manager.handle_exception(exception=e,
@@ -324,20 +324,3 @@ class ORTModule(torch.nn.Module):
         else:
             # Setting any new attributes should be done on ORTModule only when 'torch_module' is not defined
             self.__dict__[name] = value
-
-    def _switch_backend_to_pytorch(self, module):
-        self._torch_module = TorchModulePytorch(module)
-
-        # TODO: Rework by implementing the "__getattribute__" method.
-        #       Assigning all default attributes from user's original torch.nn.Module into ORTModule
-        self._backward_hooks = module._backward_hooks
-        self._forward_hooks = module._forward_hooks
-        self._forward_pre_hooks = module._forward_pre_hooks
-        self._parameters = module._parameters
-        self._buffers = module._buffers
-        self._non_persistent_buffers_set = module._non_persistent_buffers_set
-        self._is_full_backward_hook = module._is_full_backward_hook
-        self._state_dict_hooks = module._state_dict_hooks
-        self._load_state_dict_pre_hooks = module._load_state_dict_pre_hooks
-        self._modules = module._modules
-        self.forward = module.forward


### PR DESCRIPTION
This PR fixes 2 issues related to all-or-nothing fallback.

The first is that, some versions of Python seems to convert `EnvironmentError` to `OSError` in some scenarios, leading to unexpected behavior. While `EnvironmentError` was caught by ORTModule's  `try-except`, `OSError` caused immediate script termination. This PR replaces `EnvironmentError` by `RuntimeError` to prevent such difference in behavior.

The second issue is related to the fact that fallback API relies on requests to fallback when a failure is found that are fulfilled with a `fallback()` call. However, when there is an exception during *ortmodule module initialization*, `fallback()` will never be caught. Instead, the backend is switched to PyTorch. This PR adds a log to warn users about an eminent fallback, making this behavior consistent with the other fallback scenarios.

One topic that is open to discussion is whether initialization errors should fallback to pytorch. Initialization errors include missing ortmodule torch c++ extensions and unsupported pytorch versions.