### PR TITLE
squeeze and unsqueeze operators for the dnnl execution provider

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -525,16 +525,28 @@ bool DnnlDynamicQuantizeLinearNodeCapability::Supported(const Node* node, const 
 bool DnnlSqueezeNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
-  if (!IsDimensionSupported(node)) return false;
+  if (!IsDimensionSupported(node, graph_viewer)) return false;
   return true;
 }
-bool DnnlSqueezeNodeCapability::IsDimensionSupported(const Node* node) const {
+bool DnnlSqueezeNodeCapability::IsDimensionSupported(const Node* node, const GraphViewer& graph_viewer) const {
   // we don't support scalar output
   auto node_out = node->OutputDefs()[0];
   if (node_out->Exists() &&
       node_out->Shape() != nullptr &&
       node_out->Shape()->dim_size() == 0) {
     return false;
+  }
+
+  // Before opset version 13 the axis comes from an attribute. After opset version
+  // 13 we must check that the optional axis (input[1]) is a ConstantInitializer because
+  // we only handle the axis at compile time. If it changes at runtime we can not support
+  // the operator
+  auto opset = node->SinceVersion();
+  auto node_inputs = node->InputDefs();
+  if (opset >= 13 && node_inputs.size() > 1 && node_inputs[1]->Shape() != nullptr) {
+    if (!graph_viewer.IsConstantInitializer(node_inputs[1]->Name(), true)) {
+      return false;
+    }
   }
   return true;
 }

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -519,4 +519,24 @@ bool DnnlDynamicQuantizeLinearNodeCapability::Supported(const Node* node, const 
   return true;
 }
 
+
+// DnnlSqueezeCapability class
+//-------------------------------------
+bool DnnlSqueezeNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
+  ORT_UNUSED_PARAMETER(graph_viewer);
+  if (!IsTypeSupported(node)) return false;
+  if (!IsDimensionSupported(node)) return false;
+  return true;
+}
+bool DnnlSqueezeNodeCapability::IsDimensionSupported(const Node* node) const {
+  // we don't support scalar output
+  auto node_out = node->OutputDefs()[0];
+  if (node_out->Exists() &&
+      node_out->Shape() != nullptr &&
+      node_out->Shape()->dim_size() == 0) {
+    return false;
+  }
+  return true;
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -301,4 +301,19 @@ class DnnlDynamicQuantizeLinearNodeCapability : public DnnlDefaultNodeCapability
  private:
 };
 
