### PR TITLE
Improve error msg if Input of LayerNorm has no data

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
@@ -41,6 +41,14 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   Tensor* output = ctx->Output(0, input->Shape());
 
+  if (input->SizeInBytes() == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'input' has no data from upstream nodes");
+  }
+
+  if (skip->SizeInBytes() == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'skip' has no data from upstream nodes");
+  }
+
   const auto& input_dims = input->Shape().GetDims();
   if (input_dims.size() != 3) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -61,6 +61,12 @@ Status LayerNorm<T, U, simplified>::ComputeInternal(OpKernelContext* ctx) const 
   auto bias_data = (simplified || (nullptr == bias)) ? nullptr : reinterpret_cast<const CudaT*>(bias->template Data<T>());
 
   const TensorShape& x_shape = X->Shape();
+  // Sometimes due to conversion issue, the input 'X' has no data which is a case that cuda kernel cannot handle.
+  // Provide more error infomation here instead of CUDA errors.
+  if (X->SizeInBytes() == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'X' has no data from upstream nodes");
+  }
+
   const int64_t axis = HandleNegativeAxis(axis_, x_shape.NumDimensions());
 
   int n1 = gsl::narrow<int>(x_shape.SizeToDimension(axis));


### PR DESCRIPTION
**Description**: Describe your changes.
Previously, if input 'X' of LayerNorm has no data, we see CUDA error: cudaErrorInvalidConfiguration : invalid configuration argument. 
This change catches it earlier and provide better information for debugging. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
an internal model has this error, but seems the real issue is the graph logic
- If it fixes an open issue, please link to the issue here.
may shed some light for https://github.com/microsoft/onnxruntime/issues/9778
