### PR TITLE
Replace wstring_convert with std::wstring

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -46,9 +46,8 @@ ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* thread_
   child_thread_stats_.assign(num_threads, {});
   if (thread_pool_name) {
 #ifdef _WIN32
-    using convert_type = std::codecvt_utf8<wchar_t>;
-    std::wstring_convert<convert_type, wchar_t> converter;
-    thread_pool_name_ = converter.to_bytes(thread_pool_name);
+    std::wstring ws(thread_pool_name);
+    thread_pool_name_.assign(ws.begin(), ws.end());
 #else
     thread_pool_name_ = thread_pool_name;
 #endif

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -47,7 +47,10 @@ ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* thread_
   if (thread_pool_name) {
 #ifdef _WIN32
     std::wstring ws(thread_pool_name);
-    thread_pool_name_.assign(ws.begin(), ws.end());
+	thread_pool_name_.resize(ws.length());
+	std::transform(ws.begin(), ws.end(), thread_pool_name_.begin(), [] (wchar_t c) {
+		return (char)c;
+	});
 #else
     thread_pool_name_ = thread_pool_name;
 #endif

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -47,10 +47,10 @@ ThreadPoolProfiler::ThreadPoolProfiler(int num_threads, const CHAR_TYPE* thread_
   if (thread_pool_name) {
 #ifdef _WIN32
     std::wstring ws(thread_pool_name);
-	thread_pool_name_.resize(ws.length());
-	std::transform(ws.begin(), ws.end(), thread_pool_name_.begin(), [] (wchar_t c) {
+    thread_pool_name_.resize(ws.length());
+    std::transform(ws.begin(), ws.end(), thread_pool_name_.begin(), [] (wchar_t c) {
 		return (char)c;
-	});
+    });
 #else
     thread_pool_name_ = thread_pool_name;
 #endif


### PR DESCRIPTION
**Description**: Replace wstring_convert with std::wstring for conversion to std::string
 
**Motivation and Context**
- Why is this change required? What problem does it solve?
  the usage of wstring_convert adds a bunch of overheads and would sometimes cause the thread to crash

- If it fixes an open issue, please link to the issue here.
