### PR TITLE
[python api] align api with other language bindings' treatment of explicit provider registrations. enforce use of providers param in python InferenceSession when execution providers other than default CPU are enabled.

### DIFF
--- a/onnxruntime/python/backend/backend.py
+++ b/onnxruntime/python/backend/backend.py
@@ -10,7 +10,7 @@ from onnx import helper
 from onnx import version
 from onnx.checker import check_model
 from onnx.backend.base import Backend
-from onnxruntime import InferenceSession, SessionOptions, get_device
+from onnxruntime import InferenceSession, SessionOptions, get_device, get_available_providers
 from onnxruntime.backend.backend_rep import OnnxRuntimeBackendRep
 import unittest
 import os
@@ -107,7 +107,7 @@ class OnnxRuntimeBackend(Backend):
             for k, v in kwargs.items():
                 if hasattr(options, k):
                     setattr(options, k, v)
-            inf = InferenceSession(model, options)
+            inf = InferenceSession(model, sess_options=options, providers=get_available_providers())
             # backend API is primarily used for ONNX test/validation. As such, we should disable session.run() fallback
             # which may hide test failures.
             inf.disable_fallback()

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -356,13 +356,11 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(providers,
                                                                         provider_options,
                                                                         available_providers)
-
         if providers == [] and len(available_providers) > 1:
