### PR TITLE
fixing pypi pipeline for release

### DIFF
--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -13,11 +13,6 @@ Changes
 
 Release Notes : TBD
 
-1.9.1
-^^^^^
-
-Release Notes : https://github.com/microsoft/onnxruntime/releases/tag/v1.9.1
-
 1.9.0
 ^^^^^
 

--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -8,10 +8,10 @@ For more information on ONNX Runtime, please see `aka.ms/onnxruntime <https://ak
 Changes
 -------
 
-1.10.0
+1.9.1
 ^^^^^
 
-Release Notes : TODO
+Release Notes : https://github.com/microsoft/onnxruntime/releases/tag/v1.9.1
 
 1.9.0
 ^^^^^

--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -8,6 +8,11 @@ For more information on ONNX Runtime, please see `aka.ms/onnxruntime <https://ak
 Changes
 -------
 
+1.10.0
+^^^^^^
+
+Release Notes : TBD
+
 1.9.1
 ^^^^^
 

--- a/tools/python/update_version.py
+++ b/tools/python/update_version.py
@@ -50,7 +50,7 @@ def update_version():
                 if inserted is False and len(sections) == 3 and \
                         sections[0].isdigit() and sections[1].isdigit() and sections[2].isdigit():
                     f.write(version + '\n')
-                    f.write('^^^^^\n\n')
+                    f.write('^'*len(version) + '\n\n')
                     f.write('Release Notes : https://github.com/Microsoft/onnxruntime/releases/tag/v'
                             + version.strip() + '\n\n')
                     inserted = True


### PR DESCRIPTION
**Description**: 
Fixing the python release pipeline broken in https://github.com/microsoft/onnxruntime/pull/9006

**Motivation and Context**
- Why is this change required? What problem does it solve?
Nightly builds haven't been uploaded to pypi since Sep 22.

- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/9362

