### PR TITLE
add s8s8 support for quantized conv and gemm

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -43,6 +43,7 @@ function(setup_mlas_source_for_windows)
       target_sources(onnxruntime_mlas PRIVATE
         ${MLAS_SRC_DIR}/qgemm_kernel_neon.cpp
         ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
+        ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp
       )
 
       set(mlas_platform_preprocess_srcs
@@ -51,6 +52,7 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/arm64/QgemmU8X8KernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/QgemmS8S8KernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/QgemmU8X8KernelUdot.asm
+        ${MLAS_SRC_DIR}/arm64/QgemmS8S8KernelSdot.asm
         ${MLAS_SRC_DIR}/arm64/SgemmKernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/SgemvKernelNeon.asm
       )
@@ -271,10 +273,12 @@ else()
           ${MLAS_SRC_DIR}/aarch64/QgemmU8X8KernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/QgemmU8X8KernelUdot.S
+          ${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSdot.S
           ${MLAS_SRC_DIR}/aarch64/SgemmKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SgemvKernelNeon.S
           ${MLAS_SRC_DIR}/qgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
+          ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp
         )
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)
             onnxruntime_add_static_library(onnxruntime_mlas_arm64 ${mlas_platform_srcs})

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -80,8 +80,6 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 #if defined(MLAS_TARGET_ARM_ANY)
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t_int8_t, QLinearConv);
 #endif
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_int8_t, QLinearConv);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_uint8_t, QLinearConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QEmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, QGemm);
 // ******** End: Quantization ******************* //

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -71,6 +71,10 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv);
+#if defined(MLAS_TARGET_ARM_ANY)
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t_int8_t, QLinearConv);
+#endif
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, NhwcMaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, NhwcMaxPool);
 #if defined(MLAS_TARGET_ARM_ANY)
@@ -164,11 +168,10 @@ Status RegisterQuantizationKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv)>,
 #if defined(MLAS_TARGET_ARM_ANY)
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t_int8_t, QLinearConv)>,
 #endif
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_int8_t, QLinearConv)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_uint8_t, QLinearConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, NhwcMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, NhwcMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QEmbedLayerNormalization)>,

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -21,7 +21,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Range);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, WordConvEmbedding);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, GatherND);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, TransposeMatMul); // backward compatibility
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, TransposeMatMul);  // backward compatibility
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FusedMatMul);
 #if !defined(DISABLE_SPARSE_TENSORS)
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, SparseToDenseMatMul);
@@ -71,9 +71,13 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, NhwcMaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, NhwcMaxPool);
+#if defined(MLAS_TARGET_ARM_ANY)
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t_int8_t, QLinearConv);
+#endif
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_int8_t, QLinearConv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_uint8_t, QLinearConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QEmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, QGemm);
 // ******** End: Quantization ******************* //
@@ -160,7 +164,11 @@ Status RegisterQuantizationKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, MatMulIntegerToFloat)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, DynamicQuantizeLSTM)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, QLinearConv)>,
+#if defined(MLAS_TARGET_ARM_ANY)
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t_int8_t, QLinearConv)>,
+#endif
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_int8_t, QLinearConv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t_uint8_t, QLinearConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, int8_t, NhwcMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, uint8_t, NhwcMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, QEmbedLayerNormalization)>,
@@ -198,7 +206,7 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, SparseToDenseMatMul)>,
       #endif
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MurmurHash3)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, TransposeMatMul)>, // backward compatibility
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, TransposeMatMul)>,  // backward compatibility
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, FusedMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, MaxpoolWithMask)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, Pad)>,

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -53,7 +53,7 @@ Status DynamicQuantizeLSTM::TryPackWeights(const Tensor& weights, PackedWeights&
   }
 
   is_weight_signed = weights.IsDataType<int8_t>();
-  const size_t packed_weights_size = MlasGemmPackBSize(N, K, is_weight_signed);
+  const size_t packed_weights_size = MlasGemmPackBSize(N, K, false /*AIsSigned*/, is_weight_signed);
   if (packed_weights_size == 0) {
     return Status::OK();
   }
@@ -73,7 +73,7 @@ Status DynamicQuantizeLSTM::TryPackWeights(const Tensor& weights, PackedWeights&
 
   const auto* weights_data = static_cast<const uint8_t*>(weights.DataRaw());
   for (int i = 0; i < num_directions_; i++) {
-    MlasGemmPackB(N, K, weights_data, N, is_weight_signed, packed_weights_data);
+    MlasGemmPackB(N, K, weights_data, N, false /*AIsSigned*/, is_weight_signed, packed_weights_data);
     packed_weights_data = static_cast<uint8_t*>(packed_weights_data) + packed_weights_size;
     weights_data += N * K;
   }

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -113,7 +113,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
   }
 
   // batch gemm
-  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
   gemm_shape.M = static_cast<size_t>(helper.M());
   gemm_shape.N = static_cast<size_t>(helper.N());
   gemm_shape.K = static_cast<size_t>(helper.K());
@@ -122,7 +122,7 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
   const size_t num_gemms = helper.OutputOffsets().size();
   std::vector<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR> gemm_scale_procs;
   gemm_scale_procs.reserve(num_gemms);
-  std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_data_vec(num_gemms);
+  std::vector<MLAS_GEMM_QUANT_DATA_PARAMS> gemm_data_vec(num_gemms);
 
   for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
     gemm_scale_procs.emplace_back(y_data + helper.OutputOffsets()[gemm_idx],

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -53,6 +53,10 @@ Abstract:
 #if defined(_M_ARM) || defined(__arm__)
 #define MLAS_TARGET_ARM
 #endif
+#if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC) || defined(MLAS_TARGET_ARM)
+#define MLAS_TARGET_ARM_ANY
+#endif
+
 #if defined(__VSX__)
 #define MLAS_TARGET_POWER
 #endif
@@ -528,15 +532,23 @@ private:
     MLAS_QUANTIZATION_GRANULARITY QuantGran_;
 };
 
