### PR TITLE
[DmlEp] Updated OperatorUtility.h to avoid C2672 and C2783

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorUtility.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorUtility.h
@@ -70,6 +70,8 @@ namespace Dml
         uint32_t index;
     };
 
+    std::optional<uint32_t> TryMapStringToIndex(std::string_view mode, gsl::span<const NameAndIndex> nameAndIndexList);
+
     template<typename T>
     std::optional<T> TryMapStringToIndex(std::string_view mode, gsl::span<const NameAndIndex> nameAndIndexList)
     {
@@ -77,8 +79,6 @@ namespace Dml
         auto result = TryMapStringToIndex(mode, nameAndIndexList);
         return *reinterpret_cast<std::optional<T>*>(std::addressof(result));
     }
-
-    std::optional<uint32_t> TryMapStringToIndex(std::string_view mode, gsl::span<const NameAndIndex> nameAndIndexList);
 
     DML_INTERPOLATION_MODE MapStringToInteropolationMode(std::string_view mode);
 


### PR DESCRIPTION
**Description**: Describe your changes.

Technical details:
Updated OperatorUtility.h to avoid compiler error errors C2672 and C2783:
- Error C2672: 'TryMapStringToIndex': no matching overloaded function found
- Error C2783: 'std::optional<_Ty> Dml::TryMapStringToIndex(std::string_view,gsl::span<const Dml::NameAndIndex>)': could not deduce template argument for 'T'. note: see declaration of 'Dml::TryMapStringToIndex'. 'TryMapStringToIndex': function declaration must be available as none of the arguments depend on a template parameter

Real error:
The template version of TryMapStringToIndex uses the non-template version of TryMapStringToIndex, which was being defined & declared AFTER the template version of it, so the compiler could not find it because it had not been defined/declared yet.
I am actually confused it works on ORT itself, as we are simply using VS 2019. My guess it's that it might be due to us compiling ORT as a dynamic library vs. ORT compiling itself statically.

**Motivation and Context**
- Why is this change required? What problem does it solve? It does not compile inside of Unreal Engine due to this error.

Note: @fdwr I merged both of your changes (Clang and ORT_NO_EXCEPTION support for DML) and everything is working! I just realized this is the only change left in our forked ORT that could be mergeable. I am very sorry for doing yet another 1-file PR, in this case it just happened because it's our very final PR (I promise!) At least until new changes cause new errors ;)