### PR TITLE
ORT_NO_EXCEPTIONS working again

### DIFF
--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -276,7 +276,10 @@ static void InitNestedModelLocalFunction(onnxruntime::Graph& graph,
   }
   ORT_CATCH(const std::exception& e) {
     LOGS(logger, WARNING) << "Function body initialization failed for Function '"
-                          << onnx_function_proto.name() << "'. Error message " << e.what()
+                          << onnx_function_proto.name()
+#ifndef ORT_NO_EXCEPTIONS
+                          << "'. Error message " << e.what()
+#endif //ORT_NO_EXCEPTIONS
                           << ". Execution will fail if ORT does not have a specialized kernel for this op";
     // Return without using this function op's expansion. No need to fail just yet.
     // If ORT has a specialized kernel for this op then execution will proceed

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2537,7 +2537,9 @@ void Graph::InitFunctionBodyForNode(Node& node) {
   ORT_CATCH(const std::exception& e) {
     LOGS(logger_, WARNING) << "Function body initialization failed for node '"
                            << node.Name() << "' optype " << node.OpType()
+#ifndef ORT_NO_EXCEPTIONS
                            << ". Error message " << e.what()
+#endif //ORT_NO_EXCEPTIONS
                            << ". Execution will fail if ORT does not have a specialized kernel for this op";
     // Return without using this function op's expansion. No need to fail just yet.
     // If ORT has a specialized kernel for this op then execution will proceed


### PR DESCRIPTION
**Description**: Describe your changes.
Bug: ORT_NO_EXCEPTIONS is not working after the latest changes in:
- `onnxruntime/core/graph/function.cc`
- `onnxruntime/core/graph/graph.cc`
This PR allows ORT_NO_EXCEPTIONS to work again. There might be other cleaner or preferred ways of doing it, this is just a working alternative.

**Motivation and Context**
- Why is this change required? What problem does it solve? ORT will not compile if ORT_NO_EXCEPTIONS is enabled