### PR TITLE
Update attention_cpu_base.h to suppress static analysis warning

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -156,7 +156,7 @@ class AttentionCPUBase : public AttentionBase {
                                     output, nullptr);
 
           // Fix unidirectional mask to be parity with huggingface implementation.
-          if (has_unidirectional) {
+          if (has_unidirectional && mask_data != nullptr) {
             for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
               for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
                 int j = s_i * all_sequence_length + m_i;


### PR DESCRIPTION
**Description**: Describe your changes.

Update attention_cpu_base.h to avoid bug if mask_data == nullptr.

By looking into that code, it checks `mask_data` is not nullptr several times in that function. However, it does not check it in that for loop, so if it's nullptr, it'd be filling output with a nullptr pointer, resulting in undefined behavior.

Actually, this is caught as a warning by VPS-Studio on its Static Analysis test for Win64:
```
contrib_ops\cpu\bert\attention_cpu_base.h(163) : warning C6011: Dereferencing NULL pointer 'this->mask_data'. : Lines: 131, 132, 134, 135, 136, 139, 143, 144, 154, 159, 160, 161, 162, 163
```

**Motivation and Context**
- Why is this change required? What problem does it solve? Fixes undefined behavior if mask_data is nullptr.
