### PR TITLE
Enable JoinModels API in WinML+RT Experimental API

### DIFF
--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -555,8 +555,12 @@ endif(onnxruntime_USE_DML)
 onnxruntime_add_static_library(winml_lib_api_experimental
   ${winml_lib_api_experimental_dir}/LearningModelBuilder.cpp
   ${winml_lib_api_experimental_dir}/LearningModelBuilder.h
+  ${winml_lib_api_experimental_dir}/LearningModelExperimental.cpp
+  ${winml_lib_api_experimental_dir}/LearningModelExperimental.h
   ${winml_lib_api_experimental_dir}/LearningModelInputs.cpp
   ${winml_lib_api_experimental_dir}/LearningModelInputs.h
+  ${winml_lib_api_experimental_dir}/LearningModelJoinOptions.cpp
+  ${winml_lib_api_experimental_dir}/LearningModelJoinOptions.h
   ${winml_lib_api_experimental_dir}/LearningModelOutputs.cpp
   ${winml_lib_api_experimental_dir}/LearningModelOutputs.h
   ${winml_lib_api_experimental_dir}/LearningModelOperator.cpp

--- a/winml/adapter/winml_adapter_apis.h
+++ b/winml/adapter/winml_adapter_apis.h
@@ -128,6 +128,14 @@ ORT_API_STATUS(OperatorGetOutputName,
                _In_ size_t index,
                _Out_ const char** const name);
 
+ORT_API_STATUS(JoinModels,
+               _In_ OrtModel* first_model,
+               _In_ OrtModel* second_model,
+               _In_ const char* const* output_names,
+               _In_ const char* const* input_names,
+               size_t num_linkages,
+               bool promote_unlinked_outputs,
+               _In_ const char* const join_node_prefix);
 // maps and sequences???
 //ONNX_NAMESPACE::OpSchemaRegistry::DomainToVersionRange().Map().at(ONNX_NAMESPACE::ONNX_DOMAIN).second
 

--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -94,6 +94,7 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
     &winmla::OperatorGetInputName,
     &winmla::OperatorGetNumOutputs,
     &winmla::OperatorGetOutputName,
+    &winmla::JoinModels,
 
     // Release
     &winmla::ReleaseModel

--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -487,5 +487,14 @@ struct WinmlAdapterApi {
       _In_ size_t index,
       _Out_ const char** const name)NO_EXCEPTION;
 
+  OrtStatus*(ORT_API_CALL* JoinModels)(
+      _In_ OrtModel* first_model,
+      _In_ OrtModel* second_model,
+      _In_ const char* const* output_names,
+      _In_ const char* const* input_names,
+      size_t num_linkages,
+      bool promote_unlinked_outputs,
+      _In_ const char* const join_node_prefix)NO_EXCEPTION;
+
   ORT_CLASS_RELEASE(Model);
 };

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -810,8 +810,6 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
 
   // Remove old outputs
   if (promote_unlinked_outputs) {
-    // loop through first model outputs and remove the linked ones in the main model inputs
-
     // Copy the output of the first model
     auto first_outputs = first_model_proto->graph().output();
     

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -862,7 +862,9 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
   // add all nodes
   for (int i = 0; i < second_model_proto->graph().node_size(); i++) {
     auto& other_node = *second_model_proto->mutable_graph()->mutable_node(i);
-    *other_node.mutable_name() = second_model_prefix + other_node.name();
+    if (0 != strcmp(other_node.name().c_str(), "")) {
+      *other_node.mutable_name() = second_model_prefix + other_node.name();
+    }
     for (int j = 0; j < other_node.input_size(); j++) {
       *other_node.mutable_input(j) = second_model_prefix + other_node.input(j);
     }

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -213,6 +213,19 @@ std::unique_ptr<ONNX_NAMESPACE::ModelProto> OrtModel::DetachModelProto() {
   return std::move(model_proto_);
 }
 
+void OrtModel::RefreshModelInfo() {
+  auto new_info = std::make_unique<ModelInfo>(model_proto_.get());
+  model_info_->author_ = std::move(new_info->author_);
+  model_info_->description_ = std::move(new_info->description_);
+  model_info_->domain_= std::move(new_info->domain_);
+  model_info_->input_features_ = std::move(new_info->input_features_);
+  model_info_->model_metadata_ = std::move(new_info->model_metadata_);
+  model_info_->name_ = std::move(new_info->name_);
+  model_info_->output_features_ = std::move(new_info->output_features_);
+  model_info_->requires_float16_support_ = std::move(new_info->requires_float16_support_);
+  model_info_->version_ = std::move(new_info->version_);
+}
+
 ORT_API_STATUS_IMPL(winmla::CreateModelFromPath, _In_ const char* model_path, _In_ size_t size, _Outptr_ OrtModel** out) {
   API_IMPL_BEGIN
   if (auto status = OrtModel::CreateOrtModelFromPath(model_path, size, out)) {
@@ -777,6 +790,130 @@ ORT_API_STATUS_IMPL(winmla::OperatorGetOutputName, _In_ const char* const op_typ
   API_IMPL_BEGIN
   auto schema = GetSchema(op_type, opset, op_domain);
   *name = schema->outputs().at(index).GetName().c_str();
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(winmla::JoinModels,
+  _In_ OrtModel* first_model,
+  _In_ OrtModel* second_model,
+  _In_ const char* const* output_names,
+  _In_ const char* const* input_names,
+  size_t num_linkages,
+  bool promote_unlinked_outputs,
+  _In_ const char* const join_node_prefix) {
+  API_IMPL_BEGIN
+
+  std::string second_model_prefix = join_node_prefix;
+  auto first_model_proto = first_model->UseModelProto();
+  auto second_model_proto = second_model->DetachModelProto();
+
+  // Remove old outputs
+  if (promote_unlinked_outputs) {
+    // remove all first model outputs
+    for (int i = 0; i < second_model_proto->graph().output_size(); i++) {
+      first_model_proto->mutable_graph()->mutable_output()->Clear();
+    }
+  } else {
+    // loop through first model outputs and remove the linked ones in the main model inputs
+    for (int i = first_model_proto->graph().output_size() - 1; i >= 0 ; i--) {
+      auto& output_name = first_model_proto->graph().output(i).name();
+
+      auto found_it = std::find_if(output_names, output_names + num_linkages,
+                        [output_name](auto& name) { return std::strcmp(name, output_name.c_str()) == 0; });
+      bool is_linked = found_it != (output_names + num_linkages);  // figure out if output.name() exists in the output_names mapped
+      if (!is_linked) {
+        first_model_proto->mutable_graph()->mutable_output()->DeleteSubrange(i, 1);
+      }
+    }
+  }
+
+  // add all model outputs from the second model
+  for (int i = 0; i < second_model_proto->graph().output_size(); i++) {
+    auto& other_output = *second_model_proto->mutable_graph()->mutable_output(i);
+    *other_output.mutable_name() = second_model_prefix + other_output.name();
+    auto& output = *first_model_proto->mutable_graph()->add_output();
+    output = std::move(other_output);
+  }
+
+  // loop through second model inputs and promote the unlinked ones to the main model inputs
+  for (int i = 0; i < second_model_proto->graph().input_size(); i++) {
+    auto& other_input = *second_model_proto->mutable_graph()->mutable_input(i);
+    auto old_name = other_input.name();
+    *other_input.mutable_name() = second_model_prefix + old_name;
+
+    auto found_it = std::find_if(input_names, input_names + num_linkages,
+                                 [old_name](auto& name) { return std::strcmp(name, old_name.c_str()) == 0; });
+    bool is_linked = found_it != (input_names + num_linkages);  // figure out if other_input.name() exists in the output_names mapped
+    if (!is_linked) {
+      auto& input = *first_model_proto->mutable_graph()->add_input();
+      input = std::move(other_input);
+    }
+  }
+
+  // add all initializers
+  for (int i = 0; i < second_model_proto->graph().initializer_size(); i++) {
+    auto& other_initializer = *second_model_proto->mutable_graph()->mutable_initializer(i);
+    *other_initializer.mutable_name() = second_model_prefix + other_initializer.name();
+    auto& initializer = *first_model_proto->mutable_graph()->add_initializer();
+    initializer = std::move(other_initializer);
+  }
+
+  // add all nodes
+  for (int i = 0; i < second_model_proto->graph().node_size(); i++) {
+    auto& other_node = *second_model_proto->mutable_graph()->mutable_node(i);
+    *other_node.mutable_name() = second_model_prefix + other_node.name();
+    for (int j = 0; j < other_node.input_size(); j++) {
+      *other_node.mutable_input(j) = second_model_prefix + other_node.input(j);
+    }
+    for (int j = 0; j < other_node.output_size(); j++) {
+      *other_node.mutable_output(j) = second_model_prefix + other_node.output(j);
+    }
+    auto& node = *first_model_proto->mutable_graph()->add_node();
+    node = std::move(other_node);
+  }
+
+  int64_t opset = 7;
+  for (int i = 0; i < second_model_proto->opset_import_size(); i++) {
+    auto mutable_opset_import = second_model_proto->mutable_opset_import(i);
+    auto domain = mutable_opset_import->has_domain() ? mutable_opset_import->domain() : std::string("");
+    auto version = mutable_opset_import->version();
+
+    // does the domain exist in the first model?
+    auto found_it = std::find_if(first_model_proto->mutable_opset_import()->begin(), first_model_proto->mutable_opset_import()->end(),
+                                 [&domain](auto& mutable_opset_import) {
+                                    
+                                    auto first_model_domain = mutable_opset_import.has_domain() ? mutable_opset_import.domain() : std::string("");
+                                    return 0 == strcmp(first_model_domain.c_str(), domain.c_str());
+                                 });
+    if (found_it != first_model_proto->mutable_opset_import()->end()) {
+      found_it->set_version(std::max(found_it->version(), version));
+      if (0 == strcmp(domain.c_str(), "")) {
+        opset = found_it->version();
+      }
+    }
+  }
+
+  // add identity ops to rename all of the first model outputs to secondmodel inputs with prefix for each linkage
+  for (int i = 0; i < num_linkages; i++) {    
+    auto op_output_name = second_model_prefix + *(input_names + i);
+    const char* const op_output_name_const_str = op_output_name.c_str();
+    std::string name = "IdentityTo";
+    name += second_model_prefix + *(input_names + i);
+    ModelAddOperator(first_model,
+                     "Identity",
+                     name.c_str(),
+                     opset,
+                     "",
+                     (output_names + i), 1,
+                     &op_output_name_const_str, 1,
+                     nullptr, nullptr, 0);
+  }
+
+  // merge model metadata
+
+  first_model->RefreshModelInfo();
+
   return nullptr;
   API_IMPL_END
 }

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -810,11 +810,6 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
 
   // Remove old outputs
   if (promote_unlinked_outputs) {
-    // remove all first model outputs
-    for (int i = 0; i < second_model_proto->graph().output_size(); i++) {
-      first_model_proto->mutable_graph()->mutable_output()->Clear();
-    }
-  } else {
     // loop through first model outputs and remove the linked ones in the main model inputs
     for (int i = first_model_proto->graph().output_size() - 1; i >= 0 ; i--) {
       auto& output_name = first_model_proto->graph().output(i).name();
@@ -825,6 +820,11 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
       if (!is_linked) {
         first_model_proto->mutable_graph()->mutable_output()->DeleteSubrange(i, 1);
       }
+    }
+  } else {
+    // remove all first model outputs
+    for (int i = 0; i < second_model_proto->graph().output_size(); i++) {
+      first_model_proto->mutable_graph()->mutable_output()->Clear();
     }
   }
 

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -875,6 +875,8 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
     node = std::move(other_node);
   }
 
+  // WinML+RT API only supports opset 7 and above models.
+  // In practice this number is always overwritten by the for loop below which will find the actual opset version.
   int64_t opset = 7;
   for (int i = 0; i < second_model_proto->opset_import_size(); i++) {
     auto mutable_opset_import = second_model_proto->mutable_opset_import(i);

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -911,9 +911,6 @@ ORT_API_STATUS_IMPL(winmla::JoinModels,
                      &op_output_name_const_str, 1,
                      nullptr, nullptr, 0);
   }
-
-  // merge model metadata
-
   first_model->RefreshModelInfo();
 
   return nullptr;

--- a/winml/adapter/winml_adapter_model.h
+++ b/winml/adapter/winml_adapter_model.h
@@ -20,6 +20,8 @@ struct OrtModel {
   onnx::ModelProto* UseModelProto() const;
   std::unique_ptr<onnx::ModelProto> DetachModelProto();
 
+  void RefreshModelInfo();
+
  private:
   OrtModel(std::unique_ptr<onnx::ModelProto> model_proto);
   OrtModel(const OrtModel& other) = delete;

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -104,7 +104,7 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
   }
 
   //! \class LearningModelJoinOptions
-  //! \brief TODO:Docs
+  //! \brief This class defines Join Options to be used with the JoinModels method
   [dualapipartition(1)]
   runtimeclass LearningModelJoinOptions
   {

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -102,4 +102,29 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
 
     void Save(String file_name);
   }
+
+  //! \class LearningModelJoinOptions
+  //! \brief TODO:Docs
+  [dualapipartition(1)]
+  runtimeclass LearningModelJoinOptions
+  {
+      // default constructor
+      LearningModelJoinOptions();
+
+      Boolean PromoteUnlinkedOutputsToFusedOutputs{ get; set; };
+      Boolean CloseModelOnJoin { get; set; };
+      String JoinedNodePrefix { get; set; };
+
+      void Link(String firstModelOutput, String secondModelInput);
+  }
+
+  [marshaling_behavior(agile)]
+  [dualapipartition(1)]
+  runtimeclass LearningModelExperimental {
+    LearningModelExperimental(ROOT_NS.AI.MachineLearning.LearningModel model);
+
+    void Save(String file_name);
+    ROOT_NS.AI.MachineLearning.LearningModel JoinModel(ROOT_NS.AI.MachineLearning.LearningModel other, LearningModelJoinOptions options);
+  }
+
 }  // namespace Microsoft.AI.MachineLearning.Experimental

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -111,10 +111,23 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
       // default constructor
       LearningModelJoinOptions();
 
+      //! The PromoteUnlinkedOutputsToFusedOutputs option allows callers to toggle whether unlinked outputs of the first model,
+      //! remain as outputs in the fused model.
+      //! The default value for PromoteUnlinkedOutputsToFusedOutputs is true.
       Boolean PromoteUnlinkedOutputsToFusedOutputs{ get; set; };
+
+      //! The CloseModelOnJoin option allows callers to close the second model when the JoinModels method is made.
+      //! By enabling this, the engine can reuse the second models protobuf memory rather than copy it.
+      //! The default value for CloseModelOnJoin is false.
       Boolean CloseModelOnJoin { get; set; };
+
+      //! The JoinedNodePrefix property specifies whether the nodes of the second model should have a specific prefixed in the joined model.
+      //! Node names must be unique or empty. By enabling this, the engine can specifiy the prefix, or eliminate it entirely in cases
+      //! where the model is known to contain no duplicate node names.
+      //! The default value for CloseModelOnJoin is a new random GUID.
       String JoinedNodePrefix { get; set; };
 
+      //! The Link method joins outputs from the first model to inputs of the second model.
       void Link(String firstModelOutput, String secondModelInput);
   }
 
@@ -123,7 +136,10 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
   runtimeclass LearningModelExperimental {
     LearningModelExperimental(ROOT_NS.AI.MachineLearning.LearningModel model);
 
+    //! The Save method serializes the model as an ONNX model to a specified path.
     void Save(String file_name);
+
+    //! The JoinModel fuses two models by linking  outputs from the first model, to inupts of the second. 
     ROOT_NS.AI.MachineLearning.LearningModel JoinModel(ROOT_NS.AI.MachineLearning.LearningModel other, LearningModelJoinOptions options);
   }
 

--- a/winml/dll/module.cpp
+++ b/winml/dll/module.cpp
@@ -13,6 +13,8 @@
 #include "LearningModelOperator.h"
 #include "LearningModelSessionOptionsExperimental.h"
 #include "LearningModelSessionExperimental.h"
+#include "LearningModelExperimental.h"
+#include "LearningModelJoinOptions.h"
 
 #define STRINGIFY(x) #x
 #define XSTRINGIFY(x) STRINGIFY(x)
@@ -113,6 +115,20 @@ STDAPI DllGetExperimentalActivationFactory(void* classId, void** factory) noexce
     learning_model_session_experimental_class << XSTRINGIFY(WINML_ROOT_NS) << ".AI.MachineLearning.Experimental.LearningModelSessionExperimental";
     if (requal(name, learning_model_session_experimental_class.str())) {
       *factory = winrt::detach_abi(winrt::make<WINML_EXPERIMENTAL::factory_implementation::LearningModelSessionExperimental>());
+      return 0;
+    }
+
+    std::wostringstream learning_model_experimental_class;
+    learning_model_experimental_class << XSTRINGIFY(WINML_ROOT_NS) << ".AI.MachineLearning.Experimental.LearningModelExperimental";
+    if (requal(name, learning_model_experimental_class.str())) {
+      *factory = winrt::detach_abi(winrt::make<WINML_EXPERIMENTAL::factory_implementation::LearningModelExperimental>());
+      return 0;
+    }
+
+    std::wostringstream learning_model_join_options_class;
+    learning_model_join_options_class << XSTRINGIFY(WINML_ROOT_NS) << ".AI.MachineLearning.Experimental.LearningModelJoinOptions";
+    if (requal(name, learning_model_join_options_class.str())) {
+      *factory = winrt::detach_abi(winrt::make<WINML_EXPERIMENTAL::factory_implementation::LearningModelJoinOptions>());
       return 0;
     }
 

--- a/winml/lib/Api.Experimental/LearningModelExperimental.cpp
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.cpp
@@ -1,0 +1,32 @@
+#include "lib/Api.Experimental/pch/pch.h"
+#include "LearningModelExperimental.h"
+#include "LearningModel.h"
+#include "LearningModelJoinOptions.h"
+
+namespace WINML_EXPERIMENTALP {
+
+LearningModelExperimental::LearningModelExperimental(Microsoft::AI::MachineLearning::LearningModel const& model) : model_(model)
+{}
+
+winml::LearningModel LearningModelExperimental::JoinModel(winml::LearningModel const& other, winml_experimental::LearningModelJoinOptions const& options) {
+    telemetry_helper.LogApiUsage("LearningModelExperimental::JoinModel");
+
+    auto modelp = model_.as<winmlp::LearningModel>();
+    auto optionsp = options.as<winml_experimentalp::LearningModelJoinOptions>();
+
+    modelp->JoinModel(other,
+                      optionsp->GetLinkages(),
+                      optionsp->PromoteUnlinkedOutputsToFusedOutputs(),
+                      optionsp->CloseModelOnJoin(),
+                      optionsp->JoinedNodePrefix());
+
+    return model_;
+}
+
+void LearningModelExperimental::Save(hstring const& file_name) {
+    telemetry_helper.LogApiUsage("LearningModelExperimental::Save");
+    auto modelp = model_.as<winmlp::LearningModel>();
+    modelp->SaveToFile(file_name);
+}
+
+}

--- a/winml/lib/Api.Experimental/LearningModelExperimental.h
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "LearningModelExperimental.g.h"
+
+namespace WINML_EXPERIMENTALP {
+
+struct LearningModelExperimental : LearningModelExperimentalT<LearningModelExperimental>
+{
+    LearningModelExperimental() = default;
+
+    LearningModelExperimental(Microsoft::AI::MachineLearning::LearningModel const& model);
+    Microsoft::AI::MachineLearning::LearningModel JoinModel(Microsoft::AI::MachineLearning::LearningModel const& other, Microsoft::AI::MachineLearning::Experimental::LearningModelJoinOptions const& options);
+
+    void Save(hstring const& file_name);
+
+private:
+    Microsoft::AI::MachineLearning::LearningModel model_;
+};
+
+}
+
+namespace WINML_EXPERIMENTAL::factory_implementation {
+
+struct LearningModelExperimental : LearningModelExperimentalT<LearningModelExperimental, implementation::LearningModelExperimental>
+{
+};
+
+}

--- a/winml/lib/Api.Experimental/LearningModelJoinOptions.cpp
+++ b/winml/lib/Api.Experimental/LearningModelJoinOptions.cpp
@@ -1,0 +1,51 @@
+#include "lib/Api.Experimental/pch/pch.h"
+#include "LearningModelJoinOptions.h"
+
+namespace WINML_EXPERIMENTALP {
+
+LearningModelJoinOptions::LearningModelJoinOptions()
+{
+  GUID guid;
+  CoCreateGuid(&guid);
+
+  OLECHAR* guidString;
+  StringFromCLSID(guid, &guidString);
+
+  join_prefix_ = winrt::to_string(winrt::hstring(guidString));
+  // ensure memory is freed
+  ::CoTaskMemFree(guidString);
+}
+
+bool LearningModelJoinOptions::PromoteUnlinkedOutputsToFusedOutputs()
+{
+    return promote_unlinked_outputs_;
+}
+void LearningModelJoinOptions::PromoteUnlinkedOutputsToFusedOutputs(bool value)
+{
+    promote_unlinked_outputs_ = value;
+}
+winrt::hstring LearningModelJoinOptions::JoinedNodePrefix()
+{
+  return winrt::to_hstring(join_prefix_);
+}
+void LearningModelJoinOptions::JoinedNodePrefix(hstring const& join_prefix)
+{
+  join_prefix_ = winrt::to_string(join_prefix);
+}
+bool LearningModelJoinOptions::CloseModelOnJoin()
+{
+    return close_model_on_link_;
+}
+void LearningModelJoinOptions::CloseModelOnJoin(bool value)
+{
+    close_model_on_link_ = value;
+}
+void LearningModelJoinOptions::Link(hstring const& firstModelOutput, hstring const& secondModelInput)
+{
+    linkages_[winrt::to_string(firstModelOutput)] = winrt::to_string(secondModelInput);
+}
+const std::unordered_map<std::string, std::string>& LearningModelJoinOptions::GetLinkages() {
+    return linkages_;
+}
+
+}

--- a/winml/lib/Api.Experimental/LearningModelJoinOptions.h
+++ b/winml/lib/Api.Experimental/LearningModelJoinOptions.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "LearningModelJoinOptions.g.h"
+
+namespace WINML_EXPERIMENTALP {
+
+struct LearningModelJoinOptions : LearningModelJoinOptionsT<LearningModelJoinOptions>
+{
+    LearningModelJoinOptions();
+
+    bool PromoteUnlinkedOutputsToFusedOutputs();
+    void PromoteUnlinkedOutputsToFusedOutputs(bool value);
+    winrt::hstring JoinedNodePrefix();
+    void JoinedNodePrefix(hstring const& join_prefix);
+    
+    bool CloseModelOnJoin();
+    void CloseModelOnJoin(bool value);
+    void Link(hstring const& firstModelOutput, hstring const& secondModelInput);
+
+public:
+    const std::unordered_map<std::string, std::string>& GetLinkages();
+
+private:
+    bool promote_unlinked_outputs_ = true;
+    bool promote_unlinked_inputs_ = true;
+    bool close_model_on_link_ = false;
+
+    std::unordered_map<std::string, std::string> linkages_;
+    std::string join_prefix_;
+
+};
+}  // namespace WINML_EXPERIMENTALP
+
+namespace WINML_EXPERIMENTAL::factory_implementation {
+
+struct LearningModelJoinOptions : LearningModelJoinOptionsT<LearningModelJoinOptions, implementation::LearningModelJoinOptions>
+{
+};
+
+}

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -350,3 +350,26 @@ STDMETHODIMP OnnruntimeModel::AddModelOutput(_In_ const char* const name, _In_ I
   RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->ModelAddOutput(ort_model_.get(), name, type_info), ort_api);
   return S_OK;
 }
+
+
+STDMETHODIMP OnnruntimeModel::JoinModel(_In_ IModel* other_model,
+                                        _In_ const char* const* output_names,
+                                        _In_ const char* const* input_names,
+                                        size_t num_linkages,
+                                        bool promote_unlinked_outputs,
+                                        _In_ const char* const join_node_prefix) {
+  auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
+  auto ort_api = engine_factory_->UseOrtApi();
+  
+  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->JoinModels(ort_model_.get(),
+                                                       static_cast<OnnruntimeModel*>(other_model)->ort_model_.get(),
+                                                       output_names,
+                                                       input_names,
+                                                       num_linkages,
+                                                       promote_unlinked_outputs,
+                                                       join_node_prefix),
+                          ort_api);
+  // reset the info so that it is recreated with the new information lazily
+  info_ = nullptr;
+  return S_OK;
+}

