### PR TITLE
remove six references

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -45,7 +45,7 @@ class CalibraterBase:
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         '''
-        if isinstance(model, string_types):
+        if isinstance(model, str):
             self.model = onnx.load(model)
         elif isinstance(model, ModelProto):
             self.model = model

--- a/onnxruntime/test/python/quantization/op_test_utils.py
+++ b/onnxruntime/test/python/quantization/op_test_utils.py
@@ -1,7 +1,6 @@
 
 import onnx
 import numpy as np
-from six import string_types
 import onnxruntime
 from pathlib import Path
 from onnxruntime.quantization import CalibrationDataReader
@@ -35,7 +34,7 @@ def InputFeedsNegOneZeroOne(n, name2shape):
     return dr
 
 def check_op_type_order(testcase, model_to_check, ops):
-    if isinstance(model_to_check, string_types):
+    if isinstance(model_to_check, str):
         model = onnx.load(model_to_check)
     elif isinstance(model_to_check, onnx.ModelProto):
         model = model_to_check
@@ -79,7 +78,7 @@ def check_op_nodes(testcase, model_path, node_checker):
         testcase.assertTrue(node_checker(node))
 
 def check_qtype_by_node_type(testcase, model_to_check, check_list):
-    if isinstance(model_to_check, string_types):
+    if isinstance(model_to_check, str):
         model = onnx.load(model_to_check)
     elif isinstance(model_to_check, onnx.ModelProto):
         model = model_to_check

--- a/onnxruntime/test/testdata/sparse_initializer_as_output.py
+++ b/onnxruntime/test/testdata/sparse_initializer_as_output.py
@@ -9,7 +9,6 @@ from onnx import AttributeProto, SparseTensorProto, TensorProto, GraphProto, Val
 import traceback
 
 from typing import Text, Sequence, Any, Optional, Dict, Union, TypeVar, Callable, Tuple, List, cast
-from six import text_type, integer_types, binary_type
 
 
 def parse_arguments():
@@ -59,14 +58,14 @@ def make_sparse_tensor_value_info(
             dim = sparse_tensor_shape_proto.dim.add()
             if d is None:
                 pass
-            elif isinstance(d, integer_types):
+            elif isinstance(d, int):
                 dim.dim_value = d
-            elif isinstance(d, text_type):
+            elif isinstance(d, str):
                 dim.dim_param = d
             else:
                 raise ValueError(
                     'Invalid item in shape: {}. '
-                    'Needs to of integer_types or text_type.'.format(d))
+                    'Needs to be one of `int` or `str`.'.format(d))
 
             if shape_denotation:
                 dim.denotation = shape_denotation[i]

--- a/onnxruntime/test/testdata/sparse_to_dense_matmul.py
+++ b/onnxruntime/test/testdata/sparse_to_dense_matmul.py
@@ -9,7 +9,6 @@ from onnx import AttributeProto, SparseTensorProto, TensorProto, GraphProto, Val
 import traceback
 
 from typing import Text, Sequence, Any, Optional, Dict, Union, TypeVar, Callable, Tuple, List, cast
-from six import text_type, integer_types, binary_type
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
@@ -55,14 +54,14 @@ def make_sparse_tensor_value_info(
             dim = sparse_tensor_shape_proto.dim.add()
             if d is None:
                 pass
-            elif isinstance(d, integer_types):
+            elif isinstance(d, int):
                 dim.dim_value = d
-            elif isinstance(d, text_type):
+            elif isinstance(d, str):
                 dim.dim_param = d
             else:
                 raise ValueError(
                     'Invalid item in shape: {}. '
-                    'Needs to of integer_types or text_type.'.format(d))
+                    'Needs to be one of `int` or `text`.'.format(d))
 
             if shape_denotation:
                 dim.denotation = shape_denotation[i]


### PR DESCRIPTION
Python 2 compatibility is no longer necessary and helps unblock upgrades to mypy and others.

**Description**: removes six from test files and replaces them with the Python 3 references.

**Motivation and Context**
- We would like to upgrade mypy and drop Python 2 compatiblity in upstream onnx: https://github.com/onnx/onnx/pull/3604
- There is a test PR here already https://github.com/microsoft/onnxruntime/pull/9649
