### PR TITLE
Add build.py option for disabling memleak checker

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -344,6 +344,9 @@ def parse_arguments():
         help="Specify the minimum version of the target platform "
         "(e.g. macOS or iOS)"
         "This is only supported on MacOS")
+    parser.add_argument(
+        "--disable_memleak_checker", action='store_true',
+        help="Disable memory leak checker from Windows build")
 
     # WebAssembly build
     parser.add_argument("--build_wasm", action='store_true', help="Build for WebAssembly")
@@ -1141,7 +1144,8 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                 "-Donnxruntime_ENABLE_MEMLEAK_CHECKER=" +
                 ("ON" if config.lower() == 'debug' and not args.use_nuphar and not
                  args.use_openvino and not
-                 args.enable_msvc_static_runtime
+                 args.enable_msvc_static_runtime and not
+                 args.disable_memleak_checker
                  else "OFF"), "-DCMAKE_BUILD_TYPE={}".format(config)],
             cwd=config_build_dir)
 


### PR DESCRIPTION
The memleak checker used by default in Debug configuration does not
play nice with embedding static lib of ONNXRuntime into binaries,
because other code will not be using the same debug heap, leading
to trouble.

This makes it easier for outside builders to disable it for their
build.

Vaguely related to #8555.