### PR TITLE
Fix bug in allocation planner while planning location for initializers

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -704,7 +704,7 @@ class PlannerImpl {
         // transformer and the model will crash while running. The Memcpy transformer
         // is supposed to duplicate initializers being used on different devices within
         // the same graph level and hence we should never see an initializer being used
-        // in different devices here.
+        // on different devices here.
         // The same initializer being used on different devices across graph levels
         // (subgraphs) is okay and utils::CopyInputsAcrossDevices() will take it to
         // the right device before subgraph execution.
@@ -744,14 +744,14 @@ class PlannerImpl {
     // We do not need to maintain a vector of locations that a weight is used in.
     // We only need to know the location of its first usage because:
     // (1) If the initializer is used in the graph level it is introduced in, then it can
-    // only be used in one device as the Memcpy transformer will duplicate the initializer
-    // (with a different name) in case it is used in multiple devices.
-    // In case, the initializer is also additionally used in one of the subgraphs, we rely
+    // only be used on one device as the Memcpy transformer will duplicate the initializer
+    // (with a different name) in case it is used on multiple devices.
+    // If the initializer is also additionally used in one of the subgraphs, we rely
     // on the utils::CopyInputsAcrossDevices() to copy it over to the appropriate device
     // before the subgraphs are executed.
     // (2) If the initializer is NOT used in the level it is introduced in and only used
     // in subgraphs, even then knowing its first usage location is enough as it can't be
-    // used in different devices within the same graph level (see (1) for reason), and for
+    // used on different devices within the same graph level (see (1) for reason), and for
     // nested subgraphs, we can rely on the utils::CopyInputsAcrossDevices() to copy it
     // over to the appropriate device before the subgraphs are executed.
     std::vector<std::vector<OrtMemoryInfo>> locations(plan_.allocation_plan.size());


### PR DESCRIPTION
**Description**: 

There is a bug in location planning for initializers in the allocation planner. 
Example scenario: When a node partitioned to CUDA in the main graph and a node partitioned to CPU in a subgraph using the same initializer would mean that the the planned location for such an initializer would be CPU because of the faulty logic in the allocation planner. If we encountered this, the planned location should always be the location of the initializer's first usage (either at the graph level it is introduced or the first subgraph it is used in). It can't be used on different devices in the same graph level because Memcpy transformer handles such cases and duplicates initializers to be used on different devices. The subgraph feed copy logic will take it to the right device it is needed in the subgraph (if it is different from the planned location for the initializer)

**Motivation and Context**
Fix CUDA crash in 1P model
