### PR TITLE
fix build break in release pipeline for Node.js binding test (#9850)

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
@@ -22,7 +22,7 @@ steps:
   displayName: 'Extract package file name (POSIX)'
   inputs:
     script: |
-      echo "##vso[task.setvariable variable=NpmPackageFilesForTest;]`ls $(Build.BinariesDirectory)/nodejs-artifact/*.tgz`"
+      echo "##vso[task.setvariable variable=NpmPackageFilesForTest;]`ls $(Build.BinariesDirectory)/nodejs-artifact/*.tgz | tr '\n' ' '`"
     workingDirectory: '$(Build.BinariesDirectory)/e2e_test'
 
 - script: |


### PR DESCRIPTION
**Description**: Cherry pick https://github.com/microsoft/onnxruntime/pull/9850 to release branch
(cherry picked from commit 6eb0c8d4202d265951f5c165f0d82fff3bf81413)

**Motivation and Context**
- Why is this change required? What problem does it solve?
Fix pipeline failures
- If it fixes an open issue, please link to the issue here.
