### PR TITLE
Fixed warnings from implicit conversion from pointer to bool

### DIFF
--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -1088,7 +1088,7 @@ template <typename T>
 Status BitShift<T>::Compute(OpKernelContext* context) const {
   ProcessBroadcastSpanFuncs funcs{
       [](BroadcastHelper& per_iter_bh) {
-        bool shift_left = per_iter_bh.GetUserData();
+        bool shift_left = (per_iter_bh.GetUserData() != nullptr);
         const T& input0 = per_iter_bh.ScalarInput0<T>();
         ConstEigenVectorMap<T> input1 = per_iter_bh.EigenInput1<T>();
         EigenVectorMap<T> output = per_iter_bh.OutputEigen<T>();
@@ -1104,7 +1104,7 @@ Status BitShift<T>::Compute(OpKernelContext* context) const {
         }
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool shift_left = per_iter_bh.GetUserData();
+        bool shift_left = (per_iter_bh.GetUserData() != nullptr);
         auto input0 = per_iter_bh.EigenInput0<T>();
         const T& input1 = per_iter_bh.ScalarInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();
@@ -1120,7 +1120,7 @@ Status BitShift<T>::Compute(OpKernelContext* context) const {
         }
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool shift_left = per_iter_bh.GetUserData();
+        bool shift_left = (per_iter_bh.GetUserData() != nullptr);
         auto input0 = per_iter_bh.EigenInput0<T>();
         auto input1 = per_iter_bh.EigenInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();

--- a/onnxruntime/core/providers/cpu/tensor/where_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/where_op.cc
@@ -52,7 +52,7 @@ template <typename T>
 ProcessBroadcastSpanFuncs CreateScalarBroadcastFuncs() {
   return ProcessBroadcastSpanFuncs{
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         bool condition = per_iter_bh.ScalarInput0<bool>();
         auto value = per_iter_bh.EigenInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();
@@ -63,7 +63,7 @@ ProcessBroadcastSpanFuncs CreateScalarBroadcastFuncs() {
         }
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         auto condition = per_iter_bh.EigenInput0<bool>();
         const T& value = per_iter_bh.ScalarInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();
@@ -71,7 +71,7 @@ ProcessBroadcastSpanFuncs CreateScalarBroadcastFuncs() {
                      .select(value, EigenVectorMap<T>::PlainObject::Constant(condition.size(), T{}));
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         auto condition = per_iter_bh.EigenInput0<bool>();
         auto value = per_iter_bh.EigenInput1<T>();
         auto output = per_iter_bh.OutputEigen<T>();
@@ -84,7 +84,7 @@ template <typename T>
 ProcessBroadcastSpanFuncs CreateNonScalarBroadcastFuncs() {
   return ProcessBroadcastSpanFuncs{
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         bool condition = per_iter_bh.ScalarInput0<bool>();
         auto value = per_iter_bh.SpanInput1<T>();
         auto output = per_iter_bh.OutputSpan<T>();
@@ -95,7 +95,7 @@ ProcessBroadcastSpanFuncs CreateNonScalarBroadcastFuncs() {
         }
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         auto condition = per_iter_bh.SpanInput0<bool>();
         const T& value = per_iter_bh.ScalarInput1<T>();
         auto output = per_iter_bh.OutputSpan<T>();
@@ -105,7 +105,7 @@ ProcessBroadcastSpanFuncs CreateNonScalarBroadcastFuncs() {
                        });
       },
       [](BroadcastHelper& per_iter_bh) {
-        bool target = per_iter_bh.GetUserData();
+        bool target = (per_iter_bh.GetUserData() != nullptr);
         auto condition = per_iter_bh.SpanInput0<bool>();
         auto value = per_iter_bh.SpanInput1<T>();
         auto output = per_iter_bh.OutputSpan<T>();


### PR DESCRIPTION
**Description**: Describe your changes.

If ONNX Runtime is compiled with a compiler that adds more strict conversion casting, the following 2 files cause warnings for the conversion from pointer to bool. This commit removes that problem.

**Motivation and Context**
- Why is this change required? What problem does it solve? If ONNX Runtime is compiled in a bigger project that requires more strict compiler flags, ORT will cause implicit conversion warnings from ptr to bool. This commit fixes that.
- If it fixes an open issue, please link to the issue here.
