### PR TITLE
fix MSVC micro benchmark build warnings

### DIFF
--- a/onnxruntime/test/onnx/microbenchmark/activation.cc
+++ b/onnxruntime/test/onnx/microbenchmark/activation.cc
@@ -87,14 +87,14 @@ class MyIExecutionFrame : public IExecutionFrame {
       : IExecutionFrame(ort_value_idx_map, node_index_info, fetch_mlvalue_idxs),
         a_(a) {
     Init(
-        feed_mlvalue_idxs, feeds, initializers, [](const std::string& name) -> bool { return false; }, fetches);
+        feed_mlvalue_idxs, feeds, initializers, [](const std::string& /*name*/) -> bool { return false; }, fetches);
   }
 
   const DataTransferManager& GetDataTransferManager() const override {
     abort();
   }
 
-  Status CreateNodeOutputMLValueImpl(OrtValue& ort_value, int ort_value_idx, const TensorShape* shape) override {
+  Status CreateNodeOutputMLValueImpl(OrtValue& /*ort_value*/, int /*ort_value_idx*/, const TensorShape* /*shape*/) override {
     abort();
   }
   AllocatorPtr GetAllocatorImpl(const OrtMemoryInfo& info) const {

--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -6,6 +6,16 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-result"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#elif defined(_MSC_VER)
+// build\windows\debug\external\eigen3\unsupported\eigen\cxx11\src/Tensor/Tensor.h(76):
+// warning C4554: '&': check operator precedence for possible error; use parentheses to clarify precedence
+
+// unsupported\eigen\cxx11\src\Tensor\TensorUInt128.h(150,0): Warning C4245: 'initializing': conversion from '__int64'
+// to 'uint64_t', signed/unsigned mismatch
+#pragma warning(push)
+#pragma warning(disable : 4554)
+#pragma warning(disable : 4245)
+#pragma warning(disable : 4127)
 #endif
 
 #ifndef EIGEN_USE_THREADS
@@ -17,6 +27,8 @@
 #include <unsupported/Eigen/CXX11/src/Tensor/TensorDeviceThreadPool.h>
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
 #include <benchmark/benchmark.h>


### PR DESCRIPTION
Fix build warnings when building with --build_micro_benchmarks. These were seen when building with latest MSVC 2019 on an AVX512 system, but not with the same tools on an older AVX2 system.