### PR TITLE
fix deadlock in model.train mode forward run only

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function.py
@@ -25,6 +25,7 @@ def enable_custom_autograd_support():
     from torch.onnx import register_custom_op_symbolic
     from ._custom_autograd_function_exporter import _export
     from ._custom_autograd_function_runner import call_python_forward_function, call_python_backward_function
+    from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
     import atexit
 
     register_forward_runner(call_python_forward_function)
@@ -32,6 +33,9 @@ def enable_custom_autograd_support():
 
     # Unregister all python functions automatically upon normal interpreter termination.
     atexit.register(unregister_python_functions)
+    # Clear all gradient functions, to avoid a deadlock issue.
+    # Check the called function for more detailed comments.
+    atexit.register(torch_interop_utils.clear_all_grad_fns)
 
     try:
         # This is for the latest Pytorch nightly after this commit:

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function.py
@@ -25,7 +25,6 @@ def enable_custom_autograd_support():
     from torch.onnx import register_custom_op_symbolic
     from ._custom_autograd_function_exporter import _export
     from ._custom_autograd_function_runner import call_python_forward_function, call_python_backward_function
-    from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
     import atexit
 
     register_forward_runner(call_python_forward_function)
@@ -33,9 +32,6 @@ def enable_custom_autograd_support():
 
     # Unregister all python functions automatically upon normal interpreter termination.
     atexit.register(unregister_python_functions)
-    # Clear all gradient functions, to avoid a deadlock issue.
-    # Check the called function for more detailed comments.
-    atexit.register(torch_interop_utils.clear_all_grad_fns)
 
     try:
         # This is for the latest Pytorch nightly after this commit:

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -16,10 +16,10 @@ from .debug_options import DebugOptions
 from ._fallback import (ORTModuleFallbackException,
                         _FallbackPolicy,
                         _FallbackManager)
+from .torch_cpp_extensions.cpu.torch_interop_utils import clear_all_grad_fns
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import get_ort_device_type
-from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
 
 import torch
 import warnings
@@ -42,7 +42,7 @@ class TrainingManager(GraphExecutionManager):
 
         # Clear all gradient functions, to avoid a deadlock issue.
         # Check the called function for more detailed comments.
-        torch_interop_utils.clear_all_grad_fns()
+        clear_all_grad_fns()
 
         # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
         #   especially the backward graph outputs.

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -19,6 +19,7 @@ from ._fallback import (ORTModuleFallbackException,
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import get_ort_device_type
+from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
 
 import torch
 import warnings
@@ -38,6 +39,10 @@ class TrainingManager(GraphExecutionManager):
     @staticmethod
     def execution_session_run_forward(execution_session, onnx_model, device, gradient_accumulation_manager, *inputs):
         """Runs the forward graph on execution_session with given model inputs and device"""
+
+        # Clear all gradient functions, to avoid a deadlock issue.
+        # Check the called function for more detailed comments.
+        torch_interop_utils.clear_all_grad_fns()
 
         # TODO: Try to reuse the output buffers as some of the output tensors are same sizes,
         #   especially the backward graph outputs.

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/__init__.py
@@ -2,3 +2,8 @@
 def clear_all_grad_fns():
     from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
     torch_interop_utils.clear_all_grad_fns()
+
+import atexit
+# Clear all gradient functions, to avoid a deadlock issue.
+# Check the called function for more detailed comments.
+atexit.register(clear_all_grad_fns)

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/__init__.py
@@ -1,0 +1,4 @@
+
+def clear_all_grad_fns():
+    from onnxruntime.training.ortmodule.torch_cpp_extensions import torch_interop_utils
+    torch_interop_utils.clear_all_grad_fns()

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
@@ -48,9 +48,14 @@ class PyNodeSharedPointerPool {
     grad_fns_.erase(ctx_address);
   };
 
+  void ClearAll(){
+    grad_fns_.clear();
+  }
+
  private:
   PyNodeSharedPointerPool(){};
-  ~PyNodeSharedPointerPool(){};
+  ~PyNodeSharedPointerPool(){
+  };
 
   PyNodeSharedPointerPool(const PyNodeSharedPointerPool&) = delete;
   PyNodeSharedPointerPool& operator=(const PyNodeSharedPointerPool&) = delete;
@@ -109,8 +114,21 @@ void unregister_grad_fn(size_t ctx_address)
   PyNodeSharedPointerPool::GetInstance().UnRegisterGradFunc(ctx_address);
 }
 
