### PR TITLE
fix import torch_gpu_allocator error

### DIFF
--- a/orttraining/orttraining/python/training/optim/_apex_amp_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_apex_amp_modifier.py
@@ -21,7 +21,7 @@ class ApexAMPModifier(FP16OptimizerModifier):
 
     def override_function(m_self):
         from apex import amp as apex_amp
-        from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        from onnxruntime.training.ortmodule.torch_cpp_extensions.cuda import fused_ops
         warnings.warn('Apex AMP fp16_optimizer functions are overrided with faster implementation.', UserWarning)
 
         # Implementation adapted from https://github.com/NVIDIA/apex/blob/082f999a6e18a3d02306e27482cc7486dab71a50/apex/amp/_process_optimizer.py#L161

--- a/orttraining/orttraining/python/training/optim/fused_adam.py
+++ b/orttraining/orttraining/python/training/optim/fused_adam.py
@@ -80,7 +80,7 @@ class FusedAdam(torch.optim.Optimizer):
         # Skip buffer
         self._dummy_overflow_buf = torch.cuda.IntTensor([0])
 
-        from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        from onnxruntime.training.ortmodule.torch_cpp_extensions.cuda import fused_ops
         self._multi_tensor_adam = fused_ops.multi_tensor_adam
         self._multi_tensor_applier = MultiTensorApply(2048 * 32)
         self._TorchTensorVector = fused_ops.TorchTensorVector

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
@@ -10,7 +10,7 @@ from torch.utils.dlpack import from_dlpack, to_dlpack
 
 from ._fallback import _FallbackManager, ORTModuleFallbackException, ORTModuleIOError, wrap_exception
 
-from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
+from onnxruntime.training.ortmodule.torch_cpp_extensions.cpu import torch_interop_utils
 
 def wrap_as_dlpack_or_not(grad_flag, tensor_flag, inplace_flag, training_mode_flag, arg):
     '''

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -181,7 +181,7 @@ class GraphExecutionManager(GraphExecutionInterface):
     def _get_torch_gpu_allocator_function_addresses(self):
         if self._use_external_gpu_allocator and torch.cuda.is_available():
             # CPP extension to get torch GPU allocator's alloc and free function addresses
-            from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_gpu_allocator
+            from onnxruntime.training.ortmodule.torch_cpp_extensions.cuda import torch_gpu_allocator
             self._torch_alloc = torch_gpu_allocator.gpu_caching_allocator_raw_alloc_address()
             self._torch_free = torch_gpu_allocator.gpu_caching_allocator_raw_delete_address()
             self._torch_empty_cache = torch_gpu_allocator.gpu_caching_allocator_empty_cache_address()

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/aten_op_executor/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/aten_op_executor/__init__.py
@@ -25,6 +25,6 @@ def run_once_aten_op_executor(f):
 
 @run_once_aten_op_executor
 def load_aten_op_executor_cpp_extension():
-    from onnxruntime.training.ortmodule.torch_cpp_extensions import aten_op_executor
+    from onnxruntime.training.ortmodule.torch_cpp_extensions.cpu import aten_op_executor
     C.register_aten_op_executor(str(aten_op_executor.is_tensor_argument_address()),
                                 str(aten_op_executor.execute_aten_operator_address()))


### PR DESCRIPTION
**Description**: Describe your changes.

On a clean env, after I build the ORT and installed it and build torch cpp extensions. 

Importing torch_gpu_allocator from onnxruntime.training.ortmodule.torch_cpp_extensions failed with below error message:

    Traceback (most recent call last):
      File "repeat_test.py", line 32, in <module>
        net = ORTModule(net)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/ortmodule.py", line 118, in __init__
        override_policy=_FallbackPolicy.FALLBACK_FORCE_TORCH_FORWARD)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_fallback.py", line 151, in handle_exception
        raise exception
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/ortmodule.py", line 71, in __init__
        self._torch_module = TorchModuleFactory()(module, debug_options, self._fallback_manager)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_torch_module_factory.py", line 14, in __call__
        return TorchModuleORT(module, debug_options, fallback_manager)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_torch_module_ort.py", line 40, in __init__
        self._execution_manager = GraphExecutionManagerFactory(self._flattened_module, debug_options, fallback_manager)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_graph_execution_manager_factory.py", line 14, in __init__
        self._training_manager = TrainingManager(module, debug_options, fallback_manager)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_training_manager.py", line 34, in __init__
        super().__init__(model, debug_options, fallback_manager)
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_graph_execution_manager.py", line 165, in __init__
        self._get_torch_gpu_allocator_function_addresses()
      File "/opt/conda/lib/python3.7/site-packages/onnxruntime/training/ortmodule/_graph_execution_manager.py", line 184, in _get_torch_gpu_allocator_function_addresses
        from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_gpu_allocator
    ImportError: libtorch_cuda_cu.so: cannot open shared object file: No such file or directory
    
    The target application terminated with signal 11 (SIGSEGV)


Trying the import manually also give same error, but if we use "from onnxruntime.training.ortmodule.torch_cpp_extensions.cuda import torch_gpu_allocator", it can pass. 

root@fb9754e5e6e0:/nfs/pengwa/dev/tests# python
Python 3.7.3 (default, Mar 27 2019, 22:11:17)
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_gpu_allocator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: libtorch_cuda_cu.so: cannot open shared object file: No such file or directory
>>> from onnxruntime.training.ortmodule.torch_cpp_extensions.cuda import torch_gpu_allocator
>>>

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
