### PR TITLE
support for gradient with different type than input

### DIFF
--- a/orttraining/orttraining/core/graph/gradient_builder_base.h
+++ b/orttraining/orttraining/core/graph/gradient_builder_base.h
@@ -139,6 +139,12 @@ class GradientBuilderBase {
     return ArgDef(GradientName(node_->InputDefs()[i]->Name()), node_->InputDefs()[i]->TypeAsProto());
   }
 
+  // gradient of i-th input of forward op - useful when gradient type does not match input type
+  ArgDef GI(const size_t i, const TypeProto *type) const {
+    ORT_ENFORCE(i < node_->InputDefs().size());
+    return ArgDef(GradientName(node_->InputDefs()[i]->Name()), type);
+  }
+
   // gradient of i-th output of forward op
   ArgDef GO(const size_t i) const {
     ORT_ENFORCE(i < node_->OutputDefs().size());


### PR DESCRIPTION
**Description**: Describe your changes.
 
Add an overload to the GI() function that accepts a type.

**Motivation and Context**
- Why is this change required? What problem does it solve?
It may be desirable to define a custom gradient builder that computes gradients in a different type than the type used by the forward pass. In our use case, we have a forward pass custom op that accepts weights in Float32 for which the gradients are computed in BFloat16 (because memory is limited on our device).

