### PR TITLE
[WIP] Adds support for RelPartialLearnableAttention operator (for Transformer-XL)

### DIFF
--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -38,6 +38,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Gelu)
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BiasGelu);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FastGelu);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, NGramRepeatBlock);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, RelPartialLearnableAttention);
 
 #ifdef BUILD_MS_EXPERIMENTAL_OPS
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSExperimentalDomain, 1, DFT);
@@ -208,6 +209,7 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Gelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FastGelu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, NGramRepeatBlock)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, RelPartialLearnableAttention)>,
 
 #ifdef BUILD_MS_EXPERIMENTAL_OPS
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSExperimentalDomain, 1, DFT)>,

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "rel_partial_learnable_attention_cpu_base.h"
+#include "rel_partial_learnable_attention_helper.h"
+#include "core/framework/tensorprotoutils.h"
+#include "core/graph/onnx_protobuf.h"
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
+#include "core/common/safeint.h"
+#include "core/platform/threadpool.h"
+
+using onnxruntime::concurrency::ThreadPool;
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+class RelPartialLearnableAttention : public OpKernel, public RelPartialLearnableAttentionCPUBase {
+ public:
+  explicit RelPartialLearnableAttention(const OpKernelInfo& info);
+
+  Status Compute(OpKernelContext* context) const override;
+};
+
+// These ops are internal-only, so register outside of onnx
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    RelPartialLearnableAttention,
+    kMSDomain,
+    1,
+    float,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    RelPartialLearnableAttention<float>);
+
+Status RelPartialLearnableAttentionBase::CheckInputs(const TensorShape& input_shape,
+                                                     const TensorShape& pos_emb_shape,
+                                                     const TensorShape& u_shape,
+                                                     const TensorShape& v_shape,
+                                                     const Tensor*& attn_mask,
+                                                     const Tensor*& mems) const {
+  // Input shapes:
+  //   input       : (batch_size, sequence_length, d_model)
+  //   pos_emb     : (batch_size, sequence_length, d_model)
+  //   u           : (num_heads, head_size)
+  //   v           : (batch_size, sequence_length, d_model)
+  //   attn_mask   : nullptr, (sequence_length, sequence_length)
+  //   mems        : nullptr
+
+  const auto& dims = input_shape.GetDims();
+  if (dims.size() != 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'input' is expected to have 3 dimensions, got ",
+                           dims.size());
+  }
+  int batch_size = static_cast<int>(dims[0]);
+  int sequence_length = static_cast<int>(dims[1]);
+  int d_model = static_cast<int>(dims[2]);
+
+  const auto& pos_emb_dims = pos_emb_shape.GetDims();
+  if (pos_emb_dims.size() != 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'pos_emb' is expected to have 3 dimensions, got ",
+                           pos_emb_dims.size());
+  }
+  if (static_cast<int>(pos_emb_dims[1]) != sequence_length) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'pos_emb' dimension 0 shall have same length as dimension 1 of input 0");
+  }
+  if (static_cast<int>(pos_emb_dims[2]) != d_model) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'pos_emb' dimension 0 shall have same length as dimension 2 of input 0");
+  }
+
+  const auto& u_dims = u_shape.GetDims();
+  if (u_dims.size() != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'u' is expected to have 2 dimensions, got ",
+                           u_dims.size());
+  }
+  if (static_cast<int>(u_dims[0]) != num_heads_) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'u' dimension 0 shall have same length as num_heads");
+  }
+  if (static_cast<int>(u_dims[1]) != head_size_) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'u' dimension 1 shall have same length as head_size");
+  }
+
+  const auto& v_dims = v_shape.GetDims();
+  if (v_dims.size() != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'v' is expected to have 2 dimensions, got ",
+                           v_dims.size());
+  }
+  if (static_cast<int>(v_dims[0]) != num_heads_) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'v' dimension 0 shall have same length as num_heads");
+  }
+  if (static_cast<int>(v_dims[1]) != head_size_) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'v' dimension 1 shall have same length as head_size");
+  }
+
+  if (attn_mask != nullptr) {  // attn_mask is optional
+    const auto& attn_mask_dims = attn_mask->Shape().GetDims();
+    if (attn_mask_dims.size() != 2) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'attn_mask' is expected to have 2 dimensions, got ",
+                             attn_mask_dims.size());
+    }
+    if (static_cast<int>(attn_mask_dims[0]) != sequence_length) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'attn_mask' dimension 0 shall have same length as dimension 1 of input 0");
+    }
+    if (static_cast<int>(attn_mask_dims[1]) != sequence_length) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'attn_mask' dimension 1 shall have same length as dimension 1 of input 0");
+    }
+  }
+
+  if (mems != nullptr) {  // mems is optional
+  }
+
+  return Status::OK();
+}
+
+Status RelPartialLearnableAttentionBase::CheckInputs(const TensorShape& input_shape,
+                                                     const TensorShape& pos_emb_shape,
+                                                     const TensorShape& u_shape,
+                                                     const TensorShape& v_shape,
+                                                     const Tensor*& attn_mask,
+                                                     const Tensor*& mems,
+                                                     const int max_threads_per_block) const {
+  if (num_heads_ > max_threads_per_block) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
+  }
+
+  return CheckInputs(input_shape, pos_emb_shape, u_shape, v_shape, attn_mask, mems);
+}
+
+template <typename T>
+RelPartialLearnableAttention<T>::RelPartialLearnableAttention(const OpKernelInfo& info) : OpKernel(info), RelPartialLearnableAttentionCPUBase(info) {
+}
+
+template <typename T>
+Status RelPartialLearnableAttention<T>::Compute(OpKernelContext* context) const {
+  const Tensor* input = context->Input<Tensor>(0);
+  const Tensor* input_weight = context->Input<Tensor>(1);
+  const Tensor* pos_emb = context->Input<Tensor>(2);
+  const Tensor* pos_emb_weight = context->Input<Tensor>(3);
+  const Tensor* u = context->Input<Tensor>(4);
+  const Tensor* v = context->Input<Tensor>(5);
+  const Tensor* output_weight = context->Input<Tensor>(6);
+
+  const Tensor* attn_mask = context->Input<Tensor>(7);
+  const Tensor* mems = context->Input<Tensor>(8);
+
+  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(),
+                                  pos_emb->Shape(),
+                                  u->Shape(),
+                                  v->Shape(),
+                                  attn_mask,
+                                  mems));
+
+  const auto& shape = input->Shape().GetDims();
+  const int batch_size = static_cast<int>(shape[0]);
+  const int sequence_length = static_cast<int>(shape[1]);
+  const int d_model = static_cast<int>(shape[2]);
+
+  std::vector<int64_t> output_shape(3);
+  output_shape[0] = shape[0];
+  output_shape[1] = shape[1];
+  output_shape[2] = shape[2];
+  Tensor* output = context->Output(0, output_shape);
+
+  constexpr size_t element_size = sizeof(T);
+
+  int q_hidden_size = 0;
+  int k_hidden_size = 0;
+  int v_hidden_size = 0;
+  if (qkv_hidden_sizes_.size() == 0) {
+    q_hidden_size = hidden_size;
+    k_hidden_size = hidden_size;
+    v_hidden_size = hidden_size;
+  } else {
+    q_hidden_size = static_cast<int>(qkv_hidden_sizes_[0]);
+    k_hidden_size = static_cast<int>(qkv_hidden_sizes_[1]);
+    v_hidden_size = static_cast<int>(qkv_hidden_sizes_[2]);
+  }
+  const int qkv_head_size[3] = {q_hidden_size / num_heads_, k_hidden_size / num_heads_, v_hidden_size / num_heads_};
+
+  AllocatorPtr allocator;
+  ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
+
+  auto* tp = context->GetOperatorThreadPool();
+  // Compute Q, K, V
+  // gemm_data(BS, NT) = input(BS, D) x weights(D, NT) + bias(NT)
+  // D (input_hidden_size) is hidden dimension of input, where D could be larger than any of the hidden_sizes
+  // (NH) when model is pruned. T = H1 + H2 + H3, where H1, H2, H3 are head sizes of Q, K, V respectively
+  auto gemm_data = allocator->Alloc(SafeInt<size_t>(batch_size) * sequence_length * (q_hidden_size + k_hidden_size + v_hidden_size) * element_size);
+  BufferUniquePtr gemm_buffer(gemm_data, BufferDeleter(allocator));
+
+  auto Q = reinterpret_cast<T*>(gemm_data);
+  auto K = Q + static_cast<size_t>(batch_size) * sequence_length * q_hidden_size;
+  auto V = K + static_cast<size_t>(batch_size) * sequence_length * k_hidden_size;
+
+  T* QKV[3] = {Q, K, V};
+
+  {
+    const int loop_len = 3 * batch_size * num_heads_;
+    const auto* input_data = input->template Data<T>();
+    const auto* weights_data = weights ? weights->template Data<T>() : nullptr;
+    const auto* bias_data = bias->template Data<T>();
+
+    const double cost =
+        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(input_hidden_size);
+    ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      for (std::ptrdiff_t i = begin; i != end; ++i) {
+        const int batch_index = static_cast<int>((i / 3) / num_heads_);
+        const int head_index = static_cast<int>((i / 3) % num_heads_);
+        const int qkv_index = static_cast<int>(i % 3);
+
+        int input_offset = batch_index * sequence_length * input_hidden_size;
+
+        T* qkv_dest = QKV[qkv_index];
+        int head_size = qkv_head_size[qkv_index];
+        int weights_offset = 0;
+        int bias_offset = qkv_index * q_hidden_size + head_index * head_size;
+
+        if (!is_prepack_) {
+          weights_offset = bias_offset;
+        } else {
+          weights_offset = head_index * head_size;
+        }
+
+        int qkv_offset = (batch_index * num_heads_ + head_index) * (sequence_length * head_size);
+
+        // TODO!! memcpy here makes it not worthwhile to use Gemm batch. Possible to post process?
+        // broadcast NH -> (B.N.S.H) for each of Q, K, V
+        const T* broadcast_data_src = bias_data + bias_offset;
+        T* broadcast_data_dest = QKV[qkv_index] + qkv_offset;
+
+        for (int seq_index = 0; seq_index < sequence_length; seq_index++) {
+          memcpy(broadcast_data_dest, broadcast_data_src, head_size * sizeof(T));
+          broadcast_data_dest += head_size;
+        }
+
+        //                   original           transposed            iteration
+        // A: input          (BxSxD)            (B.)S x D             S x D
+        // B: weights        (DxNxT)             D x (N.)T            D x H
+        // C: QKV[qkv_index] (BxNxSxT)          (B.N.)S x T           S x H
+        if (is_prepack_) {
+          uint8_t* packed_weight;
+          packed_weight = static_cast<uint8_t*>(packed_weights_[qkv_index].get()) + packed_weights_size_[qkv_index] * (weights_offset / head_size);
+
+          MlasGemm(
+              CblasNoTrans,               // TransA = no
+              sequence_length,            // M      = S
+              head_size,                  // N      = H
+              input_hidden_size,          // K      = D
+              1.0f,                       // alpha
+              input_data + input_offset,  // A
+              input_hidden_size,          // lda    = D
+              packed_weight,              // B
+              1.0f,                       // beta
+              qkv_dest + qkv_offset,      // C
+              head_size,                  // ldc
+              nullptr);                   // use single-thread
+        } else {
+          math::GemmEx<float, ThreadPool>(
+              CblasNoTrans,                                   // TransA = no
+              CblasNoTrans,                                   // TransB = no
+              sequence_length,                                // M      = S
+              head_size,                                      // N      = H
+              input_hidden_size,                              // K      = D
+              1.0f,                                           // alpha
+              input_data + input_offset,                      // A
+              input_hidden_size,                              // lda    = D
+              weights_data + weights_offset,                  // B
+              q_hidden_size + k_hidden_size + v_hidden_size,  // ldb = NH1 + NH2 + NH3
+              1.0f,                                           // beta
+              qkv_dest + qkv_offset,                          // C
+              head_size,                                      // ldc
+              nullptr                                         // use single-thread
+          );
+        }
+      }
+    });
+  }
+
+  // Compute the attention score and apply the score to V
+  return ApplyRelPartialLearnableAttention(Q, K, V, mask_index, past, output,
+                                           batch_size, sequence_length,
+                                           qkv_head_size[0], qkv_head_size[2], v_hidden_size,
+                                           extra_add_qk, context);
+}
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
@@ -262,12 +262,12 @@ Status RelPartialLearnableAttention<T>::Compute(OpKernelContext* context) const 
         // TODO!! memcpy here makes it not worthwhile to use Gemm batch. Possible to post process?
         // broadcast NH -> (B.N.S.H) for each of Q, K, V
         // const T* broadcast_data_src = bias_offset;
