### PR TITLE
Disallow padding on dimension with shape 0 in edge mode

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/pad.cc
+++ b/onnxruntime/core/providers/cpu/tensor/pad.cc
@@ -171,11 +171,13 @@ Status PadBase::HandleDimValueZero(const Mode& mode, const TensorShape& input_sh
       break;
     }
     case Mode::Edge: {
-      // we need to override the default logic and set the output dim to 0 where the input dim is zero.
-      // this is to match numpy behavior.
+      // match numpy behavior of failing if mode is 'edge' and there's an attempt to pad a dimension with value of 0
       for (size_t i = 0, end = input_shape.NumDimensions(); i < end; ++i) {
-        if (input_shape[i] == 0)
-          output_shape[i] = 0;
+        if (input_shape[i] == 0 && output_shape[i] > 0) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                                 "Cannot use 'edge' mode to pad dimension with a value of 0. Input shape:",
+                                 input_shape);
+        }
       }
       break;
     }

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -725,15 +725,27 @@ TYPED_TEST(PadOpTest, Pad_Edge_DimWithZeroInput) {
   using T = TypeParam;
   RunAllOpsetAllDomainPadTests<T>({0},  // 1D
                                   {},
-                                  {1, 1},
+                                  {1, 1},  // not allowed if it pads the empty dim
                                   T(1),
                                   {0},
                                   {},
-                                  "edge");
+                                  "edge",
+                                  OpTester::ExpectResult::kExpectFailure,
+                                  "Cannot use 'edge' mode to pad dimension with a value of 0. Input shape:{0}");
 
   RunAllOpsetAllDomainPadTests<T>({2, 0},  // 2D
                                   {},
-                                  {1, 1, 1, 1},  // ignore pad for dims with value of 0 as there's no edge value to pad with
+                                  {1, 1, 1, 1},  // not allowed if it pads the empty dim 
+                                  T(1),
+                                  {4, 0},
+                                  {},
+                                  "edge",
+                                  OpTester::ExpectResult::kExpectFailure,
+                                  "Cannot use 'edge' mode to pad dimension with a value of 0. Input shape:{2,0}");
+
+  RunAllOpsetAllDomainPadTests<T>({2, 0},  // 2D
+                                  {},
+                                  {1, 0, 1, 0},  
                                   T(1),
                                   {4, 0},
                                   {},
@@ -741,7 +753,17 @@ TYPED_TEST(PadOpTest, Pad_Edge_DimWithZeroInput) {
 
   RunAllOpsetAllDomainPadTests<T>({2, 2, 0},  // 3D
                                   {},
-                                  {0, 1, 1, 0, 1, 1},
+                                  {0, 1, 1, 0, 1, 1},  // not allowed if it pads the empty dim
+                                  T(1),
+                                  {2, 4, 0},
+                                  {},
+                                  "edge",
+                                  OpTester::ExpectResult::kExpectFailure,
+                                  "Cannot use 'edge' mode to pad dimension with a value of 0. Input shape:{2,2,0}");
+
+  RunAllOpsetAllDomainPadTests<T>({2, 2, 0},  // 3D
+                                  {},
+                                  {0, 1, 0, 0, 1, 0},
                                   T(1),
                                   {2, 4, 0},
                                   {},


### PR DESCRIPTION
Current Numpy version doesn't allow padding on dimension with shape 0 in edge mode.
This PR changes the pad implementation to comply with Numpy.