-            warnings.warn("Deprecation warning. This ORT build has {} enabled. ".format(available_providers) +
-                          "The next release (ORT 1.10) will require explicitly setting the providers parameter " +
-                          "(as opposed to the current behavior of providers getting set/registered by default " +
-                          "based on the build flags) when instantiating InferenceSession."
-                          "For example, onnxruntime.InferenceSession(..., providers=[\"CUDAExecutionProvider\"], ...)")
+            raise ValueError("This ORT build has {} enabled. ".format(available_providers) +
+                             "Since ORT 1.9, you are required to explicitly set " +
+                             "the providers parameter when instantiating InferenceSession. For example, "
+                             "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers))
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -356,11 +356,11 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(providers,
                                                                         provider_options,
                                                                         available_providers)
-        #if providers == [] and len(available_providers) > 1:
-        #    raise ValueError("This ORT build has {} enabled. ".format(available_providers) +
-        #                     "Since ORT 1.9, you are required to explicitly set " +
-        #                     "the providers parameter when instantiating InferenceSession. For example, "
-        #                     "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers))
+        if providers == [] and len(available_providers) > 1:
+            raise ValueError("This ORT build has {} enabled. ".format(available_providers) +
+                             "Since ORT 1.9, you are required to explicitly set " +
+                             "the providers parameter when instantiating InferenceSession. For example, "
+                             "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers))
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -356,11 +356,11 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(providers,
                                                                         provider_options,
                                                                         available_providers)
-        if providers == [] and len(available_providers) > 1:
-            raise ValueError("This ORT build has {} enabled. ".format(available_providers) +
-                             "Since ORT 1.9, you are required to explicitly set " +
-                             "the providers parameter when instantiating InferenceSession. For example, "
-                             "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers))
+        #if providers == [] and len(available_providers) > 1:
+        #    raise ValueError("This ORT build has {} enabled. ".format(available_providers) +
+        #                     "Since ORT 1.9, you are required to explicitly set " +
+        #                     "the providers parameter when instantiating InferenceSession. For example, "
+        #                     "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers))
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -783,12 +783,7 @@ void InitializeSession(InferenceSession* sess,
   ProviderOptionsMap provider_options_map;
   GenerateProviderOptionsMap(provider_types, provider_options, provider_options_map);
 
-  if (provider_types.empty()) {
-    // use default registration priority.
-    ep_registration_fn(sess, GetAllExecutionProviderNames(), provider_options_map);
-  } else {
-    ep_registration_fn(sess, provider_types, provider_options_map);
-  }
+  ep_registration_fn(sess, provider_types, provider_options_map);
 
 #if !defined(ORT_MINIMAL_BUILD)
   if (!disabled_optimizer_names.empty()) {

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -54,7 +54,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testSetProviders(self):
         if 'CUDAExecutionProvider' in onnxrt.get_available_providers():
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
             # confirm that CUDA Provider is in list of registered providers.
             self.assertTrue('CUDAExecutionProvider' in sess.get_providers())
             # reset the session and register only CPU Provider.
@@ -64,7 +64,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testSetProvidersWithOptions(self):
         if 'TensorrtExecutionProvider' in onnxrt.get_available_providers():
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['TensorrtExecutionProvider'])
             self.assertIn('TensorrtExecutionProvider', sess.get_providers())
 
             options = sess.get_provider_options()
@@ -127,7 +127,7 @@ class TestInferenceSession(unittest.TestCase):
             import ctypes
             CUDA_SUCCESS = 0
             def runBaseTest1():
-                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
                 self.assertTrue('CUDAExecutionProvider' in sess.get_providers())
 
                 option1 = {'device_id': 0}
@@ -140,7 +140,7 @@ class TestInferenceSession(unittest.TestCase):
                 self.assertEqual(['CUDAExecutionProvider', 'CPUExecutionProvider'], sess.get_providers())
 
             def runBaseTest2():
-                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
                 self.assertIn('CUDAExecutionProvider', sess.get_providers())
 
                 # test get/set of "gpu_mem_limit" configuration.
@@ -841,8 +841,8 @@ class TestInferenceSession(unittest.TestCase):
         numpy_arr_input = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         numpy_arr_output = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
 
-        def test_session_with_ortvalue_input(ortvalue):
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+        def test_session_with_ortvalue_input(ortvalue, provider='CPUExecutionProvider'):
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=[provider])
             res = sess.run(["Y"], {"X": ortvalue})
             self.assertTrue(np.array_equal(res[0], numpy_arr_output))
 
@@ -868,7 +868,7 @@ class TestInferenceSession(unittest.TestCase):
             self.assertTrue(np.array_equal(ortvalue2.numpy(), numpy_arr_input))
 
             # Pass in the constructed OrtValue to a session via Run() and check results
-            test_session_with_ortvalue_input(ortvalue2)
+            test_session_with_ortvalue_input(ortvalue2, 'CUDAExecutionProvider')
 
             # The constructed OrtValue should still be valid after being used in a session
             self.assertTrue(np.array_equal(ortvalue2.numpy(), numpy_arr_input))

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -28,7 +28,7 @@ class TestInferenceSession(unittest.TestCase):
             so.log_verbosity_level = 1
             so.logid = "TestModelSerialization"
             so.optimized_model_filepath = "./PythonApiTestOptimizedModel.onnx"
-            onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
+            onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so, providers=['CPUExecutionProvider'])
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
         except Fail as onnxruntime_error:
             if str(onnxruntime_error) == "[ONNXRuntimeError] : 1 : FAIL : Unable to serialize model as it contains" \
@@ -42,7 +42,7 @@ class TestInferenceSession(unittest.TestCase):
         # get_all_providers() returns the default EP order from highest to lowest.
         # CPUExecutionProvider should always be last.
         self.assertTrue('CPUExecutionProvider' == onnxrt.get_all_providers()[-1])
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         self.assertTrue('CPUExecutionProvider' in sess.get_providers())
 
     def testEnablingAndDisablingTelemetry(self):
@@ -237,7 +237,7 @@ class TestInferenceSession(unittest.TestCase):
                 result = ctypes.c_int()
                 error_str = ctypes.c_char_p()
 
-                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
                 option = {'device_id': i}
                 sess.set_providers(['CUDAExecutionProvider'], [option])
                 self.assertEqual(['CUDAExecutionProvider', 'CPUExecutionProvider'], sess.get_providers())
@@ -258,7 +258,7 @@ class TestInferenceSession(unittest.TestCase):
                 for i in range(num_device):
                     setDeviceIdTest(i)
 
-                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+                sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
 
                 # configure session with invalid option values and that should fail
                 with self.assertRaises(RuntimeError):
@@ -291,7 +291,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testInvalidSetProviders(self):
         with self.assertRaises(RuntimeError) as context:
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
             sess.set_providers(['InvalidProvider'])
         self.assertTrue('Unknown Provider Type: InvalidProvider' in str(context.exception))
 
@@ -302,7 +302,7 @@ class TestInferenceSession(unittest.TestCase):
             self.assertEqual(['CPUExecutionProvider'], sess.get_providers())
 
     def testRunModel(self):
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
@@ -319,7 +319,7 @@ class TestInferenceSession(unittest.TestCase):
     def testRunModelFromBytes(self):
         with open(get_name("mul_1.onnx"), "rb") as f:
             content = f.read()
-        sess = onnxrt.InferenceSession(content)
+        sess = onnxrt.InferenceSession(content, providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
@@ -334,7 +334,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testRunModel2(self):
-        sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"))
+        sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
@@ -349,7 +349,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testRunModel2Contiguous(self):
-        sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"))
+        sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[2.0, 1.0], [4.0, 3.0], [6.0, 5.0]], dtype=np.float32)[:, [1, 0]]
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
@@ -378,7 +378,7 @@ class TestInferenceSession(unittest.TestCase):
             so = onnxrt.SessionOptions()
             so.log_verbosity_level = 1
             so.logid = "MultiThreadsTest"
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so, providers=available_providers)
             ro1 = onnxrt.RunOptions()
             ro1.logid = "thread1"
             t1 = threading.Thread(target=self.run_model, args=(sess, ro1))
