### PR TITLE
Remove one unnecessary deepcopy in unflatten_user_output

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -295,9 +295,9 @@ def unflatten_user_output(output_schema, outputs):
                     _replace_stub_with_tensor_value(uo, outputs, output_idx)
                     for uo in user_output)
         elif isinstance(user_output, abc.Mapping):
-            new_user_output = type(user_output)()
+            new_user_output = copy.copy(user_output)
             for key in sorted(user_output):
-                new_user_output[key] = _replace_stub_with_tensor_value(user_output[key], outputs, output_idx)
+                new_user_output[key] = _replace_stub_with_tensor_value(new_user_output[key], outputs, output_idx)
             user_output = new_user_output
         else:
             raise wrap_exception(ORTModuleIOError,


### PR DESCRIPTION
**Description**:

The deepcopy is called just before a function recursively walks through the same structure. The changes remove the deepcopy and uses the function to apply the same changes the deepcopy does.

**Motivation and Context**
- Performance.
