### PR TITLE
Add /bigobj for MSVC builds

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -587,6 +587,10 @@ if (MSVC)
     SET(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /guard:cf")
     SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
   endif()
+
+  # When building on Windows, compilation fails (usually in Debug) because the number of sections exceed
+  # the object file format limit. /bigobj increases the number of sections that an object file can contain.
+  string(APPEND CMAKE_CXX_FLAGS " /bigobj")
 else()
   if (NOT APPLE)
     set(onnxruntime_target_platform ${CMAKE_SYSTEM_PROCESSOR})


### PR DESCRIPTION
Currently, the Windows Debug build of onnxruntime fails with "fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj".

This change adds `/bigobj` to the build flags for MSVC in order to increase the limit.

This addresses https://github.com/microsoft/onnxruntime/issues/9396