### PR TITLE
Fix onnxruntime_PREFER_SYSTEM_LIB for protobuf by not forcing legacy protobuf

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -735,7 +735,6 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external)
 #2. if ONNX_CUSTOM_PROTOC_EXECUTABLE is not set, Compile everything(including protoc) from source code.
 
 if (onnxruntime_PREFER_SYSTEM_LIB)
-  set(protobuf_MODULE_COMPATIBLE ON)
   find_package(Protobuf)
 endif()
 
@@ -1967,7 +1966,7 @@ if (onnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS)
   endif()
 
   if (NOT ${ONNX_CUSTOM_PROTOC_EXECUTABLE} STREQUAL "")
-    message(FATAL_ERROR "External custom operator schemas is not supported with the user specified protc executable")
+    message(FATAL_ERROR "External custom operator schemas is not supported with the user specified protoc executable")
   endif()
 
   if (NOT onnxruntime_ENABLE_TRAINING)


### PR DESCRIPTION
The option `protobuf_MODULE_COMPATIBLE` is for legacy protobuf. Since onnx and onnxruntime have both moved to protobuf 3.12+, this is no longer legacy and we don't need to require legacy mode.

Removing the `protobuf_MODULE_COMPATIBLE` makes `onnxruntime_PREFER_SYSTEM_LIB` work for protobuf - currently, protobuf is always rebuilt in our setup despite being on the machines.