### PR TITLE
Add more statistics in transformer profiler

### DIFF
--- a/onnxruntime/python/tools/transformers/profiler.py
+++ b/onnxruntime/python/tools/transformers/profiler.py
@@ -8,8 +8,8 @@ from onnx import TensorProto
 This profiler tool could run a transformer model and print out the kernel time spent on each Node of the model.
 Example of profiling of longformer model:
     python profiler.py --model longformer-base-4096_fp32.onnx --batch_size 1 --sequence_length 4096 --global_length 8 --samples 1000 --thread_num 8 --dummy_inputs longformer --use_gpu
-Example of loading profile output file from onnxruntime_perf_test:
-    python profiler.py --profile_file profile_2021-10-25_12-02-41.json
+Example of importing profile result file from onnxruntime_perf_test:
+    python profiler.py --input profile_2021-10-25_12-02-41.json
 """
 
 NODES_TYPE_CONTAINING_SUBGRAPH = ['Scan', 'Loop', 'If']
@@ -17,7 +17,12 @@ NODES_TYPE_CONTAINING_SUBGRAPH = ['Scan', 'Loop', 'If']
 
 def parse_arguments(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-m', '--model', required=False, type=str, help="onnx model path")
+
+    parser.add_argument('-i', '--input', required=False,
+                        type=str,
+                        help="Set the input file for reading the profile results")
+
+    parser.add_argument('-m', '--model', required=False, type=str, help="onnx model path to run profiling. Required when --input is not specified.")
 
     parser.add_argument('-b', '--batch_size', required=False, type=int, default=1, help="batch size of input")
 
@@ -39,10 +44,6 @@ def parse_arguments(argv=None):
                         type=int,
                         default=1,
                         help="number of global tokens for longformer")
-
-    parser.add_argument('--profile_file', required=False,
-                        type=str,
-                        help="load existing profile output instead of creating a new one")
 
     parser.add_argument(
         '--samples',
@@ -174,6 +175,9 @@ def parse_kernel_results(sess_time, threshold=0):
 
             total += item["dur"]
 
+    if not kernel_time:
+        return ["No kernel record found!"]
+
     # Output items with run time ratio > thresholds, and sorted by duration in the descending order.
     lines = []
     lines.append(f"\nTop expensive kernels with Time% >= {threshold*100:.2f}:")
@@ -299,59 +303,87 @@ def group_node_results(sess_time, kernel_time_only, use_gpu):
     Returns:
         List[str]: lines of string for output.
     """
-    op_time = {}
-    op_records = {}
-    op_cpu_time = {}
-    op_cpu_records = {}
-    total = 0
-    has_non_cpu_provider = False
+    op_kernel_time = {}
+    op_kernel_records = {}
+    total_kernel_time = 0
+
+    provider_op_kernel_time = {}
+    provider_op_kernel_records = {}
+    provider_kernel_time = {}
+
+    op_fence_time = {}
+    total_fence_time = 0
+
+    provider_counter = {}
     for item in sess_time:
         if item["cat"] == "Node" and "dur" in item and "args" in item and "op_name" in item["args"]:
-            if kernel_time_only and "provider" not in item["args"]:
-                continue
-
             op_name = item["args"]["op_name"]
 
+            # TODO: shall we have a separated group for nodes with subgraph?
             if op_name in NODES_TYPE_CONTAINING_SUBGRAPH:
                 continue
 
-            if op_name in op_time:
-                op_time[op_name] += item["dur"]
-                op_records[op_name] += 1
+            if "provider" not in item["args"]:
+                if "fence" in item["name"]:
+                    if op_name in op_fence_time:
+                        op_fence_time[op_name] += item["dur"]
+                    else:
+                        op_fence_time[op_name] = item["dur"]
+                    total_fence_time += item["dur"]
+                continue
+
+            provider = item["args"]["provider"] if "provider" in item["args"] else ""
+            if provider in provider_counter:
+                provider_counter[provider] += 1
             else:
-                op_time[op_name] = item["dur"]
-                op_records[op_name] = 1
+                provider_counter[provider] = 1
 
-            total += item["dur"]
+            key = f"{provider}:{op_name}"
+            if key in provider_op_kernel_time:
+                provider_op_kernel_time[key] += item["dur"]
+                provider_op_kernel_records[key] += 1
+            else:
+                provider_op_kernel_time[key] = item["dur"]
+                provider_op_kernel_records[key] = 1
 
