### PR TITLE
[WIP] Make onnxruntime::Status nodiscard

### DIFF
--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -112,7 +112,7 @@ inline HRESULT StatusCodeToHRESULT(StatusCode status) noexcept {
 }
 #endif
 
-class Status {
+class [[nodiscard]] Status {
  public:
   Status() noexcept = default;
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -75,8 +75,7 @@ void PrepareMask(const int32_t* mask_index,
 
   // 4D mask in Megatron GPT2 is currently not support in CPU kernel
   if (nullptr != mask_index_dims && mask_index_dims->size() == 4) {
-    ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "4D mask in attention cpu kernel is not supported");
-    return;
+    ORT_NOT_IMPLEMENTED("4D mask in attention cpu kernel is not supported");
   }
 
   // For 3D mask, convert values 0 to -10000.0, and 1 to 0.0, then apply unidirectional mask if any.

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -251,7 +251,7 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
     ORT_RETURN_IF_ERROR(RegisterNchwcKernels(kernel_registry));
   }
 
-  RegisterQuantizationKernels(kernel_registry);
+  ORT_RETURN_IF_ERROR(RegisterQuantizationKernels(kernel_registry));
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/fused_conv.cc
+++ b/onnxruntime/contrib_ops/cuda/fused_conv.cc
@@ -91,8 +91,9 @@ class FusedConv : public onnxruntime::cuda::Conv<T> {
                                                    Base::s_.y_data, &beta, Base::s_.y_tensor, Base::s_.y_data));
     }
     if (Base::s_.post_slicing_required) {
-      onnxruntime::cuda::SliceOutUnwantedOutputSection(this->Stream(), Base::s_.y_data, Base::s_.y_dims_with_adjusted_pads, Base::s_.Y->MutableDataRaw(),
-                                                       Base::s_.y_dims, Base::s_.slice_starts, Base::s_.slice_ends, Base::s_.slice_axes, Base::s_.element_size);
+      ORT_RETURN_IF_ERROR(onnxruntime::cuda::SliceOutUnwantedOutputSection(
+          Stream(), Base::s_.y_data, Base::s_.y_dims_with_adjusted_pads, Base::s_.Y->MutableDataRaw(),
+          Base::s_.y_dims, Base::s_.slice_starts, Base::s_.slice_ends, Base::s_.slice_axes, Base::s_.element_size));
     }
     return Status::OK();
   }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -592,7 +592,7 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
       ORT_ENFORCE(exe_plan->allocation_plan[ml_value_idx].alloc_kind == AllocKind::kAllocate);
 
       const auto& counter = exe_plan->allocation_plan[ml_value_idx].program_counter;
-      mem_planner.TraceAllocation(ml_value_idx, counter, size);
+      ORT_RETURN_IF_ERROR(mem_planner.TraceAllocation(ml_value_idx, counter, size));
     }
   }
 
@@ -628,7 +628,7 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
         ORT_ENFORCE(exe_plan->allocation_plan[ml_value_idx].alloc_kind == AllocKind::kAllocate);
 
         const auto& counter = exe_plan->allocation_plan[ml_value_idx].program_counter;
-        mem_planner.TraceAllocation(ml_value_idx, counter, aligned_size);
+        ORT_RETURN_IF_ERROR(mem_planner.TraceAllocation(ml_value_idx, counter, aligned_size));
       }
     }
 
@@ -640,7 +640,7 @@ Status SessionState::GeneratePatternGroupCache(const std::vector<std::reference_
         continue;
       const auto* ml_data_type = static_cast<const TensorTypeBase*>(ml_type)->GetElementType();
       if (ml_data_type != DataTypeImpl::GetType<std::string>()) {
-        mem_planner.TraceFree(ml_value_idx);
+        ORT_RETURN_IF_ERROR(mem_planner.TraceFree(ml_value_idx));
       }
     }
   }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -718,7 +718,7 @@ Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* model_path,
                            tensorp->SizeInBytes(), ", Got ", m.GetLen());
   }
 
