### PR TITLE
Defect: Possible null dereferenc

### DIFF
--- a/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
+++ b/orttraining/orttraining/test/graph/optimizer_graph_builder_test.cc
@@ -199,7 +199,7 @@ static void TestOptimizerGraphBuilderWithInitialStates(OptimizerGraphConfig conf
   const ONNX_NAMESPACE::TensorProto* tensor{};
   for (auto& weight_item : opt_initializer_names_map) {
     for (auto& opt_item : weight_item.second) {
-      ASSERT_TRUE(graph.GetInitializedTensor(opt_item.second, tensor));
+      ORT_ENFORCE(graph.GetInitializedTensor(opt_item.second, tensor));
       ASSERT_TRUE(tensor->data_type() == ONNX_NAMESPACE::TensorProto::FLOAT || tensor->data_type() == ONNX_NAMESPACE::TensorProto::INT64);
       if (tensor->data_type() == ONNX_NAMESPACE::TensorProto::FLOAT) {
         VerifyTensorValue(tensor, values[0]);


### PR DESCRIPTION
**Description**: The assert doesn't prevent accessing a possibly null 'tensor' variable, so change it to an ORT_ENFORCE to throw if it ever does happen.

**Motivation and Context**
Caught by auto defect tracking