@@ -391,7 +391,7 @@ class TestInferenceSession(unittest.TestCase):
             t2.join()
 
     def testListAsInput(self):
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"))
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         res = sess.run([], {input_name: x.tolist()})
@@ -399,7 +399,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testStringListAsInput(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         x = np.array(['this', 'is', 'identity', 'test'], dtype=str).reshape((2, 2))
         x_name = sess.get_inputs()[0].name
         res = sess.run([], {x_name: x.tolist()})
@@ -410,7 +410,7 @@ class TestInferenceSession(unittest.TestCase):
         self.assertTrue('CPU' in device or 'GPU' in device)
 
     def testRunModelSymbolicInput(self):
-        sess = onnxrt.InferenceSession(get_name("matmul_2.onnx"))
+        sess = onnxrt.InferenceSession(get_name("matmul_2.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "X")
@@ -427,7 +427,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testBooleanInputs(self):
-        sess = onnxrt.InferenceSession(get_name("logicaland.onnx"))
+        sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), providers=onnxrt.get_available_providers())
         a = np.array([[True, True], [False, False]], dtype=bool)
         b = np.array([[True, False], [True, False]], dtype=bool)
 
@@ -459,7 +459,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(output_expected, res[0])
 
     def testStringInput1(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         x = np.array(['this', 'is', 'identity', 'test'], dtype=str).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
@@ -480,7 +480,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(x, res[0])
 
     def testStringInput2(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         x = np.array(['Olá', '你好', '여보세요', 'hello'], dtype=str).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
@@ -501,7 +501,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(x, res[0])
 
     def testInputBytes(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([b'this', b'is', b'identity', b'test']).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
@@ -522,7 +522,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(x, res[0].astype('|S8'))
 
     def testInputObject(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         x = np.array(['this', 'is', 'identity', 'test'], object).reshape((2, 2))
 
         x_name = sess.get_inputs()[0].name
@@ -543,7 +543,7 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_equal(x, res[0])
 
     def testInputVoid(self):
-        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"))
+        sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=onnxrt.get_available_providers())
         # numpy 1.20+ doesn't automatically pad the bytes based entries in the array when dtype is np.void,
         # so we use inputs where that is the case
         x = np.array([b'must', b'have', b'same', b'size'], dtype=np.void).reshape((2, 2))
@@ -569,7 +569,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testRaiseWrongNumInputs(self):
         with self.assertRaises(ValueError) as context:
-            sess = onnxrt.InferenceSession(get_name("logicaland.onnx"))
+            sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), providers=onnxrt.get_available_providers())
             a = np.array([[True, True], [False, False]], dtype=bool)
             res = sess.run([], {'input:0': a})
 
@@ -579,7 +579,7 @@ class TestInferenceSession(unittest.TestCase):
         model_path = "../models/opset8/test_squeezenet/model.onnx"
         if not os.path.exists(model_path):
             return
-        sess = onnxrt.InferenceSession(model_path)
+        sess = onnxrt.InferenceSession(model_path, providers=onnxrt.get_available_providers())
         modelmeta = sess.get_modelmeta()
         self.assertEqual('onnx-caffe2', modelmeta.producer_name)
         self.assertEqual('squeezenet_old', modelmeta.graph_name)
@@ -590,7 +590,8 @@ class TestInferenceSession(unittest.TestCase):
     def testProfilerWithSessionOptions(self):
         so = onnxrt.SessionOptions()
         so.enable_profiling = True
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so,
+                                       providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         sess.run([], {'X': x})
         profile_file = sess.end_profiling()
@@ -608,7 +609,8 @@ class TestInferenceSession(unittest.TestCase):
         def getSingleSessionProfilingStartTime():
             so = onnxrt.SessionOptions()
             so.enable_profiling = True
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so,
+                                           providers=onnxrt.get_available_providers())
             return sess.get_profiling_start_time_ns()
 
         # Get 1st profiling's start time
@@ -627,14 +629,16 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(opt.graph_optimization_level, onnxrt.GraphOptimizationLevel.ORT_ENABLE_ALL)
         opt.graph_optimization_level = onnxrt.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
         self.assertEqual(opt.graph_optimization_level, onnxrt.GraphOptimizationLevel.ORT_ENABLE_EXTENDED)
-        sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), sess_options=opt)
+        sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), sess_options=opt,
+                                       providers=onnxrt.get_available_providers())
         a = np.array([[True, True], [False, False]], dtype=bool)
         b = np.array([[True, False], [True, False]], dtype=bool)
 
         res = sess.run([], {'input1:0': a, 'input:0': b})
 
     def testSequenceLength(self):
