### PR TITLE
fix regression bug of scatter_nd

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
@@ -65,7 +65,7 @@ Status ScatterNDBase::ValidateShapes(const TensorShape& input_shape,
     // Per spec, the rank of the update tensor should be:
     // (Rank of input tensor) + (Rank of indices tensor) -1 - last_indice_dimension
     if (update_rank != (input_rank + indice_rank - 1 - static_cast<int64_t>(last_indice_dimension))) {
-      return true;
+      //return true;
     }
 
     // Validate shape of the update tensor

--- a/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
@@ -28,7 +28,15 @@ TEST(ScatterNDOpTest, ScatterND_scaler_string_int64) {
   test3.AddInput<std::string>("updates", {}, {"t"});
   test3.AddOutput<std::string>("output", {3,2}, {"h","k","o","z","l","t"});
   test3.Run();
+
+  OpTester test4("ScatterND", 11);
+  test4.AddInput<int64_t>("data", {3}, {1, 2, 3});
+  test4.AddInput<int64_t>("indices", {1}, {1});
+  test4.AddInput<int64_t>("updates", {1}, {5}); 
+  test4.AddOutput<int64_t>("output", {3}, {1, 5, 3});
+  test4.Run();
 }
+
 
 TEST(ScatterNDOpTest, ScatterND_matrice_int64_int64) {
   OpTester test("ScatterND", 11);


### PR DESCRIPTION
**Description**:
There was no this rank check before v1.6.0 and it used to work fine. The check doesn't work for dimension-1 input, so disable it.

To fix https://github.com/microsoft/onnxruntime/issues/9411

**Motivation and Context**
- Why is this change required? What problem does it solve?
There was no this rank check before v1.6.0 and it used to work fine. The check doesn't work for dimension-1 input, so disable it.

- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/9411