### PR TITLE
Allow opset change by not using copy of global constant

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -18,6 +18,8 @@ from .torch_cpp_extensions import is_installed as is_torch_cpp_extensions_instal
 
 ################################################################################
 # All global constant goes here, before ORTModule is imported ##################
+# NOTE: To *change* values in runtime, import onnxruntime.training.ortmodule and
+# assign them new values. Importing them directly do not propagate changes.
 ################################################################################
 ONNX_OPSET_VERSION = 12
 MINIMUM_RUNTIME_PYTORCH_VERSION_STR = '1.8.1'

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -19,7 +19,7 @@ from ._fallback import (_FallbackManager,
                         ORTModuleTorchModelException,
                         wrap_exception)
 from ._gradient_accumulation_manager import GradientAccumulationManager
-from onnxruntime.training.ortmodule import ONNX_OPSET_VERSION
+from onnxruntime.training import ortmodule
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
@@ -99,7 +99,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
         # default is enabled, if not define in os env
-        self._skip_check = _SkipCheck(_SkipCheck.SKIP_CHECK_DEVICE | _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT)        
+        self._skip_check = _SkipCheck(_SkipCheck.SKIP_CHECK_DEVICE | _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT)
         if os.getenv('ORTMODULE_SKIPCHECK_POLICY') is not None:
             self._skip_check = reduce(lambda x, y: x | y,
                                       [_SkipCheck[name] for name in
@@ -363,7 +363,7 @@ class GraphExecutionManager(GraphExecutionInterface):
                     _logger.suppress_os_stream_output(log_level=self._debug_options.logging.log_level):
                 required_export_kwargs = {'input_names': self._input_info.names,
                                           'output_names': output_names,
-                                          'opset_version': ONNX_OPSET_VERSION,
+                                          'opset_version': ortmodule.ONNX_OPSET_VERSION,
                                           'do_constant_folding': False,
                                           'training': self._export_mode,
                                           'dynamic_axes': self._input_info.dynamic_axes,

--- a/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
@@ -4,7 +4,7 @@
 import tempfile
 import torch
 from ... import ORTModule
-from ... import ONNX_OPSET_VERSION
+from .... import ortmodule
 from ...debug_options import DebugOptions
 
 
@@ -91,7 +91,7 @@ class HierarchicalORTModule(torch.nn.Module):
                     try:
                         with tempfile.NamedTemporaryFile(prefix='sub-module') as temp:
                             torch.onnx.export(
-                                module, args, temp, opset_version=ONNX_OPSET_VERSION,
+                                module, args, temp, opset_version=ortmodule.ONNX_OPSET_VERSION,
                                 do_constant_folding=False, export_params=False,
                                 keep_initializers_as_inputs=True,
                                 training=torch.onnx.TrainingMode.TRAINING)
@@ -125,7 +125,7 @@ class HierarchicalORTModule(torch.nn.Module):
                         try:
                             with tempfile.NamedTemporaryFile(prefix='sub-module') as temp:
                                 torch.onnx.export(
-                                    module, args, temp, opset_version=ONNX_OPSET_VERSION,
+                                    module, args, temp, opset_version=ortmodule.ONNX_OPSET_VERSION,
                                     do_constant_folding=False, export_params=False,
                                     keep_initializers_as_inputs=True,
                                     training=torch.onnx.TrainingMode.TRAINING)

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -13,9 +13,7 @@ from .debug_options import DebugOptions
 from ._fallback import (_FallbackManager,
                         _FallbackPolicy,
                         ORTModuleFallbackException)
-from . import (_FALLBACK_INIT_EXCEPTION,
-               ORTMODULE_FALLBACK_POLICY,
-               ORTMODULE_FALLBACK_RETRY)
+from onnxruntime.training import ortmodule
 
 from onnxruntime.tools import pytorch_export_contrib_ops
 
@@ -60,13 +58,13 @@ class ORTModule(torch.nn.Module):
 
         # Fallback settings
         self._fallback_manager = _FallbackManager(pytorch_module=module,
-                                                  policy=ORTMODULE_FALLBACK_POLICY,
-                                                  retry=ORTMODULE_FALLBACK_RETRY)
+                                                  policy=ortmodule.ORTMODULE_FALLBACK_POLICY,
+                                                  retry=ortmodule.ORTMODULE_FALLBACK_RETRY)
 
         try:
             # Read ORTModule module initialization status
-            if _FALLBACK_INIT_EXCEPTION:
-                raise _FALLBACK_INIT_EXCEPTION
+            if ortmodule._FALLBACK_INIT_EXCEPTION:
+                raise ortmodule._FALLBACK_INIT_EXCEPTION
 
             super(ORTModule, self).__init__()
 

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
@@ -3,9 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from onnxruntime.training.ortmodule import (ORTMODULE_TORCH_CPP_DIR,
-                                            ONNXRUNTIME_CUDA_VERSION,
-                                            ONNXRUNTIME_ROCM_VERSION)
+from onnxruntime.training import ortmodule
 
 from glob import glob
 from shutil import copyfile
@@ -24,11 +22,11 @@ def _list_extensions(path):
 
 
 def _list_cpu_extensions():
-    return _list_extensions(os.path.join(ORTMODULE_TORCH_CPP_DIR, 'cpu'))
+    return _list_extensions(os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR, 'cpu'))
 
 
 def _list_cuda_extensions():
-    return _list_extensions(os.path.join(ORTMODULE_TORCH_CPP_DIR, 'cuda'))
+    return _list_extensions(os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR, 'cuda'))
 
 
 def _install_extension(ext_name, ext_path, cwd):