+// Supposed to be cleared only on python program exit to resolve following bug:
+// When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
+// PyNode::release_variables() will be called.
+// (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)
+// The other hand, there is known issue when acquiring GIL in pybind11 destructors, there will be probabbly deadlock issue.
+// (https://github.com/pybind/pybind11/issues/1446)
+// The resolution here, we remove all maintained states before ~PyNodeSharedPointerPool happens (e.g. the python program exits)
+// to avoid the deadlock issue.
+void clear_all_grad_fns(){
+  PyNodeSharedPointerPool::GetInstance().ClearAll();
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("register_grad_fn", &register_grad_fn, "increase grad_fn shared pointer reference.");
   m.def("unregister_grad_fn", &unregister_grad_fn, "release grad_fn shared pointer referece.");
+  m.def("clear_all_grad_fns", &clear_all_grad_fns, "clear all grad_fn shared pointer refereces.");
   m.def("clear_grad_fns_for_next_edges", &clear_grad_fns_for_next_edges, "remove reference on next edges' gradident funtions.");
 }

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
@@ -114,14 +114,13 @@ void unregister_grad_fn(size_t ctx_address)
   PyNodeSharedPointerPool::GetInstance().UnRegisterGradFunc(ctx_address);
 }
 
-// Supposed to be cleared only on python program exit to resolve following bug:
+// Supposed to be cleared before every forward run to resolve following bug:
 // When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
 // PyNode::release_variables() will be called.
 // (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)
 // The other hand, there is known issue when acquiring GIL in pybind11 destructors, there will be probabbly deadlock issue.
 // (https://github.com/pybind/pybind11/issues/1446)
-// The resolution here, we remove all maintained states before ~PyNodeSharedPointerPool happens (e.g. the python program exits)
-// to avoid the deadlock issue.
+// The resolution here, we remove all maintained states before every forward run.
 void clear_all_grad_fns(){
   PyNodeSharedPointerPool::GetInstance().ClearAll();
 }

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
@@ -114,7 +114,7 @@ void unregister_grad_fn(size_t ctx_address)
   PyNodeSharedPointerPool::GetInstance().UnRegisterGradFunc(ctx_address);
 }
 
-// Supposed to be cleared before every forward run to resolve following bug:
+// Supposed to be cleared on python program exit or before every forward run to resolve following bug:
 // When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
 // PyNode::release_variables() will be called.
 // (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/torch_interop_utils.cc
@@ -114,13 +114,15 @@ void unregister_grad_fn(size_t ctx_address)
   PyNodeSharedPointerPool::GetInstance().UnRegisterGradFunc(ctx_address);
 }
 
-// Supposed to be cleared on python program exit or before every forward run to resolve following bug:
-// When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
-// PyNode::release_variables() will be called.
-// (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)
-// The other hand, there is known issue when acquiring GIL in pybind11 destructors, there will be probabbly deadlock issue.
-// (https://github.com/pybind/pybind11/issues/1446)
-// The resolution here, we remove all maintained states before every forward run.
+// Supposed to be cleared on python program exit or before every forward run to resolve following issues:
+// 1. When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
+//    PyNode::release_variables() will be called.
+//    (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)
+//    The other hand, there is known issue when acquiring GIL in pybind11 destructors, there will be probabbly deadlock issue.
+//    (https://github.com/pybind/pybind11/issues/1446)
+//    The resolution here, we remove all maintained states before program exits.
+// 2. When forward functions is called repeated without corresponding backward calls, grad functions keeps accumulating without releasing
+//    (happening in backward)
 void clear_all_grad_fns(){
   PyNodeSharedPointerPool::GetInstance().ClearAll();
 }

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_autograd.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_autograd.py
@@ -34,7 +34,7 @@ def test_GeLU():
                         0.1070322243 * x * x)) + 0.5 * (1 + tanh_out)
         return ff*g
 
-    class GeLUFunction(torch.autograd.Function):
+    class GeLUFunction1(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input, bias):
             ctx.save_for_backward(input, bias)
@@ -49,7 +49,7 @@ def test_GeLU():
     class GeLUModel(torch.nn.Module):
         def __init__(self, output_size):
             super(GeLUModel, self).__init__()
-            self.relu = GeLUFunction.apply
+            self.relu = GeLUFunction1.apply
             self.bias = Parameter(torch.empty(
                 output_size,
                 device=torch.cuda.current_device(),
@@ -90,7 +90,7 @@ def test_GeLU_custom_func_rets_not_as_module_output():
                         0.1070322243 * x * x)) + 0.5 * (1 + tanh_out)
         return ff*g
 
-    class GeLUFunction(torch.autograd.Function):
+    class GeLUFunction2(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input, bias):
             ctx.save_for_backward(input, bias)
@@ -105,7 +105,7 @@ def test_GeLU_custom_func_rets_not_as_module_output():
     class GeLUModel(torch.nn.Module):
         def __init__(self, output_size):
             super(GeLUModel, self).__init__()