-        sess = onnxrt.InferenceSession(get_name("sequence_length.onnx"))
+        sess = onnxrt.InferenceSession(get_name("sequence_length.onnx"),
+                                       providers=onnxrt.get_available_providers())
         x = [
             np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3)),
             np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
@@ -655,7 +659,8 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_expected, res[0])
 
     def testSequenceConstruct(self):
-        sess = onnxrt.InferenceSession(get_name("sequence_construct.onnx"))
+        sess = onnxrt.InferenceSession(get_name("sequence_construct.onnx"),
+                                       providers=onnxrt.get_available_providers())
 
         self.assertEqual(sess.get_inputs()[0].type, 'tensor(int64)')
         self.assertEqual(sess.get_inputs()[1].type, 'tensor(int64)')
@@ -684,7 +689,8 @@ class TestInferenceSession(unittest.TestCase):
     def testSequenceInsert(self):
         opt = onnxrt.SessionOptions()
         opt.execution_mode = onnxrt.ExecutionMode.ORT_SEQUENTIAL
-        sess = onnxrt.InferenceSession(get_name("sequence_insert.onnx"), sess_options=opt)
+        sess = onnxrt.InferenceSession(get_name("sequence_insert.onnx"), sess_options=opt,
+                                       providers=onnxrt.get_available_providers())
 
         self.assertEqual(sess.get_inputs()[0].type, 'seq(tensor(int64))')
         self.assertEqual(sess.get_inputs()[1].type, 'tensor(int64)')
@@ -713,7 +719,8 @@ class TestInferenceSession(unittest.TestCase):
     def testLoadingSessionOptionsFromModel(self):
         try:
             os.environ['ORT_LOAD_CONFIG_FROM_MODEL'] = str(1)
-            sess = onnxrt.InferenceSession(get_name("model_with_valid_ort_config_json.onnx"))
+            sess = onnxrt.InferenceSession(get_name("model_with_valid_ort_config_json.onnx"),
+                                           providers=onnxrt.get_available_providers())
             session_options = sess.get_session_options()
 
             self.assertEqual(session_options.inter_op_num_threads, 5)  # from the ORT config
@@ -739,7 +746,8 @@ class TestInferenceSession(unittest.TestCase):
         so = onnxrt.SessionOptions()
         so.add_free_dimension_override_by_denotation("DATA_BATCH", 3)
         so.add_free_dimension_override_by_denotation("DATA_CHANNEL", 5)
-        sess = onnxrt.InferenceSession(get_name("abs_free_dimensions.onnx"), so)
+        sess = onnxrt.InferenceSession(get_name("abs_free_dimensions.onnx"), sess_options=so,
+                                       providers=onnxrt.get_available_providers())
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "x")
         input_shape = sess.get_inputs()[0].shape
@@ -750,7 +758,8 @@ class TestInferenceSession(unittest.TestCase):
         so = onnxrt.SessionOptions()
         so.add_free_dimension_override_by_name("Dim1", 4)
         so.add_free_dimension_override_by_name("Dim2", 6)
-        sess = onnxrt.InferenceSession(get_name("abs_free_dimensions.onnx"), so)
+        sess = onnxrt.InferenceSession(get_name("abs_free_dimensions.onnx"), sess_options=so,
+                                       providers=onnxrt.get_available_providers())
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "x")
         input_shape = sess.get_inputs()[0].shape
@@ -784,7 +793,7 @@ class TestInferenceSession(unittest.TestCase):
         # Create an InferenceSession that only uses the CPU EP and validate that it uses the
         # initializer provided via the SessionOptions instance (overriding the model initializer)
         # We only use the CPU EP because the initializer we created is on CPU and we want the model to use that
