### PR TITLE
Remove python 3.6 from macos pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -1013,14 +1013,14 @@ stages:
         MACOSX_DEPLOYMENT_TARGET: '10.14'
       strategy:
         matrix:
-          Python36:
-            PythonVersion: '3.6'
           Python37:
             PythonVersion: '3.7'
           Python38:
             PythonVersion: '3.8'
           Python39:
             PythonVersion: '3.9'
+          Python310:
+            PythonVersion: '3.10'
       steps:
       - checkout: self
         clean: true

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -1019,8 +1019,6 @@ stages:
             PythonVersion: '3.8'
           Python39:
             PythonVersion: '3.9'
-          Python310:
-            PythonVersion: '3.10'
       steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
**Description**: 

Python 3.6 will be EOL this Dec. Our macos-11 image has removed it.  
See: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
