### PR TITLE
Change hard-coded DLL check to using ctypes.WinDLL

### DIFF
--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -12,10 +12,13 @@ import sys
 from . import _ld_preload  # noqa: F401
 
 if platform.system() == "Windows":
+    import ctypes
     from . import version_info
 
     if version_info.vs2019 and platform.architecture()[0] == "64bit":
-        if not os.path.isfile("C:\\Windows\\System32\\vcruntime140_1.dll"):
+        try:
+            ctypes.WinDLL("vcruntime140_1.dll")
+        except OSError:
             raise ImportError(
                 "Microsoft Visual C++ Redistributable for Visual Studio 2019 not installed on the machine.")
 @ONNXRUNTIME_SETDLOPENFLAGS_GLOBAL@


### PR DESCRIPTION
**Description**:
This PR proposes to follow the same methodology as the [TensorFlow Self-Check](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/platform/self_check.py) in using `ctypes.WinDLL` instead of a hard-coded path check for _vcruntime140_1.dll_.

**Motivation and Context**
This change enables application developers to ship entirely self-contained applications since they can simply add the DLL wherever they want as long as it is accessible through [Windows DLL search order](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order) - for example by packaging a self-contained [conda](https://docs.conda.io/en/latest/) environment including [vs2015_runtime](https://anaconda.org/conda-forge/vs2015_runtime), which installs to _Library/bin_ and pip-installing _onnxruntime(-gpu)_ on top.

**Note:** This has only been tested manually so far on a Win64 machine and is more like a suggestion. Existing tests in the context of CI/CD should do the necessary/remaining testing. I also do not know whether there are more/other places where this would have to be applied/adjusted.