### PR TITLE
Replace deprecated PyEval_CallObject() call with PyObject_CallObject().

### DIFF
--- a/onnxruntime/core/language_interop_ops/pyop/pyop.cc
+++ b/onnxruntime/core/language_interop_ops/pyop/pyop.cc
@@ -209,7 +209,7 @@ bool PyOpLibProxy::InvokePythonFunc(void*                            raw_inst,
     }
 
     scope.Add(pyArgs);
-    auto pyResult = PyEval_CallObject(pyFunc, pyArgs);
+    auto pyResult = PyObject_CallObject(pyFunc, pyArgs);
     if (nullptr == pyResult) {
         logging_func("InvokePythonFunc: no result");
         return false;


### PR DESCRIPTION
This API was changed in 3.9:
https://docs.python.org/3/whatsnew/3.9.html#changes-in-the-c-api
https://docs.python.org/3/c-api/call.html#c.PyObject_Call

Fixes: https://github.com/microsoft/onnxruntime/issues/9736