### PR TITLE
Throw earlier when expanding function

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1147,6 +1147,13 @@ class Graph {
     return Resolve(default_options);
   }
 
+  /*
+  @returns the ONNX IR version (basically a integer) used in this graph.
+  */
+  Version IrVersion() const noexcept {
+    return ir_version_;
+  }
+
   common::Status SaveToOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                  flatbuffers::Offset<onnxruntime::fbs::Graph>& fbs_graph) const;
 
@@ -1250,10 +1257,6 @@ class Graph {
                 const ArgNameToTypeMap& name_to_type);
 
 #endif
-
-  Version IrVersion() const noexcept {
-    return ir_version_;
-  }
 
   Graph& GraphResolveNeeded(bool needed) noexcept {
     graph_resolve_needed_ = needed;


### PR DESCRIPTION
This PR proposes a strategy improve the exception mechanism when expanding ONNX's FunctionProto into sub-graph nodes in ORT. It took me a long while to figure out where do we get this error in #9784 since that error was not immediately thrown when seeing a wrong node. That error was thrown when checking the entire graph in the final `Resolve(...)` call after all sub-graph nodes are created.
