### PR TITLE
fix to avoid quantizing attention with varied q,k,v sizes

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -243,24 +243,9 @@ class ONNXQuantizer:
             return self.parent.find_initializer_in_path(initializer_name)
         return False
 
-    # TODO This is a temporary fix to stop exporting QAttention with qkv_hidden_sizes
-    # attribute. This needs to be removed once the QAttention for varied q,k,v sizes
-    # is implemented
-    def is_node_excused_from_quant(self, node):
-        if 'Attention' in node.name:
-            print(node.attribute)
-            for attr in node.attribute:
-                if 'qkv_hidden_sizes' == attr.name:
-                    return True
-
-        return False
-
     def should_quantize(self, node):
         if self.nodes_to_quantize is not None and len(
                 self.nodes_to_quantize) != 0 and node.name not in self.nodes_to_quantize:
-            return False
-
-        if self.is_node_excused_from_quant(node):
             return False
 
         if (node.op_type not in self.op_types_to_quantize):

--- a/onnxruntime/python/tools/quantization/operators/attention.py
+++ b/onnxruntime/python/tools/quantization/operators/attention.py
@@ -20,6 +20,13 @@ class AttentionQuant(QuantOperatorBase):
         node = self.node
         assert (node.op_type == "Attention")
 
+        # TODO This is a temporary fix to stop exporting QAttention with qkv_hidden_sizes
+        # attribute. This needs to be removed once the QAttention for varied q,k,v sizes
+        # is implemented
+        for attr in node.attribute:
+            if 'qkv_hidden_sizes' == attr.name:
+                return super().quantize()
+
         (quantized_input_names, zero_point_names, scale_names, nodes) = \
             self.quantizer.quantize_inputs(node, [0, 1], reduce_range=True, op_level_per_channel=True)
         if quantized_input_names is None:


### PR DESCRIPTION
**Description**: 
The QAttention is not implemented currently for attention with varied q, k, v sizes.
Customers using this module would see an error when they try to load the quantized version of the graph. Made a temporary fix to not quantize attention nodes with varied q,k,v sizes.

Will be removing this part of code when QAttention for varied q,k,v sizes is implemented.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Fixes an issue with quantizing Attention OP.

- If it fixes an open issue, please link to the issue here.
NA

**Testing**:
Tested the changes on TNLRv4 model and ran post quant model successfully with perf tool. 