-        // T* broadcast_data_dest = QKV[qkv_index] + qkv_offset;
+        T* broadcast_data_dest = QKV[qkv_index] + qkv_offset;
 
-        // for (int seq_index = 0; seq_index < sequence_length; seq_index++) {
-        //   memcpy(broadcast_data_dest, broadcast_data_src, head_size_ * sizeof(T));
-        //   broadcast_data_dest += head_size_;
-        // }
+        for (int seq_index = 0; seq_index < sequence_length; seq_index++) {
+          // memcpy(broadcast_data_dest, broadcast_data_src, head_size_ * sizeof(T));
+          broadcast_data_dest += head_size_;
+        }
 
         //                   original           transposed            iteration
         // A: input          (BxSxD)            (B.)S x D             S x D

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
@@ -252,20 +252,19 @@ Status RelPartialLearnableAttention<T>::Compute(OpKernelContext* context) const 
         int input_offset = batch_index * sequence_length * d_model;
 
         T* qkv_dest = QKV[qkv_index];
-        int weights_offset = 0;
         int bias_offset = qkv_index * d_model + head_index * head_size_;
-
-        weights_offset = bias_offset;
+        int weights_offset = bias_offset;
 
         int qkv_offset = (batch_index * num_heads_ + head_index) * (sequence_length * head_size_);
 
         // TODO!! memcpy here makes it not worthwhile to use Gemm batch. Possible to post process?
         // broadcast NH -> (B.N.S.H) for each of Q, K, V
-        // const T* broadcast_data_src = bias_offset;
+        T bias_data = {0.0};
+        const T* broadcast_data_src = &bias_data + bias_offset;
         T* broadcast_data_dest = QKV[qkv_index] + qkv_offset;
 
         for (int seq_index = 0; seq_index < sequence_length; seq_index++) {
-          // memcpy(broadcast_data_dest, broadcast_data_src, head_size_ * sizeof(T));
+          memcpy(broadcast_data_dest, broadcast_data_src, head_size_ * sizeof(T));
           broadcast_data_dest += head_size_;
         }
 

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention.cc
@@ -24,11 +24,10 @@ class RelPartialLearnableAttention : public OpKernel, public RelPartialLearnable
 };
 
 // These ops are internal-only, so register outside of onnx
