### PR TITLE
Increase binary size limit and publish binary size data even if limit is exceeded.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -179,15 +179,23 @@ jobs:
 
 
   - task: AzureCLI@2
-    displayName: 'Azure CLI'
-    condition: and (succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: 'Publish binary size data'
+    condition: and(succeededOrFailed(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       azureSubscription: AIInfraBuild
       scriptLocation: inlineScript
       scriptType: bash
       inlineScript: |
-        /usr/bin/python3 $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py --commit_hash=$(Build.SourceVersion) \
-        --size_data_file=$(Build.BinariesDirectory)/MinSizeRel/binary_size_data.txt --build_project=onnxruntime --build_id=$(Build.BuildId)
+        BINARY_SIZE_DATA_FILE="$(Build.BinariesDirectory)/MinSizeRel/binary_size_data.txt"
+        if [[ ! -f "${BINARY_SIZE_DATA_FILE}" ]]; then
+          echo "File not found: ${BINARY_SIZE_DATA_FILE}"
+          exit 1
+        fi
+        /usr/bin/python3 $(Build.SourcesDirectory)/tools/ci_build/github/windows/post_binary_sizes_to_dashboard.py \
+          --commit_hash=$(Build.SourceVersion) \
+          --size_data_file="${BINARY_SIZE_DATA_FILE}" \
+          --build_project=onnxruntime \
+          --build_id=$(Build.BuildId)
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: PublishTestResults@2

--- a/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
+++ b/tools/ci_build/github/linux/ort_minimal/build_minimal_ort_android_baseline_and_report_bin_size.sh
@@ -29,7 +29,7 @@ python3 /onnxruntime_src/tools/ci_build/build.py \
     --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config
 
 # set current size limit to BINARY_SIZE_LIMIT_IN_BYTES.
-BINARY_SIZE_LIMIT_IN_BYTES=1299000
+BINARY_SIZE_LIMIT_IN_BYTES=1302000
 echo "The current preset binary size limit is $BINARY_SIZE_LIMIT_IN_BYTES"
 python3 /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/check_build_binary_size.py \
     --threshold=$BINARY_SIZE_LIMIT_IN_BYTES \


### PR DESCRIPTION
**Description**:
Increase binary size limit to fix "Linux CPU Minimal Build E2E CI Pipeline" in master.
Also updated the build definition to publish binary size data even if the size limit check fails so size data doesn't get lost.

**Motivation and Context**
Fix build.