### PR TITLE
Avoid segmentation fault when creating session with TRT EP or OpenVINO EP using python

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -607,11 +607,15 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 
       
     }
-    if (std::shared_ptr<IExecutionProviderFactory> tensorrt_provider_openvino = onnxruntime::CreateExecutionProviderFactory_OpenVINO(&params)) {
-        auto p = tensorrt_provider_openvino->CreateProvider();
-        // Reset global variables config to avoid it being accidentally passed on to the next session
-        openvino_device_type.clear();
-        return p;
+    if (std::shared_ptr<IExecutionProviderFactory> openvino_provider_factory = onnxruntime::CreateExecutionProviderFactory_OpenVINO(&params)) {
+      auto p = openvino_provider_factory->CreateProvider();
+      // Reset global variables config to avoid it being accidentally passed on to the next session
+      openvino_device_type.clear();
+      return p;
+    } else {
+      if (!Env::Default().GetEnvironmentVar("INTEL_OPENVINO_DIR").empty()) {
+        ORT_THROW("INTEL_OPENVINO_DIR is set but OpenVINO library wasn't able to be loaded. Please install the correct version of OpenVINO as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
+      }
     }
 #endif
   } else if (type == kNupharExecutionProvider) {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -607,10 +607,12 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 
       
     }
-    auto p = onnxruntime::CreateExecutionProviderFactory_OpenVINO(&params)->CreateProvider();
-    // Reset global variables config to avoid it being accidentally passed on to the next session
-    openvino_device_type.clear();
-    return p;
+    if (std::shared_ptr<IExecutionProviderFactory> tensorrt_provider_openvino = onnxruntime::CreateExecutionProviderFactory_OpenVINO(&params)) {
+        auto p = tensorrt_provider_openvino->CreateProvider();
+        // Reset global variables config to avoid it being accidentally passed on to the next session
+        openvino_device_type.clear();
+        return p;
+    }
 #endif
   } else if (type == kNupharExecutionProvider) {
 #if USE_NUPHAR

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -498,11 +498,11 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             }
           }
           if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(&params)) {
-            return tensorrt_provider_factor->CreateProvider();
+            return tensorrt_provider_factory->CreateProvider();
           }
         } else {
           if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(cuda_device_id)) {
-            return tensorrt_provider_factor->CreateProvider();
+            return tensorrt_provider_factory->CreateProvider();
           }
         }
     } else {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -497,11 +497,11 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
               ORT_THROW("Invalid TensorRT EP option: ", option.first);
             }
           }
-          if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(&params)) {
+          if (std::shared_ptr<IExecutionProviderFactory> tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(&params)) {
             return tensorrt_provider_factory->CreateProvider();
           }
         } else {
-          if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(cuda_device_id)) {
+          if (std::shared_ptr<IExecutionProviderFactory> tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(cuda_device_id)) {
             return tensorrt_provider_factory->CreateProvider();
           }
         }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -505,9 +505,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             return tensorrt_provider_factory->CreateProvider();
           }
         }
-    } else {
-      if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {
-        ORT_THROW("CUDA_PATH is set but CUDA wasn't able to be loaded. Please install the correct version of CUDA and cuDNN as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements) as well as TensorRT as mentioned in the TensorRT requirements page (https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
+        if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {
+          ORT_THROW("CUDA_PATH is set but CUDA wasn't able to be loaded. Please install the correct version of CUDA and cuDNN as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements) as well as TensorRT as mentioned in the TensorRT requirements page (https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
       }
     }
 #endif

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -497,9 +497,13 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
               ORT_THROW("Invalid TensorRT EP option: ", option.first);
             }
           }
-          return onnxruntime::CreateExecutionProviderFactory_Tensorrt(&params)->CreateProvider();
+          if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(&params)) {
+            return tensorrt_provider_factor->CreateProvider();
+          }
         } else {
-          return onnxruntime::CreateExecutionProviderFactory_Tensorrt(cuda_device_id)->CreateProvider();
+          if (auto* tensorrt_provider_factory = onnxruntime::CreateExecutionProviderFactory_Tensorrt(cuda_device_id)) {
+            return tensorrt_provider_factor->CreateProvider();
+          }
         }
     } else {
       if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -614,7 +614,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       return p;
     } else {
       if (!Env::Default().GetEnvironmentVar("INTEL_OPENVINO_DIR").empty()) {
-        ORT_THROW("INTEL_OPENVINO_DIR is set but OpenVINO library wasn't able to be loaded. Please install the correct version of OpenVINO as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
+        ORT_THROW("INTEL_OPENVINO_DIR is set but OpenVINO library wasn't able to be loaded. Please install a supported version of OpenVINO as mentioned in the requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), ensure dependency libraries are in the PATH and your hardware is supported.");
       } else {
         LOGS_DEFAULT(WARNING) << "Failed to register " << type << ". Please reference https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements to ensure all dependencies are met.";
       }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -505,7 +505,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             return tensorrt_provider_factory->CreateProvider();
           }
         }
