### PR TITLE
Optimize For Loop After ORTModule Backward

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -211,6 +211,10 @@ void addOrtValueMethods(pybind11::module& m) {
       .def("to_dlpack", [](OrtValue* ort_value) -> py::object {
         return py::reinterpret_steal<py::object>(ToDlpack(*ort_value));
       })
+      .def("is_bool_tensor", [](const OrtValue* ort_value) -> bool {
+        return ort_value->IsTensor() &&
+               ort_value->Get<Tensor>().GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_BOOL;
+      })
       .def_static("from_dlpack", [](py::object data, bool is_bool_tensor = false) {
         return FromDlpack(data.ptr(), is_bool_tensor);
       })

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -239,6 +239,26 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         self._graph_info = self._graph_builder.get_graph_info()
 
+        num_user_input_grads = len(self._input_info.require_grad_names)
+        self._graph_input_output_mapping = []
+        require_grad_names_set = set(self._input_info.require_grad_names)
+        require_grad_names_index = 0
+        for input_name in self._graph_info.user_input_names:
+            # Append to the results the backward output for each input that required grad
+            if input_name in require_grad_names_set:
+                self._graph_input_output_mapping.append(require_grad_names_index)
+                require_grad_names_index += 1
+            else:
+                self._graph_input_output_mapping.append(-1)
+
+        initializer_index = num_user_input_grads
+        for initializer_name in self._graph_info.initializer_names:
+            if initializer_name in self._graph_initializer_names_to_train:
+                self._graph_input_output_mapping.append(initializer_index)
+                initializer_index += 1
+            else:
+                self._graph_input_output_mapping.append(-1)
+
     def _get_session_config(self):
         """Creates and returns the session configuration to be used for the ExecutionAgent"""
 

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -31,9 +31,9 @@ def _ortvalue_from_torch_tensor(torch_tensor):
     return C.OrtValue.from_dlpack(to_dlpack(torch_tensor), is_bool_tensor)
 
 
-def _torch_tensor_from_dl_pack(dlpack, ortvalue, device):
-    torch_tensor = from_dlpack(dlpack) if device.type != 'ort' else C.ort_from_dlpack(dlpack)
-    return torch_tensor.to(torch.bool) if ortvalue.data_type() == 'tensor(bool)' else torch_tensor
+def _torch_tensor_from_dl_pack(dlpack, ortvalue, is_ort_device):
+    torch_tensor = from_dlpack(dlpack) if not is_ort_device else C.ort_from_dlpack(dlpack)
+    return torch_tensor.to(torch.bool) if ortvalue.is_bool_tensor() else torch_tensor
 
 
 def _ortvalue_to_torch_tensor(ortvalue, device):
@@ -41,7 +41,7 @@ def _ortvalue_to_torch_tensor(ortvalue, device):
     # and convert the config to torch.uint8 tensor duing from_dlpack().
     # So we need to convert the torch tensor to torch.bool type if OrtValue is bool tensor.
     dlpack_tensor = ortvalue.to_dlpack()
-    return _torch_tensor_from_dl_pack(dlpack_tensor, ortvalue, device)
+    return _torch_tensor_from_dl_pack(dlpack_tensor, ortvalue, device.type == 'ort')
 
 def _torch_tensor_to_dlpack(tensor):
     if tensor.device.type == 'ort':


### PR DESCRIPTION
Optimize the for loop after ORTModule backward by:
- Use map instead of for loop;
- Use bool instead of string compare;
- Move some processing out of training step.

Using ULR-XL (16 layers) as example, before the change, the for loop will take ~3.8ms, after the change, the new code will take ~2.1ms, which is 1.8x faster.