### PR TITLE
Various fixes to fix WindowsAI RI build.

### DIFF
--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -31,7 +31,7 @@ class TensorShape {
 
   TensorShape(gsl::span<const int64_t> dims);
   TensorShape(const std::vector<int64_t>& dims) : TensorShape(gsl::make_span(dims)) {}
-  TensorShape(const std::initializer_list<int64_t>& dims) : TensorShape(gsl::make_span(dims)) {}
+  TensorShape(const std::initializer_list<int64_t>& dims) : TensorShape(gsl::make_span(dims.begin(), dims.end())) {}
   TensorShape(const int64_t* dimension_sizes, size_t dimension_count) : TensorShape(gsl::span<const int64_t>(dimension_sizes, dimension_count)) {}
   TensorShape(const std::vector<int64_t>& dims, size_t start, size_t end) : TensorShape(gsl::span<const int64_t>(&dims[start], end - start)) {}
 
@@ -57,7 +57,7 @@ class TensorShape {
      Copy dims into an array with given size
   */
   void CopyDims(int64_t* dims, size_t num_dims) const {
-    memcpy(dims, reinterpret_cast<void*>(values_.begin()), sizeof(int64_t) * std::min(num_dims, NumDimensions()));
+    memcpy(dims, values_.data(), sizeof(int64_t) * std::min(num_dims, NumDimensions()));
   }
 
   /**
@@ -66,7 +66,7 @@ class TensorShape {
      and this function does no checks to ensure that
   */
   void CopyDims(int64_t* dims, size_t start_dim, size_t num_dims) const {
-    memcpy(dims, reinterpret_cast<void*>(values_.begin() + start_dim), sizeof(int64_t) * std::min(num_dims, NumDimensions() - start_dim));
+    memcpy(dims, values_.data() + start_dim, sizeof(int64_t) * std::min(num_dims, NumDimensions() - start_dim));
   }
 
   /**
@@ -128,7 +128,6 @@ class TensorShape {
   }
 
  private:
-
   struct External {};
   TensorShape(External, gsl::span<int64_t> buffer) : values_{buffer} {}
 
@@ -138,7 +137,7 @@ class TensorShape {
   int64_t small_buffer_[5];
   std::unique_ptr<int64_t[]> allocated_buffer_;
 
-  friend struct ProviderHostImpl; // So that the shared provider interface can access Allocate
+  friend struct ProviderHostImpl;  // So that the shared provider interface can access Allocate
 };
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -57,7 +57,7 @@ class TensorShape {
      Copy dims into an array with given size
   */
   void CopyDims(int64_t* dims, size_t num_dims) const {
-    memcpy(dims, values_.begin(), sizeof(int64_t) * std::min(num_dims, NumDimensions()));
+    memcpy(dims, reinterpret_cast<void*>(values_.begin()), sizeof(int64_t) * std::min(num_dims, NumDimensions()));
   }
 
   /**
@@ -66,7 +66,7 @@ class TensorShape {
      and this function does no checks to ensure that
   */
   void CopyDims(int64_t* dims, size_t start_dim, size_t num_dims) const {
-    memcpy(dims, values_.begin() + start_dim, sizeof(int64_t) * std::min(num_dims, NumDimensions() - start_dim));
+    memcpy(dims, reinterpret_cast<void*>(values_.begin() + start_dim), sizeof(int64_t) * std::min(num_dims, NumDimensions() - start_dim));
   }
 
   /**

--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -128,6 +128,7 @@ class TensorShape {
   }
 
  private:
+
   struct External {};
   TensorShape(External, gsl::span<int64_t> buffer) : values_{buffer} {}
 
@@ -137,7 +138,7 @@ class TensorShape {
   int64_t small_buffer_[5];
   std::unique_ptr<int64_t[]> allocated_buffer_;
 
-  friend struct ProviderHostImpl;  // So that the shared provider interface can access Allocate
+  friend struct ProviderHostImpl; // So that the shared provider interface can access Allocate
 };
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1507,7 +1507,7 @@ std::vector<IMLOperatorTensor*> OpKernelContextWrapper::GetOutputTensors(const E
   std::vector<IMLOperatorTensor*> ret;
   ret.reserve(m_outputTensors.size());
 
-  ORT_THROW_HR_IF(E_INVALIDARG, m_impl->OutputCount() != outputShapes.EdgeCount());
+  ORT_THROW_HR_IF(E_INVALIDARG, static_cast<size_t>(m_impl->OutputCount()) != outputShapes.EdgeCount());
 
   for (int i = 0; i < m_impl->OutputCount(); ++i) {
     ComPtr<IMLOperatorTensor> tensor;
@@ -1847,7 +1847,7 @@ void InferAndVerifyOutputSizes(
 
     if (tensorType.has_shape()) {
       const auto& shape = tensorType.shape();
-      ML_CHECK_BOOL(shape.dim_size() == outputShapes.GetShape(outputIndex).size());
+      ML_CHECK_BOOL(static_cast<size_t>(shape.dim_size()) == outputShapes.GetShape(outputIndex).size());
 
       for (uint32_t output_dim = 0; output_dim < outputShapes.GetShape(outputIndex).size(); ++output_dim) {
         if (shape.dim(output_dim).has_dim_value()) {

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1335,7 +1335,7 @@ namespace OperatorHelper
             auto inputShape = shapeInfo.GetInputTensorShape(i);
             for (size_t j = 0; j < outputShape.size(); ++j)
             {
-                if (m_axis == j)
+                if (static_cast<size_t>(m_axis) == j)
                 {
                     outputShape[j] += inputShape[j];
                 }

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -210,8 +210,9 @@ static constexpr OrtDmlApi ort_dml_api_10_to_x = {
 };
 
 const OrtDmlApi* GetOrtDmlApi(_In_ uint32_t /*version*/) NO_EXCEPTION {
-#ifdef USE_DML
+#ifdef USE_DML // USE_DML
   return &ort_dml_api_10_to_x;
-#endif  // USE_DML
-  return nullptr;
+#else
+    return nullptr;
+#endif
 }

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -210,7 +210,7 @@ static constexpr OrtDmlApi ort_dml_api_10_to_x = {
 };
 
 const OrtDmlApi* GetOrtDmlApi(_In_ uint32_t /*version*/) NO_EXCEPTION {
-#ifdef USE_DML // USE_DML
+#ifdef USE_DML
   return &ort_dml_api_10_to_x;
 #else
     return nullptr;


### PR DESCRIPTION
WindowsAI build uses different GSL headers and this change fixes the build errors.

Also if USE_DML is defined, then there is unreachable code. This change fixes that.

Also there are various type mismatch in comparisons