### PR TITLE
work around ucx in rocm ci Dockerfile

### DIFF
--- a/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
@@ -2,6 +2,13 @@ FROM rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0
 
 WORKDIR /stage
 
+# from rocm/pytorch's image, work around ucx's dlopen replacement conflicting with shared provider
+RUN cd /opt/mpi_install/ucx/build &&\
+      make clean &&\
+      ../contrib/configure-release --prefix=/opt/ucx --without-rocm &&\
+      make -j $(nproc) &&\
+      make install
+
 # rocm-ci branch contains instrumentation needed for loss curves and perf
 RUN git clone https://github.com/microsoft/huggingface-transformers.git &&\
       cd huggingface-transformers &&\


### PR DESCRIPTION
The rocm/pytorch image provides openmpi configured to use ucx.  ucx is itself configured --with-rocm.  This enables its ucm module.  The ucm module replaces dlopen with its own implementation, but it does not correctly handle onnxruntime's shared providers.  Work around the problem by rebuilding ucx inside the image to disable rocm.