-            self.relu = GeLUFunction.apply
+            self.relu = GeLUFunction2.apply
             self.bias = Parameter(torch.empty(
                 output_size,
                 device=torch.cuda.current_device(),
@@ -635,7 +635,7 @@ def test_EvalTest():
 @pytest.mark.skipif(torch_version_lower_than("1.10.0"),
                     reason='PyTorch older than 1.10.0 has bugs for exporting multiple output custom function')
 def test_TwoOutputFunction():
-    class TwoOutputFunction(torch.autograd.Function):
+    class TwoOutputFunction1(torch.autograd.Function):
         @staticmethod
         # bias is an optional argument
         def forward(ctx, x, y):
@@ -669,7 +669,7 @@ def test_TwoOutputFunction():
     class TwoOutputModel(torch.nn.Module):
         def __init__(self, output_size):
             super(TwoOutputModel, self).__init__()
-            self.fun = TwoOutputFunction.apply
+            self.fun = TwoOutputFunction1.apply
             self.bias = Parameter(torch.empty(
                 output_size,
                 device=torch.cuda.current_device(),
@@ -772,7 +772,7 @@ def test_InnerModuleCall():
 @pytest.mark.skipif(torch_version_lower_than("1.10.0"),
                     reason='PyTorch older than 1.10.0 has bugs for exporting multiple output custom function')
 def test_Share_Input():
-    class TwoOutputFunction(torch.autograd.Function):
+    class TwoOutputFunction2(torch.autograd.Function):
         @staticmethod
         # bias is an optional argument
         def forward(ctx, x, y):
@@ -791,7 +791,7 @@ def test_Share_Input():
     class TwoOutputModel(torch.nn.Module):
         def __init__(self, output_size):
             super(TwoOutputModel, self).__init__()
-            self.fun = TwoOutputFunction.apply
+            self.fun = TwoOutputFunction2.apply
             self.bias = Parameter(torch.empty(
                 output_size,
                 device=torch.cuda.current_device(),
@@ -827,7 +827,7 @@ def test_Share_Input():
 
 
 def test_MultipleStream_InForwardFunction():
-    class MultipleStreamFunction(torch.autograd.Function):
+    class MultipleStreamFunction1(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input):
             default_stream = torch.cuda.current_stream()
@@ -850,7 +850,7 @@ def test_MultipleStream_InForwardFunction():
     class MultipleStreamModel(torch.nn.Module):
         def __init__(self, output_size):
             super(MultipleStreamModel, self).__init__()
-            self.relu = MultipleStreamFunction.apply
+            self.relu = MultipleStreamFunction1.apply
 
         def forward(self, model_input):
             b = model_input * 0.2
@@ -874,7 +874,7 @@ def test_MultipleStream_InForwardFunction():
 
 
 def test_NonDefaultStream_InForwardFunction1():
-    class MultipleStreamFunction(torch.autograd.Function):
+    class MultipleStreamFunction2(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input):
             default_stream = torch.cuda.current_stream()
@@ -896,7 +896,7 @@ def test_NonDefaultStream_InForwardFunction1():
     class MultipleStreamModel(torch.nn.Module):
         def __init__(self, output_size):
             super(MultipleStreamModel, self).__init__()
-            self.relu = MultipleStreamFunction.apply
+            self.relu = MultipleStreamFunction2.apply
 
         def forward(self, model_input):
             model_input = model_input * 0.2
@@ -921,7 +921,7 @@ def test_NonDefaultStream_InForwardFunction1():
 
 
 def test_NonDefaultStream_InForwardFunction2():
-    class MultipleStreamFunction(torch.autograd.Function):
+    class MultipleStreamFunction3(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input):
             ctx.save_for_backward(input)
@@ -937,7 +937,7 @@ def test_NonDefaultStream_InForwardFunction2():
     class MultipleStreamModel(torch.nn.Module):
         def __init__(self, output_size):
             super(MultipleStreamModel, self).__init__()
-            self.relu = MultipleStreamFunction.apply
+            self.relu = MultipleStreamFunction3.apply
 
         def forward(self, model_input):
             model_input = model_input * 0.2
@@ -967,7 +967,7 @@ def test_NonDefaultStream_InForwardFunction2():
 
 
 def test_NonDefaultStreamInplaceUpdate_InForwardFunction():
-    class MultipleStreamFunction(torch.autograd.Function):
+    class MultipleStreamFunction4(torch.autograd.Function):
         @staticmethod
         def forward(ctx, input):
             default_stream = torch.cuda.current_stream()
@@ -990,7 +990,7 @@ def test_NonDefaultStreamInplaceUpdate_InForwardFunction():
     class MultipleStreamModel(torch.nn.Module):
         def __init__(self, output_size):
             super(MultipleStreamModel, self).__init__()
-            self.relu = MultipleStreamFunction.apply
+            self.relu = MultipleStreamFunction4.apply
 
         def forward(self, model_input):
             model_input = model_input * 0.2


### PR DESCRIPTION
**Description**: fix deadlock in model.train model forward run only.

Issues identified and investigated by Aishwarya. 

When training program exits, PyNodeSharedPointerPool destructor is called, if grad_fns_ is not empty,
PyNode::release_variables() will be called (https://github.com/pytorch/pytorch/blob/15532595209d2daf34d35e10f8d3d3b64966aea2/torch/csrc/autograd/python_function.cpp#L168)

The other hand, there is known issue when acquiring GIL in pybind11 destructors, there will be probabbly deadlock issue (https://github.com/pybind/pybind11/issues/1446)

The resolution here, we remove all maintained states before ~PyNodeSharedPointerPool happens (e.g. the python program exits) to avoid the deadlock issue.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
