### PR TITLE
Update mechanism to check installed cpp extensions

### DIFF
--- a/orttraining/orttraining/python/training/optim/_apex_amp_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_apex_amp_modifier.py
@@ -21,7 +21,10 @@ class ApexAMPModifier(FP16OptimizerModifier):
 
     def override_function(m_self):
         from apex import amp as apex_amp
-        from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        try:
+            from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        except ImportError:
+            import fused_ops
         warnings.warn('Apex AMP fp16_optimizer functions are overrided with faster implementation.', UserWarning)
 
         # Implementation adapted from https://github.com/NVIDIA/apex/blob/082f999a6e18a3d02306e27482cc7486dab71a50/apex/amp/_process_optimizer.py#L161

--- a/orttraining/orttraining/python/training/optim/fused_adam.py
+++ b/orttraining/orttraining/python/training/optim/fused_adam.py
@@ -80,7 +80,10 @@ class FusedAdam(torch.optim.Optimizer):
         # Skip buffer
         self._dummy_overflow_buf = torch.cuda.IntTensor([0])
 
-        from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        try:
+            from onnxruntime.training.ortmodule.torch_cpp_extensions import fused_ops
+        except ImportError:
+            import fused_ops
         self._multi_tensor_adam = fused_ops.multi_tensor_adam
         self._multi_tensor_applier = MultiTensorApply(2048 * 32)
         self._TorchTensorVector = fused_ops.TorchTensorVector

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_runner.py
@@ -10,7 +10,11 @@ from torch.utils.dlpack import from_dlpack, to_dlpack
 
 from ._fallback import _FallbackManager, ORTModuleFallbackException, ORTModuleIOError, wrap_exception
 
-from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
+try:
+    from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
+except ImportError:
+    import torch_interop_utils
+
 
 def wrap_as_dlpack_or_not(grad_flag, tensor_flag, inplace_flag, training_mode_flag, arg):
     '''

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/__init__.py
@@ -36,4 +36,27 @@ def is_installed(torch_cpp_extension_path):
     torch_cpp_exts = glob(os.path.join(torch_cpp_extension_path, '*.so'))
     torch_cpp_exts.extend(glob(os.path.join(torch_cpp_extension_path, '*.dll')))
     torch_cpp_exts.extend(glob(os.path.join(torch_cpp_extension_path, '*.dylib')))
-    return len(torch_cpp_exts) > 0
+    if len(torch_cpp_exts) > 0:
+        return True
+    n_installed = 0
+    try:
+        import aten_op_executor
+        n_installed += 1
+    except ImportError:
+        pass
+    try:
+        import torch_interop_utils
+        n_installed += 1
+    except ImportError:
+        pass
+    try:
+        import fused_ops
+        n_installed += 1
+    except ImportError:
+        pass
+    try:
+        import torch_gpu_allocator
+        n_installed += 1
+    except ImportError:
+        pass
+    return n_installed > 0

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/aten_op_executor/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/aten_op_executor/__init__.py
@@ -25,6 +25,9 @@ def run_once_aten_op_executor(f):
 
 @run_once_aten_op_executor
 def load_aten_op_executor_cpp_extension():
-    from onnxruntime.training.ortmodule.torch_cpp_extensions import aten_op_executor
+    try:
+        from onnxruntime.training.ortmodule.torch_cpp_extensions import aten_op_executor
+    except ImportError:
+        import aten_op_executor
     C.register_aten_op_executor(str(aten_op_executor.is_tensor_argument_address()),
                                 str(aten_op_executor.execute_aten_operator_address()))


### PR DESCRIPTION
**Description**:
ORTModule requires cpp extensions to be installed. onnxruntime assumes they are compiled in a subfolder and import them from this location after they were compiled. This PR introduces changes to check if these extensions are installed as a reguler package in case they are not found in the expected subfolder.

**Motivation and Context**
The cpp extensions cannot be easily installed on Windows. due to long path name, a compilation error may happen. In that case, the fallback meachnism is to manually compile every cpp extension and to install them.