-            is_cpu = "provider" in item["args"] and item["args"]["provider"] == "CPUExecutionProvider"
-            if is_cpu:
-                if op_name in op_cpu_time:
-                    op_cpu_time[op_name] += item["dur"]
-                    op_cpu_records[op_name] += 1
-                else:
-                    op_cpu_time[op_name] = item["dur"]
-                    op_cpu_records[op_name] = 1
-            if "provider" in item["args"] and item["args"]["provider"] and item["args"]["provider"] != "CPUExecutionProvider":
-                has_non_cpu_provider = True
+            if provider in provider_kernel_time:
+                provider_kernel_time[provider] += item["dur"]
+            else:
+                provider_kernel_time[provider] = item["dur"]
 
-    if use_gpu or has_non_cpu_provider:
-        lines = ["Total(μs)\tTime%\tAvg(μs)\tCalls\tCpu_Total(μs)\tCpu_Calls\tOperator"]
-    else:
-        lines = ["Total(μs)\tTime%\tAvg(μs)\tCalls\tOperator"]
+            if op_name in op_kernel_time:
+                op_kernel_time[op_name] += item["dur"]
+                op_kernel_records[op_name] += 1
+            else:
+                op_kernel_time[op_name] = item["dur"]
+                op_kernel_records[op_name] = 1
 
-    for op_name, duration in sorted(op_time.items(), key=lambda x: x[1], reverse=True):
-        ratio = duration / total
-        calls = op_records[op_name]
-        cpu_time = op_cpu_time[op_name] if op_name in op_cpu_time else 0
-        cpu_calls = op_cpu_records[op_name] if op_name in op_cpu_records else 0
-        avg_time = duration / float(calls)
+            total_kernel_time += item["dur"]
 
-        if use_gpu or has_non_cpu_provider:
-            lines.append(
-                f"{duration:10d}\t{ratio * 100.0:5.2f}\t{avg_time:8.1f}\t{calls}\t{cpu_time:13d}\t{cpu_calls:9d}\t{op_name}")
-        else:
-            lines.append(f"{duration:10d}\t{ratio * 100.0:5.2f}\t{avg_time:8.1f}\t{calls}\t{op_name}")
+    lines = ["", "Grouped by operator"]
+    lines.append("-" * 64)
+    lines.append("Total(μs)\tTime%\tKernel(μs)\tKernel%\tCalls\tAvgKernel(μs)\tFence(μs)\tOperator")
+    for op_name, kernel_time in sorted(op_kernel_time.items(), key=lambda x: x[1], reverse=True):
+        fence_time = op_fence_time[op_name] if op_name in op_fence_time else 0
+        kernel_time_ratio = kernel_time / total_kernel_time
+        total_time = kernel_time + fence_time
+        time_ratio = total_time / (total_kernel_time + total_fence_time)
+        kernel_calls = op_kernel_records[op_name]
+        avg_kernel_time = kernel_time / kernel_calls
+        lines.append(f"{total_time:10d}\t{time_ratio * 100.0:5.2f}\t{kernel_time:11d}\t{kernel_time_ratio * 100.0:5.2f}\t{kernel_calls:5d}\t{avg_kernel_time:14.1f}\t{fence_time:10d}\t{op_name}")
+
+    lines += ["", "Grouped by provider + operator"]
+    lines.append("-" * 64)
+    lines.append("Kernel(μs)\tProvider%\tCalls\tAvgKernel(μs)\tProvider\tOperator")
+    for key, kernel_time in sorted(provider_op_kernel_time.items(), key=lambda x: x[1], reverse=True):
+        parts = key.split(':')
+        provider = parts[0]
+        op_name = parts[1] 
+        short_ep = provider.replace("ExecutionProvider", "")     
+        calls = provider_op_kernel_records[key]
+        avg_kernel_time = kernel_time / calls
+        provider_time_ratio = kernel_time / provider_kernel_time[provider]
+        lines.append(f"{kernel_time:10d}\t{provider_time_ratio * 100.0:9.2f}\t{calls:5d}\t{avg_kernel_time:14.1f}\t{short_ep:8s}\t{op_name}")
 
     return lines
 
@@ -534,8 +566,6 @@ def process_results(profile_file, args):
 
     lines += parse_node_results(profile_records, args.kernel_time_only, args.threshold)
 
-    lines.append("\nGrouped by operator type:")
-    lines.append("-" * 64)
     lines += group_node_results(profile_records, args.kernel_time_only, args.use_gpu)
 
     return lines
@@ -576,11 +606,11 @@ if __name__ == '__main__':
     from benchmark_helper import setup_logger
     setup_logger(arguments.verbose)
 
-    if not arguments.profile_file:
-        assert arguments.model, "requires either --model or --profile_file"
+    if not arguments.input:
+        assert arguments.model, "requires either --model to run profiling or --input to read profiling results"
         profile_file = run(arguments)
     else:
-        profile_file = arguments.profile_file
+        profile_file = arguments.input
 
     results = process_results(profile_file, arguments)
 


### PR DESCRIPTION
**Description**:
(1) Add --input to import profiling results from onnxruntime_perf_test.
(2) Add a section to group result by provider + operator.
(3) Output kernel statistics.

