### PR TITLE
Enable LearningModel::LoadFromFilePath in UWP Apps

### DIFF
--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -26,13 +26,13 @@ LearningModel::LearningModel(
 #if WINVER >= _WIN32_WINNT_WIN8
       CreateFile2(path.c_str(),
                   GENERIC_READ,
-                  0,
+                  FILE_SHARE_READ,
                   OPEN_EXISTING,
                   NULL)};
 #else
       CreateFileW(path.c_str(),
                   GENERIC_READ,
-                  0,
+                  FILE_SHARE_READ,
                   NULL,
                   OPEN_EXISTING,
                   FILE_ATTRIBUTE_READONLY,


### PR DESCRIPTION
Issue: LearningModel::LoadFromFilePath fails on UWP because CreateFile2 and CreateFileW both disallow read access in their share mode.

Fix: Allow reading shared mode when opening files.