@@ -44,12 +42,15 @@ def build_torch_cpp_extensions():
     '''Builds PyTorch CPP extensions and returns metadata'''
 
     # Run this from within onnxruntime package folder
-    is_gpu_available = ONNXRUNTIME_CUDA_VERSION is not None or ONNXRUNTIME_ROCM_VERSION is not None
-    os.chdir(ORTMODULE_TORCH_CPP_DIR)
+    is_gpu_available = ortmodule.ONNXRUNTIME_CUDA_VERSION is not None or\
+        ortmodule.ONNXRUNTIME_ROCM_VERSION is not None
+    os.chdir(ortmodule.ORTMODULE_TORCH_CPP_DIR)
 
     # Extensions might leverage CUDA/ROCM versions internally
-    os.environ["ONNXRUNTIME_CUDA_VERSION"] = ONNXRUNTIME_CUDA_VERSION if not ONNXRUNTIME_CUDA_VERSION is None else ''
-    os.environ["ONNXRUNTIME_ROCM_VERSION"] = ONNXRUNTIME_ROCM_VERSION if not ONNXRUNTIME_ROCM_VERSION is None else ''
+    os.environ["ONNXRUNTIME_CUDA_VERSION"] = ortmodule.ONNXRUNTIME_CUDA_VERSION \
+        if not ortmodule.ONNXRUNTIME_CUDA_VERSION is None else ''
+    os.environ["ONNXRUNTIME_ROCM_VERSION"] = ortmodule.ONNXRUNTIME_ROCM_VERSION \
+        if not ortmodule.ONNXRUNTIME_ROCM_VERSION is None else ''
 
     ############################################################################
     # Pytorch CPP Extensions that DO require CUDA/ROCM
@@ -57,32 +58,32 @@ def build_torch_cpp_extensions():
     if is_gpu_available:
         for ext_setup in _list_cuda_extensions():
             _install_extension(ext_setup.split(
-                os.sep)[-2], ext_setup, ORTMODULE_TORCH_CPP_DIR)
+                os.sep)[-2], ext_setup, ortmodule.ORTMODULE_TORCH_CPP_DIR)
 
     ############################################################################
     # Pytorch CPP Extensions that DO NOT require CUDA/ROCM
     ############################################################################
     for ext_setup in _list_cpu_extensions():
         _install_extension(ext_setup.split(
-            os.sep)[-2], ext_setup, ORTMODULE_TORCH_CPP_DIR)
+            os.sep)[-2], ext_setup, ortmodule.ORTMODULE_TORCH_CPP_DIR)
 
     ############################################################################
     # Install Pytorch CPP Extensions into local onnxruntime package folder
     ############################################################################
-    torch_cpp_exts = glob(os.path.join(ORTMODULE_TORCH_CPP_DIR,
+    torch_cpp_exts = glob(os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR,
                                        'build',
                                        'lib.*',
                                        '*.so'))
-    torch_cpp_exts.extend(glob(os.path.join(ORTMODULE_TORCH_CPP_DIR,
+    torch_cpp_exts.extend(glob(os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR,
                                             'build',
                                             'lib.*',
                                             '*.dll')))
-    torch_cpp_exts.extend(glob(os.path.join(ORTMODULE_TORCH_CPP_DIR,
+    torch_cpp_exts.extend(glob(os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR,
                                             'build',
                                             'lib.*',
                                             '*.dylib')))
     for ext in torch_cpp_exts:
-        dest_ext = os.path.join(ORTMODULE_TORCH_CPP_DIR, os.path.basename(ext))
+        dest_ext = os.path.join(ortmodule.ORTMODULE_TORCH_CPP_DIR, os.path.basename(ext))
         print(f'Installing {ext} -> {dest_ext}')
         copyfile(ext, dest_ext)
 


### PR DESCRIPTION
Current implementation imports variables directly, which has the behavior of passing by value. This PR imports the namespace that contains the variable, which has the passing by reference behavior