### PR TITLE
disable inner parallel for global avg pool as normally they are small

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -591,7 +591,7 @@ void ThreadPool::ParallelFor(std::ptrdiff_t n, const TensorOpCost& c,
   auto d_of_p = DegreeOfParallelism(this);
   // Compute small problems directly in the caller thread.
   if ((!ShouldParallelizeLoop(n)) ||
-      (d_of_p = CostModel::numThreads(static_cast<double>(n), cost, d_of_p)) == 1) {
+      CostModel::numThreads(static_cast<double>(n), cost, d_of_p) == 1) {
     f(0, n);
     return;
   }


### PR DESCRIPTION
Will choose how to parallel if we could find more case in future
