### PR TITLE
Weaken x86.get_pc_thunk for NDK <= r22

### DIFF
--- a/onnxruntime/core/mlas/lib/x86/x86.get_pc_thunk.S
+++ b/onnxruntime/core/mlas/lib/x86/x86.get_pc_thunk.S
@@ -14,9 +14,6 @@ Abstract:
 
 --*/
 
-
-#include "asmmacro.h"
-
         .intel_syntax noprefix
 
 /*++
@@ -28,7 +25,9 @@ Routine Description:
 
 --*/
 
-        FUNCTION_ENTRY __x86.get_pc_thunk.bx
-
+        .p2align 4
+        .weak  __x86.get_pc_thunk.bx
+        .type   __x86.get_pc_thunk.bx,@function
+__x86.get_pc_thunk.bx:
         mov ebx, [esp]
         ret


### PR DESCRIPTION
Otherwise multiple definition of '__x86.get_pc_thunk.bx' would cause error.
