### PR TITLE
Make ORTModule serializable

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -456,8 +456,6 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._original_model_has_changed = True
 
     def __getstate__(self):
-        # Attempt to serialize graph execution manager
-
         state = copy.copy(self.__dict__)
         # Remove any re-contructible/pybound object from the state
         serialization_deny_list = [
@@ -470,17 +468,11 @@ class GraphExecutionManager(GraphExecutionInterface):
             "_torch_empty_cache"
         ]
         for attribute_name in serialization_deny_list:
-            state[attribute_name] = None
+            del state[attribute_name]
 
         return state
 
     def __setstate__(self, state):
-        # Attempt to deserialize graph execution manager
-
         self.__dict__.update(state)
 
-        # Instantiate the onnx models so they can populated on the first call to forward
-        self._onnx_models = _onnx_models.ONNXModels()
-
-        # Re-define the torch allocator
-        self._get_torch_gpu_allocator_function_addresses()
+        _utils.reinitialize_graph_execution_manager(self)

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -87,7 +87,6 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._onnx_models = _onnx_models.ONNXModels()
 
         # Model after inference optimization or gradient building.
-        self._optimized_onnx_model = None
         self._graph_builder = None
         self._graph_info = None
         self._graph_initializer_names = None
@@ -147,8 +146,8 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._module_output_schema = None
         self._device = _utils.get_device_from_module(module)
 
-        self._module_parameters = inspect.signature(
-            self._original_module.forward).parameters.values()
+        self._module_parameters = list(inspect.signature(
+            self._original_module.forward).parameters.values())
 
         # TODO: remove after PyTorch ONNX exporter supports VAR_KEYWORD parameters.
         for input_parameter in self._module_parameters:
@@ -455,3 +454,33 @@ class GraphExecutionManager(GraphExecutionInterface):
     def signal_model_changed(self):
         """Signals the execution manager to re-export the model on the next forward call"""
         self._original_model_has_changed = True
+
+    def __getstate__(self):
+        # Attempt to serialize graph execution manager
+
+        state = copy.copy(self.__dict__)
+        # Remove any re-contructible/pybound object from the state
+        serialization_deny_list = [
+            "_onnx_models",
+            "_graph_builder",
+            "_graph_info",
+            "_execution_agent",
+            "_torch_alloc",
+            "_torch_free",
+            "_torch_empty_cache"
+        ]
+        for attribute_name in serialization_deny_list:
+            state[attribute_name] = None
+
+        return state
+
+    def __setstate__(self, state):
+        # Attempt to deserialize graph execution manager
+
+        self.__dict__.update(state)
+
+        # Instantiate the onnx models so they can populated on the first call to forward
+        self._onnx_models = _onnx_models.ONNXModels()
+
+        # Re-define the torch allocator
+        self._get_torch_gpu_allocator_function_addresses()

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
@@ -8,7 +8,6 @@ from ._graph_execution_manager_factory import GraphExecutionManagerFactory
 from ._torch_module_interface import TorchModuleInterface
 from ._fallback import _FallbackManager, ORTModuleTorchModelException, wrap_exception
 from collections import OrderedDict
-import functools
 import torch
 from typing import Iterator, Optional, Tuple, TypeVar, Callable
 
@@ -163,9 +162,6 @@ class TorchModuleORT(TorchModuleInterface):
         return self._original_module
 
     def __setstate__(self, state):
-        # Attempt to deserialize torch module
-
         self.__dict__.update(state)
 
-        # Re-initialize the forward method
-        _utils.patch_torch_module_ort_forward_method(self)
+        _utils.reinitialize_torch_module_ort(self)

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 # _torch_module_ort.py
 
-from . import _io
+from . import _io, _utils
 from .debug_options import DebugOptions
 from ._graph_execution_manager_factory import GraphExecutionManagerFactory
 from ._torch_module_interface import TorchModuleInterface
@@ -21,21 +21,7 @@ class TorchModuleORT(TorchModuleInterface):
         super().__init__(module)
         self._flattened_module = _io._FlattenedModule(module)
 
