### PR TITLE
Fixed compiler error in Clang (for Win64) for ExecutionProvider

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -30,7 +30,7 @@ namespace Dml
                                   Windows::AI::MachineLearning::Adapter::IWinmlExecutionProvider>
     {
     public:
-        explicit ExecutionProviderImpl::ExecutionProviderImpl(
+        explicit ExecutionProviderImpl(
             IDMLDevice* dmlDevice,
             ID3D12Device* d3d12Device,
             ID3D12CommandQueue* queue,


### PR DESCRIPTION
**Description**: Describe your changes.

Fixed compiler error in Clang (for Windows) for ExecutionProvider.

Given that we are inside the initial declaration of ExecutionProviderImpl, adding `ExecutionProviderImpl::` to the constructor definition is redundant (and actually causes compiler errors on Clang).

**Motivation and Context**
- Why is this change required? What problem does it solve? Compiler error on Clang.
- If it fixes an open issue, please link to the issue here.
