### PR TITLE
add missing include atomic in cuda_profiler.h

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_profiler.h
+++ b/onnxruntime/core/providers/cuda/cuda_profiler.h
@@ -6,6 +6,7 @@
 
 #include "core/platform/ort_mutex.h"
 #include <cupti.h>
+#include <atomic>
 #include <mutex>
 #include <vector>
 


### PR DESCRIPTION
Not sure why this isn't happening in our CI's but it seems to affect some build configurations/platforms
I encounter this build error on ORT master, but not rel-1.9 branch (which doesn't have https://github.com/microsoft/onnxruntime/pull/8406)
C:\onnxruntime\onnxruntime\core\providers\cuda\cuda_profiler.h(54,15): error C2039: 'atomic_flag': is not a member of '
std' (compiling source file C:\onnxruntime\onnxruntime\core\providers\cuda\cuda_profiler.cc) [C:\onnxruntime\build\Wind
ows\Release\onnxruntime_providers_cuda.vcxproj]

adding the missing #include <atomic> resolves the issue