### PR TITLE
[js/web] Update the compatibility of ONNX Runtime Web

### DIFF
--- a/js/web/README.md
+++ b/js/web/README.md
@@ -39,7 +39,7 @@ Refer to the following links for development information:
 |    Windows 10    | wasm, webgl | wasm, webgl |      -      | wasm, webgl |  wasm   |
 |      macOS       | wasm, webgl | wasm, webgl | wasm, webgl | wasm, webgl |  wasm   |
 | Ubuntu LTS 18.04 | wasm, webgl | wasm, webgl |      -      | wasm, webgl |  wasm   |
-|       iOS        |    wasm     |    wasm     |    wasm     |      -      |    -    |
+|       iOS        | wasm, webgl | wasm, webgl | wasm, webgl |      -      |    -    |
 |     Android      | wasm, webgl | wasm, webgl |      -      |      -      |    -    |
 
 ### Operators


### PR DESCRIPTION
Safari 15 on iOS supports WebGL 2 now and both WebAssembly and WebGL backend of ONNX Runtime Web are working properly with Chrome, Edge, and Safari on iOS.