-  TensorProtoToTensor(env, model_path, tensor_proto, *tensorp);
+  ORT_RETURN_IF_ERROR(TensorProtoToTensor(env, model_path, tensor_proto, *tensorp));
 
   auto ml_tensor = DataTypeImpl::GetType<Tensor>();
   value.Init(tensorp.release(), ml_tensor, ml_tensor->GetDeleteFunc());

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2439,7 +2439,7 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
       // In case of nested model local functions, graph resolve is called during resolve for parent
       // function body graph otherwise type inference for nest function cannot happen.
       if (options.traverse_function_body && node.GetFunctionBody() != nullptr) {
-        node.GetMutableFunctionBody()->MutableBody().Resolve(options);
+        ORT_RETURN_IF_ERROR(node.GetMutableFunctionBody()->MutableBody().Resolve(options));
       }
     }
 

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -120,7 +120,7 @@ std::unique_ptr<RuleBasedGraphTransformer> GenerateRuleBasedGraphTransformer(
       std::make_unique<RuleBasedGraphTransformer>(GenerateRuleBasedTransformerName(level),
                                                   compatible_execution_providers);
   for (auto& entry : rewrite_rules_to_register) {
-    rule_transformer->Register(std::move(entry));
+    ORT_THROW_IF_ERROR(rule_transformer->Register(std::move(entry)));
   }
 
   return rule_transformer;

--- a/onnxruntime/core/optimizer/optimizer_execution_frame.cc
+++ b/onnxruntime/core/optimizer/optimizer_execution_frame.cc
@@ -27,7 +27,7 @@ OptimizerExecutionFrame::Info::Info(const std::vector<const Node*>& nodes,
   allocator_ptr_ = execution_provider_.GetAllocator(device_id_, mem_type_);
   ORT_ENFORCE(allocator_ptr_, "Failed to get allocator for optimizer");
 
-  data_transfer_mgr_.RegisterDataTransfer(std::make_unique<CPUDataTransfer>());
+  ORT_THROW_IF_ERROR(data_transfer_mgr_.RegisterDataTransfer(std::make_unique<CPUDataTransfer>()));
 
   // Create MLValues related maps
   auto initialize_maps = [this, &initialized_tensor_set, &model_path](const NodeArg& arg, size_t /*index*/) -> Status {
@@ -75,7 +75,7 @@ OptimizerExecutionFrame::Info::Info(const std::vector<const Node*>& nodes,
   allocator_ptr_ = execution_provider_.GetAllocator(device_id_, mem_type_);
   ORT_ENFORCE(allocator_ptr_, "Failed to get allocator for optimizer");
 
-  data_transfer_mgr_.RegisterDataTransfer(std::make_unique<CPUDataTransfer>());
+  ORT_THROW_IF_ERROR(data_transfer_mgr_.RegisterDataTransfer(std::make_unique<CPUDataTransfer>()));
 
   // Create MLValues related maps
   auto initialize_maps = [this, &initialized_tensor_set, &model_path](const NodeArg& arg, size_t /*index*/) -> Status {

--- a/onnxruntime/core/providers/cpu/activation/activations.cc
+++ b/onnxruntime/core/providers/cpu/activation/activations.cc
@@ -12,14 +12,6 @@ using namespace onnxruntime::common;
 
 namespace onnxruntime {
 
-#define CREATE_ELE_KERNEL(X)                  \
-  if (type == #X) {                           \
-    functors::X<T>* p = new functors::X<T>(); \
-    p->Init(attributes);                      \
-    out.reset(p);                             \
-    return Status::OK();                      \
-  }
-
 #define REGISTER_VERSIONED_UNARY_ELEMENTWISE_KERNEL(op, since_version, end_version) \
   ONNX_CPU_OPERATOR_VERSIONED_KERNEL(                                               \
       op, since_version, end_version,                                               \
@@ -69,6 +61,14 @@ namespace functors {
 template <typename T>
 Status ElementWiseRangedTransform<T>::Create(const std::string& type, const NodeAttributes& attributes,
                                              std::unique_ptr<ElementWiseRangedTransform<T>>& out) {
+#define CREATE_ELE_KERNEL(X)                     \
+  if (type == #X) {                              \
+    auto p = std::make_unique<functors::X<T>>(); \
+    ORT_RETURN_IF_ERROR(p->Init(attributes));    \
+    out = std::move(p);                          \
+    return Status::OK();                         \
+  }
+
   CREATE_ELE_KERNEL(Celu);
   CREATE_ELE_KERNEL(Elu);
   CREATE_ELE_KERNEL(HardSigmoid);
@@ -84,6 +84,9 @@ Status ElementWiseRangedTransform<T>::Create(const std::string& type, const Node
   CREATE_ELE_KERNEL(ParametricSoftplus);
   CREATE_ELE_KERNEL(ScaledTanh);
 #endif
+
+#undef CREATE_ELE_KERNEL
+
   return Status(ONNXRUNTIME, FAIL, "unknown kernel type");
 }
 

--- a/onnxruntime/core/providers/cpu/controlflow/if.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/if.cc
@@ -193,7 +193,7 @@ common::Status If::SetupSubgraphExecutionInfo(const SessionState& session_state,
 
   // find the location all the feeds will be coming from
   std::vector<OrtDevice> feed_locations;
-  controlflow::detail::FindDevicesForValues(session_state, feed_names, feed_locations);
+  ORT_RETURN_IF_ERROR(controlflow::detail::FindDevicesForValues(session_state, feed_names, feed_locations));
 
   std::vector<const OrtMemoryInfo*> fetch_locations;
   fetch_locations.reserve(info->num_outputs);

--- a/onnxruntime/core/providers/cpu/controlflow/scan_8.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_8.cc
@@ -425,7 +425,7 @@ Status Scan8Impl::Execute(const FeedsFetchesManager& ffm) {
     for (int64_t i = sequence_len; i < max_sequence_len_; ++i) {
       for (int output = info_.num_loop_state_variables; output < info_.num_outputs; ++output) {
         auto& iterator = *output_iterators_[output];
-        iterator.ZeroOutCurrent();
+        ORT_RETURN_IF_ERROR(iterator.ZeroOutCurrent());
         ++iterator;
       }
     }

--- a/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
+++ b/onnxruntime/core/providers/cpu/controlflow/scan_utils.cc
@@ -114,18 +114,20 @@ Status AllocateOutput(OpKernelContextInternal& context, const GraphViewer& subgr
   std::copy(graph_output_dims.cbegin(), graph_output_dims.cend(), std::back_inserter(scan_output_dims));
 
   if (!temporary) {
-    OutputIterator::Create(context, output_index, is_loop_state_var, is_v8, TensorShape(scan_output_dims),
-                           create_slicer_func, zero_data_func,
-                           output_iterator, direction);
+    ORT_RETURN_IF_ERROR(OutputIterator::Create(context, output_index, is_loop_state_var, is_v8,
+                                               TensorShape(scan_output_dims),
+                                               create_slicer_func, zero_data_func,
+                                               output_iterator, direction));
   } else {
     auto mltype = utils::GetMLDataType(*graph_output);
 
     // the outputs from Scan are constrained to tensors, so we can safely cast to TensorTypeBase
     auto ml_data_type = static_cast<const TensorTypeBase*>(mltype)->GetElementType();
 
-    OutputIterator::Create(context, output_index, is_loop_state_var, is_v8, TensorShape(scan_output_dims),
-                           create_slicer_func, zero_data_func,
-                           output_iterator, direction, temporary, ml_data_type);
+    ORT_RETURN_IF_ERROR(OutputIterator::Create(context, output_index, is_loop_state_var, is_v8,
+                                               TensorShape(scan_output_dims),
+                                               create_slicer_func, zero_data_func,
+                                               output_iterator, direction, temporary, ml_data_type));
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
+++ b/onnxruntime/core/providers/cpu/sequence/sequence_ops.cc
@@ -222,14 +222,14 @@ Status SequenceInsert::Compute(OpKernelContext* context) const {
   tensors.reserve(num_tensors_input_seq + 1);
   for (int i = 0; i < num_tensors_input_seq; ++i) {
     if (i == input_seq_idx) {
-      CreateCopyAndAppendCpuTensor(*X, context, tensors);
-      CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors);
+      ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(*X, context, tensors));
+      ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors));
     } else {
-      CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors);
+      ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors));
     }
   }
   if (input_seq_idx == num_tensors_input_seq) {
-    CreateCopyAndAppendCpuTensor(*X, context, tensors);
+    ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(*X, context, tensors));
   }
 
   Y->SetType(S->DataType());
@@ -276,7 +276,7 @@ Status SequenceErase::Compute(OpKernelContext* context) const {
     if (i == input_seq_idx) {
       continue;
     }
-    CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors);
+    ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(S->Get(i), context, tensors));
   }
   Y->SetElements(std::move(tensors));
   return Status::OK();
@@ -302,8 +302,8 @@ Status SequenceConstruct::Compute(OpKernelContext* context) const {
   for (int input_idx = 0; input_idx < num_inputs; ++input_idx) {
     const auto* X = context->Input<Tensor>(input_idx);
     if (input_idx > 0 && X->DataType() != first_dtype) {
-      ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                      "Violation of the requirment that all input tensors must have the same data type.");
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Violation of the requirment that all input tensors must have the same data type.");
     }
   }
 
@@ -313,7 +313,7 @@ Status SequenceConstruct::Compute(OpKernelContext* context) const {
   tensors.reserve(num_inputs);
   for (int input_idx = 0; input_idx < num_inputs; ++input_idx) {
     const auto* X = context->Input<Tensor>(input_idx);
-    CreateCopyAndAppendCpuTensor(*X, context, tensors);
+    ORT_RETURN_IF_ERROR(CreateCopyAndAppendCpuTensor(*X, context, tensors));
   }
   Y->SetElements(std::move(tensors));
   return Status::OK();

--- a/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
@@ -166,9 +166,9 @@ Status GatherND::Compute(OpKernelContext* context) const {
   auto bytes_per_value = input_tensor->DataType()->Size();
 
   if (indices_tensor->IsDataType<int32_t>()) {
-    PrepareForCompute<int32_t>(input_shape, indices_tensor, bytes_per_value, p, tp);
+    ORT_RETURN_IF_ERROR(PrepareForCompute<int32_t>(input_shape, indices_tensor, bytes_per_value, p, tp));
   } else if (indices_tensor->IsDataType<int64_t>()) {
-    PrepareForCompute<int64_t>(input_shape, indices_tensor, bytes_per_value, p, tp);
+    ORT_RETURN_IF_ERROR(PrepareForCompute<int64_t>(input_shape, indices_tensor, bytes_per_value, p, tp));
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "indices tensor data type not supported");
   }

--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.cc
@@ -485,43 +485,33 @@ Status CompareFunction<T, CudaT>::CompareMethod(OpKernelContext* context, ImplCo
 //for other elementwise ops
 template <typename T>
 Status Greater<T>::ComputeInternal(OpKernelContext* context) const {
-  this->CompareMethod(context, &ImplT2_Greater);
-
-  return Status::OK();
+  return CompareMethod(context, &ImplT2_Greater);
 }
 
 template <typename T>
 Status Equal<T>::ComputeInternal(OpKernelContext* context) const {
-  this->CompareMethod(context, &ImplT2_Equal);
-
-  return Status::OK();
+  return CompareMethod(context, &ImplT2_Equal);
 }
 
 //Less op output tensor type is bool, so it cannot directly fit in the macros
 //for other elementwise ops
 template <typename T>
 Status Less<T>::ComputeInternal(OpKernelContext* context) const {
-  this->CompareMethod(context, &ImplT2_Less);
-
-  return Status::OK();
+  return CompareMethod(context, &ImplT2_Less);
 }
 
 //GreaterOrEqual op output tensor type is bool, so it cannot directly fit in the macros
 //for other elementwise ops
 template <typename T>
 Status GreaterOrEqual<T>::ComputeInternal(OpKernelContext* context) const {
-  this->CompareMethod(context, &ImplT2_GreaterOrEqual);
-
-  return Status::OK();
+  return CompareMethod(context, &ImplT2_GreaterOrEqual);
 }
 
 //LessOrEqual op output tensor type is bool, so it cannot directly fit in the macros
 //for other elementwise ops
 template <typename T>
 Status LessOrEqual<T>::ComputeInternal(OpKernelContext* context) const {
-  this->CompareMethod(context, &ImplT2_LessOrEqual);
-
-  return Status::OK();
+  return CompareMethod(context, &ImplT2_LessOrEqual);
 }
 
 BINARY_LOGICALOP_REGISTER_UZILHFD(Equal, 13)

--- a/onnxruntime/core/providers/cuda/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul_integer.cc
@@ -82,29 +82,29 @@ Status MatMulInteger<int8_t, int8_t>::ComputeInternal(OpKernelContext* ctx) cons
   int alpha = 1;
   int beta = 0;
   if (a_offset != 0 || b_offset != 0) {
-    OffsetOutput(Stream(),
-                 a_row_buf.get(),
-                 b_col_buf.get(),
-                 output_ptr,
-                 a_offset,
-                 b_offset,
-                 helper);
+    ORT_RETURN_IF_ERROR(OffsetOutput(Stream(),
+                                     a_row_buf.get(),
+                                     b_col_buf.get(),
+                                     output_ptr,
+                                     a_offset,
+                                     b_offset,
+                                     helper));
     beta = 1;
   }
 
   for (size_t batch = 0; batch < helper.OutputOffsets().size(); batch++) {
-    GemmInt8(static_cast<int>(helper.M()),
-             static_cast<int>(helper.N()),
-             static_cast<int>(helper.K()),
-             alpha,
-             beta,
-             a_ptr + helper.LeftOffsets()[batch],
-             static_cast<int>(helper.K()),
-             b_ptr + helper.RightOffsets()[batch],
-             static_cast<int>(helper.N()),
-             output_ptr + helper.OutputOffsets()[batch],
-             static_cast<int>(helper.N()),
-             this);
+    ORT_RETURN_IF_ERROR(GemmInt8(static_cast<int>(helper.M()),
+                                 static_cast<int>(helper.N()),
+                                 static_cast<int>(helper.K()),
+                                 alpha,
+                                 beta,
+                                 a_ptr + helper.LeftOffsets()[batch],
+                                 static_cast<int>(helper.K()),
+                                 b_ptr + helper.RightOffsets()[batch],
+                                 static_cast<int>(helper.N()),
+                                 output_ptr + helper.OutputOffsets()[batch],
+                                 static_cast<int>(helper.N()),
+                                 this));
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -78,7 +78,7 @@ Status SliceOutUnwantedOutputSection(cudaStream_t stream,
                                      size_t element_size) {
   SliceOp::PrepareForComputeMetadata compute_metadata(input_dims);
 
-  SliceBase::PrepareForCompute(starts, ends, axes, compute_metadata);
+  ORT_THROW_IF_ERROR(SliceBase::PrepareForCompute(starts, ends, axes, compute_metadata));
 
   // As a sanity check, ensure that the slice operator's output shape matches with the expected output shape
   ORT_ENFORCE(compute_metadata.output_dims_ == output_dims);
@@ -343,8 +343,9 @@ Status Conv<T>::ComputeInternal(OpKernelContext* context) const {
   // To deal with asymmetric padding, we may have over-padded on one or both sides of the spatial dimensions
   // This may have lead to extra results that are unnecessary and hence we slice that off here
   if (s_.post_slicing_required) {
-    SliceOutUnwantedOutputSection(Stream(), s_.y_data, s_.y_dims_with_adjusted_pads, s_.Y->MutableDataRaw(),
-                                  s_.y_dims, s_.slice_starts, s_.slice_ends, s_.slice_axes, s_.element_size);
+    ORT_RETURN_IF_ERROR(SliceOutUnwantedOutputSection(Stream(), s_.y_data, s_.y_dims_with_adjusted_pads,
+                                                      s_.Y->MutableDataRaw(), s_.y_dims, s_.slice_starts,
+                                                      s_.slice_ends, s_.slice_axes, s_.element_size));
   }
   return Status::OK();
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/nn/pool.cc
+++ b/onnxruntime/core/providers/cuda/nn/pool.cc
@@ -249,7 +249,7 @@ Status Pool<T, MaxPool<8>>::ComputeInternal(OpKernelContext* context) const {
         y_data,
         i_data);
   } else {
-    Pool<T, MaxPool<1>>::ComputeInternal(context);
+    ORT_RETURN_IF_ERROR((Pool<T, MaxPool<1>>::ComputeInternal(context)));
   }
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression.cc
@@ -114,10 +114,10 @@ Status NonMaxSuppression::ComputeInternal(OpKernelContext* ctx) const {
       }
     }
 
-    concat_sizes_gpu.CopyToGpu();
-    axis_dimension_input_output_mapping_gpu.CopyToGpu();
-    concat_sizes_range_gpu.CopyToGpu();
-    input_ptr.CopyToGpu();
+    ORT_RETURN_IF_ERROR(concat_sizes_gpu.CopyToGpu());
+    ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu());
+    ORT_RETURN_IF_ERROR(concat_sizes_range_gpu.CopyToGpu());
+    ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu());
 
     ORT_RETURN_IF_ERROR(ConcatImpl(Stream(),
                                    sizeof(int64_t),

--- a/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
+++ b/onnxruntime/core/providers/cuda/rnn/cudnn_rnn_base.h
@@ -99,10 +99,10 @@ class CudnnRnnBase : public CudaKernel {
     w_data_cache_ = nullptr;
 
     size_t state_size;
-    cudnn_dropout_desc_.CreateDescriptorIfNeeded();
-    cudnn_dropout_desc_.GetCudnnDropoutStatesSize(CudnnHandle(), state_size);
+    ORT_THROW_IF_ERROR(cudnn_dropout_desc_.CreateDescriptorIfNeeded());
+    ORT_THROW_IF_ERROR(cudnn_dropout_desc_.GetCudnnDropoutStatesSize(CudnnHandle(), state_size));
     state_buffer_ = GetScratchBuffer<void>(state_size);
-    cudnn_dropout_desc_.Set(CudnnHandle(), state_buffer_.get(), state_size);
+    ORT_THROW_IF_ERROR(cudnn_dropout_desc_.Set(CudnnHandle(), state_buffer_.get(), state_size));
 
     layout_ = info.GetAttrOrDefault("layout", static_cast<int64_t>(0));
     ORT_ENFORCE(layout_ == 0, 

--- a/onnxruntime/core/providers/cuda/rnn/gru.h
+++ b/onnxruntime/core/providers/cuda/rnn/gru.h
@@ -24,7 +24,7 @@ class GRU final : public CudnnRnnBase<T> {
     // ONNX B layout is Wbzrh, Rbzrh, mapping to RNNLinLayerMatrixParams
     // the linLayerID is 1, 0, 2, 4, 3, 5, we can reuse it from W_lin_layer_id & R_lin_layer_id
 
-    CudnnRnnBase<T>::CacheCudnnRnnWeights(info);
+    ORT_THROW_IF_ERROR(CudnnRnnBase<T>::CacheCudnnRnnWeights(info));
   }
 };
 

--- a/onnxruntime/core/providers/cuda/rnn/lstm.h
+++ b/onnxruntime/core/providers/cuda/rnn/lstm.h
@@ -22,7 +22,7 @@ class LSTM final : public CudnnRnnBase<T> {
     // ONNX B layout is Wb[iofc], Rb[iofc], mapping to RNNLinLayerMatrixParams
     // the linLayerID is 0, 3, 1, 2, 4, 7, 5, 6, we can reuse it from W_lin_layer_id & R_lin_layer_id
 
-    CudnnRnnBase<T>::CacheCudnnRnnWeights(info);
+    ORT_THROW_IF_ERROR(CudnnRnnBase<T>::CacheCudnnRnnWeights(info));
   }
 };
 

--- a/onnxruntime/core/providers/cuda/rnn/rnn.h
+++ b/onnxruntime/core/providers/cuda/rnn/rnn.h
@@ -31,7 +31,7 @@ class RNN final : public CudnnRnnBase<T> {
     // ONNX B layout is Wb, Rb, mapping to RNNLinLayerMatrixParams
     // the linLayerID is 0, 1, we can reuse it from W_lin_layer_id & R_lin_layer_id
 
-    CudnnRnnBase<T>::CacheCudnnRnnWeights(info);
+    ORT_THROW_IF_ERROR(CudnnRnnBase<T>::CacheCudnnRnnWeights(info));
   }
 };
 

--- a/onnxruntime/core/providers/cuda/tensor/concat.cc
+++ b/onnxruntime/core/providers/cuda/tensor/concat.cc
@@ -70,10 +70,10 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
   CudaAsyncBuffer<int64_t> concat_sizes_gpu(this, concat_sizes);
   CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
   CudaAsyncBuffer<int64_t> concat_sizes_range_gpu(this, concat_sizes_range);
-  concat_sizes_gpu.CopyToGpu();
-  axis_dimension_input_output_mapping_gpu.CopyToGpu();
-  concat_sizes_range_gpu.CopyToGpu();
-  input_ptr.CopyToGpu();
+  ORT_RETURN_IF_ERROR(concat_sizes_gpu.CopyToGpu());
+  ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu());
+  ORT_RETURN_IF_ERROR(concat_sizes_range_gpu.CopyToGpu());
+  ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu());
   int block_size_inside_axis_dim = static_cast<int>(p.output_axis_pitch / p.output_tensor->Shape()[p.axis]);
   int block_size_including_axis_dim = static_cast<int>(p.output_axis_pitch);
   auto element_bytes = p.output_tensor->DataType()->Size();

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
@@ -30,7 +30,7 @@ Status QuantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
   const CudaU* scale = reinterpret_cast<const CudaU*>(y_scale.template Data<U>());
   const auto num_of_elements = x_shape.Size();
 
-  CudaQuantizeLinear(Stream(), input, output, scale, zero_point, num_of_elements);
+  ORT_RETURN_IF_ERROR(CudaQuantizeLinear(Stream(), input, output, scale, zero_point, num_of_elements));
 
   return Status::OK();
 }
@@ -57,7 +57,7 @@ Status DequantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
   const CudaU* scale = reinterpret_cast<const CudaU*>(y_scale.template Data<U>());
   const auto num_of_elements = x_shape.Size();
 
-  CudaDequantizeLinear(Stream(), input, output, scale, zero_point, num_of_elements);
+  ORT_RETURN_IF_ERROR(CudaDequantizeLinear(Stream(), input, output, scale, zero_point, num_of_elements));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cuda/tensor/reshape.h
+++ b/onnxruntime/core/providers/cuda/tensor/reshape.h
@@ -36,7 +36,7 @@ class Reshape final : public CudaKernel {
     void* target = Y->MutableDataRaw();
     //If source and target pointers are not equal (non-inplace operation), we need to copy the data.
     if (target != source) {
-      CopyTensor(*X, *Y);
+      ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
     }
 
     return Status::OK();
@@ -65,7 +65,7 @@ class Reshape_1 final : public CudaKernel {
     void* target = Y->MutableDataRaw();
     //If source and target pointers are not equal (non-inplace operation), we need to copy the data.
     if (target != source) {
-      CopyTensor(*X, *Y);
+      ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
     }
 
     return Status::OK();

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
@@ -37,7 +37,7 @@ Status ScatterND::ComputeInternal(OpKernelContext* context) const {
   const auto& updates_shape = updates_tensor->Shape();
 
   // Validate input shapes
-  ValidateShapes(input_shape, indices_shape, updates_shape);
+  ORT_RETURN_IF_ERROR(ValidateShapes(input_shape, indices_shape, updates_shape));
 
   auto* output_tensor = context->Output(0, input_shape);
 
@@ -68,7 +68,7 @@ Status ScatterND::ComputeInternal(OpKernelContext* context) const {
     element_counts_and_input_dims[i + last_index_dimension] = input_shape[i];
   }
   CudaAsyncBuffer<int64_t> element_counts_and_input_dims_gpu(this, element_counts_and_input_dims);
-  element_counts_and_input_dims_gpu.CopyToGpu();
+  ORT_RETURN_IF_ERROR(element_counts_and_input_dims_gpu.CopyToGpu());
 
   ORT_RETURN_IF_ERROR(ScatterNDImpl(
       Stream(),

--- a/onnxruntime/core/providers/cuda/tensor/slice.cc
+++ b/onnxruntime/core/providers/cuda/tensor/slice.cc
@@ -193,7 +193,7 @@ Status Slice<dynamic>::ComputeInternal(OpKernelContext* ctx) const {
 
   if (dynamic) {
     std::vector<int64_t> input_starts, input_ends, input_axes, input_steps;
-    FillInputVectors(ctx, input_starts, input_ends, input_axes, input_steps);
+    ORT_RETURN_IF_ERROR(FillInputVectors(ctx, input_starts, input_ends, input_axes, input_steps));
     ORT_RETURN_IF_ERROR(PrepareForCompute(input_starts, input_ends, input_axes, input_steps, compute_metadata));
 
   } else {
@@ -226,11 +226,11 @@ const Tensor* Slice<dynamic>::GetSlicedOrUnslicedTensor(OpKernelContext* ctx) co
 }
 
 template <bool dynamic>
-void Slice<dynamic>::FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
-                                      std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
-                                      std::vector<int64_t>& input_steps) const {
-  FillVectorsFromInput(*ctx->Input<Tensor>(1), *ctx->Input<Tensor>(2), ctx->Input<Tensor>(3),
-                       ctx->Input<Tensor>(4), input_starts, input_ends, input_axes, input_steps);
+Status Slice<dynamic>::FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
+                                        std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
+                                        std::vector<int64_t>& input_steps) const {
+  return FillVectorsFromInput(*ctx->Input<Tensor>(1), *ctx->Input<Tensor>(2), ctx->Input<Tensor>(3),
+                              ctx->Input<Tensor>(4), input_starts, input_ends, input_axes, input_steps);
 }
 
 template <bool dynamic>

--- a/onnxruntime/core/providers/cuda/tensor/slice.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice.h
@@ -29,9 +29,9 @@ class Slice : public CudaKernel, public SliceBase {
 
  private:
   virtual const Tensor* GetSlicedOrUnslicedTensor(OpKernelContext* ctx) const;
-  virtual void FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
-                                std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
-                                std::vector<int64_t>& input_steps) const;
+  virtual Status FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
+                                  std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
+                                  std::vector<int64_t>& input_steps) const;
 
   virtual Status CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                               const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,

--- a/onnxruntime/core/providers/cuda/tensor/split.cc
+++ b/onnxruntime/core/providers/cuda/tensor/split.cc
@@ -84,10 +84,10 @@ Status Split::ComputeInternal(OpKernelContext* ctx) const {
   }
 
   if (input_tensor->Shape().Size() > 0) {
-    output_ptr.CopyToGpu();
+    ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu());
 
     CudaAsyncBuffer<int64_t> split_sizes_gpu(this, split_sizes);
-    split_sizes_gpu.CopyToGpu();
+    ORT_RETURN_IF_ERROR(split_sizes_gpu.CopyToGpu());
 
     std::vector<int64_t> split_sizes_range(split_sizes);
     for (size_t i = 1; i < split_sizes_range.size(); ++i) {
@@ -95,10 +95,10 @@ Status Split::ComputeInternal(OpKernelContext* ctx) const {
     }
 
     CudaAsyncBuffer<int64_t> split_sizes_range_gpu(this, split_sizes_range);
-    split_sizes_range_gpu.CopyToGpu();
+    ORT_RETURN_IF_ERROR(split_sizes_range_gpu.CopyToGpu());
 
     CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
-    axis_dimension_input_output_mapping_gpu.CopyToGpu();
+    ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu());
 
     size_t element_size = input_tensor->DataType()->Size();
     ORT_RETURN_IF_ERROR(SplitImpl(Stream(),

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -519,7 +519,7 @@ common::Status InferenceSession::RegisterExecutionProvider(const std::shared_ptr
 
     auto trt_ep = execution_providers_.Get(kTensorrtExecutionProvider);
     if (trt_ep) {
-      p_exec_provider->SetComputeStream(trt_ep->GetComputeStream());
+      ORT_RETURN_IF_ERROR(p_exec_provider->SetComputeStream(trt_ep->GetComputeStream()));
     }
   }
 
@@ -1355,7 +1355,8 @@ common::Status InferenceSession::Initialize() {
 #if !defined(ORT_MINIMAL_BUILD)
     if (!loading_ort_format) {
       // add predefined transformers
-      AddPredefinedTransformers(graph_transformation_mgr_, session_options_.graph_optimization_level);
+      ORT_RETURN_IF_ERROR_SESSIONID_(AddPredefinedTransformers(graph_transformation_mgr_,
+                                                               session_options_.graph_optimization_level));
 
       // apply any transformations to the main graph and any subgraphs
       ORT_RETURN_IF_ERROR_SESSIONID_(TransformGraph(graph, graph_transformation_mgr_,
@@ -2223,8 +2224,8 @@ void InferenceSession::InitLogger(logging::LoggingManager* logging_manager) {
 #if !defined(ORT_MINIMAL_BUILD)
 
 // Registers all the predefined transformers with transformer manager
-void InferenceSession::AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
-                                                 TransformerLevel graph_optimization_level) {
+common::Status InferenceSession::AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
+                                                           TransformerLevel graph_optimization_level) {
   const auto& cpu_ep = *execution_providers_.Get(onnxruntime::kCpuExecutionProvider);
   for (int i = static_cast<int>(TransformerLevel::Level1); i <= static_cast<int>(TransformerLevel::MaxLevel); i++) {
     TransformerLevel level = static_cast<TransformerLevel>(i);
@@ -2233,10 +2234,11 @@ void InferenceSession::AddPredefinedTransformers(GraphTransformerManager& transf
       auto transformers_to_register = optimizer_utils::GenerateTransformers(level, session_options_, cpu_ep,
                                                                             optimizers_to_disable_);
       for (auto& entry : transformers_to_register) {
-        transformer_manager.Register(std::move(entry), level);
+        ORT_RETURN_IF_ERROR(transformer_manager.Register(std::move(entry), level));
       }
     }
   }
+  return Status::OK();
 }
 
 #endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -583,8 +583,8 @@ class InferenceSession {
   void ShrinkMemoryArenas(const std::vector<AllocatorPtr>& arenas_to_shrink);
 
 #if !defined(ORT_MINIMAL_BUILD)
-  virtual void AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
-                                         TransformerLevel graph_optimization_level);
+  virtual common::Status AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
+                                                   TransformerLevel graph_optimization_level);
 
   common::Status TransformGraph(onnxruntime::Graph& graph,
                                 const onnxruntime::GraphTransformerManager& graph_transformer_mgr,

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -519,13 +519,14 @@ ORT_API_STATUS_IMPL(OrtApis::AddCustomOpDomain, _Inout_ OrtSessionOptions* optio
 ORT_API_STATUS_IMPL(OrtApis::RegisterCustomOpsLibrary, _Inout_ OrtSessionOptions* options, _In_ const char* library_path, void** library_handle) {
   API_IMPL_BEGIN
 
-  Env::Default().LoadDynamicLibrary(library_path, false, library_handle);
+  ORT_API_RETURN_IF_STATUS_NOT_OK(Env::Default().LoadDynamicLibrary(library_path, false, library_handle));
   if (!*library_handle)
     return OrtApis::CreateStatus(ORT_FAIL, "RegisterCustomOpsLibrary: Failed to load library");
 
   OrtStatus*(ORT_API_CALL * RegisterCustomOps)(OrtSessionOptions * options, const OrtApiBase* api);
 
-  Env::Default().GetSymbolFromLibrary(*library_handle, "RegisterCustomOps", (void**)&RegisterCustomOps);
+  ORT_API_RETURN_IF_STATUS_NOT_OK(Env::Default().GetSymbolFromLibrary(*library_handle, "RegisterCustomOps",
+                                                                      (void**)&RegisterCustomOps));
   if (!RegisterCustomOps)
     return OrtApis::CreateStatus(ORT_FAIL, "RegisterCustomOpsLibrary: Entry point RegisterCustomOps not found in library");
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -896,7 +896,11 @@ struct ProviderSharedLibrary {
     }
 
     void (*PProvider_SetHost)(void*);
-    Env::Default().GetSymbolFromLibrary(handle_, "Provider_SetHost", (void**)&PProvider_SetHost);
+    error = Env::Default().GetSymbolFromLibrary(handle_, "Provider_SetHost", (void**)&PProvider_SetHost);
+    if (!error.IsOK()) {
+      LOGS_DEFAULT(ERROR) << error.ErrorMessage();
+      return false;
+    }
 
     PProvider_SetHost(&provider_host_);
     return true;
@@ -904,7 +908,10 @@ struct ProviderSharedLibrary {
 
   void Unload() {
     if (handle_) {
-      Env::Default().UnloadDynamicLibrary(handle_);
+      auto status = Env::Default().UnloadDynamicLibrary(handle_);
+      if (!status.IsOK()) {
+        LOGS_DEFAULT(ERROR) << status.ErrorMessage();
+      }
       handle_ = nullptr;
     }
   }
@@ -947,7 +954,11 @@ struct ProviderLibrary {
     }
 
     Provider* (*PGetProvider)();
-    Env::Default().GetSymbolFromLibrary(handle_, "GetProvider", (void**)&PGetProvider);
+    error = Env::Default().GetSymbolFromLibrary(handle_, "GetProvider", (void**)&PGetProvider);
+    if (!error.IsOK()) {
+      LOGS_DEFAULT(ERROR) << error.ErrorMessage();
+      return nullptr;
+    }
 
     provider_ = PGetProvider();
     return provider_;
@@ -958,8 +969,12 @@ struct ProviderLibrary {
       if (provider_)
         provider_->Shutdown();
 
-      if (unload_)
-        Env::Default().UnloadDynamicLibrary(handle_);
+      if (unload_) {
+        auto status = Env::Default().UnloadDynamicLibrary(handle_);
+        if (!status.IsOK()) {
+          LOGS_DEFAULT(ERROR) << status.ErrorMessage();
+        }
+      }
 
       handle_ = nullptr;
       provider_ = nullptr;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -76,7 +76,7 @@ CustomOpLibrary::CustomOpLibrary(const char* library_path, OrtSessionOptions& or
     if (status) {
       // TODO: How to handle unload failure ?
       // Currently we ignore the returned status assuming it is successful
-      platform_env.UnloadDynamicLibrary(library_handle_);
+      ORT_IGNORE_RETURN_VALUE(platform_env.UnloadDynamicLibrary(library_handle_));
 
       // Construct error message string
       std::string error_string = status->msg;
@@ -1163,7 +1163,7 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
             // is not destructed as long as any session that uses the provided OrtValue initializer is still in scope
             // This is no different than the native APIs
             const OrtValue* ml_value = ml_value_pyobject.attr(PYTHON_ORTVALUE_NATIVE_OBJECT_ATTR).cast<OrtValue*>();
-            options->AddInitializer(name, ml_value);
+            ORT_THROW_IF_ERROR(options->AddInitializer(name, ml_value));
           });
 
   py::class_<RunOptions>(m, "RunOptions", R"pbdoc(Configuration information for a single Run.)pbdoc")

--- a/onnxruntime/test/contrib_ops/function_test_util.cc
+++ b/onnxruntime/test/contrib_ops/function_test_util.cc
@@ -13,6 +13,7 @@
 #include "test/test_environment.h"
 #include "test/framework/test_utils.h"
 #include "test/common/tensor_op_test_utils.h"
+#include "asserts.h"
 
 namespace onnxruntime {
 namespace test {
@@ -142,16 +143,14 @@ std::unique_ptr<Model> FunctionTestCase::CreateModel(bool inline_call) {
   onnxruntime::Graph& graph = model->MainGraph();
   auto& call_node = AddCallNodeTo(graph);
 
-  auto status = graph.Resolve();
-  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+  EXPECT_STATUS_OK(graph.Resolve());
 
   if (inline_call) {
-    graph.InlineFunction(call_node);
+    EXPECT_STATUS_OK(graph.InlineFunction(call_node));
 #if 0
     std::cout << graph << std::endl;
 #endif
-    status = graph.Resolve();
-    EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+    EXPECT_STATUS_OK(graph.Resolve());
   }
 
   return model;

--- a/onnxruntime/test/framework/TestAllocatorManager.cc
+++ b/onnxruntime/test/framework/TestAllocatorManager.cc
@@ -72,7 +72,7 @@ AllocatorManager& AllocatorManager::Instance() {
 }
 
 AllocatorManager::AllocatorManager() {
-  InitializeAllocators();
+  ORT_THROW_IF_ERROR(InitializeAllocators());
 }
 
 Status AllocatorManager::InitializeAllocators() {

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -191,7 +191,7 @@ class PlannerTest : public ::testing::Test {
         KernelDefBuilder().SetName("Tanh").Provider(kCpuExecutionProvider).SinceVersion(1, 10).ExternalOutputs().Build();
     CPUExecutionProviderInfo epi;
     auto execution_provider = std::make_unique<CPUExecutionProvider>(epi);
-    execution_providers_.Add("CPUExecutionProvider", std::move(execution_provider));
+    ORT_THROW_IF_ERROR(execution_providers_.Add("CPUExecutionProvider", std::move(execution_provider)));
 
     state_.reset(new SessionState(graph_, execution_providers_, false, tp_.get(), nullptr, dtm_,
                                   DefaultLoggingManager().DefaultLogger(), profiler_));

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -687,10 +687,10 @@ TEST_F(PlannerTest, LocationPlanningForPassThroughExplicitAndImplicitSubgraphInp
     const auto* main_graph_plan = main_graph_session_state.GetExecutionPlan();
 
     OrtValueIndex abs_data_0_out_index;
-    main_graph_ort_value_index_map.GetIdx("abs_data_0_out", abs_data_0_out_index);
+    ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("abs_data_0_out", abs_data_0_out_index));
 
     OrtValueIndex abs_data_1_out_index;
-    main_graph_ort_value_index_map.GetIdx("abs_data_1_out", abs_data_1_out_index);
+    ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("abs_data_1_out", abs_data_1_out_index));
 
     EXPECT_EQ(main_graph_plan->allocation_plan[abs_data_0_out_index].location.device.Type(), OrtDevice::GPU);
     EXPECT_EQ(main_graph_plan->allocation_plan[abs_data_1_out_index].location.device.Type(), OrtDevice::GPU);
@@ -714,12 +714,12 @@ TEST_F(PlannerTest, LocationPlanningForPassThroughExplicitAndImplicitSubgraphInp
     const auto* first_subgraph_plan = first_subgraph_session_state.GetExecutionPlan();
 
     OrtValueIndex abs_data_0_out_index;
-    first_subgraph_ort_value_index_map.GetIdx("abs_data_0_out", abs_data_0_out_index);
+    ASSERT_STATUS_OK(first_subgraph_ort_value_index_map.GetIdx("abs_data_0_out", abs_data_0_out_index));
 
     // "abs_data_1_out" is "loop_state_var" in this scope as it was consumed as an explicit subgraph input
     // to Loop's body subgraph
     OrtValueIndex abs_data_1_out_index;
-    first_subgraph_ort_value_index_map.GetIdx("loop_state_var", abs_data_1_out_index);
+    ASSERT_STATUS_OK(first_subgraph_ort_value_index_map.GetIdx("loop_state_var", abs_data_1_out_index));
 
     // There are no explicit consumers of "abs_data_0_out" and "loop_state_var (abs_data_1_out)" in this scope.
     // There is only one implicit consumer "If". Hence, check that we are preserving the locations of these values
@@ -823,7 +823,7 @@ TEST_F(PlannerTest, LocationPlanningForInitializersOnlyUsedInANestedSubgraph) {
   const auto* main_graph_plan = main_graph_session_state.GetExecutionPlan();
 
   OrtValueIndex init_data_index;
-  main_graph_ort_value_index_map.GetIdx("init_data", init_data_index);
+  ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("init_data", init_data_index));
 
   EXPECT_EQ(main_graph_plan->allocation_plan[init_data_index].location.device.Type(), OrtDevice::GPU);
 }

--- a/onnxruntime/test/framework/cuda/fence_cuda_test.cc
+++ b/onnxruntime/test/framework/cuda/fence_cuda_test.cc
@@ -114,7 +114,7 @@ TEST(CUDAFenceTests, DISABLED_PartOnCPU) {
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());
-  LoadInferenceSessionFromModel(session, *model);
+  ASSERT_STATUS_OK(LoadInferenceSessionFromModel(session, *model));
   ASSERT_STATUS_OK(session.RegisterExecutionProvider(DefaultCudaExecutionProvider()));
   ASSERT_TRUE(session.Initialize().IsOK());
   ASSERT_TRUE(1 == CountCopyNodes(graph));
@@ -165,7 +165,7 @@ TEST(CUDAFenceTests, TileWithInitializer) {
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());
-  LoadInferenceSessionFromModel(session, *model);
+  ASSERT_STATUS_OK(LoadInferenceSessionFromModel(session, *model));
   ASSERT_STATUS_OK(session.RegisterExecutionProvider(DefaultCudaExecutionProvider()));
   ASSERT_STATUS_OK(session.Initialize());
 
@@ -226,7 +226,7 @@ TEST(CUDAFenceTests, TileWithComputedInput) {
 
   SessionOptions so;
   FenceCudaTestInferenceSession session(so, GetEnvironment());
-  LoadInferenceSessionFromModel(session, *model);
+  ASSERT_STATUS_OK(LoadInferenceSessionFromModel(session, *model));
   ASSERT_STATUS_OK(session.RegisterExecutionProvider(DefaultCudaExecutionProvider()));
   ASSERT_TRUE(session.Initialize().IsOK());
 

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -53,7 +53,7 @@ TEST_F(ExecutionFrameTest, TensorAllocationTest) {
   auto cpu_xp = CreateCPUExecutionProvider();
   auto xp_typ = cpu_xp->Type();
   ExecutionProviders execution_providers;
-  execution_providers.Add(xp_typ, std::move(cpu_xp));
+  ASSERT_STATUS_OK(execution_providers.Add(xp_typ, std::move(cpu_xp)));
   KernelRegistryManager kernel_registry_manager;
   ASSERT_STATUS_OK(kernel_registry_manager.RegisterKernels(execution_providers));
 
@@ -125,7 +125,7 @@ TEST_F(ExecutionFrameTest, OutputShapeValidationTest) {
   auto cpu_xp = CreateCPUExecutionProvider();
   auto xp_typ = cpu_xp->Type();
   ExecutionProviders execution_providers;
-  execution_providers.Add(xp_typ, std::move(cpu_xp));
+  ASSERT_STATUS_OK(execution_providers.Add(xp_typ, std::move(cpu_xp)));
   KernelRegistryManager kernel_registry_manager;
   ASSERT_STATUS_OK(kernel_registry_manager.RegisterKernels(execution_providers));
 
@@ -152,7 +152,7 @@ TEST_F(ExecutionFrameTest, OutputShapeValidationTest) {
   // Calling the method with correct shape. It should work without any warnings.
   ASSERT_STATUS_OK(frame.GetOrCreateNodeOutputMLValue(int(node->Index()), 1, &actual_shape_same_as_input, p_ml_value, *node));
 
-  frame.ReleaseMLValue(1);
+  ASSERT_STATUS_OK(frame.ReleaseMLValue(1));
   // Calling the method with in-correct shape. It should work but this time it should display a warning message.
   ASSERT_STATUS_OK(frame.GetOrCreateNodeOutputMLValue(int(node->Index()), 1, &actual_shape_diff_from_input, p_ml_value, *node));
 }
@@ -168,7 +168,7 @@ TEST_F(ExecutionFrameTest, FeedInDataTest) {
 
   graph.AddNode("node1", "Clip", "Clip operator", ArgMap{&input_def}, ArgMap{&output_def})
       .SetExecutionProviderType(kCpuExecutionProvider);
-  graph.Resolve();
+  ASSERT_STATUS_OK(graph.Resolve());
   auto element_type = DataTypeImpl::GetType<float>();
   TensorShape shape({3, 2});
   std::vector<float> fdata(static_cast<size_t>(shape.Size()));
@@ -182,7 +182,7 @@ TEST_F(ExecutionFrameTest, FeedInDataTest) {
 
   KernelRegistryManager kernel_registry_manager;
   ExecutionProviders execution_providers;
-  execution_providers.Add(xp_typ, std::move(cpu_xp));
+  ASSERT_STATUS_OK(execution_providers.Add(xp_typ, std::move(cpu_xp)));
   ASSERT_STATUS_OK(kernel_registry_manager.RegisterKernels(execution_providers));
 
   DataTransferManager dtm;
@@ -239,7 +239,7 @@ TEST_F(ExecutionFrameTest, MemPatternTest) {
   KernelRegistryManager kernel_registry_manager;
 
   ExecutionProviders execution_providers;
-  execution_providers.Add(xp_type, std::move(cpu_xp));
+  ASSERT_STATUS_OK(execution_providers.Add(xp_type, std::move(cpu_xp)));
   ASSERT_STATUS_OK(kernel_registry_manager.RegisterKernels(execution_providers));
   //1. prepare input
 

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -339,7 +339,7 @@ TEST_F(ExecutionFrameTest, MemPatternWithExternalOutputsTest) {
   KernelRegistryManager kernel_registry_manager;
 
   ExecutionProviders execution_providers;
-  execution_providers.Add(xp_type, std::move(cpu_xp));
+  ASSERT_STATUS_OK(execution_providers.Add(xp_type, std::move(cpu_xp)));
   ASSERT_STATUS_OK(kernel_registry_manager.RegisterKernels(execution_providers));
 
   DataTransferManager dtm;

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -2067,7 +2067,8 @@ TEST(InferenceSessionTests, TestArenaShrinkageAfterRun) {
   {
     // Second Run - with shrinkage
     RunOptions run_options_2;
-    run_options_2.config_options.AddConfigEntry(kOrtRunOptionsConfigEnableMemoryArenaShrinkage, "gpu:0");
+    ASSERT_STATUS_OK(run_options_2.config_options.AddConfigEntry(kOrtRunOptionsConfigEnableMemoryArenaShrinkage,
+                                                                 "gpu:0"));
     RunModel(session_object, run_options_2);
 
     static_cast<BFCArena*>(cuda_alloc.get())->GetStats(&alloc_stats);

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -276,7 +276,7 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   std::vector<int64_t> dims_mul_x_A_tmp = {3, 4};
   OrtValue input_tmp;
   CreateMLValue<float>(input_allocator, dims_mul_x_A_tmp, values_mul_x_tmp, &input_tmp);
-  io_binding->BindInput("A", input_tmp);
+  ASSERT_STATUS_OK(io_binding->BindInput("A", input_tmp));
   const void* tmp_A = io_binding->GetInputs()[0].Get<Tensor>().DataRaw();  // location of data post binding
 
   // prepare inputs
@@ -299,8 +299,8 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   CreateMLValue<float>(TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), dims_mul_x_B, values_mul_x,
                        &input_ml_value_B);
 
-  io_binding->BindInput("A", input_ml_value_A);
-  io_binding->BindInput("B", input_ml_value_B);
+  ASSERT_STATUS_OK(io_binding->BindInput("A", input_ml_value_A));
+  ASSERT_STATUS_OK(io_binding->BindInput("B", input_ml_value_B));
 
   // check location of 'A' post-binding has changed to validate that the previous value was replaced
   ASSERT_TRUE(io_binding->GetInputs()[0].Get<Tensor>().DataRaw() != tmp_A);
@@ -321,9 +321,9 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
 
   if (output_device) {
     // output should be allocated on specified device (if not preallocated here)
-    io_binding->BindOutput("Y", *output_device);
+    ASSERT_STATUS_OK(io_binding->BindOutput("Y", *output_device));
   } else {
-    io_binding->BindOutput("Y", output_ml_value);
+    ASSERT_STATUS_OK(io_binding->BindOutput("Y", output_ml_value));
   }
 
   ASSERT_TRUE(io_binding->SynchronizeInputs().IsOK());
@@ -366,7 +366,7 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
 #endif
   } else {
     if (allocation_provider == kCudaExecutionProvider || allocation_provider == kRocmExecutionProvider) {
-      gpu_provider->Sync();
+      ASSERT_STATUS_OK(gpu_provider->Sync());
     }
     VerifyOutputs(io_binding->GetOutputs(), expected_output_dims, expected_values_mul_y);
   }
@@ -924,7 +924,7 @@ TEST(InferenceSessionTests, TestIOBindingReuse) {
   OrtValue ml_value1;
   vector<float> v1{2.f};
   CreateMLValue<float>(TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), {1}, v1, &ml_value1);
-  io_binding->BindOutput("foo", ml_value1);
+  ASSERT_STATUS_OK(io_binding->BindOutput("foo", ml_value1));
   ASSERT_TRUE(io_binding->GetOutputs().size() == 1);
   auto span = io_binding->GetOutputs()[0].Get<Tensor>().DataAsSpan<float>();
   ASSERT_TRUE(static_cast<size_t>(span.size()) == v1.size());
@@ -935,7 +935,7 @@ TEST(InferenceSessionTests, TestIOBindingReuse) {
   OrtValue ml_value2;
   vector<float> v2{3.f};
   CreateMLValue<float>(TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), {1}, v2, &ml_value2);
-  io_binding->BindOutput("foo", ml_value2);
+  ASSERT_STATUS_OK(io_binding->BindOutput("foo", ml_value2));
   ASSERT_TRUE(io_binding->GetOutputs().size() == 1);
   span = io_binding->GetOutputs()[0].Get<Tensor>().DataAsSpan<float>();
   ASSERT_TRUE(static_cast<size_t>(span.size()) == v2.size());
@@ -1296,7 +1296,7 @@ TEST(ExecutionProviderTest, ShapeInferenceForFusedFunctionTest) {
   auto& fused_node_output = *fused_node.MutableOutputDefs()[0];
   fused_node_output.ClearShape();
   fused_graph.SetGraphResolveNeeded();
-  fused_graph.Resolve();
+  ASSERT_STATUS_OK(fused_graph.Resolve());
 
   ASSERT_TRUE(fused_node_output.Shape() != nullptr);
   ASSERT_TRUE(utils::GetTensorShapeFromTensorShapeProto(*fused_node_output.Shape()) == utils::GetTensorShapeFromTensorShapeProto(float_tensor.tensor_type().shape()));
@@ -2558,13 +2558,13 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsUseSameOrtCreatedAllo
   // create sessions to share the allocator
 
   SessionOptions so1;
-  so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1");
+  ASSERT_STATUS_OK(so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
   InferenceSessionTestSharingAllocator sess1(so1, *env);
   ASSERT_STATUS_OK(sess1.Load(MODEL_URI));
   ASSERT_STATUS_OK(sess1.Initialize());
 
   SessionOptions so2;
-  so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1");
+  ASSERT_STATUS_OK(so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
   InferenceSessionTestSharingAllocator sess2(so2, *env);
   ASSERT_STATUS_OK(sess2.Load(MODEL_URI));
   ASSERT_STATUS_OK(sess2.Initialize());
@@ -2603,13 +2603,13 @@ TEST(InferenceSessionTests, AllocatorSharing_EnsureSessionsDontUseSameOrtCreated
   // create sessions to share the allocator
 
   SessionOptions so1;
-  so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1");
+  ASSERT_STATUS_OK(so1.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "1"));
   InferenceSessionTestSharingAllocator sess1(so1, *env);
   ASSERT_STATUS_OK(sess1.Load(MODEL_URI));
   ASSERT_STATUS_OK(sess1.Initialize());
 
   SessionOptions so2;
-  so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "0");
+  ASSERT_STATUS_OK(so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseEnvAllocators, "0"));
   InferenceSessionTestSharingAllocator sess2(so2, *env);
   ASSERT_STATUS_OK(sess2.Load(MODEL_URI));
   ASSERT_STATUS_OK(sess2.Initialize());
@@ -2783,11 +2783,11 @@ TEST(InferenceSessionTests, GlobalThreadPoolWithDenormalAsZero) {
   ASSERT_TRUE(st.IsOK());
 
   SessionOptions so;
-  so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "1");
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "1"));
   so.use_per_session_threads = false;
 
   std::string configValue;
-  so.config_options.TryGetConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, configValue);
+  ASSERT_TRUE(so.config_options.TryGetConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, configValue));
   EXPECT_EQ(configValue, "1");
 
   // Since only the first session option for flush-to-zero and denormal-as-zero are effective,
@@ -2838,7 +2838,7 @@ TEST(InferenceSessionTests, InterThreadPoolWithDenormalAsZero) {
   // inference session without denormal as zero.
   so.execution_mode = ExecutionMode::ORT_PARALLEL;
   // inference session with denormal as zero
-  so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "1");
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "1"));
 
   // Since only the first session option for flush-to-zero and denormal-as-zero are effective,
   // set them manually here for a test.
@@ -2862,7 +2862,7 @@ TEST(InferenceSessionTests, InterThreadPoolWithDenormalAsZero) {
   VerifyThreadPoolWithDenormalAsZero(session1.GetInterOpThreadPoolToUse(), true);
 
   // inference session without denormal as zero.
-  so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "0");
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSetDenormalAsZero, "0"));
 
   // Since only the first session option for flush-to-zero and denormal-as-zero are effective,
   // set them manually here for a test.

--- a/onnxruntime/test/framework/memcpy_transformer_test.cc
+++ b/onnxruntime/test/framework/memcpy_transformer_test.cc
@@ -106,9 +106,9 @@ TEST(TransformerTest, MemcpyTransformerTest) {
 
   KernelRegistryManager kernel_registry_manager;
   ExecutionProviders execution_providers;
-  execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider());
-  execution_providers.Add(onnxruntime::kCpuExecutionProvider,
-                          std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCpuExecutionProvider,
+                                           std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo())));
   KernelRegistryManager test_registry_manager;
   ASSERT_STATUS_OK(test_registry_manager.RegisterKernels(execution_providers));
 
@@ -161,9 +161,9 @@ TEST(TransformerTest, MemcpyTransformerTestCudaFirst) {
 
   KernelRegistryManager kernel_registry_manager;
   ExecutionProviders execution_providers;
-  execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider());
-  execution_providers.Add(onnxruntime::kCpuExecutionProvider,
-                          std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCpuExecutionProvider,
+                                           std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo())));
   KernelRegistryManager test_registry_manager;
   ASSERT_STATUS_OK(test_registry_manager.RegisterKernels(execution_providers));
 
@@ -275,9 +275,9 @@ TEST(TransformerTest, TestCopyNodeInsertionInitializerInSubgraph) {
 
   KernelRegistryManager kernel_registry_manager;
   ExecutionProviders execution_providers;
-  execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider());
-  execution_providers.Add(onnxruntime::kCpuExecutionProvider,
-                          std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCudaExecutionProvider, DefaultCudaExecutionProvider()));
+  ASSERT_STATUS_OK(execution_providers.Add(onnxruntime::kCpuExecutionProvider,
+                                           std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo())));
   KernelRegistryManager test_registry_manager;
   ASSERT_STATUS_OK(test_registry_manager.RegisterKernels(execution_providers));
 

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -44,11 +44,11 @@ static void RunOrtModel(const OrtModelTestInfo& test_info) {
   SessionOptions so;
   so.session_logid = test_info.logid;
   for (const auto& config : test_info.configs) {
-    so.config_options.AddConfigEntry(config.first.c_str(), config.second.c_str());
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(config.first.c_str(), config.second.c_str()));
   }
 
   if (test_info.disable_copy_ort_buffer) {
-    so.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseORTModelBytesDirectly, "1");
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseORTModelBytesDirectly, "1"));
   }
 
   std::vector<char> model_data;
@@ -229,7 +229,7 @@ static void SaveAndCompareModels(const std::string& onnx_file, const std::basic_
   so.session_logid = "SerializeToOrtFormat";
   so.optimized_model_filepath = ort_file;
   // not strictly necessary - type should be inferred from the filename
-  so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSaveModelFormat, "ORT");
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigSaveModelFormat, "ORT"));
   InferenceSessionWrapper session_object{so, GetEnvironment()};
 
   // create .ort file during Initialize due to values in SessionOptions
@@ -240,7 +240,7 @@ static void SaveAndCompareModels(const std::string& onnx_file, const std::basic_
   so2.session_logid = "LoadOrtFormat";
   // not strictly necessary - type should be inferred from the filename, but to be sure we're testing what we
   // think we're testing set it.
-  so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT");
+  ASSERT_STATUS_OK(so2.config_options.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT"));
 
   // load serialized version
   InferenceSessionWrapper session_object2{so2, GetEnvironment()};
@@ -414,7 +414,7 @@ TEST(OrtModelOnlyTests, LoadSparseInitializersOrtFormat) {
   const std::basic_string<ORTCHAR_T> ort_file = ORT_TSTR("testdata/ort_minimal_test_models/sparse_initializer_handling.onnx.ort");
   SessionOptions so;
   so.session_logid = "LoadOrtFormat";
-  so.config_options.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT");
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT"));
   InferenceSessionWrapper session_object{so, GetEnvironment()};
   ASSERT_STATUS_OK(session_object.Load(ort_file));
   ASSERT_STATUS_OK(session_object.Initialize());

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -213,7 +213,7 @@ TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
     // Finalize the session state
     SessionOptions so;
     // disable allocating initialized tensor memory from the arena(by default it will be allocated by the arena)
-    so.config_options.AddConfigEntry(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "1");
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "1"));
     ASSERT_STATUS_OK(session_state.FinalizeSessionState(oss.str(), krm, so));
 
     // Fetch the CPU arena-allocator from the session state
@@ -477,7 +477,7 @@ TEST_P(SessionStatePrepackingTest, PrePackingTest) {
 
   ExecutionProviders execution_providers;
   auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
-  execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider));
+  ASSERT_STATUS_OK(execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider)));
 
   DataTransferManager dtm;
   profiling::Profiler profiler;
@@ -538,7 +538,7 @@ TEST(SessionStateTest, SharedInitalizersWithPrePackingTest) {
 
   ExecutionProviders execution_providers;
   auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
-  execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider));
+  ASSERT_STATUS_OK(execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider)));
 
   DataTransferManager dtm;
   profiling::Profiler profiler;
@@ -630,7 +630,7 @@ TEST(SessionStateTest, SharedInitalizersWithPrePackingTest) {
     Tensor::InitOrtValue(DataTypeImpl::GetType<float>(),
                          TensorShape(std::vector<int64_t>{1}), reinterpret_cast<void*>(float_data.data()), mem_info, *value);
 
-    sess_options.AddInitializer("node_0_input_1", value.get());
+    ASSERT_STATUS_OK(sess_options.AddInitializer("node_0_input_1", value.get()));
 
     // First session/model
     Model model_1("graph_main", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
@@ -700,7 +700,7 @@ TEST(SessionStateTest, SharedInitalizersWithPrePackingTest) {
     Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape(std::vector<int64_t>{1}),
                          reinterpret_cast<void*>(float_data.data()), mem_info, *value);
 
-    sess_options.AddInitializer("node_0_input_1", value.get());
+    ASSERT_STATUS_OK(sess_options.AddInitializer("node_0_input_1", value.get()));
 
     // Enable pre-packed weights container
     PrepackedWeightsContainer prepacked_weights_container;

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -794,7 +794,7 @@ static void TestConversion(bool use_1D_indices, int32_t indices_type,
   TensorProto dense;
   // Path is required for loading external data (if any)
   // When path is empty it will look for the data in current dir
-  utils::ConstantNodeProtoToTensorProto(node, Path(), dense);
+  ASSERT_STATUS_OK(utils::ConstantNodeProtoToTensorProto(node, Path(), dense));
 
   gsl::span<const T> expected_span = gsl::make_span<const T>(expected.data(), expected.size());
   checker(expected_span, dense);
@@ -809,7 +809,7 @@ static void TestConversionAllZeros(bool use_1D_indices,
   TensorProto dense;
   // Path is required for loading external data (if any)
   // When path is empty it will look for the data in current dir
-  utils::ConstantNodeProtoToTensorProto(node, Path(), dense);
+  ASSERT_STATUS_OK(utils::ConstantNodeProtoToTensorProto(node, Path(), dense));
 
   gsl::span<const T> expected_span = gsl::make_span<const T>(expected.data(), expected.size());
   checker(expected_span, dense);
@@ -1123,7 +1123,7 @@ static void TestDenseToSparseConversionValues(size_t indices_start,
   TensorProto dense_tensor = CreateDenseTensor(indices_start, inserter, expected_values, expected_indicies);
 
   SparseTensorProto sparse_tensor;
-  utils::DenseTensorToSparseTensorProto(dense_tensor, model_path, sparse_tensor);
+  ASSERT_STATUS_OK(utils::DenseTensorToSparseTensorProto(dense_tensor, model_path, sparse_tensor));
 
   gsl::span<const T>
       expected_values_span = gsl::make_span(expected_values.data(), expected_values.size());
@@ -1146,7 +1146,7 @@ static void TestDenseAllZerosToSparseConversion(
   TensorProto dense_tensor = CreateDenseTensorAllZeros(inserter);
 
   SparseTensorProto sparse_tensor;
-  utils::DenseTensorToSparseTensorProto(dense_tensor, model_path, sparse_tensor);
+  ASSERT_STATUS_OK(utils::DenseTensorToSparseTensorProto(dense_tensor, model_path, sparse_tensor));
 
   gsl::span<const T>
       expected_values_span = gsl::make_span(expected_values.data(), expected_values.size());
@@ -1316,7 +1316,7 @@ TEST(SparseTensorConversionTests, CsrConversion) {
   DataTransferManager dtm;
   {
     auto cpu_transfer = cpu_provider->GetDataTransfer();
-    dtm.RegisterDataTransfer(std::move(cpu_transfer));
+    ASSERT_STATUS_OK(dtm.RegisterDataTransfer(std::move(cpu_transfer)));
   }
   {
     {
@@ -1535,7 +1535,7 @@ TEST(SparseTensorConversionTests, CooConversion) {
   DataTransferManager dtm;
   {
     auto cpu_transfer = cpu_provider->GetDataTransfer();
-    dtm.RegisterDataTransfer(std::move(cpu_transfer));
+    ASSERT_STATUS_OK(dtm.RegisterDataTransfer(std::move(cpu_transfer)));
   }
 
   {
@@ -1744,7 +1744,7 @@ TEST(SparseTensorConversionTests, BlockSparse) {
   DataTransferManager dtm;
   {
     auto cpu_transfer = cpu_provider->GetDataTransfer();
-    dtm.RegisterDataTransfer(std::move(cpu_transfer));
+    ASSERT_STATUS_OK(dtm.RegisterDataTransfer(std::move(cpu_transfer)));
   }
 
   {

--- a/onnxruntime/test/framework/sparse_kernels_test.cc
+++ b/onnxruntime/test/framework/sparse_kernels_test.cc
@@ -1455,7 +1455,7 @@ TEST(SparseTensorConversionTests, CsrConversion) {
   auto cuda_allocator = cuda_provider->GetAllocator(0, OrtMemTypeDefault);
   {
     auto cuda_transfer = cuda_provider->GetDataTransfer();
-    dtm.RegisterDataTransfer(std::move(cuda_transfer));
+    ASSERT_STATUS_OK(dtm.RegisterDataTransfer(std::move(cuda_transfer)));
   }
   {
     // test where source is on GPU and destination is on CPU
@@ -1682,7 +1682,7 @@ TEST(SparseTensorConversionTests, CooConversion) {
   auto cuda_allocator = cuda_provider->GetAllocator(0, OrtMemTypeDefault);
   {
     auto cuda_transfer = cuda_provider->GetDataTransfer();
-    dtm.RegisterDataTransfer(std::move(cuda_transfer));
+    ASSERT_STATUS_OK(dtm.RegisterDataTransfer(std::move(cuda_transfer)));
   }
   {
     // test where source is on GPU and destination is on GPU

--- a/onnxruntime/test/ir/common_data_structure_test.cc
+++ b/onnxruntime/test/ir/common_data_structure_test.cc
@@ -3,6 +3,7 @@
 
 #include "core/graph/record.h"
 #include "gtest/gtest.h"
+#include "asserts.h"
 
 using namespace ::onnxruntime::common;
 
@@ -22,12 +23,12 @@ TEST(RecordTest, CommonDataStructureTest) {
   auto status = record.GetName(2, &name);
   EXPECT_FALSE(status.IsOK());
 
-  record.GetName(0, &name);
+  ASSERT_STATUS_OK(record.GetName(0, &name));
   auto& value = std::get<0>(record.GetValues());
   EXPECT_EQ("featureName", *name);
   EXPECT_EQ("streamLength", value);
 
-  record.GetName(1, &name);
+  ASSERT_STATUS_OK(record.GetName(1, &name));
   auto& value2 = std::get<1>(record.GetValues());
   EXPECT_EQ("featureValue", *name);
   EXPECT_EQ(2.0f, value2);
@@ -37,7 +38,7 @@ TEST(RecordTest, CommonDataStructureTest) {
   std::tuple<float> values2(2.0f);
   Record<float> record2(names, values2);
 
-  record2.GetName(0, &name);
+  ASSERT_STATUS_OK(record2.GetName(0, &name));
   auto& value3 = std::get<0>(record2.GetValues());
   EXPECT_EQ("streamLength", *name);
   EXPECT_EQ(2.0f, value3);

--- a/onnxruntime/test/optimizer/free_dimension_override_test.cc
+++ b/onnxruntime/test/optimizer/free_dimension_override_test.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "core/optimizer/free_dim_override_transformer.h"
 #include "core/session/inference_session.h"
+#include "asserts.h"
 
 using namespace std;
 using namespace ONNX_NAMESPACE;
@@ -42,10 +43,10 @@ void TestFreeDimensions(FreeDimensionOverrideType overrideType) {
   auto graph_transformer = std::make_unique<FreeDimensionOverrideTransformer>(overrides);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr(5);
-  graph_transformation_mgr.Register(std::move(graph_transformer), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(graph_transformer), TransformerLevel::Level1));
 
-  graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1,
-                                             DefaultLoggingManager().DefaultLogger());
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1,
+                                                              DefaultLoggingManager().DefaultLogger()));
 
   // Verify that the shape of the input graph has the correct values
 

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -93,9 +93,9 @@ TEST_F(GraphTransformationTests, IdentityElimination) {
   ASSERT_TRUE(op_to_count["Identity"] == 1);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<EliminateIdentity>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateIdentity>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -111,9 +111,9 @@ TEST_F(GraphTransformationTests, IdentityEliminationWithGraphOutput) {
   ASSERT_TRUE(op_to_count["Identity"] == 1);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<EliminateIdentity>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateIdentity>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -130,10 +130,11 @@ TEST_F(GraphTransformationTests, IdentityWithSharedNodeArgNotEliminated) {
   ASSERT_TRUE(op_to_count["Add"] == 2);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<CommonSubexpressionElimination>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<CommonSubexpressionElimination>(),
+                                                     TransformerLevel::Level1));
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<EliminateIdentity>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateIdentity>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // after CommonSubexpressionElimination, Add would have 1 output def and 2 edges
@@ -157,8 +158,8 @@ TEST_F(GraphTransformationTests, IdentityInputIsGraphOutputNotEliminated) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<EliminateIdentity>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateIdentity>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // Identity's input in subgraph is also graph output. Thus skip.
@@ -175,9 +176,9 @@ TEST_F(GraphTransformationTests, NoopElimination) {
   ASSERT_TRUE(op_to_count["Add"] == 4);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<NoopElimination>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<NoopElimination>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -194,9 +195,9 @@ TEST_F(GraphTransformationTests, DropoutElimination) {
   ASSERT_TRUE(op_to_count["Dropout"] == 6);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<EliminateDropout>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateDropout>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -219,9 +220,9 @@ TEST_F(GraphTransformationTests, SliceElimination) {
     int initial_slice_num = op_to_count["Slice"];
 
     auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-    rule_transformer_L1->Register(std::make_unique<EliminateSlice>());
+    ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<EliminateSlice>()));
     onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-    graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+    ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
     ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
     op_to_count = CountOpsInGraph(graph);
@@ -240,7 +241,8 @@ TEST_F(GraphTransformationTests, ConstantFolding) {
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -258,7 +260,8 @@ TEST_F(GraphTransformationTests, ConstantFoldingNodesOnDifferentEP) {
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1));
 
   // assign all nodes to CUDA. the constant folding should override this to perform the constant folding on cpu
   for (auto& node : graph.Nodes()) {
@@ -339,7 +342,8 @@ TEST_F(GraphTransformationTests, ConstantFoldingSubgraph) {
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -364,13 +368,14 @@ TEST_F(GraphTransformationTests, ConstantFoldingWithShapeToInitializer) {
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(),
-                                                                      false /*skip_dequantize_linear*/,
-                                                                      compatible_eps,
-                                                                      excluded_initializers),
-                                    TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(),
+                                        false /*skip_dequantize_linear*/,
+                                        compatible_eps,
+                                        excluded_initializers),
+      TransformerLevel::Level1));
 
-  ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_).IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -392,12 +397,13 @@ TEST_F(GraphTransformationTests, ConstantFoldingWithScalarShapeToInitializer) {
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(),
-                                                                      false /*skip_dequantize_linear*/,
-                                                                      compatible_eps),
-                                    TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(),
+                                        false /*skip_dequantize_linear*/,
+                                        compatible_eps),
+      TransformerLevel::Level1));
 
-  ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_).IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -419,13 +425,13 @@ static void VerifyConstantFoldingWithDequantizeLinear(int quantize_linear_count,
   auto transformers = optimizer_utils::GenerateTransformers(TransformerLevel::Level1, session_options, *e.get(), {});
   for (auto& transformer : transformers) {
     if (transformer->Name() == "ConstantFolding") {
-      graph_transformation_mgr.Register(std::move(transformer), TransformerLevel::Level1);
+      ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(transformer), TransformerLevel::Level1));
       has_constant_folding = true;
     }
   }
 
   ASSERT_TRUE(has_constant_folding);
-  ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, logger).IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["QuantizeLinear"] == quantize_linear_count);
@@ -436,7 +442,7 @@ static void VerifyConstantFoldingWithDequantizeLinear(int quantize_linear_count,
 TEST_F(GraphTransformationTests, ConstantFoldingWithDequantizeLinear) {
   auto model_uri = MODEL_FOLDER "fusion/constant_folding_dequantizelinear.onnx";
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, model, nullptr, *logger_));
   Graph& graph = model->MainGraph();
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["QuantizeLinear"] == 1);
@@ -448,18 +454,18 @@ TEST_F(GraphTransformationTests, ConstantFoldingWithDequantizeLinear) {
   VerifyConstantFoldingWithDequantizeLinear(1, 3, 1, graph, session_options, *logger_);
 
   // set kOrtSessionOptionsDisableQuantQDQ to enable it explicitly
-  session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "0");
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "0"));
   VerifyConstantFoldingWithDequantizeLinear(1, 3, 1, graph, session_options, *logger_);
 
   // set SessionOptionsEnableQuantQDQ to disable it
-  session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "1");
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableQuantQDQ, "1"));
   VerifyConstantFoldingWithDequantizeLinear(1, 1, 1, graph, session_options, *logger_);
 }
 
 TEST_F(GraphTransformationTests, ConstantFolding_RemoveDanglingInputNodesToConstantFoldedNode) {
   auto model_uri = MODEL_FOLDER "fusion/constant_folding_remove_dangling_inputs.onnx";
   std::shared_ptr<Model> model;
-  ASSERT_TRUE(Model::Load(model_uri, model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, model, nullptr, *logger_));
   Graph& graph = model->MainGraph();
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 1);          // Shape node that will be constant folded
@@ -469,7 +475,8 @@ TEST_F(GraphTransformationTests, ConstantFolding_RemoveDanglingInputNodesToConst
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -490,9 +497,8 @@ TEST_F(GraphTransformationTests, ConstantFoldingAShapeNodeDeepInTheGraph) {
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   std::unique_ptr<CPUExecutionProvider> e =
       std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
-  graph_transformation_mgr.Register(std::make_unique<ConstantFolding>(*e.get(),
-                                                                      false /*skip_dequantize_linear*/),
-                                    TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(
+      std::make_unique<ConstantFolding>(*e.get(), false /*skip_dequantize_linear*/), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -548,8 +554,8 @@ TEST_F(GraphTransformationTests, FuseConvBNNoBias) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
-  rule_transformer_L1->Register(std::make_unique<ConvBNFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -582,8 +588,8 @@ TEST_F(GraphTransformationTests, DontFuseConvWithBNWithOptionalOutputs) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
-  rule_transformer_L1->Register(std::make_unique<ConvBNFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -604,11 +610,11 @@ TEST_F(GraphTransformationTests, FuseConvBNMulAddUnsqueeze) {
 
     onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
     auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-    rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>());
-    rule_transformer_L1->Register(std::make_unique<ConvAddFusion>());
-    rule_transformer_L1->Register(std::make_unique<ConvBNFusion>());
-    rule_transformer_L1->Register(std::make_unique<ConvMulFusion>());
-    graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+    ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>()));
+    ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvAddFusion>()));
+    ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+    ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvMulFusion>()));
+    ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
     ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -631,8 +637,8 @@ TEST_F(GraphTransformationTests, DivMulFusion) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<DivMulFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<DivMulFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -651,8 +657,8 @@ TEST_F(GraphTransformationTests, NotWhereFusion) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<NotWhereFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<NotWhereFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -674,7 +680,7 @@ TEST_F(GraphTransformationTests, FuseCudaConvAddRelu) {
   ASSERT_TRUE(op_to_count["Add"] == 1);
   ASSERT_TRUE(op_to_count["Relu"] == 1);
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);   //Add removed from graph
@@ -695,7 +701,7 @@ TEST_F(GraphTransformationTests, FuseCudaConvAddReluIdentity) {
   ASSERT_TRUE(op_to_count["Relu"] == 1);
   ASSERT_TRUE(op_to_count["Identity"] == 1);
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 1);       //Add remains
@@ -715,7 +721,7 @@ TEST_F(GraphTransformationTests, FuseCudaConvAdd) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 1);
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 1);  //Add remains, no transform applied to the graph
@@ -750,7 +756,7 @@ TEST_F(GraphTransformationTests, FuseConvActivation) {
 
     // Apply transformer
     onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-    graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2);
+    ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2));
     ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
     op_to_count = CountOpsInGraph(graph);
@@ -769,7 +775,7 @@ TEST_F(GraphTransformationTests, FuseConvClip11Activation) {
 
   // Apply transformer
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -805,9 +811,9 @@ TEST_F(GraphTransformationTests, FuseConvMulNoBias) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>());
-  rule_transformer_L1->Register(std::make_unique<ConvMulFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvMulFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -825,9 +831,9 @@ TEST_F(GraphTransformationTests, FuseConvAddNoBias) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>());
-  rule_transformer_L1->Register(std::make_unique<ConvAddFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvAddFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -847,9 +853,9 @@ TEST_F(GraphTransformationTests, NegativeFuseConvAddNoBias) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>());
-  rule_transformer_L1->Register(std::make_unique<ConvAddFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<UnsqueezeElimination>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvAddFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
@@ -868,9 +874,9 @@ static void TestFuseConvAddMul(logging::Logger& logger, const CharType* model_ur
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
-  rule_transformer_L1->Register(std::make_unique<ConvAddFusion>());
-  rule_transformer_L1->Register(std::make_unique<ConvMulFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvAddFusion>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvMulFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, logger));
 
@@ -907,7 +913,7 @@ TEST_F(GraphTransformationTests, MatMulAddFusion_two_input) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -924,7 +930,7 @@ TEST_F(GraphTransformationTests, MatMulAddFusion_three_input) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -945,7 +951,7 @@ TEST_F(GraphTransformationTests, MatMulAddFusion_negitive_case) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -964,7 +970,7 @@ TEST_F(GraphTransformationTests, MatMulAddFusion_NotBroadcastable) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -981,7 +987,7 @@ TEST_F(GraphTransformationTests, MatMulAddFusion_MissingShape) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulAddFusion>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -999,7 +1005,7 @@ TEST_F(GraphTransformationTests, Gemm_Relu_three_input) {
   Graph& graph = p_model->MainGraph();
   std::map<std::string, int> op_to_count1 = CountOpsInGraph(graph);
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GemmActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GemmActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1009,13 +1015,12 @@ TEST_F(GraphTransformationTests, Gemm_Relu_three_input) {
 TEST_F(GraphTransformationTests, TransposeMatmulFusion) {
   auto model_uri = MODEL_FOLDER "fusion/transpose_matmul_4d_fusion.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
@@ -1036,14 +1041,14 @@ TEST_F(GraphTransformationTests, TransposeCastMatmulFusion) {
   };
   for (const auto& model_uri : model_uris) {
     std::shared_ptr<Model> p_model;
-    ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+    ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
     Graph& graph = p_model->MainGraph();
     std::map<std::string, int> orig_op_to_count = CountOpsInGraph(graph);  // Original op count
 
     onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-    graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(), TransformerLevel::Level1);
-    auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-    ASSERT_TRUE(ret.IsOK());
+    ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(),
+                                                       TransformerLevel::Level1));
+    ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
     std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
     ASSERT_TRUE(op_to_count["Transpose"] == 0);
     ASSERT_TRUE(op_to_count["MatMul"] == 0);
@@ -1055,13 +1060,13 @@ TEST_F(GraphTransformationTests, TransposeCastMatmulFusion) {
 TEST_F(GraphTransformationTests, TransposeMatmulFusionOnTwoTranspose) {
   auto model_uri = MODEL_FOLDER "fusion/transpose_matmul_4d_fusion_2_transpose.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(),
+                                                     TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
@@ -1077,13 +1082,13 @@ TEST_F(GraphTransformationTests, TransposeMatmulFusionOnTwoTranspose) {
 TEST_F(GraphTransformationTests, TransposeMatmulFusionOnThreeTranspose) {
   auto model_uri = MODEL_FOLDER "fusion/transpose_matmul_4d_fusion_3_transpose.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatmulTransposeFusion>(),
+                                                     TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Transpose"] == 0);
@@ -1180,7 +1185,7 @@ TEST_F(GraphTransformationTests, Gemm_LeakyRelu_Fusion) {
   Graph& graph = p_model->MainGraph();
   std::map<std::string, int> op_to_count1 = CountOpsInGraph(graph);
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GemmActivationFusion>(), TransformerLevel::Level2);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GemmActivationFusion>(), TransformerLevel::Level2));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1202,8 +1207,8 @@ TEST_F(GraphTransformationTests, GemmTransposeFusion2Inputs) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -1232,8 +1237,8 @@ TEST_F(GraphTransformationTests, GemmTransposeFusion2OutputsFromTranspose) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -1268,8 +1273,8 @@ TEST_F(GraphTransformationTests, GemmTransposeFusion2OutputsFromTransposeTo2Gemm
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -1316,8 +1321,8 @@ TEST_F(GraphTransformationTests, GemmTransposeFusionOutput) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -1345,8 +1350,8 @@ TEST_F(GraphTransformationTests, GemmTransposeFusionInputOutput) {
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>());
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
@@ -1368,18 +1373,18 @@ TEST_F(GraphTransformationTests, FuseConvBnAddMulFloat16) {
   SessionOptions so;
   so.session_logid = "GraphTransformationTests.LoadModelToTransform";
   InferenceSession session_object{so, GetEnvironment()};
-  ASSERT_TRUE(session_object.Load(model_uri).IsOK());
+  ASSERT_STATUS_OK(session_object.Load(model_uri));
 
   std::shared_ptr<Model> p_model;
   ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
-  rule_transformer_L1->Register(std::make_unique<ConvAddFusion>());
-  rule_transformer_L1->Register(std::make_unique<ConvBNFusion>());
-  rule_transformer_L1->Register(std::make_unique<ConvMulFusion>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvAddFusion>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvMulFusion>()));
   ASSERT_STATUS_OK(session_object.RegisterGraphTransformer(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
-  ASSERT_TRUE(session_object.Initialize().IsOK());
+  ASSERT_STATUS_OK(session_object.Initialize());
 
   NameMLValMap feeds;
   RunOptions run_options;
@@ -1400,7 +1405,7 @@ TEST_F(GraphTransformationTests, FuseConvBnAddMulFloat16) {
   output_names.push_back("PROD");
   std::vector<OrtValue> fetches;
 
-  ASSERT_TRUE(session_object.Run(run_options, feeds, output_names, &fetches).IsOK());
+  ASSERT_STATUS_OK(session_object.Run(run_options, feeds, output_names, &fetches));
 
   auto prod_f = MLFloat16(math::floatToHalf(6.0));
   std::vector<int64_t> expected_dims_prod = {1, 1, 2, 2};
@@ -1472,10 +1477,10 @@ TEST_F(GraphTransformationTests, ReluClip6Fusion) {
   ASSERT_TRUE(op_to_count["Relu"] == 3);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<FuseReluClip>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<FuseReluClip>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
-  ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_).IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Relu"] == 0);
@@ -1557,18 +1562,16 @@ TEST_F(GraphTransformationTests, ReluClip11Fusion) {
   auto& clip3 = graph.AddNode("clip3", "Clip", "Clip with no min", {&relu3_output}, {&clip3_output});
 
   graph.SetInputs({&input0, &input1, &input2, &input3, &min_input_0});
-  auto status = graph.Resolve();
-  EXPECT_EQ(status, Status::OK()) << status;
+  ASSERT_STATUS_OK(graph.Resolve());
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Relu"] == 4);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<FuseReluClip>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<FuseReluClip>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
-  status = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(status.IsOK()) << status;
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Relu"] == 1) << "All except the first Relu should have been fused";
@@ -1621,9 +1624,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -1658,9 +1660,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionOneConstTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -1690,13 +1691,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionOneConstTest) {
 TEST_F(GraphTransformationTests, ReshapeFusionInternalNodeIsOutput) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_internal_node_is_graph_output.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 1);
@@ -1727,13 +1727,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionInternalNodeIsOutput) {
 TEST_F(GraphTransformationTests, ReshapeFusionInternalReuseTest) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_internal_nodes_reused.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 1);
@@ -1772,9 +1771,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionGraphInputsTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 1);
@@ -1787,14 +1785,13 @@ TEST_F(GraphTransformationTests, ReshapeFusionGraphInputsTest) {
 TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerSubgraphTest) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_multiple_values_in_initializer_tensor_1.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
   std::map<std::string, int> op_to_count_orig = CountOpsInGraph(graph);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // The optimization does not apply.
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1823,13 +1820,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerSubgrap
 TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerAppliesTest) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_multiple_values_in_initializer_tensor_2.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -1857,13 +1853,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerApplies
 TEST_F(GraphTransformationTests, ReshapeFusionAnotherGraphInput) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_input_is_graph_input.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // The optimization does not apply.
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1877,14 +1872,13 @@ TEST_F(GraphTransformationTests, ReshapeFusionAnotherGraphInput) {
 TEST_F(GraphTransformationTests, ReshapeFusionOverridableInitializer) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_overridable_initializer.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
   std::map<std::string, int> op_to_count_orig = CountOpsInGraph(graph);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // The optimization does not apply.
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1894,13 +1888,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionOverridableInitializer) {
 TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphMultipleOutputs) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_concat_subgraph_multiple_outputs.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // The optimization applies but certain paths with multiple outputs/graph outputs are not removed.
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
@@ -1930,13 +1923,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphMultipleOutputs) {
 TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraph) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_concat_subgraph.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -1965,13 +1957,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraph) {
 TEST_F(GraphTransformationTests, ReshapeFusionWithSlice1) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_with_slice1.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -2000,13 +1991,12 @@ TEST_F(GraphTransformationTests, ReshapeFusionWithSlice1) {
 TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphNotTriggered) {
   auto model_uri = MODEL_FOLDER "fusion/reshape_fusion_concat_subgraph_not_triggered.onnx";
   std::shared_ptr<Model> p_model;
-  ASSERT_TRUE(Model::Load(model_uri, p_model, nullptr, *logger_).IsOK());
+  ASSERT_STATUS_OK(Model::Load(model_uri, p_model, nullptr, *logger_));
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // Two of the branches leading to Concat are candidates to trigger the optimization
   // (Shape -> Gather -> Unsqueeze -> Concat).
@@ -2039,9 +2029,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithDiv) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -2076,9 +2065,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithMul) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_EQ(op_to_count["Shape"], 0);
@@ -2113,9 +2101,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionDistilBertTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ReshapeFusion>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -2150,9 +2137,8 @@ TEST_F(GraphTransformationTests, ConcatSliceEliminationTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ConcatSliceElimination>(), TransformerLevel::Level1);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ConcatSliceElimination>(), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Concat"] == 0);
@@ -2168,9 +2154,9 @@ TEST_F(GraphTransformationTests, ExpandElimination) {
   ASSERT_TRUE(op_to_count["Expand"] == 6);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<ExpandElimination>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ExpandElimination>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
   ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_).IsOK());
 
   op_to_count = CountOpsInGraph(graph);
@@ -2186,10 +2172,10 @@ TEST_F(GraphTransformationTests, CastElimination) {
   ASSERT_TRUE(op_to_count["Cast"] == 7);
 
   auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformer1");
-  rule_transformer_L1->Register(std::make_unique<CastElimination>());
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<CastElimination>()));
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
-  ASSERT_TRUE(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_).IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 4);
@@ -2317,9 +2303,8 @@ TEST_F(GraphTransformationTests, AttentionFusionInt32Test) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["MatMul"], 1);
@@ -2340,9 +2325,8 @@ TEST_F(GraphTransformationTests, AttentionFusionInt64Test) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["MatMul"], 1);
@@ -2363,9 +2347,8 @@ TEST_F(GraphTransformationTests, AttentionFusionFloat32Test) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["MatMul"], 1);
@@ -2389,9 +2372,8 @@ TEST_F(GraphTransformationTests, AttentionFusionWithPastAndUnidirMaskTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
@@ -2417,9 +2399,8 @@ TEST_F(GraphTransformationTests, AttentionFusionWithPastAndNoUnidirMaskTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
@@ -2445,9 +2426,8 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTWithPastAndMaskTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
@@ -2463,9 +2443,8 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTWithPastNoMaskTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
@@ -2481,9 +2460,8 @@ TEST_F(GraphTransformationTests, AttentionFusionGPTTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Transpose"], 0);
@@ -2498,9 +2476,8 @@ TEST_F(GraphTransformationTests, AttentionFusionDistilBertTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2);
-  auto ret1 = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret1.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<AttentionFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["ReduceSum"], 0);
@@ -2520,9 +2497,8 @@ TEST_F(GraphTransformationTests, GeluFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -2539,9 +2515,8 @@ TEST_F(GraphTransformationTests, GeluFusionTestSwitchOrderFormat2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -2558,9 +2533,8 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -2577,9 +2551,8 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphInput) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -2596,10 +2569,9 @@ TEST_F(GraphTransformationTests, GeluFusionTestFormat2GraphOutput) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["com.microsoft.Gelu"] == 0);
@@ -2613,10 +2585,10 @@ TEST_F(GraphTransformationTests, BiasGeluTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
+
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2698,10 +2670,10 @@ TEST_F(GraphTransformationTests, GeluApproximation_SessionOptionConfig) {
   // GeluApproximation is not enabled by default.
   VerifyGeluApproximation(false, session_options);
 
-  session_options.config_options.AddConfigEntry(kOrtSessionOptionsEnableGeluApproximation, "1");
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsEnableGeluApproximation, "1"));
   VerifyGeluApproximation(true, session_options);
 
-  session_options.config_options.AddConfigEntry(kOrtSessionOptionsEnableGeluApproximation, "0");
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsEnableGeluApproximation, "0"));
   VerifyGeluApproximation(false, session_options);
 }
 