-struct MLAS_GEMM_U8X8_SHAPE_PARAMS {
-    size_t M = 0;
-    size_t N = 0;
-    size_t K = 0;
-    bool BIsSigned = false;
-    bool IsAccumulateMode = false;
+/**
+ * @brief Supply matrices shape and data type information to quantized gemm functions
+ *
+ ** NOTE: AIsSigned == true is not supported on non-ARM devices for now. 
+ **       AIsSigned == true is supported on ARM devices when BIsSigned is also true.
+ *
+*/
+struct MLAS_GEMM_QUANT_SHAPE_PARAMS {
+    size_t M = 0;                  /**< Supplies the row size of matrix A */
+    size_t N = 0;                  /**< Supplies the column size of matrix B */
+    size_t K = 0;                  /**< Supplies the column size of matrix A and row size of matrix B */
+    bool AIsSigned = false;        /**< Indicates whether type of A is int8_t or uint8_t.*/
+    bool BIsSigned = false;        /**< Indicates whether type of B is int8_t or uint8_t */
+    bool IsAccumulateMode = false; /**< Indicates whether to accumulate to matrix C or override matrix C */
 };
 
-struct MLAS_GEMM_U8X8_DATA_PARAMS {
+struct MLAS_GEMM_QUANT_DATA_PARAMS {
     const uint8_t* A = nullptr;
     size_t lda = 0;
     uint8_t ZeroPointA = 0;
@@ -553,8 +565,8 @@ struct MLAS_GEMM_U8X8_DATA_PARAMS {
 void
 MLASCALL
 MlasGemm(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS& DataParams,
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS& DataParams,
     MLAS_THREADPOOL* ThreadPool
     );
 
@@ -572,8 +584,8 @@ MlasGemm(
 void
 MLASCALL
 MlasGemmBatch(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* DataParams,
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
     const size_t BatchN,
     MLAS_THREADPOOL* ThreadPool
     );
@@ -605,6 +617,7 @@ MLASCALL
 MlasGemmPackBSize(
     size_t N,
     size_t K,
+    bool AIsSigned,
     bool BIsSigned
     );
 
@@ -615,6 +628,7 @@ MlasGemmPackB(
     size_t K,
     const uint8_t* B,
     size_t ldb,
+    bool AIsSigned,
     bool BIsSigned,
     void* PackedB
     );
@@ -696,9 +710,10 @@ MlasConv(
 void
 MLASCALL
 MlasConvDepthwise(
-    const uint8_t* const* Input,
+    const void* const* Input,
     uint8_t InputZeroPoint,
-    const uint8_t* Filter,
+    bool InputIsSigned,
+    const void* Filter,
     uint8_t FilterZeroPoint,
     bool FilterIsSigned,
     int32_t* Output,
@@ -716,7 +731,8 @@ MlasConvSymPackWSize(
     size_t GroupCount,
     size_t InputChannels,
     size_t OutputChannels,
-    size_t KernelSize
+    size_t KernelSize,
+    bool InputIsSigned
     );
 
 void
@@ -727,19 +743,21 @@ MlasConvSymPackW(
     size_t KernelSize,
     const int8_t* W,
     int8_t* PackedW,
-    size_t PackedWSize
+    size_t PackedWSize,
+    bool InputIsSigned
     );
 
 int32_t
 MlasConvSymFixupInputZeroPoint(
-    uint8_t zero_point_value
+    int32_t zero_point_value,
+    bool InputIsSigned
     );
 
 struct MLAS_CONV_SYM_PARAMS {
-    const uint8_t* InputDirect;
-    const uint8_t* const* InputIndirection;
+    const void* InputDirect;
+    const void* const* InputIndirection;
     const void* Filter;
-    uint8_t* Output;
+    void* Output;
     size_t InputChannels;
     size_t OutputChannels;
     size_t OutputCount;
@@ -747,7 +765,8 @@ struct MLAS_CONV_SYM_PARAMS {
     const int32_t* Bias;
     const float* Scale;
     bool PerChannelScale;
-    uint8_t OutputZeroPoint;
+    int32_t OutputZeroPoint;
+    bool InputIsSigned;
 };
 
 void
@@ -866,6 +885,15 @@ MLASCALL
 MlasTranspose(
     const uint8_t* Input,
     uint8_t* Output,
+    size_t M,
+    size_t N
+    );
+
+void
+MLASCALL
+MlasTranspose(
+    const int8_t* Input,
+    int8_t* Output,
     size_t M,
     size_t N
     );
@@ -1064,18 +1092,20 @@ class MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR : public MLAS_QGEMM_OUTPUT_PROCESSOR
 {
    public:
     MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR(
-        uint8_t* Output,
+        void* Output,
         size_t OutputLeadingDimension,
         const int32_t* Bias,
         const float* Scale,
         bool PerColumnScale,
-        uint8_t ZeroPoint)
+        int32_t ZeroPoint,
+        bool OutputIsSigned)
         : Output_(Output),
           OutputLeadingDimension_(OutputLeadingDimension),
           Bias_(Bias),
           Scale_(Scale),
           PerColumnScale_(PerColumnScale),
-          ZeroPoint_(ZeroPoint)
+          ZeroPoint_(ZeroPoint),
+          OutputIsSigned_(OutputIsSigned)
     {
     }
 
@@ -1086,18 +1116,26 @@ class MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR : public MLAS_QGEMM_OUTPUT_PROCESSOR
                  size_t CountN,
                  size_t ldc) const override
     {
-        MlasRequantizeOutput(C, ldc, Output_, OutputLeadingDimension_, Bias_, Scale_,
-                             PerColumnScale_, ZeroPoint_, StartM, StartN, CountM, CountN);
+        if(OutputIsSigned_){
+            MlasRequantizeOutput(C, ldc, reinterpret_cast<int8_t*>(Output_), OutputLeadingDimension_,
+                                 Bias_, Scale_, PerColumnScale_, static_cast<int8_t>(ZeroPoint_),
+                                 StartM, StartN, CountM, CountN);
+        } else {
+            MlasRequantizeOutput(C, ldc, reinterpret_cast<uint8_t*>(Output_), OutputLeadingDimension_,
+                                 Bias_, Scale_, PerColumnScale_, static_cast<uint8_t>(ZeroPoint_),
+                                 StartM, StartN, CountM, CountN);
+        }
     }
 
 
    private:
-    uint8_t* Output_;
+    void* Output_;
     size_t OutputLeadingDimension_;
     const int32_t* Bias_;
     const float* Scale_;
     bool PerColumnScale_;
-    uint8_t ZeroPoint_;
+    int32_t ZeroPoint_;
+    bool OutputIsSigned_;
 };
 
 

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -711,10 +711,10 @@ void
 MLASCALL
 MlasConvDepthwise(
     const void* const* Input,
-    uint8_t InputZeroPoint,
+    int32_t InputZeroPoint,
     bool InputIsSigned,
     const void* Filter,
-    uint8_t FilterZeroPoint,
+    int32_t FilterZeroPoint,
     bool FilterIsSigned,
     int32_t* Output,
     size_t Channels,

--- a/onnxruntime/core/mlas/lib/aarch32/QgemmU8X8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch32/QgemmU8X8KernelNeon.S
@@ -48,10 +48,10 @@ Routine Description:
 Arguments:
 
     A (r0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>.
 
     B (r1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>.
 
     C (r2) - Supplies the address of matrix C.
 

--- a/onnxruntime/core/mlas/lib/aarch64/AssembleDotProduct.h
+++ b/onnxruntime/core/mlas/lib/aarch64/AssembleDotProduct.h
@@ -22,6 +22,39 @@ Abstract:
 
 Macro Description:
 
+    This macro builds a SDOT instruction of the form:
+
+        SDOT DestReg.4s, Src1Reg.16b, Src2Reg.4b[Index]
+
+Arguments:
+
+    DestReg - Specifies the destination register.
+
+    Src1Reg - Specifies the first source register.
+
+    Src2Reg - Specifies the second source register.
+
+    Index - Specifies the element index of the second source register.
+
+--*/
+
+        .macro  SdotByElement DestReg, Src1Reg, Src2Reg, Index
+
+        .set    Instruction, 0x4F80E000
+        .set    Instruction, Instruction + (\DestReg\() << 0)
+        .set    Instruction, Instruction + (\Src1Reg\() << 5)
+        .set    Instruction, Instruction + (\Src2Reg\() << 16)
+        .set    Instruction, Instruction + ((\Index\() & 2) << 10)
+        .set    Instruction, Instruction + ((\Index\() & 1) << 21)
+
+        .inst   Instruction
+
+        .endm
+
+/*++
+
+Macro Description:
+
     This macro builds a UDOT instruction of the form:
 
         UDOT DestReg.4s, Src1Reg.16b, Src2Reg.4b[Index]

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelNeon.S
@@ -39,10 +39,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_X8S8_KERNEL_NEON>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>.
 
     C (x2) - Supplies the address of matrix C.
 

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelSdot.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmS8S8KernelSdot.S
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 
 Module Name:
 
-    QgemmU8X8KernelUdot.asm
+    QgemmS8S8KernelSdot.S
 
 Abstract:
 
@@ -17,22 +17,22 @@ Abstract:
 
 --*/
 
-#include "kxarm64.h"
+#include "asmmacro.h"
 #include "AssembleDotProduct.h"
 
 //
-// Stack frame layout for the U8X8 kernel.
+// Stack frame layout for the S8S8 kernel.
 // Defining spaces for saving 2 vector registers, and pointers to parameters
 // on the stack
 //
 
-#define GemmU8X8KernelFrame_SavedNeonRegisters       (2 * 8)
-#define GemmU8X8KernelFrame_SavedRegisters           GemmU8X8KernelFrame_SavedNeonRegisters
-#define GemmU8X8KernelFrame_ColumnSumBuffer          (0 + GemmU8X8KernelFrame_SavedRegisters)
-#define GemmU8X8KernelFrame_ZeroPointB               (8 + GemmU8X8KernelFrame_SavedRegisters)
-#define GemmU8X8KernelFrame_ZeroMode                 (16 + GemmU8X8KernelFrame_SavedRegisters)
+        .equ    .LGemmS8S8KernelFrame_SavedNeonRegisters, (2 * 8)
+        .equ    .LGemmS8S8KernelFrame_SavedRegisters, .LGemmS8S8KernelFrame_SavedNeonRegisters
+        .equ    .LGemmS8S8KernelFrame_ColumnSumBuffer, 0 + .LGemmS8S8KernelFrame_SavedRegisters
+        .equ    .LGemmS8S8KernelFrame_ZeroPointB, 8 + .LGemmS8S8KernelFrame_SavedRegisters
+        .equ    .LGemmS8S8KernelFrame_ZeroMode, 16 + .LGemmS8S8KernelFrame_SavedRegisters
 
-        TEXTAREA
+        .text
 
 /*++
 
@@ -44,10 +44,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SDOT>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>.
 
     C (x2) - Supplies the address of matrix C.
 
@@ -85,34 +85,34 @@ Return Value:
 
 --*/
 
-        NESTED_ENTRY MlasGemmU8X8KernelUdot
+        FUNCTION_ENTRY MlasGemmS8S8KernelSDot
 
-        PROLOG_SAVE_REG_PAIR d8,d9,#-16!
-        ldr     x8,[sp,#GemmU8X8KernelFrame_ColumnSumBuffer]
-        ldr     x9,[sp,#GemmU8X8KernelFrame_ZeroPointB]
-        ldrb    w13,[sp,#GemmU8X8KernelFrame_ZeroMode]
+        stp     d8,d9,[sp,#-16]!
+        ldr     x8,[sp,#.LGemmS8S8KernelFrame_ColumnSumBuffer]
+        ldr     x9,[sp,#.LGemmS8S8KernelFrame_ZeroPointB]
+        ldrb    w13,[sp,#.LGemmS8S8KernelFrame_ZeroMode]
         mov     x14,x0
-        ld1     {v8.4s},[x7],#16            // load row sum 0 ~ 4
+        ld1     {v8.4s},[x7],#16            // load row sum 1 ~ 4
         mov     x15,x3
         cmp     x4,#1                       // CountM == 1?
-        beq     ProcessLoopM1
+        beq     .LGemmS8S8.M1.ProcessLoop
         cmp     x4,#4                       // CountM < 4?
-        blo     ProcessLoopM2
+        blo     .LGemmS8S8.M2.ProcessLoop
         cmp     x4,#8                       // CountM < 8?
-        blo     ProcessNextColumnLoopM4
+        blo     .LGemmS8S8.M4.ProcessNextColumnLoop
         ld1     {v9.4s},[x7]                // load row sum 5 ~ 8
 
 //
 // Process 8 rows of the matrices.
-// Row Sums: v8 ~ v9  
-//                                      A  4x8 block
-//                           /-----------------------------------------|
+// Row Sums: v8 ~ v9 
+//                                          B 4x8 block
+//                            -----------------------------------------
 //                           |v0.b[0] ... v0.b[12] v1.b[0] ... v1.b[12]|
 //                           |  ...                              ...   |
 //                           |v0.b[3] ... v0.b[15] v1.b[3] ... v1.b[15]|
-//                           \-----------------------------------------/
-//    B 8x4 block
-//  /---------------------\  /-----------------------------------------|
+//                            -----------------------------------------
+//       A 8x4 block
+//   ---------------------    -----------------------------------------
 //  |v4.b[0]  ... v4.b[3] |  |v16.s[0] .. v16.s[3] v17.s[0] .. v17.s[3]|
 //  |v4.b[4]  ... v4.b[7] |  |v18.s[0] .. v18.s[3] v19.s[0] .. v19.s[3]|
 //  |v4.b[8]  ... v4.b[11]|  |v20.s[0] .. v20.s[3] v21.s[0] .. v21.s[3]|
@@ -121,15 +121,15 @@ Return Value:
 //  |v5.b[4]  ... v5.b[7] |  |v26.s[0] .. v26.s[3] v27.s[0] .. v27.s[3]|
 //  |v5.b[8]  ... v5.b[11]|  |v28.s[0] .. v28.s[3] v29.s[0] .. v29.s[3]|
 //  |v5.b[12] ... v5.b[15]|  |v30.s[0] .. v30.s[3] v31.s[0] .. v31.s[3]|
-//  \---------------------/  \-----------------------------------------/
+//   ---------------------    -----------------------------------------
 //
 //  unroll for the next 4 in k dimension
-//                           /-----------------------------------------|
+//                            -----------------------------------------
 //                           |v2.b[0] ... v2.b[12] v3.b[0] ... v3.b[12]|
 //                           |  ...                              ...   |
 //                           |v2.b[3] ... v2.b[15] v3.b[3] ... v3.b[15]|
-//                           \-----------------------------------------/
-//  /---------------------\  /-----------------------------------------\
+//                            -----------------------------------------
+//   ---------------------    -----------------------------------------
 //  |v6.b[0]  ... v6.b[3] |  |v16.s[0] .. v16.s[3] v17.s[0] .. v17.s[3]|
 //  |v6.b[4]  ... v6.b[7] |  |v18.s[0] .. v18.s[3] v19.s[0] .. v19.s[3]|
 //  |v6.b[8]  ... v6.b[11]|  |v20.s[0] .. v20.s[3] v21.s[0] .. v21.s[3]|
@@ -138,7 +138,7 @@ Return Value:
 //  |v7.b[4]  ... v7.b[7] |  |v26.s[0] .. v26.s[3] v27.s[0] .. v27.s[3]|
 //  |v7.b[8]  ... v7.b[11]|  |v28.s[0] .. v28.s[3] v29.s[0] .. v29.s[3]|
 //  |v7.b[12] ... v7.b[15]|  |v30.s[0] .. v30.s[3] v31.s[0] .. v31.s[3]|
-//  \---------------------/  \-----------------------------------------/
+//   ---------------------    -----------------------------------------
 
 // Starting the loop: initialize accumulators with scaled combination
 //                    of row and column sums
@@ -151,12 +151,12 @@ Return Value:
         dup     v29.4s,v9.s[2]
         dup     v31.4s,v9.s[3]
 
-ProcessNextColumnLoopM8
+.LGemmS8S8.M8.ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A
         ld1     {v3.4s},[x8],#16            // load ColumnSumBuffer[0]
         mov     x3,x15                      // reload PackedCountK
         ld1     {v7.4s},[x8],#16            // load ColumnSumBuffer[4]
-        cbz     x9,SkipScaleByZeroPointBM8
+        cbz     x9,.LGemmS8S8.M8.SkipScaleByZeroPointB
 
         // accumulator = zero point B * row sum A + column sum B 
         ld1     {v0.4s},[x9],#16           // load ZeroPointB[0]
@@ -201,9 +201,9 @@ ProcessNextColumnLoopM8
         add     v27.4s,v7.4s,v27.4s
         add     v29.4s,v7.4s,v29.4s
         add     v31.4s,v7.4s,v31.4s
-        b       ComputeBlockLoopM8
+        b       .LGemmS8S8.M8.ComputeBlockLoop
 
-SkipScaleByZeroPointBM8
+.LGemmS8S8.M8.SkipScaleByZeroPointB:
         // accumulator = row sum A + column sum B 
         ld1     {v0.16b},[x1],#16           // load packed B0
         add     v16.4s,v3.4s,v17.4s
@@ -228,53 +228,53 @@ SkipScaleByZeroPointBM8
         add     v29.4s,v7.4s,v29.4s
         add     v31.4s,v7.4s,v31.4s
 
-ComputeBlockLoopM8
+.LGemmS8S8.M8.ComputeBlockLoop:
         sub     x3,x3,#1
         ld1     {v3.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 18, 0, 4, 1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 18, 0, 4, 1
         ldr     q7,[x0],#16                 // load packed A3
-        UdotByElement 20, 0, 4, 2
-        UdotByElement 22, 0, 4, 3
-        cbz     x3,ComputeBlockLoopFinishM8
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
-        UdotByElement 21, 1, 4, 2
-        UdotByElement 23, 1, 4, 3
+        SdotByElement 20, 0, 4, 2
+        SdotByElement 22, 0, 4, 3
+        cbz     x3,.LGemmS8S8.M8.ComputeBlockLoopFinish
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
+        SdotByElement 21, 1, 4, 2
+        SdotByElement 23, 1, 4, 3
         ldr     q4,[x0],#16                 // load packed A0 for next iteration
-        UdotByElement 24, 0, 5, 0
-        UdotByElement 26, 0, 5, 1
-        UdotByElement 28, 0, 5, 2
-        UdotByElement 30, 0, 5, 3
+        SdotByElement 24, 0, 5, 0
+        SdotByElement 26, 0, 5, 1
+        SdotByElement 28, 0, 5, 2
+        SdotByElement 30, 0, 5, 3
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iteration
-        UdotByElement 25, 1, 5, 0
-        UdotByElement 27, 1, 5, 1
-        UdotByElement 29, 1, 5, 2
-        UdotByElement 31, 1, 5, 3
+        SdotByElement 25, 1, 5, 0
+        SdotByElement 27, 1, 5, 1
+        SdotByElement 29, 1, 5, 2
+        SdotByElement 31, 1, 5, 3
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iteration
 
-        UdotByElement 16, 2, 6, 0
-        UdotByElement 18, 2, 6, 1
+        SdotByElement 16, 2, 6, 0
+        SdotByElement 18, 2, 6, 1
         ldr     q5,[x0],#16                 // load packed A1 for next iteration
-        UdotByElement 20, 2, 6, 2
-        UdotByElement 22, 2, 6, 3
-        UdotByElement 17, 3, 6, 0
-        UdotByElement 19, 3, 6, 1
-        UdotByElement 21, 3, 6, 2
-        UdotByElement 23, 3, 6, 3
+        SdotByElement 20, 2, 6, 2
+        SdotByElement 22, 2, 6, 3
+        SdotByElement 17, 3, 6, 0
+        SdotByElement 19, 3, 6, 1
+        SdotByElement 21, 3, 6, 2
+        SdotByElement 23, 3, 6, 3
         ldr     q6,[x0],#16                 // load packed A2 for next iteration
-        UdotByElement 24, 2, 7, 0
-        UdotByElement 26, 2, 7, 1
-        UdotByElement 28, 2, 7, 2
-        UdotByElement 30, 2, 7, 3
+        SdotByElement 24, 2, 7, 0
+        SdotByElement 26, 2, 7, 1
+        SdotByElement 28, 2, 7, 2
+        SdotByElement 30, 2, 7, 3
         ld1     {v2.16b},[x1],#16           // load packed B0_next4k for next iteration
-        UdotByElement 25, 3, 7, 0
-        UdotByElement 27, 3, 7, 1
-        UdotByElement 29, 3, 7, 2
-        UdotByElement 31, 3, 7, 3
-        b       ComputeBlockLoopM8
+        SdotByElement 25, 3, 7, 0
+        SdotByElement 27, 3, 7, 1
+        SdotByElement 29, 3, 7, 2
+        SdotByElement 31, 3, 7, 3
+        b       .LGemmS8S8.M8.ComputeBlockLoop
 
-ComputeBlockLoopFinishM8
+.LGemmS8S8.M8.ComputeBlockLoopFinish:
         // postfix, compute tail values and prepare to write results
         // We are either about to go to ProcessNextColumnLoopM8
         // where x0 and x3 are about to be restored, or exit
@@ -282,44 +282,45 @@ ComputeBlockLoopFinishM8
         // x4 x7 has finished their task
         // so we can use x0 x3 x4 x7 as output row pointers
 
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
         add     x10,x2,x6,lsl #2            // compute output row 2
         add     x11,x10,x6,lsl #2           // compute output row 3
-        UdotByElement 21, 1, 4, 2
-        UdotByElement 23, 1, 4, 3
+        SdotByElement 21, 1, 4, 2
+        SdotByElement 23, 1, 4, 3
         add     x12,x11,x6,lsl #2           // compute output row 4
         add     x0,x12,x6,lsl #2            // compute output row 5
-        UdotByElement 24, 0, 5, 0
-        UdotByElement 26, 0, 5, 1
+        SdotByElement 24, 0, 5, 0
+        SdotByElement 26, 0, 5, 1
         add     x3,x0,x6,lsl #2             // compute output row 6
         add     x4,x3,x6,lsl #2             // compute output row 7
-        UdotByElement 28, 0, 5, 2
-        UdotByElement 30, 0, 5, 3
+        SdotByElement 28, 0, 5, 2
+        SdotByElement 30, 0, 5, 3
         add     x7,x4,x6,lsl #2             // compute output row 8
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 25, 1, 5, 0
-        UdotByElement 27, 1, 5, 1
-        UdotByElement 29, 1, 5, 2
-        UdotByElement 31, 1, 5, 3
-        UdotByElement 16, 2, 6, 0
-        UdotByElement 18, 2, 6, 1
-        UdotByElement 20, 2, 6, 2
-        UdotByElement 22, 2, 6, 3
-        UdotByElement 17, 3, 6, 0
-        UdotByElement 19, 3, 6, 1
-        UdotByElement 21, 3, 6, 2
-        UdotByElement 23, 3, 6, 3
-        UdotByElement 24, 2, 7, 0
-        UdotByElement 26, 2, 7, 1
-        UdotByElement 28, 2, 7, 2
-        UdotByElement 30, 2, 7, 3
-        UdotByElement 25, 3, 7, 0
-        UdotByElement 27, 3, 7, 1
-        UdotByElement 29, 3, 7, 2
-        UdotByElement 31, 3, 7, 3
-        blo     StoreOutputPartialM8
-        cbnz    x13,SkipAccumulateOutputM8
+        SdotByElement 25, 1, 5, 0
+        SdotByElement 27, 1, 5, 1
+        SdotByElement 29, 1, 5, 2
+        SdotByElement 31, 1, 5, 3
+
+        SdotByElement 16, 2, 6, 0
+        SdotByElement 18, 2, 6, 1
+        SdotByElement 20, 2, 6, 2
+        SdotByElement 22, 2, 6, 3
+        SdotByElement 17, 3, 6, 0
+        SdotByElement 19, 3, 6, 1
+        SdotByElement 21, 3, 6, 2
+        SdotByElement 23, 3, 6, 3
+        SdotByElement 24, 2, 7, 0
+        SdotByElement 26, 2, 7, 1
+        SdotByElement 28, 2, 7, 2
+        SdotByElement 30, 2, 7, 3
+        SdotByElement 25, 3, 7, 0
+        SdotByElement 27, 3, 7, 1
+        SdotByElement 29, 3, 7, 2
+        SdotByElement 31, 3, 7, 3
+        blo     .LGemmS8S8.M8.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M8.SkipAccumulateOutput
         ldp     q0,q1,[x2]
         ldp     q2,q3,[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -345,7 +346,7 @@ ComputeBlockLoopFinishM8
         add     v30.4s,v30.4s,v6.4s
         add     v31.4s,v31.4s,v7.4s
 
-SkipAccumulateOutputM8
+.LGemmS8S8.M8.SkipAccumulateOutput:
         stp     q16,q17,[x2],#32
         dup     v17.4s,v8.s[0]              // broadcast row sums
         stp     q18,q19,[x10]
@@ -362,23 +363,24 @@ SkipAccumulateOutputM8
         dup     v29.4s,v9.s[2]
         stp     q30,q31,[x7]
         dup     v31.4s,v9.s[3]
-        cbnz    x5,ProcessNextColumnLoopM8
 
-ExitKernelM8
+        cbnz    x5,.LGemmS8S8.M8.ProcessNextColumnLoop
+
+.LGemmS8S8.M8.ExitKernel:
         mov     x0,#8                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d8,d9,#16!
-        EPILOG_RETURN
+        ldp     d8,d9,[sp],#16
+        ret
 
 //
 // Store the partial 1 to 7 columns either overwriting the output matrix or
 // accumulating into the existing contents of the output matrix.
 //
 
-StoreOutputPartialM8
-        cbz     x13,StoreOutputPartialAddModeM8
+.LGemmS8S8.M8.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M8.StoreOutputPartialAddMode
 
-StoreOutputPartialZeroModeM8
-        tbz     x5,#2,StoreOutputPartial2ZeroModeM8
+.LGemmS8S8.M8.StoreOutputPartialZeroMode:
+        tbz     x5,#2,.LGemmS8S8.M8.StoreOutputPartial2ZeroMode
         st1     {v16.4s},[x2],#16
         mov     v16.16b,v17.16b             // shift remaining elements down
         st1     {v18.4s},[x10],#16
@@ -396,8 +398,8 @@ StoreOutputPartialZeroModeM8
         st1     {v30.4s},[x7],#16
         mov     v30.16b,v31.16b
 
-StoreOutputPartial2ZeroModeM8
-        tbz     x5,#1,StoreOutputPartial1ZeroModeM8
+.LGemmS8S8.M8.StoreOutputPartial2ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M8.StoreOutputPartial1ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
         st1     {v18.2s},[x10],#8
@@ -415,8 +417,8 @@ StoreOutputPartial2ZeroModeM8
         st1     {v30.2s},[x7],#8
         dup     v30.4s,v30.s[2]
 
-StoreOutputPartial1ZeroModeM8
-        tbz     x5,#0,ExitKernelM8
+.LGemmS8S8.M8.StoreOutputPartial1ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M8.ExitKernel
         st1     {v16.s}[0],[x2]
         st1     {v18.s}[0],[x10]
         st1     {v20.s}[0],[x11]
@@ -425,10 +427,10 @@ StoreOutputPartial1ZeroModeM8
         st1     {v26.s}[0],[x3]
         st1     {v28.s}[0],[x4]
         st1     {v30.s}[0],[x7]
-        b       ExitKernelM8
+        b       .LGemmS8S8.M8.ExitKernel
 
-StoreOutputPartialAddModeM8
-        tbz     x5,#2,StoreOutputPartial2AddModeM8
+.LGemmS8S8.M8.StoreOutputPartialAddMode:
+        tbz     x5,#2,.LGemmS8S8.M8.StoreOutputPartial2AddMode
         ld1     {v0.4s},[x2]
         ld1     {v1.4s},[x10]
         ld1     {v2.4s},[x11]
@@ -462,8 +464,8 @@ StoreOutputPartialAddModeM8
         st1     {v30.4s},[x7],#16
         mov     v30.16b,v31.16b
 
-StoreOutputPartial2AddModeM8
-        tbz     x5,#1,StoreOutputPartial1AddModeM8
+.LGemmS8S8.M8.StoreOutputPartial2AddMode:
+        tbz     x5,#1,.LGemmS8S8.M8.StoreOutputPartial1AddMode
         ld1     {v0.2s},[x2]
         ld1     {v1.2s},[x10]
         ld1     {v2.2s},[x11]
@@ -497,8 +499,8 @@ StoreOutputPartial2AddModeM8
         st1     {v30.2s},[x7],#8
         dup     v30.4s,v30.s[2]
 
-StoreOutputPartial1AddModeM8
-        tbz     x5,#0,ExitKernelM8
+.LGemmS8S8.M8.StoreOutputPartial1AddMode:
+        tbz     x5,#0,.LGemmS8S8.M8.ExitKernel
         ld1     {v0.s}[0],[x2]
         ld1     {v1.s}[0],[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -523,7 +525,7 @@ StoreOutputPartial1AddModeM8
         st1     {v28.s}[0],[x4]
         add     v30.4s,v30.4s,v7.4s
         st1     {v30.s}[0],[x7]
-        b       ExitKernelM8
+        b       .LGemmS8S8.M8.ExitKernel
 
 
 //
@@ -544,35 +546,36 @@ StoreOutputPartial1AddModeM8
 //
 // A55-based cores are optimized for 64-bit loads, so use 64-bit loads for
 // packed matrix A. At the time of this implementation, using a wider 128-bit
-// load didn't affect performance for higher end cores.
+// load did not affect performance for higher end cores.
 //
 //                                      B 4x8 block
-//                           /-----------------------------------------|
+//                            -----------------------------------------
 //                           |v0.b[0] ... v0.b[12] v1.b[0] ... v1.b[12]|
 //                           |  ...                              ...   |
 //                           |v0.b[3] ... v0.b[15] v1.b[3] ... v1.b[15]|
-//                           \-----------------------------------------/
-//    A 4x4 block
-//  /---------------------\  /-----------------------------------------|
+//                            -----------------------------------------
+//       A 4x4 block
+//   ---------------------    -----------------------------------------
 //  |d4.b[0]  ... d4.b[3] |  |v16.s[0] .. v16.s[3] v17.s[0] .. v17.s[3]|
 //  |d4.b[4]  ... d4.b[7] |  |v18.s[0] .. v18.s[3] v19.s[0] .. v19.s[3]|
 //  |d5.b[0]  ... d5.b[3] |  |v20.s[0] .. v20.s[3] v21.s[0] .. v21.s[3]|
 //  |d5.b[4]  ... d5.b[7] |  |v22.s[0] .. v22.s[3] v23.s[0] .. v23.s[3]|
-//  \---------------------/  \-----------------------------------------/
+//   ---------------------    -----------------------------------------
+//
 //  unroll for the next 4 in k dimension
-//                           /-----------------------------------------|
+//                            -----------------------------------------
 //                           |v0.b[0] ... v0.b[12] v1.b[0] ... v1.b[12]|
 //                           |  ...                              ...   |
 //                           |v0.b[3] ... v0.b[15] v1.b[3] ... v1.b[15]|
-//                           \-----------------------------------------/
-//  /---------------------\  /-----------------------------------------\
+//                            -----------------------------------------
+//   ---------------------    -----------------------------------------
 //  |d6.b[0]  ... d6.b[3] |  |v24.s[0] .. v24.s[3] v25.s[0] .. v25.s[3]|
 //  |d6.b[4]  ... d6.b[7] |  |v26.s[0] .. v26.s[3] v27.s[0] .. v27.s[3]|
 //  |d7.b[0]  ... d7.b[3] |  |v28.s[0] .. v24.s[3] v29.s[0] .. v29.s[3]|
 //  |d7.b[4]  ... d7.b[7] |  |v30.s[0] .. v24.s[3] v31.s[0] .. v31.s[3]|
-//  \---------------------/  \-----------------------------------------/
+//   ---------------------    -----------------------------------------
 
-ProcessNextColumnLoopM4
+.LGemmS8S8.M4.ProcessNextColumnLoop:
         ld1     {v0.16b},[x1],#16           // load packed B0
         mov     x0,x14                      // reload matrix A
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
@@ -582,7 +585,7 @@ ProcessNextColumnLoopM4
         dup     v19.4s,v8.s[1]
         dup     v21.4s,v8.s[2]
         dup     v23.4s,v8.s[3]
-        cbz     x9,SkipScaleByZeroPointBM4
+        cbz     x9,.LGemmS8S8.M4.SkipScaleByZeroPointB
         ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
         mul     v16.4s,v30.4s,v17.4s
         mul     v18.4s,v30.4s,v19.4s
@@ -601,9 +604,9 @@ ProcessNextColumnLoopM4
         add     v19.4s,v3.4s,v19.4s
         add     v21.4s,v3.4s,v21.4s
         add     v23.4s,v3.4s,v23.4s
-        b       ComputeBlockLoopStartM4
+        b       .LGemmS8S8.M4.ComputeBlockLoopStart
 
-SkipScaleByZeroPointBM4
+.LGemmS8S8.M4.SkipScaleByZeroPointB:
         add     v16.4s,v2.4s,v17.4s
         add     v18.4s,v2.4s,v19.4s
         add     v20.4s,v2.4s,v21.4s
@@ -613,7 +616,7 @@ SkipScaleByZeroPointBM4
         add     v21.4s,v3.4s,v21.4s
         add     v23.4s,v3.4s,v23.4s
 
-ComputeBlockLoopStartM4
+.LGemmS8S8.M4.ComputeBlockLoopStart:
         ldr     d4,[x0],#32                 // load packed A0.l
         movi    v24.4s,#0
         movi    v25.4s,#0
@@ -626,47 +629,47 @@ ComputeBlockLoopStartM4
         movi    v30.4s,#0
         movi    v31.4s,#0
 
-ComputeBlockLoopM4
+.LGemmS8S8.M4.ComputeBlockLoop:
         ld1     {v1.16b},[x1],#16           // load packed B1
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 18, 0, 4, 1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 18, 0, 4, 1
         ldur    d7,[x0,#-8]                 // load packed A1.h
-        UdotByElement 20, 0, 5, 0
-        UdotByElement 22, 0, 5, 1
+        SdotByElement 20, 0, 5, 0
+        SdotByElement 22, 0, 5, 1
         ld1     {v0.16b},[x1],#16           // load packed B0_next4k
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
         sub     x3,x3,#1
-        cbz     x3,ComputeBlockLoopFinishM4
+        cbz     x3,.LGemmS8S8.M4.ComputeBlockLoopFinish
         ldr     d4,[x0],#32                 // load packed A0.l for next iteration
-        UdotByElement 21, 1, 5, 0
-        UdotByElement 23, 1, 5, 1
+        SdotByElement 21, 1, 5, 0
+        SdotByElement 23, 1, 5, 1
         ld1     {v1.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 24, 0, 6, 0
-        UdotByElement 26, 0, 6, 1
+        SdotByElement 24, 0, 6, 0
+        SdotByElement 26, 0, 6, 1
         ldur    d5,[x0,#-24]                // load packed A0.h for next iteration
-        UdotByElement 28, 0, 7, 0
-        UdotByElement 30, 0, 7, 1
+        SdotByElement 28, 0, 7, 0
+        SdotByElement 30, 0, 7, 1
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iteration
-        UdotByElement 25, 1, 6, 0
-        UdotByElement 27, 1, 6, 1
+        SdotByElement 25, 1, 6, 0
+        SdotByElement 27, 1, 6, 1
         ldur    d6,[x0,#-16]                // load packed A1.l for next iteration
-        UdotByElement 29, 1, 7, 0
-        UdotByElement 31, 1, 7, 1
-        b       ComputeBlockLoopM4
+        SdotByElement 29, 1, 7, 0
+        SdotByElement 31, 1, 7, 1
+        b       .LGemmS8S8.M4.ComputeBlockLoop
 
-ComputeBlockLoopFinishM4
-        UdotByElement 21, 1, 5, 0
-        UdotByElement 23, 1, 5, 1
+.LGemmS8S8.M4.ComputeBlockLoopFinish:
+        SdotByElement 21, 1, 5, 0
+        SdotByElement 23, 1, 5, 1
         ld1     {v1.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 24, 0, 6, 0
-        UdotByElement 26, 0, 6, 1
-        UdotByElement 28, 0, 7, 0
-        UdotByElement 30, 0, 7, 1
-        UdotByElement 25, 1, 6, 0
-        UdotByElement 27, 1, 6, 1
-        UdotByElement 29, 1, 7, 0
-        UdotByElement 31, 1, 7, 1
+        SdotByElement 24, 0, 6, 0
+        SdotByElement 26, 0, 6, 1
+        SdotByElement 28, 0, 7, 0
+        SdotByElement 30, 0, 7, 1
+        SdotByElement 25, 1, 6, 0
+        SdotByElement 27, 1, 6, 1
+        SdotByElement 29, 1, 7, 0
+        SdotByElement 31, 1, 7, 1
         add     x10,x2,x6,lsl #2            // compute output row 2
         add     v16.4s,v16.4s,v24.4s        // fold high results into low results
         add     v18.4s,v18.4s,v26.4s
@@ -679,8 +682,8 @@ ComputeBlockLoopFinishM4
         add     v23.4s,v23.4s,v31.4s
         add     x12,x11,x6,lsl #2           // compute output row 4
         subs    x5,x5,#8                    // adjust CountN remaining
-        blo     StoreOutputPartialM4
-        cbnz    x13,SkipAccumulateOutputM4
+        blo     .LGemmS8S8.M4.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M4.SkipAccumulateOutput
         ldp     q0,q1,[x2]
         ldp     q2,q3,[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -694,28 +697,28 @@ ComputeBlockLoopFinishM4
         add     v22.4s,v22.4s,v6.4s
         add     v23.4s,v23.4s,v7.4s
 
-SkipAccumulateOutputM4
+.LGemmS8S8.M4.SkipAccumulateOutput:
         stp     q16,q17,[x2],#32
         stp     q18,q19,[x10]
         stp     q20,q21,[x11]
         stp     q22,q23,[x12]
-        cbnz    x5,ProcessNextColumnLoopM4
+        cbnz    x5,.LGemmS8S8.M4.ProcessNextColumnLoop
 
-ExitKernelM4
+.LGemmS8S8.M4.ExitKernel:
         mov     x0,#4                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d8,d9,#16!
-        EPILOG_RETURN
+        ldp     d8,d9,[sp],#16
+        ret
 
 //
 // Store the partial 1 to 7 columns either overwriting the output matrix or
 // accumulating into the existing contents of the output matrix.
 //
 
-StoreOutputPartialM4
-        cbz     x13,StoreOutputPartialAddModeM4
+.LGemmS8S8.M4.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M4.StoreOutputPartial.AddMode
 
-StoreOutputPartialZeroModeM4
-        tbz     x5,#2,StoreOutputPartial2ZeroModeM4
+.LGemmS8S8.M4.StoreOutputPartial.ZeroMode:
+        tbz     x5,#2,.LGemmS8S8.M4.StoreOutputPartial2.ZeroMode
         st1     {v16.4s},[x2],#16
         mov     v16.16b,v17.16b             // shift remaining elements down
         st1     {v18.4s},[x10],#16
@@ -725,8 +728,8 @@ StoreOutputPartialZeroModeM4
         st1     {v22.4s},[x12],#16
         mov     v22.16b,v23.16b
 
-StoreOutputPartial2ZeroModeM4
-        tbz     x5,#1,StoreOutputPartial1ZeroModeM4
+.LGemmS8S8.M4.StoreOutputPartial2.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M4.StoreOutputPartial1.ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
         st1     {v18.2s},[x10],#8
@@ -736,16 +739,16 @@ StoreOutputPartial2ZeroModeM4
         st1     {v22.2s},[x12],#8
         dup     v22.4s,v22.s[2]
 
-StoreOutputPartial1ZeroModeM4
-        tbz     x5,#0,ExitKernelM4
+.LGemmS8S8.M4.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M4.ExitKernel
         st1     {v16.s}[0],[x2]
         st1     {v18.s}[0],[x10]
         st1     {v20.s}[0],[x11]
         st1     {v22.s}[0],[x12]
-        b       ExitKernelM4
+        b       .LGemmS8S8.M4.ExitKernel
 
-StoreOutputPartialAddModeM4
-        tbz     x5,#2,StoreOutputPartial2AddModeM4
+.LGemmS8S8.M4.StoreOutputPartial.AddMode:
+        tbz     x5,#2,.LGemmS8S8.M4.StoreOutputPartial2.AddMode
         ld1     {v0.4s},[x2]
         ld1     {v1.4s},[x10]
         ld1     {v2.4s},[x11]
@@ -763,8 +766,8 @@ StoreOutputPartialAddModeM4
         st1     {v22.4s},[x12],#16
         mov     v22.16b,v23.16b
 
-StoreOutputPartial2AddModeM4
-        tbz     x5,#1,StoreOutputPartial1AddModeM4
+.LGemmS8S8.M4.StoreOutputPartial2.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M4.StoreOutputPartial1.AddMode
         ld1     {v0.2s},[x2]
         ld1     {v1.2s},[x10]
         ld1     {v2.2s},[x11]
@@ -782,8 +785,8 @@ StoreOutputPartial2AddModeM4
         st1     {v22.2s},[x12],#8
         dup     v22.4s,v22.s[2]
 
-StoreOutputPartial1AddModeM4
-        tbz     x5,#0,ExitKernelM4
+.LGemmS8S8.M4.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M4.ExitKernel
         ld1     {v0.s}[0],[x2]
         ld1     {v1.s}[0],[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -796,23 +799,23 @@ StoreOutputPartial1AddModeM4
         add     v22.4s,v22.4s,v3.4s
         st1     {v20.s}[0],[x11]
         st1     {v22.s}[0],[x12]
-        b       ExitKernelM4
+        b       .LGemmS8S8.M4.ExitKernel
 
 //
 // Process 2 rows of the matrices.
 //
-ProcessLoopM2
+.LGemmS8S8.M2.ProcessLoop:
         dup     v9.4s, v8.s[1]
         dup     v8.4s, v8.s[0]
 
-ProcessNextColumnLoopM2
+.LGemmS8S8.M2.ProcessNextColumnLoop:
         ld1     {v0.16b},[x1],#16           // load packed B0
         ld1     {v1.16b},[x1],#16           // load packed B1
         mov     x0,x14                      // reload matrix A
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
         mov     x3,x15                      // reload PackedCountK
         ld1     {v3.4s},[x8],#16            // load ColumnSumBuffer[4]
-        cbz     x9,SkipScaleByZeroPointBM2
+        cbz     x9,.LGemmS8S8.M2.SkipScaleByZeroPointB
         ld1     {v30.4s},[x9],#16           // load ZeroPointB[0]
         ld1     {v31.4s},[x9],#16           // load ZeroPointB[4]
         mul     v16.4s,v30.4s,v8.4s
@@ -825,9 +828,9 @@ ProcessNextColumnLoopM2
         ldr     d5,[x0],#8                  // load packed A0.h
         add     v17.4s,v3.4s,v17.4s
         add     v19.4s,v3.4s,v19.4s
-        b       ComputeBlockLoopM2
+        b       .LGemmS8S8.M2.ComputeBlockLoop
 
-SkipScaleByZeroPointBM2
+.LGemmS8S8.M2.SkipScaleByZeroPointB:
         ldr     d4,[x0],#8                  // load packed A0.l
         add     v16.4s,v2.4s,v8.4s
         add     v18.4s,v2.4s,v9.4s
@@ -835,34 +838,34 @@ SkipScaleByZeroPointBM2
         add     v17.4s,v3.4s,v8.4s
         add     v19.4s,v3.4s,v9.4s
 
-ComputeBlockLoopM2
+.LGemmS8S8.M2.ComputeBlockLoop:
         sub     x3,x3,#1
         ld1     {v6.16b},[x1],#16           // load packed B0 next 4 k
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 18, 0, 4, 1
-        UdotByElement 19, 1, 4, 1
-        cbz     x3,ComputeBlockLoopFinishM2
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 18, 0, 4, 1
+        SdotByElement 19, 1, 4, 1
+        cbz     x3,.LGemmS8S8.M2.ComputeBlockLoopFinish
         ldr     d4,[x0],#8                  // load packed A0.l for next iter
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iter
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iter
-        UdotByElement 16, 6, 5, 0
-        UdotByElement 17, 7, 5, 0
-        UdotByElement 18, 6, 5, 1
-        UdotByElement 19, 7, 5, 1
+        SdotByElement 16, 6, 5, 0
+        SdotByElement 17, 7, 5, 0
+        SdotByElement 18, 6, 5, 1
+        SdotByElement 19, 7, 5, 1
         ldr     d5,[x0],#8                  // load packed A0.h for next iter
-        b       ComputeBlockLoopM2
+        b       .LGemmS8S8.M2.ComputeBlockLoop
 
-ComputeBlockLoopFinishM2
+.LGemmS8S8.M2.ComputeBlockLoopFinish:
         add     x10,x2,x6,lsl #2            // compute output row 2
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 16, 6, 5, 0
-        UdotByElement 17, 7, 5, 0
-        UdotByElement 18, 6, 5, 1
-        UdotByElement 19, 7, 5, 1
-        blo     StoreOutputPartialM2
-        cbnz    x13,SkipAccumulateOutputM2
+        SdotByElement 16, 6, 5, 0
+        SdotByElement 17, 7, 5, 0
+        SdotByElement 18, 6, 5, 1
+        SdotByElement 19, 7, 5, 1
+        blo     .LGemmS8S8.M2.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M2.SkipAccumulateOutput
         ldp     q0,q1,[x2]
         ldp     q2,q3,[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -870,46 +873,46 @@ ComputeBlockLoopFinishM2
         add     v18.4s,v18.4s,v2.4s
         add     v19.4s,v19.4s,v3.4s
 
-SkipAccumulateOutputM2
+.LGemmS8S8.M2.SkipAccumulateOutput:
         stp     q16,q17,[x2],#32
         stp     q18,q19,[x10]
-        cbnz    x5,ProcessNextColumnLoopM2
+        cbnz    x5,.LGemmS8S8.M2.ProcessNextColumnLoop
 
-ExitKernelM2
+.LGemmS8S8.M2.ExitKernel:
         mov     x0,#2                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d8,d9,#16!
-        EPILOG_RETURN
+        ldp     d8,d9,[sp],#16
+        ret
 
 //
 // Store the partial 1 to 7 columns either overwriting the output matrix or
 // accumulating into the existing contents of the output matrix.
 //
 
-StoreOutputPartialM2
-        cbz     x13,StoreOutputPartialAddModeM2
+.LGemmS8S8.M2.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M2.StoreOutputPartial.AddMode
 
-StoreOutputPartialZeroModeM2
-        tbz     x5,#2,StoreOutputPartial2ZeroModeM2
+.LGemmS8S8.M2.StoreOutputPartial.ZeroMode:
+        tbz     x5,#2,.LGemmS8S8.M2.StoreOutputPartial2.ZeroMode
         st1     {v16.4s},[x2],#16
         mov     v16.16b,v17.16b             // shift remaining elements down
         st1     {v18.4s},[x10],#16
         mov     v18.16b,v19.16b
 
-StoreOutputPartial2ZeroModeM2
-        tbz     x5,#1,StoreOutputPartial1ZeroModeM2
+.LGemmS8S8.M2.StoreOutputPartial2.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M2.StoreOutputPartial1.ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
         st1     {v18.2s},[x10],#8
         dup     v18.4s,v18.s[2]
 
-StoreOutputPartial1ZeroModeM2
-        tbz     x5,#0,ExitKernelM2
+.LGemmS8S8.M2.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M2.ExitKernel
         st1     {v16.s}[0],[x2]
         st1     {v18.s}[0],[x10]
-        b       ExitKernelM2
+        b       .LGemmS8S8.M2.ExitKernel
 
-StoreOutputPartialAddModeM2
-        tbz     x5,#2,StoreOutputPartial2AddModeM2
+.LGemmS8S8.M2.StoreOutputPartial.AddMode:
+        tbz     x5,#2,.LGemmS8S8.M2.StoreOutputPartial2.AddMode
         ld1     {v0.4s},[x2]
         ld1     {v1.4s},[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -919,8 +922,8 @@ StoreOutputPartialAddModeM2
         st1     {v18.4s},[x10],#16
         mov     v18.16b,v19.16b
 
-StoreOutputPartial2AddModeM2
-        tbz     x5,#1,StoreOutputPartial1AddModeM2
+.LGemmS8S8.M2.StoreOutputPartial2.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M2.StoreOutputPartial1.AddMode
         ld1     {v0.2s},[x2]
         ld1     {v1.2s},[x10]
         add     v16.4s,v16.4s,v0.4s
@@ -930,30 +933,31 @@ StoreOutputPartial2AddModeM2
         st1     {v18.2s},[x10],#8
         dup     v18.4s,v18.s[2]
 
-StoreOutputPartial1AddModeM2
-        tbz     x5,#0,ExitKernelM2
+.LGemmS8S8.M2.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M2.ExitKernel
         ld1     {v0.s}[0],[x2]
         ld1     {v1.s}[0],[x10]
         add     v16.4s,v16.4s,v0.4s
         add     v18.4s,v18.4s,v1.4s
         st1     {v16.s}[0],[x2]
         st1     {v18.s}[0],[x10]
-        b       ExitKernelM2
+        b       .LGemmS8S8.M2.ExitKernel
 
 //
 // Process 1 row of the matrices.
 //
+.LGemmS8S8.M1.ProcessLoop:
 
-ProcessLoopM1
         dup     v8.4s,v8.s[0]
-ProcessNextColumnLoopM1
+
+.LGemmS8S8.M1.ProcessNextColumnLoop:
         ld1     {v0.16b},[x1],#16           // load packed B0
         ld1     {v1.16b},[x1],#16           // load packed B1
         mov     x0,x14                      // reload matrix A
         ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer0
         mov     x3,x15                      // reload PackedCountK
         ld1     {v3.4s},[x8],#16            // load ColumnSumBuffer1
-        cbz     x9,SkipScaleByZeroPointBM1
+        cbz     x9,.LGemmS8S8.M1.SkipScaleByZeroPointB
         ld1     {v30.4s},[x9],#16           // load ZeroPointB0
         ld1     {v31.4s},[x9],#16           // load ZeroPointB1
         mul     v16.4s,v30.4s,v8.4s
@@ -963,92 +967,90 @@ ProcessNextColumnLoopM1
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k
         add     v16.4s,v2.4s,v16.4s
         add     v17.4s,v3.4s,v17.4s
-        b       ComputeBlockLoopM1
+        b       .LGemmS8S8.M1.ComputeBlockLoop
 
-SkipScaleByZeroPointBM1
+.LGemmS8S8.M1.SkipScaleByZeroPointB:
         ldr     d4,[x0],#8                  // load packed A0
         ld1     {v6.16b},[x1],#16           // load packed B0 next 4 k
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k
         add     v16.4s,v2.4s,v8.4s
         add     v17.4s,v3.4s,v8.4s
 
-ComputeBlockLoopM1
+.LGemmS8S8.M1.ComputeBlockLoop:
         sub     x3,x3,#1
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 17, 1, 4, 0
-        cbz     x3,ComputeBlockLoopFinishM1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 17, 1, 4, 0
+        cbz     x3,.LGemmS8S8.M1.ComputeBlockLoopFinish
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iter
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iter
-        UdotByElement 16, 6, 4, 1
-        UdotByElement 17, 7, 4, 1
+        SdotByElement 16, 6, 4, 1
+        SdotByElement 17, 7, 4, 1
         ldr     d4,[x0],#8                  // load packed A0 for next iter
         ld1     {v6.16b},[x1],#16           // load packed B0 next 4 k for next iter
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k for next iter
-        b       ComputeBlockLoopM1
+        b       .LGemmS8S8.M1.ComputeBlockLoop
 
-ComputeBlockLoopFinishM1
+.LGemmS8S8.M1.ComputeBlockLoopFinish:
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 16, 6, 4, 1
-        UdotByElement 17, 7, 4, 1
-        blo     StoreOutputPartialM1
-        cbnz    x13,SkipAccumulateOutputM1
+        SdotByElement 16, 6, 4, 1
+        SdotByElement 17, 7, 4, 1
+        blo     .LGemmS8S8.M1.StoreOutputPartial
+        cbnz    x13,.LGemmS8S8.M1.SkipAccumulateOutput
         ldp     q0,q1,[x2]
         add     v16.4s,v16.4s,v0.4s
         add     v17.4s,v17.4s,v1.4s
 
-SkipAccumulateOutputM1
+.LGemmS8S8.M1.SkipAccumulateOutput:
         stp     q16,q17,[x2],#32
-        cbnz    x5,ProcessNextColumnLoopM1
+        cbnz    x5,.LGemmS8S8.M1.ProcessNextColumnLoop
 
-ExitKernelM1
+.LGemmS8S8.M1.ExitKernel:
         mov     x0,#1                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d8,d9,#16!
-        EPILOG_RETURN
+        ldp     d8,d9,[sp],#16
+        ret
 
 //
 // Store the partial 1 to 7 columns either overwriting the output matrix or
 // accumulating into the existing contents of the output matrix.
 //
 
-StoreOutputPartialM1
-        cbz     x13,StoreOutputPartialAddModeM1
+.LGemmS8S8.M1.StoreOutputPartial:
+        cbz     x13,.LGemmS8S8.M1.StoreOutputPartial.AddMode
 
-StoreOutputPartialZeroModeM1
-        tbz     x5,#2,StoreOutputPartial2ZeroModeM1
+.LGemmS8S8.M1.StoreOutputPartial.ZeroMode:
+        tbz     x5,#2,.LGemmS8S8.M1.StoreOutputPartial2.ZeroMode
         st1     {v16.4s},[x2],#16
         mov     v16.16b,v17.16b             // shift remaining elements down
 
-StoreOutputPartial2ZeroModeM1
-        tbz     x5,#1,StoreOutputPartial1ZeroModeM1
+.LGemmS8S8.M1.StoreOutputPartial2.ZeroMode:
+        tbz     x5,#1,.LGemmS8S8.M1.StoreOutputPartial1.ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
 
-StoreOutputPartial1ZeroModeM1
-        tbz     x5,#0,ExitKernelM1
+.LGemmS8S8.M1.StoreOutputPartial1.ZeroMode:
+        tbz     x5,#0,.LGemmS8S8.M1.ExitKernel
         st1     {v16.s}[0],[x2]
-        b       ExitKernelM1
+        b       .LGemmS8S8.M1.ExitKernel
 
-StoreOutputPartialAddModeM1
-        tbz     x5,#2,StoreOutputPartial2AddModeM1
+.LGemmS8S8.M1.StoreOutputPartial.AddMode:
+        tbz     x5,#2,.LGemmS8S8.M1.StoreOutputPartial2.AddMode
         ld1     {v0.4s},[x2]
         add     v16.4s,v16.4s,v0.4s
         st1     {v16.4s},[x2],#16
         mov     v16.16b,v17.16b             // shift remaining elements down
 
-StoreOutputPartial2AddModeM1
-        tbz     x5,#1,StoreOutputPartial1AddModeM1
+.LGemmS8S8.M1.StoreOutputPartial2.AddMode:
+        tbz     x5,#1,.LGemmS8S8.M1.StoreOutputPartial1.AddMode
         ld1     {v0.2s},[x2]
         add     v16.4s,v16.4s,v0.4s
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
 
-StoreOutputPartial1AddModeM1
-        tbz     x5,#0,ExitKernelM1
+.LGemmS8S8.M1.StoreOutputPartial1.AddMode:
+        tbz     x5,#0,.LGemmS8S8.M1.ExitKernel
         ld1     {v0.s}[0],[x2]
         add     v16.4s,v16.4s,v0.4s
         st1     {v16.s}[0],[x2]
-        b       ExitKernelM1
+        b       .LGemmS8S8.M1.ExitKernel
 
-        NESTED_END MlasGemmU8X8KernelUdot
-
-        END
+        .end

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmU8X8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmU8X8KernelNeon.S
@@ -37,10 +37,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>.
 
     C (x2) - Supplies the address of matrix C.
 

--- a/onnxruntime/core/mlas/lib/aarch64/QgemmU8X8KernelUdot.S
+++ b/onnxruntime/core/mlas/lib/aarch64/QgemmU8X8KernelUdot.S
@@ -44,10 +44,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>.
 
     C (x2) - Supplies the address of matrix C.
 
@@ -92,7 +92,7 @@ Return Value:
         ldr     x9,[sp,#.LGemmU8X8KernelFrame_ZeroPointB]
         ldrb    w13,[sp,#.LGemmU8X8KernelFrame_ZeroMode]
         mov     x14,x0
-        ld1     {v8.4s},[x7],#16            // load row sum 0 ~ 4
+        ld1     {v8.4s},[x7],#16            // load row sum 1 ~ 4
         mov     x15,x3
         cmp     x4,#1                       // CountM == 1?
         beq     .LGemmU8X8.M1.ProcessLoop

--- a/onnxruntime/core/mlas/lib/arm64/AssembleDotProduct.h
+++ b/onnxruntime/core/mlas/lib/arm64/AssembleDotProduct.h
@@ -22,6 +22,33 @@ Abstract:
 
 Macro Description:
 
+    This macro builds a SDOT instruction of the form:
+
+        SDOT DestReg.4s, Src1Reg.16b, Src2Reg.4b[Index]
+
+Arguments:
+
+    DestReg - Specifies the destination register.
+
+    Src1Reg - Specifies the first source register.
+
+    Src2Reg - Specifies the second source register.
+
+    Index - Specifies the element index of the second source register.
+
+--*/
+
+        MACRO
+        SdotByElement $DestReg, $Src1Reg, $Src2Reg, $Index
+
+        DCD     0x4F80E000:OR:($DestReg):OR:($Src1Reg:SHL:5):OR:($Src2Reg:SHL:16):OR:(($Index:AND:2):SHL:10):OR:(($Index:AND:1):SHL:21)
+
+        MEND
+
+/*++
+
+Macro Description:
+
     This macro builds a UDOT instruction of the form:
 
         UDOT DestReg.4s, Src1Reg.16b, Src2Reg.4b[Index]

--- a/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelNeon.asm
@@ -39,10 +39,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_X8S8_KERNEL_NEON>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>.
 
     C (x2) - Supplies the address of matrix C.
 

--- a/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelSdot.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelSdot.asm
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 
 Module Name:
 
-    QgemmU8X8KernelUdot.asm
+    QgemmS8S8KernelUdot.asm
 
 Abstract:
 
@@ -21,16 +21,16 @@ Abstract:
 #include "AssembleDotProduct.h"
 
 //
-// Stack frame layout for the U8X8 kernel.
+// Stack frame layout for the S8S8 kernel.
 // Defining spaces for saving 2 vector registers, and pointers to parameters
 // on the stack
 //
 
-#define GemmU8X8KernelFrame_SavedNeonRegisters       (2 * 8)
-#define GemmU8X8KernelFrame_SavedRegisters           GemmU8X8KernelFrame_SavedNeonRegisters
-#define GemmU8X8KernelFrame_ColumnSumBuffer          (0 + GemmU8X8KernelFrame_SavedRegisters)
-#define GemmU8X8KernelFrame_ZeroPointB               (8 + GemmU8X8KernelFrame_SavedRegisters)
-#define GemmU8X8KernelFrame_ZeroMode                 (16 + GemmU8X8KernelFrame_SavedRegisters)
+#define GemmS8S8KernelFrame_SavedNeonRegisters       (2 * 8)
+#define GemmS8S8KernelFrame_SavedRegisters           GemmS8S8KernelFrame_SavedNeonRegisters
+#define GemmS8S8KernelFrame_ColumnSumBuffer          (0 + GemmS8S8KernelFrame_SavedRegisters)
+#define GemmS8S8KernelFrame_ZeroPointB               (8 + GemmS8S8KernelFrame_SavedRegisters)
+#define GemmS8S8KernelFrame_ZeroMode                 (16 + GemmS8S8KernelFrame_SavedRegisters)
 
         TEXTAREA
 
@@ -44,10 +44,10 @@ Routine Description:
 Arguments:
 
     A (x0) - Supplies the address of matrix A. The matrix data has been packed
-        using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_UDOT>.
 
     B (x1) - Supplies the address of matrix B. The matrix data has been packed
-        using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>.
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_UDOT>.
 
     C (x2) - Supplies the address of matrix C.
 
@@ -85,12 +85,12 @@ Return Value:
 
 --*/
 
-        NESTED_ENTRY MlasGemmU8X8KernelUdot
+        NESTED_ENTRY MlasGemmS8S8KernelSDot
 
         PROLOG_SAVE_REG_PAIR d8,d9,#-16!
-        ldr     x8,[sp,#GemmU8X8KernelFrame_ColumnSumBuffer]
-        ldr     x9,[sp,#GemmU8X8KernelFrame_ZeroPointB]
-        ldrb    w13,[sp,#GemmU8X8KernelFrame_ZeroMode]
+        ldr     x8,[sp,#GemmS8S8KernelFrame_ColumnSumBuffer]
+        ldr     x9,[sp,#GemmS8S8KernelFrame_ZeroPointB]
+        ldrb    w13,[sp,#GemmS8S8KernelFrame_ZeroMode]
         mov     x14,x0
         ld1     {v8.4s},[x7],#16            // load row sum 0 ~ 4
         mov     x15,x3
@@ -231,47 +231,47 @@ SkipScaleByZeroPointBM8
 ComputeBlockLoopM8
         sub     x3,x3,#1
         ld1     {v3.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 18, 0, 4, 1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 18, 0, 4, 1
         ldr     q7,[x0],#16                 // load packed A3
-        UdotByElement 20, 0, 4, 2
-        UdotByElement 22, 0, 4, 3
+        SdotByElement 20, 0, 4, 2
+        SdotByElement 22, 0, 4, 3
         cbz     x3,ComputeBlockLoopFinishM8
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
-        UdotByElement 21, 1, 4, 2
-        UdotByElement 23, 1, 4, 3
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
+        SdotByElement 21, 1, 4, 2
+        SdotByElement 23, 1, 4, 3
         ldr     q4,[x0],#16                 // load packed A0 for next iteration
-        UdotByElement 24, 0, 5, 0
-        UdotByElement 26, 0, 5, 1
-        UdotByElement 28, 0, 5, 2
-        UdotByElement 30, 0, 5, 3
+        SdotByElement 24, 0, 5, 0
+        SdotByElement 26, 0, 5, 1
+        SdotByElement 28, 0, 5, 2
+        SdotByElement 30, 0, 5, 3
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iteration
-        UdotByElement 25, 1, 5, 0
-        UdotByElement 27, 1, 5, 1
-        UdotByElement 29, 1, 5, 2
-        UdotByElement 31, 1, 5, 3
+        SdotByElement 25, 1, 5, 0
+        SdotByElement 27, 1, 5, 1
+        SdotByElement 29, 1, 5, 2
+        SdotByElement 31, 1, 5, 3
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iteration
 
-        UdotByElement 16, 2, 6, 0
-        UdotByElement 18, 2, 6, 1
+        SdotByElement 16, 2, 6, 0
+        SdotByElement 18, 2, 6, 1
         ldr     q5,[x0],#16                 // load packed A1 for next iteration
-        UdotByElement 20, 2, 6, 2
-        UdotByElement 22, 2, 6, 3
-        UdotByElement 17, 3, 6, 0
-        UdotByElement 19, 3, 6, 1
-        UdotByElement 21, 3, 6, 2
-        UdotByElement 23, 3, 6, 3
+        SdotByElement 20, 2, 6, 2
+        SdotByElement 22, 2, 6, 3
+        SdotByElement 17, 3, 6, 0
+        SdotByElement 19, 3, 6, 1
+        SdotByElement 21, 3, 6, 2
+        SdotByElement 23, 3, 6, 3
         ldr     q6,[x0],#16                 // load packed A2 for next iteration
-        UdotByElement 24, 2, 7, 0
-        UdotByElement 26, 2, 7, 1
-        UdotByElement 28, 2, 7, 2
-        UdotByElement 30, 2, 7, 3
+        SdotByElement 24, 2, 7, 0
+        SdotByElement 26, 2, 7, 1
+        SdotByElement 28, 2, 7, 2
+        SdotByElement 30, 2, 7, 3
         ld1     {v2.16b},[x1],#16           // load packed B0_next4k for next iteration
-        UdotByElement 25, 3, 7, 0
-        UdotByElement 27, 3, 7, 1
-        UdotByElement 29, 3, 7, 2
-        UdotByElement 31, 3, 7, 3
+        SdotByElement 25, 3, 7, 0
+        SdotByElement 27, 3, 7, 1
+        SdotByElement 29, 3, 7, 2
+        SdotByElement 31, 3, 7, 3
         b       ComputeBlockLoopM8
 
 ComputeBlockLoopFinishM8
@@ -282,42 +282,42 @@ ComputeBlockLoopFinishM8
         // x4 x7 has finished their task
         // so we can use x0 x3 x4 x7 as output row pointers
 
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
         add     x10,x2,x6,lsl #2            // compute output row 2
         add     x11,x10,x6,lsl #2           // compute output row 3
-        UdotByElement 21, 1, 4, 2
-        UdotByElement 23, 1, 4, 3
+        SdotByElement 21, 1, 4, 2
+        SdotByElement 23, 1, 4, 3
         add     x12,x11,x6,lsl #2           // compute output row 4
         add     x0,x12,x6,lsl #2            // compute output row 5
-        UdotByElement 24, 0, 5, 0
-        UdotByElement 26, 0, 5, 1
+        SdotByElement 24, 0, 5, 0
+        SdotByElement 26, 0, 5, 1
         add     x3,x0,x6,lsl #2             // compute output row 6
         add     x4,x3,x6,lsl #2             // compute output row 7
-        UdotByElement 28, 0, 5, 2
-        UdotByElement 30, 0, 5, 3
+        SdotByElement 28, 0, 5, 2
+        SdotByElement 30, 0, 5, 3
         add     x7,x4,x6,lsl #2             // compute output row 8
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 25, 1, 5, 0
-        UdotByElement 27, 1, 5, 1
-        UdotByElement 29, 1, 5, 2
-        UdotByElement 31, 1, 5, 3
-        UdotByElement 16, 2, 6, 0
-        UdotByElement 18, 2, 6, 1
-        UdotByElement 20, 2, 6, 2
-        UdotByElement 22, 2, 6, 3
-        UdotByElement 17, 3, 6, 0
-        UdotByElement 19, 3, 6, 1
-        UdotByElement 21, 3, 6, 2
-        UdotByElement 23, 3, 6, 3
-        UdotByElement 24, 2, 7, 0
-        UdotByElement 26, 2, 7, 1
-        UdotByElement 28, 2, 7, 2
-        UdotByElement 30, 2, 7, 3
-        UdotByElement 25, 3, 7, 0
-        UdotByElement 27, 3, 7, 1
-        UdotByElement 29, 3, 7, 2
-        UdotByElement 31, 3, 7, 3
+        SdotByElement 25, 1, 5, 0
+        SdotByElement 27, 1, 5, 1
+        SdotByElement 29, 1, 5, 2
+        SdotByElement 31, 1, 5, 3
+        SdotByElement 16, 2, 6, 0
+        SdotByElement 18, 2, 6, 1
+        SdotByElement 20, 2, 6, 2
+        SdotByElement 22, 2, 6, 3
+        SdotByElement 17, 3, 6, 0
+        SdotByElement 19, 3, 6, 1
+        SdotByElement 21, 3, 6, 2
+        SdotByElement 23, 3, 6, 3
+        SdotByElement 24, 2, 7, 0
+        SdotByElement 26, 2, 7, 1
+        SdotByElement 28, 2, 7, 2
+        SdotByElement 30, 2, 7, 3
+        SdotByElement 25, 3, 7, 0
+        SdotByElement 27, 3, 7, 1
+        SdotByElement 29, 3, 7, 2
+        SdotByElement 31, 3, 7, 3
         blo     StoreOutputPartialM8
         cbnz    x13,SkipAccumulateOutputM8
         ldp     q0,q1,[x2]
@@ -628,45 +628,45 @@ ComputeBlockLoopStartM4
 
 ComputeBlockLoopM4
         ld1     {v1.16b},[x1],#16           // load packed B1
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 18, 0, 4, 1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 18, 0, 4, 1
         ldur    d7,[x0,#-8]                 // load packed A1.h
-        UdotByElement 20, 0, 5, 0
-        UdotByElement 22, 0, 5, 1
+        SdotByElement 20, 0, 5, 0
+        SdotByElement 22, 0, 5, 1
         ld1     {v0.16b},[x1],#16           // load packed B0_next4k
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 19, 1, 4, 1
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 19, 1, 4, 1
         sub     x3,x3,#1
         cbz     x3,ComputeBlockLoopFinishM4
         ldr     d4,[x0],#32                 // load packed A0.l for next iteration
-        UdotByElement 21, 1, 5, 0
-        UdotByElement 23, 1, 5, 1
+        SdotByElement 21, 1, 5, 0
+        SdotByElement 23, 1, 5, 1
         ld1     {v1.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 24, 0, 6, 0
-        UdotByElement 26, 0, 6, 1
+        SdotByElement 24, 0, 6, 0
+        SdotByElement 26, 0, 6, 1
         ldur    d5,[x0,#-24]                // load packed A0.h for next iteration
-        UdotByElement 28, 0, 7, 0
-        UdotByElement 30, 0, 7, 1
+        SdotByElement 28, 0, 7, 0
+        SdotByElement 30, 0, 7, 1
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iteration
-        UdotByElement 25, 1, 6, 0
-        UdotByElement 27, 1, 6, 1
+        SdotByElement 25, 1, 6, 0
+        SdotByElement 27, 1, 6, 1
         ldur    d6,[x0,#-16]                // load packed A1.l for next iteration
-        UdotByElement 29, 1, 7, 0
-        UdotByElement 31, 1, 7, 1
+        SdotByElement 29, 1, 7, 0
+        SdotByElement 31, 1, 7, 1
         b       ComputeBlockLoopM4
 
 ComputeBlockLoopFinishM4
-        UdotByElement 21, 1, 5, 0
-        UdotByElement 23, 1, 5, 1
+        SdotByElement 21, 1, 5, 0
+        SdotByElement 23, 1, 5, 1
         ld1     {v1.16b},[x1],#16           // load packed B1_next4k
-        UdotByElement 24, 0, 6, 0
-        UdotByElement 26, 0, 6, 1
-        UdotByElement 28, 0, 7, 0
-        UdotByElement 30, 0, 7, 1
-        UdotByElement 25, 1, 6, 0
-        UdotByElement 27, 1, 6, 1
-        UdotByElement 29, 1, 7, 0
-        UdotByElement 31, 1, 7, 1
+        SdotByElement 24, 0, 6, 0
+        SdotByElement 26, 0, 6, 1
+        SdotByElement 28, 0, 7, 0
+        SdotByElement 30, 0, 7, 1
+        SdotByElement 25, 1, 6, 0
+        SdotByElement 27, 1, 6, 1
+        SdotByElement 29, 1, 7, 0
+        SdotByElement 31, 1, 7, 1
         add     x10,x2,x6,lsl #2            // compute output row 2
         add     v16.4s,v16.4s,v24.4s        // fold high results into low results
         add     v18.4s,v18.4s,v26.4s
@@ -839,28 +839,28 @@ ComputeBlockLoopM2
         sub     x3,x3,#1
         ld1     {v6.16b},[x1],#16           // load packed B0 next 4 k
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 17, 1, 4, 0
-        UdotByElement 18, 0, 4, 1
-        UdotByElement 19, 1, 4, 1
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 17, 1, 4, 0
+        SdotByElement 18, 0, 4, 1
+        SdotByElement 19, 1, 4, 1
         cbz     x3,ComputeBlockLoopFinishM2
         ldr     d4,[x0],#8                  // load packed A0.l for next iter
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iter
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iter
-        UdotByElement 16, 6, 5, 0
-        UdotByElement 17, 7, 5, 0
-        UdotByElement 18, 6, 5, 1
-        UdotByElement 19, 7, 5, 1
+        SdotByElement 16, 6, 5, 0
+        SdotByElement 17, 7, 5, 0
+        SdotByElement 18, 6, 5, 1
+        SdotByElement 19, 7, 5, 1
         ldr     d5,[x0],#8                  // load packed A0.h for next iter
         b       ComputeBlockLoopM2
 
 ComputeBlockLoopFinishM2
         add     x10,x2,x6,lsl #2            // compute output row 2
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 16, 6, 5, 0
-        UdotByElement 17, 7, 5, 0
-        UdotByElement 18, 6, 5, 1
-        UdotByElement 19, 7, 5, 1
+        SdotByElement 16, 6, 5, 0
+        SdotByElement 17, 7, 5, 0
+        SdotByElement 18, 6, 5, 1
+        SdotByElement 19, 7, 5, 1
         blo     StoreOutputPartialM2
         cbnz    x13,SkipAccumulateOutputM2
         ldp     q0,q1,[x2]
@@ -974,13 +974,13 @@ SkipScaleByZeroPointBM1
 
 ComputeBlockLoopM1
         sub     x3,x3,#1
-        UdotByElement 16, 0, 4, 0
-        UdotByElement 17, 1, 4, 0
+        SdotByElement 16, 0, 4, 0
+        SdotByElement 17, 1, 4, 0
         cbz     x3,ComputeBlockLoopFinishM1
         ld1     {v0.16b},[x1],#16           // load packed B0 for next iter
         ld1     {v1.16b},[x1],#16           // load packed B1 for next iter
-        UdotByElement 16, 6, 4, 1
-        UdotByElement 17, 7, 4, 1
+        SdotByElement 16, 6, 4, 1
+        SdotByElement 17, 7, 4, 1
         ldr     d4,[x0],#8                  // load packed A0 for next iter
         ld1     {v6.16b},[x1],#16           // load packed B0 next 4 k for next iter
         ld1     {v7.16b},[x1],#16           // load packed B1 next 4 k for next iter
@@ -988,8 +988,8 @@ ComputeBlockLoopM1
 
 ComputeBlockLoopFinishM1
         subs    x5,x5,#8                    // adjust CountN remaining
-        UdotByElement 16, 6, 4, 1
-        UdotByElement 17, 7, 4, 1
+        SdotByElement 16, 6, 4, 1
+        SdotByElement 17, 7, 4, 1
         blo     StoreOutputPartialM1
         cbnz    x13,SkipAccumulateOutputM1
         ldp     q0,q1,[x2]
@@ -1049,6 +1049,6 @@ StoreOutputPartial1AddModeM1
         st1     {v16.s}[0],[x2]
         b       ExitKernelM1
 
-        NESTED_END MlasGemmU8X8KernelUdot
+        NESTED_END MlasGemmS8S8KernelSDot
 
         END

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -465,14 +465,14 @@ void
     int8_t ZeroPoint
     );
 
-template<typename FilterType>
-struct MLAS_U8X8_KERNEL
+template<typename InputType, typename FilterType>
+struct MLAS_QUANT_KERNEL
 {
     typedef
     void
     (MLASCALL DepthwiseKernel)(
-        const uint8_t* const* Input,
-        uint8_t InputZeroPoint,
+        const InputType* const* Input,
+        InputType InputZeroPoint,
         const FilterType* Filter,
         FilterType FilterZeroPoint,
         int32_t* Output,
@@ -655,17 +655,19 @@ MlasSgemmOperation(
 // Quantized integer matrix/matrix dispatch structure.
 //
 
-struct MLAS_GEMM_U8X8_DISPATCH;
+struct MLAS_GEMM_QUANT_DISPATCH;
 
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchSse;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8S8DispatchSse41;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8S8DispatchAvx2;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8U8DispatchAvx2;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmS8S8DispatchNeon;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchUdot;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchWasmSimd;
-extern const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchDefault;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchSse;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchSse41;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchAvx2;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8U8DispatchAvx2;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchNeon;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmS8S8DispatchNeon;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchUdot;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmS8S8DispatchSdot;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchWasmSimd;
+extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchDefault;
 
 //
 // Symmetric quantized integer convolution dispatch structure.
@@ -683,12 +685,12 @@ extern const MLAS_CONV_SYM_DISPATCH MlasConvSymDispatchNeon;
 // Quantized depthwise convolution kernels.
 //
 
-template<typename FilterType>
+template<typename InputType, typename FilterType>
 void
 MLASCALL
 MlasConvDepthwiseKernel(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
+    const InputType* const* Input,
+    InputType InputZeroPoint,
     const FilterType* Filter,
     FilterType FilterZeroPoint,
     int32_t* Output,
@@ -697,12 +699,12 @@ MlasConvDepthwiseKernel(
     size_t KernelSize
     );
 
-template<typename FilterType>
+template <typename InputType, typename FilterType>
 void
 MLASCALL
 MlasConvDepthwiseKernelAvx2(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
+    const InputType* const* Input,
+    InputType InputZeroPoint,
     const FilterType* Filter,
     FilterType FilterZeroPoint,
     int32_t* Output,
@@ -755,13 +757,14 @@ struct MLAS_PLATFORM {
 #endif
 
 #if defined(MLAS_TARGET_AMD64_IX86)
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8S8Dispatch;
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8U8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmU8S8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmU8U8Dispatch;
 #elif defined(MLAS_TARGET_ARM64)
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8X8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmU8X8Dispatch;
 #endif
 
-    const MLAS_CONV_SYM_DISPATCH* ConvSymDispatch{nullptr};
+    const MLAS_CONV_SYM_DISPATCH* ConvSymU8S8Dispatch{nullptr};
+    const MLAS_CONV_SYM_DISPATCH* ConvSymS8S8Dispatch{nullptr};
 #if defined(MLAS_TARGET_POWER)
     MLAS_GEMM_DOUBLE_KERNEL* GemmDoubleKernel;
 #endif
@@ -781,8 +784,10 @@ struct MLAS_PLATFORM {
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ErfKernelRoutine;
     MLAS_QLINEAR_BINARY_OP_S8_KERNEL* QLinearAddS8Kernel;
     MLAS_QLINEAR_BINARY_OP_U8_KERNEL* QLinearAddU8Kernel;
-    MLAS_U8X8_KERNEL<int8_t>::DepthwiseKernel* ConvDepthwiseU8S8Kernel;
-    MLAS_U8X8_KERNEL<uint8_t>::DepthwiseKernel* ConvDepthwiseU8U8Kernel;
+    MLAS_QUANT_KERNEL<uint8_t, int8_t>::DepthwiseKernel* ConvDepthwiseU8S8Kernel;
+    MLAS_QUANT_KERNEL<uint8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseU8U8Kernel;
+    MLAS_QUANT_KERNEL<int8_t, int8_t>::DepthwiseKernel* ConvDepthwiseS8S8Kernel;
+    MLAS_QUANT_KERNEL<int8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseS8U8Kernel;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ComputeExpF32Kernel;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* LogisticKernelRoutine;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* TanhKernelRoutine;

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -765,6 +765,12 @@ struct MLAS_PLATFORM {
 
     const MLAS_CONV_SYM_DISPATCH* ConvSymU8S8Dispatch{nullptr};
     const MLAS_CONV_SYM_DISPATCH* ConvSymS8S8Dispatch{nullptr};
+
+    MLAS_QUANT_KERNEL<uint8_t, int8_t>::DepthwiseKernel* ConvDepthwiseU8S8Kernel;
+    MLAS_QUANT_KERNEL<uint8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseU8U8Kernel;
+    MLAS_QUANT_KERNEL<int8_t, int8_t>::DepthwiseKernel* ConvDepthwiseS8S8Kernel;
+    MLAS_QUANT_KERNEL<int8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseS8U8Kernel;
+
 #if defined(MLAS_TARGET_POWER)
     MLAS_GEMM_DOUBLE_KERNEL* GemmDoubleKernel;
 #endif
@@ -784,10 +790,6 @@ struct MLAS_PLATFORM {
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ErfKernelRoutine;
     MLAS_QLINEAR_BINARY_OP_S8_KERNEL* QLinearAddS8Kernel;
     MLAS_QLINEAR_BINARY_OP_U8_KERNEL* QLinearAddU8Kernel;
-    MLAS_QUANT_KERNEL<uint8_t, int8_t>::DepthwiseKernel* ConvDepthwiseU8S8Kernel;
-    MLAS_QUANT_KERNEL<uint8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseU8U8Kernel;
-    MLAS_QUANT_KERNEL<int8_t, int8_t>::DepthwiseKernel* ConvDepthwiseS8S8Kernel;
-    MLAS_QUANT_KERNEL<int8_t, uint8_t>::DepthwiseKernel* ConvDepthwiseS8U8Kernel;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* ComputeExpF32Kernel;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* LogisticKernelRoutine;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL* TanhKernelRoutine;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -123,6 +123,11 @@ Return Value:
 --*/
 {
 
+    this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernel<uint8_t, int8_t>;
+    this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernel<uint8_t, uint8_t>;
+    this->ConvDepthwiseS8S8Kernel = MlasConvDepthwiseKernel<int8_t, int8_t>;
+    this->ConvDepthwiseS8U8Kernel = MlasConvDepthwiseKernel<int8_t, uint8_t>;
+
 #if defined(MLAS_TARGET_AMD64_IX86)
 
     //
@@ -157,10 +162,6 @@ Return Value:
     this->QLinearAddU8Kernel = MlasQLinearAddU8Kernel;
     this->QuantizeLinearS8Kernel = MlasQuantizeLinearS8Kernel;
     this->QuantizeLinearU8Kernel = MlasQuantizeLinearU8Kernel;
-    this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernel<uint8_t, int8_t>;
-    this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernel<uint8_t, uint8_t>;
-    this->ConvDepthwiseS8S8Kernel = MlasConvDepthwiseKernel<int8_t, int8_t>;
-    this->ConvDepthwiseS8U8Kernel = MlasConvDepthwiseKernel<int8_t, uint8_t>;
 
     this->NchwcBlockSize = 8;
     this->PreferredBufferAlignment = MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -157,8 +157,10 @@ Return Value:
     this->QLinearAddU8Kernel = MlasQLinearAddU8Kernel;
     this->QuantizeLinearS8Kernel = MlasQuantizeLinearS8Kernel;
     this->QuantizeLinearU8Kernel = MlasQuantizeLinearU8Kernel;
-    this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernel<int8_t>;
-    this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernel<uint8_t>;
+    this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernel<uint8_t, int8_t>;
+    this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernel<uint8_t, uint8_t>;
+    this->ConvDepthwiseS8S8Kernel = MlasConvDepthwiseKernel<int8_t, int8_t>;
+    this->ConvDepthwiseS8U8Kernel = MlasConvDepthwiseKernel<int8_t, uint8_t>;
 
     this->NchwcBlockSize = 8;
     this->PreferredBufferAlignment = MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT;
@@ -238,7 +240,7 @@ Return Value:
                 this->GemvU8S8Kernel = MlasGemvU8S8KernelAvx2;
                 this->GemmU8U8Dispatch = &MlasGemmU8U8DispatchAvx2;
                 this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx2;
-                this->ConvSymDispatch = &MlasConvSymDispatchAvx2;
+                this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx2;
 
                 this->GemmFloatKernel = MlasGemmFloatKernelFma3;
                 this->GemmDoubleKernel = MlasGemmDoubleKernelFma3;
@@ -252,8 +254,10 @@ Return Value:
                 this->ErfKernelRoutine = MlasErfKernelFma3;
                 this->QLinearAddS8Kernel = MlasQLinearAddS8KernelAvx2;
                 this->QLinearAddU8Kernel = MlasQLinearAddU8KernelAvx2;
-                this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernelAvx2<int8_t>;
-                this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernelAvx2<uint8_t>;
+                this->ConvDepthwiseU8S8Kernel = MlasConvDepthwiseKernelAvx2<uint8_t, int8_t>;
+                this->ConvDepthwiseU8U8Kernel = MlasConvDepthwiseKernelAvx2<uint8_t, uint8_t>;
+                this->ConvDepthwiseS8S8Kernel = MlasConvDepthwiseKernelAvx2<int8_t, int8_t>;
+                this->ConvDepthwiseS8U8Kernel = MlasConvDepthwiseKernelAvx2<int8_t, uint8_t>;
                 this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelFma3;
 
                 //
@@ -280,7 +284,7 @@ Return Value:
                     this->GemmU8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
                     this->GemmU8S8Kernel = MlasGemmU8S8KernelAvxVnni;
                     this->GemvU8S8Kernel = MlasGemvU8S8KernelAvxVnni;
-                    this->ConvSymDispatch = &MlasConvSymDispatchAvxVnni;
+                    this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvxVnni;
                 }
 
 #if !defined(ORT_MINIMAL_BUILD)
@@ -318,7 +322,7 @@ Return Value:
                         this->GemmU8S8Kernel = MlasGemmU8S8KernelAvx512Core;
                         this->GemvU8S8Kernel = MlasGemvU8S8KernelAvx512Core;
                         this->GemmU8U8Kernel = MlasGemmU8U8KernelAvx512Core;
-                        this->ConvSymDispatch = &MlasConvSymDispatchAvx512Core;
+                        this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx512Core;
 
                         //
                         // Check if the processor supports AVX512VNNI.
@@ -329,7 +333,7 @@ Return Value:
                             this->GemmU8U8Dispatch = &MlasGemmU8S8DispatchAvx2;
                             this->GemmU8S8Kernel = MlasGemmU8S8KernelAvx512Vnni;
                             this->GemvU8S8Kernel = MlasGemvU8S8KernelAvx512Vnni;
-                            this->ConvSymDispatch = &MlasConvSymDispatchAvx512Vnni;
+                            this->ConvSymU8S8Dispatch = &MlasConvSymDispatchAvx512Vnni;
                         }
                     }
                 }
@@ -348,7 +352,7 @@ Return Value:
 #if defined(MLAS_TARGET_ARM64)
 
     this->GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;
-    this->ConvSymDispatch = &MlasConvSymDispatchNeon;
+    this->ConvSymU8S8Dispatch = &MlasConvSymDispatchNeon;
 
     //
     // Check if the processor supports ASIMD dot product instructions.

--- a/onnxruntime/core/mlas/lib/qdwconv.cpp
+++ b/onnxruntime/core/mlas/lib/qdwconv.cpp
@@ -17,15 +17,18 @@ Abstract:
 #include "mlasi.h"
 
 template <typename InputType, typename FilterType>
-void MLASCALL
-MlasConvDepthwiseKernel(const InputType* const* Input,
-                        InputType InputZeroPoint,
-                        const FilterType* Filter,
-                        FilterType FilterZeroPoint,
-                        int32_t* Output,
-                        size_t Channels,
-                        size_t OutputCount,
-                        size_t KernelSize)
+void
+MLASCALL
+MlasConvDepthwiseKernel(
+    const InputType* const* Input,
+    InputType InputZeroPoint,
+    const FilterType* Filter,
+    FilterType FilterZeroPoint,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    )
 {
 #if defined(MLAS_SSE2_INTRINSICS)
     const __m128i ZeroVector = _mm_setzero_si128();
@@ -163,57 +166,76 @@ MlasConvDepthwiseKernel(const InputType* const* Input,
     }
 }
 
-template void MLASCALL
-MlasConvDepthwiseKernel(const uint8_t* const* Input,
-                        uint8_t InputZeroPoint,
-                        const int8_t* Filter,
-                        int8_t FilterZeroPoint,
-                        int32_t* Output,
-                        size_t Channels,
-                        size_t OutputCount,
-                        size_t KernelSize);
+template
+void
+MLASCALL
+MlasConvDepthwiseKernel(
+    const uint8_t* const* Input,
+    uint8_t InputZeroPoint,
+    const int8_t* Filter,
+    int8_t FilterZeroPoint,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    );
 
-template void MLASCALL
-MlasConvDepthwiseKernel(const uint8_t* const* Input,
-                        uint8_t InputZeroPoint,
-                        const uint8_t* Filter,
-                        uint8_t FilterZeroPoint,
-                        int32_t* Output,
-                        size_t Channels,
-                        size_t OutputCount,
-                        size_t KernelSize);
+template
+void
+MLASCALL
+MlasConvDepthwiseKernel(
+    const uint8_t* const* Input,
+    uint8_t InputZeroPoint,
+    const uint8_t* Filter,
+    uint8_t FilterZeroPoint,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    );
 
-template void MLASCALL
-MlasConvDepthwiseKernel(const int8_t* const* Input,
-                        int8_t InputZeroPoint,
-                        const int8_t* Filter,
-                        int8_t FilterZeroPoint,
-                        int32_t* Output,
-                        size_t Channels,
-                        size_t OutputCount,
-                        size_t KernelSize);
+template
+void
+MLASCALL
+MlasConvDepthwiseKernel(
+    const int8_t* const* Input,
+    int8_t InputZeroPoint,
+    const int8_t* Filter,
+    int8_t FilterZeroPoint,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    );
 
-template void MLASCALL
-MlasConvDepthwiseKernel(const int8_t* const* Input,
-                        int8_t InputZeroPoint,
-                        const uint8_t* Filter,
-                        uint8_t FilterZeroPoint,
-                        int32_t* Output,
-                        size_t Channels,
-                        size_t OutputCount,
-                        size_t KernelSize);
+template
+void
+MLASCALL
+MlasConvDepthwiseKernel(
+    const int8_t* const* Input,
+    int8_t InputZeroPoint,
+    const uint8_t* Filter,
+    uint8_t FilterZeroPoint,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    );
 
-void MLASCALL
-MlasConvDepthwise(const void* const* Input,
-                  uint8_t InputZeroPoint,
-                  bool InputIsSigned,
-                  const void* Filter,
-                  uint8_t FilterZeroPoint,
-                  bool FilterIsSigned,
-                  int32_t* Output,
-                  size_t Channels,
-                  size_t OutputCount,
-                  size_t KernelSize)
+void
+MLASCALL
+MlasConvDepthwise(
+    const void* const* Input,
+    int32_t InputZeroPoint,
+    bool InputIsSigned,
+    const void* Filter,
+    int32_t FilterZeroPoint,
+    bool FilterIsSigned,
+    int32_t* Output,
+    size_t Channels,
+    size_t OutputCount,
+    size_t KernelSize
+    )
 /*++
 
 Routine Description:
@@ -263,57 +285,37 @@ Return Value:
 
 --*/
 {
-#if defined(MLAS_TARGET_AMD64)
     if (InputIsSigned) {
         if (FilterIsSigned) {
+
             MlasPlatform.ConvDepthwiseS8S8Kernel(
                 reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
                 reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
-                Output, Channels, OutputCount, KernelSize);
+                Output, Channels, OutputCount, KernelSize
+                );
         } else {
+
             MlasPlatform.ConvDepthwiseS8U8Kernel(
                 reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
-                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
-                OutputCount, KernelSize);
+                reinterpret_cast<const uint8_t*>(Filter), static_cast<uint8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize
+                );
         }
     } else {
         if (FilterIsSigned) {
+
             MlasPlatform.ConvDepthwiseU8S8Kernel(
-                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
+                reinterpret_cast<const uint8_t* const*>(Input), static_cast<uint8_t>(InputZeroPoint),
                 reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
-                Output, Channels, OutputCount, KernelSize);
+                Output, Channels, OutputCount, KernelSize
+                );
         } else {
+
             MlasPlatform.ConvDepthwiseU8U8Kernel(
-                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
-                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
-                OutputCount, KernelSize);
+                reinterpret_cast<const uint8_t* const*>(Input), static_cast<uint8_t>(InputZeroPoint),
+                reinterpret_cast<const uint8_t*>(Filter), static_cast<uint8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize
+                );
         }
     }
-#else
-    if (InputIsSigned) {
-        if (FilterIsSigned) {
-            MlasConvDepthwiseKernel<int8_t, int8_t>(
-                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
-                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
-                Output, Channels, OutputCount, KernelSize);
-        } else {
-            MlasConvDepthwiseKernel<int8_t, uint8_t>(
-                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
-                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
-                OutputCount, KernelSize);
-        }
-    } else {
-        if (FilterIsSigned) {
-            MlasConvDepthwiseKernel<uint8_t, int8_t>(
-                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
-                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
-                Output, Channels, OutputCount, KernelSize);
-        } else {
-            MlasConvDepthwiseKernel<uint8_t, uint8_t>(
-                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
-                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
-                OutputCount, KernelSize);
-        }
-    }
-#endif
 }

--- a/onnxruntime/core/mlas/lib/qdwconv.cpp
+++ b/onnxruntime/core/mlas/lib/qdwconv.cpp
@@ -16,48 +16,47 @@ Abstract:
 
 #include "mlasi.h"
 
-template<typename FilterType>
-void
-MLASCALL
-MlasConvDepthwiseKernel(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
-    const FilterType* Filter,
-    FilterType FilterZeroPoint,
-    int32_t* Output,
-    size_t Channels,
-    size_t OutputCount,
-    size_t KernelSize
-    )
+template <typename InputType, typename FilterType>
+void MLASCALL
+MlasConvDepthwiseKernel(const InputType* const* Input,
+                        InputType InputZeroPoint,
+                        const FilterType* Filter,
+                        FilterType FilterZeroPoint,
+                        int32_t* Output,
+                        size_t Channels,
+                        size_t OutputCount,
+                        size_t KernelSize)
 {
 #if defined(MLAS_SSE2_INTRINSICS)
     const __m128i ZeroVector = _mm_setzero_si128();
     const __m128i InputZeroPointVector = _mm_set1_epi16(InputZeroPoint);
     const __m128i FilterZeroPointVector = _mm_set1_epi16(FilterZeroPoint);
 #elif defined(MLAS_NEON_INTRINSICS)
-    const uint8x8_t InputZeroPointVector = vdup_n_u8(InputZeroPoint);
+    const uint8x8_t InputZeroPointVector = vdup_n_u8(uint8_t(InputZeroPoint));
     const uint8x8_t FilterZeroPointVector = vdup_n_u8(uint8_t(FilterZeroPoint));
 #endif
 
     while (OutputCount > 0) {
-
         size_t ChannelOffset = 0;
         size_t c = Channels;
 
 #if defined(MLAS_SSE2_INTRINSICS)
 
         while (c >= 8) {
-
             __m128i Accumulator0 = _mm_setzero_si128();
             __m128i Accumulator1 = _mm_setzero_si128();
             size_t ChannelKernelOffset = ChannelOffset;
 
             for (size_t k = 0; k < KernelSize; k++) {
-
                 __m128i InputVector = _mm_loadl_epi64((const __m128i*)&Input[k][ChannelOffset]);
-                __m128i FilterVector = _mm_loadl_epi64((const __m128i*)&Filter[ChannelKernelOffset]);
+                __m128i FilterVector =
+                    _mm_loadl_epi64((const __m128i*)&Filter[ChannelKernelOffset]);
 
-                InputVector = _mm_unpacklo_epi8(InputVector, ZeroVector);
+                if (std::is_signed<InputType>::value) {
+                    InputVector = _mm_srai_epi16(_mm_unpacklo_epi8(ZeroVector, InputVector), 8);
+                } else {
+                    InputVector = _mm_unpacklo_epi8(InputVector, ZeroVector);
+                }
 
                 if (std::is_signed<FilterType>::value) {
                     FilterVector = _mm_srai_epi16(_mm_unpacklo_epi8(ZeroVector, FilterVector), 8);
@@ -91,30 +90,41 @@ MlasConvDepthwiseKernel(
 #elif defined(MLAS_NEON_INTRINSICS)
 
         while (c >= 8) {
-
             int32x4_t Accumulator0 = vdupq_n_s32(0);
             int32x4_t Accumulator1 = vdupq_n_s32(0);
             size_t ChannelKernelOffset = ChannelOffset;
 
             for (size_t k = 0; k < KernelSize; k++) {
+                uint8x8_t InputVector =
+                    vld1_u8(reinterpret_cast<const uint8_t*>(&Input[k][ChannelOffset]));
+                uint8x8_t FilterVector =
+                    vld1_u8(reinterpret_cast<const uint8_t*>(&Filter[ChannelKernelOffset]));
 
-                uint8x8_t InputVector = vld1_u8(&Input[k][ChannelOffset]);
-                uint8x8_t FilterVector = vld1_u8(reinterpret_cast<const uint8_t*>(&Filter[ChannelKernelOffset]));
-
-                int16x8_t InputVector16 = vreinterpretq_s16_u16(vsubl_u8(InputVector, InputZeroPointVector));
-                int16x8_t FilterVector16;
-
-                if (std::is_signed<FilterType>::value) {
-                    FilterVector16 = vsubl_s8(vreinterpret_s8_u8(FilterVector), vreinterpret_s8_u8(FilterZeroPointVector));
+                int16x8_t InputVector16;
+                if (std::is_signed<InputType>::value) {
+                    InputVector16 = vsubl_s8(vreinterpret_s8_u8(InputVector),
+                                             vreinterpret_s8_u8(InputZeroPointVector));
                 } else {
-                    FilterVector16 = vreinterpretq_s16_u16(vsubl_u8(FilterVector, FilterZeroPointVector));
+                    InputVector16 =
+                        vreinterpretq_s16_u16(vsubl_u8(InputVector, InputZeroPointVector));
                 }
 
-                Accumulator0 = vmlal_s16(Accumulator0, vget_low_s16(InputVector16), vget_low_s16(FilterVector16));
+                int16x8_t FilterVector16;
+                if (std::is_signed<FilterType>::value) {
+                    FilterVector16 = vsubl_s8(vreinterpret_s8_u8(FilterVector),
+                                              vreinterpret_s8_u8(FilterZeroPointVector));
+                } else {
+                    FilterVector16 =
+                        vreinterpretq_s16_u16(vsubl_u8(FilterVector, FilterZeroPointVector));
+                }
+
+                Accumulator0 = vmlal_s16(Accumulator0, vget_low_s16(InputVector16),
+                                         vget_low_s16(FilterVector16));
 #if defined(MLAS_NEON64_INTRINSICS)
                 Accumulator1 = vmlal_high_s16(Accumulator1, InputVector16, FilterVector16);
 #else
-                Accumulator1 = vmlal_s16(Accumulator1, vget_high_s16(InputVector16), vget_high_s16(FilterVector16));
+                Accumulator1 = vmlal_s16(Accumulator1, vget_high_s16(InputVector16),
+                                         vget_high_s16(FilterVector16));
 #endif
 
                 ChannelKernelOffset += Channels;
@@ -131,12 +141,10 @@ MlasConvDepthwiseKernel(
 #endif
 
         while (c > 0) {
-
             int32_t Accumulator = 0;
             size_t ChannelKernelOffset = ChannelOffset;
 
             for (size_t k = 0; k < KernelSize; k++) {
-
                 int32_t InputValue = int32_t(Input[k][ChannelOffset]) - InputZeroPoint;
                 int32_t FilterValue = int32_t(Filter[ChannelKernelOffset]) - FilterZeroPoint;
 
@@ -155,47 +163,57 @@ MlasConvDepthwiseKernel(
     }
 }
 
-template
-void
-MLASCALL
-MlasConvDepthwiseKernel(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
-    const int8_t* Filter,
-    int8_t FilterZeroPoint,
-    int32_t* Output,
-    size_t Channels,
-    size_t OutputCount,
-    size_t KernelSize
-    );
+template void MLASCALL
+MlasConvDepthwiseKernel(const uint8_t* const* Input,
+                        uint8_t InputZeroPoint,
+                        const int8_t* Filter,
+                        int8_t FilterZeroPoint,
+                        int32_t* Output,
+                        size_t Channels,
+                        size_t OutputCount,
+                        size_t KernelSize);
 
-template
-void
-MLASCALL
-MlasConvDepthwiseKernel(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
-    const uint8_t* Filter,
-    uint8_t FilterZeroPoint,
-    int32_t* Output,
-    size_t Channels,
-    size_t OutputCount,
-    size_t KernelSize
-    );
+template void MLASCALL
+MlasConvDepthwiseKernel(const uint8_t* const* Input,
+                        uint8_t InputZeroPoint,
+                        const uint8_t* Filter,
+                        uint8_t FilterZeroPoint,
+                        int32_t* Output,
+                        size_t Channels,
+                        size_t OutputCount,
+                        size_t KernelSize);
 
-void
-MLASCALL
-MlasConvDepthwise(
-    const uint8_t* const* Input,
-    uint8_t InputZeroPoint,
-    const uint8_t* Filter,
-    uint8_t FilterZeroPoint,
-    bool FilterIsSigned,
-    int32_t* Output,
-    size_t Channels,
-    size_t OutputCount,
-    size_t KernelSize
-    )
+template void MLASCALL
+MlasConvDepthwiseKernel(const int8_t* const* Input,
+                        int8_t InputZeroPoint,
+                        const int8_t* Filter,
+                        int8_t FilterZeroPoint,
+                        int32_t* Output,
+                        size_t Channels,
+                        size_t OutputCount,
+                        size_t KernelSize);
+
+template void MLASCALL
+MlasConvDepthwiseKernel(const int8_t* const* Input,
+                        int8_t InputZeroPoint,
+                        const uint8_t* Filter,
+                        uint8_t FilterZeroPoint,
+                        int32_t* Output,
+                        size_t Channels,
+                        size_t OutputCount,
+                        size_t KernelSize);
+
+void MLASCALL
+MlasConvDepthwise(const void* const* Input,
+                  uint8_t InputZeroPoint,
+                  bool InputIsSigned,
+                  const void* Filter,
+                  uint8_t FilterZeroPoint,
+                  bool FilterIsSigned,
+                  int32_t* Output,
+                  size_t Channels,
+                  size_t OutputCount,
+                  size_t KernelSize)
 /*++
 
 Routine Description:
@@ -218,6 +236,9 @@ Arguments:
     Input - Supplies an indirection buffer to the elements of the input tensor.
 
     InputZeroPoint - Supplies the zero point offset of the input tensor.
+
+    InputIsSigned - Supplies true if the input tensor is signed data, else
+        false if the input tensor is unsigned data.
 
     Filter - Supplies the filter tensor.
 
@@ -242,36 +263,57 @@ Return Value:
 
 --*/
 {
-    if (FilterIsSigned) {
-
 #if defined(MLAS_TARGET_AMD64)
-        MlasPlatform.ConvDepthwiseU8S8Kernel(
-#else
-        MlasConvDepthwiseKernel<int8_t>(
-#endif
-            Input,
-            InputZeroPoint,
-            reinterpret_cast<const int8_t*>(Filter),
-            static_cast<int8_t>(FilterZeroPoint),
-            Output,
-            Channels,
-            OutputCount,
-            KernelSize);
-
+    if (InputIsSigned) {
+        if (FilterIsSigned) {
+            MlasPlatform.ConvDepthwiseS8S8Kernel(
+                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
+                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize);
+        } else {
+            MlasPlatform.ConvDepthwiseS8U8Kernel(
+                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
+                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
+                OutputCount, KernelSize);
+        }
     } else {
-
-#if defined(MLAS_TARGET_AMD64)
-        MlasPlatform.ConvDepthwiseU8U8Kernel(
-#else
-        MlasConvDepthwiseKernel<uint8_t>(
-#endif
-            Input,
-            InputZeroPoint,
-            Filter,
-            FilterZeroPoint,
-            Output,
-            Channels,
-            OutputCount,
-            KernelSize);
+        if (FilterIsSigned) {
+            MlasPlatform.ConvDepthwiseU8S8Kernel(
+                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
+                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize);
+        } else {
+            MlasPlatform.ConvDepthwiseU8U8Kernel(
+                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
+                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
+                OutputCount, KernelSize);
+        }
     }
+#else
+    if (InputIsSigned) {
+        if (FilterIsSigned) {
+            MlasConvDepthwiseKernel<int8_t, int8_t>(
+                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
+                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize);
+        } else {
+            MlasConvDepthwiseKernel<int8_t, uint8_t>(
+                reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
+                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
+                OutputCount, KernelSize);
+        }
+    } else {
+        if (FilterIsSigned) {
+            MlasConvDepthwiseKernel<uint8_t, int8_t>(
+                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
+                reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
+                Output, Channels, OutputCount, KernelSize);
+        } else {
+            MlasConvDepthwiseKernel<uint8_t, uint8_t>(
+                reinterpret_cast<const uint8_t* const*>(Input), InputZeroPoint,
+                reinterpret_cast<const uint8_t*>(Filter), FilterZeroPoint, Output, Channels,
+                OutputCount, KernelSize);
+        }
+    }
+#endif
 }

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -23,16 +23,16 @@ Abstract:
 // threads.
 //
 
-struct MLAS_GEMM_U8X8_WORK_BLOCK {
+struct MLAS_GEMM_QUANT_WORK_BLOCK {
     ptrdiff_t ThreadCountM;
     ptrdiff_t ThreadCountN;
 };
 
 void
-MlasGemmU8X8Threaded(
-    const MLAS_GEMM_U8X8_WORK_BLOCK* WorkBlock,
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS* Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* Data,
+MlasGemmQuantThreaded(
+    const MLAS_GEMM_QUANT_WORK_BLOCK* WorkBlock,
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS* Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* Data,
     ptrdiff_t ThreadId
     )
 /*++
@@ -96,24 +96,24 @@ Return Value:
     // Dispatch the partitioned operation.
     //
 
-    const auto* GemmU8X8Dispatch = MlasGemmU8X8GetDispatch(Shape->BIsSigned);
-    MLAS_GEMM_U8X8_OPERATION* GemmU8X8Operation;
+    const auto* GemmQuantDispatch = MlasGemmQuantGetDispatch(Shape->AIsSigned, Shape->BIsSigned);
+    MLAS_GEMM_QUANT_OPERATION* GemmQuantOperation;
 
     if (Data->BIsPacked) {
-        GemmU8X8Operation = GemmU8X8Dispatch->PackedOperation;
+        GemmQuantOperation = GemmQuantDispatch->PackedOperation;
     } else {
-        GemmU8X8Operation = GemmU8X8Dispatch->Operation;
+        GemmQuantOperation = GemmQuantDispatch->Operation;
     }
 
-    GemmU8X8Operation(Shape, Data, RangeStartM, RangeCountM, RangeStartN, RangeCountN);
+    GemmQuantOperation(Shape, Data, RangeStartM, RangeCountM, RangeStartN, RangeCountN);
 }
 
 
 void
 MLASCALL
 MlasGemm(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS &Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS &DataParams,
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS &Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS &DataParams,
     MLAS_THREADPOOL *ThreadPool)
 /*++
 
@@ -143,11 +143,29 @@ Return Value:
 void
 MLASCALL
 MlasGemmBatch(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS& Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* DataParams,
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
     const size_t BatchN,
     MLAS_THREADPOOL* ThreadPool)
 {
+    if (Shape.AIsSigned) {
+        if (!Shape.BIsSigned) {
+#ifdef MLAS_NO_EXCEPTION
+            abort();
+#else
+            throw std::invalid_argument("Only support B is signed if A is signed.");
+#endif
+        }
+
+#if !defined(MLAS_TARGET_ARM64)
+#if defined(MLAS_NO_EXCEPTION)
+        abort();
+#else
+        throw std::invalid_argument("Only ARM64 supports A is signed.");
+#endif
+#endif
+    }
+
     const size_t M = Shape.M;
     const size_t N = Shape.N;
     const size_t K = Shape.K;
@@ -185,7 +203,7 @@ MlasGemmBatch(
     // works okay for operations involving skinny matrices.
     //
 
-    MLAS_GEMM_U8X8_WORK_BLOCK WorkBlock;
+    MLAS_GEMM_QUANT_WORK_BLOCK WorkBlock;
 
     if (N > M) {
 
@@ -213,7 +231,7 @@ MlasGemmBatch(
     MlasTrySimpleParallel(ThreadPool, TargetThreadCount, [&](ptrdiff_t tid) {
         const auto gemm_i = tid / ThreadsPerGemm;
         const auto blk_i = tid % ThreadsPerGemm;
-        MlasGemmU8X8Threaded(&WorkBlock, &Shape, &DataParams[gemm_i], blk_i);
+        MlasGemmQuantThreaded(&WorkBlock, &Shape, &DataParams[gemm_i], blk_i);
     });
 }
 
@@ -222,7 +240,8 @@ size_t
 MLASCALL
 MlasGemmPackBSize(
     size_t N,
-    size_t K,
+    size_t K, 
+    bool AIsSigned,
     bool BIsSigned
     )
 /*++
@@ -252,10 +271,10 @@ Return Value:
     // Retrieve the packing parameters.
     //
 
-    const auto* GemmU8X8Dispatch = MlasGemmU8X8GetDispatch(BIsSigned);
+    const auto* GemmQuantDispatch = MlasGemmQuantGetDispatch(AIsSigned, BIsSigned);
 
-    size_t PackedK = GemmU8X8Dispatch->PackedK;
-    size_t PackedStrideK = GemmU8X8Dispatch->PackedStrideK;
+    size_t PackedK = GemmQuantDispatch->PackedK;
+    size_t PackedStrideK = GemmQuantDispatch->PackedStrideK;
 
     if (PackedStrideK == 0) {
         return 0;
@@ -285,6 +304,7 @@ MlasGemmPackB(
     size_t K,
     const uint8_t* B,
     size_t ldb,
+    bool AIsSigned,
     bool BIsSigned,
     void* PackedB
     )
@@ -320,10 +340,10 @@ Return Value:
     // Retrieve the packing parameters.
     //
 
-    const auto* GemmU8X8Dispatch = MlasGemmU8X8GetDispatch(BIsSigned);
+    const auto* GemmQuantDispatch = MlasGemmQuantGetDispatch(AIsSigned, BIsSigned);
 
-    size_t PackedK = GemmU8X8Dispatch->PackedK;
-    size_t PackedStrideK = GemmU8X8Dispatch->PackedStrideK;
+    size_t PackedK = GemmQuantDispatch->PackedK;
+    size_t PackedStrideK = GemmQuantDispatch->PackedStrideK;
 
     //
     // Reserve and initialize storage for the column sum buffer to hold the sums
@@ -362,7 +382,7 @@ Return Value:
 
             CountN = std::min(N - n, BatchedN);
 
-            GemmU8X8Dispatch->CopyPackBRoutine(pb, B + n, ldb, CountN, CountK, ColumnSumBuffer, BIsSigned);
+            GemmQuantDispatch->CopyPackBRoutine(pb, B + n, ldb, CountN, CountK, ColumnSumBuffer, BIsSigned);
 
             //
             // Accumulate this batch of the column sum buffer into the packed

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -148,24 +148,6 @@ MlasGemmBatch(
     const size_t BatchN,
     MLAS_THREADPOOL* ThreadPool)
 {
-    if (Shape.AIsSigned) {
-        if (!Shape.BIsSigned) {
-#ifdef MLAS_NO_EXCEPTION
-            abort();
-#else
-            throw std::invalid_argument("Only support B is signed if A is signed.");
-#endif
-        }
-
-#if !defined(MLAS_TARGET_ARM64)
-#if defined(MLAS_NO_EXCEPTION)
-        abort();
-#else
-        throw std::invalid_argument("Only ARM64 supports A is signed.");
-#endif
-#endif
-    }
-
     const size_t M = Shape.M;
     const size_t N = Shape.N;
     const size_t K = Shape.K;

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -13,16 +13,16 @@ Abstract:
     This module defines the set of template functions to implement a kernel of
     quantized integer matrix/matrix multiply operation (QGEMM).
 
-    To implement a new kernel, there needs to specialize template functions below:
-        MlasGemmU8X8FixupZeroPointA
-        MlasGemmU8X8FixupZeroPointB
-        MlasGemmU8X8CopyPackA
-        MlasGemmU8X8CopyPackB
-        MlasGemmU8X8Kernel
-    Specialization of MlasGemmU8X8TryGemvKernel is optional.
+    To implement a new kernel, template functions below need to be specialized:
+        MlasGemmQuantFixupZeroPointA
+        MlasGemmQuantFixupZeroPointB
+        MlasGemmQuantCopyPackA
+        MlasGemmQuantCopyPackB
+        MlasGemmQuantKernel
+    Specialization of MlasGemmQuantTryGemvKernel is optional.
 
-    MlasGemmU8X8Operation and MlasGemmU8X8PackedOperation are shared kernel drivers.
-    MlasGemmU8X8ScaleSumBuffer is a helper function.
+    MlasGemmQuantOperation and MlasGemmQuantPackedOperation are shared kernel drivers.
+    MlasGemmQuantScaleSumBuffer is a helper function.
 
     It also includes the dispatcher logics.
 
@@ -37,7 +37,7 @@ Abstract:
 // matrix/matrix multiply operation.
 //
 
-struct MLAS_GEMM_U8X8_STRIDES {
+struct MLAS_GEMM_QUANT_STRIDES {
     size_t M;
     size_t N;
     size_t K;
@@ -46,13 +46,14 @@ struct MLAS_GEMM_U8X8_STRIDES {
 template<typename KernelType>
 MLAS_FORCEINLINE
 bool
-MlasGemmU8X8TryGemvKernel(
+MlasGemmQuantTryGemvKernel(
     const uint8_t* A,
     const uint8_t* B,
     size_t ldb,
     int32_t* C,
     size_t CountK,
     size_t CountN,
+    bool AIsSigned,
     bool BIsSigned
 )
 {
@@ -62,21 +63,26 @@ MlasGemmU8X8TryGemvKernel(
     MLAS_UNREFERENCED_PARAMETER(C);
     MLAS_UNREFERENCED_PARAMETER(CountK);
     MLAS_UNREFERENCED_PARAMETER(CountN);
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     MLAS_UNREFERENCED_PARAMETER(BIsSigned);
 
     return false;
 }
 
 template <typename KernelType>
-MLAS_FORCEINLINE int32_t
-MlasGemmU8X8FixupZeroPointA(int32_t ZeroPointA)
+MLAS_FORCEINLINE
+int32_t
+MlasGemmQuantFixupZeroPointA(
+    int32_t ZeroPointA,
+    bool AIsSigned)
 {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     return ZeroPointA;
 }
 
 template<typename KernelType>
 int32_t
-MlasGemmU8X8FixupZeroPointB(
+MlasGemmQuantFixupZeroPointB(
     int32_t ZeroPointB,
     bool BIsSigned
 )
@@ -89,7 +95,7 @@ MlasGemmU8X8FixupZeroPointB(
 template<typename KernelType>
 MLAS_FORCEINLINE
 void
-MlasGemmU8X8FixupZeroPointB(
+MlasGemmQuantFixupZeroPointB(
     const uint8_t* PackedZeroPointB,
     int32_t* ZeroPointBBuffer,
     size_t N,
@@ -101,13 +107,13 @@ MlasGemmU8X8FixupZeroPointB(
     for (size_t n = 0; n < N; n++) {
 
         ZeroPointB = typename KernelType::OffsetBType(PackedZeroPointB[n]);
-        ZeroPointB = MlasGemmU8X8FixupZeroPointB<KernelType>(ZeroPointB, BIsSigned);
+        ZeroPointB = MlasGemmQuantFixupZeroPointB<KernelType>(ZeroPointB, BIsSigned);
 
         ZeroPointBBuffer[n] = -ZeroPointB;
     }
 
     //
-    // Fill the misaligned slots of the zero point buffer with zeroes to guard
+    // Fill the misaligned slots of the zero point buffer with zeros to guard
     // against tools that check for uninitialized data usage.
     //
 
@@ -120,18 +126,19 @@ MlasGemmU8X8FixupZeroPointB(
 
 template<typename KernelType>
 void
-MlasGemmU8X8CopyPackA(
+MlasGemmQuantCopyPackA(
     typename KernelType::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
 );
 
 template<typename KernelType>
 void
-MlasGemmU8X8CopyPackB(
+MlasGemmQuantCopyPackB(
     typename KernelType::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -143,7 +150,7 @@ MlasGemmU8X8CopyPackB(
 
 template<typename KernelType>
 size_t
-MlasGemmU8X8Kernel(
+MlasGemmQuantKernel(
     const typename KernelType::PackedAType* A,
     const typename KernelType::PackedBType* B,
     int32_t* C,
@@ -160,7 +167,7 @@ MlasGemmU8X8Kernel(
 
 inline
 void
-MlasGemmU8X8ScaleSumBuffer(
+MlasGemmQuantScaleSumBuffer(
     int32_t* Output,
     const int32_t* Input,
     size_t N,
@@ -175,21 +182,21 @@ MlasGemmU8X8ScaleSumBuffer(
 
 MLAS_FORCEINLINE
 void
-MlasGemmU8X8ScaleSumBuffer(
+MlasGemmQuantScaleSumBuffer(
     int32_t* SumBuffer,
     size_t N,
     int32_t Scale
 )
 {
-    return MlasGemmU8X8ScaleSumBuffer(SumBuffer, SumBuffer, N, Scale);
+    return MlasGemmQuantScaleSumBuffer(SumBuffer, SumBuffer, N, Scale);
 }
 
 
 template<typename KernelType>
 void
-MlasGemmU8X8Operation(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS* Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* Data,
+MlasGemmQuantOperation(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS* Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* Data,
     const size_t RangeStartM,
     const size_t RangeCountM,
     const size_t RangeStartN,
@@ -222,7 +229,7 @@ Return Value:
 
 --*/
 {
-    constexpr MLAS_GEMM_U8X8_STRIDES Strides = KernelType::Strides;
+    constexpr MLAS_GEMM_QUANT_STRIDES Strides = KernelType::Strides;
 
     MLAS_DECLSPEC_ALIGN(typename KernelType::PackedAType PanelA[Strides.M * Strides.K], 64);
     MLAS_DECLSPEC_ALIGN(typename KernelType::PackedBType PanelB[Strides.N * Strides.K], 64);
@@ -244,7 +251,7 @@ Return Value:
         Data->ZeroPointB + RangeStartN : nullptr;
     bool IsAccumulateMode = Shape->IsAccumulateMode;
 
-    int32_t ZeroPointA = Data->ZeroPointA;
+    int32_t ZeroPointA = typename KernelType::OffsetAType(Data->ZeroPointA);
     int32_t ZeroPointB = typename KernelType::OffsetBType(*Data->ZeroPointB);
 
     //
@@ -254,7 +261,7 @@ Return Value:
     if ((RangeCountM == 1) &&
         (ZeroPointA == 0) && (PackedZeroPointB == nullptr) && (ZeroPointB == 0) &&
         (Data->OutputProcessor == nullptr)) {
-        if (MlasGemmU8X8TryGemvKernel<KernelType>(A, B, ldb, C, K, RangeCountN, Shape->BIsSigned)) {
+        if (MlasGemmQuantTryGemvKernel<KernelType>(A, B, ldb, C, K, RangeCountN, Shape->AIsSigned, Shape->BIsSigned)) {
             return;
         }
     }
@@ -264,7 +271,7 @@ Return Value:
     // kernel requires signed data.
     //
 
-    ZeroPointA = MlasGemmU8X8FixupZeroPointA<KernelType>(ZeroPointA);
+    ZeroPointA = MlasGemmQuantFixupZeroPointA<KernelType>(ZeroPointA, Shape->AIsSigned);
 
     //
     // Fixup the sign bit of the per-matrix zero point offset of matrix B if the
@@ -272,7 +279,7 @@ Return Value:
     // ignored if per-column zero point offsets are used instead.
     //
 
-    ZeroPointB = MlasGemmU8X8FixupZeroPointB<KernelType>(ZeroPointB, Shape->BIsSigned);
+    ZeroPointB = MlasGemmQuantFixupZeroPointB<KernelType>(ZeroPointB, Shape->BIsSigned);
 
     //
     // Step through each slice of matrix B along the K dimension.
@@ -302,7 +309,7 @@ Return Value:
             //
 
             if (PackedZeroPointB != nullptr) {
-                MlasGemmU8X8FixupZeroPointB<KernelType>(
+                MlasGemmQuantFixupZeroPointB<KernelType>(
                     PackedZeroPointB + n,
                     ZeroPointBBuffer,
                     CountN,
@@ -313,7 +320,7 @@ Return Value:
             // Copy a panel of matrix B to a local packed buffer.
             //
 
-            MlasGemmU8X8CopyPackB<KernelType>(
+            MlasGemmQuantCopyPackB<KernelType>(
                 PanelB,
                 B + n,
                 ldb,
@@ -322,7 +329,7 @@ Return Value:
                 ColumnSumBuffer,
                 Shape->BIsSigned);
 
-            MlasGemmU8X8ScaleSumBuffer(ColumnSumBuffer, CountN, -ZeroPointA);
+            MlasGemmQuantScaleSumBuffer(ColumnSumBuffer, CountN, -ZeroPointA);
 
             //
             // Step through each slice of matrix A along the M dimension.
@@ -339,13 +346,14 @@ Return Value:
                 // Copy a panel of matrix A to a local packed buffer.
                 //
 
-                MlasGemmU8X8CopyPackA<KernelType>(
+                MlasGemmQuantCopyPackA<KernelType>(
                     PanelA,
                     A + m * lda,
                     lda,
                     CountM,
                     CountK,
-                    RowSumBuffer);
+                    RowSumBuffer,
+                    Shape->AIsSigned);
 
                 //
                 // Apply the global depth value constant without the ZeroPointB scaling from:
@@ -367,7 +375,7 @@ Return Value:
                 //
 
                 if (PackedZeroPointB == nullptr) {
-                    MlasGemmU8X8ScaleSumBuffer(RowSumBuffer, CountM, -ZeroPointB);
+                    MlasGemmQuantScaleSumBuffer(RowSumBuffer, CountM, -ZeroPointB);
                 }
 
                 //
@@ -383,7 +391,7 @@ Return Value:
 
                 while (RowsRemaining > 0) {
 
-                    size_t RowsHandled = MlasGemmU8X8Kernel<KernelType>(
+                    size_t RowsHandled = MlasGemmQuantKernel<KernelType>(
                         pa,
                         PanelB,
                         c,
@@ -422,9 +430,9 @@ Return Value:
 
 template<typename KernelType>
 void
-MlasGemmU8X8PackedOperation(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS* Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* Data,
+MlasGemmQuantPackedOperation(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS* Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* Data,
     const size_t RangeStartM,
     const size_t RangeCountM,
     const size_t RangeStartN,
@@ -457,7 +465,7 @@ Return Value:
 
 --*/
 {
-    constexpr MLAS_GEMM_U8X8_STRIDES Strides = KernelType::PackedStrides;
+    constexpr MLAS_GEMM_QUANT_STRIDES Strides = KernelType::PackedStrides;
 
     MLAS_DECLSPEC_ALIGN(typename KernelType::PackedAType PanelA[Strides.M * Strides.K], 64);
 
@@ -477,7 +485,7 @@ Return Value:
         Data->ZeroPointB + RangeStartN : nullptr;
     bool IsAccumulateMode = Shape->IsAccumulateMode;
 
-    int32_t ZeroPointA = Data->ZeroPointA;
+    int32_t ZeroPointA = typename KernelType::OffsetAType(Data->ZeroPointA);
     int32_t ZeroPointB = typename KernelType::OffsetBType(*Data->ZeroPointB);
 
     //
@@ -485,7 +493,7 @@ Return Value:
     // kernel requires signed data.
     //
 
-    ZeroPointA = MlasGemmU8X8FixupZeroPointA<KernelType>(ZeroPointA);
+    ZeroPointA = MlasGemmQuantFixupZeroPointA<KernelType>(ZeroPointA, Shape->AIsSigned);
 
     //
     // Fixup the sign bit of the per-matrix zero point offset of matrix B if the
@@ -493,7 +501,7 @@ Return Value:
     // ignored if per-column zero point offsets are used instead.
     //
 
-    ZeroPointB = MlasGemmU8X8FixupZeroPointB<KernelType>(ZeroPointB, Shape->BIsSigned);
+    ZeroPointB = MlasGemmQuantFixupZeroPointB<KernelType>(ZeroPointB, Shape->BIsSigned);
 
     //
     // Extract the pointer to the column sum buffer from the packed matrix.
@@ -532,7 +540,7 @@ Return Value:
             CountN = std::min(RangeCountN - n, Strides.N);
 
             if (k == 0) {
-                MlasGemmU8X8ScaleSumBuffer(ColumnSumBuffer, PackedColumnSumBuffer + n,
+                MlasGemmQuantScaleSumBuffer(ColumnSumBuffer, PackedColumnSumBuffer + n,
                     CountN, -ZeroPointA);
             }
 
@@ -542,7 +550,7 @@ Return Value:
             //
 
             if (PackedZeroPointB != nullptr) {
-                MlasGemmU8X8FixupZeroPointB<KernelType>(
+                MlasGemmQuantFixupZeroPointB<KernelType>(
                     PackedZeroPointB + n,
                     ZeroPointBBuffer,
                     CountN,
@@ -566,13 +574,14 @@ Return Value:
                 // Copy a panel of matrix A to a local packed buffer.
                 //
 
-                MlasGemmU8X8CopyPackA<KernelType>(
+                MlasGemmQuantCopyPackA<KernelType>(
                     PanelA,
                     A + m * lda,
                     lda,
                     CountM,
                     CountK,
-                    RowSumBuffer);
+                    RowSumBuffer,
+                    Shape->AIsSigned);
 
                 //
                 // Apply the global depth value constant without the ZeroPointB scaling from:
@@ -594,7 +603,7 @@ Return Value:
                 //
 
                 if (PackedZeroPointB == nullptr) {
-                    MlasGemmU8X8ScaleSumBuffer(RowSumBuffer, CountM, -ZeroPointB);
+                    MlasGemmQuantScaleSumBuffer(RowSumBuffer, CountM, -ZeroPointB);
                 }
 
                 //
@@ -610,7 +619,7 @@ Return Value:
 
                 while (RowsRemaining > 0) {
 
-                    size_t RowsHandled = MlasGemmU8X8Kernel<KernelType>(
+                    size_t RowsHandled = MlasGemmQuantKernel<KernelType>(
                         pa,
                         b,
                         c,
@@ -652,9 +661,9 @@ Return Value:
 
 typedef
 void
-(MLAS_GEMM_U8X8_OPERATION)(
-    const MLAS_GEMM_U8X8_SHAPE_PARAMS* Shape,
-    const MLAS_GEMM_U8X8_DATA_PARAMS* Data,
+(MLAS_GEMM_QUANT_OPERATION)(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS* Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* Data,
     const size_t RangeStartM,
     const size_t RangeCountM,
     const size_t RangeStartN,
@@ -663,7 +672,7 @@ void
 
 typedef
 void
-(MLAS_GEMM_U8X8_COPY_PACKB_ROUTINE)(
+(MLAS_GEMM_QUANT_COPY_PACKB_ROUTINE)(
     uint8_t* D,
     const uint8_t* B,
     size_t ldb,
@@ -673,45 +682,62 @@ void
     bool BIsSigned
     );
 
-struct MLAS_GEMM_U8X8_DISPATCH {
-    MLAS_GEMM_U8X8_OPERATION* Operation;
-    MLAS_GEMM_U8X8_OPERATION* PackedOperation;
-    MLAS_GEMM_U8X8_COPY_PACKB_ROUTINE* CopyPackBRoutine;
+struct MLAS_GEMM_QUANT_DISPATCH {
+    MLAS_GEMM_QUANT_OPERATION* Operation;
+    MLAS_GEMM_QUANT_OPERATION* PackedOperation;
+    MLAS_GEMM_QUANT_COPY_PACKB_ROUTINE* CopyPackBRoutine;
     size_t PackedK;
     size_t PackedStrideK;
 };
 
-#define USE_NEONS8_KERNEL true
 
 MLAS_FORCEINLINE
-const MLAS_GEMM_U8X8_DISPATCH*
-MlasGemmU8X8GetDispatch(
+const MLAS_GEMM_QUANT_DISPATCH*
+MlasGemmQuantGetDispatch(
+    bool AIsSigned,
     bool BIsSigned
 )
 {
-    const MLAS_GEMM_U8X8_DISPATCH* GemmU8X8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmQuantDispatch = nullptr;
 
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     MLAS_UNREFERENCED_PARAMETER(BIsSigned);
 
 #if defined(MLAS_TARGET_AMD64_IX86)
+    if (AIsSigned) {
+        return GemmQuantDispatch;
+    }
+
     if (BIsSigned) {
-        GemmU8X8Dispatch = MlasPlatform.GemmU8S8Dispatch;
+        GemmQuantDispatch = MlasPlatform.GemmU8S8Dispatch;
     }
     else {
-        GemmU8X8Dispatch = MlasPlatform.GemmU8U8Dispatch;
+        GemmQuantDispatch = MlasPlatform.GemmU8U8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64)
-    GemmU8X8Dispatch = MlasPlatform.GemmU8X8Dispatch;
-    if (USE_NEONS8_KERNEL && BIsSigned && GemmU8X8Dispatch == &MlasGemmU8X8DispatchNeon) {
-        GemmU8X8Dispatch = &MlasGemmS8S8DispatchNeon;
+    GemmQuantDispatch = MlasPlatform.GemmU8X8Dispatch;
+    if(BIsSigned) {
+        if(GemmQuantDispatch == &MlasGemmU8X8DispatchNeon) {
+            GemmQuantDispatch = &MlasGemmX8S8DispatchNeon;
+        } else if(AIsSigned) {
+            GemmQuantDispatch = &MlasGemmS8S8DispatchSdot;
+        }
     }
 #elif defined(MLAS_TARGET_ARM64EC) || (defined(MLAS_TARGET_ARM) && !defined(_MSC_VER))
-    GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;
+    GemmQuantDispatch = &MlasGemmU8X8DispatchNeon;
 #elif defined(MLAS_TARGET_WASM_SIMD)
-    GemmU8X8Dispatch = &MlasGemmU8X8DispatchWasmSimd;
+    if (AIsSigned) {
+        return GemmQuantDispatch;
+    }
+
+    GemmQuantDispatch = &MlasGemmU8X8DispatchWasmSimd;
 #else
-    GemmU8X8Dispatch = &MlasGemmU8X8DispatchDefault;
+    if (AIsSigned) {
+        return GemmQuantDispatch;
+    }
+
+    GemmQuantDispatch = &MlasGemmU8X8DispatchDefault;
 #endif
 
-    return GemmU8X8Dispatch;
+    return GemmQuantDispatch;
 }

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_default.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_default.cpp
@@ -21,21 +21,22 @@ struct MLAS_GEMM_U8X8_KERNEL_DEFAULT
 {
     typedef uint8_t PackedAType;
     typedef uint8_t PackedBType;
+    typedef uint8_t OffsetAType;
     typedef uint8_t OffsetBType;
 
     static constexpr size_t PackedK = 4;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{ 16, 128, 128 };
-    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{ 16, 128, 128 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 16, 128, 128 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 16, 128, 128 };
 };
 
 constexpr size_t MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_DEFAULT::Strides;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedStrides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_DEFAULT::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedStrides;
 
 template<>
 MLAS_FORCEINLINE
 int32_t
-MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
     int32_t ZeroPointB,
     bool BIsSigned
     )
@@ -49,15 +50,17 @@ MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
 
 template<>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
+MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
     MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
     )
 {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     const size_t AlignedCountK =
         (CountK + MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedK - 1) & ~(MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedK - 1);
 
@@ -90,7 +93,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
+MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
     MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -140,7 +143,7 @@ MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
 
 template<>
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
+MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
     const MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedAType* A,
     const MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedBType* B,
     int32_t* C,
@@ -195,8 +198,8 @@ MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_DEFAULT>(
     return 1;
 }
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchDefault = {
-    MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_DEFAULT>,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchDefault = {
+    MlasGemmQuantOperation<MLAS_GEMM_U8X8_KERNEL_DEFAULT>,
     nullptr,
     nullptr,
     MLAS_GEMM_U8X8_KERNEL_DEFAULT::PackedK,

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -46,21 +46,35 @@ struct MLAS_GEMM_U8X8_KERNEL_NEON
 {
     typedef uint8_t PackedAType;
     typedef uint8_t PackedBType;
+    typedef uint8_t OffsetAType;
     typedef uint8_t OffsetBType;
 
     static constexpr size_t PackedK = 4;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{ 24, 128, 256 };
-    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{ 24, 128, 256 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 24, 128, 256 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 24, 128, 256 };
 };
 
 constexpr size_t MLAS_GEMM_U8X8_KERNEL_NEON::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_NEON::Strides;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_NEON::PackedStrides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_NEON::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_NEON::PackedStrides;
+
+template <>
+MLAS_FORCEINLINE int32_t
+MlasGemmQuantFixupZeroPointA<MLAS_GEMM_U8X8_KERNEL_NEON>(
+    int32_t ZeroPointA,
+    bool AIsSigned)
+{
+    if(AIsSigned) {
+        ZeroPointA = (uint8_t)(ZeroPointA ^ 0x80);
+    }
+
+    return ZeroPointA;
+}
 
 template<>
 MLAS_FORCEINLINE
 int32_t
-MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_NEON>(
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_NEON>(
     int32_t ZeroPointB,
     bool BIsSigned
     )
@@ -74,15 +88,20 @@ MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
 template<>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
+MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
     )
 {
+    const uint8_t BitFlipByte = AIsSigned ? 0x80 : 0;
+    const uint32_t BitFlip4Bytes = AIsSigned ? 0x80808080 : 0;
+    const uint32x4_t BitFlipVector = vdupq_n_u32(BitFlip4Bytes);
+
     //
     // Process four rows of matrix A in a loop.
     //
@@ -110,13 +129,13 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
         while (k >= 16) {
 
-            uint32x4_t v0 = vld1q_u32(reinterpret_cast<const uint32_t*>(a0));
+            uint32x4_t v0 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a0)), BitFlipVector);
             a0 += 16;
-            uint32x4_t v1 = vld1q_u32(reinterpret_cast<const uint32_t*>(a1));
+            uint32x4_t v1 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a1)), BitFlipVector);
             a1 += 16;
-            uint32x4_t v2 = vld1q_u32(reinterpret_cast<const uint32_t*>(a2));
+            uint32x4_t v2 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a2)), BitFlipVector);
             a2 += 16;
-            uint32x4_t v3 = vld1q_u32(reinterpret_cast<const uint32_t*>(a3));
+            uint32x4_t v3 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a3)), BitFlipVector);
             a3 += 16;
 
 #if defined(MLAS_NEON32_INTRINSICS)
@@ -163,13 +182,13 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
         while (k >= 4) {
 
-            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+            uint32_t v0 = (*reinterpret_cast<const uint32_t*>(a0)) ^ BitFlip4Bytes;
             a0 += 4;
-            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+            uint32_t v1 = (*reinterpret_cast<const uint32_t*>(a1)) ^ BitFlip4Bytes;
             a1 += 4;
-            uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2);
+            uint32_t v2 = (*reinterpret_cast<const uint32_t*>(a2)) ^ BitFlip4Bytes;
             a2 += 4;
-            uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3);
+            uint32_t v3 = (*reinterpret_cast<const uint32_t*>(a3)) ^ BitFlip4Bytes;
             a3 += 4;
 
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
@@ -195,10 +214,10 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
             while (k > 0) {
 
-                d[0] = *a0++;
-                d[4] = *a1++;
-                d[8] = *a2++;
-                d[12] = *a3++;
+                d[0] = (*a0++) ^ BitFlipByte;
+                d[4] = (*a1++) ^ BitFlipByte;
+                d[8] = (*a2++) ^ BitFlipByte;
+                d[12] = (*a3++) ^ BitFlipByte;
 
                 d += 1;
                 k -= 1;
@@ -241,9 +260,9 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
         while (k >= 4) {
 
-            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+            uint32_t v0 = (*reinterpret_cast<const uint32_t*>(a0))^ BitFlip4Bytes;
             a0 += 4;
-            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+            uint32_t v1 = (*reinterpret_cast<const uint32_t*>(a1)) ^ BitFlip4Bytes;
             a1 += 4;
 
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
@@ -267,8 +286,8 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
             while (k > 0) {
 
-                d[0] = *a0++;
-                d[4] = *a1++;
+                d[0] = (*a0++) ^ BitFlipByte;
+                d[4] = (*a1++) ^ BitFlipByte;
 
                 d += 1;
                 k -= 1;
@@ -307,7 +326,7 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_NEON>(
 
         while (k >= 16) {
 
-            uint8x16_t v = vld1q_u8(a);
+            uint8x16_t v = veorq_u8(vld1q_u8(a), vreinterpretq_u8_u32(BitFlipVector));
             a += 16;
 
             vst1q_u8(D, v);
@@ -374,7 +393,7 @@ MlasGemmU8X8CopyPackBProcessNeon(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>(
+MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>(
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -471,7 +490,7 @@ MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>(
 template<>
 MLAS_FORCEINLINE
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_NEON>(
+MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_NEON>(
     const MLAS_GEMM_U8X8_KERNEL_NEON::PackedAType* A,
     const MLAS_GEMM_U8X8_KERNEL_NEON::PackedBType* B,
     int32_t* C,
@@ -489,10 +508,10 @@ MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_NEON>(
                                   RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
 }
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchNeon = {
-    MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_NEON>,
-    MlasGemmU8X8PackedOperation<MLAS_GEMM_U8X8_KERNEL_NEON>,
-    MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchNeon = {
+    MlasGemmQuantOperation<MLAS_GEMM_U8X8_KERNEL_NEON>,
+    MlasGemmQuantPackedOperation<MLAS_GEMM_U8X8_KERNEL_NEON>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_NEON>,
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedK,
     MLAS_GEMM_U8X8_KERNEL_NEON::PackedStrides.K,
 };
@@ -522,31 +541,38 @@ extern "C" {
         );
 }
 
-struct MLAS_GEMM_S8S8_KERNEL_NEON {
+struct MLAS_GEMM_X8S8_KERNEL_NEON {
     typedef uint8_t PackedAType;
     typedef uint8_t PackedBType;
+    typedef int8_t OffsetAType;
     typedef int8_t OffsetBType;
 
     static constexpr size_t PackedK = 16;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{24, 128, 256};
-    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{24, 128, 384};
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{24, 128, 256};
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{24, 128, 384};
 };
 
-constexpr size_t MLAS_GEMM_S8S8_KERNEL_NEON::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_S8S8_KERNEL_NEON::Strides;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_S8S8_KERNEL_NEON::PackedStrides;
+constexpr size_t MLAS_GEMM_X8S8_KERNEL_NEON::PackedK;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_X8S8_KERNEL_NEON::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_X8S8_KERNEL_NEON::PackedStrides;
 
 template <>
 MLAS_FORCEINLINE int32_t
-MlasGemmU8X8FixupZeroPointA<MLAS_GEMM_S8S8_KERNEL_NEON>(int32_t ZeroPointA)
+MlasGemmQuantFixupZeroPointA<MLAS_GEMM_X8S8_KERNEL_NEON>(
+    int32_t ZeroPointA,
+    bool AIsSigned)
 {
-    return int8_t(ZeroPointA ^ 0x80);
+    if(AIsSigned) {
+        return ZeroPointA;
+    }
+
+    return MLAS_GEMM_X8S8_KERNEL_NEON::OffsetAType(ZeroPointA ^ 0x80);
 }
 
-template<>
+template<bool AIsSigned>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
-    MLAS_GEMM_S8S8_KERNEL_NEON::PackedAType* D,
+MlasGemmQuantCopyPackAX8S8Neon(
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
@@ -554,8 +580,10 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
     int32_t* RowSumBuffer
     )
 {
-
     const uint8x16_t BitFlipVector = vdupq_n_u8(0x80);
+    if constexpr(AIsSigned) {
+        MLAS_UNREFERENCED_PARAMETER(BitFlipVector);
+    }
 
     //
     // Process four rows of matrix A.
@@ -576,14 +604,32 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
         while (k >= 16) {
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
-            a0 += 16;
-            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
-            a1 += 16;
-            int8x16_t v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a2), BitFlipVector));
-            a2 += 16;
-            int8x16_t v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a3), BitFlipVector));
-            a3 += 16;
+            int8x16_t v0;
+            int8x16_t v1;
+            int8x16_t v2;
+            int8x16_t v3;
+
+            if constexpr (AIsSigned) {
+
+                v0 = vreinterpretq_s8_u8(vld1q_u8(a0));
+                a0 += 16;
+                v1 = vreinterpretq_s8_u8(vld1q_u8(a1));
+                a1 += 16;
+                v2 = vreinterpretq_s8_u8(vld1q_u8(a2));
+                a2 += 16;
+                v3 = vreinterpretq_s8_u8(vld1q_u8(a3));
+                a3 += 16;
+            } else {
+
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+                a0 += 16;
+                v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
+                a1 += 16;
+                v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a2), BitFlipVector));
+                a2 += 16;
+                v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a3), BitFlipVector));
+                a3 += 16;
+            }
 
             RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
             RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
@@ -603,10 +649,19 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
             uint8_t* d = D;
 
-            vst1q_u8(&D[0], BitFlipVector);
-            vst1q_u8(&D[16], BitFlipVector);
-            vst1q_u8(&D[32], BitFlipVector);
-            vst1q_u8(&D[48], BitFlipVector);
+            if constexpr (AIsSigned) {
+
+                vst1q_u8(&D[0], vmovq_n_u8(0));
+                vst1q_u8(&D[16], vmovq_n_u8(0));
+                vst1q_u8(&D[32], vmovq_n_u8(0));
+                vst1q_u8(&D[48], vmovq_n_u8(0));
+            } else {
+
+                vst1q_u8(&D[0], BitFlipVector);
+                vst1q_u8(&D[16], BitFlipVector);
+                vst1q_u8(&D[32], BitFlipVector);
+                vst1q_u8(&D[48], BitFlipVector);
+            }
 
             if (k >= 8) {
 
@@ -654,20 +709,36 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
                 k -= 1;
             }
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
-            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
-            int8x16_t v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[32]), BitFlipVector));
-            int8x16_t v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[48]), BitFlipVector));
+            int8x16_t v0;
+            int8x16_t v1;
+            int8x16_t v2;
+            int8x16_t v3;
+
+            if constexpr (AIsSigned) {
+
+                v0 = vreinterpretq_s8_u8(vld1q_u8(&D[0]));
+                v1 = vreinterpretq_s8_u8(vld1q_u8(&D[16]));
+                v2 = vreinterpretq_s8_u8(vld1q_u8(&D[32]));
+                v3 = vreinterpretq_s8_u8(vld1q_u8(&D[48]));
+            } else {
+
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+                v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
+                v2 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[32]), BitFlipVector));
+                v3 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[48]), BitFlipVector));
+            }
 
             RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
             RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
             RowSums2 = vpadalq_s16(RowSums2, vpaddlq_s8(v2));
             RowSums3 = vpadalq_s16(RowSums3, vpaddlq_s8(v3));
 
-            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
-            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
-            vst1q_u8(&D[32], vreinterpretq_u8_s8(v2));
-            vst1q_u8(&D[48], vreinterpretq_u8_s8(v3));
+            if constexpr (!AIsSigned) {
+                vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+                vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+                vst1q_u8(&D[32], vreinterpretq_u8_s8(v2));
+                vst1q_u8(&D[48], vreinterpretq_u8_s8(v3));
+            }
 
             D += 64;
         }
@@ -698,10 +769,22 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
         while (k >= 16) {
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
-            a0 += 16;
-            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
-            a1 += 16;
+            int8x16_t v0;
+            int8x16_t v1;
+
+            if constexpr (AIsSigned) {
+
+                v0 = vreinterpretq_s8_u8(vld1q_u8(a0));
+                a0 += 16;
+                v1 = vreinterpretq_s8_u8(vld1q_u8(a1));
+                a1 += 16;
+            } else {
+
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+                a0 += 16;
+                v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a1), BitFlipVector));
+                a1 += 16;
+            }
 
             RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
             RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
@@ -717,8 +800,15 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
             uint8_t* d = D;
 
-            vst1q_u8(&D[0], BitFlipVector);
-            vst1q_u8(&D[16], BitFlipVector);
+            if constexpr (AIsSigned) {
+
+                vst1q_u8(&D[0], vmovq_n_u8(0));
+                vst1q_u8(&D[16], vmovq_n_u8(0));
+            } else {
+
+                vst1q_u8(&D[0], BitFlipVector);
+                vst1q_u8(&D[16], BitFlipVector);
+            }
 
             while (k > 0) {
 
@@ -729,14 +819,24 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
                 k -= 1;
             }
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
-            int8x16_t v1 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
+            int8x16_t v0;
+            int8x16_t v1;
+
+            if constexpr (AIsSigned) {
+                v0 = vreinterpretq_s8_u8(vld1q_u8(&D[0]));
+                v1 = vreinterpretq_s8_u8(vld1q_u8(&D[16]));
+            } else {
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+                v1= vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[16]), BitFlipVector));
+            }
 
             RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
             RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(v1));
 
-            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
-            vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+            if constexpr (!AIsSigned) {
+                vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+                vst1q_u8(&D[16], vreinterpretq_u8_s8(v1));
+            }
 
             D += 32;
         }
@@ -763,8 +863,16 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
         while (k >= 16) {
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
-            a0 += 16;
+            int8x16_t v0;
+            if constexpr (AIsSigned){
+
+                v0 = vreinterpretq_s8_u8(vld1q_u8(a0));
+                a0 += 16;
+            } else {
+
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(a0), BitFlipVector));
+                a0 += 16;
+            }
 
             RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
 
@@ -778,7 +886,11 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
             uint8_t* d = D;
 
-            vst1q_u8(&D[0], BitFlipVector);
+            if constexpr (AIsSigned){
+                vst1q_u8(&D[0], vmovq_n_u8(0));
+            } else{
+                vst1q_u8(&D[0], BitFlipVector);
+            }
 
             while (k > 0) {
 
@@ -788,11 +900,17 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
                 k -= 1;
             }
 
-            int8x16_t v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+            int8x16_t v0;
+            if constexpr (AIsSigned){
 
-            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+                v0 = vreinterpretq_s8_u8(vld1q_u8(&D[0]));
+                RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+            } else {
 
-            vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+                v0 = vreinterpretq_s8_u8(veorq_u8(vld1q_u8(&D[0]), BitFlipVector));
+                RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(v0));
+                vst1q_u8(&D[0], vreinterpretq_u8_s8(v0));
+            }
 
             D += 16;
         }
@@ -813,8 +931,27 @@ MlasGemmU8X8CopyPackA<MLAS_GEMM_S8S8_KERNEL_NEON>(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>(
-    MLAS_GEMM_S8S8_KERNEL_NEON::PackedBType* D,
+MlasGemmQuantCopyPackA<MLAS_GEMM_X8S8_KERNEL_NEON>(
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedAType* D,
+    const uint8_t* A,
+    size_t lda,
+    size_t CountM,
+    size_t CountK,
+    int32_t* RowSumBuffer,
+    bool AIsSigned
+    )
+{
+    if(AIsSigned) {
+        MlasGemmQuantCopyPackAX8S8Neon<true>(D, A, lda, CountM, CountK, RowSumBuffer);
+    } else {
+        MlasGemmQuantCopyPackAX8S8Neon<false>(D, A, lda, CountM, CountK, RowSumBuffer);
+    }
+}
+
+template<>
+void
+MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>(
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
     size_t CountN,
@@ -944,9 +1081,9 @@ MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>(
 template<>
 MLAS_FORCEINLINE
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_S8S8_KERNEL_NEON>(
-    const MLAS_GEMM_S8S8_KERNEL_NEON::PackedAType* A,
-    const MLAS_GEMM_S8S8_KERNEL_NEON::PackedBType* B,
+MlasGemmQuantKernel<MLAS_GEMM_X8S8_KERNEL_NEON>(
+    const MLAS_GEMM_X8S8_KERNEL_NEON::PackedAType* A,
+    const MLAS_GEMM_X8S8_KERNEL_NEON::PackedBType* B,
     int32_t* C,
     size_t PackedCountK,
     size_t CountM,
@@ -963,12 +1100,12 @@ MlasGemmU8X8Kernel<MLAS_GEMM_S8S8_KERNEL_NEON>(
 }
 
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmS8S8DispatchNeon = {
-    MlasGemmU8X8Operation<MLAS_GEMM_S8S8_KERNEL_NEON>,
-    MlasGemmU8X8PackedOperation<MLAS_GEMM_S8S8_KERNEL_NEON>,
-    MlasGemmU8X8CopyPackB<MLAS_GEMM_S8S8_KERNEL_NEON>,
-    MLAS_GEMM_S8S8_KERNEL_NEON::PackedK,
-    MLAS_GEMM_S8S8_KERNEL_NEON::PackedStrides.K,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon = {
+    MlasGemmQuantOperation<MLAS_GEMM_X8S8_KERNEL_NEON>,
+    MlasGemmQuantPackedOperation<MLAS_GEMM_X8S8_KERNEL_NEON>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>,
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedK,
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedStrides.K,
 };
 
 #endif  //defined(MLAS_TARGET_ARM64)

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
@@ -529,7 +529,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SDOT>(
 
 MLAS_FORCEINLINE
 void
-MlasGemmU8X8CopyPackBProcessSDot(
+MlasGemmS8S8CopyPackBProcessSDot(
     int8_t* D,
     int8x8_t BytesRow[4],
     int32x4_t ColumnSums[2]
@@ -605,7 +605,7 @@ MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>(
             BytesRow[2] = vld1_s8(&b[ldb * 2]);
             BytesRow[3] = vld1_s8(&b[ldb * 3]);
 
-            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
 
             b += ldb * 4;
             D += 32;
@@ -619,7 +619,7 @@ MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>(
             BytesRow[2] = (k > 2) ? vld1_s8(&b[ldb * 2]) : vget_low_s8(ZeroVector);
             BytesRow[3] = vget_low_s8(ZeroVector);
 
-            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
 
             D += 32;
         }
@@ -706,7 +706,7 @@ MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>(
             BytesRow[2] = vld1_s8(&PaddedMatrixBData[16]);
             BytesRow[3] = vld1_s8(&PaddedMatrixBData[24]);
 
-            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
 
             D += 32;
         }

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
@@ -1,0 +1,759 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    qgemm_kernel_sdot.cpp
+
+Abstract:
+
+    This module implements sdot QGEMM kernel.
+
+--*/
+
+#include "mlasi.h"
+#include "qgemm.h"
+
+//
+// Define the prototypes of the NEON SDOT routines written in assembly.
+//
+
+extern "C" {
+
+    size_t
+    MLASCALL
+    MlasGemmS8S8KernelSDot(
+        const uint8_t* A,
+        const uint8_t* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        const int32_t* RowSumVector,
+        const int32_t* ColumnSumVector,
+        const int32_t* ZeroPointB,
+        bool ZeroMode
+        );
+}
+
+struct MLAS_GEMM_S8S8_KERNEL_SDOT
+{
+    typedef uint8_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef int8_t OffsetAType;
+    typedef int8_t OffsetBType;
+
+    static constexpr size_t PackedK = 8;
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 24, 128, 256 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 24, 128, 384 };
+};
+
+constexpr size_t MLAS_GEMM_S8S8_KERNEL_SDOT::PackedK;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_S8S8_KERNEL_SDOT::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_S8S8_KERNEL_SDOT::PackedStrides;
+
+template<>
+MLAS_FORCEINLINE
+int32_t
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_S8S8_KERNEL_SDOT>(
+    int32_t ZeroPointB,
+    bool BIsSigned
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(BIsSigned);
+    return ZeroPointB;
+}
+
+template<>
+void
+MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SDOT>(
+    MLAS_GEMM_S8S8_KERNEL_SDOT::PackedAType* D_uint8_t,
+    const uint8_t* A,
+    size_t lda,
+    size_t CountM,
+    size_t CountK,
+    int32_t* RowSumBuffer,
+    bool AIsSigned
+    )
+{
+    int8_t* D = reinterpret_cast<int8_t*>(D_uint8_t);
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
+    int8_t PaddedMatrixAData[16];
+
+    //
+    // Process 8 rows of matrix A.
+    // 
+    // DOT kernels load 8x4 block of A with two vector registers. So A is packed
+    // a series of 16 byte vectors where four rows are interleaved with the
+    // following pattern:
+    //
+    //      [ A0 A1 A2 A3 B0 B1 B2 B3 C0 C1 C2 C3 D0 D1 D2 D3 ]
+    //      [ E0 E1 E2 E3 F0 F1 F2 F3 G0 G1 G2 G3 H0 H1 H2 H3 ]
+    // 
+    //      [ A4 A5 A6 A7 B4 B5 B6 B7 C4 C5 C6 C7 D4 D5 D6 D7 ]
+    //      [ E4 E5 E6 E7 F4 F5 F6 F7 G4 G5 G6 G7 H4 H5 H6 H7 ]
+    // 
+    //      ...
+    //
+    // This pattern is repeated (CountK / 8) times.
+    //
+    // If CountK is not aligned to a multiple of eight, then the vector is padded
+    // with zeroes.
+    //
+
+    while (CountM >= 8) {
+        const int8_t* a0 = reinterpret_cast<const int8_t*>(A);
+        const int8_t* a1 = a0 + lda;
+        const int8_t* a2 = a0 + lda * 2;
+        const int8_t* a3 = a0 + lda * 3;
+        const int8_t* a4 = a0 + lda * 4;
+        const int8_t* a5 = a0 + lda * 5;
+        const int8_t* a6 = a0 + lda * 6;
+        const int8_t* a7 = a0 + lda * 7;
+
+        size_t k = CountK;
+        int32x4_t RowSums0 = vmovq_n_s32(0);
+        int32x4_t RowSums1 = vmovq_n_s32(0);
+
+        while (k >= 16) {
+            int32x4_t v0 = vld1q_s32(reinterpret_cast<const int32_t*>(a0));
+            a0 += 16;
+            int32x4_t v1 = vld1q_s32(reinterpret_cast<const int32_t*>(a1));
+            a1 += 16;
+            int32x4_t v2 = vld1q_s32(reinterpret_cast<const int32_t*>(a2));
+            a2 += 16;
+            int32x4_t v3 = vld1q_s32(reinterpret_cast<const int32_t*>(a3));
+            a3 += 16;
+            int32x4_t v4 = vld1q_s32(reinterpret_cast<const int32_t*>(a4));
+            a4 += 16;
+            int32x4_t v5 = vld1q_s32(reinterpret_cast<const int32_t*>(a5));
+            a5 += 16;
+            int32x4_t v6 = vld1q_s32(reinterpret_cast<const int32_t*>(a6));
+            a6 += 16;
+            int32x4_t v7 = vld1q_s32(reinterpret_cast<const int32_t*>(a7));
+            a7 += 16;
+
+            int32x4_t z0 = vzip1q_s32(v0, v2);
+            int32x4_t z1 = vzip2q_s32(v0, v2);
+            int32x4_t z2 = vzip1q_s32(v1, v3);
+            int32x4_t z3 = vzip2q_s32(v1, v3);
+
+            int32x4_t z4 = vzip1q_s32(v4, v6);
+            int32x4_t z5 = vzip2q_s32(v4, v6);
+            int32x4_t z6 = vzip1q_s32(v5, v7);
+            int32x4_t z7 = vzip2q_s32(v5, v7);
+
+            v0 = vzip1q_s32(z0, z2);
+            v1 = vzip2q_s32(z0, z2);
+            v2 = vzip1q_s32(z1, z3);
+            v3 = vzip2q_s32(z1, z3);
+
+            v4 = vzip1q_s32(z4, z6);
+            v5 = vzip2q_s32(z4, z6);
+            v6 = vzip1q_s32(z5, z7);
+            v7 = vzip2q_s32(z5, z7);
+
+            vst1q_s8(&D[0], vreinterpretq_s8_s32(v0));
+            vst1q_s8(&D[16], vreinterpretq_s8_s32(v4));
+            vst1q_s8(&D[32], vreinterpretq_s8_s32(v1));
+            vst1q_s8(&D[48], vreinterpretq_s8_s32(v5));
+            vst1q_s8(&D[64], vreinterpretq_s8_s32(v2));
+            vst1q_s8(&D[80], vreinterpretq_s8_s32(v6));
+            vst1q_s8(&D[96], vreinterpretq_s8_s32(v3));
+            vst1q_s8(&D[112], vreinterpretq_s8_s32(v7));
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vreinterpretq_s8_s32(v0)));
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vreinterpretq_s8_s32(v1)));
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vreinterpretq_s8_s32(v2)));
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vreinterpretq_s8_s32(v3)));
+
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vreinterpretq_s8_s32(v4)));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vreinterpretq_s8_s32(v5)));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vreinterpretq_s8_s32(v6)));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vreinterpretq_s8_s32(v7)));
+
+            D += 128;
+            k -= 16;
+        }
+
+        while (k >= 4) {
+            int32_t v0 = *reinterpret_cast<const int32_t*>(a0);
+            a0 += 4;
+            int32_t v1 = *reinterpret_cast<const int32_t*>(a1);
+            a1 += 4;
+            int32_t v2 = *reinterpret_cast<const int32_t*>(a2);
+            a2 += 4;
+            int32_t v3 = *reinterpret_cast<const int32_t*>(a3);
+            a3 += 4;
+            int32_t v4 = *reinterpret_cast<const int32_t*>(a4);
+            a4 += 4;
+            int32_t v5 = *reinterpret_cast<const int32_t*>(a5);
+            a5 += 4;
+            int32_t v6 = *reinterpret_cast<const int32_t*>(a6);
+            a6 += 4;
+            int32_t v7 = *reinterpret_cast<const int32_t*>(a7);
+            a7 += 4;
+
+            *reinterpret_cast<int32_t*>(&D[0]) = v0;
+            *reinterpret_cast<int32_t*>(&D[4]) = v1;
+            *reinterpret_cast<int32_t*>(&D[8]) = v2;
+            *reinterpret_cast<int32_t*>(&D[12]) = v3;
+            *reinterpret_cast<int32_t*>(&D[16]) = v4;
+            *reinterpret_cast<int32_t*>(&D[20]) = v5;
+            *reinterpret_cast<int32_t*>(&D[24]) = v6;
+            *reinterpret_cast<int32_t*>(&D[28]) = v7;
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vld1q_s8(D)));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vld1q_s8(&D[16])));
+
+            D += 32;
+            k -= 4;
+        }
+
+        if (k > 0) {
+            //
+            // Copy the remaining bytes to the zero padded stack buffer.
+            //
+            int8_t* d = D;
+
+            vst1q_s8(d, vmovq_n_s8(0));
+            vst1q_s8(&d[16], vmovq_n_s8(0));
+
+            while (k > 0) {
+                d[0] = *a0++;
+                d[4] = *a1++;
+                d[8] = *a2++;
+                d[12] = *a3++;
+                d[16] = *a4++;
+                d[20] = *a5++;
+                d[24] = *a6++;
+                d[28] = *a7++;
+                d += 1;
+                k -= 1;
+            }
+
+            RowSums0 = vpadalq_s16(RowSums0, vpaddlq_s8(vld1q_s8(D)));
+            RowSums1 = vpadalq_s16(RowSums1, vpaddlq_s8(vld1q_s8(&D[16])));
+
+            D += 32;
+        }
+
+        if (((CountK - 1) & 7) < 4) {
+            vst1q_s8(D, vmovq_n_s8(0));
+            vst1q_s8(&D[16], vmovq_n_s8(0));
+            D += 32;
+        }
+
+        vst1q_s32(RowSumBuffer, RowSums0);
+        vst1q_s32(&RowSumBuffer[4], RowSums1);
+
+        RowSumBuffer += 8;
+
+        A = A + lda * 8;
+        CountM -= 8;
+    }
+
+    //
+    // Process four rows of matrix A.
+    //
+    // The buffer is packed as a series of 16 byte vectors where four rows are
+    // interleaved with the following pattern:
+    //
+    //      [ A0 A1 A2 A3 B0 B1 B2 B3 C0 C1 C2 C3 D0 D1 D2 D3 ]
+    //      [ A4 A5 A6 A7 B4 B5 B6 B7 C4 C5 C6 C7 D4 D5 D6 D7 ]
+    //
+    // This pattern is repeated (CountK / 8) times.
+    //
+    // If CountK is not aligned to a multiple of eight, then the vector is padded
+    // with zeroes.
+    //
+
+    if (CountM >= 4) {
+
+        const int8_t* a0 = reinterpret_cast<const int8_t*>(A);
+        const int8_t* a1 = a0 + lda;
+        const int8_t* a2 = a1 + lda;
+        const int8_t* a3 = a2 + lda;
+
+        size_t k = CountK;
+        int32x4_t RowSums = vmovq_n_s32(0);
+
+        while (k >= 16) {
+
+            int32x4_t v0 = vld1q_s32(reinterpret_cast<const int32_t*>(a0));
+            a0 += 16;
+            int32x4_t v1 = vld1q_s32(reinterpret_cast<const int32_t*>(a1));
+            a1 += 16;
+            int32x4_t v2 = vld1q_s32(reinterpret_cast<const int32_t*>(a2));
+            a2 += 16;
+            int32x4_t v3 = vld1q_s32(reinterpret_cast<const int32_t*>(a3));
+            a3 += 16;
+
+            int32x4_t z0 = vzip1q_s32(v0, v2);
+            int32x4_t z1 = vzip2q_s32(v0, v2);
+            int32x4_t z2 = vzip1q_s32(v1, v3);
+            int32x4_t z3 = vzip2q_s32(v1, v3);
+
+            v0 = vzip1q_s32(z0, z2);
+            v1 = vzip2q_s32(z0, z2);
+            v2 = vzip1q_s32(z1, z3);
+            v3 = vzip2q_s32(z1, z3);
+
+            vst1q_s8(&D[0], vreinterpretq_s8_s32(v0));
+            vst1q_s8(&D[16], vreinterpretq_s8_s32(v1));
+            vst1q_s8(&D[32], vreinterpretq_s8_s32(v2));
+            vst1q_s8(&D[48], vreinterpretq_s8_s32(v3));
+
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(vreinterpretq_s8_s32(v0)));
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(vreinterpretq_s8_s32(v1)));
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(vreinterpretq_s8_s32(v2)));
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(vreinterpretq_s8_s32(v3)));
+
+            D += 64;
+            k -= 16;
+        }
+
+        while (k >= 4) {
+
+            int32_t v0 = *reinterpret_cast<const int32_t*>(a0);
+            a0 += 4;
+            int32_t v1 = *reinterpret_cast<const int32_t*>(a1);
+            a1 += 4;
+            int32_t v2 = *reinterpret_cast<const int32_t*>(a2);
+            a2 += 4;
+            int32_t v3 = *reinterpret_cast<const int32_t*>(a3);
+            a3 += 4;
+
+            *reinterpret_cast<int32_t*>(&D[0]) = v0;
+            *reinterpret_cast<int32_t*>(&D[4]) = v1;
+            *reinterpret_cast<int32_t*>(&D[8]) = v2;
+            *reinterpret_cast<int32_t*>(&D[12]) = v3;
+
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(vld1q_s8(D)));
+
+            D += 16;
+            k -= 4;
+        }
+
+        if (k > 0) {
+
+            //
+            // Copy the remaining bytes to the zero padded stack buffer.
+            //
+
+            int8_t* d = PaddedMatrixAData;
+
+            vst1q_s8(PaddedMatrixAData, vmovq_n_s8(0));
+
+            while (k > 0) {
+
+                d[0] = *a0++;
+                d[4] = *a1++;
+                d[8] = *a2++;
+                d[12] = *a3++;
+
+                d += 1;
+                k -= 1;
+            }
+
+            int8x16_t PackedVector = vld1q_s8(PaddedMatrixAData);
+            vst1q_s8(D, PackedVector);
+
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(PackedVector));
+
+            D += 16;
+        }
+
+        if (((CountK - 1) & 7) < 4) {
+
+            vst1q_s8(D, vmovq_n_s8(0));
+
+            D += 16;
+        }
+
+        vst1q_s32(RowSumBuffer, RowSums);
+        RowSumBuffer += 4;
+
+        A = A + lda * 4;
+        CountM -= 4;
+    }
+
+    //
+    // Process two rows of matrix A.
+    //
+    // The buffer is packed as a series of 8 byte vectors where two rows are
+    // interleaved with the following pattern:
+    //
+    //      [ A0 A1 A2 A3 B0 B1 B2 B3 ]
+    //      [ A4 A5 A6 A7 B4 B5 B6 B7 ]
+    //
+    // This pattern is repeated (CountK / 8) times.
+    //
+    // If CountK is not aligned to a multiple of four, then the vector is padded
+    // with zeroes.
+    //
+
+    if (CountM >= 2) {
+
+        const int8_t* a0 = reinterpret_cast<const int8_t*>(A);
+        const int8_t* a1 = a0 + lda;
+
+        size_t k = CountK;
+        int32x2_t RowSums = vmov_n_s32(0);
+
+        while (k >= 4) {
+
+            int32_t v0 = *reinterpret_cast<const int32_t*>(a0);
+            a0 += 4;
+            int32_t v1 = *reinterpret_cast<const int32_t*>(a1);
+            a1 += 4;
+
+            *reinterpret_cast<int32_t*>(&D[0]) = v0;
+            *reinterpret_cast<int32_t*>(&D[4]) = v1;
+
+            RowSums = vpadal_s16(RowSums, vpaddl_s8(vld1_s8(D)));
+
+            D += 8;
+            k -= 4;
+        }
+
+        if (k > 0) {
+
+            //
+            // Copy the remaining bytes to the zero padded stack buffer.
+            //
+
+            int8_t* d = PaddedMatrixAData;
+
+            vst1_s8(PaddedMatrixAData, vmov_n_s8(0));
+
+            while (k > 0) {
+
+                d[0] = *a0++;
+                d[4] = *a1++;
+
+                d += 1;
+                k -= 1;
+            }
+
+            int8x8_t PackedVector = vld1_s8(PaddedMatrixAData);
+            vst1_s8(D, PackedVector);
+
+            RowSums = vpadal_s16(RowSums, vpaddl_s8(PackedVector));
+
+            D += 8;
+        }
+
+        if (((CountK - 1) & 7) < 4) {
+
+            vst1_s8(D, vmov_n_s8(0));
+
+            D += 8;
+        }
+
+        vst1_s32(RowSumBuffer, RowSums);
+        RowSumBuffer += 2;
+
+        A = A + lda * 2;
+        CountM -= 2;
+    }
+
+    //
+    // Process one row of matrix A.
+    //
+    // The buffer is packed as a series of 4 byte with the following pattern:
+    //
+    //      [ A0 A1 A2 A3 ]
+    //      [ A4 A5 A6 A7 ]
+    //
+    // This pattern is repeated (CountK / 8) times.
+    //
+    // If CountK is not aligned to a multiple of four, then the vector is padded
+    // with zeroes.
+    //
+
+    if (CountM > 0) {
+
+        const int8_t* a = reinterpret_cast<const int8_t*>(A);
+        size_t k = CountK;
+        int32x4_t RowSums = vmovq_n_s32(0);
+
+        while (k >= 16) {
+
+            int8x16_t v = vld1q_s8(a);
+            a += 16;
+
+            vst1q_s8(D, v);
+
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(v));
+
+            D += 16;
+            k -= 16;
+        }
+
+        if (k > 0) {
+
+            //
+            // Copy the remaining bytes to the zero padded stack buffer.
+            //
+
+            vst1q_s8(PaddedMatrixAData, vmovq_n_s8(0));
+
+            for (size_t kk = 0; kk < k; kk++) {
+                PaddedMatrixAData[kk] = a[kk];
+            }
+
+            int8x16_t v = vld1q_s8(PaddedMatrixAData);
+            vst1q_s8(D, v);
+
+            RowSums = vpadalq_s16(RowSums, vpaddlq_s8(v));
+        }
+
+#if defined(_M_ARM64)
+        // N.B. The workaround of defining a local vaddvq_u32 doesn't work here
+        // as VS2019 added new intrinsics to make the operation work. Also, not
+        // all build environments using VS2019 have the up-to-date arm64_neon.h,
+        // so fallback to pairwise addition.
+        RowSums = vpaddq_s32(RowSums, RowSums);
+        RowSums = vpaddq_s32(RowSums, RowSums);
+        vst1q_lane_s32(reinterpret_cast<int32_t*>(RowSumBuffer), RowSums, 0);
+#else
+        *RowSumBuffer = int32_t(vaddvq_s32(RowSums));
+#endif
+    }
+}
+
+MLAS_FORCEINLINE
+void
+MlasGemmU8X8CopyPackBProcessSDot(
+    int8_t* D,
+    int8x8_t BytesRow[4],
+    int32x4_t ColumnSums[2]
+    )
+{
+    int8x16_t v02 = vcombine_s8(BytesRow[0], BytesRow[2]);
+    int8x16_t v13 = vcombine_s8(BytesRow[1], BytesRow[3]);
+
+    int8x16x2_t zw = vzipq_s8(v02, v13);
+    int16x8x2_t zd = vzipq_s16(vreinterpretq_s16_s8(zw.val[0]), vreinterpretq_s16_s8(zw.val[1]));
+
+    vst1q_s8(&D[0], vreinterpretq_s8_s16(zd.val[0]));
+    vst1q_s8(&D[16], vreinterpretq_s8_s16(zd.val[1]));
+
+    ColumnSums[0] = vpadalq_s16(ColumnSums[0], vpaddlq_s8(vreinterpretq_s8_s16(zd.val[0])));
+    ColumnSums[1] = vpadalq_s16(ColumnSums[1], vpaddlq_s8(vreinterpretq_s8_s16(zd.val[1])));
+}
+
+template<>
+void
+MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>(
+    MLAS_GEMM_S8S8_KERNEL_SDOT::PackedBType* Dst,
+    const uint8_t* B,
+    size_t ldb,
+    size_t CountN,
+    size_t CountK,
+    int32_t* ColumnSumBuffer,
+    bool BIsSigned
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(BIsSigned);
+    int8_t* D = reinterpret_cast<int8_t*>(Dst);
+    const int8x16_t ZeroVector = vmovq_n_s8(0);
+    int8x8_t BytesRow[4];
+
+    //
+    // Process 8 columns of matrix B in a loop.
+    //
+    // The buffer is packed as a series of 16 byte vectors where eight rows are
+    // interleaved with the following pattern:
+    //
+    //      [ A0 A1 A2 A3 B0 B1 B2 B3 C0 C1 C2 C3 D0 D1 D2 D3 ]
+    //      [ E0 E1 E2 E3 F0 F1 F2 F3 G0 G1 G2 G3 H0 H1 H2 H3 ]
+    //      [ A4 A5 A6 A7 B4 B5 B6 B7 C4 C5 C6 C7 D4 D5 D6 D7 ]
+    //      [ E4 E5 E6 E7 F4 F5 F6 F7 G4 G5 G6 G7 H4 H5 H6 H7 ]
+    //
+    // Copy columns from matrix B to the packed buffer.
+    //
+    // If CountK is not aligned to a multiple of eight, then the packed buffer
+    // is padded with zero vectors.
+    //
+    // If CountN is not aligned to a multiple of eight, then the extra columns
+    // are padded with zeroes.
+    //
+
+    while (CountN >= 8) {
+
+        const int8_t* b = reinterpret_cast<const int8_t*>(B);
+        size_t k = CountK;
+        int32x4_t ColumnSums[2];
+
+        ColumnSums[0] = vmovq_n_s32(0);
+        ColumnSums[1] = vmovq_n_s32(0);
+
+        //
+        // Interleave rows of matrix B and write to the packed buffer.
+        //
+
+        while (k >= 4) {
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0]);
+            BytesRow[1] = vld1_s8(&b[ldb * 1]);
+            BytesRow[2] = vld1_s8(&b[ldb * 2]);
+            BytesRow[3] = vld1_s8(&b[ldb * 3]);
+
+            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+
+            b += ldb * 4;
+            D += 32;
+            k -= 4;
+        }
+
+        if (k > 0) {
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0]);
+            BytesRow[1] = (k >= 2) ? vld1_s8(&b[ldb * 1]) : vget_low_s8(ZeroVector);
+            BytesRow[2] = (k > 2) ? vld1_s8(&b[ldb * 2]) : vget_low_s8(ZeroVector);
+            BytesRow[3] = vget_low_s8(ZeroVector);
+
+            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+
+            D += 32;
+        }
+
+        //
+        // Zero pad the output buffer to a multiple of PackedK if the above
+        // processed an odd number of four row bundles.
+        //
+
+        if (((CountK - 1) & 7) < 4) {
+
+            vst1q_s8(&D[0], ZeroVector);
+            vst1q_s8(&D[16], ZeroVector);
+
+            D += 32;
+        }
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums[0]);
+        vst1q_s32(&ColumnSumBuffer[4], ColumnSums[1]);
+        ColumnSumBuffer += 8;
+
+        B += 8;
+        CountN -= 8;
+    }
+
+    //
+    // Process the remaining columns of matrix B.
+    //
+
+    if (CountN > 0) {
+
+        const int8_t* b = reinterpret_cast<const int8_t*>(B);
+        size_t k = CountK;
+        int8_t PaddedMatrixBData[32];
+        int32x4_t ColumnSums[2];
+
+        vst1q_s8(&PaddedMatrixBData[0], ZeroVector);
+        vst1q_s8(&PaddedMatrixBData[16], ZeroVector);
+
+        ColumnSums[0] = vmovq_n_s32(0);
+        ColumnSums[1] = vmovq_n_s32(0);
+
+        //
+        // Interleave rows of matrix B using an intermediate zero padded stack
+        // buffer and write to the packed buffer.
+        //
+
+        while (k > 0) {
+
+            const int8_t* bcopy0 = &b[ldb * 0];
+            const int8_t* bcopy1 = &b[ldb * 1];
+            const int8_t* bcopy2 = &b[ldb * 2];
+            const int8_t* bcopy3 = &b[ldb * 3];
+
+            if (k >= 4) {
+
+                b += ldb * 4;
+                k -= 4;
+
+            } else {
+
+                vst1q_s8(&PaddedMatrixBData[0], ZeroVector);
+                vst1q_s8(&PaddedMatrixBData[16], ZeroVector);
+
+                bcopy1 = (k >= 2) ? bcopy1 : &PaddedMatrixBData[24];
+                bcopy2 = (k > 2) ? bcopy2 : &PaddedMatrixBData[24];
+                bcopy3 = &PaddedMatrixBData[24];
+
+                k = 0;
+            }
+
+            int8_t* padded = PaddedMatrixBData;
+            int8_t* padded_end = padded + CountN;
+
+            do {
+                padded[0] = *bcopy0++;
+                padded[8] = *bcopy1++;
+                padded[16] = *bcopy2++;
+                padded[24] = *bcopy3++;
+            } while (++padded < padded_end);
+
+            BytesRow[0] = vld1_s8(&PaddedMatrixBData[0]);
+            BytesRow[1] = vld1_s8(&PaddedMatrixBData[8]);
+            BytesRow[2] = vld1_s8(&PaddedMatrixBData[16]);
+            BytesRow[3] = vld1_s8(&PaddedMatrixBData[24]);
+
+            MlasGemmU8X8CopyPackBProcessSDot(D, BytesRow, ColumnSums);
+
+            D += 32;
+        }
+
+        //
+        // Zero pad the output buffer to a multiple of PackedK if the above
+        // processed an odd number of four row bundles.
+        //
+
+        if (((CountK - 1) & 7) < 4) {
+
+            vst1q_s8(&D[0], ZeroVector);
+            vst1q_s8(&D[16], ZeroVector);
+
+            D += 32;
+        }
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums[0]);
+        vst1q_s32(&ColumnSumBuffer[4], ColumnSums[1]);
+    }
+}
+
+template<>
+MLAS_FORCEINLINE
+size_t
+MlasGemmQuantKernel<MLAS_GEMM_S8S8_KERNEL_SDOT>(
+    const MLAS_GEMM_S8S8_KERNEL_SDOT::PackedAType* A,
+    const MLAS_GEMM_S8S8_KERNEL_SDOT::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool ZeroMode
+    )
+{
+    return MlasGemmS8S8KernelSDot(A, B, C, PackedCountK, CountM, CountN, ldc,
+        RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
+}
+
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmS8S8DispatchSdot = {
+    MlasGemmQuantOperation<MLAS_GEMM_S8S8_KERNEL_SDOT>,
+    MlasGemmQuantPackedOperation<MLAS_GEMM_S8S8_KERNEL_SDOT>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>,
+    MLAS_GEMM_S8S8_KERNEL_SDOT::PackedK,
+    MLAS_GEMM_S8S8_KERNEL_SDOT::PackedStrides.K,
+};

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sse.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sse.cpp
@@ -21,19 +21,20 @@ struct MLAS_GEMM_U8X8_KERNEL_SSE
 {
     typedef int16_t PackedAType;
     typedef int16_t PackedBType;
+    typedef uint8_t OffsetAType;
     typedef int8_t OffsetBType;
 
     static constexpr size_t PackedK = 2;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{ 12, 128, 128 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 12, 128, 128 };
 };
 
 constexpr size_t MLAS_GEMM_U8X8_KERNEL_SSE::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_SSE::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_SSE::Strides;
 
 template<>
 MLAS_FORCEINLINE
 int32_t
-MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_SSE>(
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_SSE>(
     int32_t ZeroPointB,
     bool BIsSigned
     )
@@ -47,15 +48,17 @@ MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_SSE>(
 
 template<>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_SSE>(
+MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_SSE>(
     MLAS_GEMM_U8X8_KERNEL_SSE::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
     )
 {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     const __m128i ZeroVector = _mm_setzero_si128();
     const __m128i OnesWordBroadcast = _mm_set1_epi16(1);
     uint8_t PaddedMatrixAData[8] = { 0 };
@@ -172,7 +175,7 @@ MlasGemmU8X8CopyPackBProcessSse(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_SSE>(
+MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_SSE>(
     MLAS_GEMM_U8X8_KERNEL_SSE::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -324,7 +327,7 @@ MlasGemmU8X8MultiplyAccumulateRowSse(
 
 template<>
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_SSE>(
+MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_SSE>(
     const MLAS_GEMM_U8X8_KERNEL_SSE::PackedAType* A,
     const MLAS_GEMM_U8X8_KERNEL_SSE::PackedBType* B,
     int32_t* C,
@@ -483,8 +486,8 @@ MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_SSE>(
     return 1;
 }
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchSse = {
-    MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_SSE>,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchSse = {
+    MlasGemmQuantOperation<MLAS_GEMM_U8X8_KERNEL_SSE>,
     nullptr,
     nullptr,
     MLAS_GEMM_U8X8_KERNEL_SSE::PackedK,

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sse41.cpp
@@ -24,28 +24,31 @@ struct MLAS_GEMM_U8S8_KERNEL_SSE41
 {
     typedef uint8_t PackedAType;
     typedef uint8_t PackedBType;
+    typedef uint8_t OffsetAType;
     typedef int8_t OffsetBType;
 
     static constexpr size_t PackedK = 4;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{ 24, 128, 128 };
-    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{ 24, 128, 128 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 24, 128, 128 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 24, 128, 128 };
 };
 
 constexpr size_t MLAS_GEMM_U8S8_KERNEL_SSE41::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8S8_KERNEL_SSE41::Strides;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8S8_KERNEL_SSE41::PackedStrides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8S8_KERNEL_SSE41::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8S8_KERNEL_SSE41::PackedStrides;
 
 template<>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_U8S8_KERNEL_SSE41>(
+MlasGemmQuantCopyPackA<MLAS_GEMM_U8S8_KERNEL_SSE41>(
     MLAS_GEMM_U8S8_KERNEL_SSE41::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
     )
 {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     const __m128i ZeroVector = _mm_setzero_si128();
     const __m128i OnesWordBroadcast = _mm_set1_epi16(1);
 
@@ -143,7 +146,7 @@ MlasGemmU8X8CopyPackBProcessSse41(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_U8S8_KERNEL_SSE41>(
+MlasGemmQuantCopyPackB<MLAS_GEMM_U8S8_KERNEL_SSE41>(
     MLAS_GEMM_U8S8_KERNEL_SSE41::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -288,7 +291,7 @@ MlasGemmU8X8MultiplyAccumulateRowSse41(
 
 template<>
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_U8S8_KERNEL_SSE41>(
+MlasGemmQuantKernel<MLAS_GEMM_U8S8_KERNEL_SSE41>(
     const MLAS_GEMM_U8S8_KERNEL_SSE41::PackedAType* A,
     const MLAS_GEMM_U8S8_KERNEL_SSE41::PackedBType* B,
     int32_t* C,
@@ -436,10 +439,10 @@ MlasGemmU8X8Kernel<MLAS_GEMM_U8S8_KERNEL_SSE41>(
     return 1;
 }
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8S8DispatchSse41 = {
-    MlasGemmU8X8Operation<MLAS_GEMM_U8S8_KERNEL_SSE41>,
-    MlasGemmU8X8PackedOperation<MLAS_GEMM_U8S8_KERNEL_SSE41>,
-    MlasGemmU8X8CopyPackB<MLAS_GEMM_U8S8_KERNEL_SSE41>,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchSse41 = {
+    MlasGemmQuantOperation<MLAS_GEMM_U8S8_KERNEL_SSE41>,
+    MlasGemmQuantPackedOperation<MLAS_GEMM_U8S8_KERNEL_SSE41>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_U8S8_KERNEL_SSE41>,
     MLAS_GEMM_U8S8_KERNEL_SSE41::PackedK,
     MLAS_GEMM_U8S8_KERNEL_SSE41::PackedStrides.K,
 };

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_udot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_udot.cpp
@@ -6,11 +6,11 @@ Licensed under the MIT License.
 
 Module Name:
 
-    qgemm_kernel_default.cpp
+    qgemm_kernel_udot.cpp
 
 Abstract:
 
-    This module implements default QGEMM kernel.
+    This module implements udot QGEMM kernel.
 
 --*/
 
@@ -44,21 +44,22 @@ struct MLAS_GEMM_U8X8_KERNEL_UDOT
 {
     typedef uint8_t PackedAType;
     typedef uint8_t PackedBType;
+    typedef uint8_t OffsetAType;
     typedef uint8_t OffsetBType;
 
     static constexpr size_t PackedK = 8;
-    static constexpr MLAS_GEMM_U8X8_STRIDES Strides{ 24, 128, 256 };
-    static constexpr MLAS_GEMM_U8X8_STRIDES PackedStrides{ 24, 128, 384 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES Strides{ 24, 128, 256 };
+    static constexpr MLAS_GEMM_QUANT_STRIDES PackedStrides{ 24, 128, 384 };
 };
 
 constexpr size_t MLAS_GEMM_U8X8_KERNEL_UDOT::PackedK;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_UDOT::Strides;
-constexpr MLAS_GEMM_U8X8_STRIDES MLAS_GEMM_U8X8_KERNEL_UDOT::PackedStrides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_UDOT::Strides;
+constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_UDOT::PackedStrides;
 
 template<>
 MLAS_FORCEINLINE
 int32_t
-MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
+MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     int32_t ZeroPointB,
     bool BIsSigned
     )
@@ -72,15 +73,17 @@ MlasGemmU8X8FixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
 template<>
 void
-MlasGemmU8X8CopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
+MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     MLAS_GEMM_U8X8_KERNEL_UDOT::PackedAType* D,
     const uint8_t* A,
     size_t lda,
     size_t CountM,
     size_t CountK,
-    int32_t* RowSumBuffer
+    int32_t* RowSumBuffer,
+    bool AIsSigned
     )
 {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     uint8_t PaddedMatrixAData[16];
 
     //
@@ -550,7 +553,7 @@ MlasGemmU8X8CopyPackBProcessUdot(
 
 template<>
 void
-MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
+MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     MLAS_GEMM_U8X8_KERNEL_UDOT::PackedBType* D,
     const uint8_t* B,
     size_t ldb,
@@ -732,7 +735,7 @@ MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 template<>
 MLAS_FORCEINLINE
 size_t
-MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_UDOT>(
+MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     const MLAS_GEMM_U8X8_KERNEL_UDOT::PackedAType* A,
     const MLAS_GEMM_U8X8_KERNEL_UDOT::PackedBType* B,
     int32_t* C,
@@ -750,10 +753,10 @@ MlasGemmU8X8Kernel<MLAS_GEMM_U8X8_KERNEL_UDOT>(
         RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
 }
 
-const MLAS_GEMM_U8X8_DISPATCH MlasGemmU8X8DispatchUdot = {
-    MlasGemmU8X8Operation<MLAS_GEMM_U8X8_KERNEL_UDOT>,
-    MlasGemmU8X8PackedOperation<MLAS_GEMM_U8X8_KERNEL_UDOT>,
-    MlasGemmU8X8CopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>,
+const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchUdot = {
+    MlasGemmQuantOperation<MLAS_GEMM_U8X8_KERNEL_UDOT>,
+    MlasGemmQuantPackedOperation<MLAS_GEMM_U8X8_KERNEL_UDOT>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UDOT>,
     MLAS_GEMM_U8X8_KERNEL_UDOT::PackedK,
     MLAS_GEMM_U8X8_KERNEL_UDOT::PackedStrides.K,
 };

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -305,18 +305,16 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOn
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int32_t, DequantizeLinear);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, uint8_t, QuantizeLinear);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int8_t, QuantizeLinear);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul);
 #if defined(MLAS_TARGET_ARM_ANY)
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearMatMul);
 #endif
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearMatMul);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t, MatMulInteger);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv);
 #if defined(MLAS_TARGET_ARM_ANY)
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearConv);
 #endif
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearConv);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearConv);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10, Slice);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 11, Dropout);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10, NonMaxSuppression);
@@ -1209,19 +1207,17 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
                                                                           QuantizeLinear)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int8_t,
                                                                           QuantizeLinear)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul)>,
 #if defined(MLAS_TARGET_ARM_ANY)
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearMatMul)>,
 #endif
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearMatMul)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearMatMul)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t,
                                                                 MatMulInteger)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv)>,
 #if defined(MLAS_TARGET_ARM_ANY)
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearConv)>,
 #endif
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearConv)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearConv)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10,
                                                                     Slice)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 11,

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/cpu_execution_provider.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/kernel_registry.h"
+#include "core/mlas/inc/mlas.h"
 
 #ifndef DISABLE_CONTRIB_OPS
 #include "contrib_ops/cpu/cpu_contrib_kernels.h"
@@ -304,10 +305,18 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOn
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int32_t, DequantizeLinear);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, uint8_t, QuantizeLinear);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int8_t, QuantizeLinear);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul);
+#if defined(MLAS_TARGET_ARM_ANY)
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearMatMul);
+#endif
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearMatMul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t, MatMulInteger);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv);
+#if defined(MLAS_TARGET_ARM_ANY)
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearConv);
+#endif
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearConv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearConv);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10, Slice);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 11, Dropout);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10, NonMaxSuppression);
@@ -1200,11 +1209,19 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
                                                                           QuantizeLinear)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 12, int8_t,
                                                                           QuantizeLinear)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearMatMul)>,
+#if defined(MLAS_TARGET_ARM_ANY)
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearMatMul)>,
+#endif
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearMatMul)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearMatMul)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t,
                                                                 MatMulInteger)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, ConvInteger)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, QLinearConv)>,
+#if defined(MLAS_TARGET_ARM_ANY)
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, int8_t_int8_t, QLinearConv)>,
+#endif
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_int8_t, QLinearConv)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, uint8_t_uint8_t, QLinearConv)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 10,
                                                                     Slice)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 10, 11,

--- a/onnxruntime/core/providers/cpu/math/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul_integer.cc
@@ -85,14 +85,14 @@ Status MatMulInteger::Compute(OpKernelContext* ctx) const {
   const auto* a_data = a->template Data<uint8_t>();
   auto* y_data = y->template MutableData<int32_t>();
 
-  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
   gemm_shape.M = static_cast<size_t>(helper.M());
   gemm_shape.N = static_cast<size_t>(helper.N());
   gemm_shape.K = static_cast<size_t>(helper.K());
   gemm_shape.BIsSigned = b_is_signed;
 
   const size_t batch_size = helper.OutputOffsets().size();
-  std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_data_vec(batch_size);
+  std::vector<MLAS_GEMM_QUANT_DATA_PARAMS> gemm_data_vec(batch_size);
 
   for (size_t batch = 0; batch < batch_size; batch++) {
     auto& gemm_params = gemm_data_vec[batch];

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -12,6 +12,16 @@
 #include "core/mlas/inc/mlas.h"
 
 namespace onnxruntime {
+ONNX_OPERATOR_KERNEL_EX(
+    QLinearMatMul,
+    kOnnxDomain,
+    10,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
+        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>()),
+    QLinearMatMul);
 
 #define REGISTER_QLINEARMATMUL_TYPED_KERNEL(act_type, weight_type)          \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                            \
@@ -29,8 +39,6 @@ namespace onnxruntime {
 #if defined(MLAS_TARGET_ARM_ANY)
 REGISTER_QLINEARMATMUL_TYPED_KERNEL(int8_t, int8_t);
 #endif
-REGISTER_QLINEARMATMUL_TYPED_KERNEL(uint8_t, uint8_t);
-REGISTER_QLINEARMATMUL_TYPED_KERNEL(uint8_t, int8_t);
 
 Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
   const auto* a = ctx->Input<Tensor>(IN_A);

--- a/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/quantize_linear_matmul.cc
@@ -13,16 +13,24 @@
 
 namespace onnxruntime {
 
-ONNX_OPERATOR_KERNEL_EX(
-    QLinearMatMul,
-    kOnnxDomain,
-    10,
-    kCpuExecutionProvider,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
-        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>()),
-    QLinearMatMul);
+#define REGISTER_QLINEARMATMUL_TYPED_KERNEL(act_type, weight_type)          \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                            \
+      QLinearMatMul,                                                        \
+      kOnnxDomain,                                                          \
+      10,                                                                   \
+      act_type##_##weight_type,                                             \
+      kCpuExecutionProvider,                                                \
+      KernelDefBuilder()                                                    \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<act_type>())    \
+          .TypeConstraint("T2", DataTypeImpl::GetTensorType<weight_type>()) \
+          .TypeConstraint("T3", DataTypeImpl::GetTensorType<act_type>()),   \
+      QLinearMatMul);
+
+#if defined(MLAS_TARGET_ARM_ANY)
+REGISTER_QLINEARMATMUL_TYPED_KERNEL(int8_t, int8_t);
+#endif
+REGISTER_QLINEARMATMUL_TYPED_KERNEL(uint8_t, uint8_t);
+REGISTER_QLINEARMATMUL_TYPED_KERNEL(uint8_t, int8_t);
 
 Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
   const auto* a = ctx->Input<Tensor>(IN_A);
@@ -79,29 +87,32 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
   }
 
   const size_t num_gemms = helper.OutputOffsets().size();
-  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
   gemm_shape.M = static_cast<size_t>(helper.M());
   gemm_shape.N = static_cast<size_t>(helper.N());
   gemm_shape.K = static_cast<size_t>(helper.K());
+  gemm_shape.AIsSigned = a->IsDataType<int8_t>();
   gemm_shape.BIsSigned = b_is_signed;
 
   AllocatorPtr alloc;
   ORT_RETURN_IF_ERROR(ctx->GetTempSpaceAllocator(&alloc));
   auto gemm_output_data = alloc->Alloc(SafeInt<size_t>(gemm_shape.M) *
-      gemm_shape.N * sizeof(int32_t) * num_gemms);
+                                       gemm_shape.N * sizeof(int32_t) * num_gemms);
   BufferUniquePtr gemm_output_buffer(gemm_output_data, BufferDeleter(alloc));
   auto* gemm_output = static_cast<int32_t*>(gemm_output_buffer.get());
 
-
-  std::vector<MLAS_GEMM_U8X8_DATA_PARAMS> gemm_params(num_gemms);
+  std::vector<MLAS_GEMM_QUANT_DATA_PARAMS> gemm_params(num_gemms);
   std::vector<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR> requant_procs;
   requant_procs.reserve(num_gemms);
 
+  bool is_output_signed = y->IsDataType<int8_t>();
+  int32_t output_offset = is_output_signed ? *(static_cast<const int8_t*>(y_offset->DataRaw()))
+                                           : *(static_cast<const uint8_t*>(y_offset->DataRaw()));
   auto b_zp_data = static_cast<const uint8_t*>(b_offset->DataRaw());
   for (size_t i = 0; i < num_gemms; i++) {
-    gemm_params[i].A = a->template Data<uint8_t>() + helper.LeftOffsets()[i];
+    gemm_params[i].A = static_cast<const uint8_t*>(a->DataRaw()) + helper.LeftOffsets()[i];
     gemm_params[i].lda = gemm_shape.K;
-    gemm_params[i].ZeroPointA = *a_offset->template Data<uint8_t>();
+    gemm_params[i].ZeroPointA = *(static_cast<const uint8_t*>(a_offset->DataRaw()));
 
     gemm_params[i].B = b_data + helper.RightOffsets()[i];
     gemm_params[i].ldb = gemm_shape.N;
@@ -113,12 +124,13 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
 
     gemm_params[i].PerColumnZeroPoints = !IsScalarOr1ElementVector(b_offset);
 
-    requant_procs.emplace_back(y->template MutableData<uint8_t>() + helper.OutputOffsets()[i],
+    requant_procs.emplace_back(static_cast<uint8_t*>(y->MutableDataRaw()) + helper.OutputOffsets()[i],
                                static_cast<size_t>(helper.N()),
                                nullptr,
                                output_scales.data() + helper.RightScaleOffsets()[i],
                                output_scales.size() > 1,
-                               *y_offset->template Data<uint8_t>());
+                               output_offset,
+                               is_output_signed);
     gemm_params[i].OutputProcessor = &(requant_procs[i]);
   }
 

--- a/onnxruntime/core/providers/cpu/nn/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_integer.cc
@@ -149,12 +149,12 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
         }
       }
 
