### PR TITLE
[DmlEp] Avoid warning C4495

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1246,7 +1246,7 @@ void OpKernelContextWrapper::Close() {
 
   ClearTempAllocations();
 
-  __super::Close();
+  Closable::Close();
 }
 
 HRESULT STDMETHODCALLTYPE OpKernelContextWrapper::GetInputTensor(uint32_t inputIndex, IMLOperatorTensor** tensor) const noexcept try {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorRecurrentNeuralNetwork.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorRecurrentNeuralNetwork.cpp
@@ -185,7 +185,7 @@ public:
     {
         // Assume that enough GPU work has been queued up after the RNN operator that it is worth
         // kicking it off, to enable subsequent CPU work to be parallelized with this GPU work.
-        __super::Compute(kernelContext);
+        DmlOperator::Compute(kernelContext);
         m_executionProvider->Flush();
     }
 


### PR DESCRIPTION
**Description**: Describe your changes.
Update MLOperatorAuthorImpl and DmlOperatorRecurentNeuralNetwork to avoid warning C4495: nonstandard extension '__super' used: replace with explicit base class name

**Motivation and Context**
- Why is this change required? What problem does it solve? In more strict compilers, it avoids warning C4495: nonstandard extension '__super' used: replace with explicit base class name