### PR TITLE
change a for iteration in extract_outputs_and_maybe_update_cache

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_gradient_accumulation_manager.py
@@ -55,7 +55,7 @@ class GradientAccumulationManager(object):
             forward_outputs (OrtValueVector): List of outputs returned by forward function
         """
         if not self.enabled:
-            return tuple(_utils._ortvalue_to_torch_tensor(forward_output, device) for forward_output in forward_outputs)
+            return tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i], device) for i in range(len(forward_outputs)))
         if self._update_cache:
             for i in range(self._cache_start, len(forward_outputs)):
                 self.cache.insert(


### PR DESCRIPTION
**Description**: Change a for iteration in `extract_outputs_and_maybe_update_cache`.

**Motivation and Context**
- Why is this change required? What problem does it solve?

When testing operator benchmarking, found this line brings up to 100+ μs of overhead, after `run_forward`.
After changing the `for ... in` logic into `for i in range(*)`, this overhead is gone.

Test case: benchmarking for Tile
Before the change (~92 μs gap):
![image](https://user-images.githubusercontent.com/30493312/140557158-72a5c614-a759-4b4f-82b0-8e317f60d7c3.png)
After this change:
![image](https://user-images.githubusercontent.com/30493312/140557483-45a44f37-7f4e-4a01-9199-34f7daaf4b17.png)


<details>
<summary>Other details</summary>
The nvtx markers are added at:

```python
    def extract_outputs_and_maybe_update_cache(self, forward_outputs, device):
        """Extract the user outputs from the forward outputs as torch tensor and update cache, if needed

        Args:
            forward_outputs (OrtValueVector): List of outputs returned by forward function
        """
        if not self.enabled:
            with nvtx.annotate('return tuple(*)', color='red'):
                return tuple(_utils._ortvalue_to_torch_tensor(forward_output, device) for forward_output in forward_outputs)
                # this change
                # return tuple(_utils._ortvalue_to_torch_tensor(forward_outputs[i], device) for i in range(len(forward_outputs)))
```
and

```py
def _ortvalue_to_torch_tensor(ortvalue, device):
    # PyTorch's to_dlpack() uses same config for both torch.bool and torch.uint8,
    # and convert the config to torch.uint8 tensor duing from_dlpack().
    # So we need to convert the torch tensor to torch.bool type if OrtValue is bool tensor.
    with nvtx.annotate('', color='orange'):
        dlpack_tensor = ortvalue.to_dlpack()
    with nvtx.annotate('_torch_tensor_from_dl_pack', color='cyan'):
        return _torch_tensor_from_dl_pack(dlpack_tensor, ortvalue, device)
```
In a real training model, ProphetNet, the gap also exists, and the phenomenon is similar.
Before this change (145 μs gap):
![image](https://user-images.githubusercontent.com/30493312/140558473-3ef7354b-0d63-4139-92d4-2438e9eae150.png)
After this change:
![image](https://user-images.githubusercontent.com/30493312/140558548-af114b64-9328-44b9-91d1-42559a03ea31.png)
</details>