### PR TITLE
add --amdgpu-target=gfx90a

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1101,6 +1101,9 @@ if (onnxruntime_USE_ROCM)
 
   # Generate GPU code for GFX9 Generation
   list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx906 --amdgpu-target=gfx908)
+  if (ROCM_VERSION_DEV_INT GREATER_EQUAL 50000)
+    list(APPEND HIP_CLANG_FLAGS --amdgpu-target=gfx90a)
+  endif()
 
   #onnxruntime_add_shared_library_module(onnxruntime_providers_rocm ${onnxruntime_providers_rocm_src})
   hip_add_library(onnxruntime_providers_rocm MODULE ${onnxruntime_providers_rocm_src})


### PR DESCRIPTION
Add support for amdgpu-target gfx90a in preparation for future ROCm release.