-        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), so, ['CPUExecutionProvider'])
+        sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so, providers=['CPUExecutionProvider'])
         res = sess.run(["Y"], {"X": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)})
         self.assertTrue(np.array_equal(res[0], np.array([[2.0, 2.0], [12.0, 12.0], [30.0, 30.0]], dtype=np.float32)))
 
@@ -812,8 +821,10 @@ class TestInferenceSession(unittest.TestCase):
         so1 = onnxrt.SessionOptions()
         so1.register_custom_ops_library(shared_library)
 
+        available_providers = onnxrt.get_available_providers()
+
         # Model loading successfully indicates that the custom op node could be resolved successfully
-        sess1 = onnxrt.InferenceSession(custom_op_model, so1)
+        sess1 = onnxrt.InferenceSession(custom_op_model, sess_options=so1, providers=available_providers)
         #Run with input data
         input_name_0 = sess1.get_inputs()[0].name
         input_name_1 = sess1.get_inputs()[1].name
@@ -829,20 +840,21 @@ class TestInferenceSession(unittest.TestCase):
         so2 = so1
 
         # Model loading successfully indicates that the custom op node could be resolved successfully
-        sess2 = onnxrt.InferenceSession(custom_op_model, so2)
+        sess2 = onnxrt.InferenceSession(custom_op_model, sess_options=so2, providers=available_providers)
 
         # Create another SessionOptions instance with the same shared library referenced
         so3 = onnxrt.SessionOptions()
         so3.register_custom_ops_library(shared_library)
-        sess3 = onnxrt.InferenceSession(custom_op_model, so3)
+        sess3 = onnxrt.InferenceSession(custom_op_model, sess_options=so3, providers=available_providers)
 
     def testOrtValue(self):
 
         numpy_arr_input = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         numpy_arr_output = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
 
-        def test_session_with_ortvalue_input(ortvalue, provider='CPUExecutionProvider'):
-            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=[provider])
+        def test_session_with_ortvalue_input(ortvalue):
+            sess = onnxrt.InferenceSession(get_name("mul_1.onnx"),
+                                           providers=onnxrt.get_available_providers())
             res = sess.run(["Y"], {"X": ortvalue})
             self.assertTrue(np.array_equal(res[0], numpy_arr_output))
 
@@ -868,7 +880,7 @@ class TestInferenceSession(unittest.TestCase):
             self.assertTrue(np.array_equal(ortvalue2.numpy(), numpy_arr_input))
 
             # Pass in the constructed OrtValue to a session via Run() and check results
-            test_session_with_ortvalue_input(ortvalue2, 'CUDAExecutionProvider')
+            test_session_with_ortvalue_input(ortvalue2)
 
             # The constructed OrtValue should still be valid after being used in a session
             self.assertTrue(np.array_equal(ortvalue2.numpy(), numpy_arr_input))
@@ -1009,12 +1021,12 @@ class TestInferenceSession(unittest.TestCase):
         so1 = onnxrt.SessionOptions()
         so1.log_severity_level = 1
         so1.add_session_config_entry("session.use_env_allocators", "1");
-        onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so1)
+        onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so1, providers=onnxrt.get_available_providers())
 
         # Create a session that will NOT use the registered arena based allocator
         so2 = onnxrt.SessionOptions()
         so2.log_severity_level = 1
-        onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so2)
+        onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so2, providers=onnxrt.get_available_providers())
 
     def testCheckAndNormalizeProviderArgs(self):
         from onnxruntime.capi.onnxruntime_inference_collection import check_and_normalize_provider_args

