### PR TITLE
Fix a bug in CMakeLists.txt when handling NO RTTI

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -407,7 +407,7 @@ if (onnxruntime_DISABLE_EXTERNAL_INITIALIZERS)
 endif()
 
 if (onnxruntime_DISABLE_RTTI)
-  add_compile_definitions(ORT_NO_RTTI GOOGLE_PROTOBUF_NO_RTTI)
+  add_compile_definitions(ORT_NO_RTTI)
   if (MSVC)
     # Disable RTTI and turn usage of dynamic_cast and typeid into errors
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/GR->" "$<$<COMPILE_LANGUAGE:CXX>:/we4541>")


### PR DESCRIPTION
**Description**: 

1. When onnxruntime_DISABLE_RTTI is ON, we would want to set protobuf_DISABLE_RTTI to ON, not OFF. It was introduced in PR #7632 by me. But the bug doesn't any real impact because we also manually set the GOOGLE_PROTOBUF_NO_RTTI macro. 
2. Some other tiny improvements. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
