### PR TITLE
Use SafeInt for malloc related computation

### DIFF
--- a/orttraining/orttraining/core/framework/communication/mpi/mpi_context.cc
+++ b/orttraining/orttraining/core/framework/communication/mpi/mpi_context.cc
@@ -4,11 +4,11 @@
 #define SHARED_PROVIDER_TODO 0
 
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"
+#include "core/common/safeint.h"
 #ifndef _WIN32
 #include <chrono>
 #include <thread>
 #include <pthread.h>
-#include <SafeInt.h>
 #endif
 
 namespace onnxruntime {


### PR DESCRIPTION
See title. 
Required by Microsoft security guidance. 