### PR TITLE
Add redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "just-the-docs"
 gem "jekyll-toc"
 gem 'rake'
 gem 'html-proofer'
+gem 'jekyll-redirect-from'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,9 +19,9 @@ GEM
     concurrent-ruby (1.1.9)
     dnsruby (1.61.7)
       simpleidn (~> 0.1)
-    em-websocket (0.5.2)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     ethon (0.15.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
@@ -109,7 +109,7 @@ GEM
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
-    http_parser.rb (0.6.0)
+    http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jekyll (3.9.0)
@@ -297,6 +297,7 @@ DEPENDENCIES
   github-pages (~> 207)
   html-proofer
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   jekyll-toc
   just-the-docs
   kramdown-parser-gfm

--- a/_config.yml
+++ b/_config.yml
@@ -7,13 +7,13 @@ search.heading_level: 2
 search.button: true
 plugins:
   - jekyll-toc
+  - jekyll-redirect-from
 kramdown:
   parse_block_html: true
   toc_levels: "1,2,3"
 logo: "/images/ONNX-Runtime-logo.svg"
 aux_links:  
-
-  "Onnx Runtime":
+  "ONNX Runtime":
     - "/"
   "Install":
     - "/docs/install/"

--- a/docs/api/csharp-api.md
+++ b/docs/api/csharp-api.md
@@ -1,6 +1,7 @@
 ---
 title: C# API
 nav_exclude: true
+redirect_from: /docs/reference/api/csharp-api
 ---
 
 # C# API Reference

--- a/docs/api/csharp-api.md
+++ b/docs/api/csharp-api.md
@@ -1,5 +1,6 @@
 ---
 title: C# API
+description: Overview of the C# API
 nav_exclude: true
 redirect_from: /docs/reference/api/csharp-api
 ---


### PR DESCRIPTION
Add capability for generic redirect to the ONNX Runtime docs website, with one test case.

Changes staged here: https://natke.github.io/onnxruntime/docs

To test the redirect, navigate to this old URL: https://natke.github.io/onnxruntime/docs/reference/api/csharp-api.html