### PR TITLE
Small addendum to #9624

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -690,7 +690,7 @@ void SessionState::ResolveMemoryPatternFlag() {
     }
 
     // For subgraphs, the implicit inputs need to meet the same crieria
-    // as the explicit inputs for memory pattern flag to be enabled
+    // as the explicit inputs for memory pattern to be enabled
     if (graph_viewer_->IsSubgraph()) {
       const auto* parent_node = graph_viewer_->ParentNode();
 

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -688,6 +688,19 @@ void SessionState::ResolveMemoryPatternFlag() {
         break;
       }
     }
+
+    // For subgraphs, the implicit inputs need to meet the same crieria
+    // as the explicit inputs for memory pattern flag to be enabled
+    if (graph_viewer_->IsSubgraph()) {
+      const auto* parent_node = graph_viewer_->ParentNode();
+
+      for (auto* implicit_input : parent_node->ImplicitInputDefs()) {
+        if (!implicit_input->HasTensorOrScalarShape()) {
+          enable_mem_pattern_ = false;
+          break;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**Description**: While handling subgraphs in `ResolveMemoryPatternFlags()`, we must ensure that implicit inputs to the subgraph meet the same criteria as explicit inputs. 

The logic in memory pattern planning deals with `feeds` which includes both implicit and explicit inputs and hence the same checks that apply to explicit graph inputs need to apply to implicit subgraph inputs : https://github.com/microsoft/onnxruntime/blob/c315d1b3cdee1d5662e529d7fdce120eefa18193/onnxruntime/core/framework/execution_frame.cc#L380

**Motivation and Context**
Small addendum to https://github.com/microsoft/onnxruntime/pull/9624