Example outputs
```
Top expensive kernels with Time% >= 1.00:
----------------------------------------------------------------
Total(μs)      Time%   Calls   Avg(μs)        Kernel
    222203      56.35    1112      199.8        _Z23implicit_convolve_sgemmI6__halfS0_Li128ELi5ELi5ELi3ELi3ELi3ELi1ELb0ELb1ELb1EEviiiPKT_iPT0_S3_18kernel_conv_paramsyiffiPKS4_S8_bii
     49005      12.43     229      214.0        _Z23explicit_convolve_sgemmI6__halfiLi1024ELi5ELi5ELi3ELi3ELi3ELi0ELb0EEviiiPKT_iS3_iPS1_18kernel_conv_paramsyiyiffiS3_S3_
     21049       5.34      82      256.7        maxwell_sgemm_128x64_nn
     14441       3.66     257       56.2        _ZN5cudnn3cnn15im2col4d_kernelI6__halfxEEvNS0_15im2col4d_paramsE22cudnnConvolutionStruct19cudnnTensor4dStructPKT_PS6_
     11393       2.89      55      207.1        _Z23implicit_convolve_sgemmI6__halfS0_Li1024ELi5ELi5ELi3ELi3ELi3ELi1ELb0ELb1ELb1EEviiiPKT_iPT0_S3_18kernel_conv_paramsyiffiPKS4_S8_bii
      9091       2.31     135       67.3        maxwell_scudnn_winograd_128x128_ldg1_ldg4_mobile_relu_tile148t_nt_v0
      7930       2.01     270       29.4        _ZN5cudnn3ops20convertTensor_kernelI6__halfffLi0EEEvT1_PKT_S3_PT0_y
      5799       1.47    1133        5.1        _Z24op_generic_tensor_kernelILi3E6__halffS0_Li256EL16cudnnGenericOp_t0EL21cudnnNanPropagation_t0ELi0EEv17cudnnTensorStructPT2_S3_PKT0_S3_S8_T1_S9_S9_S9_19reducedDivisorArrayi
      5677       1.44      64       88.7        _Z13gemv2N_kernelIii6float2S0_S0_Li128ELi8ELi4ELi4ELi1ELb0E16cublasGemvParamsI30cublasGemvTensorStridedBatchedIKS0_ES2_IS0_ES0_EEvT10_
      5352       1.36     550        9.7        _ZN11onnxruntime4cuda37_BinaryElementWiseRhsPerChannelBatch1I6__halfS2_S2_NS0_8OP_PReluIS2_S2_S2_EELi256ELi4EEEvPKT0_PKT1_NS0_11fast_divmodEPT_T2_i
      5198       1.32      82       63.4        _ZN5cudnn17winograd_nonfused24winogradForwardOutput4x4If6__halfEEvNS0_20WinogradOutputParamsIT_T0_EE
      4771       1.21      82       58.2        _ZN5cudnn17winograd_nonfused22winogradForwardData4x4If6__halfEEvNS0_18WinogradDataParamsIT_T0_EE

Group kernel time by operator:
----------------------------------------------------------------
Total(μs)      Time%   Operator
    380584      96.51   Conv
      5352       1.36   PRelu
      4399       1.12   BatchNormalization
      2201       0.56   Add
      1644       0.42   Gemm
       143       0.04   (MemcpyHostToDevice)
        19       0.00   Cast
         9       0.00   (MemcpyDeviceToHost)
         
Grouped by operator
----------------------------------------------------------------
Total(μs)      Time%   Kernel(μs)     Kernel% Calls   AvgKernel(μs)  Fence(μs)      Operator
   1270314      82.16       1270209     82.17    1133           1121.1         105      Conv
    173844      11.24        173840     11.25      22           7901.8           4      Cast
     56090       3.63         55959      3.62     561             99.7         131      BatchNormalization
     22531       1.46         22493      1.46     550             40.9          38      PRelu
     21646       1.40         21611      1.40     539             40.1          35      Add
      1486       0.10          1486      0.10      11            135.1           0      Gemm
       210       0.01           209      0.01      11             19.0           1      Flatten
       
Grouped by provider + operator
----------------------------------------------------------------
Kernel(μs)     Provider%       Calls   AvgKernel(μs)  Provider        Operator
   1270209          82.17        1133           1121.1  CUDA            Conv
    173840          11.25          22           7901.8  CUDA            Cast
     55959           3.62         561             99.7  CUDA            BatchNormalization
     22493           1.46         550             40.9  CUDA            PRelu
     21611           1.40         539             40.1  CUDA            Add
      1486           0.10          11            135.1  CUDA            Gemm
       209           0.01          11             19.0  CUDA            Flatten
```

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
