### PR TITLE
Fix build warnings with VS 2022

### DIFF
--- a/onnxruntime/core/common/helper.cc
+++ b/onnxruntime/core/common/helper.cc
@@ -26,8 +26,10 @@ std::string ToMBString(const std::wstring& s) {
   const int len = WideCharToMultiByte(CP_ACP, 0, s.data(), src_len, nullptr, 0, nullptr, nullptr);
   assert(len > 0);
   std::string ret(static_cast<size_t>(len) - 1, '\0');
+#pragma warning(disable: 4189)
   const int r = WideCharToMultiByte(CP_ACP, 0, s.data(), src_len, (char*)ret.data(), len, nullptr, nullptr);
   assert(len == r);
+#pragma warning(default: 4189)
   return ret;
 }
 
@@ -39,8 +41,10 @@ std::wstring ToWideString(const std::string& s) {
   const int len = MultiByteToWideChar(CP_UTF8, 0, s.data(), src_len, nullptr, 0);
   assert(len > 0);
   std::wstring ret(static_cast<size_t>(len) - 1, '\0');
+#pragma warning(disable: 4189)
   const int r = MultiByteToWideChar(CP_UTF8, 0, s.data(), src_len, (wchar_t*)ret.data(), len);
   assert(len == r);
+#pragma warning(default: 4189)
   return ret;
 }
 #endif  //#ifdef _WIN32


### PR DESCRIPTION
Build warnings stop build with VS 2022 in helper.cc.