-        def _forward(self, *inputs, **kwargs):
-            '''Forward pass starts here and continues at `_ORTModuleFunction.forward`
-
-            ONNX model is exported the first time this method is executed.
-            Next, we build a full training graph with module_gradient_graph_builder.
-            Finally, we instantiate the ONNX Runtime InferenceSession.
-            '''
-
-            return self._execution_manager(self.is_training()).forward(*inputs, **kwargs)
-
-        # Bind the forward method.
-        self.forward = _forward.__get__(self)
-        # Copy the forward signature from the PyTorch module.
-        functools.update_wrapper(
-            self.forward.__func__, self._original_module.forward.__func__)
+        _utils.patch_torch_module_ort_forward_method(self)
 
         self._execution_manager = GraphExecutionManagerFactory(self._flattened_module, debug_options, fallback_manager)
 
@@ -175,3 +161,11 @@ class TorchModuleORT(TorchModuleInterface):
         # to save and load a complete checkpoint
 
         return self._original_module
+
+    def __setstate__(self, state):
+        # Attempt to deserialize torch module
+
+        self.__dict__.update(state)
+
+        # Re-initialize the forward method
+        _utils.patch_torch_module_ort_forward_method(self)

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -347,20 +347,15 @@ class TrainingManager(GraphExecutionManager):
         return False
 
     def __getstate__(self):
-        # Attempt to serialize training manager
-
         state = super(TrainingManager, self).__getstate__()
 
         # Only top level classes are pickleable. So, _ORTModuleFunction is
         # not pickleable. So, let's not pickle it, and redefine it when
         # loading the state.
-        state['_forward_class'] = None
+        del state['_forward_class']
         return state
 
     def __setstate__(self, state):
-        # Attempt to deserialize training manager
-
         super(TrainingManager, self).__setstate__(state)
 
-        # Redefine self._forward_class
-        self._forward_class = self._create_autofunction_class()
+        _utils.reinitialize_training_manager(self)

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -70,24 +70,7 @@ class ORTModule(torch.nn.Module):
 
             self._torch_module = TorchModuleFactory()(module, debug_options, self._fallback_manager)
 
-            # Create forward dynamically, so each ORTModule instance will have its own copy.
-            # This is needed to be able to copy the forward signatures from the original PyTorch models
-            # and possibly have different signatures for different instances.
-            def _forward(self, *inputs, **kwargs):
-                '''Forward pass starts here and continues at `_ORTModuleFunction.forward`
-
-                ONNX model is exported the first time this method is executed.
-                Next, we build a full training graph with module_gradient_graph_builder.
-                Finally, we instantiate the ONNX Runtime InferenceSession.
-                '''
-
-                return self._torch_module.forward(*inputs, **kwargs)
-
-            # Bind the forward method.
-            self.forward = _forward.__get__(self)
-            # Copy the forward signature from the _torch_module's forward signature.
-            functools.update_wrapper(
-                self.forward.__func__, self._torch_module.forward.__func__)
+            _utils.patch_ortmodule_forward_method(self)
 
             # Support contrib OPs
             pytorch_export_contrib_ops.register()
@@ -322,3 +305,25 @@ class ORTModule(torch.nn.Module):
         else:
             # Setting any new attributes should be done on ORTModule only when 'torch_module' is not defined
             self.__dict__[name] = value
+
+    def __getstate__(self):
+        # Attempting to serialize ORTModule
+
+        state = _utils.get_state_after_deletion_of_non_ortmodule_methods(self, self.module)
+        return state
+
+    def __setstate__(self, state):
+        # Attempt to deserialize ORTModule
+
+        self.__dict__.update(state)
+
+        # Re-register contrib OPs
+        pytorch_export_contrib_ops.register()
+        CustomOpSymbolicRegistry.register_all()
+        CustomGradientRegistry.register_all()
+
+        # Re-initialize the ORTModule forward method
+        _utils.patch_ortmodule_forward_method(self)
+
+        # Re-bind users custom methods to ORTModule
+        _utils.check_for_name_collisions_and_bind_methods_to_ortmodule(self, self.module)


### PR DESCRIPTION
Models that make use of `torch.multiprocessing` or `python.multiprocessing` require the model to be serializable and deserializable. Currenlty `ORTModule` is not serializable because of some of some of its attributes.

This pull request makes `ORTModule` serializable by introducing methods ```__getstate__``` and ```__setstate__``` that drop and reconstruct non serializable/deserializable attributes respectively.