### PR TITLE
Improve print functions for NodeArg, Node, and Graph

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1535,7 +1535,7 @@ std::ostream& operator<<(std::ostream& out, const Node& node);
 // Print Graph as, for example,
 // Inputs:
 //    "Input": tensor(float)
-// Nodes: (name, type, domain) : (inputs) -> (outputs)
+// Nodes:
 //    ("add0", Add, "", 7) : ("Input": tensor(float),"Bias": tensor(float),) -> ("add0_out": tensor(float),) 
 //    ("matmul", MatMul, "", 9) : ("add0_out": tensor(float),"matmul_weight": tensor(float),) -> ("matmul_out": tensor(float),) 
 //    ("add1", Add, "", 7) : ("matmul_out": tensor(float),"add_weight": tensor(float),) -> ("add1_out": tensor(float),) 

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1522,6 +1522,28 @@ class Graph {
 };
 
 #if !defined(ORT_MINIMAL_BUILD)
+// Print NodeArg as
+//  name : type
+// For example,
+//  "110": tensor(float)
+std::ostream& operator<<(std::ostream& out, const NodeArg& node_arg);
+// Print Node as,
+//  (operator's name, operator's type, domain, version) : (input0, input1, ...) -> (output0, output1, ...)
+// For example,
+//  ("Add_14", Add, "", 7) : ("110": tensor(float),"109": tensor(float),) -> ("111": tensor(float),) 
+std::ostream& operator<<(std::ostream& out, const Node& node);
+// Print Graph as, for example,
+// Inputs:
+//    "Input": tensor(float)
+// Nodes: (name, type, domain) : (inputs) -> (outputs)
+//    ("add0", Add, "", 7) : ("Input": tensor(float),"Bias": tensor(float),) -> ("add0_out": tensor(float),) 
+//    ("matmul", MatMul, "", 9) : ("add0_out": tensor(float),"matmul_weight": tensor(float),) -> ("matmul_out": tensor(float),) 
+//    ("add1", Add, "", 7) : ("matmul_out": tensor(float),"add_weight": tensor(float),) -> ("add1_out": tensor(float),) 
+//    ("reshape", Reshape, "", 5) : ("add1_out": tensor(float),"concat_out": tensor(int64),) -> ("Result": tensor(float),) 
+// Outputs:
+//    "Result": tensor(float)
+// Inputs' and outputs' format is described in document of NodeArg's operator<< above.
+// Node format is described in Node's operator<< above.
 std::ostream& operator<<(std::ostream& out, const Graph& graph);
 #endif
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2517,9 +2517,8 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
         }
         ORT_CATCH(const std::exception& ex) {
           ORT_HANDLE_EXCEPTION([&]() {
-            std::ostringstream err_msg;
-            err_msg << "This is an invalid model. In Node, " << node << ", Error ";
-            status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, err_msg.str(), ex.what());
+            status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH,
+                                     "This is an invalid model. In Node, ", node, ", Error ", ex.what());
           });
         }
         ORT_RETURN_IF_ERROR(status);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4174,7 +4174,7 @@ std::ostream& operator<<(std::ostream& out, const Graph& graph) {
   for (auto* x : graph.GetInputs()) {
     out << "   " << *x << "\n";
   }
-  out << "Nodes: (name, type, domain) : (inputs) -> (outputs)\n";
+  out << "Nodes:\n";
   for (auto& node : graph.Nodes()) {
     out << "   " << node << "\n";
   }

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4134,7 +4134,7 @@ std::ostream& operator<<(std::ostream& out, const NodeArg& node_arg) {
   out << "\"" << node_arg.Name() << "\"";
   if (node_arg.Type()) {
     out << ": " << *node_arg.Type();
-  } 
+  }
   return out;
 }
 
@@ -4153,7 +4153,11 @@ std::ostream& operator<<(std::ostream& out, const Node& node) {
     if (x->Exists()) {
       out << *x << ",";
     } else {
-      out << "" << ",";
+      // Print missing (or optional) inputs
+      // because operator schema uses positional
+      // arguments in ONNX.
+      out << "\"\""
+          << ",";
     }
   }
   out << ") -> (";
