### PR TITLE
rocblas alt impl during backward pass only

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel_context.h
+++ b/include/onnxruntime/core/framework/op_kernel_context.h
@@ -196,6 +196,12 @@ class OpKernelContext {
     return true;
   }
 
+#ifdef ENABLE_TRAINING
+  bool GetIsBackward() const { return is_backward_; }
+
+  void SetIsBackward(bool value) { is_backward_ = value; }
+#endif
+
  protected:
   onnxruntime::NodeIndex GetNodeIndex() const;
 
@@ -228,6 +234,10 @@ class OpKernelContext {
   int node_input_start_index_{-1};
   int node_implicit_input_start_index_{-1};
   int node_output_start_index_{-1};
+
+#ifdef ENABLE_TRAINING
+  bool is_backward_;
+#endif
 };
 
 // Fetching output tensor without shape is not allowed except when it already exists

--- a/onnxruntime/core/framework/op_kernel.cc
+++ b/onnxruntime/core/framework/op_kernel.cc
@@ -34,6 +34,10 @@ OpKernelContext::OpKernelContext(_Inout_ IExecutionFrame* frame, _In_ const OpKe
   node_input_start_index_ = frame->GetNodeOffset(kernel->Node().Index());
   node_implicit_input_start_index_ = node_input_start_index_ + InputCount();
   node_output_start_index_ = node_implicit_input_start_index_ + ImplicitInputCount();
+
+#ifdef ENABLE_TRAINING
+  is_backward_ = false;
+#endif
 }
 
 Tensor* OpKernelContext::Output(int index, const TensorShape& shape) {

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -7,6 +7,10 @@
 #include "core/providers/rocm/rocm_execution_provider.h"
 #include "core/providers/rocm/rocm_fwd.h"
 
+#ifdef ENABLE_TRAINING
+#include "orttraining/core/framework/backward_guard.h"
+#endif
+
 namespace onnxruntime {
 namespace rocm {
 
@@ -22,6 +26,9 @@ class RocmKernel : public OpKernel {
   }
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
+#ifdef ENABLE_TRAINING
+    onnxruntime::training::BackwardPassGuard guard(p_op_kernel_context->GetIsBackward());
+#endif
     auto s = ComputeInternal(p_op_kernel_context);
     // use this to precisely locate the node where ROCM failure comes from
     //  if (hipSuccess != hipDeviceSynchronize())

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -683,6 +683,10 @@ struct ProviderHost {
   virtual bool OpKernelContext__GetUseDeterministicCompute(const OpKernelContext* p) = 0;
   virtual bool OpKernelContext__TryGetInferredOutputShape(const OpKernelContext* p, int index, TensorShape& shape) = 0;
   virtual bool OpKernelContext__TryGetInferredInputShape(const OpKernelContext* p, int index, TensorShape& shape) = 0;
+#ifdef ENABLE_TRAINING
+  virtual void OpKernelContext__SetIsBackward(OpKernelContext* p, bool value) = 0;
+  virtual bool OpKernelContext__GetIsBackward(const OpKernelContext* p) = 0;
+#endif
 
   // OpKernelInfo
   virtual std::unique_ptr<OpKernelInfo> CopyOpKernelInfo(const OpKernelInfo& info) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -729,6 +729,11 @@ struct OpKernelContext final {
   bool TryGetInferredOutputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredOutputShape(this, index, shape); }
   bool TryGetInferredInputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredInputShape(this, index, shape); }
 
+#ifdef ENABLE_TRAINING
+  void SetIsBackward(bool value) { g_host->OpKernelContext__SetIsBackward(this, value); }
+  bool GetIsBackward() const { return g_host->OpKernelContext__GetIsBackward(this); }
+#endif
+
   PROVIDER_DISALLOW_ALL(OpKernelContext)
 };
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -777,6 +777,10 @@ struct ProviderHostImpl : ProviderHost {
   bool OpKernelContext__GetUseDeterministicCompute(const OpKernelContext* p) override { return p->GetUseDeterministicCompute(); }
   bool OpKernelContext__TryGetInferredOutputShape(const OpKernelContext* p, int index, TensorShape& shape) override { return p->TryGetInferredOutputShape(index, shape); }
   bool OpKernelContext__TryGetInferredInputShape(const OpKernelContext* p, int index, TensorShape& shape) override { return p->TryGetInferredInputShape(index, shape); }
+#ifdef ENABLE_TRAINING
+  void OpKernelContext__SetIsBackward(OpKernelContext* p, bool value) override { p->SetIsBackward(value); }
+  bool OpKernelContext__GetIsBackward(const OpKernelContext* p) override { return p->GetIsBackward(); }
+#endif
 
   // OpKernelInfo (wrapped)
   std::unique_ptr<OpKernelInfo> CopyOpKernelInfo(const OpKernelInfo& info) override { return onnxruntime::CopyOpKernelInfo(info); }

--- a/orttraining/orttraining/core/framework/backward_guard.cc
+++ b/orttraining/orttraining/core/framework/backward_guard.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "orttraining/core/framework/backward_guard.h"
+
+namespace onnxruntime {
+namespace training {
+
+thread_local bool BackwardPassGuard::is_backward_pass_;
+
+BackwardPassGuard::BackwardPassGuard(bool value) {
+  is_backward_pass_ = value;
+}
+
+BackwardPassGuard::~BackwardPassGuard() {
+  is_backward_pass_ = false;
+}
+
+bool BackwardPassGuard::is_backward_pass() {
+  return is_backward_pass_;
+}
+
+}  // namespace training
+}  // namespace onnxruntime

--- a/orttraining/orttraining/core/framework/backward_guard.h
+++ b/orttraining/orttraining/core/framework/backward_guard.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+namespace onnxruntime {
+namespace training {
+
+struct BackwardPassGuard {
+  BackwardPassGuard(bool value = true);
+  ~BackwardPassGuard();
+  static bool is_backward_pass();
+private:
+  static thread_local bool is_backward_pass_;
+};
+
+}  // namespace training
+}  // namespace onnxruntime


### PR DESCRIPTION
In preparation of adopting future rocblas library options, it is necessary to track when the backward pass of training is executing.  For builds that enable training, the `is_backward_` attribute is added to the `OpKernelContext`.  In addition, the scope-based helper class `BackwardPassGuard` is provided to toggle state.