### PR TITLE
Add ONNX opset 15 support for NNAPI/CoreML EPs

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
+++ b/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
@@ -15,7 +15,7 @@ class BaseOpBuilder : public IOpBuilder {
   virtual ~BaseOpBuilder() = default;
 
   // Add operator related
-  
+
 #ifdef __APPLE__
  public:
   virtual void AddInitializersToSkip(ModelBuilder& /* model_builder */, const Node& /* node */) const override {}
@@ -46,7 +46,7 @@ class BaseOpBuilder : public IOpBuilder {
   virtual bool HasSupportedInputsImpl(const Node& node, const logging::Logger& logger) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
-  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 14; }
+  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 15; }
 
  private:
   bool HasSupportedOpSet(const Node& node, const logging::Logger& logger) const;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -86,7 +86,7 @@ class BaseOpSupportChecker : public IOpSupportChecker {
   virtual bool HasSupportedInputsImpl(const Node& node) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
-  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 14; }
+  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 15; }
 
  private:
   bool HasSupportedOpSet(const Node& node) const;


### PR DESCRIPTION
**Description**: Add ONNX opset 15 support for NNAPI/CoreML EPs

**Motivation and Context**
- The changes in ONNX opset 15 (https://github.com/onnx/onnx/wiki/Logistics-for-ONNX-Release-1.10#changelog) will not affect NNAPI and CoreML EPs, (Reshape is not supported by these EPs, and BatchNorm scale and bias type constraints change does not apply to these EPs as well)
- Bump up the GetMaxSupportedOpSet to opset 15