-        LOGS_DEFAULT(WARNING) << "Failed to load TensorRT EP library and will skip TensorRT EP registration. TensorRT EP can only be registered when correct version of TensorRT is installed as mentioned in the TensorRT requirements page (https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
+        LOGS_DEFAULT(WARNING) << "Failed to register " << type << ". Please reference https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements to ensure all dependencies are met.";
     }
 #endif
   } else if (type == kMIGraphXExecutionProvider) {
@@ -530,7 +530,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
         if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {
           ORT_THROW("CUDA_PATH is set but CUDA wasn't able to be loaded. Please install the correct version of CUDA and cuDNN as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
         } else {
-          LOGS_DEFAULT(WARNING) << "Failed to load CUDA EP library and will skip CUDA EP registration. CUDA EP can only be registered when correct version of CUDA and cuDNN are installed as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
+          LOGS_DEFAULT(WARNING) << "Failed to register " << type << ". Please reference https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements to ensure all dependencies are met.";
         }
       }
     }
@@ -616,7 +616,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       if (!Env::Default().GetEnvironmentVar("INTEL_OPENVINO_DIR").empty()) {
         ORT_THROW("INTEL_OPENVINO_DIR is set but OpenVINO library wasn't able to be loaded. Please install the correct version of OpenVINO as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
       } else {
-        LOGS_DEFAULT(WARNING) << "Failed to load OpenVINO EP library and will skip OpenVINO EP registration. OpenVINO EP can only be registered when correct version of OpenVINO is installed as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
+        LOGS_DEFAULT(WARNING) << "Failed to register " << type << ". Please reference https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements to ensure all dependencies are met.";
       }
     }
 #endif

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -505,9 +505,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             return tensorrt_provider_factory->CreateProvider();
           }
         }
-        if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {
-          ORT_THROW("CUDA_PATH is set but CUDA wasn't able to be loaded. Please install the correct version of CUDA and cuDNN as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements) as well as TensorRT as mentioned in the TensorRT requirements page (https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
-      }
+        LOGS_DEFAULT(WARNING) << "Failed to load TensorRT EP library and will skip TensorRT EP registration. TensorRT EP can only be registered when correct version of TensorRT is installed as mentioned in the TensorRT requirements page (https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
     }
 #endif
   } else if (type == kMIGraphXExecutionProvider) {
@@ -531,6 +529,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       } else {
         if (!Env::Default().GetEnvironmentVar("CUDA_PATH").empty()) {
           ORT_THROW("CUDA_PATH is set but CUDA wasn't able to be loaded. Please install the correct version of CUDA and cuDNN as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
+        } else {
+          LOGS_DEFAULT(WARNING) << "Failed to load CUDA EP library and will skip CUDA EP registration. CUDA EP can only be registered when correct version of CUDA and cuDNN are installed as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
         }
       }
     }
@@ -615,6 +615,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
     } else {
       if (!Env::Default().GetEnvironmentVar("INTEL_OPENVINO_DIR").empty()) {
         ORT_THROW("INTEL_OPENVINO_DIR is set but OpenVINO library wasn't able to be loaded. Please install the correct version of OpenVINO as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.");
+      } else {
+        LOGS_DEFAULT(WARNING) << "Failed to load OpenVINO EP library and will skip OpenVINO EP registration. OpenVINO EP can only be registered when correct version of OpenVINO is installed as mentioned in the GPU requirements page (https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements), make sure they're in the PATH, and that your GPU is supported.";
       }
     }
 #endif


### PR DESCRIPTION
When creating ort session with TRT EP or OpenVINO EP in an environment where dependencies are not installed or not in the LD_LIBRARY_PATH, in some cases, it will cause segmentation fault due to not properly handle return value. 
issue is described in https://github.com/microsoft/onnxruntime/issues/9747

This PR fixes this issue as well as makes TRT EP follow the same pattern as CUDA EP. 
Which means when user explicitly sets TRT EP but having one of following situation:

> 1. ORT_TENSORRT_UNAVAILABLE is set to 1 by _ld_preload.py (in manylinux only)

> 2. ORT_TENSORRT_UNAVAILABLE/CUDA_PATH not being set and TRT libraries are not installed or not in the LD_LIBRARY_PATH

TRT EP will be skipped and fallback to other EPs.  

