### PR TITLE
[js/web] Enable ort model testing

### DIFF
--- a/js/web/script/prepare-test-data.ts
+++ b/js/web/script/prepare-test-data.ts
@@ -50,3 +50,16 @@ if (args.f || args.force || !fs.existsSync(TEST_DATA_NODE)) {
   }
   npmlog.info('PrepareTestData', 'Revert git index... DONE');
 }
+
+if (args.ort) {
+  npmlog.info('PrepareTestData', 'Convert onnx to ort...');
+  const scriptPath = path.join(ROOT, 'tools', 'python', 'convert_onnx_models_to_ort.py');
+  const convert = spawnSync('python', [scriptPath, '--allow_conversion_failures', TEST_DATA_NODE], {stdio: 'ignore'});
+  if (convert.status !== 0) {
+    if (convert.error) {
+      console.error(convert.error);
+    }
+    process.exit(convert.status === null ? undefined : convert.status);
+  }
+  npmlog.info('PrepareTestData', 'Convert onnx to ort... DONE');
+}

--- a/js/web/script/test-runner-cli-args.ts
+++ b/js/web/script/test-runner-cli-args.ts
@@ -48,6 +48,7 @@ Options:
  -P[=<...>], --perf[=<...>]    Generate performance number. Cannot be used with flag --debug.
                                  This flag can be used with a number as value, specifying the total count of test cases to run. The test cases may be used multiple times. Default value is 10.
  -c, --file-cache              Enable file cache.
+ -o, --ort                     Test ort model instead of onnx model.
 
 *** Logging Options ***
 
@@ -147,6 +148,11 @@ export interface TestRunnerCliArgs {
    * Specify the times that test cases to run
    */
   times?: number;
+
+  /**
+   * Whether to use ort model instead of onnx model
+   */
+  ort: boolean;
 
   cpuOptions?: InferenceSession.CpuExecutionProviderOption;
   cudaOptions?: InferenceSession.CudaExecutionProviderOption;
@@ -388,6 +394,8 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
   // Option: --no-sandbox
   const noSandbox = !!args['no-sandbox'];
 
+  const ort = (args.ort || args.O) ? true : false;
+
   npmlog.verbose('TestRunnerCli.Init', ` Mode:              ${mode}`);
   npmlog.verbose('TestRunnerCli.Init', ` Env:               ${env}`);
   npmlog.verbose('TestRunnerCli.Init', ` Debug:             ${debug}`);
@@ -404,6 +412,7 @@ export function parseTestRunnerCliArgs(cmdlineArgs: string[]): TestRunnerCliArgs
     logConfig,
     profile,
     times: perf ? times : undefined,
+    ort,
     fileCache,
     cpuOptions,
     webglOptions,


### PR DESCRIPTION
Currently, npm test only allows a onnx model. This PR enables to test a ort model with "--ort" or "-o" arguments. It also prepare ort models for opset tests, but it needs a separate whitelist than existing one due to difference in coverage, which will be done in other PR.