### PR TITLE
[DmlEp] Update MLOperatorAuthorPrivate.h

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -5,7 +5,6 @@
 
 interface IDMLOperation;
 interface IDMLOperator;
-enum DML_TENSOR_DATA_TYPE;
 struct DML_OPERATOR_DESC;
 
 struct MLOperatorKernelDmlProperties


### PR DESCRIPTION
**Description**: Describe your changes.
(DML related) Updated MLOperatorAuthorPrivate.h to remove `enum DML_TENSOR_DATA_TYPE;` to avoid warning "C4471: 'DML_TENSOR_DATA_TYPE': a forward declaration of an unscoped enumeration must have an underlying type"

Note that `DML_TENSOR_DATA_TYPE` was not used at all in this function anyway, so removing it should not affect the existing code in that file.

**Motivation and Context**
- Why is this change required? What problem does it solve? Warning in more strict compilers (e.g., compiling ORT inside of UE).
