### PR TITLE
[js/web] always use new data dir for ort web E2E karma tests

### DIFF
--- a/js/web/test/e2e/run.js
+++ b/js/web/test/e2e/run.js
@@ -29,6 +29,7 @@ function getNextUserDataDir() {
   const dir = path.resolve(CHROME_USER_DATA_FOLDER, nextUserDataDirId.toString())
   nextUserDataDirId++;
   fs.emptyDirSync(dir);
+  return dir;
 }
 
 // find packed package


### PR DESCRIPTION
**Description**: This change fixes a [build failure](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=507737&view=logs&j=4cf9212c-8936-5e77-cbdb-290c1c5567eb&t=8a4f1cc9-2423-5c1e-71f3-5ad7e67ee036&l=228) caused by deleting a temporary chrome user data dir in ORT Web E2E test. Always use a new folder for test cases.