### PR TITLE
Add CI minimal build with all options disabled. Fix python binding code if sparse tensors are disabled.

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state_common.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.cc
@@ -80,6 +80,7 @@ OrtValue FromDlpack(PyObject* dlpack_tensor, const bool is_bool_tensor) {
 
 #endif
 
+#if !defined(DISABLE_SPARSE_TENSORS)
 std::unique_ptr<OrtValue> PySparseTensor::AsOrtValue() const {
   if (instance_) {
     auto ort_value = std::make_unique<OrtValue>();
@@ -108,6 +109,7 @@ PySparseTensor::~PySparseTensor() {
     }
   }
 }
+#endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 }  // namespace python
 }  // namespace onnxruntime

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -202,7 +202,7 @@ extern onnxruntime::ArenaExtendStrategy arena_extend_strategy;
 #include "core/providers/shared_library/provider_host_api.h"
 
 namespace onnxruntime {
-#ifndef SHARED_PROVIDER
+#if !defined(SHARED_PROVIDER) && !defined(DISABLE_SPARSE_TENSORS)
 class SparseTensor;
 #endif
 namespace python {
@@ -307,6 +307,7 @@ inline AllocatorPtr& GetAllocator() {
   return alloc;
 }
 
+#if !defined(DISABLE_SPARSE_TENSORS)
 // This class exposes SparseTensor to Python
 // The class serves two major purposes
 // - to be able to map numpy arrays memory and use it on input, this serves as a reference holder
@@ -387,6 +388,7 @@ class PySparseTensor {
   // We create a copy of OrtValue when we obtain it from a run method.
   OrtValue ort_value_;
 };
+#endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 class SessionObjectInitializer {
  public:

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -254,8 +254,13 @@ jobs:
     displayName: Discard local changes to Git repository files
     workingDirectory: $(Build.SourcesDirectory)
 
-  - script: echo -n > /home/onnxruntimedev/.test_data/include_no_operators.config
+  - task: CmdLine@2
     displayName: Create empty config for build with no operators
+    inputs:
+      script: |
+        docker run --rm \
+          onnxruntimecpubuild \
+            echo -n > /home/onnxruntimedev/.test_data/include_no_operators.config
 
   - task: CmdLine@2
     displayName: 7a. Regular build with python and all optional features disabled. 

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -254,6 +254,9 @@ jobs:
     displayName: Discard local changes to Git repository files
     workingDirectory: $(Build.SourcesDirectory)
 
+  - script: echo -n > /home/onnxruntimedev/.test_data/include_no_operators.config
+    displayName: Create empty config for build with no operators
+
   - task: CmdLine@2
     displayName: 7a. Regular build with python and all optional features disabled. 
     inputs:

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -40,6 +40,8 @@ jobs:
       script: |
         # Create a folder for all test data
         mkdir -p $(test_data_directory)
+        # create empty config used in some parts
+        touch $(test_data_directory)/include_no_operators.config
       workingDirectory: $(Build.SourcesDirectory)
 
   - template: templates/get-docker-image-steps.yml
@@ -255,20 +257,13 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
-    displayName: Create empty config for build with no operators
-    inputs:
-      script: |
-        docker run --rm \
-          onnxruntimecpubuild \
-            echo -n > /home/onnxruntimedev/.test_data/include_no_operators.config
-
-  - task: CmdLine@2
     displayName: 7a. Regular build with python and all optional features disabled. 
     inputs:
       script: |
         docker run --rm \
           --volume $(Build.SourcesDirectory):/onnxruntime_src \
           --volume $(Build.BinariesDirectory):/build \
+          --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
@@ -297,6 +292,7 @@ jobs:
         docker run --rm \
           --volume $(Build.SourcesDirectory):/onnxruntime_src \
           --volume $(Build.BinariesDirectory):/build \
+          --volume $(test_data_directory):/home/onnxruntimedev/.test_data \
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -14,6 +14,11 @@
 # 5. Build baseline minimal ORT for Android arm64-v8a including no kernels and disable exceptions.
 #    This step is to report the baseline binary size for Android.
 # 6. Build full (6a) and extended minimal (6b) ORT with runtime optimizations enabled.
+# 7. Build with all optional features disabled and no kernels.
+#    7a: regular build with python enabled checks that the exclusions don't break code paths in a full build.
+#    7b: minimal build with exceptions and python disabled checks that the exclusions don't break code paths in a 
+#        minimal build.
+
 jobs:
 - job: Linux_CPU_Minimal_Build_E2E
   timeoutInMinutes: 120
@@ -243,6 +248,68 @@ jobs:
               --parallel \
               --minimal_build extended \
               --cmake_extra_defines onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=ON
+      workingDirectory: $(Build.SourcesDirectory)
+
+  - script: git checkout -- .
+    displayName: Discard local changes to Git repository files
+    workingDirectory: $(Build.SourcesDirectory)
+
+  - task: CmdLine@2
+    displayName: 7a. Regular build with python and all optional features disabled. 
+    inputs:
+      script: |
+        docker run --rm \
+          --volume $(Build.SourcesDirectory):/onnxruntime_src \
+          --volume $(Build.BinariesDirectory):/build \
+          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+          -e NIGHTLY_BUILD \
+          -e BUILD_BUILDNUMBER \
+          onnxruntimecpubuild \
+            /opt/python/cp37-cp37m/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
+              --build_dir /build/7a \
+              --cmake_generator Ninja \
+              --config MinSizeRel \
+              --skip_submodule_sync \
+              --build_shared_lib \
+              --build_wheel \
+              --parallel \
+              --skip_tests \
+              --disable_ml_ops \
+              --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
+              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
+                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
+                                    onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=OFF \
+                                    onnxruntime_BUILD_UNIT_TESTS=OFF 
+      workingDirectory: $(Build.SourcesDirectory)
+
+  - task: CmdLine@2
+    displayName: 7b. Minimal build with all optional features disabled. 
+    inputs:
+      script: |
+        docker run --rm \
+          --volume $(Build.SourcesDirectory):/onnxruntime_src \
+          --volume $(Build.BinariesDirectory):/build \
+          -e ALLOW_RELEASED_ONNX_OPSET_ONLY=1 \
+          -e NIGHTLY_BUILD \
+          -e BUILD_BUILDNUMBER \
+          onnxruntimecpubuild \
+            /opt/python/cp37-cp37m/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
+              --build_dir /build/7b \
+              --cmake_generator Ninja \
+              --config MinSizeRel \
+              --skip_submodule_sync \
+              --build_shared_lib \
+              --parallel \
+              --minimal_build \
+              --disable_exceptions \
+              --disable_ml_ops \
+              --skip_tests \
+              --enable_reduced_operator_type_support \
+              --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
+              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
+                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
+                                    onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=OFF \
+                                    onnxruntime_BUILD_UNIT_TESTS=OFF 
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: PublishTestResults@2


### PR DESCRIPTION
**Description**: 
Add CI builds that check the code compiles with all the optional features disabled.

Those are:
```
              --disable_exceptions \
              --disable_ml_ops \
              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
                                    onnxruntime_ENABLE_ORT_FORMAT_RUNTIME_GRAPH_OPTIMIZATION=OFF \
                                    onnxruntime_BUILD_UNIT_TESTS=OFF 
```

Fix the python binding code when DISABLE_SPARSE_TENSORS is defined. 

**Motivation and Context**
Validate options used by 1P partners compile cleanly.