-ONNX_OPERATOR_TYPED_KERNEL_EX(
+ONNX_OPERATOR_KERNEL_EX(
     RelPartialLearnableAttention,
     kMSDomain,
     1,
-    float,
     kCpuExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_base.h
@@ -13,9 +13,12 @@ class RelPartialLearnableAttentionBase {
  public:
   // This check function is specifically used in cuda
   Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& input_weights_shape,
                      const TensorShape& pos_emb_shape,
-                     const TensorShape& u_shape,
-                     const TensorShape& v_shape,
+                     const TensorShape& pos_emb_weights_shape,
+                     const TensorShape& r_w_bias_shape,
+                     const TensorShape& r_r_bias_shape,
+                     const TensorShape& output_weights_shape,
                      const Tensor*& attn_mask,
                      const Tensor*& mems,
                      const int max_threads_per_block) const;
@@ -36,15 +39,18 @@ class RelPartialLearnableAttentionBase {
   }
 
   Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& input_weights_shape,
                      const TensorShape& pos_emb_shape,
-                     const TensorShape& u_shape,
-                     const TensorShape& v_shape,
+                     const TensorShape& pos_emb_weights_shape,
+                     const TensorShape& r_w_bias_shape,
+                     const TensorShape& r_r_bias_shape,
+                     const TensorShape& output_weights_shape,
                      const Tensor*& attn_mask,
                      const Tensor*& mems) const;
 
-  int num_heads_;           // number of attention heads
-  int head_size_;           // size of attention heads
-  int d_model_;           // dimension of hidden states
+  int num_heads_;  // number of attention heads
+  int head_size_;  // size of attention heads
+  int d_model_;    // dimension of hidden states
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_base.h
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+class RelPartialLearnableAttentionBase {
+ public:
+  // This check function is specifically used in cuda
+  Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& pos_emb_shape,
+                     const TensorShape& u_shape,
+                     const TensorShape& v_shape,
+                     const Tensor*& attn_mask,
+                     const Tensor*& mems,
+                     const int max_threads_per_block) const;
+
+ protected:
+  RelPartialLearnableAttentionBase(const OpKernelInfo& info) {
+    int64_t num_heads = 0;
+    ORT_ENFORCE(info.GetAttr("num_heads", &num_heads).IsOK() && num_heads > 0);
+    num_heads_ = static_cast<int>(num_heads);
+
+    int64_t head_size = 0;
+    ORT_ENFORCE(info.GetAttr("head_size", &head_size).IsOK() && head_size > 0);
+    head_size_ = static_cast<int>(head_size);
+
+    int64_t d_model = 0;
+    ORT_ENFORCE(info.GetAttr("d_model", &d_model).IsOK() && d_model > 0);
+    d_model_ = static_cast<int>(d_model);
+  }
+
+  Status CheckInputs(const TensorShape& input_shape,
+                     const TensorShape& pos_emb_shape,
+                     const TensorShape& u_shape,
+                     const TensorShape& v_shape,
+                     const Tensor*& attn_mask,
+                     const Tensor*& mems) const;
+
+  int num_heads_;           // number of attention heads
+  int head_size_;           // size of attention heads
+  int d_model_;           // dimension of hidden states
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
@@ -21,17 +21,17 @@ class RelPartialLearnableAttentionCPUBase : public RelPartialLearnableAttentionB
   Status ApplyRelPartialLearnableAttention(const T* Q,                  // Q data with size BxNxSxH
                                            const T* K,                  // K data with size BxNxSxH
                                            const T* V,                  // V value with size BxNxSxH
-                                           const T* R,                  // R value with size BxNxSxH
-                                           const T* U,                  // U value with size NxH
-                                           const T* V,                  // V value with size NxH
+                                          //  const T* R,                  // R value with size BxNxSxH
+                                          //  const T* U,                  // U value with size NxH
+                                          //  const T* V,                  // V value with size NxH
                                            const Tensor* attn_mask,     // attention mask. nullptr if no mask or its size is SxS
-                                           const Tensor* attn_mask,     // memories. nullptr if no memories
+                                           const Tensor* mems,     // memories. nullptr if no memories
                                            Tensor* output,              // output tensor
                                            int batch_size,              // batch size
                                            int sequence_length,         // sequence length
                                            int d_model,                 // dimension hidden states
                                            int num_heads,               // number of heads
-                                           int head_size                // head size
+                                           int head_size,               // head size
                                            OpKernelContext* context) const {
     AllocatorPtr allocator;
     ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
@@ -18,227 +18,24 @@ class RelPartialLearnableAttentionCPUBase : public RelPartialLearnableAttentionB
   RelPartialLearnableAttentionCPUBase(const OpKernelInfo& info) : RelPartialLearnableAttentionBase(info) {}
 
   template <typename T>
-  Status ApplyRelPartialLearnableAttention(const T* Q,                  // Q data with size BxNxSxH
-                                           const T* K,                  // K data with size BxNxSxH
-                                           const T* V,                  // V value with size BxNxSxH
-                                          //  const T* R,                  // R value with size BxNxSxH
-                                          //  const T* U,                  // U value with size NxH
-                                          //  const T* V,                  // V value with size NxH
-                                           const Tensor* attn_mask,     // attention mask. nullptr if no mask or its size is SxS
-                                           const Tensor* mems,     // memories. nullptr if no memories
-                                           Tensor* output,              // output tensor
-                                           int batch_size,              // batch size
-                                           int sequence_length,         // sequence length
-                                           int d_model,                 // dimension hidden states
-                                           int num_heads,               // number of heads
-                                           int head_size,               // head size
+  Status ApplyRelPartialLearnableAttention(const T* Q,               // Q data with size BxNxSxH
+                                           const T* K,               // K data with size BxNxSxH
+                                           const T* V,               // V value with size BxNxSxH
+                                           const Tensor* pos_emb,
+                                           const Tensor* pos_emb_weights,
+                                           const Tensor* r_w_bias,
+                                           const Tensor* r_r_bias,
+                                           const Tensor* output_weights,
+                                           const Tensor* attn_mask,  // attention mask. nullptr if no mask or its size is SxS
+                                           const Tensor* mems,       // memories. nullptr if no memories
+                                           Tensor* output,           // output tensor
+                                           int batch_size,           // batch size
+                                           int sequence_length,      // sequence length
+                                           int d_model,              // dimension hidden states
+                                           int num_heads,            // number of heads
+                                           int head_size,            // head size
                                            OpKernelContext* context) const {
-    AllocatorPtr allocator;
-    ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
-
-    auto* tp = context->GetOperatorThreadPool();
-
-    //
-    // (Q + U) x K = AC
-    // (Q + V) x R = BD
-    // (AC + BD) x 1/sqrt(H) + attn_mask = attn_probs
-    // Softmax(attn_probs) x V = attn_vec
-    // attn_vec x O = output
-    // Compute the attention score. It does 2 things:
-    //         I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
-    //                                           1 x mask_data(B, N, S, S*)
-    //         II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
-    size_t attention_probs_bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T);
-    auto attention_probs = allocator->Alloc(attention_probs_bytes);
-    BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
-
-    bool has_unidirectional = (is_unidirectional_ && sequence_length > 1);
-
-    void* mask_data = nullptr;
-    if (mask_index != nullptr || has_unidirectional) {
-      size_t mask_data_bytes = SafeInt<size_t>(batch_size) * sequence_length * all_sequence_length * sizeof(T);
-      mask_data = allocator->Alloc(mask_data_bytes);
-      memset(mask_data, 0, mask_data_bytes);
-    }
-    BufferUniquePtr mask_data_buffer(mask_data, BufferDeleter(allocator));
-
-    const int32_t* mask_index_data = mask_index != nullptr ? mask_index->template Data<int32_t>() : nullptr;
-    const std::vector<int64_t>* mask_index_dims = mask_index != nullptr ? &(mask_index->Shape().GetDims()) : nullptr;
-    const T* past_data = past != nullptr ? past->template Data<T>() : nullptr;
-    T* present_data = present != nullptr ? present->template MutableData<T>() : nullptr;
-
-    const T* extra_add_qk_data = nullptr;
-    if (extra_add_qk != nullptr) {
-      extra_add_qk_data = extra_add_qk->template Data<T>();
-    }
-
-    ComputeRelPartialLearnableAttentionProbs<T>(static_cast<T*>(attention_probs), Q, K,
-                                                mask_index_data, mask_index_dims, static_cast<T*>(mask_data), has_unidirectional,
-                                                batch_size, sequence_length, past_sequence_length, qk_head_size == 0 ? v_head_size : qk_head_size,
-                                                past_data, present_data, tp, extra_add_qk_data);
-
-    // Compute the attentionScore * Value. It does: out_tmp(B, N, S, H) = attention_probs(B, N, S, S*) x V(B, N, S*, H)
-    auto out_tmp_data =
-        allocator->Alloc(SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * v_head_size * sizeof(T));
-    BufferUniquePtr out_tmp_buffer(out_tmp_data, BufferDeleter(allocator));
-
-    ComputeVxRelPartialLearnableAttentionScore(output->template MutableData<T>(), static_cast<T*>(out_tmp_data), static_cast<T*>(attention_probs), V,
-                                               batch_size, sequence_length, past_sequence_length, v_head_size, v_hidden_size,
-                                               past_data, present_data, tp);
-
     return Status::OK();
-  }
-
- private:
-  // Helper function to compute the attention probs. It does 2 things:
-  //  I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
-  //                                    1 x mask_data(B, N, S, S*)
-  //  II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
-  template <typename T>
-  void ComputeRelPartialLearnableAttentionProbs(T* attention_probs,                           // output buffer for the attention probs. Its size is BxNxSxS*
-                                                const T* Q,                                   // Q data. Its size is BxNxSxH
-                                                const T* K,                                   // k data. Its size is BxNxSxH
-                                                const int32_t* mask_index,                    // mask index. nullptr if no mask or its size is B
-                                                const std::vector<int64_t>* mask_index_dims,  // mask index shape
-                                                T* mask_data,                                 // buffer for mask data. It is nullptr if mask_index is nullptr and not unidirectional, otherwise its shape is BxSxS*
-                                                bool has_unidirectional,                      // has unidirectional mask
-                                                int batch_size,                               // batch size of self-attention
-                                                int sequence_length,                          // sequence length of self-attention
-                                                int past_sequence_length,                     // sequence length of past state
-                                                int head_size,                                // head size of self-attention
-                                                const T* past,                                // past state
-                                                T* present,                                   // present state
-                                                ThreadPool* tp,                               // thread pool
-                                                const T* extra_add_qk_data                    // extra add matrix with shape BxNxSxS*
-  ) const {
-    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
-    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // S' x H
-    const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // S x H
-    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
-
-    {
-      if (mask_data != nullptr) {
-        PrepareMask(mask_index, mask_index_dims, mask_data, has_unidirectional, batch_size, sequence_length, past_sequence_length);
-      } else {  // no any mask
-        memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
-      }
-
-      const int loop_len = batch_size * num_heads_;
-      const float alpha = 1.0f / sqrt(static_cast<float>(head_size));
-
-      // The cost of Gemm
-      const double cost = static_cast<double>(head_size) * sequence_length * all_sequence_length;
-
-      ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-        for (std::ptrdiff_t i = begin; i != end; ++i) {
-          const int batch_index = static_cast<int>(i) / num_heads_;
-
-          const int output_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
-          const int mask_offset = batch_index * sequence_length * all_sequence_length;
-          T* output = attention_probs + output_offset;
-
-          // Broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
-          if (mask_data != nullptr) {
-            memcpy(output, mask_data + mask_offset, sequence_length * all_sequence_length * sizeof(T));
-          }
-
-          const T* k = K + input_chunk_length * i;
-          if (nullptr != present) {
-            // Concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
-            k = ConcatStateChunk(past, k, present, past_chunk_length, present_chunk_length, i);
-          }
-
-          // Compute Q*K' + AttentionMask
-          //                     original                 transposed             each iteration
-          // A: Q                (B x N x) S x H          (B x N x) S x H        S x H
-          // B: K'               (B x N x) S* x H         (B x N x) H x S*       H x S*
-          // C: attention_probs  (B x N x) S x S*         (B x N x) S x S*       S x S*
-          math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, all_sequence_length, head_size, alpha,
-                                    Q + input_chunk_length * i, k, 1.0,
-                                    output, nullptr);
-
-          // Fix unidirectional mask to be parity with huggingface implementation.
-          if (has_unidirectional) {
-            for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
-              for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
-                int j = s_i * all_sequence_length + m_i;
-                output[j] = mask_data[mask_offset + j];
-              }
-            }
-          }
-
-          if (extra_add_qk_data != nullptr) {
-            for (int j = 0; j < sequence_length * all_sequence_length; j++) {
-              output[j] += extra_add_qk_data[output_offset + j];
-            }
-          }
-        }
-      });
-    }
-
-    //  attention_probs(B, N, S, S*) = Softmax(attention_probs)
-    {
-      const int N = batch_size * num_heads_ * sequence_length;
-      const int D = all_sequence_length;
-      ComputeRelPartialLearnableAttentionSoftmaxInplace(attention_probs, N, D, tp);
-    }
-  }
-
-  template <typename T>
-  void ComputeVxRelPartialLearnableAttentionScore(T* output,                 // buffer for the result with size BxSxNxH
-                                                  T* tmp_buffer,             // buffer for temp use with size is BxNxSxH
-                                                  const T* attention_probs,  // Attention probs with size BxNxSxS*
-                                                  const T* V,                // V value with size BxNxSxH
-                                                  int batch_size,            // batch size
-                                                  int sequence_length,       // sequence length
-                                                  int past_sequence_length,  // sequence length in past state
-                                                  int head_size,             // head size
-                                                  int hidden_size,           // hidden size
-                                                  const T* past,             // past state
-                                                  T* present,                // present state
-                                                  ThreadPool* tp) const {
-    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
-    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length * head_size);  // S' x H
-    const size_t input_chunk_length = static_cast<size_t>(sequence_length * head_size);      // S x H
-    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
-
-    // Move the pointer of past and present to start of v values.
-    if (nullptr != past) {
-      past += batch_size * num_heads_ * past_sequence_length * head_size;
-    }
-    if (nullptr != present) {
-      present += batch_size * num_heads_ * all_sequence_length * head_size;
-    }
-
-    const double cost =
-        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(sequence_length);
-
-    ThreadPool::TryParallelFor(tp, batch_size * num_heads_, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
-      for (std::ptrdiff_t i = begin; i != end; ++i) {
-        const T* v = V + input_chunk_length * i;
-        if (nullptr != present) {
-          // concatenate past_V and V: (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
-          v = ConcatStateChunk(past, v, present, past_chunk_length, present_chunk_length, i);
-        }
-
-        T* current_tmp_data = reinterpret_cast<T*>(tmp_buffer) + input_chunk_length * i;
-        math::MatMul<T>(sequence_length, head_size, all_sequence_length,
-                        attention_probs + sequence_length * all_sequence_length * i,
-                        v, current_tmp_data, nullptr);
-
-        // transpose: out(B, S, N, H) = transpose out_tmp(B, N, S, H)
-        const int batch_index = static_cast<int>(i / num_heads_);
-        const int head_index = static_cast<int>(i % num_heads_);
-        T* src = current_tmp_data;
-        T* dest = output + (batch_index * sequence_length * num_heads_ + head_index) * head_size;
-        const auto bytes_to_copy = SafeInt<size_t>(head_size) * sizeof(T);
-        for (int j = 0; j < sequence_length; j++) {
-          memcpy(dest, src, bytes_to_copy);
-          src += head_size;
-          dest += hidden_size;
-        }
-      }
-    });
   }
 };
 

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_cpu_base.h
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "rel_partial_learnable_attention_base.h"
+#include "rel_partial_learnable_attention_helper.h"
+
+#include "core/common/common.h"
+#include "core/common/safeint.h"
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+class RelPartialLearnableAttentionCPUBase : public RelPartialLearnableAttentionBase {
+ protected:
+  RelPartialLearnableAttentionCPUBase(const OpKernelInfo& info) : RelPartialLearnableAttentionBase(info) {}
+
+  template <typename T>
+  Status ApplyRelPartialLearnableAttention(const T* Q,                  // Q data with size BxNxSxH
+                                           const T* K,                  // K data with size BxNxSxH
+                                           const T* V,                  // V value with size BxNxSxH
+                                           const T* R,                  // R value with size BxNxSxH
+                                           const T* U,                  // U value with size NxH
+                                           const T* V,                  // V value with size NxH
+                                           const Tensor* attn_mask,     // attention mask. nullptr if no mask or its size is SxS
+                                           const Tensor* attn_mask,     // memories. nullptr if no memories
+                                           Tensor* output,              // output tensor
+                                           int batch_size,              // batch size
+                                           int sequence_length,         // sequence length
+                                           int d_model,                 // dimension hidden states
+                                           int num_heads,               // number of heads
+                                           int head_size                // head size
+                                           OpKernelContext* context) const {
+    AllocatorPtr allocator;
+    ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
+
+    auto* tp = context->GetOperatorThreadPool();
+
+    //
+    // (Q + U) x K = AC
+    // (Q + V) x R = BD
+    // (AC + BD) x 1/sqrt(H) + attn_mask = attn_probs
+    // Softmax(attn_probs) x V = attn_vec
+    // attn_vec x O = output
+    // Compute the attention score. It does 2 things:
+    //         I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
+    //                                           1 x mask_data(B, N, S, S*)
+    //         II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
+    size_t attention_probs_bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T);
+    auto attention_probs = allocator->Alloc(attention_probs_bytes);
+    BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
+
+    bool has_unidirectional = (is_unidirectional_ && sequence_length > 1);
+
+    void* mask_data = nullptr;
+    if (mask_index != nullptr || has_unidirectional) {
+      size_t mask_data_bytes = SafeInt<size_t>(batch_size) * sequence_length * all_sequence_length * sizeof(T);
+      mask_data = allocator->Alloc(mask_data_bytes);
+      memset(mask_data, 0, mask_data_bytes);
+    }
+    BufferUniquePtr mask_data_buffer(mask_data, BufferDeleter(allocator));
+
+    const int32_t* mask_index_data = mask_index != nullptr ? mask_index->template Data<int32_t>() : nullptr;
+    const std::vector<int64_t>* mask_index_dims = mask_index != nullptr ? &(mask_index->Shape().GetDims()) : nullptr;
+    const T* past_data = past != nullptr ? past->template Data<T>() : nullptr;
+    T* present_data = present != nullptr ? present->template MutableData<T>() : nullptr;
+
+    const T* extra_add_qk_data = nullptr;
+    if (extra_add_qk != nullptr) {
+      extra_add_qk_data = extra_add_qk->template Data<T>();
+    }
+
+    ComputeRelPartialLearnableAttentionProbs<T>(static_cast<T*>(attention_probs), Q, K,
+                                                mask_index_data, mask_index_dims, static_cast<T*>(mask_data), has_unidirectional,
+                                                batch_size, sequence_length, past_sequence_length, qk_head_size == 0 ? v_head_size : qk_head_size,
+                                                past_data, present_data, tp, extra_add_qk_data);
+
+    // Compute the attentionScore * Value. It does: out_tmp(B, N, S, H) = attention_probs(B, N, S, S*) x V(B, N, S*, H)
+    auto out_tmp_data =
+        allocator->Alloc(SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * v_head_size * sizeof(T));
+    BufferUniquePtr out_tmp_buffer(out_tmp_data, BufferDeleter(allocator));
+
+    ComputeVxRelPartialLearnableAttentionScore(output->template MutableData<T>(), static_cast<T*>(out_tmp_data), static_cast<T*>(attention_probs), V,
+                                               batch_size, sequence_length, past_sequence_length, v_head_size, v_hidden_size,
+                                               past_data, present_data, tp);
+
+    return Status::OK();
+  }
+
+ private:
+  // Helper function to compute the attention probs. It does 2 things:
+  //  I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
+  //                                    1 x mask_data(B, N, S, S*)
+  //  II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
+  template <typename T>
+  void ComputeRelPartialLearnableAttentionProbs(T* attention_probs,                           // output buffer for the attention probs. Its size is BxNxSxS*
+                                                const T* Q,                                   // Q data. Its size is BxNxSxH
+                                                const T* K,                                   // k data. Its size is BxNxSxH
+                                                const int32_t* mask_index,                    // mask index. nullptr if no mask or its size is B
+                                                const std::vector<int64_t>* mask_index_dims,  // mask index shape
+                                                T* mask_data,                                 // buffer for mask data. It is nullptr if mask_index is nullptr and not unidirectional, otherwise its shape is BxSxS*
+                                                bool has_unidirectional,                      // has unidirectional mask
+                                                int batch_size,                               // batch size of self-attention
+                                                int sequence_length,                          // sequence length of self-attention
+                                                int past_sequence_length,                     // sequence length of past state
+                                                int head_size,                                // head size of self-attention
+                                                const T* past,                                // past state
+                                                T* present,                                   // present state
+                                                ThreadPool* tp,                               // thread pool
+                                                const T* extra_add_qk_data                    // extra add matrix with shape BxNxSxS*
+  ) const {
+    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
+    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // S' x H
+    const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // S x H
+    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
+
+    {
+      if (mask_data != nullptr) {
+        PrepareMask(mask_index, mask_index_dims, mask_data, has_unidirectional, batch_size, sequence_length, past_sequence_length);
+      } else {  // no any mask
+        memset(attention_probs, 0, static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T));
+      }
+
+      const int loop_len = batch_size * num_heads_;
+      const float alpha = 1.0f / sqrt(static_cast<float>(head_size));
+
+      // The cost of Gemm
+      const double cost = static_cast<double>(head_size) * sequence_length * all_sequence_length;
+
+      ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+        for (std::ptrdiff_t i = begin; i != end; ++i) {
+          const int batch_index = static_cast<int>(i) / num_heads_;
+
+          const int output_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
+          const int mask_offset = batch_index * sequence_length * all_sequence_length;
+          T* output = attention_probs + output_offset;
+
+          // Broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
+          if (mask_data != nullptr) {
+            memcpy(output, mask_data + mask_offset, sequence_length * all_sequence_length * sizeof(T));
+          }
+
+          const T* k = K + input_chunk_length * i;
+          if (nullptr != present) {
+            // Concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+            k = ConcatStateChunk(past, k, present, past_chunk_length, present_chunk_length, i);
+          }
+
+          // Compute Q*K' + AttentionMask
+          //                     original                 transposed             each iteration
+          // A: Q                (B x N x) S x H          (B x N x) S x H        S x H
+          // B: K'               (B x N x) S* x H         (B x N x) H x S*       H x S*
+          // C: attention_probs  (B x N x) S x S*         (B x N x) S x S*       S x S*
+          math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, all_sequence_length, head_size, alpha,
+                                    Q + input_chunk_length * i, k, 1.0,
+                                    output, nullptr);
+
+          // Fix unidirectional mask to be parity with huggingface implementation.
+          if (has_unidirectional) {
+            for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
+              for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
+                int j = s_i * all_sequence_length + m_i;
+                output[j] = mask_data[mask_offset + j];
+              }
+            }
+          }
+
+          if (extra_add_qk_data != nullptr) {
+            for (int j = 0; j < sequence_length * all_sequence_length; j++) {
+              output[j] += extra_add_qk_data[output_offset + j];
+            }
+          }
+        }
+      });
+    }
+
+    //  attention_probs(B, N, S, S*) = Softmax(attention_probs)
+    {
+      const int N = batch_size * num_heads_ * sequence_length;
+      const int D = all_sequence_length;
+      ComputeRelPartialLearnableAttentionSoftmaxInplace(attention_probs, N, D, tp);
+    }
+  }
+
+  template <typename T>
+  void ComputeVxRelPartialLearnableAttentionScore(T* output,                 // buffer for the result with size BxSxNxH
+                                                  T* tmp_buffer,             // buffer for temp use with size is BxNxSxH
+                                                  const T* attention_probs,  // Attention probs with size BxNxSxS*
+                                                  const T* V,                // V value with size BxNxSxH
+                                                  int batch_size,            // batch size
+                                                  int sequence_length,       // sequence length
+                                                  int past_sequence_length,  // sequence length in past state
+                                                  int head_size,             // head size
+                                                  int hidden_size,           // hidden size
+                                                  const T* past,             // past state
+                                                  T* present,                // present state
+                                                  ThreadPool* tp) const {
+    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
+    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length * head_size);  // S' x H
+    const size_t input_chunk_length = static_cast<size_t>(sequence_length * head_size);      // S x H
+    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
+
+    // Move the pointer of past and present to start of v values.
+    if (nullptr != past) {
+      past += batch_size * num_heads_ * past_sequence_length * head_size;
+    }
+    if (nullptr != present) {
+      present += batch_size * num_heads_ * all_sequence_length * head_size;
+    }
+
+    const double cost =
+        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(sequence_length);
+
+    ThreadPool::TryParallelFor(tp, batch_size * num_heads_, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+      for (std::ptrdiff_t i = begin; i != end; ++i) {
+        const T* v = V + input_chunk_length * i;
+        if (nullptr != present) {
+          // concatenate past_V and V: (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+          v = ConcatStateChunk(past, v, present, past_chunk_length, present_chunk_length, i);
+        }
+
+        T* current_tmp_data = reinterpret_cast<T*>(tmp_buffer) + input_chunk_length * i;
+        math::MatMul<T>(sequence_length, head_size, all_sequence_length,
+                        attention_probs + sequence_length * all_sequence_length * i,
+                        v, current_tmp_data, nullptr);
+
+        // transpose: out(B, S, N, H) = transpose out_tmp(B, N, S, H)
+        const int batch_index = static_cast<int>(i / num_heads_);
+        const int head_index = static_cast<int>(i % num_heads_);
+        T* src = current_tmp_data;
+        T* dest = output + (batch_index * sequence_length * num_heads_ + head_index) * head_size;
+        const auto bytes_to_copy = SafeInt<size_t>(head_size) * sizeof(T);
+        for (int j = 0; j < sequence_length; j++) {
+          memcpy(dest, src, bytes_to_copy);
+          src += head_size;
+          dest += hidden_size;
+        }
+      }
+    });
+  }
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transfo_xl/rel_partial_learnable_attention_helper.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
+#include "core/common/safeint.h"
+#include "core/platform/threadpool.h"
+#include "core/providers/common.h"
+#include "core/mlas/inc/mlas.h"
+
+using onnxruntime::concurrency::ThreadPool;
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+void ComputeRelPartialLearnableAttentionSoftmaxInplace(T* score, int N, int D, ThreadPool* tp) {
+  ThreadPool::TryParallelFor(tp, N, D * 2.0, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
+    for (std::ptrdiff_t j = begin; j != end; ++j) {
+      float* x = reinterpret_cast<T*>(score) + j * D;
+      float* y = x;
+
+      // e^x is represented as infinity if x is large enough, like 100.f.
+      // Infinity divided by Infinity is a NAN. Thus, softmax gets a NAN if
+      // one or more item are large enough. a math transform as below is
+      // leveraged to get a stable softmax: e^xi/(e^x1 + ...e^xn) = e^(xi -
+      // max) / (e^(x1 - max) + ... + e^(xn - max))
+      float max = -std::numeric_limits<float>::infinity();
+      for (int i = 0; i < D; i++) {
+        if (max < x[i])
+          max = x[i];
+      }
+      for (int i = 0; i < D; i++) {
+        y[i] = expf(x[i] - max);
+      }
+
+      double sum = 0.0;
+
+      for (int i = 0; i < D; i++) {
+        sum += x[i];
+      }
+
+      if (sum == 0) {
+        for (int i = 0; i < D; i++) {
+          y[i] = 1.0f / (float)D;
+        }
+      } else {
+        for (int i = 0; i < D; i++) {
+          y[i] = x[i] / (float)sum;
+        }
+      }
+    }
+  });
+}
+
+template <>
+inline void ComputeRelPartialLearnableAttentionSoftmaxInplace(float* score, int N, int D, ThreadPool* tp) {
+  MlasComputeSoftmax(score, score, N, D, false, tp);
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -850,7 +850,11 @@ void RelPartialLearnableAttentionTypeAndShapeInference(ONNX_NAMESPACE::Inference
 
 void RegisterTransfoXLSchemas() {
   static const char* RelPartialLearnableAttention_ver1_doc = R"DOC(
-RelPartial...
+Relative Partial-Learnable Multi-Head Attention incorporates relative positional encondings
+to keep the positional information coherent when reusing states within a multi-head attention layer.
+The attention mask (sequence_length, sequence_length) is optional and used to mask the usage of future tokens, which is a common setting
+in autoregressive tasks. Additionally, memories (extension of previous states) can be used to feed
+additional information into the multi-head attentions.
 )DOC";
 
   ONNX_CONTRIB_OPERATOR_SCHEMA(RelPartialLearnableAttention)
@@ -868,7 +872,7 @@ RelPartial...
       .Input(5, "r_r_bias", "2D input tensor with shape (num_heads, head_size)", "T")
       .Input(6, "output_weights", "2D input tensor with shape (num_heads * head_size, d_model)", "T")
       .Input(7, "attn_mask", "Attention mask with shape (sequence_length, sequence_length).", "M", OpSchema::Optional)
-      .Input(8, "mems", "Memories with shape (?, ?, ?).", "T", OpSchema::Optional)
+      .Input(8, "mems", "Memories with shape (batch_size, sequence_length + memory_length, d_model).", "T", OpSchema::Optional)
       .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, d_model)", "T")
       .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float tensors.")
       .TypeConstraint("M", {"tensor(int32)"}, "Constrain mask index to integer types")

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -832,29 +832,11 @@ void RelPartialLearnableAttentionTypeAndShapeInference(ONNX_NAMESPACE::Inference
   ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
   // Shape inference
-  if (hasInputShape(ctx, 0) && hasInputShape(ctx, 2) && hasInputShape(ctx, 4) && hasInputShape(ctx, 5)) {
+  if (hasInputShape(ctx, 0)) {
     auto& input_shape = getInputShape(ctx, 0);
     auto& input_dims = input_shape.dim();
     if (input_dims.size() != 3) {
       fail_shape_inference("Inputs 0 shall be 3 dimensions");
-    }
-
-    auto& pos_emb_shape = getInputShape(ctx, 2);
-    auto& pos_emb_dims = pos_emb_shape.dim();
-    if (pos_emb_dims.size() != 3) {
-      fail_shape_inference("Inputs 2 shall be 3 dimensions");
-    }
-
-    auto& u_shape = getInputShape(ctx, 4);
-    auto& u_dims = u_shape.dim();
-    if (u_dims.size() != 2) {
-      fail_shape_inference("Inputs 4 shall be 2 dimensions");
-    }
-
-    auto& v_shape = getInputShape(ctx, 5);
-    auto& v_dims = v_shape.dim();
-    if (v_dims.size() != 5) {
-      fail_shape_inference("Inputs 5 shall be 2 dimensions");
     }
 
     ONNX_NAMESPACE::TensorShapeProto output_shape;
@@ -879,12 +861,12 @@ RelPartial...
       .Attr("head_size", "Size of attention heads", AttributeProto::INT)
       .Attr("d_model", "Dimension of hidden states", AttributeProto::INT)
       .Input(0, "input", "3D input tensor with shape (batch_size, sequence_length, d_model)", "T")
-      .Input(1, "input_weight", "2D input tensor with shape (d_model, 3 * num_heads * head_size)", "T")
+      .Input(1, "input_weights", "2D input tensor with shape (d_model, 3 * num_heads * head_size)", "T")
       .Input(2, "pos_emb", "3D input tensor with shape (batch_size, sequence_length, d_model)", "T")
-      .Input(3, "pos_emb_weight", "2D input tensor with shape (d_model, num_heads * head_size)", "T")
-      .Input(4, "u", "2D input tensor with shape (num_heads, head_size)", "T")
-      .Input(5, "v", "2D input tensor with shape (num_heads, head_size)", "T")
-      .Input(6, "output_weight", "2D input tensor with shape (num_heads * head_size, d_model)", "T")
+      .Input(3, "pos_emb_weights", "2D input tensor with shape (d_model, num_heads * head_size)", "T")
+      .Input(4, "r_w_bias", "2D input tensor with shape (num_heads, head_size)", "T")
+      .Input(5, "r_r_bias", "2D input tensor with shape (num_heads, head_size)", "T")
+      .Input(6, "output_weights", "2D input tensor with shape (num_heads * head_size, d_model)", "T")
       .Input(7, "attn_mask", "Attention mask with shape (sequence_length, sequence_length).", "M", OpSchema::Optional)
       .Input(8, "mems", "Memories with shape (?, ?, ?).", "T", OpSchema::Optional)
       .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, d_model)", "T")

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.h
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.h
@@ -32,6 +32,7 @@ namespace contrib {
 void RegisterContribSchemas();
 void RegisterNchwcSchemas();
 void RegisterNhwcSchemas();
+void RegisterTransfoXLSchemas();
 void RegisterQuantizationSchemas();
 
 constexpr const float kDefaultSkipLayerNormEpsilon = 1e-12f;

--- a/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+static void RunRelPartialLearnableAttentionTest(
+    const std::vector<float>& input_data,            // input: [batch_size, sequence_length, d_model]
+    const std::vector<float>& input_weights_data,    // input_weights: [d_model, 3 * num_heads * head_size]
+    const std::vector<float>& pos_emb_data,          // pos_emb: [batch_size, sequence_length, d_model]
+    const std::vector<float>& pos_emb_weights_data,  // pos_emb_weights: [d_model, num_heads * head_size]
+    const std::vector<float>& r_w_bias_data,         // r_w_bias: [num_heads, head_size]
+    const std::vector<float>& r_r_bias_data,         // r_r_bias: [num_heads, head_size]
+    const std::vector<float>& output_weights_data,   // output_weights: [num_heads * head_size, d_model]
+    const std::vector<int32_t>& attn_mask_data,      // attn_mask: [sequence_length, sequence_length] or empty
+    const std::vector<float>& mems_data,             // mems: [batch_size, sequence_length + memory_length, d_model] or empty
+    const std::vector<float>& output_data,           // output: [batch_size, sequence_length, d_model]
+    int batch_size,
+    int sequence_length,
+    int d_model,
+    int number_of_heads,
+    int head_size,
+    bool use_float16 = false,
+    int memory_length = 0,
+    int input_d_model = 0,
+    bool only_enable_cuda = false,
+    bool only_enable_cpu = false) {
+  input_d_model = (input_d_model == 0 ? d_model : input_d_model);  // By default, no pruning.
+
+  int min_cuda_architecture = use_float16 ? 530 : 0;
+  bool enable_cuda = HasCudaEnvironment(min_cuda_architecture) && !is_weights_constant && !only_enable_cpu;
+  bool enable_cpu = (nullptr != DefaultCpuExecutionProvider().get()) && !use_float16 && !only_enable_cuda;
+
+  if (enable_cpu || enable_cuda) {
+    OpTester tester("RelPartialLearnableAttention", 1, onnxruntime::kMSDomain);
+    tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
+    tester.AddAttribute<int64_t>("head_size", static_cast<int64_t>(head_size));
+    tester.AddAttribute<int64_t>("d_model", static_cast<int64_t>(d_model));
+
+    std::vector<int64_t> input_dims = {batch_size, sequence_length, input_d_model};
+    std::vector<int64_t> input_weights_dims = {input_d_model, 3 * number_of_heads * head_size};
+    std::vector<int64_t> pos_emb_dims = {batch_size, sequence_length, input_d_model};
+    std::vector<int64_t> pos_emb_weights_dims = {input_d_model, number_of_heads * head_size};
+    std::vector<int64_t> r_w_bias_dims = {number_of_heads, head_size};
+    std::vector<int64_t> r_r_bias_dims = {number_of_heads, head_size};
+    std::vector<int64_t> output_weights_dims = {number_of_heads * head_size, input_d_model};
+    std::vector<int64_t> attn_mask_dims = {sequence_length, sequence_length};
+    std::vector<int64_t> mems_dims = {batch_size, sequence_length + memory_length, d_model};
+
+    std::vector<int64_t> output_dims = {batch_size, sequence_length, d_model};
+
+    if (use_float16) {
+      tester.AddInput<MLFloat16>("input", input_dims, ToFloat16(input_data));
+      tester.AddInput<MLFloat16>("input_weights", input_weights_dims, ToFloat16(input_weights_data));
+      tester.AddInput<MLFloat16>("pos_emb", pos_emb_dims, ToFloat16(pos_emb_data));
+      tester.AddInput<MLFloat16>("pos_emb_weights", pos_emb_weights_dims, ToFloat16(pos_emb_weights_data));
+      tester.AddInput<MLFloat16>("r_w_bias", r_w_bias_dims, ToFloat16(r_w_bias_data));
+      tester.AddInput<MLFloat16>("r_r_bias", r_r_bias_dims, ToFloat16(r_r_bias_data));
+      tester.AddInput<MLFloat16>("output_weights", output_weights_dims, ToFloat16(output_weights_data));
+      tester.AddOutput<MLFloat16>("output", output_dims, ToFloat16(output_data));
+    } else {
+      tester.AddInput<float>("input", input_dims, input_data);
+      tester.AddInput<float>("input_weights", input_weights_dims, input_weights_data);
+      tester.AddInput<float>("pos_emb", pos_emb_dims, pos_emb_data);
+      tester.AddInput<float>("pos_emb_weights", pos_emb_weights_dims, pos_emb_weights_data);
+      tester.AddInput<float>("r_w_bias", r_w_bias_dims, r_w_bias_data);
+      tester.AddInput<float>("r_r_bias", r_r_bias_dims, r_r_bias_data);
+      tester.AddInput<float>("output_weights", output_weights_dims, output_weights_data);
+      tester.AddOutput<float>("output", output_dims, output_data);
+    }
+
+    if (attn_mask_data.size() > 0) {  // attention mask is optional.
+      tester.AddInput<int32_t>("attn_mask", attn_mask_dims, attn_mask_data);
+    } else {
+      tester.AddOptionalInputEdge<int32_t>();
+    }
+
+    if (mems_data.size() > 0) {  // memories are optional.
+      if (use_float16) {
+        tester.AddInput<MLFloat16>("mems", mems_dims, ToFloat16(mems_data));
+      } else {
+        tester.AddInput<float>("mems", mems_dims, mems_data);
+      }
+    } else {
+      tester.AddOptionalInputEdge<float>();
+    }
+
+    if (enable_cuda) {
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCudaExecutionProvider());
+      tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
+
+    if (enable_cpu) {
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCpuExecutionProvider());
+      tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
+  }
+}
+
+static void RunRelPartiaLearnableAttentionTest(
+    const std::vector<float>& input_data,            // input: [batch_size, sequence_length, d_model]
+    const std::vector<float>& input_weights_data,    // input_weights: [d_model, 3 * num_heads * head_size]
+    const std::vector<float>& pos_emb_data,          // pos_emb: [batch_size, sequence_length, d_model]
+    const std::vector<float>& pos_emb_weights_data,  // pos_emb_weights: [d_model, num_heads * head_size]
+    const std::vector<float>& r_w_bias_data,         // r_w_bias: [num_heads, head_size]
+    const std::vector<float>& r_r_bias_data,         // r_r_bias: [num_heads, head_size]
+    const std::vector<float>& output_weights_data,   // output_weights: [num_heads * head_size, d_model]
+    const std::vector<int32_t>& attn_mask_data,      // attn_mask: [sequence_length, sequence_length] or empty
+    const std::vector<float>& mems_data,             // mems: [batch_size, sequence_length + memory_length, d_model] or empty
+    const std::vector<float>& output_data,           // output: [batch_size, sequence_length, d_model]
+    int batch_size,
+    int sequence_length,
+    int d_model,
+    int number_of_heads,
+    int head_size,
+    bool use_float16 = false,
+    int memory_length = 0,
+    int input_d_model = 0,
+    bool only_enable_cuda = false,
+    bool only_enable_cpu = false) {
+  RunRelPartiaLearnableAttentionTest(input_data, input_weights_data, pos_emb, pos_emb_weights,
+                                     r_w_bias_data, r_r_bias_data, output_weights_data, attn_mask_data,
+                                     mems_data, output_data, batch_size, sequence_length, d_model,
+                                     number_of_heads, head_size, use_float16, input_d_model,
+                                     only_enable_cuda, only_enable_cpu);
+}
+
+TEST(RelPartiaLearnableAttentionTest, RelPartiaLearnableAttentionBatch1) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int d_model = 4;
+  int number_of_heads = 2;
+  int head_size = 4;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+
+  std::vector<int32_t> mask_index_data = {2L};
+
+  std::vector<float> output_data = {
+      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
+      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f};
+
+  RunRelPartiaLearnableAttentionTest(input_data, input_weights_data, pos_emb_data, pos_emb_weights_data,
+                                     r_w_bias_data, r_r_bias_data, output_weights_data, attn_mask_data,
+                                     mems_data, output_data, batch_size, sequence_length, d_model,
+                                     number_of_heads, head_size);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
@@ -113,52 +113,48 @@ TEST(RelPartialLearnableAttentionTest, RelPartialLearnableAttentionBatch1) {
   int sequence_length = 2;
   int d_model = 4;
   int number_of_heads = 2;
-  int head_size = 4;
+  int head_size = 2;
 
   std::vector<float> input_data = {
-      0.8f, -0.5f, 0.0f, 1.f,
-      0.5f, 0.2f, 0.3f, -0.6f};
+      1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f};
 
   std::vector<float> input_weights_data = {
-      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
-      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
-      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
-      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
 
   std::vector<float> pos_emb_data = {
-      0.8f, -0.5f, 0.0f, 1.f,
-      0.5f, 0.2f, 0.3f, -0.6f};
+      1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f};
 
   std::vector<float> pos_emb_weights_data = {
-      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
-      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
-      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
-      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,};
 
   std::vector<float> r_w_bias_data = {
-      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+      1.f, 1.f, 1.f, 1.f};
 
   std::vector<float> r_r_bias_data = {
-      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+       1.f, 1.f, 1.f, 1.f};
 
   std::vector<float> output_weights_data = {
-      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
-      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
-      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
-      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,};
 
   std::vector<int32_t> attn_mask_data = {};
 
   std::vector<float> mems_data = {};
 
   std::vector<float> output_data = {
-      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
-      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f};
+      1.f, 1.f, 1.f, 1.f,
+      1.f, 1.f, 1.f, 1.f};
 
   RunRelPartialLearnableAttentionTest(input_data, input_weights_data, pos_emb_data, pos_emb_weights_data,
-                                     r_w_bias_data, r_r_bias_data, output_weights_data, attn_mask_data,
-                                     mems_data, output_data, batch_size, sequence_length, d_model,
-                                     number_of_heads, head_size);
+                                      r_w_bias_data, r_r_bias_data, output_weights_data, attn_mask_data,
+                                      mems_data, output_data, batch_size, sequence_length, d_model,
+                                      number_of_heads, head_size);
 }
 
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/rel_partial_learnable_attention_op_test.cc
@@ -116,14 +116,14 @@ TEST(RelPartialLearnableAttentionTest, RelPartialLearnableAttentionBatch1) {
   int head_size = 2;
 
   std::vector<float> input_data = {
-      1.f, 1.f, 1.f, 1.f,
-      1.f, 1.f, 1.f, 1.f};
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
 
   std::vector<float> input_weights_data = {
-      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
-      1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
 
   std::vector<float> pos_emb_data = {
       1.f, 1.f, 1.f, 1.f,


### PR DESCRIPTION
**Description**: Adds a new contributor operator that supports the `RelPartialLearnableMultiHeadAttn` (renamed as `RelPartialLearnableAttention` in `onnxruntime` for the sake of standardizing) implementation from Transformer-XL.

**Motivation and Context**: This pull request is purely motivated by introducing a new operator that might allow users in fusing their messy exported ONNX graphs when using Transformer-XL-based architectures.

*This pull request is currently a WIP and will take a time before being ready to be merged. Nonetheless, it has been added here to avoid people on working on the same issue/implementation.*
