### PR TITLE
Fix some documentation errors plus errors generating doxygen warnings

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3066,12 +3066,14 @@ struct OrtApi {
   /// @{
   /** \brief Used for custom operators, gets the GPU compute stream to use to launch the custom a GPU kernel     
   *   \see ::OrtCustomOp
-  * \param[context] OrtKernelContext instance
-  * \param[out] Returns pointer to a GPU compute stream that can be used to launch the custom GPU kernel.
+  * \param[in]  context OrtKernelContext instance
+  * \param[out] out Returns pointer to a GPU compute stream that can be used to launch the custom GPU kernel.
   *             If retrieving the GPU compute stream is not relevant (GPU not enabled in the build, kernel partitioned to
   *             some other EP), then a nullptr is returned as the output param.
   *             Do not free or mutate the returned pointer as it refers to internal data owned by the underlying session.
   *             Only use it for custom kernel launching.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value 
   */
   ORT_API2_STATUS(KernelContext_GetGPUComputeStream, _In_ const OrtKernelContext* context, _Outptr_ void** out);
 
@@ -3079,7 +3081,7 @@ struct OrtApi {
   /// \name GetTensorMemoryInfo
   /// @{
   /** \brief Returns a pointer to the ::OrtMemoryInfo of a Tensor
-   * \param[in] ort_value ::OrtValue containing tensor.
+   * \param[in] value ::OrtValue containing tensor.
    * \param[out] mem_info ::OrtMemoryInfo of the tensor. Do NOT free the returned pointer. It is valid for the lifetime of the ::OrtValue
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
@@ -3107,28 +3109,28 @@ struct OrtApi {
   /// @{
   /** \brief Set custom thread creation function
   *
-  * \param[in] session options
-  * \param[in] custom thread creation function
+  * \param[in] options Session options
+  * \param[in] ort_custom_create_thread_fn Custom thread creation function
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomCreateThreadFn, _Inout_ OrtSessionOptions* options, _In_ OrtCustomCreateThreadFn ort_custom_create_thread_fn);
 
   /** \brief Set creation options for custom thread 
   *
-  * \param[in] session options
-  * \param[in] custom thread creation options (can be nullptr)
+  * \param[in] options Session options
+  * \param[in] ort_custom_thread_creation_options Custom thread creation options (can be nullptr)
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomThreadCreationOptions, _Inout_ OrtSessionOptions* options, _In_ void* ort_custom_thread_creation_options);
 
   /** \brief Set custom thread join function
   *
-  * \param[in] session options
-  * \param[in] custom join thread function, must not be nullptr when ort_custom_create_thread_fn is set
+  * \param[in] options Session options
+  * \param[in] ort_custom_join_thread_fn Custom join thread function, must not be nullptr when ort_custom_create_thread_fn is set
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSessionOptions* options, _In_ OrtCustomJoinThreadFn ort_custom_join_thread_fn);
   /// @}
@@ -3138,27 +3140,27 @@ struct OrtApi {
   /** \brief Set custom thread creation function for global thread pools
   *
   * \param[inout] tp_options
-  * \param[in] custom thread creation function
+  * \param[in] ort_custom_create_thread_fn Custom thread creation function
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomCreateThreadFn, _Inout_ OrtThreadingOptions* tp_options, _In_ OrtCustomCreateThreadFn ort_custom_create_thread_fn);
 
   /** \brief Set custom thread creation options for global thread pools
   *
   * \param[inout] tp_options
-  * \param[in] custom thread creation options (can be nullptr)
+  * \param[in] ort_custom_thread_creation_options Custom thread creation options (can be nullptr)
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomThreadCreationOptions, _Inout_ OrtThreadingOptions* tp_options, _In_ void* ort_custom_thread_creation_options);
 
   /** \brief Set custom thread join function for global thread pools
   *
   * \param[inout] tp_options
-  * \param[in] custom thread join function, must not be nullptr when global ort_custom_create_thread_fn is set
+  * \param[in] ort_custom_join_thread_fn Custom thread join function, must not be nullptr when global ort_custom_create_thread_fn is set
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomJoinThreadFn, _Inout_ OrtThreadingOptions* tp_options, _In_ OrtCustomJoinThreadFn ort_custom_join_thread_fn);
   /// @}
@@ -3169,7 +3171,7 @@ struct OrtApi {
   *
   * \param[inout] binding_ptr
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SynchronizeBoundInputs, _Inout_ OrtIoBinding* binding_ptr);
 
@@ -3179,7 +3181,7 @@ struct OrtApi {
   *
   * \param[inout] binding_ptr
   * 
-  * * \snippet{doc} snippets.dox OrtStatus Return Value
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SynchronizeBoundOutputs, _Inout_ OrtIoBinding* binding_ptr);
 };


### PR DESCRIPTION
**Description**: Documentation build has some warnings due to some wrong syntax. Fixed.