### PR TITLE
Fix a couple of bugs with how memory pattern planning is enabled/disabled 

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -241,6 +241,7 @@ bool NodeArg::HasTensorOrScalarShape() const {
   const auto type_case = type->value_case();
   switch (type_case) {
     case TypeProto::kTensorType:
+      return true;
 #if !defined(DISABLE_SPARSE_TENSORS)
     case TypeProto::kSparseTensorType:
       // Standard tensor has a valid shape field while

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -241,17 +241,13 @@ bool NodeArg::HasTensorOrScalarShape() const {
   const auto type_case = type->value_case();
   switch (type_case) {
     case TypeProto::kTensorType:
-      // Standard tensor has a valid shape field while
-      // scalar's shape is empty. Thus, we don't need to
-      // check shape here.
-      return true;
 #if !defined(DISABLE_SPARSE_TENSORS)
     case TypeProto::kSparseTensorType:
+#endif
       // Standard tensor has a valid shape field while
       // scalar's shape is empty. Thus, we don't need to
       // check shape here.
       return true;
-#endif
     case TypeProto::kSequenceType:
     case TypeProto::kMapType:
     case TypeProto::kOpaqueType:

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -241,6 +241,9 @@ bool NodeArg::HasTensorOrScalarShape() const {
   const auto type_case = type->value_case();
   switch (type_case) {
     case TypeProto::kTensorType:
+      // Standard tensor has a valid shape field while
+      // scalar's shape is empty. Thus, we don't need to
+      // check shape here.
       return true;
 #if !defined(DISABLE_SPARSE_TENSORS)
     case TypeProto::kSparseTensorType:

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1443,7 +1443,7 @@ common::Status InferenceSession::Initialize() {
     // Resolve the memory pattern flag of the main graph session state
     session_state_->ResolveMemoryPatternFlag();
 
-    // Resolve all memory patterns flags of the subgraph session states
+    // Resolve all memory pattern flags of subgraph session states
     ResolveSubgrapMemoryPatternFlags(*session_state_);
 
     is_inited_ = true;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1232,10 +1232,12 @@ Status AssignNodesToEpsFromHashes(Graph& graph, const fbs::SessionState& fbs_ses
 }  // namespace
 #endif  // defined(ENABLE_ORT_FORMAT_LOAD)
 
-static void ResolveSubgraphMemoryPatternFlags(SessionState& session_state) {
+static void ResolveMemoryPatternFlags(SessionState& session_state) {
+  session_state.ResolveMemoryPatternFlag();
+
   for (const auto& entry : session_state.GetSubgraphSessionStateMap()) {
     for (const auto& name_to_subgraph_session_state : entry.second) {
-      name_to_subgraph_session_state.second->ResolveMemoryPatternFlag();
+      ResolveMemoryPatternFlags(*name_to_subgraph_session_state.second);
     }
   }
 }
@@ -1440,11 +1442,8 @@ common::Status InferenceSession::Initialize() {
     }
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
-    // Resolve the memory pattern flag of the main graph session state
-    session_state_->ResolveMemoryPatternFlag();
-
-    // Resolve all memory pattern flags of subgraph session states
-    ResolveSubgraphMemoryPatternFlags(*session_state_);
+    // Resolve memory pattern flags of the main graph and subgraph session states
+    ResolveMemoryPatternFlags(*session_state_);
 
     is_inited_ = true;
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1232,7 +1232,7 @@ Status AssignNodesToEpsFromHashes(Graph& graph, const fbs::SessionState& fbs_ses
 }  // namespace
 #endif  // defined(ENABLE_ORT_FORMAT_LOAD)
 
-static void ResolveSubgrapMemoryPatternFlags(SessionState& session_state) {
+static void ResolveSubgraphMemoryPatternFlags(SessionState& session_state) {
   for (const auto& entry : session_state.GetSubgraphSessionStateMap()) {
     for (const auto& name_to_subgraph_session_state : entry.second) {
       name_to_subgraph_session_state.second->ResolveMemoryPatternFlag();
@@ -1444,7 +1444,7 @@ common::Status InferenceSession::Initialize() {
     session_state_->ResolveMemoryPatternFlag();
 
     // Resolve all memory pattern flags of subgraph session states
-    ResolveSubgrapMemoryPatternFlags(*session_state_);
+    ResolveSubgraphMemoryPatternFlags(*session_state_);
 
     is_inited_ = true;
 


### PR DESCRIPTION
**Description**: 

1) When a build option to disable sparse tensor support was added, logic was accidentally changed such that if sparse tensor support was disabled, memory pattern planning was disabled altogether (See change in graph.cc)

2) We resolve flag indicating if memory pattern is to be enabled/disabled only for the main graph but don't do it for subgraphs 

This change fixes both

**Motivation and Context**
Fix bugs