@@ -4161,7 +4165,11 @@ std::ostream& operator<<(std::ostream& out, const Node& node) {
     if (x->Exists()) {
       out << *x << ",";
     } else {
-      out << "" << ",";
+      // Print missing (or optional) outputs
+      // because operator schema uses positional
+      // arguments in ONNX.
+      out << "\"\""
+          << ",";
     }
   }
   out << ") ";
@@ -4171,7 +4179,12 @@ std::ostream& operator<<(std::ostream& out, const Node& node) {
 std::ostream& operator<<(std::ostream& out, const Graph& graph) {
   out << "Inputs:\n";
   for (const auto* x : graph.GetInputs()) {
-    out << "   " << *x << "\n";
+    // Unlike we print missing input and output for operator, we don't
+    // print missing input for graph because they are not helpful (we
+    // don't have a fixed schema for graph to match arguments).
+    if (x) {
+      out << "   " << *x << "\n";
+    }
   }
   out << "Nodes:\n";
   for (const auto& node : graph.Nodes()) {
@@ -4179,7 +4192,10 @@ std::ostream& operator<<(std::ostream& out, const Graph& graph) {
   }
   out << "Outputs:\n";
   for (const auto* x : graph.GetOutputs()) {
-    out << "   " << *x << "\n";
+    // Similar to graph input, missing graph output is not printed.
+    if (x) {
+      out << "   " << *x << "\n";
+    }
   }
   return out;
 }

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4140,17 +4140,17 @@ std::ostream& operator<<(std::ostream& out, const NodeArg& node_arg) {
 }
 
 std::ostream& operator<<(std::ostream& out, const Node& node) {
-  out << "(\"" << node.Name() << "\"";
-  out << ", ";
-  out << node.OpType();
-  out << ", ";
-  // Use quote so default ONNX domain is shown as ""
-  // rather than misleading empty string.
-  out << "\"" << node.Domain() << "\"";
-  out << ", ";
-  out << node.SinceVersion();
-  out << ") : (";
-  for (auto* x : node.InputDefs()) {
+  out << "(\"" << node.Name() << "\""
+      << ", "
+      << node.OpType()
+      << ", "
+      // Use quote so default ONNX domain is shown as ""
+      // rather than misleading empty string.
+      << "\"" << node.Domain() << "\""
+      << ", "
+      << node.SinceVersion()
+      << ") : (";
+  for (const auto* x : node.InputDefs()) {
     if (x->Exists()) {
       out << *x << ",";
     } else {
@@ -4158,7 +4158,7 @@ std::ostream& operator<<(std::ostream& out, const Node& node) {
     }
   }
   out << ") -> (";
-  for (auto* x : node.OutputDefs()) {
+  for (const auto* x : node.OutputDefs()) {
     if (x->Exists()) {
       out << *x << ",";
     } else {
@@ -4171,15 +4171,15 @@ std::ostream& operator<<(std::ostream& out, const Node& node) {
 
 std::ostream& operator<<(std::ostream& out, const Graph& graph) {
   out << "Inputs:\n";
-  for (auto* x : graph.GetInputs()) {
+  for (const auto* x : graph.GetInputs()) {
     out << "   " << *x << "\n";
   }
   out << "Nodes:\n";
-  for (auto& node : graph.Nodes()) {
+  for (const auto& node : graph.Nodes()) {
     out << "   " << node << "\n";
   }
   out << "Outputs:\n";
-  for (auto* x : graph.GetOutputs()) {
+  for (const auto* x : graph.GetOutputs()) {
     out << "   " << *x << "\n";
   }
   return out;


### PR DESCRIPTION
When investigating into #9784, I realized we don't have print functions for several fundamental classes, `NodeArg` and `Node`. To make my life easier, I did a small revise to existing print functions. Please see each revised function's header for its output format.
