### PR TITLE
Added missing include <algorithm> for std::clamp

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/Common.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/Common.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #define ML_CHECK_VALID_ARGUMENT(x, ...)\
   {\
     if ((x) == false) {\


### PR DESCRIPTION
**Description**: Describe your changes.

std::clamp comes in the `<algorithm>` header. We were facing a bug in our code for using this header without the missing include.

**Motivation and Context**
- Why is this change required? What problem does it solve? Compilation error when compiling ORT inside of UE for not knowing where std::clamp comes from.