+class DnnlSqueezeNodeCapability : public DnnlDefaultNodeCapability {
+ public:
+  DnnlSqueezeNodeCapability() : DnnlDefaultNodeCapability({type_float32,
+                                                           type_float16,
+                                                           type_bfloat16,
+                                                           type_int32,
+                                                           type_int8,
+                                                           type_uint8}) {}
+
+  bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
+
+ private:
+  bool IsDimensionSupported(const Node* node) const;
+};
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -313,7 +313,7 @@ class DnnlSqueezeNodeCapability : public DnnlDefaultNodeCapability {
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
  private:
-  bool IsDimensionSupported(const Node* node) const;
+  bool IsDimensionSupported(const Node* node, const GraphViewer& graph_viewer) const;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -33,6 +33,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Sigmoid", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Softmax", std::unique_ptr<DnnlNodeCapability>(new DnnlSoftmaxNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Softplus", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Squeeze", std::unique_ptr<DnnlNodeCapability>(new DnnlSqueezeNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sqrt", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sub", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Sum", std::unique_ptr<DnnlNodeCapability>(new DnnlSumNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -39,6 +39,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Sum", std::unique_ptr<DnnlNodeCapability>(new DnnlSumNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Tanh", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Transpose", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Unsqueeze", std::unique_ptr<DnnlNodeCapability>(new DnnlSqueezeNodeCapability())));
 #if defined(ENABLE_TRAINING)
   dnnl_ops_map_.emplace(std::make_pair("AveragePoolGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ConvGrad", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc
@@ -1,0 +1,75 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_squeeze.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+#include "core/providers/common.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+DnnlSqueeze::DnnlSqueeze() {}
+
+void DnnlSqueeze::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto dnnl_engine = sp.GetEngine();
+
+  // the input shape assumes OrtFormat so we get the memory in OrtFormat.
+  auto data_mem = sp.GetMemoryInOrtFormat(node.Input(IN_DATA), dnnl_engine);
+  dnnl::memory::dims data_dims = data_mem.get_desc().dims();
+
+  std::vector<int64_t> axes_data;
+  // ONNX Squeeze version 13+ the axes is an input tensor
+  // ONNX Squeeze before version 13 axes comes from an Attribute.
+  if (node.Input(IN_AXES).Exists()) {
+    auto axes_mem = sp.GetMemory(node.Input(IN_AXES));
+    dnnl::memory::dims axes_dims = axes_mem.get_desc().dims();
+    int64_t* p_axes_data = (int64_t*)axes_mem.get_data_handle();
+    axes_data = std::vector<int64_t>(p_axes_data, p_axes_data + axes_dims[0]);
+  } else {
+    axes_data = GetAxes(node);
+  }
+
+  // convert negative axis to the positive axis
+  for (size_t i = 0; i < axes_data.size(); ++i) {
+    axes_data[i] = HandleNegativeAxis(axes_data[i], data_dims.size());
+  }
+
+  // Handle out of order and repeating dims.
+  std::sort(axes_data.begin(), axes_data.end());
+  axes_data.erase(std::unique(axes_data.begin(), axes_data.end()), axes_data.end());
+
+  std::vector<int64_t> output_shape;
+  size_t j = 0;
+  for (size_t i = 0; i < data_dims.size(); ++i) {
+    if ((j < axes_data.size() && axes_data[j] == static_cast<int64_t>(i)) ||
+        (axes_data.size() == 0 && data_dims[i] == 1)) {
+      ORT_ENFORCE(data_dims[i] == 1, "Dimension of input ", i, " must be 1 instead of ", data_dims[i],
+                  ". shape=", data_dims);
+      ++j;
+      continue;
+    }
+    output_shape.push_back(data_dims[i]);
+  }
+
+  dnnl::memory::desc squeeze_md(output_shape, node.Input(IN_DATA).Type(), sp.GetDnnlFormat(output_shape.size()));
+
+  dnnl::memory squeeze_mem = dnnl::memory(squeeze_md, dnnl_engine, nullptr);
+  sp.AddReshape(data_mem, squeeze_mem);
+
+  sp.SetMemory(node.Output(OUT_SQUEEZED), squeeze_mem, true);
+}
+
+std::vector<int64_t> DnnlSqueeze::GetAxes(DnnlNode& node) {
+  auto attr = node.Attributes().find("axes");
+  std::vector<int64_t> axes;
+  if (attr != node.Attributes().end() && 
+      attr->second().type() == ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INTS) {
+    axes.reserve(attr->second().ints_size());
+    for (int i = 0; i < attr->second().ints_size(); ++i) {
+      axes.push_back(attr->second().ints(i));
+    }
+  } 
+  return axes;
+}
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.h
@@ -1,0 +1,30 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlSqueeze {
+ public:
+  enum InputTensors : int {
+    IN_DATA = 0,
+    IN_AXES = 1,
+  };
+
+  enum OutputTensors : int {
+    OUT_SQUEEZED = 0
+  };
+
+  DnnlSqueeze();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+  private:
+  std::vector<int64_t> GetAxes(DnnlNode& node);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -18,6 +18,7 @@
 #include "dnnl_reshape.h"
 #include "dnnl_softmax.h"
 #include "dnnl_softmaxgrad.h"
+#include "dnnl_squeeze.h"
 #include "dnnl_sum.h"
 #include "dnnl_transpose.h"
 
@@ -75,6 +76,8 @@ void DnnlSubgraphPrimitive::AddKernels() {
       DnnlReshape().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Softmax") {
       DnnlSoftmax().CreatePrimitive(*this, node);
+    } else if (node.OpType() == "Squeeze") {
+      DnnlSqueeze().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Sum") {
       DnnlSum().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Transpose") {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -63,6 +63,10 @@ class DnnlSubgraphPrimitive {
   dnnl::memory::desc GetOutputInfo(std::string name);
   bool IsScalarOutput(const std::string& name);
   bool IsDynamic();
+  // All Scalar inputs are automatically converterted to a one dimentional tensor when used in OneDNN
+  // If the input being a scalar affects the operator this function can be used to determine if the
+  // original input from ORT was a scalar.
+  bool IsScalar(const DnnlTensor& tensor);
   OrtMutex& GetMutex() { return mutex_; }
 
   //GetMemory in OrtFormat if the memory is not in the OrtFormat this will reorder the memory.
@@ -77,6 +81,8 @@ class DnnlSubgraphPrimitive {
 
   std::unordered_map<std::string, dnnl::memory> inputs_;
   std::unordered_map<std::string, dnnl::memory::desc> inputs_md_;
+  std::unordered_set<std::string> input_is_scalar_;
+
 
   std::unordered_map<std::string, dnnl::memory> outputs_;
   std::unordered_map<std::string, dnnl::memory::desc> outputs_md_;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_unsqueeze.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_unsqueeze.cc
@@ -1,0 +1,85 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_unsqueeze.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+#include "core/providers/common.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+DnnlUnsqueeze::DnnlUnsqueeze() {}
+
+void DnnlUnsqueeze::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto dnnl_engine = sp.GetEngine();
+
+  // the input shape assumes OrtFormat so we get the memory in OrtFormat.
+  auto data_mem = sp.GetMemoryInOrtFormat(node.Input(IN_DATA), dnnl_engine);
+  bool data_is_scalar = sp.IsScalar(node.Input(IN_DATA));
+
+  // The OneDNN execution provider automatically expands all scalar inputs to dim {1} tensors.
+  // this will result in the data_dims.size() being 1 too large if the input is from a scalar.
+  // To counter this data_dims is left empty if the input is from a scalar.
+  dnnl::memory::dims data_dims;
+  if (!data_is_scalar) {
+    data_dims = data_mem.get_desc().dims();
+  }
+
+  std::vector<int64_t> axes_data;
+  // ONNX Unsqueeze version 13+ the axes is an input tensor
+  // ONNX Unsqueeze before version 13 axes comes from an Attribute.
+  if (node.Input(IN_AXES).Exists()) {
+    auto axes_mem = sp.GetMemory(node.Input(IN_AXES));
+    dnnl::memory::dims axes_dims = axes_mem.get_desc().dims();
+    int64_t* p_axes_data = (int64_t*)axes_mem.get_data_handle();
+    axes_data = std::vector<int64_t>(p_axes_data, p_axes_data + axes_dims[0]);
+  } else {
+    axes_data = GetAxes(node);
+  }
+
+  std::vector<int64_t> output_shape(axes_data.size() + data_dims.size(), 0);
+  // Set all axes indices to 1 in output_dims and check for duplicates
+  for (int64_t axes : axes_data) {
+    // Valid axis range is [0, output_rank - 1]
+    axes = HandleNegativeAxis(axes, output_shape.size());
+    if (axes < 0 || axes >= static_cast<int64_t>(output_shape.size()))
+      ORT_ENFORCE("'axes' has an out of range axis");
+    if (output_shape[axes] != 0)
+      ORT_ENFORCE("'axes' has a duplicate axis");
+    output_shape[axes] = 1;
+  }
+
+  // Now fill in the zero entries with the existing shape
+  {
+    auto begin = data_dims.cbegin();
+    for (auto& axisSize : output_shape) {
+      if (axisSize == 0)
+        axisSize = *begin++;
+    }
+    assert(begin == data_dims.cend());
+  }
+
+  dnnl::memory::desc squeeze_md(output_shape, node.Input(IN_DATA).Type(), sp.GetDnnlFormat(output_shape.size()));
+
+  dnnl::memory expanded_mem = dnnl::memory(squeeze_md, dnnl_engine, nullptr);
+  sp.AddReshape(data_mem, expanded_mem);
+
+  sp.SetMemory(node.Output(OUT_EXPANDED), expanded_mem, true);
+}
+
+std::vector<int64_t> DnnlUnsqueeze::GetAxes(DnnlNode& node) {
+  auto attr = node.Attributes().find("axes");
+  std::vector<int64_t> axes;
+  if (attr != node.Attributes().end() && 
+      attr->second().type() == ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INTS) {
+    axes.reserve(attr->second().ints_size());
+    for (int i = 0; i < attr->second().ints_size(); ++i) {
+      axes.push_back(attr->second().ints(i));
+    }
+  } else {
+    ORT_ENFORCE("Missing/Invalid 'axes' attribute value");
+  } 
+  return axes;
+}
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_unsqueeze.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_unsqueeze.h
@@ -1,0 +1,30 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlUnsqueeze {
+ public:
+  enum InputTensors : int {
+    IN_DATA = 0,
+    IN_AXES = 1,
+  };
+
+  enum OutputTensors : int {
+    OUT_EXPANDED = 0
+  };
+
+  DnnlUnsqueeze();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+  private:
+  std::vector<int64_t> GetAxes(DnnlNode& node);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/unsqueeze_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/unsqueeze_op_test.cc
@@ -45,6 +45,64 @@ TEST(TensorOpTest, Unsqueeze_3) {
   test.Run();
 }
 
+TEST(TensorOpTest, Unsqueeze_scalar) {
+  {
+    OpTester test("Unsqueeze");
+
+    test.AddAttribute("axes", std::vector<int64_t>{0});
+    test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+    test.AddOutput<float>("output", {1}, std::vector<float>{1.0f});
+    test.Run();
+  }
+  {
+    OpTester test("Unsqueeze");
+
+    test.AddAttribute("axes", std::vector<int64_t>{-1});
+    test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+    test.AddOutput<float>("output", {1}, std::vector<float>{1.0f});
+    test.Run();
+  }
+
+  auto run_test = [](bool axes_is_initializer) {
+    {
+      OpTester test("Unsqueeze", 13);
+      test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+      test.AddInput<int64_t>("axes", {1}, std::vector<int64_t>{0}, axes_is_initializer);
+      test.AddOutput<float>("output", {1}, std::vector<float>{1.0f});
+      test.Run();
+    }
+    {
+      OpTester test("Unsqueeze", 13);
+      test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+      test.AddInput<int64_t>("axes", {1}, std::vector<int64_t>{-1}, axes_is_initializer);
+      test.AddOutput<float>("output", {1}, std::vector<float>{1.0f});
+      test.Run();
+    }
+  };
+  run_test(false);
+  run_test(true);
+}
+
+  TEST(TensorOpTest, Unsqueeze_scalar_2) {
+  {
+    OpTester test("Unsqueeze");
+
+    test.AddAttribute("axes", std::vector<int64_t>{0, 1});
+    test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+    test.AddOutput<float>("output", {1, 1}, std::vector<float>{1.0f});
+    test.Run();
+  }
+  auto run_test = [](bool axes_is_initializer) {
+    OpTester test("Unsqueeze", 13);
+    test.AddInput<float>("input", {}, std::vector<float>{1.0f});
+    test.AddInput<int64_t>("axes", {2}, std::vector<int64_t>{0, -1}, axes_is_initializer);
+    test.AddOutput<float>("output", {1, 1}, std::vector<float>{1.0f});
+    test.Run();
+  };
+  run_test(false);
+  run_test(true);
+  }
+
 TEST(TensorOpTest, Unsqueeze_Duplicate) {
   {
     OpTester test("Unsqueeze", 12); // opset 1-12 has axes attribute
@@ -98,35 +156,45 @@ TEST(TensorOpTest, UnsqueezeNegAxis_3) {
     // TensorRT does not support negative axis.
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   }
-  {
+  auto run_test = [](bool axes_is_initializer) {
     OpTester test("Unsqueeze", 13);  // use latest opset with axis input
     test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
-    test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{-4, 1, -6});
+    test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{-4, 1, -6}, axes_is_initializer);
     test.AddOutput<float>("output", {1, 1, 1, 2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
     // TensorRT does not support negative axis.
     // TODO: TensorRT, OpenVINO dont support "axes" input in opset 13, re-enable after
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", { kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
-  }
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  };
+  run_test(false);
+  run_test(true);
 }
 
 TEST(TensorOpTest, Unsqueeze_1_int32_axes_input) {
-  OpTester test("Unsqueeze", 13);
+  auto run_test = [](bool axes_is_initializer) {
+    OpTester test("Unsqueeze", 13);
 
-  test.AddInput<int32_t>("input", {2, 3, 4}, std::vector<int32_t>(2 * 3 * 4, 1));
-  test.AddInput<int64_t>("axes", {1}, std::vector<int64_t>{1});
-  test.AddOutput<int32_t>("output", {2, 1, 3, 4}, std::vector<int32_t>(2 * 3 * 4, 1));
-  // TODO: TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+    test.AddInput<int32_t>("input", {2, 3, 4}, std::vector<int32_t>(2 * 3 * 4, 1));
+    test.AddInput<int64_t>("axes", {1}, std::vector<int64_t>{1}, axes_is_initializer);
+    test.AddOutput<int32_t>("output", {2, 1, 3, 4}, std::vector<int32_t>(2 * 3 * 4, 1));
+    // TODO: TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  };
+  run_test(false);
+  run_test(true);
 }
 
 TEST(TensorOpTest, Unsqueeze_3_axes_input) {
-  OpTester test("Unsqueeze", 13);
+  auto run_test = [](bool axes_is_initializer) {
+    OpTester test("Unsqueeze", 13);
 
-  test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
-  test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{2, 1, 0});
-  test.AddOutput<float>("output", {1, 1, 1, 2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
-  // TODO: TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+    test.AddInput<float>("input", {2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
+    test.AddInput<int64_t>("axes", {3}, std::vector<int64_t>{2, 1, 0}, axes_is_initializer);
+    test.AddOutput<float>("output", {1, 1, 1, 2, 3, 4}, std::vector<float>(2 * 3 * 4, 1.0f));
+    // TODO: TensorRT and OpenVINO dont support "axes" input in opset 13, re-enable after
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  };
+  run_test(false);
+  run_test(true);
 }
 
 }  // namespace test


### PR DESCRIPTION
**Description**: 
This adds two additional operators to the dnnl execution provider
- Squeeze
- Unsqueeze

**Motivation and Context**
- Why is this change required? What problem does it solve?
    - This expands the op coverage for the dnnl execution provider for OnnxRuntime
    - Expanding op coverage enables building larger subgraphs inside the dnnl ep resulting in less memory copies when running 
       models using the dnnl ep.

- If it fixes an open issue, please link to the issue here.
