### PR TITLE
Use the same allocator following Pytorch

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/___gpu_identifier___/___gpu_allocator_header___.h>
 #include <torch/extension.h>
 
 void* delegate_raw_alloc(size_t nbytes) {
-  auto allocator = c10::cuda::CUDACachingAllocator::get();
+  auto allocator = c10::___gpu_identifier___::___gpu_allocator_header___::get();
   return allocator->raw_allocate(nbytes);
 }
 
 void delegate_raw_delete(void* ptr) {
-  auto allocator = c10::cuda::CUDACachingAllocator::get();
+  auto allocator = c10::___gpu_identifier___::___gpu_allocator_header___::get();
   allocator->raw_deallocate(ptr);
 }
 

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
@@ -1,33 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <torch/extension.h>
-#include <c10/___gpu_identifier___/___gpu_allocator_header___.h>
 
 void* delegate_raw_alloc(size_t nbytes) {
-  std::cout << "[delegate_raw_alloc]" << std::endl;
-  auto allocator = c10::cuda::CUDACachingAllocator::get()
-  return allocator.raw_allocate(nbytes);
+  auto allocator = c10::cuda::CUDACachingAllocator::get();
+  return allocator->raw_allocate(nbytes);
 }
 
 void delegate_raw_delete(void* ptr) {
-  std::cout << "[delegate_raw_delete]" << std::endl;
-  auto allocator = c10::cuda::CUDACachingAllocator::get()
-  allocator.raw_deallocate(ptr);
+  auto allocator = c10::cuda::CUDACachingAllocator::get();
+  allocator->raw_deallocate(ptr);
 }
 
 size_t gpu_caching_allocator_raw_alloc_address() {
-  //return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_alloc);
   return reinterpret_cast<size_t>(&delegate_raw_alloc);
 }
 
 size_t gpu_caching_allocator_raw_delete_address() {
-  //return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_delete);
   return reinterpret_cast<size_t>(&delegate_raw_delete);
 }
 
 size_t gpu_caching_allocator_empty_cache_address() {
-  return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::emptyCache);
+  // This is useful only if PYTORCH_NO_CUDA_MEMORY_CACHING=1 is not set.
+  return reinterpret_cast<size_t>(&c10::cuda::CUDACachingAllocator::emptyCache);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/torch_gpu_allocator.cc
@@ -4,12 +4,26 @@
 #include <torch/extension.h>
 #include <c10/___gpu_identifier___/___gpu_allocator_header___.h>
 
+void* delegate_raw_alloc(size_t nbytes) {
+  std::cout << "[delegate_raw_alloc]" << std::endl;
+  auto allocator = c10::cuda::CUDACachingAllocator::get()
+  return allocator.raw_allocate(nbytes);
+}
+
+void delegate_raw_delete(void* ptr) {
+  std::cout << "[delegate_raw_delete]" << std::endl;
+  auto allocator = c10::cuda::CUDACachingAllocator::get()
+  allocator.raw_deallocate(ptr);
+}
+
 size_t gpu_caching_allocator_raw_alloc_address() {
-  return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_alloc);
+  //return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_alloc);
+  return reinterpret_cast<size_t>(&delegate_raw_alloc);
 }
 
 size_t gpu_caching_allocator_raw_delete_address() {
-  return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_delete);
+  //return reinterpret_cast<size_t>(&c10::___gpu_identifier___::___gpu_allocator_header___::raw_delete);
+  return reinterpret_cast<size_t>(&delegate_raw_delete);
 }
 
 size_t gpu_caching_allocator_empty_cache_address() {


### PR DESCRIPTION
Pytorch has a few CUDA allocators. Per our nsys profiling result, Pytorch uses `CUDACachingAllocator` and ORT uses `THCCachingAllocator`. This PR makes ORT also using `CUDACachingAllocator`. To disable Pytorch's memory caching (aka BFCArena in ORT), run `export PYTORCH_NO_CUDA_MEMORY_CACHING=1` and then you will see (in most cases), memory reaches peak at the beginning of BW. To re-enabling memory caching, do `unset PYTORCH_NO_CUDA_MEMORY_CACHING`. NOTICE: without this PR, ORT's memory peak happens at the end of BW even if Pytorch memory caching is disabled, because `THCCachingAllocator` never releases memory.