### PR TITLE
Minor DirectML EP provider factory comments

### DIFF
--- a/include/onnxruntime/core/providers/dml/dml_provider_factory.h
+++ b/include/onnxruntime/core/providers/dml/dml_provider_factory.h
@@ -25,18 +25,22 @@ extern "C" {
 #endif
 
 /**
+ * [[deprecated]]
+ * This export is deprecated.
+ * The OrtSessionOptionsAppendExecutionProvider_DML export on the OrtDmlApi should be used instead.
+ *
  * Creates a DirectML Execution Provider which executes on the hardware adapter with the given device_id, also known as
  * the adapter index. The device ID corresponds to the enumeration order of hardware adapters as given by 
  * IDXGIFactory::EnumAdapters. A device_id of 0 always corresponds to the default adapter, which is typically the 
  * primary display GPU installed on the system. A negative device_id is invalid.
- * 
- * [[deprecated]]
- * This export should be deprecated.
- * The OrtSessionOptionsAppendExecutionProvider_DML export on the OrtDmlApi should be used instead.
  */
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_DML, _In_ OrtSessionOptions* options, int device_id);
 
 /**
+ * [[deprecated]]
+ * This export is deprecated.
+ * The OrtSessionOptionsAppendExecutionProvider_DML1 export on the OrtDmlApi should be used instead.
+ *
  * Creates a DirectML Execution Provider using the given DirectML device, and which executes work on the supplied D3D12
  * command queue. The DirectML device and D3D12 command queue must have the same parent ID3D12Device, or an error will
  * be returned. The D3D12 command queue must be of type DIRECT or COMPUTE (see D3D12_COMMAND_LIST_TYPE). If this 
@@ -44,10 +48,6 @@ ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_DML, _In_ OrtSessionOpti
  * objects.
  * See also: DMLCreateDevice
  * See also: ID3D12Device::CreateCommandQueue
- * 
- * [[deprecated]]
- * This export should be deprecated.
- * The OrtSessionOptionsAppendExecutionProvider_DML1 export on the OrtDmlApi should be used instead.
  */
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProviderEx_DML, _In_ OrtSessionOptions* options,
                _In_ IDMLDevice* dml_device, _In_ ID3D12CommandQueue* cmd_queue);
@@ -79,21 +79,21 @@ struct OrtDmlApi {
 
   /**
     * CreateGPUAllocationFromD3DResource
-    * This api is used to create a DML EP input based on a user specified d3d12 resource.
+    * This API creates a DML EP resource based on a user-specified D3D12 resource.
   */
   ORT_API2_STATUS(CreateGPUAllocationFromD3DResource, _In_ ID3D12Resource* d3d_resource, _Out_ void** dml_resource);
 
   /**
     * FreeGPUAllocation
-    * This api is used free the DML EP input created by CreateGPUAllocationFromD3DResource.
+    * This API frees the DML EP resource created by CreateGPUAllocationFromD3DResource.
     */
   ORT_API2_STATUS(FreeGPUAllocation, _In_ void* dml_resource);
 
   /**
     * GetD3D12ResourceFromAllocation
-    * This api is used to get the D3D12 resource when a OrtValue has been allocated by the DML EP and accessed via GetMutableTensorData.
+    * This API gets the D3D12 resource when an OrtValue has been allocated by the DML EP.
     */
-  ORT_API2_STATUS(GetD3D12ResourceFromAllocation, _In_ OrtAllocator* provider, _In_ void* dml_allocation, _Out_ ID3D12Resource** d3d_resource);
+  ORT_API2_STATUS(GetD3D12ResourceFromAllocation, _In_ OrtAllocator* provider, _In_ void* dml_resource, _Out_ ID3D12Resource** d3d_resource);
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
**Description**: Small editorial changes in the comments

**Motivation and Context**
- *Why is this change required?* It's not - just clean up I noticed while investigating a bug (1) rename parameter `dml_allocation` to `dml_resource` to be consistent with other functions (2) few typos (3) move deprecation notice to top of comment for visibility.