--- a/onnxruntime/test/python/onnxruntime_test_python_backend.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_backend.py
@@ -39,7 +39,7 @@ class TestBackend(unittest.TestCase):
         This test is to ensure that the case is covered.
         """
         name = get_name("alloc_tensor_reuse.onnx")
-        sess = onnxrt.InferenceSession(name)
+        sess = onnxrt.InferenceSession(name, providers=onnxrt.get_available_providers())
 
         run_options = onnxrt.RunOptions()
         run_options.only_execute_path_to_fetches = True

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -48,7 +48,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_only(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"))
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -69,7 +69,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_and_preallocated_output(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"))
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -95,7 +95,7 @@ class TestIOBinding(unittest.TestCase):
 
 
     def test_bind_input_and_non_preallocated_output(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"))
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -136,7 +136,7 @@ class TestIOBinding(unittest.TestCase):
         self.assertTrue(np.array_equal(self.create_expected_output_alternate(), ort_outputs[0].numpy()))
 
     def test_bind_input_and_bind_output_with_ortvalues(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"))
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
         io_binding = session.io_binding()
         
         # Bind ortvalue as input

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -27,7 +27,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_to_cpu_arr(self):
         input = self.create_numpy_input()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"))
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind Numpy object (input) that's on CPU to wherever the model needs it
@@ -48,7 +48,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_only(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -69,7 +69,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_and_preallocated_output(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -95,7 +95,7 @@ class TestIOBinding(unittest.TestCase):
 
 
     def test_bind_input_and_non_preallocated_output(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -136,7 +136,7 @@ class TestIOBinding(unittest.TestCase):
         self.assertTrue(np.array_equal(self.create_expected_output_alternate(), ort_outputs[0].numpy()))
 
     def test_bind_input_and_bind_output_with_ortvalues(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=['CUDAExecutionProvider'])
+        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind ortvalue as input

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime as onnxrt
 import unittest
 
 from helper import get_name
@@ -7,13 +7,13 @@ from helper import get_name
 class TestIOBinding(unittest.TestCase):
 
     def create_ortvalue_input_on_gpu(self):
-        return onnxruntime.OrtValue.ortvalue_from_numpy(np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32), 'cuda', 0)
+        return onnxrt.OrtValue.ortvalue_from_numpy(np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32), 'cuda', 0)
 
     def create_ortvalue_alternate_input_on_gpu(self):
-        return onnxruntime.OrtValue.ortvalue_from_numpy(np.array([[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]], dtype=np.float32), 'cuda', 0)
+        return onnxrt.OrtValue.ortvalue_from_numpy(np.array([[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]], dtype=np.float32), 'cuda', 0)
 
     def create_uninitialized_ortvalue_input_on_gpu(self):
-        return onnxruntime.OrtValue.ortvalue_from_shape_and_type([3, 2], np.float32, 'cuda', 0)
+        return onnxrt.OrtValue.ortvalue_from_shape_and_type([3, 2], np.float32, 'cuda', 0)
 
     def create_numpy_input(self):
         return np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
@@ -27,7 +27,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_to_cpu_arr(self):
         input = self.create_numpy_input()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
+        session = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind Numpy object (input) that's on CPU to wherever the model needs it
@@ -48,7 +48,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_only(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
+        session = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -69,7 +69,7 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_and_preallocated_output(self):
         input = self.create_ortvalue_input_on_gpu()
 
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
+        session = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -95,7 +95,7 @@ class TestIOBinding(unittest.TestCase):
 
 
     def test_bind_input_and_non_preallocated_output(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
+        session = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind input to CUDA
@@ -136,7 +136,7 @@ class TestIOBinding(unittest.TestCase):
         self.assertTrue(np.array_equal(self.create_expected_output_alternate(), ort_outputs[0].numpy()))
 
     def test_bind_input_and_bind_output_with_ortvalues(self):
-        session = onnxruntime.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
+        session = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         io_binding = session.io_binding()
         
         # Bind ortvalue as input

--- a/onnxruntime/test/python/onnxruntime_test_python_mlops.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_mlops.py
@@ -11,7 +11,8 @@ from helper import get_name
 class TestInferenceSession(unittest.TestCase):
 
     def testZipMapStringFloat(self):
-        sess = onnxrt.InferenceSession(get_name("zipmap_stringfloat.onnx"))
+        sess = onnxrt.InferenceSession(get_name("zipmap_stringfloat.onnx"),
+                                       providers=onnxrt.get_available_providers())
         x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
 
         x_name = sess.get_inputs()[0].name
@@ -37,7 +38,8 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_expected, res[0])
 
     def testZipMapInt64Float(self):
-        sess = onnxrt.InferenceSession(get_name("zipmap_int64float.onnx"))
+        sess = onnxrt.InferenceSession(get_name("zipmap_int64float.onnx"),
+                                       providers=onnxrt.get_available_providers())
         x = np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3))
 
         x_name = sess.get_inputs()[0].name
@@ -55,7 +57,8 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual(output_expected, res[0])
 
     def testDictVectorizer(self):
-        sess = onnxrt.InferenceSession(get_name("pipeline_vectorize.onnx"))
+        sess = onnxrt.InferenceSession(get_name("pipeline_vectorize.onnx"),
+                                       providers=onnxrt.get_available_providers())
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "float_input")
         input_type = str(sess.get_inputs()[0].type)
@@ -99,7 +102,8 @@ class TestInferenceSession(unittest.TestCase):
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
     def testLabelEncoder(self):
-        sess = onnxrt.InferenceSession(get_name("LabelEncoder.onnx"))
+        sess = onnxrt.InferenceSession(get_name("LabelEncoder.onnx"),
+                                       providers=onnxrt.get_available_providers())
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "input")
         input_type = str(sess.get_inputs()[0].type)
@@ -141,7 +145,7 @@ class TestInferenceSession(unittest.TestCase):
             sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"), None,
                                            ['DmlExecutionProvider', 'CPUExecutionProvider'])
         else:
-            sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"))
+            sess = onnxrt.InferenceSession(get_name("mlnet_encoder.onnx"), providers=available_providers)
 
         names = [_.name for _ in sess.get_outputs()]
         self.assertEqual(['C00', 'C12'], names)

--- a/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_nuphar.py
@@ -502,7 +502,7 @@ class TestNuphar(unittest.TestCase):
             data_seq_len = np.random.randint(1, seq_len, size=(batch_size,), dtype=np.int32)
 
             # run lstm as baseline
-            sess = onnxrt.InferenceSession(lstm_model_name)
+            sess = onnxrt.InferenceSession(lstm_model_name, providers=onnxrt.get_available_providers())
             first_lstm_data_output = sess.run([], {'input': data_input[:, 0:1, :], 'seq_len': data_seq_len[0:1]})
 
             lstm_data_output = []
@@ -524,7 +524,7 @@ class TestNuphar(unittest.TestCase):
                         check=True)
 
             # run scan_batch with batch size 1
-            sess = onnxrt.InferenceSession(scan_model_name)
+            sess = onnxrt.InferenceSession(scan_model_name, providers=onnxrt.get_available_providers())
             scan_batch_data_output = sess.run([], {'input': data_input[:, 0:1, :], 'seq_len': data_seq_len[0:1]})
             assert np.allclose(first_lstm_data_output, scan_batch_data_output)
 
@@ -579,7 +579,7 @@ class TestNuphar(unittest.TestCase):
                 '--output', matmul_model_name, '--mode', 'gemm_to_matmul'
             ], check=True)
 
-            sess = onnxrt.InferenceSession(matmul_model_name)
+            sess = onnxrt.InferenceSession(matmul_model_name, providers=onnxrt.get_available_providers())
             test_inputs = {}
             set_gemm_model_inputs(running_config, test_inputs, a, b, c)
             actual_y = sess.run([], test_inputs)
@@ -651,7 +651,7 @@ class TestNuphar(unittest.TestCase):
             b1 = b1.reshape((1, ) + b1.shape)
             a2 = a2.reshape((1, ) + a2.shape)
             b2 = b2.reshape((1, ) + b2.shape)
-            sess = onnxrt.InferenceSession(gemm_model_name)
+            sess = onnxrt.InferenceSession(gemm_model_name, providers=onnxrt.get_available_providers())
 
             test_inputs = {}
             set_gemm_model_inputs(running_config1, test_inputs, a1, b1, c1)
@@ -667,7 +667,7 @@ class TestNuphar(unittest.TestCase):
             ], check=True)
 
             # run after model editing
-            sess = onnxrt.InferenceSession(matmul_model_name)
+            sess = onnxrt.InferenceSession(matmul_model_name, providers=onnxrt.get_available_providers())
             actual_y = sess.run([], test_inputs)
 
             assert np.allclose(expected_y, actual_y, atol=1e-7)

--- a/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
@@ -24,7 +24,8 @@ class TestSparseToDenseMatmul(unittest.TestCase):
         dense_shape = [3,3]
         values = np.array([1.764052391052246, 0.40015721321105957, 0.978738009929657], np.float)
         indices = np.array([2, 3, 5], np.int64)
-        sess = onnxrt.InferenceSession(get_name("sparse_initializer_as_output.onnx"))
+        sess = onnxrt.InferenceSession(get_name("sparse_initializer_as_output.onnx"),
+                                       providers=onnxrt.get_available_providers())
         res = sess.run_with_ort_values(["values"], {})
         self.assertEqual(len(res), 1)
         ort_value = res[0]
@@ -83,7 +84,8 @@ class TestSparseToDenseMatmul(unittest.TestCase):
                             786, 915, 1044, 3324, 3462, 3600, 4911, 5178, 5445,
                             894, 1041, 1188, 3756, 3912, 4068, 5559, 5862, 6165], np.float).reshape(common_shape)
 
-        sess = onnxrt.InferenceSession(get_name("sparse_to_dense_matmul.onnx"))
+        sess = onnxrt.InferenceSession(get_name("sparse_to_dense_matmul.onnx"),
+                                       providers=onnxrt.get_available_providers())
         res = sess.run_with_ort_values(["dense_Y"], { "sparse_A" : A_ort_value, "dense_B" : B_ort_value })
         self.assertEqual(len(res), 1)
         ort_value = res[0]

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -80,7 +80,8 @@ class ONNXExporterTest(unittest.TestCase):
                               custom_opsets=custom_opsets)
 
             # compute onnxruntime output prediction
-            ort_sess = onnxruntime.InferenceSession(f.getvalue())
+            ort_sess = onnxruntime.InferenceSession(f.getvalue(),
+                                                    providers=onnxruntime.get_available_providers())
             input_copy = copy.deepcopy(input)
             ort_test_with_input(ort_sess, input_copy, output, rtol, atol)
 

--- a/onnxruntime/test/python/transformers/test_data/bert_squad_tensorflow2.1_keras2onnx_opset11/generate_tiny_keras2onnx_bert_models.py
+++ b/onnxruntime/test/python/transformers/test_data/bert_squad_tensorflow2.1_keras2onnx_opset11/generate_tiny_keras2onnx_bert_models.py
@@ -280,7 +280,8 @@ def generate_test_data(onnx_file,
         else:
             sess_options.optimized_model_filepath = path_prefix + "_optimized_gpu.onnx"
 
-        session = onnxruntime.InferenceSession(onnx_file, sess_options)
+        session = onnxruntime.InferenceSession(onnx_file, sess_options=sess_options,
+                                               providers=onnxruntime.get_available_providers())
         if use_cpu:
             session.set_providers(['CPUExecutionProvider'])  # use cpu
         else:

--- a/orttraining/orttraining/python/deprecated/training_session.py
+++ b/orttraining/orttraining/python/deprecated/training_session.py
@@ -20,6 +20,11 @@ class TrainingSession(InferenceSession):
         else:
             self._sess = C.TrainingSession()
 
+        # providers needs to be passed explicitly as of ORT 1.10
+        # retain the pre-1.10 behavior by setting to the available providers.
+        if providers is None:
+            providers = C.get_availabile_providers()
+
         providers, provider_options = check_and_normalize_provider_args(providers, provider_options,
                                                                         C.get_available_providers())
 

--- a/orttraining/orttraining/python/deprecated/training_session.py
+++ b/orttraining/orttraining/python/deprecated/training_session.py
@@ -23,7 +23,7 @@ class TrainingSession(InferenceSession):
         # providers needs to be passed explicitly as of ORT 1.10
         # retain the pre-1.10 behavior by setting to the available providers.
         if providers is None:
-            providers = C.get_availabile_providers()
+            providers = C.get_available_providers()
 
         providers, provider_options = check_and_normalize_provider_args(providers, provider_options,
                                                                         C.get_available_providers())

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -315,7 +315,7 @@ class ORTTrainer(object):
             training_mode_node.attribute[0].name = "value"
             ratio_node.attribute[0].name = "value"
 
-        _inference_sess = ort.InferenceSession(onnx_model_copy.SerializeToString())
+        _inference_sess = ort.InferenceSession(onnx_model_copy.SerializeToString(), providers=ort.get_available_providers())
         inf_inputs = {}
         for i, input_elem in enumerate(input):
             inf_inputs[_inference_sess.get_inputs()[i].name] = input_elem.cpu().numpy()


### PR DESCRIPTION
In ORT 1.9, we deprecated implicit provider registration and warned users that in ORT 1.10 providers would need to be explicitly specified when the build has execution providers other than CPUExecutionProvider enabled.
see https://github.com/microsoft/onnxruntime/blob/517fff0a392f0316da64b9351deac7b7fb9c05ee/onnxruntime/python/onnxruntime_inference_collection.py#L361
This PR aligns python api with other language bindings (C/C++/C# etc.) by removing default registration in python bindings.
Raise ValueError exception if user has not explicitly set the providers when creating an InferenceSession when available_providers > 1 (meaning the build has providers other than default CPU provider enabled)
Modify tests to set providers via ort.get_available_providers() in most cases to preserve the test coverage.
