### PR TITLE
Updated cpuid_info.cc to fix PVS-Studio error C1012

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -24,7 +24,7 @@
 #if _WIN32
 #define HAS_WINDOWS_DESKTOP WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #endif
-#if (defined(CPUIDINFO_ARCH_X86) || defined(CPUIDINFO_ARCH_ARM)) && defined(CPUINFO_SUPPORTED) && (!_WIN32 || HAS_WINDOWS_DESKTOP)
+#if (defined(CPUIDINFO_ARCH_X86) || defined(CPUIDINFO_ARCH_ARM)) && defined(CPUINFO_SUPPORTED) && (!_WIN32 || defined(HAS_WINDOWS_DESKTOP))
 #include <cpuinfo.h>
 #endif
 


### PR DESCRIPTION
**Description**: Describe your changes.
Updated cpuid_info.cc to fix PVS-Studio error: "fatal error C1012: unmatched parenthesis: missing ')'"

The error seems to be that the "ifdef" tag is not being used.

**Motivation and Context**
- Why is this change required? What problem does it solve? PVS studio compiler error fix due to the missing "defined(x)"