@@ -2713,9 +2685,8 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["com.microsoft.Gelu"], 0);
@@ -2730,9 +2701,8 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu_Add_Bias) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["com.microsoft.BiasGelu"], 0);
@@ -2747,9 +2717,8 @@ TEST_F(GraphTransformationTests, GeluApproximation_Gelu_Add_MatMul) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GeluApproximation>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["com.microsoft.BiasGelu"], 0);
@@ -2765,9 +2734,8 @@ TEST_F(GraphTransformationTests, FastGeluFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Identity"] == 2);
@@ -2785,9 +2753,8 @@ TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2804,10 +2771,9 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2824,10 +2790,9 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2844,9 +2809,8 @@ TEST_F(GraphTransformationTests, FastGeluFusionTest2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2863,9 +2827,8 @@ TEST_F(GraphTransformationTests, FastGeluUseGraphInputFusionTest2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2882,10 +2845,9 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasFusionTest2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2902,10 +2864,9 @@ TEST_F(GraphTransformationTests, FastGeluWithBiasUseGraphInputFusionTest2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2923,15 +2884,14 @@ TEST_F(GraphTransformationTests, FastGeluFusionWithCastsTest3) {
 
   // ORTModule for gpt2 model has two casts fused into one before FastGeluFusion
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<CommonSubexpressionElimination>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<CommonSubexpressionElimination>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Cast"] == 2);
 
-  graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<FastGeluFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -2972,8 +2932,8 @@ struct BiasSoftmaxFusionTester {
     // move to cuda since fusion only takes place in that case
     SetExecutionProvider(execution_provider);
 
-    graph_transformation_mgr_.Register(
-        std::make_unique<BiasSoftmaxFusion>(), TransformerLevel::Level2);
+    ORT_THROW_IF_ERROR(graph_transformation_mgr_.Register(
+        std::make_unique<BiasSoftmaxFusion>(), TransformerLevel::Level2));
   }
 
   void SetExecutionProvider(const char* ep) {
@@ -2988,8 +2948,7 @@ struct BiasSoftmaxFusionTester {
     int expected_softmax_axis = 1;
     GetAxis("Softmax", "axis", &expected_softmax_axis);
 
-    auto ret = graph_transformation_mgr_.ApplyTransformers(p_model_->MainGraph(), TransformerLevel::Level2, *logger_);
-    ASSERT_STATUS_OK(ret);
+    ASSERT_STATUS_OK(graph_transformation_mgr_.ApplyTransformers(p_model_->MainGraph(), TransformerLevel::Level2, *logger_));
     std::map<std::string, int> op_to_count = CountOpsInGraph(p_model_->MainGraph());
 
     ASSERT_EQ(op_to_count["Add"], 0);
@@ -3007,8 +2966,7 @@ struct BiasSoftmaxFusionTester {
   void TestNoFusionOccurs() {
     ASSERT_STATUS_OK(model_load_);
 
-    auto ret = graph_transformation_mgr_.ApplyTransformers(p_model_->MainGraph(), TransformerLevel::Level2, *logger_);
-    ASSERT_STATUS_OK(ret);
+    ASSERT_STATUS_OK(graph_transformation_mgr_.ApplyTransformers(p_model_->MainGraph(), TransformerLevel::Level2, *logger_));
 
     std::map<std::string, int> op_to_count = CountOpsInGraph(p_model_->MainGraph());
     ASSERT_EQ(op_to_count["Add"], 1);
@@ -3077,9 +3035,8 @@ static void TestBiasDropoutFusion(const PathString& file_path, const logging::Lo
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<BiasDropoutFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, logger);
-  ASSERT_STATUS_OK(ret);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<BiasDropoutFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
@@ -3105,9 +3062,8 @@ TEST_F(GraphTransformationTests, LayerNormFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -3141,9 +3097,8 @@ TEST_F(GraphTransformationTests, LayerNormWithCastFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
@@ -3163,9 +3118,8 @@ TEST_F(GraphTransformationTests, LayerNormWithCastFusionTest_2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
@@ -3180,9 +3134,8 @@ TEST_F(GraphTransformationTests, LayerNormWithSubDupFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -3216,9 +3169,8 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -3248,9 +3200,8 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormWithCastsFusionTest_Precisio
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 1);
@@ -3270,9 +3221,8 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormWithCastsFusionTest_Precisio
 
   std::unordered_set<std::string> compatible_eps;
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(compatible_eps, true), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SimplifiedLayerNormFusion>(compatible_eps, true), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -3305,10 +3255,9 @@ static void TestSkipLayerNormFusion(const std::basic_string<ORTCHAR_T>& file_pat
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Div"] == 0);
@@ -3342,10 +3291,9 @@ TEST_F(GraphTransformationTests, SkipLayerNormFusion_Input_Output_Check) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<LayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   for (Node& node : graph.Nodes()) {
     if (node.OpType() == "SkipLayerNormalization") {
@@ -3379,9 +3327,8 @@ TEST_F(GraphTransformationTests, SkipLayerNormFusion_NoBeta) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<SkipLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Add"] == 0);
@@ -3396,9 +3343,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat1) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Gather"] == 0);
@@ -3416,9 +3362,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat2) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -3442,9 +3387,8 @@ static void EmbedLayerNormFusionFormat3(const std::basic_string<ORTCHAR_T>& file
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Shape"], 0);
@@ -3475,9 +3419,8 @@ static void EmbedLayerNormFusionFormat3NoCast(const std::basic_string<ORTCHAR_T>
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Shape"], 0);
@@ -3509,9 +3452,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionFormat4) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   ASSERT_TRUE(op_to_count["Shape"] == 0);
@@ -3536,9 +3478,8 @@ static void EmbedLayerNormFusionFormat5(const std::basic_string<ORTCHAR_T>& file
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Gather"], 0);
@@ -3585,9 +3526,8 @@ static void EmbedLayerNormFusionFormat6(const std::basic_string<ORTCHAR_T>& file
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Shape"], 0);
@@ -3623,9 +3563,8 @@ static void TestEmbedLayerNormFusionDistilBert(const std::basic_string<ORTCHAR_T
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret1 = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret1.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   op_to_count = CountOpsInGraph(graph);
 }
@@ -3709,9 +3648,8 @@ static void EmbedLayerNormFusionFormatMultiple(const std::basic_string<ORTCHAR_T
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<EmbedLayerNormFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["Shape"], 0);
@@ -3743,10 +3681,9 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["DynamicQuantizeLinear"], 0);
@@ -3763,10 +3700,9 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_Bias) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["DynamicQuantizeLinear"], 0);
@@ -3783,10 +3719,9 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_ND_bias) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["DynamicQuantizeLinear"], 0);
@@ -3804,10 +3739,9 @@ TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest_With_Bias_No_B_ZP) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["DynamicQuantizeLinear"], 0);
@@ -3824,10 +3758,9 @@ TEST_F(GraphTransformationTests, MatMulIntegerToFloatTest) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2);
-  graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<MatMulIntegerToFloatFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<DynamicQuantizeMatMulFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["DynamicQuantizeLinear"], 1);
@@ -3854,7 +3787,7 @@ static void GatherNDComputationReductionTest(const std::string op_type, logging:
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{1};
-  graph_transformation_mgr.Register(std::make_unique<ComputationReductionTransformer>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ComputationReductionTransformer>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, logger));
 
   GraphViewer graph_viewer(graph);
@@ -3946,7 +3879,7 @@ TEST_F(GraphTransformationTests, ComputationReductionTransformer_GatherND_E2E) {
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<ComputationReductionTransformer>(), TransformerLevel::Level1);
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<ComputationReductionTransformer>(), TransformerLevel::Level1));
   ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *logger_));
 
   // check the expected node orders.
@@ -3975,7 +3908,7 @@ TEST_F(GraphTransformationTests, ComputationReductionTransformer_GatherND_E2E) {
 
   // check result diff after the re-order
   auto new_model_uri = "computation_reduction_transformer_after.onnx";
-  Model::Save(*model, new_model_uri);
+  ASSERT_STATUS_OK(Model::Save(*model, new_model_uri));
 
   float scale = 1.f;
   float mean = 0.f;
@@ -4195,9 +4128,8 @@ TEST_F(GraphTransformationTests, IsInfReduceSum_Test) {
   Graph& graph = p_model->MainGraph();
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
-  graph_transformation_mgr.Register(std::make_unique<IsInfReduceSumFusion>(), TransformerLevel::Level2);
-  auto ret = graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_);
-  ASSERT_TRUE(ret.IsOK());
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<IsInfReduceSumFusion>(), TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger_));
 
   std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
   EXPECT_EQ(op_to_count["IsInf"], 0);
@@ -4394,7 +4326,7 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests) {
       Path p = Path::Parse(test_case.model_uri);
       ASSERT_FALSE(p.GetComponents().empty());
       PathString transformed_model_uri = temp_dir.Path() + GetPathSep<PathChar>() + ORT_TSTR("transformed_") + p.GetComponents().back();
-      Model::Save(*p_model, transformed_model_uri);
+      ASSERT_STATUS_OK(Model::Save(*p_model, transformed_model_uri));
       // Load the transformed model to validate
       ASSERT_STATUS_OK(Model::Load(transformed_model_uri, p_model, nullptr, *logger_));
       Graph& transformed_graph = p_model->MainGraph();

--- a/onnxruntime/test/optimizer/optimizer_test.cc
+++ b/onnxruntime/test/optimizer/optimizer_test.cc
@@ -15,6 +15,7 @@
 #include "test/framework/test_utils.h"
 #include "test/capturing_sink.h"
 #include "test/test_environment.h"
+#include "asserts.h"
 #include "gtest/gtest.h"
 
 using namespace std;
@@ -57,7 +58,7 @@ TEST(OptimizerTest, Basic) {
   std::vector<NodeArg*> tmp_inputs{inputs[0].get(), inputs[1].get()};
   std::vector<NodeArg*> tmp_outputs{outputs[0].get()};
   graph.AddNode("a", "Add", "a", tmp_inputs, tmp_outputs);
-  graph.Resolve();
+  ASSERT_STATUS_OK(graph.Resolve());
 
   std::vector<const Node*> nodes;
   for (auto& node : graph.Nodes()) {
@@ -97,7 +98,7 @@ TEST(OptimizerTest, Basic) {
     ASSERT_TRUE(st.IsOK()) << st.ErrorMessage();
 
     std::vector<OrtValue> fetches;
-    frame.GetOutputs(fetches);
+    ASSERT_STATUS_OK(frame.GetOutputs(fetches));
     auto& tensor = fetches[0].Get<Tensor>();
     const std::vector<int32_t> found(tensor.template Data<int32_t>(), tensor.template Data<int32_t>() + tensor_dim);
     std::vector<int32_t> expected;

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -106,7 +106,7 @@ Status PerformanceRunner::Run() {
   }
 
   // warm up
-  RunOneIteration<true>();
+  ORT_RETURN_IF_ERROR(RunOneIteration<true>());
 
   // TODO: start profiling
   // if (!performance_test_config_.run_config.profile_file.empty())

--- a/onnxruntime/test/providers/provider_test_utils.cc
+++ b/onnxruntime/test/providers/provider_test_utils.cc
@@ -1003,7 +1003,7 @@ void OpTester::Run(
       InferenceSession session_object{so, GetEnvironment()};
 
       if (add_prepacked_shared_container_to_sessions_) {
-        session_object.AddPrePackedWeightsContainer(&prepacked_weights_container_);
+        ASSERT_STATUS_OK(session_object.AddPrePackedWeightsContainer(&prepacked_weights_container_));
       }
 
       ASSERT_TRUE(!execution_providers->empty())
@@ -1048,7 +1048,7 @@ void OpTester::Run(
         InferenceSession session_object{so, GetEnvironment()};
 
         if (add_prepacked_shared_container_to_sessions_) {
-          session_object.AddPrePackedWeightsContainer(&prepacked_weights_container_);
+          ASSERT_STATUS_OK(session_object.AddPrePackedWeightsContainer(&prepacked_weights_container_));
         }
 
         for (auto& custom_session_registry : custom_session_registries_)

--- a/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
+++ b/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
@@ -37,20 +37,21 @@ struct MyEP_Provider : Provider {
   std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(const void* provider_options) override {
     ProviderOptions* options = (ProviderOptions*)(provider_options);
     MyProviderInfo info;
-    ProviderOptionsParser{}
-        .AddValueParser(
-            "device_id",
-            [&info](const std::string& value_str) -> Status {
-              ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
-              return Status::OK();
-            })
-        .AddValueParser(
-            "some_config",
-            [&info](const std::string& value_str) -> Status {
-              ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.some_config));
-              return Status::OK();
-            })
-        .Parse(*options);
+    ORT_THROW_IF_ERROR(
+        ProviderOptionsParser{}
+            .AddValueParser(
+                "device_id",
+                [&info](const std::string& value_str) -> Status {
+                  ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
+                  return Status::OK();
+                })
+            .AddValueParser(
+                "some_config",
+                [&info](const std::string& value_str) -> Status {
+                  ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.some_config));
+                  return Status::OK();
+                })
+            .Parse(*options));
     return std::make_shared<MyProviderFactory>(info);
   }
 

--- a/orttraining/orttraining/core/agent/training_agent.cc
+++ b/orttraining/orttraining/core/agent/training_agent.cc
@@ -77,7 +77,8 @@ void TrainingAgent::CreateAndInitializeFeedsFetchesManager(const SessionState& s
                                                            const std::vector<std::string>& fetches_names,
                                                            const std::vector<OrtDevice>& outputs_device_info,
                                                            std::unique_ptr<FeedsFetchesManager>& feeds_fetches_manager) {
-  FeedsFetchesManager::Create(feed_names, fetches_names, session_state.GetOrtValueNameIdxMap(), feeds_fetches_manager);
+  ORT_THROW_IF_ERROR(FeedsFetchesManager::Create(feed_names, fetches_names, session_state.GetOrtValueNameIdxMap(),
+                                                 feeds_fetches_manager));
   auto& fetch_info = feeds_fetches_manager->GetMutableFetchesDeviceCopyInfo();
   for (size_t i = 0, end = fetches_names.size(); i < end; ++i) {
     fetch_info[i].target_device = outputs_device_info[i];

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -32,10 +32,10 @@ GradientGraphBuilder::GradientGraphBuilder(Graph* graph,
       logger_(logger) {
   auto rule_based_graph_transformer =
       std::make_unique<RuleBasedGraphTransformer>("pre_training_rule_based_graph_transformer");
-  rule_based_graph_transformer->Register(std::make_unique<InsertMaxPoolOutput>());
+  ORT_THROW_IF_ERROR(rule_based_graph_transformer->Register(std::make_unique<InsertMaxPoolOutput>()));
 
-  graph_transformation_mgr_.Register(std::move(rule_based_graph_transformer),
-                                     TransformerLevel::Level2);
+  ORT_THROW_IF_ERROR(graph_transformation_mgr_.Register(std::move(rule_based_graph_transformer),
+                                                        TransformerLevel::Level2));
 
   auto forward_reachable_nodes = BFSWithStopGradient(x_node_arg_names);
 

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -164,14 +164,15 @@ Status OrtModuleGraphBuilder::OptimizeInferenceGraph(std::unordered_set<std::str
     auto transformers_to_register = transformer_utils::GeneratePreTrainingTransformers(
         level, x_node_arg_names, config_.graph_transformer_config, *cpu_execution_provider);
     for (auto& entry : transformers_to_register) {
-      graph_transformation_mgr.Register(std::move(entry), level);
+      ORT_RETURN_IF_ERROR(graph_transformation_mgr.Register(std::move(entry), level));
     }
+    return Status::OK();
   };
 
   for (int i = static_cast<int>(TransformerLevel::Level1); i <= static_cast<int>(TransformerLevel::MaxLevel); i++) {
     TransformerLevel level = static_cast<TransformerLevel>(i);
     if (TransformerLevel::MaxLevel >= level) {
-      add_transformers(level);
+      ORT_RETURN_IF_ERROR(add_transformers(level));
     }
   }
 
@@ -407,7 +408,7 @@ void OrtModuleGraphBuilder::ReorderOutputs() {
 
 void OrtModuleGraphBuilder::FindModuleOutputNeededForBackward() {
   Graph& gradient_graph = gradient_model_->MainGraph();
-  gradient_graph.Resolve();
+  ORT_THROW_IF_ERROR(gradient_graph.Resolve());
   GraphViewer gradient_graph_viewer(gradient_graph);
   const auto& exec_order = gradient_graph_viewer.GetNodesInTopologicalOrder();
 

--- a/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
+++ b/orttraining/orttraining/core/graph/mixed_precision_transformer.cc
@@ -463,11 +463,11 @@ static Status HandleFunctionBody(const Function& node_func, ONNX_NAMESPACE::Tens
         // Introduce cast to full-precision if required:
         // TODO: fix const_cast; Graph doesn't provide us a method "GetMutableInputs".
         NodeArg* mutable_input = const_cast<NodeArg*>(input);
-        CastNodeArg(graph,
+        ORT_RETURN_IF_ERROR(CastNodeArg(graph,
                     stage1_fp32_node_args,
                     std::unordered_map<Node*, std::vector<int>>(),
                     mutable_input,
-                    ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+                    ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
       }
     }
 
@@ -663,7 +663,7 @@ Status TransformGraphForMixedPrecision(Graph& graph,
 
   ORT_RETURN_IF_ERROR(graph.Resolve(options));
 
-  TransformStage2(graph, mixed_precision_type, loss_subgraph.GetFP32NodeArgs());
+  ORT_RETURN_IF_ERROR(TransformStage2(graph, mixed_precision_type, loss_subgraph.GetFP32NodeArgs()));
 
   ORT_RETURN_IF_ERROR(graph.Resolve(options));
 

--- a/orttraining/orttraining/core/graph/pipeline_transformer.cc
+++ b/orttraining/orttraining/core/graph/pipeline_transformer.cc
@@ -587,7 +587,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_recv_waited_event_name,
         pipeline_tensor_names.forward_recv_wait_output_name);
     ORT_ENFORCE(forward_recv_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
 
     // Insert Record after Forward-Recv.
     forward_recv_record = &AppendEventNode(
@@ -597,7 +597,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_recv_recorded_event_name,
         pipeline_tensor_names.forward_recv_record_output_name);
     ORT_ENFORCE(forward_recv_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Forward Send
@@ -610,7 +610,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_send_waited_event_name,
         pipeline_tensor_names.forward_send_wait_output_name);
     ORT_ENFORCE(forward_send_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
 
     // Insert Record after Forward-Send.
     forward_send_record = &AppendEventNode(
@@ -620,7 +620,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_send_recorded_event_name,
         pipeline_tensor_names.forward_send_record_output_name);
     ORT_ENFORCE(forward_send_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Backward Recv
@@ -633,7 +633,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_recv_waited_event_name,
         pipeline_tensor_names.backward_recv_wait_output_name);
     ORT_ENFORCE(backward_recv_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
 
     // Insert Record after Forward-Recv.
     backward_recv_record = &AppendEventNode(
@@ -643,7 +643,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_recv_recorded_event_name,
         pipeline_tensor_names.backward_recv_record_output_name);
     ORT_ENFORCE(backward_recv_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Backward Send
@@ -656,7 +656,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_send_waited_event_name,
         pipeline_tensor_names.backward_send_wait_output_name);
     ORT_ENFORCE(backward_send_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
 
     // Insert Record after Backward-Send and all nodes.
     backward_send_record = &AppendEventNode(
@@ -666,7 +666,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_send_recorded_event_name,
         pipeline_tensor_names.backward_send_record_output_name);
     ORT_ENFORCE(backward_send_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Forward-Compute Wait.
@@ -679,7 +679,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_compute_waited_event_name,
         pipeline_tensor_names.forward_compute_wait_output_name);
     ORT_ENFORCE(forward_compute_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   } else {
     // Insert one Wait after Forward-Recv Record.
     forward_compute_wait = &AppendEventNode(
@@ -689,7 +689,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_compute_waited_event_name,
         pipeline_tensor_names.forward_compute_wait_output_name);
     ORT_ENFORCE(forward_compute_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Forward-Compute Record
@@ -702,7 +702,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.forward_compute_recorded_event_name,
         pipeline_tensor_names.forward_compute_record_output_name);
     ORT_ENFORCE(forward_compute_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Backward-Compute Wait.
@@ -715,7 +715,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_compute_waited_event_name,
         pipeline_tensor_names.backward_compute_wait_output_name);
     ORT_ENFORCE(backward_compute_wait);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // Backward-Compute Record.
@@ -728,7 +728,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_compute_recorded_event_name,
         pipeline_tensor_names.backward_compute_record_output_name);
     ORT_ENFORCE(backward_compute_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   } else {
     // Insert one Record before Backward-Send Wait.
     backward_compute_record = &PrependEventNode(
@@ -738,7 +738,7 @@ Status TransformGraphForPipeline(
         pipeline_tensor_names.backward_compute_recorded_event_name,
         pipeline_tensor_names.backward_compute_record_output_name);
     ORT_ENFORCE(backward_compute_record);
-    ResolveForTraining(graph, weights_to_train);
+    ORT_RETURN_IF_ERROR(ResolveForTraining(graph, weights_to_train));
   }
 
   // If user wants to keep original outputs, we add fake outputs if the
@@ -803,7 +803,7 @@ void SetDataDependency(
   graph.AddNode(graph.GenerateNodeName("OrderingPassThrough"),
                 "PassThrough", "", pass_through_inputs, pass_through_outputs, nullptr, kMSDomain);
 
-  graph.Resolve();
+  ORT_THROW_IF_ERROR(graph.Resolve());
 }
 
 // This function is used when you want to create a scalar constant in a graph.
@@ -1621,7 +1621,7 @@ Status ApplyPipelinePartitionToMainGraph(Graph& graph,
   graph.SetOutputs({visited_outputs.begin(), visited_outputs.end()});
   graph.SetGraphResolveNeeded();
   graph.SetGraphProtoSyncNeeded();
-  graph.Resolve();
+  ORT_RETURN_IF_ERROR(graph.Resolve());
 
   // TODO(jufranc): once we allow partition of training graphs, we need to add
   // some code to make sure that the backward receive starts after the forward

--- a/orttraining/orttraining/core/graph/zero_optimizer_graph_builder.cc
+++ b/orttraining/orttraining/core/graph/zero_optimizer_graph_builder.cc
@@ -206,15 +206,15 @@ void PartitionOptimizerState(
       if (utils::IsPrimitiveDataType<float>(element_type)) {
         float* data_buffer = init_tensor->MutableData<float>();
         p_tensor = std::make_unique<Tensor>(element_type,
-                                                    shape,
-                                                    data_buffer + partition_offset,
-                                                    info);
+                                            shape,
+                                            data_buffer + partition_offset,
+                                            info);
       } else if (utils::IsPrimitiveDataType<MLFloat16>(element_type)) {
         MLFloat16* data_buffer = init_tensor->MutableData<MLFloat16>();
         p_tensor = std::make_unique<Tensor>(element_type,
-                                                    shape,
-                                                    data_buffer + partition_offset,
-                                                    info);
+                                            shape,
+                                            data_buffer + partition_offset,
+                                            info);
 
       } else {
         ORT_THROW("Unsupported type: ", element_type, "for initial optimizer moments.");
@@ -366,23 +366,26 @@ static Status ModifyParametersForOptimizerPartitioning(
           int64_t size_for_current_rank = offset + tensor_count - rank_start;
           std::vector<TensorShape> view_shapes = {{size_for_previous_rank}, {size_for_current_rank}, {0}};
           std::vector<bool> enabled = {false, true};
-          AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config, view_shapes, enabled,
-                                new_opt_configs, new_weight_argdefs, new_gradient_argdefs, updated_weight_names_map, weight_partition_info);
+          ORT_RETURN_IF_ERROR(AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config,
+                                                    view_shapes, enabled, new_opt_configs, new_weight_argdefs,
+                                                    new_gradient_argdefs, updated_weight_names_map, weight_partition_info));
         } else if (offset >= rank_start && offset + tensor_count > rank_end) {
           int64_t size_for_current_rank = rank_end - offset;
           int64_t size_for_next_rank = offset + tensor_count - rank_end;
           std::vector<TensorShape> view_shapes = {{0}, {size_for_current_rank}, {size_for_next_rank}};
           std::vector<bool> enabled = {true, false};
-          AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config, view_shapes, enabled,
-                                new_opt_configs, new_weight_argdefs, new_gradient_argdefs, updated_weight_names_map, weight_partition_info);
+          ORT_RETURN_IF_ERROR(AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config,
+                                                    view_shapes, enabled, new_opt_configs, new_weight_argdefs,
+                                                    new_gradient_argdefs, updated_weight_names_map, weight_partition_info));
         } else {  // offset < rank_start && offset + tensor_count > rank_end
           int64_t size_for_previous_rank = rank_start - offset;
           int64_t size_for_current_rank = rank_end - rank_start;
           int64_t size_for_next_rank = offset + tensor_count - rank_end;
           std::vector<TensorShape> view_shapes = {{size_for_previous_rank}, {size_for_current_rank}, {size_for_next_rank}};
           std::vector<bool> enabled = {false, true, false};
-          AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config, view_shapes, enabled,
-                                new_opt_configs, new_weight_argdefs, new_gradient_argdefs, updated_weight_names_map, weight_partition_info);
+          ORT_RETURN_IF_ERROR(AddParameterPartition(graph, graph_defs, weight_argdef, gradient_argdef, opt_config,
+                                                    view_shapes, enabled, new_opt_configs, new_weight_argdefs,
+                                                    new_gradient_argdefs, updated_weight_names_map, weight_partition_info));
         }
       }
     } else {

--- a/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_utils.cc
@@ -75,17 +75,17 @@ std::vector<std::unique_ptr<GraphTransformer>> GeneratePreTrainingTransformers(
       rule_transformer =
           std::make_unique<RuleBasedGraphTransformer>(optimizer_utils::GenerateRuleBasedTransformerName(level),
                                                       compatible_eps);
-      rule_transformer->Register(std::make_unique<InsertMaxPoolOutput>());
-      rule_transformer->Register(std::make_unique<BatchNormReplacement>());
-      rule_transformer->Register(std::make_unique<UnsqueezeElimination>());
-      rule_transformer->Register(std::make_unique<ExpandElimination>());
-      rule_transformer->Register(std::make_unique<CastElimination>());
-      rule_transformer->Register(std::make_unique<NoopElimination>());
-      rule_transformer->Register(std::make_unique<DivMulFusion>());
-      rule_transformer->Register(std::make_unique<EliminateDropout>());
-      rule_transformer->Register(std::make_unique<GemmTransposeFusion>());
-      rule_transformer->Register(std::make_unique<NotWhereFusion>());
-      rule_transformer->Register(std::make_unique<InsertSoftmaxCrossEntropyLossOutput>());
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<InsertMaxPoolOutput>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<BatchNormReplacement>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<UnsqueezeElimination>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<ExpandElimination>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<CastElimination>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<NoopElimination>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<DivMulFusion>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<EliminateDropout>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<GemmTransposeFusion>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<NotWhereFusion>()));
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<InsertSoftmaxCrossEntropyLossOutput>()));
 
       // Remove duplicate nodes. Must be applied before any recompute transformations.
       transformers.emplace_back(std::make_unique<CommonSubexpressionEliminationApplyOnce>(compatible_eps));
@@ -136,7 +136,7 @@ std::vector<std::unique_ptr<GraphTransformer>> GeneratePreTrainingTransformers(
       rule_transformer =
           std::make_unique<RuleBasedGraphTransformer>(optimizer_utils::GenerateRuleBasedTransformerName(level),
                                                       compatible_eps);
-      rule_transformer->Register(std::make_unique<ConcatReplacement>());
+      ORT_THROW_IF_ERROR(rule_transformer->Register(std::make_unique<ConcatReplacement>()));
     } break;
 
     case TransformerLevel::Level3: {

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -747,7 +747,7 @@ void TrainingSession::AddPreTrainingTransformers(const IExecutionProvider& execu
       auto transformers_to_register = transformer_utils::GeneratePreTrainingTransformers(
           level, weights_to_train, config, execution_provider);
       for (auto& entry : transformers_to_register) {
-        transformer_manager.Register(std::move(entry), level);
+        ORT_THROW_IF_ERROR(transformer_manager.Register(std::move(entry), level));
       }
     }
   }
@@ -771,6 +771,8 @@ Status TrainingSession::AddPredefinedTransformers(GraphTransformerManager& trans
       }
     }
   }
+
+  return Status::OK();
 }
 
 Status TrainingSession::ApplyModelParallelTransformationsToMainGraph(std::unordered_set<std::string>& weights_to_train,
@@ -795,7 +797,7 @@ Status TrainingSession::ApplyModelParallelTransformationsToMainGraph(std::unorde
 
   // Generate and register transformers for level
   for (auto& entry : transformers_to_register) {
-    graph_transformation_mgr.Register(std::move(entry), TransformerLevel::Level1);
+    ORT_RETURN_IF_ERROR(graph_transformation_mgr.Register(std::move(entry), TransformerLevel::Level1));
   }
 
   Graph& graph = model_->MainGraph();
@@ -809,9 +811,9 @@ Status TrainingSession::AddGistEncoding(int op_type, std::string compr_type) {
     Graph& graph = model_->MainGraph();
 
     auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleGistTransformer1");
-    rule_transformer_L1->Register(std::make_unique<GistEncodeDecode>(op_type, compr_type));
+    ORT_RETURN_IF_ERROR(rule_transformer_L1->Register(std::make_unique<GistEncodeDecode>(op_type, compr_type)));
     onnxruntime::GraphTransformerManager graph_transformation_mgr{1};
-    graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1);
+    ORT_RETURN_IF_ERROR(graph_transformation_mgr.Register(std::move(rule_transformer_L1), TransformerLevel::Level1));
 
     ORT_RETURN_IF_ERROR(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level1, *session_logger_));
   } catch (const OnnxRuntimeException& exp) {
@@ -1071,7 +1073,7 @@ common::Status TrainingSession::GetOptimizerState(std::unordered_map<std::string
     }
     NameMLValMap curr_opt_tensors;
     const auto& weight_name = weight_map.first;
-    GetSessionState().GetInitializedTensors(opt_names, allow_missing, curr_opt_tensors);
+    ORT_RETURN_IF_ERROR(GetSessionState().GetInitializedTensors(opt_names, allow_missing, curr_opt_tensors));
     opt_state_tensors[weight_name] = {};
     // Keep only prefix in returned value
     for (const auto& opt_pair : weight_map.second) {
@@ -1107,7 +1109,7 @@ common::Status TrainingSession::GetModelState(std::unordered_map<std::string, Na
   }
 
   NameMLValMap fp_weights;
-  GetSessionState().GetInitializedTensors(fp_tensor_names, allow_missing, fp_weights);
+  ORT_RETURN_IF_ERROR(GetSessionState().GetInitializedTensors(fp_tensor_names, allow_missing, fp_weights));
   // Change key from sharded_name to weight_name using partition_info
   for (const auto& weight : weight_partition_info_) {
     if (weight.second.weight_partitioned) {
@@ -1131,7 +1133,7 @@ common::Status TrainingSession::GetModelState(std::unordered_map<std::string, Na
     mp_tensor_names.insert(
         mixed_precision_weight_initializer_names.begin(), mixed_precision_weight_initializer_names.end());
     NameMLValMap mp_weights;
-    GetSessionState().GetInitializedTensors(mp_tensor_names, allow_missing, mp_weights);
+    ORT_RETURN_IF_ERROR(GetSessionState().GetInitializedTensors(mp_tensor_names, allow_missing, mp_weights));
     // Change key from fp16_name to weight_name
     for (const auto& weight_fp16_pair : weight_to_mixed_precision_map_) {
       const auto& it = mp_weights.find(weight_fp16_pair.second);
@@ -1741,9 +1743,9 @@ void PipelineTrainingSession::CreateMicroBatchVariables(
       const size_t slice_axis = static_cast<size_t>(pipeline_context_.sliced_axes[name]);
       if (has_element(pipeline_context_.sliced_tensor_names, name)) {
         OrtValue sliced_value = SliceTensor(values[i], slice_id, slice_axis, num_slices, *this);
-        (sub_io_binding.*bind)(name, sliced_value);
+        ORT_THROW_IF_ERROR((sub_io_binding.*bind)(name, sliced_value));
       } else {
-        (sub_io_binding.*bind)(name, values[i]);
+        ORT_THROW_IF_ERROR((sub_io_binding.*bind)(name, values[i]));
       }
     }
   };
@@ -1792,7 +1794,7 @@ void PipelineTrainingSession::CreatePipelineEvents(
     auto event = onnxruntime::MakeScalarMLValue<int64_t>(bfc_arena, event_value, false);
 
     // Add the created event to the list.
-    io_binding.BindInput(event_name, event);
+    ORT_THROW_IF_ERROR(io_binding.BindInput(event_name, event));
   };
 
   int id = -1;

--- a/orttraining/orttraining/core/session/training_session.cc
+++ b/orttraining/orttraining/core/session/training_session.cc
@@ -754,11 +754,11 @@ void TrainingSession::AddPreTrainingTransformers(const IExecutionProvider& execu
 }
 
 // Registers all the predefined transformers with transformer manager
-void TrainingSession::AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
-                                                TransformerLevel graph_optimization_level) {
-  ORT_ENFORCE(graph_optimization_level <= TransformerLevel::MaxLevel,
-              "Exceeded max transformer level. Current level is set to " +
-                  std::to_string(static_cast<uint32_t>(graph_optimization_level)));
+Status TrainingSession::AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
+                                                  TransformerLevel graph_optimization_level) {
+  ORT_RETURN_IF_NOT(graph_optimization_level <= TransformerLevel::MaxLevel,
+                    "Exceeded max transformer level. Current level is set to " +
+                        std::to_string(static_cast<uint32_t>(graph_optimization_level)));
 
   for (int i = static_cast<int>(TransformerLevel::Level1); i <= static_cast<int>(TransformerLevel::MaxLevel); i++) {
     TransformerLevel level = static_cast<TransformerLevel>(i);
@@ -767,7 +767,7 @@ void TrainingSession::AddPredefinedTransformers(GraphTransformerManager& transfo
       auto transformers_to_register = transformer_utils::GenerateTransformers(
           level, weights_to_train_, GetSessionOptions().free_dimension_overrides, {});
       for (auto& entry : transformers_to_register) {
-        transformer_manager.Register(std::move(entry), level);
+        ORT_RETURN_IF_ERROR(transformer_manager.Register(std::move(entry), level));
       }
     }
   }

--- a/orttraining/orttraining/core/session/training_session.h
+++ b/orttraining/orttraining/core/session/training_session.h
@@ -485,8 +485,8 @@ class TrainingSession : public InferenceSession {
                                   TransformerLevel graph_optimization_level = TransformerLevel::MaxLevel);
 
   /** override the parent method in inference session for training specific transformers */
-  void AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
-                                 TransformerLevel graph_optimization_level) override;
+  common::Status AddPredefinedTransformers(GraphTransformerManager& transformer_manager,
+                                           TransformerLevel graph_optimization_level) override;
 
   /** Perform auto-diff to add backward graph into the model.
   @param weights_to_train a set of weights to be training.

--- a/orttraining/orttraining/models/mnist/mnist_data_provider.cc
+++ b/orttraining/orttraining/models/mnist/mnist_data_provider.cc
@@ -49,7 +49,7 @@ void ConvertData(const vector<vector<float>>& images,
       OrtValue labelMLValue;
       TrainingUtil::CreateCpuMLValue(label_dims, labels[i], &labelMLValue);
 
-      data_set.AddData(make_unique<vector<OrtValue>>(vector<OrtValue>{imageMLValue, labelMLValue}));
+      ORT_THROW_IF_ERROR(data_set.AddData(make_unique<vector<OrtValue>>(vector<OrtValue>{imageMLValue, labelMLValue})));
     }
   }
 }

--- a/orttraining/orttraining/models/runner/training_runner.cc
+++ b/orttraining/orttraining/models/runner/training_runner.cc
@@ -293,7 +293,7 @@ Status TrainingRunner::Initialize() {
 Status TrainingRunner::Run(IDataLoader* training_data_loader, IDataLoader* test_data_loader,
                            const MapStringToString& mapped_dimensions) {
   if (MPIContext::GetInstance().GetWorldRank() == 0 && !params_.model_actual_running_graph_path.empty()) {
-    session_.Save(params_.model_actual_running_graph_path, TrainingSession::SaveOption::NO_RELOAD);
+    ORT_RETURN_IF_ERROR(session_.Save(params_.model_actual_running_graph_path, TrainingSession::SaveOption::NO_RELOAD));
   }
 
   // maybe in the future we can support an evaluation-only run
@@ -1135,13 +1135,13 @@ Status TrainingRunner::Evaluate(TrainingSession& session, IDataLoader& data_load
     std::vector<std::string> fetch_names;
     std::vector<OrtValue> fetches;
 
-    PrepareFeedNamesAndFeeds(EvaluateStep,
-                             data_loader,
-                             *test_data,
-                             nullptr,
-                             batch_idx,
-                             feed_names,
-                             feeds);
+    ORT_RETURN_IF_ERROR(PrepareFeedNamesAndFeeds(EvaluateStep,
+                                                 data_loader,
+                                                 *test_data,
+                                                 nullptr,
+                                                 batch_idx,
+                                                 feed_names,
+                                                 feeds));
     if (!session.GetDropoutEvalFeeds().empty()) {
       float eval_ratio = 0.0f;
       for (auto& dropout_ratio : session.GetDropoutEvalFeeds()) {
@@ -1163,9 +1163,9 @@ Status TrainingRunner::Evaluate(TrainingSession& session, IDataLoader& data_load
       }
     }
 
-    PrepareFetchNamesAndFetches(EvaluateStep,
-                                fetch_names,
-                                fetches);
+    ORT_RETURN_IF_ERROR(PrepareFetchNamesAndFetches(EvaluateStep,
+                                                    fetch_names,
+                                                    fetches));
 
     run_options.only_execute_path_to_fetches = true;
     run_options.training_mode = false;

--- a/orttraining/orttraining/test/distributed/partition_utils.hpp
+++ b/orttraining/orttraining/test/distributed/partition_utils.hpp
@@ -420,14 +420,14 @@ common::Status SplitGraph(Graph& graph,
       // once we find out the producer node for id.node_arg_name, find which output index that leads
       // to id.node_arg_name
       int upstream_nodes_output_index{-1};
-      producer_node->ForEachWithIndex(
+      ORT_RETURN_IF_ERROR(producer_node->ForEachWithIndex(
           producer_node->OutputDefs(),
           [&](const NodeArg& def, size_t index) {
             if (def.Name() == id.node_arg_name) {
               upstream_nodes_output_index = static_cast<int>(index);
             }
             return Status::OK();
-          });
+          }));
 
       if (upstream_nodes_output_index < 0) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Node with name: ", producer_node->Name(),

--- a/orttraining/orttraining/test/framework/checkpointing_test.cc
+++ b/orttraining/orttraining/test/framework/checkpointing_test.cc
@@ -112,7 +112,7 @@ TEST(CheckpointingTest, SaveAndLoad) {
       ConcatPathComponent<PathChar>(tmp_dir.Path(), ORT_TSTR("test_model.onnx"))};
 
   DataTransferManager data_transfer{};
-  data_transfer.RegisterDataTransfer(std::make_unique<CPUDataTransfer>());
+  ASSERT_STATUS_OK(data_transfer.RegisterDataTransfer(std::make_unique<CPUDataTransfer>()));
 
   ASSERT_STATUS_OK(SaveModelCheckpoint(
       checkpoint_path, data_transfer, name_to_ort_value, properties));

--- a/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
+++ b/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
@@ -25,7 +25,7 @@ TwoDArray OpFunctionTester::RunFunctionBodyGraphOnCPU() {
   auto& node = *graph.Nodes().begin();
   ORT_ENFORCE(node.OpType() == op_);
   // Inline function will call Resolve itself
-  graph.InlineFunction(node);
+  ORT_THROW_IF_ERROR(graph.InlineFunction(node));
 
   // Hookup the inputs and outputs
   std::unordered_map<std::string, OrtValue> feeds;

--- a/orttraining/orttraining/training_ops/cpu/nn/pool_gradient_op.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/pool_gradient_op.cc
@@ -221,15 +221,15 @@ Status AveragePoolGrad<T>::Compute(OpKernelContext* context) const {
 
   switch (dX_shape.NumDimensions()) {
     case 3:
-      Compute1DAveragePoolGrad(context);
+      ORT_RETURN_IF_ERROR(Compute1DAveragePoolGrad(context));
       break;
 
     case 4:
-      Compute2DAveragePoolGrad(context);
+      ORT_RETURN_IF_ERROR(Compute2DAveragePoolGrad(context));
       break;
 
     case 5:
-      Compute3DAveragePoolGrad(context);
+      ORT_RETURN_IF_ERROR(Compute3DAveragePoolGrad(context));
       break;
 
     default:

--- a/orttraining/orttraining/training_ops/cpu/tensor/gather_nd_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/gather_nd_grad.cc
@@ -66,9 +66,9 @@ Status GatherNDGrad::Compute(OpKernelContext* context) const {
   auto bytes_per_value = update_tensor->DataType()->Size();
   concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
   if (indices_tensor->IsDataType<int32_t>()) {
-    PrepareForCompute<int32_t>(input_shape, indices_tensor, bytes_per_value, p, tp);
+    ORT_RETURN_IF_ERROR(PrepareForCompute<int32_t>(input_shape, indices_tensor, bytes_per_value, p, tp));
   } else if (indices_tensor->IsDataType<int64_t>()) {
-    PrepareForCompute<int64_t>(input_shape, indices_tensor, bytes_per_value, p, tp);
+    ORT_RETURN_IF_ERROR(PrepareForCompute<int64_t>(input_shape, indices_tensor, bytes_per_value, p, tp));
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "indices tensor data type not supported");
   }

--- a/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.cc
@@ -32,8 +32,9 @@ Status SliceGrad::Compute(OpKernelContext* context) const {
   std::vector<int64_t> input_ends;
   std::vector<int64_t> input_axes;
   std::vector<int64_t> input_steps;
-  FillVectorsFromInput(*context->Input<Tensor>(2), *context->Input<Tensor>(3), context->Input<Tensor>(4),
-                       context->Input<Tensor>(5), input_starts, input_ends, input_axes, input_steps);
+  ORT_RETURN_IF_ERROR(FillVectorsFromInput(*context->Input<Tensor>(2), *context->Input<Tensor>(3),
+                                           context->Input<Tensor>(4), context->Input<Tensor>(5),
+                                           input_starts, input_ends, input_axes, input_steps));
 
   SliceOp::PrepareForComputeMetadata compute_metadata(data_shape.GetDims());
   ORT_RETURN_IF_ERROR(PrepareForCompute(input_starts, input_ends, input_axes, input_steps, compute_metadata));

--- a/orttraining/orttraining/training_ops/cuda/controlflow/record.cc
+++ b/orttraining/orttraining/training_ops/cuda/controlflow/record.cc
@@ -44,7 +44,7 @@ Status RecordEvent::ComputeInternal(OpKernelContext* ctx) const {
     const Tensor* X = ctx->Input<Tensor>(i_out + 1);
     const TensorShape& data_shape = X->Shape();
     Tensor* Y = ctx->Output(i_out, data_shape);
-    CopyTensor(*X, *Y);
+    ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
   }
 
 #ifdef ENABLE_NVTX_PROFILE

--- a/orttraining/orttraining/training_ops/cuda/controlflow/wait.cc
+++ b/orttraining/orttraining/training_ops/cuda/controlflow/wait.cc
@@ -44,7 +44,7 @@ Status WaitEvent::ComputeInternal(OpKernelContext* ctx) const {
     const Tensor* X = ctx->Input<Tensor>(i_out + 1);
     const TensorShape& data_shape = X->Shape();
     Tensor* Y = ctx->Output(i_out, data_shape);
-    CopyTensor(*X, *Y);
+    ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
   }
 
 #ifdef ENABLE_NVTX_PROFILE

--- a/orttraining/orttraining/training_ops/cuda/math/div_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/math/div_grad.cc
@@ -96,13 +96,13 @@ Status DivGrad<T>::ComputeInternal(OpKernelContext* context) const {
 
       if (da_output_tensor) {
         std::vector<int64_t> a_output_dims = prepended_dimension_1(a_shape, dy_shape.NumDimensions());
-        ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+        ORT_RETURN_IF_ERROR((ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
             temp_da_data,
             dy_shape,
             da_data,
             TensorShape({}),
             CUDNN_REDUCE_TENSOR_ADD,
-            a_output_dims);
+            a_output_dims)));
       }
       break;
     }
@@ -125,13 +125,13 @@ Status DivGrad<T>::ComputeInternal(OpKernelContext* context) const {
 
       if (db_output_tensor) {
         std::vector<int64_t> b_output_dims = prepended_dimension_1(b_shape, dy_shape.NumDimensions());
-        ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+        ORT_RETURN_IF_ERROR((ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
             temp_db_data,
             dy_shape,
             db_data,
             TensorShape({}),
             CUDNN_REDUCE_TENSOR_ADD,
-            b_output_dims);
+            b_output_dims)));
       }
       break;
     }
@@ -170,13 +170,13 @@ Status DivGrad<T>::ComputeInternal(OpKernelContext* context) const {
 
       if (db_output_tensor) {
         std::vector<int64_t> b_output_dims = prepended_dimension_1(b_shape, dy_shape.NumDimensions());
-        ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+        ORT_RETURN_IF_ERROR((ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
             temp_db_data,
             dy_shape,
             db_data,
             b_shape,
             CUDNN_REDUCE_TENSOR_ADD,
-            b_output_dims);
+            b_output_dims)));
       }
       break;
     }
@@ -217,24 +217,24 @@ Status DivGrad<T>::ComputeInternal(OpKernelContext* context) const {
 
       if (need_reduce_da) {
         std::vector<int64_t> a_output_dims = prepended_dimension_1(a_shape, dy_shape.NumDimensions());
-        ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+        ORT_RETURN_IF_ERROR((ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
             da_data_ref,
             dy_shape,
             da_data,
             a_shape,
             CUDNN_REDUCE_TENSOR_ADD,
-            a_output_dims);
+            a_output_dims)));
       }
 
       if (need_reduce_db) {
         std::vector<int64_t> b_output_dims = prepended_dimension_1(b_shape, dy_shape.NumDimensions());
-        ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+        ORT_RETURN_IF_ERROR((ReduceKernelShared<T, T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
             db_data_ref,
             dy_shape,
             db_data,
             b_shape,
             CUDNN_REDUCE_TENSOR_ADD,
-            b_output_dims);
+            b_output_dims)));
       }
     }
   }

--- a/orttraining/orttraining/training_ops/cuda/nn/conv_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/conv_grad.cc
@@ -363,7 +363,7 @@ Status ConvGrad<T>::ComputeInternal(OpKernelContext* context) const {
 
 template <typename T>
 Status ConvGrad<T>::ComputeInputGradient() const {
-  AlgoIterator<T_BwdDataPerf>(args_).TryAll(
+  return AlgoIterator<T_BwdDataPerf>(args_).TryAll(
       static_cast<const CUDAExecutionProvider*>(Info().GetExecutionProvider()),
       [&](const T_BwdDataPerf& algo_perf) -> Status {
         const auto one = Consts<CudaT>::One;
@@ -375,12 +375,11 @@ Status ConvGrad<T>::ComputeInputGradient() const {
             algo_perf.algo, workspace.get(), algo_perf.memory, &zero, args_.x_tensor, args_.dx_data));
         return Status::OK();
       });
-  return Status::OK();
 }
 
 template <typename T>
 Status ConvGrad<T>::ComputeWeightGradient() const {
-  AlgoIterator<T_BwdFilterPerf>(args_).TryAll(
+  return AlgoIterator<T_BwdFilterPerf>(args_).TryAll(
       static_cast<const CUDAExecutionProvider*>(Info().GetExecutionProvider()),
       [&](const T_BwdFilterPerf& algo_perf) -> Status {
         const auto one = Consts<CudaT>::One;
@@ -392,7 +391,6 @@ Status ConvGrad<T>::ComputeWeightGradient() const {
             algo_perf.algo, workspace.get(), algo_perf.memory, &zero, args_.w_desc, args_.dw_data));
         return Status::OK();
       });
-  return Status::OK();
 }
 
 template <typename T>

--- a/orttraining/orttraining/training_ops/cuda/tensor/concat.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/concat.cc
@@ -71,7 +71,7 @@ Status ConcatTraining::ComputeInternal(OpKernelContext* ctx) const {
  
     } else {
       // too many inputs, so copy sizes to device memory
-      input_ptr.CopyToGpu();
+      ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu());
       ORT_RETURN_IF_ERROR(ConcatSameConcatDimImpl(Stream(),
                                  element_bytes,
                                  block_size_including_axis_dim,
@@ -84,13 +84,13 @@ Status ConcatTraining::ComputeInternal(OpKernelContext* ctx) const {
   } else {
     // input sizes vary, copy input sizes and range metadata to device
     // todo: pass by value when few inputs
-    input_ptr.CopyToGpu();
+    ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu());
     CudaAsyncBuffer<int64_t> concat_sizes_gpu(this, concat_sizes);
     CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
     CudaAsyncBuffer<int64_t> concat_sizes_range_gpu(this, concat_sizes_range);
-    concat_sizes_gpu.CopyToGpu();
-    axis_dimension_input_output_mapping_gpu.CopyToGpu();
-    concat_sizes_range_gpu.CopyToGpu();
+    ORT_RETURN_IF_ERROR(concat_sizes_gpu.CopyToGpu());
+    ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu());
+    ORT_RETURN_IF_ERROR(concat_sizes_range_gpu.CopyToGpu());
 
     ORT_RETURN_IF_ERROR(ConcatImpl(Stream(),
                                   element_bytes,

--- a/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.cc
@@ -40,11 +40,11 @@ const Tensor* SliceGrad::GetSlicedOrUnslicedTensor(OpKernelContext* ctx) const {
   return GetOutputGradientTensor(ctx);
 }
 
-void SliceGrad::FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
-                                 std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
-                                 std::vector<int64_t>& input_steps) const {
-  FillVectorsFromInput(*ctx->Input<Tensor>(2), *ctx->Input<Tensor>(3), ctx->Input<Tensor>(4),
-                       ctx->Input<Tensor>(5), input_starts, input_ends, input_axes, input_steps);
+Status SliceGrad::FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts,
+                                   std::vector<int64_t>& input_ends, std::vector<int64_t>& input_axes,
+                                   std::vector<int64_t>& input_steps) const {
+  return FillVectorsFromInput(*ctx->Input<Tensor>(2), *ctx->Input<Tensor>(3), ctx->Input<Tensor>(4),
+                              ctx->Input<Tensor>(5), input_starts, input_ends, input_axes, input_steps);
 }
 
 Status SliceGrad::CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,

--- a/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.h
@@ -12,8 +12,8 @@ class SliceGrad final : public Slice<true> {
 
  private:
   const Tensor* GetSlicedOrUnslicedTensor(OpKernelContext* ctx) const override;
-  void FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts, std::vector<int64_t>& input_ends,
-                        std::vector<int64_t>& input_axes, std::vector<int64_t>& input_steps) const override;
+  Status FillInputVectors(OpKernelContext* ctx, std::vector<int64_t>& input_starts, std::vector<int64_t>& input_ends,
+                          std::vector<int64_t>& input_axes, std::vector<int64_t>& input_steps) const override;
 
   Status CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                       const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,

--- a/orttraining/orttraining/training_ops/cuda/tensor/split.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/split.cc
@@ -89,7 +89,7 @@ Status SplitTraining::ComputeInternal(OpKernelContext* ctx) const {
                                   output_table,
                                   input_shape.Size()));
       } else {
-        output_ptr.CopyToGpu();
+        ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu());
         ORT_RETURN_IF_ERROR(SplitSameSplitDimImpl(Stream(),
                                   element_size,
                                   block_size_including_axis_dim,
@@ -101,13 +101,13 @@ Status SplitTraining::ComputeInternal(OpKernelContext* ctx) const {
                                   input_shape.Size()));
       }
     } else {
-      output_ptr.CopyToGpu();
+      ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu());
       CudaAsyncBuffer<int64_t> split_sizes_gpu(this, split_sizes);
       CudaAsyncBuffer<int64_t> split_sizes_range_gpu(this, split_sizes_range);
       CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
-      split_sizes_gpu.CopyToGpu();
-      split_sizes_range_gpu.CopyToGpu();
-      axis_dimension_input_output_mapping_gpu.CopyToGpu();
+      ORT_RETURN_IF_ERROR(split_sizes_gpu.CopyToGpu());
+      ORT_RETURN_IF_ERROR(split_sizes_range_gpu.CopyToGpu());
+      ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu());
   
       ORT_RETURN_IF_ERROR(SplitImpl(Stream(),
                                   element_size,


### PR DESCRIPTION
**Description**
Mark onnxruntime::Status class with [[nodiscard]] attribute.
Fix existing warnings.

**Motivation and Context**
With this change, the return value of functions returning a Status can no longer be accidentally ignored.
It is still possible (but usually not advisable) to explicitly ignore a Status with `ORT_IGNORE_RETURN_VALUE()`.