### PR TITLE
Remove pointless assert in C# iOS unit test

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.iOS/InferenceTest.ios.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.iOS/InferenceTest.ios.cs
@@ -9,7 +9,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         {
             var opt = new SessionOptions();
             opt.AppendExecutionProvider_CoreML(CoreMLFlags.COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE);
-            Assert.NotNull(opt);
         }
     }
 }


### PR DESCRIPTION
**Description**: 
Remove meaningless assert.

**Motivation and Context**
Cleanup