### PR TITLE
bumping up ORT_API_VERSION to 10

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -30,7 +30,7 @@
 *
 * This value is used by some API functions to behave as this version of the header expects.
 */
-#define ORT_API_VERSION 9
+#define ORT_API_VERSION 10
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
**Description**: ORT_API_VERSION should be 10 for 1.10.0 release

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
