### PR TITLE
[js/web] remove webgl from default fallback list

### DIFF
--- a/js/common/lib/backend-impl.ts
+++ b/js/common/lib/backend-impl.ts
@@ -20,7 +20,8 @@ const backendsSortedByPriority: string[] = [];
  *
  * @param name - the name as a key to lookup as an execution provider.
  * @param backend - the backend object.
- * @param priority - an integer indicating the priority of the backend. Higher number means higher priority.
+ * @param priority - an integer indicating the priority of the backend. Higher number means higher priority. if priority
+ * < 0, it will be considered as a 'beta' version and will not be used as a fallback backend by default.
  *
  * @internal
  */
@@ -35,13 +36,15 @@ export const registerBackend = (name: string, backend: Backend, priority: number
       throw new Error(`backend "${name}" is already registered`);
     }
 
-    for (let i = 0; i < backendsSortedByPriority.length; i++) {
-      if (backends[backendsSortedByPriority[i]].priority <= priority) {
-        backendsSortedByPriority.splice(i, 0, name);
-        return;
+    if (priority >= 0) {
+      for (let i = 0; i < backendsSortedByPriority.length; i++) {
+        if (backends[backendsSortedByPriority[i]].priority <= priority) {
+          backendsSortedByPriority.splice(i, 0, name);
+          return;
+        }
       }
+      backendsSortedByPriority.push(name);
     }
-    backendsSortedByPriority.push(name);
     return;
   }
 

--- a/js/web/lib/index.ts
+++ b/js/web/lib/index.ts
@@ -6,5 +6,5 @@ import {registerBackend} from 'onnxruntime-common';
 import {onnxjsBackend} from './backend-onnxjs';
 import {wasmBackend} from './backend-wasm';
 
-registerBackend('webgl', onnxjsBackend, 1);
-registerBackend('wasm', wasmBackend, 2);
+registerBackend('webgl', onnxjsBackend, -1);
+registerBackend('wasm', wasmBackend, 0);


### PR DESCRIPTION
**Description**: This change removes webgl backend from the default execution provider list. It will be used only when explicitly specified in session options.