--- a/winml/lib/Api.Ort/OnnxruntimeModel.h
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.h
@@ -83,6 +83,10 @@ class OnnruntimeModel : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(AddModelOutput)
   (_In_ const char* const name, _In_ IDescriptorInfoProvider* descriptor_provider);
 
+  STDMETHOD(JoinModel)
+  (_In_ IModel* other_model, _In_ const char* const* output_names, _In_ const char* const* input_names,
+   size_t num_linkages, bool promote_unlinked_outputs, _In_ const char* const join_node_prefix);
+
  private:
   UniqueOrtModel ort_model_;
 

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -309,6 +309,43 @@ LearningModel::GetEngineFactory() {
   return engine_factory_.get();
 }
 
+void LearningModel::SaveToFile(const hstring& file_name) {
+  model_->SaveModel(file_name.c_str(), file_name.size());
+}
+
+void LearningModel::JoinModel(
+    winml::LearningModel other,
+    const std::unordered_map<std::string, std::string>& linkages,
+    bool promote_unlinked_outputs,
+    bool close_model_on_join,
+    const winrt::hstring& join_node_prefix) {
+  auto otherp = other.as<winmlp::LearningModel>();
+  winrt::com_ptr<_winml::IModel> other_model;
+  if (close_model_on_join) {
+    other_model.attach(otherp->DetachModel());
+  } else {
+    other_model.attach(otherp->CloneModel());
+  }
+
+  std::vector<const char*> raw_outputs(linkages.size());
+  std::vector<const char*> raw_inputs(linkages.size());
+  std::transform(std::begin(linkages), std::end(linkages), std::begin(raw_outputs),
+                 [](auto& pair) { return pair.first.c_str(); });
+  std::transform(std::begin(linkages), std::end(linkages), std::begin(raw_inputs),
+                 [](auto& pair) { return pair.second.c_str(); });
+
+  auto prefix = winrt::to_string(join_node_prefix);
+  WINML_THROW_IF_FAILED(model_->JoinModel(other_model.get(),
+                                          raw_outputs.data(),
+                                          raw_inputs.data(),
+                                          linkages.size(),
+                                          promote_unlinked_outputs,
+                                          prefix.c_str()));
+
+  model_info_ = nullptr;
+  WINML_THROW_IF_FAILED(model_->GetModelInfo(model_info_.put()));
+}
+
 }  // namespace WINMLP
 
 namespace WINML::factory_implementation {

--- a/winml/lib/Api/LearningModel.h
+++ b/winml/lib/Api/LearningModel.h
@@ -102,6 +102,13 @@ struct LearningModel : LearningModelT<LearningModel> {
   _winml::IModel* DetachModel();
   _winml::IModel* CloneModel();
   _winml::IEngineFactory* GetEngineFactory();
+  void SaveToFile(const hstring& file_name);
+  void JoinModel(
+      winml::LearningModel other,
+      const std::unordered_map<std::string, std::string>& linkages,
+      bool promote_unlinked_outputs,
+      bool close_model_on_join,
+      const winrt::hstring& join_node_prefix);
 
  private:
   com_ptr<_winml::IEngineFactory> engine_factory_;

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -111,6 +111,10 @@ IModel : IUnknown {
 
   STDMETHOD(AddModelOutput)
   (_In_ const char* const name, _In_ IDescriptorInfoProvider* descriptor_provider) PURE;
+
+  STDMETHOD(JoinModel)
+  (_In_ IModel* other_model, _In_ const char* const* output_names, _In_ const char* const* input_names,
+   size_t num_linkages, bool promote_unlinked_outputs, _In_ const char * const join_node_prefix) PURE;
 };
 
 MIDL_INTERFACE("30c99886-38d2-41cb-a615-203fe7d7daac")

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -811,7 +811,7 @@ static void ModelBuilding_StandardDeviationNormalization() {
   auto session = LearningModelSession(final_model, LearningModelDevice(LearningModelDeviceKind::Cpu));
   LearningModelBinding binding(session);
 
-  // Bind A
+  // Bind
   auto input = std::vector<float>(SIZET(height * width * channels), 1);
   binding.Bind(L"Input", TensorFloat::CreateFromArray(input_shape, input));
   auto channels_shape = std::vector<int64_t>(SIZET(1), 3);

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -793,20 +793,20 @@ static void ModelBuilding_StandardDeviationNormalization() {
                .SetOutput(L"transposed", L"Output"))
       .CreateModel();
 
-  auto sub_eperimental = winml_experimental::LearningModelExperimental(sub_model);
+  auto sub_experimental = winml_experimental::LearningModelExperimental(sub_model);
   winml_experimental::LearningModelJoinOptions div_join_options;
   div_join_options.Link(sub_model.OutputFeatures().GetAt(0).Name(), div_model.InputFeatures().GetAt(0).Name());
   div_join_options.JoinedNodePrefix(L"DivModel.");
-  auto joined_model = sub_eperimental.JoinModel(div_model, div_join_options);
+  auto joined_model = sub_experimental.JoinModel(div_model, div_join_options);
 
-  auto joined_model_eperimental = winml_experimental::LearningModelExperimental(joined_model);
+  auto joined_model_experimental = winml_experimental::LearningModelExperimental(joined_model);
   winml_experimental::LearningModelJoinOptions transpose_join_options;
   transpose_join_options.Link(joined_model.OutputFeatures().GetAt(0).Name(), transpose_model.InputFeatures().GetAt(0).Name());
   transpose_join_options.JoinedNodePrefix(L"TransposeModel.");
-  auto final_model = joined_model_eperimental.JoinModel(transpose_model, transpose_join_options);
+  auto final_model = joined_model_experimental.JoinModel(transpose_model, transpose_join_options);
 
-  auto final_model_eperimental = winml_experimental::LearningModelExperimental(final_model);
-  final_model_eperimental.Save(L"ModelBuilding_StandardDeviationNormalization.onnx");
+  auto final_model_experimental = winml_experimental::LearningModelExperimental(final_model);
+  final_model_experimental.Save(L"ModelBuilding_StandardDeviationNormalization.onnx");
 
   auto session = LearningModelSession(final_model, LearningModelDevice(LearningModelDeviceKind::Cpu));
   LearningModelBinding binding(session);

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -763,25 +763,64 @@ static void ModelBuilding_StandardDeviationNormalization() {
   int64_t channels = 3;
   std::vector<int64_t> input_shape = {1, height, width, channels};  
   std::vector<int64_t> output_shape = {1, channels, height, width};  
-  LearningModelBuilder::Create(13)
-    .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input", L"The NHWC image", TensorKind::Float, input_shape))
-    .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Means", TensorKind::Float, {channels}))
-    .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"StdDevs", TensorKind::Float, {channels}))
-    .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output", L"The NCHW image normalized with mean and stddev.", TensorKind::Float, output_shape))
-    .Operators().Add(Operator(L"Sub")
-                       .SetInput(L"A", L"Input")
-                       .SetInput(L"B", L"Means")
-                       .SetOutput(L"C", L"SubOutput"))
-    .Operators().Add(Operator(L"Div")
-                       .SetInput(L"A", L"SubOutput")
-                       .SetInput(L"B", L"StdDevs")
-                       .SetOutput(L"C", L"DivOutput"))
-    .Operators().Add(Operator(L"Transpose")
-                       .SetInput(L"data", L"DivOutput")
-                       .SetAttribute(L"perm", TensorInt64Bit::CreateFromArray({4}, {0,3,1,2}))
-                       .SetOutput(L"transposed", L"Output"))
-    .Save(L"StandardDeviationNormalization.onnx");
-  //.CreateModel();
+  auto sub_model =
+      LearningModelBuilder::Create(13)
+        .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input", L"The NHWC image", TensorKind::Float, input_shape))
+        .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Means", TensorKind::Float, {channels}))
+        .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output", L"The NCHW image normalized with mean and stddev.", TensorKind::Float, input_shape))
+        .Operators().Add(Operator(L"Sub")
+                           .SetInput(L"A", L"Input")
+                           .SetInput(L"B", L"Means")
+                           .SetOutput(L"C", L"Output"))
+        .CreateModel();
+  auto div_model = 
+    LearningModelBuilder::Create(13)
+      .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input", L"The NHWC image", TensorKind::Float, input_shape))
+      .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"StdDevs", TensorKind::Float, {channels}))
+      .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output", L"The NCHW image normalized with mean and stddev.", TensorKind::Float, input_shape))
+      .Operators().Add(Operator(L"Div")
+               .SetInput(L"A", L"Input")
+               .SetInput(L"B", L"StdDevs")
+               .SetOutput(L"C", L"Output"))
+      .CreateModel();
+  auto transpose_model =
+    LearningModelBuilder::Create(13)
+      .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input", L"The NHWC image", TensorKind::Float, input_shape))
+      .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output", L"The NCHW image normalized with mean and stddev.", TensorKind::Float, output_shape))
+      .Operators().Add(Operator(L"Transpose")
+               .SetInput(L"data", L"Input")
+               .SetAttribute(L"perm", TensorInt64Bit::CreateFromArray({4}, {0, 3, 1, 2}))
+               .SetOutput(L"transposed", L"Output"))
+      .CreateModel();
+
+  auto sub_eperimental = winml_experimental::LearningModelExperimental(sub_model);
+  winml_experimental::LearningModelJoinOptions div_join_options;
+  div_join_options.Link(sub_model.OutputFeatures().GetAt(0).Name(), div_model.InputFeatures().GetAt(0).Name());
+  div_join_options.JoinedNodePrefix(L"DivModel.");
+  auto joined_model = sub_eperimental.JoinModel(div_model, div_join_options);
+
+  auto joined_model_eperimental = winml_experimental::LearningModelExperimental(joined_model);
+  winml_experimental::LearningModelJoinOptions transpose_join_options;
+  transpose_join_options.Link(joined_model.OutputFeatures().GetAt(0).Name(), transpose_model.InputFeatures().GetAt(0).Name());
+  transpose_join_options.JoinedNodePrefix(L"TransposeModel.");
+  auto final_model = joined_model_eperimental.JoinModel(transpose_model, transpose_join_options);
+
+  auto final_model_eperimental = winml_experimental::LearningModelExperimental(final_model);
+  final_model_eperimental.Save(L"ModelBuilding_StandardDeviationNormalization.onnx");
+
+  auto session = LearningModelSession(final_model, LearningModelDevice(LearningModelDeviceKind::Cpu));
+  LearningModelBinding binding(session);
+
+  // Bind A
+  auto input = std::vector<float>(SIZET(height * width * channels), 1);
+  binding.Bind(L"Input", TensorFloat::CreateFromArray(input_shape, input));
+  auto channels_shape = std::vector<int64_t>(SIZET(1), 3);
+  binding.Bind(L"Means", TensorFloat::CreateFromArray(channels_shape, {2, 2, 2}));
+  binding.Bind(L"DivModel.StdDevs", TensorFloat::CreateFromArray(channels_shape, {.1f, .1f, .1f}));
+
+  // Evaluate
+  auto result = session.Evaluate(binding, L"");
+
 #endif
 }
 


### PR DESCRIPTION
Enable experimental model fusion API in WinML+RT Experimental API

Issue: Machine Learning workflows generally depend on
1) tensorization and pre-processing,
2) inference
3) post-processing and visualization

The WinML+RT Experimental API contains a basic model building API that can enable users to develop 1) and 3) with the ONNX model format rather than depend on platform/hardware specific implementations. This change enables developers to fuse these helper models and the trained inference model into a single model that can be used for an e2e ML workflow.

This enables EPs to optimize an e2e graph for performance, and allows these phases of the workflow to take advantage of other inference optimizations like automatic batching.