### PR TITLE
Fix bug in determining default slice axes

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/slice_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_helper.h
@@ -27,7 +27,7 @@ inline Status PrepareForComputeHelper(const std::vector<int64_t>& raw_starts,
   std::vector<int64_t> axes(raw_axes);
   if (axes.empty()) {
     //axes are omitted, they are set to[0, ..., ndim - 1]
-    axes.resize(compute_metadata.starts_.size());
+    axes.resize(raw_starts.size());
     std::iota(axes.begin(), axes.end(), 0);
   }
 
@@ -77,7 +77,7 @@ inline Status PrepareForComputeHelper(const std::vector<int64_t>& raw_starts,
 
   if (axes.empty()) {
     // axes are omitted, they are set to[0, ..., ndim - 1]
-    axes.resize(compute_metadata.starts_.size());
+    axes.resize(raw_starts.size());
     std::iota(axes.begin(), axes.end(), 0);
   }
 

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -192,6 +192,17 @@ TEST(SliceTest, Slice2D_TwoAxesEque) {
                       {});
 }
 
+TEST(SliceTest, Slice2D_DefaultAxes) {
+  RunSliceTest<float>({2, 2},
+                      {1.0f, 2.0f, 3.0f, 4.0f},
+                      {0},
+                      {1},
+                      {},  // default axes
+                      {},  // default steps
+                      {1, 2},
+                      {1.0f, 2.0f});
+}
+
 TEST(SliceTest, Slice3D) {
   RunSliceTest<float>({3, 3, 3},
                       {111.0f, 112.0f, 113.0f,


### PR DESCRIPTION
**Description**: Fix Slice op implementation to correctly compute default axes when length of starts does not match rank of input

**Motivation and Context**
Existing implementation attempts to make axes equal to [0, 1, ..., len(starts) - 1] but uses wrong variable for starts. `compute_metadata.starts_` has length always equal to rank of the input, while `raw_starts` has the correct length.