### PR TITLE
WinML RT API: Add PixelRange Metadata to Bind() call PropertySet

### DIFF
--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -123,6 +123,25 @@ static std::optional<wgi::BitmapBounds> GetBoundsFromMetadata(const wfc::IProper
   return {};
 }
 
+static std::optional<winml::LearningModelPixelRange> GetBitmapPixelRangeFromMetadata(const wfc::IPropertySet& properties) {
+  if (properties != nullptr && properties.HasKey(L"PixelRange")) {
+    if (auto pixelRangeInspectable = properties.Lookup(L"PixelRange")) {
+      auto pixelRangeValue = pixelRangeInspectable.as<wf::IPropertyValue>();
+      auto pixelRange = static_cast<winml::LearningModelPixelRange>(pixelRangeValue.GetInt32());
+      WINML_THROW_HR_IF_FALSE_MSG(
+          WINML_ERR_INVALID_BINDING,
+          pixelRange == winml::LearningModelPixelRange::ZeroTo255 ||
+              pixelRange == winml::LearningModelPixelRange::ZeroToOne ||
+              pixelRange == winml::LearningModelPixelRange::MinusOneToOne,
+          "LearningModelPixelRange must be either ZeroTo255, ZeroToOne, or MinusOneToOne");
+
+      return pixelRange;
+    }
+  }
+
+  return {};
+}
+
 wgi::BitmapBounds ImageFeatureValue::CenterAndCropBounds(
     uint32_t idx,
     uint32_t desiredWidth,
@@ -366,7 +385,6 @@ std::optional<ImageFeatureValue::ImageResourceMetadata> ImageFeatureValue::GetIn
   // TODO: Validate Bounds
 
   // Set up BitmapPixelFormat
-
   auto pixelFormat = std::optional<wgi::BitmapPixelFormat>{};
   pixelFormat = GetBitmapPixelFormatFromMetadata(context.properties);
   if (!pixelFormat.has_value() && spImageDescriptor) {
@@ -387,13 +405,18 @@ std::optional<ImageFeatureValue::ImageResourceMetadata> ImageFeatureValue::GetIn
   }
 
   // Set up LearningModelPixelRange
-  winml::LearningModelPixelRange pixelRange = winml::LearningModelPixelRange::ZeroTo255;  //default;
-  if (spImageDescriptor) {
+  auto pixelRange = std::optional<winml::LearningModelPixelRange>{};
+  pixelRange = GetBitmapPixelRangeFromMetadata(context.properties);
+  if (!pixelFormat.has_value() && spImageDescriptor) {
     pixelRange = spImageDescriptor->PixelRange();
+  } else if (!pixelFormat.has_value() && spTensorDescriptor) {
+    pixelRange = winml::LearningModelPixelRange::ZeroTo255;  //default;
+  } else {
+    THROW_HR(WINML_ERR_INVALID_BINDING);
   }
   
   //NCHW layout
-  auto imageTensorDescriptor = CreateImageTensorDescriptor(tensorKind, pixelFormat.value(), pixelRange, m_batchSize, descriptorWidth, descriptorHeight);
+  auto imageTensorDescriptor = CreateImageTensorDescriptor(tensorKind, pixelFormat.value(), pixelRange.value(), m_batchSize, descriptorWidth, descriptorHeight);
 
   return ImageResourceMetadata{bounds, imageTensorDescriptor};
 }

--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -407,9 +407,9 @@ std::optional<ImageFeatureValue::ImageResourceMetadata> ImageFeatureValue::GetIn
   // Set up LearningModelPixelRange
   auto pixelRange = std::optional<winml::LearningModelPixelRange>{};
   pixelRange = GetBitmapPixelRangeFromMetadata(context.properties);
-  if (!pixelFormat.has_value() && spImageDescriptor) {
+  if (!pixelRange.has_value() && spImageDescriptor) {
     pixelRange = spImageDescriptor->PixelRange();
-  } else if (!pixelFormat.has_value() && spTensorDescriptor) {
+  } else if (!pixelRange.has_value() && spTensorDescriptor) {
     pixelRange = winml::LearningModelPixelRange::ZeroTo255;  //default;
   } else {
     THROW_HR(WINML_ERR_INVALID_BINDING);

--- a/winml/lib/Api/ImageFeatureValue.cpp
+++ b/winml/lib/Api/ImageFeatureValue.cpp
@@ -407,7 +407,10 @@ std::optional<ImageFeatureValue::ImageResourceMetadata> ImageFeatureValue::GetIn
   // Set up LearningModelPixelRange
   auto pixelRange = std::optional<winml::LearningModelPixelRange>{};
   pixelRange = GetBitmapPixelRangeFromMetadata(context.properties);
-  if (!pixelRange.has_value() && spImageDescriptor) {
+  if (pixelRange.has_value()) {
+    // The pixel range was set by the bind properties, skip all checks and honor
+    // the user provided normalization property. Do nothing.
+  } else if (!pixelRange.has_value() && spImageDescriptor) {
     pixelRange = spImageDescriptor->PixelRange();
   } else if (!pixelRange.has_value() && spTensorDescriptor) {
     pixelRange = winml::LearningModelPixelRange::ZeroTo255;  //default;

--- a/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
+++ b/winml/test/scenario/cppwinrt/scenariotestscppwinrt.cpp
@@ -260,6 +260,14 @@ static void Scenario6BindWithProperties() {
     // insert it in the property set
     propertySet.Insert(L"BitmapPixelFormat", bitmapPixelFormatProperty);
 
+    // make a LearningModelPixelRange
+    LearningModelPixelRange pixelRange = LearningModelPixelRange::ZeroTo255;
+    // translate it to an int so it can be used as a PropertyValue;
+    int intFromLearningModelPixelRange = static_cast<int>(pixelRange);
+    auto pixelRangeProperty = wf::PropertyValue::CreateInt32(intFromLearningModelPixelRange);
+    // insert it in the property set
+    propertySet.Insert(L"PixelRange", pixelRangeProperty);
+
     // bind with properties
     WINML_EXPECT_NO_THROW(binding.Bind(input.Name(), imageValue, propertySet));
   }


### PR DESCRIPTION
Issue: The WinML RT API supports support setting model metadata to indicate normalization schemes and pixel formats for model inputs. The Bind() call supports setting or overriding input metadata properties like BitmapPixelFormat, and Bounds, but currently does not allow users to override the input normalization mode: LearningModelPixelRange.

The LearningModelPixelRange enum defines the normalization scheme, currently allows for direct image tensorization when the normalization scheme is specified manually on the model using the WinML Dashboard. Models without the metadata specified cannot take advantage of this automatic tensorization feature.

This change enables specifying the PixelRange metadata as a Bind property, so callers can still inform the WinML RT API of their needed normalization mode when models don't have the metadate specified in the onnx model file.
