### PR TITLE
Specify version for pyquickhelper

### DIFF
--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -6,7 +6,7 @@ sphinx
 sphinx-gallery
 sphinxcontrib.imagesvg
 sphinx_rtd_theme
-pyquickhelper
+pyquickhelper==1.10.3626
 tensorflow==2.5.0
 tf2onnx
 pandas


### PR DESCRIPTION
New version released(1.10.3651) causes a break for python3.6 in python packaging pipelines.
@xadupre is working on doing another release of pyquickhelper to fix this, while we roll back to the previous version(1.10.3626).
