### PR TITLE
Fix build error when using '--build_minimal extended' and '--build_wheel' build.py options.

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1502,9 +1502,7 @@ void CreateInferencePybindStateModule(py::module& m) {
   addSparseTensorMethods(m);
   addIoBindingMethods(m);
 
-#if !defined(__APPLE__) && \
-    (!defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
-  Ort::SessionOptions tmp_options;
+#if !defined(__APPLE__) && !defined(ORT_MINIMAL_BUILD)
   if (!InitProvidersSharedLibrary()) {
     const logging::Logger& default_logger = logging::LoggingManager::DefaultLogger();
     LOGS(default_logger, WARNING) << "Init provider bridge failed.";


### PR DESCRIPTION
**Description**
Fix build error when using '--build_minimal extended' and '--build_wheel' build.py options.
```
onnxruntime_pybind_state.obj : error LNK2019: unresolved external symbol "bool __cdecl onnxruntime::InitProvidersSharedLibrary(void)"
```

**Motivation and Context**
Fix build error.
