### PR TITLE
Disable partial runtime optimization implementation by default

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -117,8 +117,9 @@ option(onnxruntime_EXTENDED_MINIMAL_BUILD "onnxruntime_MINIMAL_BUILD with suppor
 option(onnxruntime_MINIMAL_BUILD_CUSTOM_OPS "Add custom operator kernels support to a minimal build." OFF)
 option(onnxruntime_REDUCED_OPS_BUILD "Reduced set of kernels are registered in build via modification of the kernel registration source files." OFF)
 option(onnxruntime_DISABLE_EXTERNAL_INITIALIZERS "Don't allow models to load external data" OFF)
-cmake_dependent_option(onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION "Enable runtime graph optimization of ORT format models." ON
-                       "NOT onnxruntime_MINIMAL_BUILD OR onnxruntime_EXTENDED_MINIMAL_BUILD" OFF)
+cmake_dependent_option(onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION
+                       "Enable runtime graph optimization of ORT format models. Warning: Not yet ready for general use."
+                       OFF "NOT onnxruntime_MINIMAL_BUILD OR onnxruntime_EXTENDED_MINIMAL_BUILD" OFF)
 
 #A special option just for debugging and sanitize check. Please do not enable in option in retail builds.
 #The option has no effect on Windows.

--- a/onnxruntime/core/flatbuffers/schema/README.md
+++ b/onnxruntime/core/flatbuffers/schema/README.md
@@ -37,6 +37,3 @@ Support for storing `graph_doc_string` field in Model (ORT FlatBuffers format).
 
 ## Version 4.
 Update kernel def hashing to not depend on ordering of type constraint types (NOT BACKWARDS COMPATIBLE).
-
-## Next version (TODO finalize changes for next version before 1.10 release).
-Support for storing runtime optimizations in graph.

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3129,9 +3129,13 @@ common::Status Graph::SaveToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
   auto node_edges = builder.CreateVector(node_edges_vec);
 
 #if defined(ORT_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION)
-  flatbuffers::Offset<RuntimeOptimizationRecordContainer::FbsRuntimeOptimizationRecordContainer> runtime_optimization_records;
-  ORT_RETURN_IF_ERROR(RuntimeOptimizations().SaveToOrtFormat(builder, runtime_optimization_records));
-  const auto runtime_optimizations = fbs::CreateRuntimeOptimizations(builder, runtime_optimization_records);
+  auto runtime_optimizations = flatbuffers::Offset<fbs::RuntimeOptimizations>{};  // null value
+  if (!RuntimeOptimizations().IsEmpty()) {
+    flatbuffers::Offset<RuntimeOptimizationRecordContainer::FbsRuntimeOptimizationRecordContainer>
+        runtime_optimization_records;
+    ORT_RETURN_IF_ERROR(RuntimeOptimizations().SaveToOrtFormat(builder, runtime_optimization_records));
+    runtime_optimizations = fbs::CreateRuntimeOptimizations(builder, runtime_optimization_records);
+  }
 #endif
 
   fbs::GraphBuilder gb(builder);

--- a/onnxruntime/core/graph/runtime_optimization_record_container.h
+++ b/onnxruntime/core/graph/runtime_optimization_record_container.h
@@ -32,6 +32,8 @@ struct RuntimeOptimizationRecordContainerEntry;
 
 class RuntimeOptimizationRecordContainer {
  public:
+  bool IsEmpty() const { return sat_to_optimizations_.empty(); }
+
 #if defined(ORT_ENABLE_ADDING_RUNTIME_OPTIMIZATION_RECORDS)
   void AddRecord(const std::string& optimizer_key, RuntimeOptimizationRecord&& runtime_optimization_record);
 #endif

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -537,10 +537,6 @@ def parse_arguments():
     parser.add_argument("--disable_exceptions", action='store_true',
                         help="Disable exceptions to reduce binary size. Requires --minimal_build.")
 
-    parser.add_argument("--disable_ort_format_runtime_graph_optimizations", action='store_true',
-                        help="Disable the ORT format model runtime graph optimization capability "
-                             "(reduces binary size)")
-
     parser.add_argument(
         "--rocm_version", help="The version of ROCM stack to use. ")
     parser.add_argument("--use_rocm", action='store_true', help="Build with ROCm")
@@ -772,8 +768,6 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
                                                      args.minimal_build or args.use_extensions))
                                                      else "OFF"),
         "-Donnxruntime_REDUCED_OPS_BUILD=" + ("ON" if is_reduced_ops_build(args) else "OFF"),
-        "-Donnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=" + (
-            "ON" if not args.disable_ort_format_runtime_graph_optimizations else "OFF"),
         "-Donnxruntime_ENABLE_LANGUAGE_INTEROP_OPS=" + ("ON" if args.enable_language_interop_ops else "OFF"),
         "-Donnxruntime_USE_DML=" + ("ON" if args.use_dml else "OFF"),
         "-Donnxruntime_USE_WINML=" + ("ON" if args.use_winml else "OFF"),

--- a/tools/ci_build/github/android/default_mobile_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_mobile_aar_build_settings.json
@@ -19,7 +19,6 @@
         "--disable_exceptions",
         "--enable_reduced_operator_type_support",
         "--use_nnapi",
-        "--skip_tests",
-        "--disable_ort_format_runtime_graph_optimizations"
+        "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
@@ -20,7 +20,6 @@
         "--enable_reduced_operator_type_support",
         "--use_coreml",
         "--skip_tests",
-        "--apple_deploy_target=11.0",
-        "--disable_ort_format_runtime_graph_optimizations"
+        "--apple_deploy_target=11.0"
     ]
 }

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -205,7 +205,7 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
-    displayName: 6a. Build full onnxruntime with runtime optimizations disabled
+    displayName: 6a. Build full onnxruntime with runtime optimizations enabled
     inputs:
       script: |
         docker run --rm \
@@ -221,11 +221,11 @@ jobs:
               --skip_submodule_sync \
               --build_shared_lib \
               --parallel \
-              --disable_ort_format_runtime_graph_optimizations
+              --cmake_extra_defines onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=ON
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
-    displayName: 6b. Build extended minimal onnxruntime with runtime optimizations disabled
+    displayName: 6b. Build extended minimal onnxruntime with runtime optimizations enabled
     inputs:
       script: |
         docker run --rm \
@@ -242,7 +242,7 @@ jobs:
               --build_shared_lib \
               --parallel \
               --minimal_build extended \
-              --disable_ort_format_runtime_graph_optimizations
+              --cmake_extra_defines onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=ON
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: PublishTestResults@2

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -13,7 +13,7 @@
 #    in <repo root>/onnxruntime/test/testdata/, so the tests for those models are skipped.
 # 5. Build baseline minimal ORT for Android arm64-v8a including no kernels and disable exceptions.
 #    This step is to report the baseline binary size for Android.
-# 6. Build full (6a) and extended minimal (6b) ORT with runtime optimizations disabled.
+# 6. Build full (6a) and extended minimal (6b) ORT with runtime optimizations enabled.
 jobs:
 - job: Linux_CPU_Minimal_Build_E2E
   timeoutInMinutes: 120


### PR DESCRIPTION
**Description**
Follow up to #9723.
- Disabling the partial runtime optimization implementation by default. It will not be included in any release builds.
- Avoid saving empty runtime optimizations structure in the ORT format model if no runtime optimizations have been added in the graph.
- Update flatbuffers schema readme to not mention this partially implemented feature.

**Motivation and Context**
Exclude partial implementation from release builds, some clean up.
