### PR TITLE
Resolve issue when running Yolov4 on DNNL EP

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
@@ -11,6 +11,7 @@
 #include "dnnl_fwd.h"
 #include "dnnl_node_capability.h"
 
+#include <iomanip>
 #include <fstream>
 #include "gsl/gsl"
 #define ORT_API_MANUAL_INIT
@@ -217,10 +218,12 @@ std::vector<std::unique_ptr<ComputeCapability>> DNNLExecutionProvider::GetCapabi
   }
 
   if (debug_log_) {
+    float percent_dnnl = 100.0f * (static_cast<float>(num_of_supported_nodes) / static_cast<float>(graph_viewer.NumberOfNodes()));
     LOGS_DEFAULT(ERROR) << "DNNLExecutionProvider::GetCapability,"
                         << " number of partitions supported by DNNL: " << result.size()
                         << " number of nodes in the graph: " << graph_viewer.NumberOfNodes()
-                        << " number of nodes supported by DNNL: " << num_of_supported_nodes;
+                        << " number of nodes supported by DNNL: " << num_of_supported_nodes
+                        << std::fixed << std::setprecision(2) << " (" << percent_dnnl << "%)";
   }
 
   if (dump_subgraphs_) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
@@ -23,8 +23,9 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
     ORT_THROW("op type not supported");
   }
 
-  auto src_0_ori_md = sp.GetMemory(node.Input(IN_A)).get_desc();
-  auto src_1_ori_md = sp.GetMemory(node.Input(IN_B)).get_desc();
+  // GetMemory in OrtFormat. Broadcasting and mix format binary ops can result in computation failure
+  auto src_0_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_A), eng).get_desc();
+  auto src_1_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_B), eng).get_desc();
 
   auto src_0_dims = src_0_ori_md.dims();
   auto src_1_dims = src_1_ori_md.dims();
@@ -54,6 +55,8 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto binary_src0_mem = sp.GetMemoryAndReshape(node.Input(IN_A), binary_pd.src0_desc(), eng);
   auto binary_src1_mem = sp.GetMemoryAndReshape(node.Input(IN_B), binary_pd.src1_desc(), eng);
+
+
 
   auto binary_dst_mem = dnnl::memory(binary_pd.dst_desc(), eng);
   auto binary_prim = dnnl::binary(binary_pd);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reshape.h
@@ -23,7 +23,6 @@ class DnnlReshape{
   void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
 
   private:
-  bool IsMemoryInExpectedOrtFormat(const dnnl::memory::desc& desc);
   bool GetAllowZero(DnnlNode& node);
 };
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
@@ -45,7 +45,7 @@ dnnl::memory::dims DnnlTensor::Dim() {
   return dnnl_dims;
 }
 
-dnnl::memory::data_type DnnlTensor::Type() {
+dnnl::memory::data_type DnnlTensor::Type() const {
   auto data_type = arg_->TypeAsProto()->tensor_type().elem_type();
   switch (data_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED:

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
@@ -18,7 +18,7 @@ class DnnlTensor {
   DnnlTensor(std::string name);
   std::string Name() const;
   dnnl::memory::dims Dim();
-  dnnl::memory::data_type Type();
+  dnnl::memory::data_type Type() const;
   dnnl::memory::format_tag Format();
   //check whether the tensor is dynamic, e.g. contains unspecified dimension
   bool IsDynamic();

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -63,6 +63,11 @@ class DnnlSubgraphPrimitive {
   bool IsDynamic();
   OrtMutex& GetMutex() { return mutex_; }
 
+  //GetMemory in OrtFormat if the memory is not in the OrtFormat this will reorder the memory.
+  //All memory will be moved to the dnnl_engine even if it is already in OrtFormat.
+  dnnl::memory GetMemoryInOrtFormat(const DnnlTensor& tensor, const dnnl::engine& eng);
+  bool IsMemoryInExpectedOrtFormat(const dnnl::memory::desc& desc) const;
+
  private:
   std::string shape_key_;
 


### PR DESCRIPTION
The dnnl_binary ops need the memory format to match the format expected by
Onnxruntime. If the memory format of the inputs does not match each other
there will be an error in the calculated results.

Additionally, since the code manually pads the tensor dimensions for broadcasting
the inputs are expected to be in Onnxruntimes format.

Since detecting and reordering the memory to Ort format matches what was previously
done for the Reshape op the code was moved from dnnl_reshape to
dnnl_subgraph_primitive under the name GetMemoryInOrtFormat.

One small additional change was made to the capability code log to also print the
percentage of nodes run by the dnnl execution provider.

Signed-off-by: George Nash <george.nash@intel.com>

**Description**: 
The commit message describes the change.

This fixes an issue that occurs when one dnnl op reorders the memory then that memory is passed to the binary ops which manipulate the tensor shape so broadcasting can be done by the dnnl ep. The tensor must use the same memory format as OnnxRuntime or the shape manipulation will result in a calculation error.

**Motivation and Context**
- Why is this change required?
Without this change Yolov4 model will fail on the DNNL ep.
-  What problem does it solve?
This fixes an issue that Yolov4 models were failing on the DNNL ep.  The underlying issue was not specific to Yolov4 models but so far has only been seen when running that model.
- If it fixes an open issue, please link to the issue here.
N\A
