### PR TITLE
[WIP] ORTTrainer's AllReduce graph builder supports models with different float types.

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -1239,7 +1239,7 @@ Example 4:
       .Output(0, "output", "reduced tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
+          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
           "Constrain to float, float16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         assert(getAttribute(ctx, "group_type", 0) < static_cast<int64_t>(WorkerGroupType::WorkerGroupTypeCount));


### PR DESCRIPTION
**Description**: Describe your changes.

We seek to run a data-parallel model that has weights of different float types (BFloat16 and Float32). At the moment, the NcclAllReduce graph builder assumes all gradients have the same type.

This PR adds cast nodes to convert gradients to a single type for the AllReduce node; after the AllReduce, the output gradients are casted back to their original types.

This change unconditionally casts gradients to BFloat16; we need to make the type configurable from python.  
