### PR TITLE
Bug in DmlOperatorResize.cpp?

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorResize.cpp
@@ -213,7 +213,7 @@ public:
         // Find any useless dimensions of size 1 that occur in both input and output.
         for (size_t i = 0, rank = m_outputDimensions.size(); i < rank; ++i)
         {
-            if (m_inputDimensions[i] = 1 && m_outputDimensions[i] == 1)
+            if (m_inputDimensions[i] == 1 && m_outputDimensions[i] == 1)
             {
                 squeezableDimensionIndices.push_back(gsl::narrow_cast<uint32_t>(i));
             }


### PR DESCRIPTION
**Description**: Describe your changes.
I believe `if (m_inputDimensions[i] = 1 && m_outputDimensions[i] == 1)` should be: `if (m_inputDimensions[i] == 1 && m_outputDimensions[i] == 1)`.

Otherwise, it should be:
```
m_inputDimensions[i] = 1;
if (m_outputDimensions[i] == 1)
```



**Motivation and Context**
- Why is this change required? What problem does it solve? It might be omitting an important check, causing wrong results in some cases.
- If it fixes an open issue, please link to the issue here.