-      MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+      MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
       gemm_shape.M = static_cast<size_t>(M / conv_attrs_.group);
       gemm_shape.N = static_cast<size_t>(output_image_size);
       gemm_shape.K = static_cast<size_t>(kernel_dim);
       
-      MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
+      MLAS_GEMM_QUANT_DATA_PARAMS gemm_params;
       gemm_params.A = Wdata + group_id * W_offset;
       gemm_params.lda = static_cast<size_t>(kernel_dim);
       gemm_params.ZeroPointA = filter_offset;

--- a/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
@@ -215,6 +215,16 @@ class QLinearConv : public OpKernel {
   std::vector<int32_t> column_sums_;
 };
 
+ONNX_CPU_OPERATOR_KERNEL(
+    QLinearConv,
+    10,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
+        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),
+    QLinearConv<uint8_t>);
+
 #define REGISTER_QLINEARCONV_TYPED_KERNEL(domain, version, act_type, weight_type) \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                  \
       QLinearConv,                                                                \
@@ -232,8 +242,6 @@ class QLinearConv : public OpKernel {
 #if defined(MLAS_TARGET_ARM_ANY)
 REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, int8_t, int8_t);
 #endif
-REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, uint8_t, uint8_t);
-REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, uint8_t, int8_t);
 
 #ifndef DISABLE_CONTRIB_OPS
 
