### PR TITLE
GraphPartitioner.cpp: fixed Merge function to handle duplicated parti…

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
@@ -105,7 +105,7 @@ namespace Dml
 
         for (GraphPartition* partitionToMerge : partitionsToMerge)
         {
-            if (partitionToMerge == this)
+            if (partitionToMerge->GetRootMergedPartition() == this)
             {
                 continue;
             }


### PR DESCRIPTION
This fixes a graph partitioning bug in the DML execution provider that was reached while executing a YOLOV4 model. 