@@ -241,11 +249,21 @@ namespace contrib {
 
 // Register an alternate version of this kernel that supports the channels_last
 // attribute in order to consume and produce NHWC tensors.
+ONNX_OPERATOR_KERNEL_EX(
+    QLinearConv,
+    kMSDomain,
+    1,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
+        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>())
+        .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),
+    QLinearConv<uint8_t>);
+
 #if defined(MLAS_TARGET_ARM_ANY)
 REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, int8_t, int8_t);
 #endif
-REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, uint8_t, uint8_t);
-REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, uint8_t, int8_t);
 
 }  // namespace contrib
 

--- a/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/nn/qlinearconv.cc
@@ -13,6 +13,7 @@
 
 namespace onnxruntime {
 
+template <typename ActType>
 class QLinearConv : public OpKernel {
  public:
   explicit QLinearConv(const OpKernelInfo& info) : OpKernel(info), conv_attrs_(info) {
@@ -53,8 +54,8 @@ class QLinearConv : public OpKernel {
 
   static void ComputeOffset(OpKernelContext* context,
                             int64_t M,
-                            uint8_t& X_zero_point_value,
-                            uint8_t& Y_zero_point_value,
+                            ActType& X_zero_point_value,
+                            ActType& Y_zero_point_value,
                             uint8_t& W_zero_point_value) {
     const Tensor* X_zero_point = context->Input<Tensor>(InputTensors::IN_X_ZERO_POINT);
     const Tensor* W_zero_point = context->Input<Tensor>(InputTensors::IN_W_ZERO_POINT);
@@ -66,8 +67,8 @@ class QLinearConv : public OpKernel {
     ORT_ENFORCE(IsValidQuantParam(W_zero_point, M),
                 "QLinearConv : filter zero point shape invalid");
 
-    X_zero_point_value = *(X_zero_point->template Data<uint8_t>());
-    Y_zero_point_value = *(Y_zero_point->template Data<uint8_t>());
+    X_zero_point_value = *(X_zero_point->template Data<ActType>());
+    Y_zero_point_value = *(Y_zero_point->template Data<ActType>());
 
     const int64_t W_zero_point_size = W_zero_point->Shape().Size();
     const auto* W_zero_point_data = static_cast<const uint8_t*>(W_zero_point->DataRaw());
@@ -142,11 +143,11 @@ class QLinearConv : public OpKernel {
     const Tensor* W_zero_point = nullptr;
     if (Info().TryGetConstantInput(InputTensors::IN_X_ZERO_POINT, &X_zero_point) && IsScalarOr1ElementVector(X_zero_point) &&
         Info().TryGetConstantInput(InputTensors::IN_W_ZERO_POINT, &W_zero_point) && IsValidQuantParam(W_zero_point, static_cast<int64_t>(output_channels))) {
-      auto X_zero_point_value = *(X_zero_point->template Data<uint8_t>());
+      auto X_zero_point_value = *(X_zero_point->template Data<ActType>());
       const size_t W_zero_point_size = static_cast<size_t>(W_zero_point->Shape().Size());
       const auto* W_zero_point_data = W_zero_point->Data<int8_t>();
       if (std::all_of(W_zero_point_data, W_zero_point_data + W_zero_point_size, [](int8_t v) { return v == 0; })) {
-        size_t packed_size = MlasConvSymPackWSize(group_count, group_input_channels, group_output_channels, kernel_size);
+        size_t packed_size = MlasConvSymPackWSize(group_count, group_input_channels, group_output_channels, kernel_size, std::is_signed<ActType>::value);
         if (packed_size != 0) {
           const Tensor* B = nullptr;
           Info().TryGetConstantInput(8, &B);
@@ -154,7 +155,7 @@ class QLinearConv : public OpKernel {
 
           column_sums_.resize(output_channels);
           const int8_t* sdata = (const int8_t*)Wdata;
-          int32_t X_zero_point_fixup = MlasConvSymFixupInputZeroPoint(X_zero_point_value);
+          int32_t X_zero_point_fixup = MlasConvSymFixupInputZeroPoint(X_zero_point_value, std::is_signed<ActType>::value);
           for (size_t oc = 0; oc < output_channels; oc++) {
             int32_t sum = 0;
             for (size_t ks = 0; ks < kernel_size * group_input_channels; ks++) {
@@ -172,7 +173,8 @@ class QLinearConv : public OpKernel {
                            kernel_size,
                            reinterpret_cast<const int8_t*>(Wdata),
                            reinterpret_cast<int8_t*>(packed_W),
-                           packed_size);
+                           packed_size,
+                           std::is_signed<ActType>::value);
 
           is_symmetric_conv_ = true;
 
@@ -213,15 +215,25 @@ class QLinearConv : public OpKernel {
   std::vector<int32_t> column_sums_;
 };
 
-ONNX_CPU_OPERATOR_KERNEL(
-    QLinearConv,
-    10,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
-        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),
-    QLinearConv);
+#define REGISTER_QLINEARCONV_TYPED_KERNEL(domain, version, act_type, weight_type) \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                  \
+      QLinearConv,                                                                \
+      domain,                                                                     \
+      version,                                                                    \
+      act_type##_##weight_type,                                                   \
+      kCpuExecutionProvider,                                                      \
+      KernelDefBuilder()                                                          \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<act_type>())          \
+          .TypeConstraint("T2", DataTypeImpl::GetTensorType<weight_type>())       \
+          .TypeConstraint("T3", DataTypeImpl::GetTensorType<act_type>())          \
+          .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),          \
+      QLinearConv<act_type>);
+
+#if defined(MLAS_TARGET_ARM_ANY)
+REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, int8_t, int8_t);
+#endif
+REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, uint8_t, uint8_t);
+REGISTER_QLINEARCONV_TYPED_KERNEL(kOnnxDomain, 10, uint8_t, int8_t);
 
 #ifndef DISABLE_CONTRIB_OPS
 
@@ -229,25 +241,20 @@ namespace contrib {
 
 // Register an alternate version of this kernel that supports the channels_last
 // attribute in order to consume and produce NHWC tensors.
-ONNX_OPERATOR_KERNEL_EX(
-    QLinearConv,
-    kMSDomain,
-    1,
-    kCpuExecutionProvider,
-    KernelDefBuilder()
-        .TypeConstraint("T1", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<uint8_t>(), DataTypeImpl::GetTensorType<int8_t>()})
-        .TypeConstraint("T3", DataTypeImpl::GetTensorType<uint8_t>())
-        .TypeConstraint("T4", DataTypeImpl::GetTensorType<int32_t>()),
-    QLinearConv);
+#if defined(MLAS_TARGET_ARM_ANY)
+REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, int8_t, int8_t);
+#endif
+REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, uint8_t, uint8_t);
+REGISTER_QLINEARCONV_TYPED_KERNEL(kMSDomain, 1, uint8_t, int8_t);
 
 }  // namespace contrib
 
 #endif
 
-Status QLinearConv::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
-                            /*out*/ bool& is_packed,
-                            /*out*/ PrePackedWeights* prepacked_weights) {
+template <typename ActType>
+Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
+                                     /*out*/ bool& is_packed,
+                                     /*out*/ PrePackedWeights* prepacked_weights) {
   is_packed = false;
 
   // Support packing the weight matrix.
@@ -302,7 +309,10 @@ Status QLinearConv::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr al
 
   // Don't pack the filter buffer if the MlasConvDepthwise path is used.
   if (group_input_channels != 1 && group_output_channels != 1) {
-    packed_W_size_ = MlasGemmPackBSize(group_output_channels, kernel_dim, is_W_signed_);
+    packed_W_size_ = MlasGemmPackBSize(group_output_channels,
+                                       kernel_dim,
+                                       std::is_same<ActType, int8_t>::value,
+                                       is_W_signed_);
     if (packed_W_size_ != 0) {
       size_t packed_W_data_size = SafeInt<size_t>(group_count) * packed_W_size_;
       auto* packed_W = static_cast<uint8_t*>(alloc->Alloc(packed_W_data_size));
@@ -326,7 +336,13 @@ Status QLinearConv::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr al
 
       for (int64_t group_id = 0; group_id < conv_attrs_.group; ++group_id) {
         ReorderFilter(Wdata, group_reordered_W, group_output_channels, group_input_channels, kernel_size);
-        MlasGemmPackB(group_output_channels, kernel_dim, group_reordered_W, group_output_channels, is_W_signed_, packed_W);
+        MlasGemmPackB(group_output_channels,
+                      kernel_dim,
+                      group_reordered_W,
+                      group_output_channels,
+                      std::is_same<ActType, int8_t>::value,
+                      is_W_signed_,
+                      packed_W);
         packed_W += packed_W_size_;
         Wdata += W_offset;
       }
@@ -369,9 +385,10 @@ Status QLinearConv::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr al
   return Status::OK();
 }
 
-Status QLinearConv::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                              int input_idx,
-                                              /*out*/ bool& used_shared_buffers) {
+template <typename ActType>
+Status QLinearConv<ActType>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
+                                                       int input_idx,
+                                                       /*out*/ bool& used_shared_buffers) {
   if (input_idx != 3) {
     return Status::OK();
   }
@@ -389,7 +406,8 @@ Status QLinearConv::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prep
   return Status::OK();
 }
 
-Status QLinearConv::Compute(OpKernelContext* context) const {
+template <typename ActType>
+Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(InputTensors::IN_X);
   const Tensor* W = is_W_packed_ ? nullptr : context->Input<Tensor>(InputTensors::IN_W);
   const auto& W_shape = W ? W->Shape() : W_shape_;
@@ -398,8 +416,8 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
   const int64_t N = X->Shape()[0];
   const int64_t M = W_shape[0];
 
-  uint8_t X_zero_point_value;
-  uint8_t Y_zero_point_value;
+  ActType X_zero_point_value;
+  ActType Y_zero_point_value;
   uint8_t W_zero_point_value;
   ComputeOffset(context, M, X_zero_point_value, Y_zero_point_value, W_zero_point_value);
   std::vector<float> output_scales = ComputeOutputScale(context, M);
@@ -504,24 +522,24 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
     gemm_output_buffer = BufferUniquePtr(gemm_output_data, BufferDeleter(alloc));
   }
 
-  const auto* Xdata = X->template Data<uint8_t>();
+  const auto* Xdata = X->template Data<ActType>();
   const auto* Bdata = B != nullptr ? B->template Data<int32_t>() : nullptr;
-  auto* Ydata = Y->template MutableData<uint8_t>();
+  auto* Ydata = Y->template MutableData<ActType>();
 
   BufferUniquePtr transpose_input_buffer;
   BufferUniquePtr transpose_output_buffer;
 
   // Allocate temporary buffers for transposing to channels last format.
   if (!channels_last_) {
-    auto* transpose_input = alloc->Alloc(SafeInt<size_t>(sizeof(uint8_t)) * X_offset);
+    auto* transpose_input = alloc->Alloc(SafeInt<size_t>(sizeof(ActType)) * X_offset);
     transpose_input_buffer = BufferUniquePtr(transpose_input, BufferDeleter(alloc));
-    auto* transpose_output = alloc->Alloc(SafeInt<size_t>(sizeof(uint8_t)) * Y_offset);
+    auto* transpose_output = alloc->Alloc(SafeInt<size_t>(sizeof(ActType)) * Y_offset);
     transpose_output_buffer = BufferUniquePtr(transpose_output, BufferDeleter(alloc));
   }
 
   BufferUniquePtr col_buffer;
   BufferUniquePtr indirection_buffer;
-  std::vector<uint8_t> padding_data;
+  std::vector<ActType> padding_data;
 
   bool use_indirection_buffer = false;
   if (is_depthwise_conv) {
@@ -533,14 +551,14 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
       // Pointwise convolutions can use the original input tensor in place,
       // otherwise a temporary buffer is required for the im2col transform.
       int64_t group_col_buffer_size = (kernel_rank > 2) ? group_count * col_buffer_size : col_buffer_size;
-      auto* col_data = alloc->Alloc(SafeInt<size_t>(sizeof(uint8_t)) * group_col_buffer_size);
+      auto* col_data = alloc->Alloc(SafeInt<size_t>(sizeof(ActType)) * group_col_buffer_size);
       col_buffer = BufferUniquePtr(col_data, BufferDeleter(alloc));
     }
   }
   if (use_indirection_buffer) {
     // Allocate indirection buffer pointers and prepare a padding vector for
     // the im2col transform.
-    auto* indirection_data = alloc->Alloc(SafeInt<size_t>(sizeof(const uint8_t*)) * kernel_size * output_image_size);
+    auto* indirection_data = alloc->Alloc(SafeInt<size_t>(sizeof(const ActType*)) * kernel_size * output_image_size);
     indirection_buffer = BufferUniquePtr(indirection_data, BufferDeleter(alloc));
     padding_data.resize(static_cast<size_t>(C), X_zero_point_value);
   }
@@ -557,18 +575,18 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
       // Transpose the input from channels first (NCHW) to channels last (NHWC).
       MlasTranspose(
           Xdata,
-          static_cast<uint8_t*>(transpose_input_buffer.get()),
+          static_cast<ActType*>(transpose_input_buffer.get()),
           static_cast<size_t>(C),
           static_cast<size_t>(input_image_size));
-      input_data = static_cast<uint8_t*>(transpose_input_buffer.get());
-      output_data = static_cast<uint8_t*>(transpose_output_buffer.get());
+      input_data = static_cast<ActType*>(transpose_input_buffer.get());
+      output_data = static_cast<ActType*>(transpose_output_buffer.get());
     }
 
     // Threaded implementation of ND convolution is not yet supported, so
     // prepare all im2col transformations here.
     if (col_buffer && kernel_rank > 2) {
       for (int64_t group_id = 0; group_id < group_count; ++group_id) {
-        math::Im2col<uint8_t, StorageOrder::NHWC>()(
+        math::Im2col<ActType, StorageOrder::NHWC>()(
             input_data + group_id * group_input_channels,
             group_input_channels,
             C,
@@ -579,7 +597,7 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
             dilations.data(),
             pads.data(),
             static_cast<int64_t>(kernel_rank),
-            static_cast<uint8_t*>(col_buffer.get()) + group_id * col_buffer_size,
+            static_cast<ActType*>(col_buffer.get()) + group_id * col_buffer_size,
             X_zero_point_value);
       }
     }
@@ -589,10 +607,10 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
       int64_t output_start = static_cast<int64_t>(work.start);
       int64_t output_count = static_cast<int64_t>(work.end - work.start);
 
-      uint8_t const** worker_indirection_buffer = nullptr;
+      ActType const** worker_indirection_buffer = nullptr;
       if (indirection_buffer) {
-        worker_indirection_buffer = static_cast<uint8_t const**>(indirection_buffer.get()) + output_start * kernel_size;
-        math::Im2col<uint8_t, StorageOrder::NHWC>()(
+        worker_indirection_buffer = static_cast<ActType const**>(indirection_buffer.get()) + output_start * kernel_size;
+        math::Im2col<ActType, StorageOrder::NHWC>()(
             input_data,
             C,
             input_shape.GetDims().data(),
@@ -613,7 +631,7 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
       if (is_symmetric_conv_) {
         MLAS_CONV_SYM_PARAMS conv_params = {};
         if (worker_indirection_buffer) {
-          conv_params.InputIndirection = worker_indirection_buffer;
+          conv_params.InputIndirection = reinterpret_cast<void const**>(worker_indirection_buffer);
         } else {
           conv_params.InputDirect = input_data + output_start * C;
         }
@@ -627,6 +645,7 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
         conv_params.Scale = output_scales.data();
         conv_params.PerChannelScale = output_scales.size() > 1;
         conv_params.OutputZeroPoint = Y_zero_point_value;
+        conv_params.InputIsSigned = std::is_signed<ActType>::value;
 
         if (is_depthwise_conv) {
           MlasConvSymDepthwise(conv_params);
@@ -640,9 +659,10 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
 
       if (is_depthwise_conv) {
         MlasConvDepthwise(
-            worker_indirection_buffer,
+            reinterpret_cast<const void* const*>(worker_indirection_buffer),
             X_zero_point_value,
-            reordered_W,
+            std::is_signed<ActType>::value,
+            reinterpret_cast<const void* const*>(reordered_W),
             W_zero_point_value,
             is_W_signed,
             worker_gemm_output,
@@ -651,8 +671,8 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
             static_cast<size_t>(kernel_size));
       } else {
         for (int64_t group_id = 0; group_id < group_count; ++group_id) {
-          MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
-          gemm_params.ZeroPointA = X_zero_point_value;
+          MLAS_GEMM_QUANT_DATA_PARAMS gemm_params;
+          gemm_params.ZeroPointA = static_cast<uint8_t>(X_zero_point_value);
           if (packed_W_buffer_) {
             gemm_params.B = static_cast<const int8_t*>(packed_W_buffer_.get()) + group_id * packed_W_size_,
             gemm_params.BIsPacked = true;
@@ -668,9 +688,9 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
           // pointwise convolutions.
           const auto* group_input_data = input_data + group_id * group_input_channels;
           if (col_buffer) {
-            auto* worker_col_buffer = static_cast<uint8_t*>(col_buffer.get()) + output_start * kernel_dim;
+            auto* worker_col_buffer = static_cast<ActType*>(col_buffer.get()) + output_start * kernel_dim;
             if (kernel_rank == 2) {
-              math::Im2col<uint8_t, StorageOrder::NHWC>()(
+              math::Im2col<ActType, StorageOrder::NHWC>()(
                   group_input_data,
                   group_input_channels,
                   C,
@@ -690,7 +710,7 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
                   worker_col_buffer,
                   X_zero_point_value);
             } else if (kernel_rank == 1) {
-              math::Im2col<uint8_t, StorageOrder::NHWC>()(
+              math::Im2col<ActType, StorageOrder::NHWC>()(
                   group_input_data,
                   group_input_channels,
                   C,
@@ -713,17 +733,18 @@ Status QLinearConv::Compute(OpKernelContext* context) const {
               // Use the im2col buffer prepared outside the thread, indexed by group.
               worker_col_buffer += group_id * col_buffer_size;
             }
-            gemm_params.A = worker_col_buffer;
+            gemm_params.A = reinterpret_cast<const uint8_t*>(worker_col_buffer);
             gemm_params.lda = static_cast<size_t>(kernel_dim);
           } else {
-            gemm_params.A = group_input_data + output_start * C;
+            gemm_params.A = reinterpret_cast<const uint8_t*>(group_input_data + output_start * C);
             gemm_params.lda = static_cast<size_t>(C);
           }
 
-          MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+          MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
           gemm_shape.M = static_cast<size_t>(output_count);
           gemm_shape.N = static_cast<size_t>(group_output_channels);
           gemm_shape.K = static_cast<size_t>(kernel_dim);
+          gemm_shape.AIsSigned = std::is_signed<ActType>::value;
           gemm_shape.BIsSigned = is_W_signed;
 
           MlasGemm(gemm_shape, gemm_params, nullptr);

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -288,13 +288,13 @@ void ComputeGemm(const int M,
       beta == 1.0f ? MLAS_QGEMM_OUTPUT_MODE::AccumulateMode : MLAS_QGEMM_OUTPUT_MODE::ZeroMode,
       scale_multiplier.size() == 1 ? MLAS_QUANTIZATION_GRANULARITY::PerMatrix : MLAS_QUANTIZATION_GRANULARITY::PerColumn);
 
-  MLAS_GEMM_U8X8_SHAPE_PARAMS gemm_shape;
+  MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
   gemm_shape.M = static_cast<size_t>(M);
   gemm_shape.N = static_cast<size_t>(N);
   gemm_shape.K = static_cast<size_t>(K);
   gemm_shape.BIsSigned = b_is_signed;
 
-  MLAS_GEMM_U8X8_DATA_PARAMS gemm_params;
+  MLAS_GEMM_QUANT_DATA_PARAMS gemm_params;
   gemm_params.A = quantized_A_buffer;
   gemm_params.lda = static_cast<size_t>(K);
   gemm_params.ZeroPointA = a_zero_point;

--- a/onnxruntime/test/mlas/unittest/test_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.cpp
@@ -1,38 +1,61 @@
 #include "test_qgemm.h"
 #include "test_qgemm_fixture.h"
 
-template <> MlasQgemmU8X8Test<int8_t, int32_t, false, false>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, int32_t, false, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, int32_t, false, true>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, int32_t, false, true>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, int32_t, true, false>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, int32_t, true, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, int32_t, true, true>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, int32_t, true, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, int32_t, false, false>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, int32_t, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, int32_t, false, true>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, int32_t, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, int32_t, true, false>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, int32_t, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, int32_t, true, true>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, int32_t, true, true>>::mlas_tester(nullptr);
 
-template <> MlasQgemmU8X8Test<uint8_t, int32_t, false, false>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, int32_t, false, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, int32_t, false, true>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, int32_t, false, true>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, int32_t, true, false>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, int32_t, true, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, int32_t, true, true>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, int32_t, true, true>>::mlas_tester(nullptr);
+#if defined(MLAS_TARGET_ARM_ANY)
+template <> MlasQgemmTest<int8_t, int8_t, int32_t, false, false>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, int32_t, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, int32_t, false, true>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, int32_t, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, int32_t, true, false>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, int32_t, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, int32_t, true, true>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, int32_t, true, true>>::mlas_tester(nullptr);
+#endif
 
-template <> MlasQgemmU8X8Test<int8_t, float, false, false>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, float, false, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, float, false, true>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, float, false, true>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, float, true, false>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, float, true, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<int8_t, float, true, true>* MlasTestFixture<MlasQgemmU8X8Test<int8_t, float, true, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, int32_t, false, false>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, int32_t, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, int32_t, false, true>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, int32_t, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, int32_t, true, false>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, int32_t, true, true>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, true>>::mlas_tester(nullptr);
 
-template <> MlasQgemmU8X8Test<uint8_t, float, false, false>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, float, false, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, float, false, true>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, float, false, true>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, float, true, false>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, float, true, false>>::mlas_tester(nullptr);
-template <> MlasQgemmU8X8Test<uint8_t, float, true, true>* MlasTestFixture<MlasQgemmU8X8Test<uint8_t, float, true, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, float, false, false>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, float, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, float, false, true>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, float, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, float, true, false>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, float, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, int8_t, float, true, true>* MlasTestFixture<MlasQgemmTest<uint8_t, int8_t, float, true, true>>::mlas_tester(nullptr);
+
+#if defined(MLAS_TARGET_ARM_ANY)
+template <> MlasQgemmTest<int8_t, int8_t, float, false, false>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, float, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, float, false, true>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, float, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, float, true, false>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, float, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<int8_t, int8_t, float, true, true>* MlasTestFixture<MlasQgemmTest<int8_t, int8_t, float, true, true>>::mlas_tester(nullptr);
+#endif
+
+template <> MlasQgemmTest<uint8_t, uint8_t, float, false, false>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, float, false, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, float, false, true>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, float, false, true>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, float, true, false>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, float, true, false>>::mlas_tester(nullptr);
+template <> MlasQgemmTest<uint8_t, uint8_t, float, true, true>* MlasTestFixture<MlasQgemmTest<uint8_t, uint8_t, float, true, true>>::mlas_tester(nullptr);
 
 static size_t QGemmRegistLongExecute() {
   size_t count = 0;
 
-  count += MlasLongExecuteTests<MlasQgemmU8X8Test<int8_t, int32_t, false, false>>::RegisterLongExecute();
-  count += MlasLongExecuteTests<MlasQgemmU8X8Test<int8_t, int32_t, true, false>>::RegisterLongExecute();
-  count += MlasLongExecuteTests<MlasQgemmU8X8Test<uint8_t, int32_t, false, false>>::RegisterLongExecute();
-  count += MlasLongExecuteTests<MlasQgemmU8X8Test<uint8_t, int32_t, true, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, int8_t, int32_t, false, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, int8_t, int32_t, true, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, false, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, false>>::RegisterLongExecute();
+#if defined(MLAS_TARGET_ARM_ANY)
+  count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, false, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, true, false>>::RegisterLongExecute();
+#endif
+
   if (GetMlasThreadPool() != nullptr) {
-    count += MlasLongExecuteTests<MlasQgemmU8X8Test<int8_t, int32_t, false, true>>::RegisterLongExecute();
-    count += MlasLongExecuteTests<MlasQgemmU8X8Test<int8_t, int32_t, true, true>>::RegisterLongExecute();
-    count += MlasLongExecuteTests<MlasQgemmU8X8Test<uint8_t, int32_t, false, true>>::RegisterLongExecute();
-    count += MlasLongExecuteTests<MlasQgemmU8X8Test<uint8_t, int32_t, true, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, int8_t, int32_t, false, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, int8_t, int32_t, true, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, false, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<uint8_t, uint8_t, int32_t, true, true>>::RegisterLongExecute();
+#if defined(MLAS_TARGET_ARM_ANY)
+    count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, false, true>>::RegisterLongExecute();
+    count += MlasLongExecuteTests<MlasQgemmTest<int8_t, int8_t, int32_t, true, true>>::RegisterLongExecute();
+#endif
   }
 
   return count;
@@ -41,36 +64,58 @@ static size_t QGemmRegistLongExecute() {
 static size_t QGemmRegistShortExecute() {
   size_t count = 0;
 
-  count += QgemmShortExecuteTest<int8_t, float, false, false>::RegisterShortExecuteTests();
-  count += QgemmShortExecuteTest<uint8_t, float, false, false>::RegisterShortExecuteTests();
-  count += QgemmShortExecuteTest<int8_t, int32_t, false, false>::RegisterShortExecuteTests();
-  count += QgemmShortExecuteTest<uint8_t, int32_t, false, false>::RegisterShortExecuteTests();
-  if (MlasGemmPackBSize(128, 128, false) > 0) {
+  count += QgemmShortExecuteTest<uint8_t, int8_t, float, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<uint8_t, uint8_t, float, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, false, false>::RegisterShortExecuteTests();
+  #if defined(MLAS_TARGET_ARM_ANY)
+  count += QgemmShortExecuteTest<int8_t, int8_t, float, false, false>::RegisterShortExecuteTests();
+  count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, false>::RegisterShortExecuteTests();
+  #endif
+  if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/) > 0) {
     // QGEMM U8U8=float packed tests
-    count += QgemmShortExecuteTest<uint8_t, float, true, false>::RegisterShortExecuteTests();
-    // QGEMM U8u8=int32_t packed tests
-    count += QgemmShortExecuteTest<uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
+    // QGEMM U8U8=int32_t packed tests
+    count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, true, false>::RegisterShortExecuteTests();
   }
-  if (MlasGemmPackBSize(128, 128, true) > 0) {
+  if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, true /*BIsSigned*/) > 0) {
     // QGEMM U8S8=float packed tests
-    count += QgemmShortExecuteTest<int8_t, float, true, false>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
     // QGEMM U8S8=int32_t packed tests
-    count += QgemmShortExecuteTest<int8_t, int32_t, true, false>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
   }
+  #if defined(MLAS_TARGET_ARM_ANY)
+ if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+    // QGEMM U8S8=float packed tests
+    count += QgemmShortExecuteTest<int8_t, int8_t, float, true, false>::RegisterShortExecuteTests();
+    // QGEMM U8S8=int32_t packed tests
+    count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, false>::RegisterShortExecuteTests();
+  }
+  #endif
 
   if (GetMlasThreadPool() != nullptr) {
-    count += QgemmShortExecuteTest<int8_t, float, false, true>::RegisterShortExecuteTests();
-    count += QgemmShortExecuteTest<uint8_t, float, false, true>::RegisterShortExecuteTests();
-    count += QgemmShortExecuteTest<int8_t, int32_t, false, true>::RegisterShortExecuteTests();
-    count += QgemmShortExecuteTest<uint8_t, int32_t, false, true>::RegisterShortExecuteTests();
-    if (MlasGemmPackBSize(128, 128, false) > 0) {
-      count += QgemmShortExecuteTest<uint8_t, float, true, true>::RegisterShortExecuteTests();
-      count += QgemmShortExecuteTest<uint8_t, int32_t, true, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, int8_t, float, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, uint8_t, float, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, false, true>::RegisterShortExecuteTests();
+    #if defined(MLAS_TARGET_ARM_ANY)
+    count += QgemmShortExecuteTest<int8_t, int8_t, float, false, true>::RegisterShortExecuteTests();
+    count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, true>::RegisterShortExecuteTests();
+    #endif
+    if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/) > 0) {
+      count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, true>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
-    if (MlasGemmPackBSize(128, 128, true) > 0) {
-      count += QgemmShortExecuteTest<int8_t, float, true, true>::RegisterShortExecuteTests();
-      count += QgemmShortExecuteTest<int8_t, int32_t, true, true>::RegisterShortExecuteTests();
+    if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+      count += QgemmShortExecuteTest<uint8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<uint8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
     }
+    #if defined(MLAS_TARGET_ARM_ANY)
+    if (MlasGemmPackBSize(128, 128, true /*AIsSigned*/, true /*BIsSigned*/) > 0) {
+      count += QgemmShortExecuteTest<int8_t, int8_t, float, true, true>::RegisterShortExecuteTests();
+      count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, true, true>::RegisterShortExecuteTests();
+    }
+    #endif
   }
 
   return count;

--- a/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
@@ -9,11 +9,11 @@
 //
 // Short Execute() test helper to register each test seperately by all parameters.
 //
-template <typename xint8_t, typename OutputType, bool Packed, bool Threaded>
+template <typename AType, typename BType, typename OutputType, bool Packed, bool Threaded>
 class QgemmShortExecuteTest;
 
-template <typename xint8_t, bool Packed, bool Threaded>
-class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>> {
+template <typename AType, typename BType, bool Packed, bool Threaded>
+class QgemmShortExecuteTest<AType, BType, int32_t, Packed, Threaded> : public MlasTestFixture<MlasQgemmTest<AType, BType, int32_t, Packed, Threaded>> {
  public:
   explicit QgemmShortExecuteTest(bool use_offb, size_t M, size_t N, size_t K, size_t Batch, uint8_t offa, uint8_t offb)
       : use_offb_(use_offb), M_(M), N_(N), K_(K), Batch_(Batch), offa_(offa), offb_(offb) {
@@ -21,9 +21,9 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
 
   void TestBody() override {
     if (use_offb_) {
-      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_, offb_);
+      MlasTestFixture<MlasQgemmTest<AType, BType, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_, offb_);
     } else {
-      MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_);
+      MlasTestFixture<MlasQgemmTest<AType, BType, int32_t, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_);
     }
   }
 
@@ -40,15 +40,15 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
     auto test_name = ss.str();
 
     testing::RegisterTest(
-        MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>::GetTestSuiteName(),
+        MlasQgemmTest<AType, BType, int32_t, Packed, Threaded>::GetTestSuiteName(),
         test_name.c_str(),
         nullptr,
         test_name.c_str(),
         __FILE__,
         __LINE__,
         // Important to use the fixture type as the return type here.
-        [=]() -> MlasTestFixture<MlasQgemmU8X8Test<xint8_t, int32_t, Packed, Threaded>>* {
-          return new QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded>(
+        [=]() -> MlasTestFixture<MlasQgemmTest<AType, BType, int32_t, Packed, Threaded>>* {
+          return new QgemmShortExecuteTest<AType, BType, int32_t, Packed, Threaded>(
               use_offb, M, N, K, Batch, offa, offb);
         });
 
@@ -111,8 +111,8 @@ class QgemmShortExecuteTest<xint8_t, int32_t, Packed, Threaded> : public MlasTes
   uint8_t offa_, offb_;
 };
 
-template <typename xint8_t, bool Packed, bool Threaded>
-class QgemmShortExecuteTest<xint8_t, float, Packed, Threaded> : public MlasTestFixture<MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>> {
+template <typename AType, typename BType, bool Packed, bool Threaded>
+class QgemmShortExecuteTest<AType, BType, float, Packed, Threaded> : public MlasTestFixture<MlasQgemmTest<AType, BType, float, Packed, Threaded>> {
  public:
   explicit QgemmShortExecuteTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb)
       : M_(M), N_(N), K_(K), offa_(offa), offb_(offb) {
@@ -120,7 +120,7 @@ class QgemmShortExecuteTest<xint8_t, float, Packed, Threaded> : public MlasTestF
 
   void TestBody() override {
     // Batching code is agnostic to result type. Only cover batches above, not here.
-    MlasTestFixture<MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, 1, offa_, offb_);
+    MlasTestFixture<MlasQgemmTest<AType, BType, float, Packed, Threaded>>::mlas_tester->Test(M_, N_, K_, 1, offa_, offb_);
   }
 
   static size_t RegisterSingleTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
@@ -131,15 +131,15 @@ class QgemmShortExecuteTest<xint8_t, float, Packed, Threaded> : public MlasTestF
     auto test_name = ss.str();
 
     testing::RegisterTest(
-        MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>::GetTestSuiteName(),
+        MlasQgemmTest<AType, BType, float, Packed, Threaded>::GetTestSuiteName(),
         test_name.c_str(),
         nullptr,
         test_name.c_str(),
         __FILE__,
         __LINE__,
         // Important to use the fixture type as the return type here.
-        [=]() -> MlasTestFixture<MlasQgemmU8X8Test<xint8_t, float, Packed, Threaded>>* {
-          return new QgemmShortExecuteTest<xint8_t, float, Packed, Threaded>(M, N, K, offa, offb);
+        [=]() -> MlasTestFixture<MlasQgemmTest<AType, BType, float, Packed, Threaded>>* {
+          return new QgemmShortExecuteTest<AType, BType, float, Packed, Threaded>(M, N, K, offa, offb);
         });
     return 1;
   }

--- a/onnxruntime/test/mlas/unittest/test_util.h
+++ b/onnxruntime/test/mlas/unittest/test_util.h
@@ -186,7 +186,7 @@ class MlasTestFixture : public testing::Test {
   static TMlasTester* mlas_tester;
 };
 
-// Long Execute test. It is too heavy register each single test, treat long execute big groups.
+// Long Execute test. It is too heavy to register each single test, treat long execute big groups.
 template <typename TMlasTester>
 class MlasLongExecuteTests : public MlasTestFixture<TMlasTester> {
  public:

--- a/onnxruntime/test/providers/kernel_def_hash_test.cc
+++ b/onnxruntime/test/providers/kernel_def_hash_test.cc
@@ -178,6 +178,9 @@ TEST(KernelDefHashTest, ExpectedCpuKernelDefHashes) {
     AppendKernelDefHashesFromFile(ORT_TSTR("testdata/kernel_def_hashes/onnx.optional_type_ops.cpu.json"), result);
 #endif  // !DISABLE_OPTIONAL_TYPE
 
+#if defined(MLAS_TARGET_ARM_ANY)
+    AppendKernelDefHashesFromFile(ORT_TSTR("testdata/kernel_def_hashes/arm_ops.cpu.json"), result);
+#endif  // MLAS_TARGET_ARM_ANY
     // TODO also handle kernels enabled by these symbols: BUILD_MS_EXPERIMENTAL_OPS
     std::sort(result.begin(), result.end());
     return result;

--- a/onnxruntime/test/testdata/kernel_def_hashes/arm_ops.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/arm_ops.cpu.json
@@ -1,0 +1,26 @@
+[
+    [
+        "NhwcMaxPool com.microsoft CPUExecutionProvider",
+        11773579655431087496
+    ],
+    [
+        "QLinearAveragePool com.microsoft CPUExecutionProvider",
+        7697522567125769728
+    ],
+    [
+        "QLinearConv ai.onnx CPUExecutionProvider",
+        1301685544574905024
+    ],
+    [
+        "QLinearConv com.microsoft CPUExecutionProvider",
+        10904143578341560456
+    ],
+    [
+        "QLinearGlobalAveragePool com.microsoft CPUExecutionProvider",
+        2087133060447455992
+    ],
+    [
+        "QLinearMatMul ai.onnx CPUExecutionProvider",
+        7936962119982759552
+    ]
+]

--- a/onnxruntime/test/testdata/kernel_def_hashes/arm_ops.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/arm_ops.cpu.json
@@ -1,23 +1,11 @@
 [
     [
-        "NhwcMaxPool com.microsoft CPUExecutionProvider",
-        11773579655431087496
-    ],
-    [
-        "QLinearAveragePool com.microsoft CPUExecutionProvider",
-        7697522567125769728
-    ],
-    [
         "QLinearConv ai.onnx CPUExecutionProvider",
         1301685544574905024
     ],
     [
         "QLinearConv com.microsoft CPUExecutionProvider",
         10904143578341560456
-    ],
-    [
-        "QLinearGlobalAveragePool com.microsoft CPUExecutionProvider",
-        2087133060447455992
     ],
     [
         "QLinearMatMul ai.onnx CPUExecutionProvider",

--- a/onnxruntime/test/testdata/kernel_def_hashes/contrib.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/contrib.cpu.json
@@ -189,7 +189,11 @@
     ],
     [
         "QLinearConv com.microsoft CPUExecutionProvider",
-        16835965565578160400
+        11232265474041605760
+    ],
+    [
+        "QLinearConv com.microsoft CPUExecutionProvider",
+        11596245951504387848
     ],
     [
         "QLinearGlobalAveragePool com.microsoft CPUExecutionProvider",

--- a/onnxruntime/test/testdata/kernel_def_hashes/contrib.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/contrib.cpu.json
@@ -189,11 +189,7 @@
     ],
     [
         "QLinearConv com.microsoft CPUExecutionProvider",
-        11232265474041605760
-    ],
-    [
-        "QLinearConv com.microsoft CPUExecutionProvider",
-        11596245951504387848
+        16835965565578160400
     ],
     [
         "QLinearGlobalAveragePool com.microsoft CPUExecutionProvider",

--- a/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
@@ -1517,11 +1517,19 @@
     ],
     [
         "QLinearConv ai.onnx CPUExecutionProvider",
-        6630340551594954312
+        6684227707397124552
+    ],
+    [
+        "QLinearConv ai.onnx CPUExecutionProvider",
+        14667481778195371632
     ],
     [
         "QLinearMatMul ai.onnx CPUExecutionProvider",
-        17071666635484846840
+        5423869068634665208
+    ],
+    [
+        "QLinearMatMul ai.onnx CPUExecutionProvider",
+        8138822876968303736
     ],
     [
         "QuantizeLinear ai.onnx CPUExecutionProvider",

--- a/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
+++ b/onnxruntime/test/testdata/kernel_def_hashes/onnx.cpu.json
@@ -1517,19 +1517,11 @@
     ],
     [
         "QLinearConv ai.onnx CPUExecutionProvider",
-        6684227707397124552
-    ],
-    [
-        "QLinearConv ai.onnx CPUExecutionProvider",
-        14667481778195371632
+        6630340551594954312
     ],
     [
         "QLinearMatMul ai.onnx CPUExecutionProvider",
-        5423869068634665208
-    ],
-    [
-        "QLinearMatMul ai.onnx CPUExecutionProvider",
-        8138822876968303736
+        17071666635484846840
     ],
     [
         "QuantizeLinear ai.onnx CPUExecutionProvider",


### PR DESCRIPTION
**Description**: Describe your changes.
Add support of S8S8 quantization format, with which both activation and weight are quantized in int8 format. This PR adds s8s8 implementation on ARM devices for operators: QLinearConv, QLinearMatMul.

QGEMM is the most complex part in the change. Here are the dispatchers for quantized gemm:
|      | ARM64 with dot product           | ARM64                            | ARM32                                    |
|------|----------------------------------|----------------------------------|------------------------------------------|
| U8U8 | MlasGemmU8X8DispatchUdot         | MlasGemmU8X8DispatchNeon         | MlasGemmU8X8DispatchNeon                 |
| U8S8 | MlasGemmU8X8DispatchUdot(B flip) | MlasGemmX8S8DispatchNeon(A flip) | MlasGemmU8X8DispatchNeon(B flip)         |
| S8S8 | MlasGemmS8S8DispatchSdot         | MlasGemmX8S8DispatchNeon         | MlasGemmU8X8DispatchNeon(A flip, B flip) |