### PR TITLE
Change some const to constexpr

### DIFF
--- a/onnxruntime/test/common/denormal_test.cc
+++ b/onnxruntime/test/common/denormal_test.cc
@@ -16,8 +16,8 @@ namespace test {
 
 TEST(DenormalTest, DenormalAsZeroTest) {
   auto test_denormal = [&](bool set_denormal_as_zero) {
-    const float denormal_float = 1e-38f;
-    const double denormal_double = 1e-308;
+    constexpr float denormal_float = 1e-38f;
+    constexpr double denormal_double = 1e-308;
 
     volatile float input_float = denormal_float;
     volatile double input_double = denormal_double;

--- a/onnxruntime/test/common/logging/logging_test.cc
+++ b/onnxruntime/test/common/logging/logging_test.cc
@@ -10,7 +10,10 @@
 #include "core/common/logging/sinks/clog_sink.h"
 
 #include "test/common/logging/helpers.h"
-
+//TODO: fix the warnings
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 // if we pull in the whole 'testing' namespace we get warnings from date.h as both use '_' in places.
 // to avoid that we explicitly pull in the pieces we are using
 using testing::Eq;
@@ -88,7 +91,7 @@ TEST_F(LoggingTestsFixture, TestWhereMacro) {
 TEST_F(LoggingTestsFixture, TestDefaultFiltering) {
   const std::string logid{"TestDefaultFiltering"};
   const Severity min_log_level = Severity::kWARNING;
-  const bool filter_user_data = true;
+  constexpr bool filter_user_data = true;
 
   MockSink* sink_ptr = new MockSink();
 
@@ -117,8 +120,8 @@ TEST_F(LoggingTestsFixture, TestDefaultFiltering) {
 /// </summary>
 TEST_F(LoggingTestsFixture, TestLoggerFiltering) {
   const std::string logid{"TestLoggerFiltering"};
-  const bool default_filter_user_data = true;
-  const int default_max_vlog_level = -1;
+  constexpr bool default_filter_user_data = true;
+  constexpr int default_max_vlog_level = -1;
 
   MockSink* sink_ptr = new MockSink();
 
@@ -166,7 +169,7 @@ TEST_F(LoggingTestsFixture, TestLoggingManagerCtor) {
 TEST_F(LoggingTestsFixture, TestConditionalMacros) {
   const std::string logger_id{"TestConditionalMacros"};
   const Severity min_log_level = Severity::kVERBOSE;
-  const bool filter_user_data = false;
+  constexpr bool filter_user_data = false;
 
   MockSink* sink_ptr = new MockSink();
 
@@ -211,7 +214,7 @@ TEST_F(LoggingTestsFixture, TestVLog) {
       .Times(0);
 #endif
 
-  const bool filter_user_data = false;
+  constexpr bool filter_user_data = false;
   LoggingManager manager{std::unique_ptr<ISink>(sink_ptr), Severity::kVERBOSE, filter_user_data, InstanceType::Temporal};
 
   int max_vlog_level = 2;
@@ -246,7 +249,7 @@ class CTestSink : public OStreamSink {
 TEST_F(LoggingTestsFixture, TestTruncation) {
   const std::string logger_id{"TestTruncation"};
   const Severity min_log_level = Severity::kVERBOSE;
-  const bool filter_user_data = false;
+  constexpr bool filter_user_data = false;
 
   std::ostringstream out;
   auto* sink_ptr = new CTestSink{out};

--- a/onnxruntime/test/common/logging/sinks_test.cc
+++ b/onnxruntime/test/common/logging/sinks_test.cc
@@ -121,7 +121,10 @@ TEST(LoggingTests, TestFileSink) {
   CheckStringInFile(filename, message);
   DeleteFile(filename);
 }
-
+//TODO: fix the warnings
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 /// <summary>
 /// Tests that a composite_sink works correctly.
 /// </summary>

--- a/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_lstm_op_test.cc
@@ -250,15 +250,15 @@ static std::vector<T> ConvertIcfoToIofc(const std::vector<T>& icfo, int cell_hid
 }
 
 //Settings for this group of test data
-static const int batch_size = 1;
-static const int memory_max_step = 3;
-static const int memory_depth = 3;
-static const int input_max_step = 3;
-static const int input_only_depth = 3;
-static const int am_attn_size = 2;
-static const int cell_hidden_size = 3;
-static const int aw_attn_size = 2;
-static const int input_size = input_only_depth + aw_attn_size;
+static constexpr int batch_size = 1;
+static constexpr int memory_max_step = 3;
+static constexpr int memory_depth = 3;
+static constexpr int input_max_step = 3;
+static constexpr int input_only_depth = 3;
+static constexpr int am_attn_size = 2;
+static constexpr int cell_hidden_size = 3;
+static constexpr int aw_attn_size = 2;
+static constexpr int input_size = input_only_depth + aw_attn_size;
 
 // [batch_size=1, memory_max_step=3, memory_depth=3]
 static std::vector<float> s_M_data{0.1f, -0.25f, 1.0f, 1.0f, -1.0f, -1.5f, 1.0f, 0.25f, -0.125f};
@@ -324,7 +324,7 @@ TEST(AttnLSTMTest, ForwardLstmWithBahdanauAMZeroAttention) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   // Fake zero for attention input weight now
   std::fill(W_T_data.begin() + 3 * 12, W_T_data.begin() + W_data_size, 0.0f);
@@ -364,7 +364,7 @@ TEST(AttnLSTMTest, ForwardLstmWithBahdanauAM) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   std::vector<float> R_T_data(&(WR_T_data[0]) + W_data_size, &(WR_T_data[0]) + WR_T_data.size());
 
@@ -401,7 +401,7 @@ TEST(AttnLSTMTest, ForwardLstmWithBahdanauAMShortenSeqLength) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   std::vector<float> R_T_data(&(WR_T_data[0]) + W_data_size, &(WR_T_data[0]) + WR_T_data.size());
 
@@ -440,7 +440,7 @@ TEST(AttnLSTMTest, ReverseLstmWithBahdanauAMShortenSeqLength) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   std::vector<float> R_T_data(&(WR_T_data[0]) + W_data_size, &(WR_T_data[0]) + WR_T_data.size());
 
@@ -479,7 +479,7 @@ TEST(AttnLSTMTest, BidirectionLstmWithBahdanauAMShortenSeqLength) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   std::vector<float> R_T_data(&(WR_T_data[0]) + W_data_size, &(WR_T_data[0]) + WR_T_data.size());
 
@@ -529,8 +529,8 @@ TEST(AttnLSTMTest, BidirectionLstmWithBahdanauAMShortenSeqLength) {
 }
 
 TEST(AttnLSTMTest, BidirectionLstmWithBahdanauAM2BatchShortenSeqLen) {
-  const int batch2Size = 2;
-  const int inputMaxStep4 = 4;
+  constexpr int batch2Size = 2;
+  constexpr int inputMaxStep4 = 4;
 
   static const std::vector<float> s_X_T_2batch{0.25f, -1.5f, 1.0f, 0.25f, -0.5f, -1.5f, 0.1f, 1.5f, 0.25f, 0.0f, 0.0f, 0.0f,
                                                0.1f, -0.125f, 0.25f, -0.5f, 0.25f, 0.1f, 1.0f, 0.5f, -1.5f, 0.0f, 0.0f, 0.0f};
@@ -540,7 +540,7 @@ TEST(AttnLSTMTest, BidirectionLstmWithBahdanauAM2BatchShortenSeqLen) {
 
   std::vector<float> WR_T_data = ConvertIcfoToIofc(s_WR_T_data_ICFO, cell_hidden_size);
 
-  const size_t W_data_size = 5 * 12;
+  constexpr size_t W_data_size = 5 * 12;
   std::vector<float> W_T_data(&(WR_T_data[0]), &(WR_T_data[0]) + W_data_size);
   std::vector<float> R_T_data(&(WR_T_data[0]) + W_data_size, &(WR_T_data[0]) + WR_T_data.size());
 

--- a/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
+++ b/onnxruntime/test/contrib_ops/bias_dropout_op_test.cc
@@ -33,7 +33,7 @@ void RunBiasDropoutTest(const bool use_mask, const std::vector<int64_t>& input_s
                         TrainingMode training_mode = TrainingTrue, bool use_float16_ratio = false,
                         bool has_residual = true, bool has_same_shape_bias = false) {
   OpTester t{"BiasDropout", 1, kMSDomain};
-  const int64_t seed = 42;
+  constexpr int64_t seed = 42;
   t.AddAttribute("seed", seed);
 
   const auto input_size = std::accumulate(

--- a/onnxruntime/test/contrib_ops/tokenizer_test.cc
+++ b/onnxruntime/test/contrib_ops/tokenizer_test.cc
@@ -13,7 +13,7 @@ const std::string end_mark{0x3};
 const std::string padval(u8"0xdeadbeaf");
 
 constexpr const char* domain = onnxruntime::kMSDomain;
-const int opset_ver = 1;
+constexpr int opset_ver = 1;
 
 }  // namespace tokenizer_test
 

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -271,7 +271,7 @@ class PlannerTest : public ::testing::Test {
 
     // CreatePlan is called inside FinalizeSessionState and usually the initializers are removed following that.
     // Leave initializers so we can duplicate the call to CreatePlan from here to validate.
-    const bool remove_initializers = false;
+    constexpr bool remove_initializers = false;
     status = state_->FinalizeSessionState(ORT_TSTR(""), kernel_registry_manager, {}, nullptr, remove_initializers);
 
     EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();

--- a/onnxruntime/test/framework/allocator_test.cc
+++ b/onnxruntime/test/framework/allocator_test.cc
@@ -32,7 +32,9 @@ TEST(AllocatorTest, CPUAllocatorTest) {
   cpu_arena->Free(bytes);
   //todo: test the used / max api.
 }
-
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 // helper class to validate values in Alloc and Free calls made via IAllocator::MakeUniquePtr
 class TestAllocator : public IAllocator {
  public:

--- a/onnxruntime/test/framework/bfc_arena_test.cc
+++ b/onnxruntime/test/framework/bfc_arena_test.cc
@@ -221,7 +221,7 @@ TEST(BFCArenaTest, AllocationsAndDeallocationsWithGrowth) {
   // 64 megs.
   std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-  const int32_t max_mem = 1 << 27;
+  constexpr int32_t max_mem = 1 << 27;
 
   std::vector<void*> initial_ptrs;
   for (int s = 1; s < 10; s++) {
@@ -242,7 +242,7 @@ TEST(BFCArenaTest, AllocationsAndDeallocationsWithGrowth) {
     }
   }
 
-  const int32_t max_mem_2 = 1 << 26;
+  constexpr int32_t max_mem_2 = 1 << 26;
   // Allocate a lot of raw pointers between 100 bytes and 64 megs.
   for (int s = 1; s < 10; s++) {
     size_t size = std::min<size_t>(

--- a/onnxruntime/test/framework/data_types_test.cc
+++ b/onnxruntime/test/framework/data_types_test.cc
@@ -419,7 +419,7 @@ TEST_F(DataTypeTest, VectorMapInt64ToFloatTest) {
 TEST_F(DataTypeTest, BFloat16Test) {
   // Test data type
   {
-    const float sample = 1.0f;
+    constexpr float sample = 1.0f;
     BFloat16 flt16(sample);
     auto int_rep = flt16.val;
     BFloat16 flt_from_int(int_rep);

--- a/onnxruntime/test/framework/endian_test.cc
+++ b/onnxruntime/test/framework/endian_test.cc
@@ -13,7 +13,7 @@ namespace utils {
 namespace test {
 
 TEST(EndianTest, EndiannessDetection) {
-  const uint16_t test_value = 0x1234;
+  constexpr uint16_t test_value = 0x1234;
   const unsigned char* test_value_first_byte = reinterpret_cast<const unsigned char*>(&test_value);
   if constexpr (endian::native == endian::little) {
     EXPECT_EQ(*test_value_first_byte, 0x34);

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -2706,7 +2706,7 @@ TEST(InferenceSessionTests, InitializerSharing_EnsureSessionsUseUserAddedInitial
 void RunModelWithDenormalAsZero(InferenceSession& session_object,
                                 const RunOptions& run_options,
                                 bool set_denormal_as_zero) {
-  const float denormal_float = 1e-38f;
+  constexpr float denormal_float = 1e-38f;
 
   // prepare input X
   std::vector<int64_t> dims_mul{3, 2};
@@ -2741,9 +2741,9 @@ void RunModelWithDenormalAsZero(InferenceSession& session_object,
 
 void VerifyThreadPoolWithDenormalAsZero(onnxruntime::concurrency::ThreadPool* tp,
                                         bool set_denormal_as_zero) {
-  const int num_tasks = 4;
-  const float denormal_float = 1e-38f;
-  const double denormal_double = 1e-308;
+  constexpr int num_tasks = 4;
+  constexpr float denormal_float = 1e-38f;
+  constexpr double denormal_double = 1e-308;
 
   std::array<float, num_tasks> input_float;
   input_float.fill(denormal_float);

--- a/onnxruntime/test/framework/insert_cast_transformer_test.cc
+++ b/onnxruntime/test/framework/insert_cast_transformer_test.cc
@@ -228,7 +228,7 @@ TEST(TransformerTest, Fp16NodeWithSubgraph) {
 
   const Graph& subgraph = *node_with_subgraph_iter->GetSubgraphs().front();
 
-  const bool recurse_into_subgraphs = false;
+  constexpr bool recurse_into_subgraphs = false;
   std::map<std::string, int> orig_graph_ops = CountOpsInGraph(graph, recurse_into_subgraphs);
   std::map<std::string, int> orig_subgraph_ops = CountOpsInGraph(subgraph, recurse_into_subgraphs);
 

--- a/onnxruntime/test/framework/math_test.cc
+++ b/onnxruntime/test/framework/math_test.cc
@@ -28,7 +28,7 @@ namespace onnxruntime {
 //parameter is thread pool size
 class MathGemmTest : public testing::TestWithParam<int> {
  protected:
-  static OrtThreadPoolParams CreateThreadPoolOptions(int size) {
+  constexpr static OrtThreadPoolParams CreateThreadPoolOptions(int size) {
     OrtThreadPoolParams option;
     option.thread_pool_size = size;
     return option;
@@ -51,9 +51,9 @@ TEST_P(MathGemmTest, GemmNoTransNoTrans) {
     EXPECT_EQ(W[i], 1);
   }
 
-  const float kOne = 1.0;
-  const float kPointFive = 0.5;
-  const float kZero = 0.0;
+  constexpr float kOne = 1.0;
+  constexpr float kPointFive = 0.5;
+  constexpr float kZero = 0.0;
   math::Gemm<float>(CblasNoTrans, CblasNoTrans, 5, 6, 10, kOne,
                     VECTOR_HEAD(X), VECTOR_HEAD(W), kZero, VECTOR_HEAD(Y),
                     tp.get());
@@ -96,9 +96,9 @@ TEST_P(MathGemmTest, GemmNoTransTrans) {
     EXPECT_EQ(W[i], 1);
   }
 
-  const float kOne = 1.0;
-  const float kPointFive = 0.5;
-  const float kZero = 0.0;
+  constexpr float kOne = 1.0;
+  constexpr float kPointFive = 0.5;
+  constexpr float kZero = 0.0;
   math::Gemm<float>(CblasNoTrans, CblasTrans, 5, 6, 10, kOne,
                     VECTOR_HEAD(X), VECTOR_HEAD(W), kZero, VECTOR_HEAD(Y),
                     tp.get());
@@ -141,9 +141,9 @@ TEST(MathTest, GemvNoTrans) {
     EXPECT_EQ(X[i], 1);
   }
 
-  const float kOne = 1.0;
-  const float kPointFive = 0.5;
-  const float kZero = 0.0;
+  constexpr float kOne = 1.0;
+  constexpr float kPointFive = 0.5;
+  constexpr float kZero = 0.0;
   math::Gemv<float, CPUMathUtil>(CblasNoTrans, 5, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kZero, VECTOR_HEAD(Y), &provider);
   for (size_t i = 0; i < Y.size(); ++i) {
@@ -179,9 +179,9 @@ TEST(MathTest, GemvTrans) {
     EXPECT_EQ(X[i], 1);
   }
 
-  const float kOne = 1.0;
-  const float kPointFive = 0.5;
-  const float kZero = 0.0;
+  constexpr float kOne = 1.0;
+  constexpr float kPointFive = 0.5;
+  constexpr float kZero = 0.0;
   math::Gemv<float, CPUMathUtil>(CblasTrans, 6, 10, kOne, VECTOR_HEAD(A), VECTOR_HEAD(X),
                                  kZero, VECTOR_HEAD(Y), &provider);
   for (size_t i = 0; i < Y.size(); ++i) {

--- a/onnxruntime/test/framework/mem_pattern_planner_test.cc
+++ b/onnxruntime/test/framework/mem_pattern_planner_test.cc
@@ -7,7 +7,7 @@
 namespace onnxruntime {
 namespace test {
 TEST(MemPatternPlannerTest, TraceAllocaitonTest) {
-  const bool using_counters = false;  // we're not tracking start/end for use/re-use of each allocation via counters
+  constexpr bool using_counters = false;  // we're not tracking start/end for use/re-use of each allocation via counters
   MemPatternPlanner planner{using_counters};
   planner.TraceAllocation(0, 1024);
   planner.TraceAllocation(1, 256);

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -25,7 +25,7 @@ void TestUnpackFloatTensor(TensorProto_DataType type, const Path& model_path) {
   TensorProto float_tensor_proto;
   float_tensor_proto.set_data_type(type);
   T f[4] = {1.1f, 2.2f, 3.3f, 4.4f};
-  const size_t len = sizeof(T) * 4;
+  constexpr size_t len = sizeof(T) * 4;
   char rawdata[len];
   for (int i = 0; i < 4; ++i) {
     memcpy(rawdata + i * sizeof(T), &(f[i]), sizeof(T));

--- a/onnxruntime/test/framework/test_tensor_loader.cc
+++ b/onnxruntime/test/framework/test_tensor_loader.cc
@@ -138,7 +138,7 @@ TEST(CApiTensorTest, load_huge_tensor_with_external_data) {
   for (int i = 0; i != 1025; ++i) {
     ASSERT_EQ(len, fwrite(data.data(), 1, len, fp));
   }
-  const size_t total_ele_count = 524288 * 1025;
+  constexpr size_t total_ele_count = 524288 * 1025;
   ASSERT_EQ(0, fclose(fp));
   // construct a tensor proto
   onnx::TensorProto p;

--- a/onnxruntime/test/ir/op_test.cc
+++ b/onnxruntime/test/ir/op_test.cc
@@ -63,27 +63,23 @@ TEST(FeatureVectorizerTest, TraditionalMlOpTest) {
   map_value_type->set_elem_type(TensorProto::FLOAT);
   map_value_type->mutable_shape();
 
-  NodeArg* input_arg1 = new NodeArg("node_1_in_1", &map_int64_float);
+  std::unique_ptr<NodeArg> input_arg1 = std::make_unique<NodeArg>("node_1_in_1", &map_int64_float);
   inputs.clear();
-  inputs.push_back(input_arg1);
-  NodeArg* output_arg1 = new NodeArg("node_1_out_1", &tensor_float);
+  inputs.push_back(input_arg1.get());
+  std::unique_ptr<NodeArg> output_arg1 = std::make_unique<NodeArg>("node_1_out_1", &tensor_float);
   outputs.clear();
-  outputs.push_back(output_arg1);
+  outputs.push_back(output_arg1.get());
   graph.AddNode("node_1", "CastMap", "node 1", inputs, outputs, nullptr, kMLDomain);
 
   inputs.clear();
-  inputs.push_back(output_arg1);
+  inputs.push_back(output_arg1.get());
 
-  NodeArg* output_arg4 = new NodeArg("node_4_out_1", &tensor_float);
+  std::unique_ptr<NodeArg> output_arg4 = std::make_unique<NodeArg>("node_4_out_1", &tensor_float);
   outputs.clear();
-  outputs.push_back(output_arg4);
+  outputs.push_back(output_arg4.get());
   graph.AddNode("node_4", "FeatureVectorizer", "node 4", inputs, outputs, nullptr, kMLDomain);
   auto status = graph.Resolve();
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
-
-  delete input_arg1;
-  delete output_arg1;
-  delete output_arg4;
 }
 #endif
 

--- a/onnxruntime/test/mlas/unittest/test_pool2d.h
+++ b/onnxruntime/test/mlas/unittest/test_pool2d.h
@@ -31,8 +31,8 @@ class MlasPool2DTest : public MlasTestBase {
             size_t PaddingRightWidth,
             size_t StrideHeight,
             size_t StrideWidth) {
-    const size_t DilationHeight = 1;
-    const size_t DilationWidth = 1;
+    constexpr size_t DilationHeight = 1;
+    constexpr size_t DilationWidth = 1;
 
     int64_t OutputHeight64 =
         ((int64_t(InputHeight) + int64_t(PaddingLeftHeight) + int64_t(PaddingRightHeight)) -

--- a/onnxruntime/test/mlas/unittest/test_pool3d.h
+++ b/onnxruntime/test/mlas/unittest/test_pool3d.h
@@ -38,9 +38,9 @@ class MlasPool3DTest : public MlasTestBase {
             size_t StrideDepth,
             size_t StrideHeight,
             size_t StrideWidth) {
-    const size_t DilationDepth = 1;
-    const size_t DilationHeight = 1;
-    const size_t DilationWidth = 1;
+    constexpr size_t DilationDepth = 1;
+    constexpr size_t DilationHeight = 1;
+    constexpr size_t DilationWidth = 1;
 
     int64_t OutputDepth64 =
         ((int64_t(InputDepth) + int64_t(PaddingLeftDepth) + int64_t(PaddingRightDepth)) -

--- a/onnxruntime/test/mlas/unittest/test_qgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.h
@@ -413,19 +413,19 @@ class MlasQgemmTest<AType, BType, float, Packed, Threaded> : public MlasQgemmTes
     float* CReference = BufferCReference.GetBuffer(N * M * BatchSize);
     const float* Bias = BufferBias.GetBuffer(N);
 
-    const float AScale = 0.5f;
+    constexpr float AScale = 0.5f;
     float* AFloat = BufferAFloat.GetBuffer(K * M * BatchSize);
     for (size_t b = 0; b < BatchSize; b++) {
       DequantizeLinear((AType*)(A + K * M * b), AFloat + K * M * b, K * M, AScale, (AType)offa);
     }
 
-    const float BScale = 0.25f;
+    constexpr float BScale = 0.25f;
     float* BFloat = BufferBFloat.GetBuffer(N * K * BatchSize);
     for (size_t b = 0; b < BatchSize; b++) {
       DequantizeLinear((BType*)(B + N * K * b), BFloat + N * K * b, N * K, BScale, BType(offb));
     }
 
-    const float CScale = AScale * BScale;
+    constexpr float CScale = AScale * BScale;
 
     Test(M, N, K, BatchSize, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, nullptr);
     Test(M, N, K, BatchSize, A, AFloat, K, offa, B, BFloat, N, offb, C, CReference, N, CScale, Bias);

--- a/onnxruntime/test/mlas/unittest/test_util.h
+++ b/onnxruntime/test/mlas/unittest/test_util.h
@@ -110,8 +110,8 @@ class MatrixGuardBuffer {
       std::fill_n(buffer, Elements, T(0));
 
     } else {
-      const int MinimumFillValue = -23;
-      const int MaximumFillValue = 23;
+      constexpr int MinimumFillValue = -23;
+      constexpr int MaximumFillValue = 23;
 
       int FillValue = MinimumFillValue;
       T* FillAddress = buffer;

--- a/onnxruntime/test/onnx/heap_buffer.cc
+++ b/onnxruntime/test/onnx/heap_buffer.cc
@@ -15,9 +15,6 @@ HeapBuffer::~HeapBuffer() {
   for (auto d : deleters_) {
     d.Run();
   }
-  for (void* p : buffers_) {
-    delete[] reinterpret_cast<uint8_t*>(p);
-  }
 }
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/onnx/heap_buffer.h
+++ b/onnxruntime/test/onnx/heap_buffer.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include "callback.h"
 
+#include <memory>
 #include <vector>
 #include <stdlib.h>
 #include <stdint.h>
-
+#include "callback.h"
 namespace onnxruntime {
 namespace test {
 /**
@@ -22,9 +22,10 @@ class HeapBuffer {
    */
   ~HeapBuffer();
   void* AllocMemory(size_t size) {
-    void* p = new (std::nothrow) uint8_t[size];
-    buffers_.push_back(p);
-    return p;
+    auto p = std::make_unique<uint8_t[]>(size);
+    void* ret = p.get();
+    buffers_.emplace_back(std::move(p));
+    return ret;
   }
   void AddDeleter(const OrtCallback& d);
 
@@ -33,7 +34,7 @@ class HeapBuffer {
 
  private:
   std::vector<OrtCallback> deleters_;
-  std::vector<void*> buffers_;
+  std::vector<std::unique_ptr<uint8_t[]> > buffers_;
 };
 
 }  // namespace test

--- a/onnxruntime/test/onnx/testcase_request.cc
+++ b/onnxruntime/test/onnx/testcase_request.cc
@@ -204,6 +204,7 @@ void TestCaseRequestContext::CalculateAndLogStats() const {
         break;
       case EXECUTE_RESULT::MODEL_TYPE_MISMATCH:
         LOGF_DEFAULT(ERROR, "%s: type in model file mismatch. Dataset:%s\n", test_case_name.c_str(), s.c_str());
+        break;
       default:
         //nothing to do
         break;

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -1234,8 +1234,8 @@ TEST(NchwcOptimizerTests, UpsampleNearest) {
         std::vector<int64_t> sizes_shape(4);
         sizes_shape[0] = 3;
         sizes_shape[1] = 42;
-        sizes_shape[2] = static_cast<int64_t>(scale_h * 27);
-        sizes_shape[3] = static_cast<int64_t>(scale_w * 15);
+        sizes_shape[2] = static_cast<int64_t>(scale_h) * 27;
+        sizes_shape[3] = static_cast<int64_t>(scale_w) * 15;
         input_args.push_back(helper.Make1DInitializer<float>({}));
         input_args.push_back(helper.Make1DInitializer<int64_t>(sizes_shape));
       } else {

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -1234,8 +1234,11 @@ TEST(NchwcOptimizerTests, UpsampleNearest) {
         std::vector<int64_t> sizes_shape(4);
         sizes_shape[0] = 3;
         sizes_shape[1] = 42;
-        sizes_shape[2] = static_cast<int64_t>(scale_h) * 27;
-        sizes_shape[3] = static_cast<int64_t>(scale_w) * 15;
+        constexpr int64_t shape2 = 27;
+        constexpr int64_t shape3 = 15;
+        //The result is 64-bit. Use double for calculation to get better precision.
+        sizes_shape[2] = static_cast<int64_t>(static_cast<double>(scale_h) * shape2);
+        sizes_shape[3] = static_cast<int64_t>(static_cast<double>(scale_w) * shape3);
         input_args.push_back(helper.Make1DInitializer<float>({}));
         input_args.push_back(helper.Make1DInitializer<int64_t>(sizes_shape));
       } else {

--- a/onnxruntime/test/optimizer/nhwc_transformer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_transformer_test.cc
@@ -270,7 +270,7 @@ TEST(NhwcTransformerTests, ConvSplit) {
       auto* qladd_output_arg = builder.MakeIntermediate();
       auto* output_arg = builder.MakeOutput();
 
-      const int64_t conv1_output_channels = 32;
+      constexpr int64_t conv1_output_channels = 32;
       auto* conv1_weight_arg = NhwcMakeInitializer<uint8_t>(builder, {conv1_output_channels, 23, 3, 3});
 
       Node& conv_node = builder.AddQLinearConvNode<uint8_t>(input_arg, .01f, 135,
@@ -315,7 +315,7 @@ TEST(NhwcTransformerTests, ConvSplitQLinearConcat) {
       auto* qlconcat_output_arg = builder.MakeIntermediate();
       auto* output_arg = builder.MakeOutput();
 
-      const int64_t conv1_output_channels = 32;
+      constexpr int64_t conv1_output_channels = 32;
       auto* conv1_weight_arg = NhwcMakeInitializer<uint8_t>(builder, {conv1_output_channels, 23, 3, 3});
       Node& conv_node = builder.AddQLinearConvNode<uint8_t>(input_arg, .01f, 135,
                                                             conv1_weight_arg, .02f, 126,

--- a/onnxruntime/test/optimizer/optimizer_test.cc
+++ b/onnxruntime/test/optimizer/optimizer_test.cc
@@ -30,8 +30,8 @@ TEST(OptimizerTest, Basic) {
   Model model("OptimizerBasic", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(), {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
   auto& graph = model.MainGraph();
 
-  const int tensor_dim = 10;
-  const int input_num = 2;
+  constexpr int tensor_dim = 10;
+  constexpr int input_num = 2;
   TensorProto initializer_tensor[input_num];
   std::vector<std::unique_ptr<NodeArg>> inputs(input_num);
   std::vector<std::unique_ptr<NodeArg>> outputs(1);

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -171,7 +171,7 @@ void TestPoolCreation(const std::string&, int iter) {
 // Test multi-loop parallel sections, with a series of fixed-size loops
 void TestMultiLoopSections(const std::string& name, int num_threads, int num_loops) {
   for (int rep = 0; rep < 5; rep++) {
-    const int num_tasks = 1024;
+    constexpr int num_tasks = 1024;
     auto test_data = CreateTestData(num_tasks);
     CreateThreadPoolAndTest(name, num_threads, [&](ThreadPool* tp) {
 	ThreadPool::ParallelSection ps(tp);

--- a/onnxruntime/test/platform/windows/logging/etw_sink_test.cc
+++ b/onnxruntime/test/platform/windows/logging/etw_sink_test.cc
@@ -10,7 +10,9 @@
 #include "core/common/logging/sinks/composite_sink.h"
 
 #include "test/common/logging/helpers.h"
-
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 namespace onnxruntime {
 namespace test {
 

--- a/onnxruntime/test/providers/cpu/controlflow/loop_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/loop_test.cc
@@ -34,8 +34,8 @@ struct RunOptions {
 
 static const ONNX_NAMESPACE::GraphProto CreateSubgraph(const RunOptions& options);
 
-static const float kOuterNodeAddValue = 3.f;
-static const float kSumMax = 8.f;
+static constexpr float kOuterNodeAddValue = 3.f;
+static constexpr float kSumMax = 8.f;
 
 class LoopOpTester : public OpTester {
  public:
@@ -371,7 +371,7 @@ void RunTest(int64_t max_iterations,
 // this should take 3 iterations as we add 3 each time.
 void ExitDueToCond(const RunOptions& options) {
   int64_t max_iterations = 5;
-  const int64_t expected_num_iterations = 3;
+  constexpr int64_t expected_num_iterations = 3;
 
   float loop_var_0_final = kOuterNodeAddValue * expected_num_iterations;
 
@@ -438,7 +438,7 @@ TEST(Loop, LoopSubgraphRankMismatch) {
 
 TEST(Loop, ExitDueToMaxIterations) {
   int64_t max_iterations = 2;
-  const int64_t expected_num_iterations = 2;
+  constexpr int64_t expected_num_iterations = 2;
 
   float loop_var_0_final = kOuterNodeAddValue * expected_num_iterations;
 

--- a/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/scan_test.cc
@@ -30,7 +30,7 @@ struct RunOptions {
 
 static common::Status CreateSubgraph(Graph& graph, RunOptions& options, const std::string& failure_message = "");
 
-static const float kOuterNodeAddValue = 42.f;
+static constexpr float kOuterNodeAddValue = 42.f;
 
 class ScanOpTester : public OpTester {
  public:
@@ -420,9 +420,9 @@ static void RunTest_v9(const std::string test_name, int64_t sequence_len, int64_
 }
 
 static void ShortSequenceOneInBatchOneLoopStateVar(const RunOptions& options, const std::string& expected_error = "") {
-  const int64_t batch_size = 1;
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 
@@ -581,9 +581,9 @@ TEST(Scan9, DISABLED_BadShape) {
 }
 
 TEST(Scan8, ShortSequenceTwoInBatchOneLoopStateVar) {
-  const int64_t batch_size = 2;
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f, 10.f};  // start at 0 for first item in batch, and 10 for second
 
@@ -615,9 +615,9 @@ TEST(Scan8, ShortSequenceTwoInBatchOneLoopStateVar) {
 }
 
 TEST(Scan8, MixedSequenceLens) {
-  const int64_t batch_size = 3;
-  const int64_t max_sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 3;
+  constexpr int64_t max_sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<int64_t> sequence_lens{1, 2, 2};
 
@@ -662,9 +662,9 @@ TEST(Scan8, MixedSequenceLens) {
 }
 
 TEST(Scan8, MixedSequenceLensReverse) {
-  const int64_t batch_size = 2;
-  const int64_t max_sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t max_sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<int64_t> sequence_lens{1, 2};
   std::vector<int64_t> directions{1, 1};  // reverse both inputs
@@ -706,9 +706,9 @@ TEST(Scan8, MixedSequenceLensReverse) {
 }
 
 TEST(Scan8, ShortSequenceTwoInBatchOneLoopStateVarReverseFirstInput) {
-  const int64_t batch_size = 2;
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f, 10.f};  // start at 0 for first item in batch, and 10 for second
 
@@ -744,8 +744,8 @@ TEST(Scan8, ShortSequenceTwoInBatchOneLoopStateVarReverseFirstInput) {
 }
 
 TEST(Scan9, ReversedInput) {
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 
@@ -773,8 +773,8 @@ TEST(Scan9, ReversedInput) {
 }
 
 TEST(Scan9, ReversedOutput) {
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 
@@ -802,8 +802,8 @@ TEST(Scan9, ReversedOutput) {
 }
 
 TEST(Scan9, TransposeInput) {
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 
@@ -833,8 +833,8 @@ TEST(Scan9, TransposeInput) {
 }
 
 TEST(Scan9, TransposeOutput) {
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 
@@ -904,9 +904,9 @@ TEST(Scan9, TransposeOutputDim2) {
 }
 
 static void InvalidInput(bool is_v8) {
-  const int64_t batch_size = 1;
-  const int64_t sequence_len = 2;
-  const int64_t input_size = 2;
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t sequence_len = 2;
+  constexpr int64_t input_size = 2;
 
   std::vector<float> iteration_count_in{0.f};
 

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -824,9 +824,9 @@ static void TestThreaded(int64_t k, int64_t n, int64_t batch_size) {
 // and sufficient items to process given this calculation:
 //   int64_t threads_needed = static_cast<int64_t>(std::floor(input_shape.Size() * k / (128 * 1024)));
 TEST(TopKOperator, PriorityQueueThreaded) {
-  const int64_t k = 200;
-  const int64_t n = 2;
-  const int64_t batch_size = 1000;
+  constexpr int64_t k = 200;
+  constexpr int64_t n = 2;
+  constexpr int64_t batch_size = 1000;
   TestThreaded<float>(k, n, batch_size);
   TestThreaded<double>(k, n, batch_size);
 }
@@ -835,9 +835,9 @@ TEST(TopKOperator, PriorityQueueThreaded) {
 // and sufficient items to process given this calculation:
 //   int64_t threads_needed = static_cast<int64_t>(std::floor(input_shape.Size() * k / (128 * 1024)));
 TEST(TopKOperator, SelectTopKThreaded) {
-  const int64_t k = 400;
-  const int64_t n = 2;
-  const int64_t batch_size = 500;
+  constexpr int64_t k = 400;
+  constexpr int64_t n = 2;
+  constexpr int64_t batch_size = 500;
   TestThreaded<float>(k, n, batch_size);
   TestThreaded<double>(k, n, batch_size);
 }

--- a/onnxruntime/test/providers/cpu/ml/array_feature_extractor_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/array_feature_extractor_test.cc
@@ -16,11 +16,11 @@ class ArrayFeatureExtractorTest : public ::testing::Test {
 };
 
 TEST_F(ArrayFeatureExtractorTest, Basic) {
-  const int N = 3;
+  constexpr int N = 3;
   const std::vector<float> X = {0.8f, -1.5f, 2.0f, 3.8f, -4.0f, 5.0f,
                                 6.8f, -7.5f, 8.0f, 9.8f, -9.0f, 4.0f,
                                 4.8f, -4.5f, 4.0f, 4.8f, -4.0f, 4.0f};
-  const int kCols = 6;
+  constexpr int kCols = 6;
   const vector<int64_t> x_dims = {N, kCols};
   test_.AddInput<float>("X", x_dims, X);
 

--- a/onnxruntime/test/providers/cpu/ml/imputer_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/imputer_test.cc
@@ -9,7 +9,7 @@ namespace test {
 
 TEST(MLOpTest, ImputerOpFloat) {
   OpTester test("Imputer", 1, onnxruntime::kMLDomain);
-  const int N = 5;
+  constexpr int N = 5;
   std::vector<float> impute = {10.0f};
   float replace = 1.f;
   test.AddAttribute("imputed_value_floats", impute);

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_classifier_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_classifier_test.cc
@@ -34,7 +34,7 @@ TEST(MLOpTest, TreeEnsembleClassifier) {
   std::vector<float> log_probs = {};
 
   //define the context of the operator call
-  const int N = 8;
+  constexpr int N = 8;
   test.AddAttribute("nodes_truenodeids", lefts);
   test.AddAttribute("nodes_falsenodeids", rights);
   test.AddAttribute("nodes_treeids", treeids);
@@ -79,7 +79,7 @@ TEST(MLOpTest, TreeEnsembleClassifier_N1) {
   std::vector<float> log_probs = {};
 
   //define the context of the operator call
-  const int N = 1;
+  constexpr int N = 1;
   test.AddAttribute("nodes_truenodeids", lefts);
   test.AddAttribute("nodes_falsenodeids", rights);
   test.AddAttribute("nodes_treeids", treeids);
@@ -126,7 +126,7 @@ TEST(MLOpTest, TreeEnsembleClassifierLabels) {
   std::vector<float> scores{-5, 5, 1, -1, 1, -1, 1, -1, 1, -1, -1, 1, 1, -1, 3, -3};
 
   //define the context of the operator call
-  const int N = 8;
+  constexpr int N = 8;
   test.AddAttribute("nodes_truenodeids", lefts);
   test.AddAttribute("nodes_falsenodeids", rights);
   test.AddAttribute("nodes_treeids", treeids);
@@ -175,7 +175,7 @@ TEST(MLOpTest, TreeEnsembleClassifierBinary) {
   std::vector<float> scores{5, -1, -1, -1, -1, 1, -1, -3};
 
   //define the context of the operator call
-  const int N = 8;
+  constexpr int N = 8;
   test.AddAttribute("nodes_truenodeids", lefts);
   test.AddAttribute("nodes_falsenodeids", rights);
   test.AddAttribute("nodes_treeids", treeids);
@@ -232,7 +232,7 @@ TEST(MLOpTest, TreeEnsembleClassifierBinaryProbabilities) {
       0.5f, 0.04742586f};
 
   //define the context of the operator call
-  const int N = 8;
+  constexpr int N = 8;
   test.AddAttribute("nodes_truenodeids", lefts);
   test.AddAttribute("nodes_falsenodeids", rights);
   test.AddAttribute("nodes_treeids", treeids);

--- a/onnxruntime/test/providers/cpu/nn/max_roi_pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/max_roi_pool_op_test.cc
@@ -11,12 +11,12 @@ namespace test {
 TEST(RoIPoolTest, MaxRoiPool) {
   OpTester test("MaxRoiPool");
 
-  const int64_t pooled_height = 1, pooled_width = 1;
+  constexpr int64_t pooled_height = 1, pooled_width = 1;
   test.AddAttribute("pooled_shape", std::vector<int64_t>{pooled_height, pooled_width});
 
-  const int H = 6, W = 6;
-  const int image_size = H * W;
-  const int input_channels = 3;
+  constexpr int H = 6, W = 6;
+  constexpr int image_size = H * W;
+  constexpr int input_channels = 3;
   std::vector<float> input;
   for (int i = 0; i < input_channels * image_size; i++)
     input.push_back(1.0f * i / 10);

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -25,8 +25,8 @@ struct QuantizedTensor {
     min = std::min(min, 0.f);
     max = std::max(max, 0.f);
 
-    float qmin = std::numeric_limits<uint8_t>::min();
-    float qmax = std::numeric_limits<uint8_t>::max();
+    constexpr float qmin = std::numeric_limits<uint8_t>::min();
+    constexpr float qmax = std::numeric_limits<uint8_t>::max();
 
     // compute scale and zero point
     scale_ = (max - min) / (qmax - qmin);

--- a/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
@@ -11,7 +11,7 @@ namespace onnxruntime {
 namespace test {
 namespace tfidfvectorizer_test {
 
-const int opset_ver = 9;
+constexpr int opset_ver = 9;
 
 void InitTestAttr(OpTester& test, const std::string& mode,
                   int64_t min_gram_length, int64_t max_gram_length, int64_t max_skip_count,

--- a/onnxruntime/test/providers/cpu/object_detection/roialign_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/roialign_test.cc
@@ -14,10 +14,10 @@ TEST(RoiAlignTest, AvgModePositive) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
  std::vector<float> rois{0.,7.,5.,7.,5.,0.,-15.,-15.,-15.,-15.,0.,-10.,21.,-10.,21.,0.,13.,8.,13.,8.,0.,-14.,19.,-14.,19.};
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
@@ -56,10 +56,10 @@ TEST(RoiAlignTest, OnnxTest) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f);
 
-  const int N = 1;
-  const int C = 1;
-  const int H = 10;
-  const int W = 10;
+  constexpr int N = 1;
+  constexpr int C = 1;
+  constexpr int H = 10;
+  constexpr int W = 10;
 
   test.AddInput<float>("X", {N, C, H, W}, {
                     0.2764f, 0.7150f, 0.1958f, 0.3416f, 0.4638f, 0.0259f, 0.2963f, 0.6518f, 0.4856f, 0.7250f,
@@ -105,10 +105,10 @@ TEST(RoiAlignTest, MaxModePositive) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
  std::vector<float> rois{0.,7.,5.,7.,5.,0.,-15.,-15.,-15.,-15.,0.,-10.,21.,-10.,21.,0.,13.,8.,13.,8.,0.,-14.,19.,-14.,19.};
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
@@ -143,10 +143,10 @@ TEST(RoiAlignTest, AvgModeNegativeInvalidMode) {
   test.AddAttribute<int64_t>("sampling_ratio", -2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
  std::vector<float> rois{0.,7.,5.,7.,5.,0.,-15.,-15.,-15.,-15.,0.,-10.,21.,-10.,21.,0.,13.,8.,13.,8.,0.,-14.,19.,-14.,19.};
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
@@ -185,10 +185,10 @@ TEST(RoiAlignTest, AvgModeNegativeSamplingRatio) {
   test.AddAttribute<int64_t>("sampling_ratio", -2); // <-- failure condition
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
                                            25.,26.,27.,28.,29.,30.,31.,32.,33.,34.,35.,36.,37.,38.,39.,40.,41.,42.,43.,44.,45.,46.,
@@ -226,10 +226,10 @@ TEST(RoiAlignTest, AvgModeNegativeInvalidNumRoiDims) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
   std::vector<float> rois{0.,7.,5.,7.,5.,0.,-15.,-15.,-15.,-15.,0.,-10.,21.,-10.,21.,0.,13.,8.,13.,8.,0.,-14.,19.,-14.,19.};
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
@@ -268,10 +268,10 @@ TEST(RoiAlignTest, AvgModeNegativeInvalidSecondRoiDims) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
  test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,
                                           25.,26.,27.,28.,29.,30.,31.,32.,33.,34.,35.,36.,37.,38.,39.,40.,41.,42.,43.,44.,45.,46.,
@@ -309,10 +309,10 @@ TEST(RoiAlignTest, MismatchNumRois) {
   test.AddAttribute<int64_t>("sampling_ratio", 2);
   test.AddAttribute<float>("spatial_scale", 1.0f / 16.0f);
 
-  const int N = 1;
-  const int C = 3;
-  const int H = 5;
-  const int W = 5;
+  constexpr int N = 1;
+  constexpr int C = 3;
+  constexpr int H = 5;
+  constexpr int W = 5;
 
  std::vector<float> rois{0.,7.,5.,7.,5.,0.,-15.,-15.,-15.,-15.,0.,-10.,21.,-10.,21.,0.,13.,8.,13.,8.,0.,-14.,19.,-14.,19.};
   test.AddInput<float>("X", {N, C, H, W}, {0.,1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,21.,22.,23.,24.,

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -310,7 +310,7 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearB
       0.19538902f, -0.19016478f, -0.05644283f,
       0.30856851f, -0.15190377f, 0.05999807f};
 
-  const bool linear_before_reset = true;
+  constexpr bool linear_before_reset = true;
   DefaultActivationsSimpleWeightsWithBias("forward", Y_data, linear_before_reset);
 }
 
@@ -322,7 +322,7 @@ TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearB
       0.12252139f, -0.12032216f, -0.05064924f,
       0.21249877f, -0.08884402f, 0.04751285f};
 
-  const bool linear_before_reset = true;
+  constexpr bool linear_before_reset = true;
   DefaultActivationsSimpleWeightsWithBias("reverse", Y_data, linear_before_reset);
 }
 
@@ -332,8 +332,8 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset) {
       0.15024948f, -0.11097029f, -0.02121867f,
       0.19538902f, -0.19016478f, -0.05644283f};
 
-  const bool linear_before_reset = true;
-  const bool one_row = true;
+  constexpr bool linear_before_reset = true;
+  constexpr bool one_row = true;
   DefaultActivationsSimpleWeightsWithBias("forward", Y_data, linear_before_reset, one_row);
 }
 
@@ -343,8 +343,8 @@ TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset) {
       0.20910699f, -0.18880953f, -0.04005555f,
       0.12252139f, -0.12032216f, -0.05064924f};
 
-  const bool linear_before_reset = true;
-  const bool one_row = true;
+  constexpr bool linear_before_reset = true;
+  constexpr bool one_row = true;
   DefaultActivationsSimpleWeightsWithBias("reverse", Y_data, linear_before_reset, one_row);
 }
 
@@ -543,8 +543,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBasic) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch = 1;
-  const int seq_length = 2;
+  constexpr int batch = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -561,8 +561,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpBackwardBasic) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.185934f, -0.269585f,
                           -0.455351f, -0.276391f};
   std::vector<int> sequence_length = {2};
@@ -580,8 +580,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpBidirectionalBasic) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -603,8 +603,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardActivation) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -622,8 +622,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardInitialHiddenState) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -641,8 +641,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatch) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 2;
-  const int seq_length = 2;
+  constexpr int batch_size = 2;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.455351f, -0.276391f,
 
@@ -668,8 +668,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatchLinearBeforeReset) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 2;
-  const int seq_length = 2;
+  constexpr int batch_size = 2;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.455351f, -0.276391f,
 
@@ -695,8 +695,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLength) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -707,8 +707,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLength) {
 
   ctx.RunTest(X, batch_size, seq_length, sequence_length, &initial_h, expected_Y, expected_Y_h);
 
-  const int batch2 = 2;
-  const int seq_length2 = 2;
+  constexpr int batch2 = 2;
+  constexpr int seq_length2 = 2;
   std::vector<float> X2 = {-0.455351f, -0.276391f,
                            -0.455351f, -0.276391f,
 
@@ -735,8 +735,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLengthLinearBeforeReset) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -747,8 +747,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLengthLinearBeforeReset) {
 
   ctx.RunTest(X, batch_size, seq_length, sequence_length, &initial_h, expected_Y, expected_Y_h, true);
 
-  const int batch2 = 2;
-  const int seq_length2 = 2;
+  constexpr int batch2 = 2;
+  constexpr int seq_length2 = 2;
   std::vector<float> X2 = {-0.455351f, -0.276391f,
                            -0.455351f, -0.276391f,
 
@@ -775,8 +775,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
   std::vector<int> sequence_length = {2};
@@ -796,8 +796,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 1;
-  const int seq_length = 2;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 2;
   std::vector<float> X = {0.855351f, 0.676391f,
                           0.585934f, 0.669585f};
   std::vector<int> sequence_length = {2};
@@ -816,8 +816,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 2;
-  const int seq_length = 2;
+  constexpr int batch_size = 2;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           0.855351f, 0.676391f,
                           -0.185934f, -0.269585f,
@@ -844,8 +844,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpShorterSeqInMiddle) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 3;
-  const int seq_length = 2;
+  constexpr int batch_size = 3;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           0.855351f, 0.676391f,
                           -0.185934f, -0.269585f,
@@ -877,8 +877,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpZeroSeqInMiddle) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 4;
-  const int seq_length = 2;
+  constexpr int batch_size = 4;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           0.855351f, 0.676391f,
                           -0.185934f, -0.269585f,
@@ -910,8 +910,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithPartialZero) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch_size = 2;
-  const int seq_length = 2;
+  constexpr int batch_size = 2;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           0.455351f, 0.276391f,
                           -0.185934f, -0.269585f,
@@ -938,8 +938,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthShorterThanInputSequenceLength)
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch = 1;
-  const int seq_length = 2;
+  constexpr int batch = 1;
+  constexpr int seq_length = 2;
 
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.185934f, -0.269585f};
@@ -967,8 +967,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthAllZeros) {
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
-  const int batch = 2;
-  const int seq_length = 2;
+  constexpr int batch = 2;
+  constexpr int seq_length = 2;
   std::vector<float> X = {-0.455351f, -0.276391f,
                           -0.455351f, -0.276391f,
 
@@ -995,8 +995,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSingleBatchMultipleHiddenThreads) {
 
   DeepCpuGruOpTestContext ctx(direction, activations, true, {}, {}, /*large_hidden*/ true);
 
-  const int batch_size = 1;
-  const int seq_length = 1;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 1;
   std::vector<float> X = {0.1f, -0.2f};
   std::vector<int> sequence_length = {1};
   std::vector<float> initial_h(32);
@@ -1025,8 +1025,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUPositiveActivationClipping) {
 
   DeepCpuGruOpTestContext ctx(direction, activations, true, {}, {}, /*large_hidden*/ true);
 
-  const int batch_size = 2;
-  const int seq_length = 1;
+  constexpr int batch_size = 2;
+  constexpr int seq_length = 1;
   std::vector<float> X = {1000.0f, 2000.0f, -1e+20f, -1e+10f};
   std::vector<int> sequence_length = {1, 1};
   std::vector<float> initial_h(64);
@@ -1054,9 +1054,9 @@ TEST(GRUTest, ONNXRuntime_TestGRUPositiveActivationAlphaBeta) {
   const std::vector<float> alpha = {0.5f, 2.0f};
   const std::vector<float> beta = {2.0f};
 
-  const int input_size = 2;  //  4;
-  const int batch_size = 1;
-  const int seq_length = 1;
+  constexpr int input_size = 2;  //  4;
+  constexpr int batch_size = 1;
+  constexpr int seq_length = 1;
   std::vector<float> X = {1.0f, 2.0f};  //  , -3.0f, -4.0f};
 
   std::vector<int> sequence_length = {1};

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -662,7 +662,7 @@ class LstmOpContext2x1x2x2 {
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardPeepHole) {
   ///////////////Attributes////////////////////////
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   std::vector<float> input = {-0.455351f, -0.276391f, -0.185934f, -0.269585f};
   std::vector<float> Y_data = {-0.0251062475f, 0.0561261699f, -0.03277518f, 0.05935364f};
@@ -675,7 +675,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardPeepHole) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMBidirectionalBasic) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   std::vector<float> X_data = {-0.455351f, -0.276391f,
                                -0.185934f, -0.269585f};
@@ -693,7 +693,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBidirectionalBasic) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardNoBiasUsePeepholes) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   bool use_bias = false;
   bool use_peepholes = true;
@@ -711,7 +711,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardNoBiasUsePeepholes) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardInputForget) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   bool use_bias = true;
   bool use_peepholes = true;
@@ -732,7 +732,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardInputForget) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardClip) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   bool use_bias = true;
   bool use_peepholes = true;
@@ -751,7 +751,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardClip) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMBackward) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   std::vector<float> X_data = {-0.455351f, -0.276391f, -0.185934f, -0.269585f};
 
@@ -765,7 +765,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBackward) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMBackward_gpu) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   std::vector<float> X_data = {-0.455351f, -0.276391f, -0.185934f, -0.269585f};
 
@@ -780,7 +780,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBackward_gpu) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardHiddenState) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   bool use_bias = true;
   bool use_peepholes = false;
@@ -799,7 +799,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardHiddenState) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMForwardCellState) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   bool use_bias = true;
   bool use_peepholes = false;
@@ -819,7 +819,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMForwardCellState) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMActivation) {
-  const int seq_len = 2, batch_size = 1;
+  constexpr int seq_len = 2, batch_size = 1;
 
   std::vector<std::string> activations = {"tanh", "sigmoid", "tanh"};
 
@@ -844,10 +844,10 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMActivation) {
 // The reallocation doesn't apply any more so this mainly tests larger batches with non-default activations.
 TEST(LSTMTest, ONNXRuntime_TestLSTMBatchReallocation) {
   ///////////////Attributes////////////////////////
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 1;
-  bool use_bias = true;
-  bool use_peepholes = false;
+  constexpr bool use_bias = true;
+  constexpr bool use_peepholes = false;
 
   std::vector<std::string> activations = {"tanh", "sigmoid", "tanh"};
 
@@ -903,7 +903,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMBatchReallocation) {
 // Most of these aren't relevant anymore as we don't re-use buffers given Compute is stateless.
 // It does test a batch > 1 with bidirectional output and custom activations though.
 TEST(LSTMTest, ONNXRuntime_TestLSTMOutputWrite) {
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 1;
   std::vector<std::string> activations = {"tanh", "sigmoid", "tanh", "tanh", "sigmoid", "tanh"};
 
@@ -975,7 +975,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMOutputWrite) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthAllZeros) {
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 2;
   std::vector<std::string> activations = {"tanh", "sigmoid", "tanh", "tanh", "sigmoid", "tanh"};
 
@@ -1019,7 +1019,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthAllZeros) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthPartialZeros) {
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 2;
   std::vector<std::string> activations = {"tanh", "sigmoid", "tanh", "tanh", "sigmoid", "tanh"};
 
@@ -1065,8 +1065,8 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthPartialZeros) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthShorterThanInputSequenceLength) {
-  const int seq_len = 2;
-  const int batch_size = 1;
+  constexpr int seq_len = 2;
+  constexpr int batch_size = 1;
 
   std::vector<float> X_data = {-0.455351f, -0.276391f,
                                -0.185934f, -0.269585f};
@@ -1095,8 +1095,8 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthShorterThanInputSequenceLength)
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthShorterThanInputSequenceLengthNoP) {
-  const int seq_len = 2;
-  const int batch_size = 1;
+  constexpr int seq_len = 2;
+  constexpr int batch_size = 1;
 
   std::vector<float> X_data = {-0.455351f, -0.276391f,
                                -0.185934f, -0.269585f};
@@ -1126,7 +1126,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMSequenceLengthShorterThanInputSequenceLengthN
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMShorterSeqInMiddle) {
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 3;
   std::vector<std::string> activations = {"sigmoid", "tanh", "tanh", "sigmoid", "tanh", "tanh"};
 
@@ -1166,7 +1166,7 @@ TEST(LSTMTest, ONNXRuntime_TestLSTMShorterSeqInMiddle) {
 }
 
 TEST(LSTMTest, ONNXRuntime_TestLSTMZeroSeqInMiddle) {
-  const int seq_len = 2;
+  constexpr int seq_len = 2;
   int batch_size = 4;
   std::vector<std::string> activations = {"sigmoid", "tanh", "tanh", "sigmoid", "tanh", "tanh"};
 

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -360,7 +360,7 @@ TEST(GatherElementsOpTest, BigIndices) {
   OpTester test1("GatherElements", 11);
 
   test1.AddAttribute<int64_t>("axis", 0LL);
-  const int kNumIndices = 10 * 1000;  // must be >= kParallelizationThreshold in gather_elements.cc
+  constexpr int kNumIndices = 10 * 1000;  // must be >= kParallelizationThreshold in gather_elements.cc
   std::vector<float> input(2 * kNumIndices);
   std::iota(std::begin(input), std::end(input), 0.f);
   test1.AddInput<float>("data", {2, kNumIndices}, input);

--- a/onnxruntime/test/providers/cpu/tensor/isinf_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/isinf_test.cc
@@ -9,13 +9,13 @@
 namespace onnxruntime {
 namespace test {
 
-const float FLOAT_INF = std::numeric_limits<float>::infinity();
-const float FLOAT_NINF = -std::numeric_limits<float>::infinity();
-const float FLOAT_NAN = std::numeric_limits<float>::quiet_NaN();
+constexpr float FLOAT_INF = std::numeric_limits<float>::infinity();
+constexpr float FLOAT_NINF = -std::numeric_limits<float>::infinity();
+constexpr float FLOAT_NAN = std::numeric_limits<float>::quiet_NaN();
 
-const double DOUBLE_INF = std::numeric_limits<double>::infinity();
-const double DOUBLE_NINF = -std::numeric_limits<double>::infinity();
-const double DOUBLE_NAN = std::numeric_limits<double>::quiet_NaN();
+constexpr double DOUBLE_INF = std::numeric_limits<double>::infinity();
+constexpr double DOUBLE_NINF = -std::numeric_limits<double>::infinity();
+constexpr double DOUBLE_NAN = std::numeric_limits<double>::quiet_NaN();
 
 TEST(IsInfTest, test_isinf_float) {
   // Defaults for detect_negative = 1

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -16,7 +16,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_tf_crop_and_resize) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
 
-  const int64_t H = 4, W = 4;
+  constexpr int64_t H = 4, W = 4;
 
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
@@ -46,7 +46,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_tf_crop_and_resize_with_extrapol
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
   test.AddAttribute("extrapolation_value", 10.0f);
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -72,7 +72,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear) {
 
   test.AddAttribute("mode", "linear");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -104,7 +104,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear1) {
 
     test.AddAttribute("mode", "linear");
 
-    const int64_t N = 1, C = 1, H = 2, W = 4;
+    constexpr int64_t N = 1, C = 1, H = 2, W = 4;
     std::vector<float> X = {
         1.0f, 2.0f, 3.0f, 4.0f,
         5.0f, 6.0f, 7.0f, 8.0f};
@@ -129,7 +129,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear1_WithSizes) {
     OpTester test("Resize", 13);
     std::vector<float> roi{};
     std::vector<float> scales{};
-    const int64_t N = 1, C = 1, H = 2, W = 4;
+    constexpr int64_t N = 1, C = 1, H = 2, W = 4;
     std::vector<int64_t> sizes{N, C, 1, 2};
     test.AddAttribute("mode", "linear");
 
@@ -162,7 +162,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear_align_corners) {
     test.AddAttribute("mode", "linear");
     test.AddAttribute("coordinate_transformation_mode", "align_corners");
 
-    const int64_t N = 1, C = 1, H = 2, W = 4;
+    constexpr int64_t N = 1, C = 1, H = 2, W = 4;
     std::vector<float> X = {
         1.0f, 2.0f, 3.0f, 4.0f,
         5.0f, 6.0f, 7.0f, 8.0f};
@@ -195,7 +195,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_2DBilinear_pytorch_half_pixel) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "pytorch_half_pixel");
 
-  const int64_t H = 4, W = 4;
+  constexpr int64_t H = 4, W = 4;
 
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
@@ -224,7 +224,7 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_4DBilinear_asymmetric) {
     test.AddAttribute("mode", "linear");
     test.AddAttribute("coordinate_transformation_mode", "asymmetric");
 
-    const int64_t N = 2, C = 1, H = 2, W = 2;
+    constexpr int64_t N = 2, C = 1, H = 2, W = 2;
     std::vector<float> X = {1.0f, 3.0f,
                             4.0f, 8.0f,
 
@@ -261,7 +261,7 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_2DBilinear_align_corners) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "align_corners");
 
-  const int64_t H = 2, W = 2;
+  constexpr int64_t H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           4.0f, 8.0f};
 
@@ -288,7 +288,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_3DTrilinear_pytorch_half_pixel) 
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "pytorch_half_pixel");
 
-  const int64_t D = 2, H = 4, W = 4;
+  constexpr int64_t D = 2, H = 4, W = 4;
 
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
@@ -320,7 +320,7 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_5DTrilinear_pytorch_half_pixel) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "pytorch_half_pixel");
 
-  const int64_t N = 1, C = 2, D = 2, H = 1, W = 2;
+  constexpr int64_t N = 1, C = 2, D = 2, H = 1, W = 2;
 
   std::vector<float> X = {
       1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
@@ -346,7 +346,7 @@ TEST(ResizeOpTest, ResizeOpLinearScalesNoOpTest) {
     std::vector<float> scales{1.0f, 1.0f, 1.0f, 1.0f};
     test.AddAttribute("mode", "linear");
 
-    const int64_t N = 2, C = 1, H = 2, W = 2;
+    constexpr int64_t N = 2, C = 1, H = 2, W = 2;
     std::vector<float> X = {1.0f, 3.0f,
                             4.0f, 8.0f,
 
@@ -378,7 +378,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -400,7 +400,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest_Opset12) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -423,7 +423,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest_WithSizes) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -448,7 +448,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest_tf_half_pixel) {
   test.AddAttribute("coordinate_transformation_mode", "tf_half_pixel_for_nn");
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -477,7 +477,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest_tf_crop_and_resize_with_extrapo
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
   test.AddAttribute("extrapolation_value", 10.0f);
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -505,7 +505,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSample5dTest_tf_crop_and_resize_with_extra
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
   test.AddAttribute("extrapolation_value", 10.0f);
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -532,7 +532,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSampleTest) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f};
 
   test.AddInput<float>("X", {N, C, H, W}, X);
@@ -557,7 +557,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSampleTest_WithSizes_CeilMode) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("nearest_mode", "ceil");
 
-  const int64_t N = 1, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f};
 
   test.AddInput<float>("X", {N, C, H, W}, X);
@@ -586,7 +586,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample5dTest_WithSizes_CeilMode) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("nearest_mode", "ceil");
 
-  const int64_t N = 1, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f};
 
   test.AddInput<float>("X", {1, N, C, H, W}, X);
@@ -617,7 +617,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_Floor_Align_Corners) {
   test.AddAttribute("coordinate_transformation_mode", "align_corners");
   test.AddAttribute("nearest_mode", "floor");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -655,7 +655,7 @@ TEST(ResizeOpTest, ResizeOpNearest_OneToOneMappingBetweenInputAndOutputDataDims)
   test.AddAttribute("coordinate_transformation_mode", "tf_half_pixel_for_nn");
   test.AddAttribute("nearest_mode", "ceil");
 
-  const int64_t C = 2, D = 3;
+  constexpr int64_t C = 2, D = 3;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
 
   test.AddInput<float>("X", {C, D}, X);
@@ -720,7 +720,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_Nearest2xOptimization_Scales) {
     test.AddAttribute("coordinate_transformation_mode", "asymmetric");
     test.AddAttribute("nearest_mode", "floor");
 
-    const int64_t N = 1, C = 1, H = 2, W = 2;
+    constexpr int64_t N = 1, C = 1, H = 2, W = 2;
     std::vector<float> X = {
         1.0f, 2.0f,
         3.0f, 4.0f};
@@ -753,7 +753,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSample_Nearest2xOptimization_Sizes) {
     test.AddAttribute("coordinate_transformation_mode", "asymmetric");
     test.AddAttribute("nearest_mode", "floor");
 
-    const int64_t N = 1, C = 1, H = 2, W = 2;
+    constexpr int64_t N = 1, C = 1, H = 2, W = 2;
     std::vector<float> X = {
         1.0f, 2.0f,
         3.0f, 4.0f};
@@ -783,7 +783,7 @@ TEST(ResizeOpTest, ResizeOpCubicDownSampleTest) {
 
   test.AddAttribute("mode", "cubic");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -812,7 +812,7 @@ TEST(ResizeOpTest, ResizeOpCubicDownSampleTest_exclude_outside) {
   test.AddAttribute("exclude_outside", static_cast<int64_t>(1));
   test.AddAttribute("cubic_coeff_a", -0.5f);
 
-  const int64_t H = 4, W = 4;
+  constexpr int64_t H = 4, W = 4;
 
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
@@ -840,7 +840,7 @@ TEST(ResizeOpTest, ResizeOpCubicDownSampleTest_coeff) {
   test.AddAttribute("mode", "cubic");
   test.AddAttribute("cubic_coeff_a", -0.5f);
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -867,7 +867,7 @@ TEST(ResizeOpTest, ResizeOpCubicDownSampleTest_with_roi) {
   test.AddAttribute("mode", "cubic");
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -894,7 +894,7 @@ TEST(ResizeOpTest, ResizeOpCubicDownSampleTest_asymmetric) {
   test.AddAttribute("mode", "cubic");
   test.AddAttribute("coordinate_transformation_mode", "asymmetric");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -921,7 +921,7 @@ TEST(ResizeOpTest, ResizeOpCubicUpSampleTest) {
   test.AddAttribute("mode", "cubic");
   test.AddAttribute("coordinate_transformation_mode", "asymmetric");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -953,7 +953,7 @@ TEST(ResizeOpTest, ResizeOpCubicUpSampleTest_MultiChannel) {
 
   test.AddAttribute("mode", "cubic");
 
-  const int64_t N = 1, C = 2, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 2, H = 4, W = 4;
   std::vector<float> X = {
       0.0f, 1.0f, 2.0f, 3.0f,
       4.0f, 5.0f, 6.0f, 7.0f,
@@ -1002,7 +1002,7 @@ TEST(ResizeOpTest, ResizeOpCubicUpSampleTest_tf_half_pixel_for_nn) {
   test.AddAttribute("mode", "cubic");
   test.AddAttribute("coordinate_transformation_mode", "tf_half_pixel_for_nn");
 
-  const int64_t N = 1, C = 1, H = 4, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 4, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f,
@@ -1032,7 +1032,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear_Ver10) {
 
   test.AddAttribute("mode", "linear");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -1052,7 +1052,7 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_2DBilinear_Ver10) {
 
   test.AddAttribute("mode", "linear");
 
-  const int64_t H = 2, W = 4;
+  constexpr int64_t H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -1071,7 +1071,7 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_4DBilinear_Ver10) {
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 4.0f};
   test.AddAttribute("mode", "linear");
 
-  const int64_t N = 2, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 2, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           4.0f, 8.0f,
 
@@ -1101,7 +1101,7 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_2DBilinear_Ver10) {
   std::vector<float> scales{2.0f, 4.0f};
   test.AddAttribute("mode", "linear");
 
-  const int64_t H = 2, W = 2;
+  constexpr int64_t H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           4.0f, 8.0f};
 
@@ -1123,7 +1123,7 @@ TEST(ResizeOpTest, ResizeOpLinearScalesNoOpTest_Ver10) {
   std::vector<float> scales{1.0f, 1.0f, 1.0f, 1.0f};
   test.AddAttribute("mode", "linear");
 
-  const int64_t N = 2, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 2, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           4.0f, 8.0f,
 
@@ -1149,7 +1149,7 @@ TEST(ResizeOpTest, ResizeOpNearestDownSampleTest_Ver10) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 4;
   std::vector<float> X = {
       1.0f, 2.0f, 3.0f, 4.0f,
       5.0f, 6.0f, 7.0f, 8.0f};
@@ -1169,7 +1169,7 @@ TEST(ResizeOpTest, ResizeOpNearestUpSampleTest_Ver10) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f};
 
   test.AddInput<float>("X", {N, C, H, W}, X);
@@ -1190,7 +1190,7 @@ TEST(UpsampleOpTest, ResizeOpNearestNoScaleTest_Ver10) {
 
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 2.0f, 3.0f, 4.0f};
 
   test.AddInput<float>("X", {N, C, H, W}, X);
@@ -1208,7 +1208,7 @@ TEST(ResizeOpTest, ResizeOp_MissingRoiAndMissingScalesOptionalInputs) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("coordinate_transformation_mode", "tf_crop_and_resize");
 
-  const int64_t H = 4, W = 4;
+  constexpr int64_t H = 4, W = 4;
 
   std::vector<float> X = {
       1.0f, 1.0f, 1.0f, 1.0f,

--- a/onnxruntime/test/providers/cpu/tensor/space_depth_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/space_depth_ops_test.cc
@@ -10,9 +10,9 @@ namespace test {
 
 TEST(TensorOpTest, SpaceToDepthTest_1) {
   OpTester test("SpaceToDepth");
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
-  const int64_t N = 1, C = 2, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 4;
   const std::vector<float> X =
       {0.0f, 0.1f, 0.2f, 0.3f,
        1.0f, 1.1f, 1.2f, 1.3f,
@@ -40,9 +40,9 @@ TEST(TensorOpTest, SpaceToDepthTest_1) {
 
 TEST(TensorOpTest, SpaceToDepthTest_1_double) {
   OpTester test("SpaceToDepth");
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
-  const int64_t N = 1, C = 2, H = 2, W = 4;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 4;
   const std::vector<double> X =
       {0.0, 0.1, 0.2, 0.3,
        1.0, 1.1, 1.2, 1.3,
@@ -70,9 +70,9 @@ TEST(TensorOpTest, SpaceToDepthTest_1_double) {
 }
 TEST(TensorOpTest, SpaceToDepthTest_2) {
   OpTester test("SpaceToDepth");
-  const int64_t blocksize = 3;
+  constexpr int64_t blocksize = 3;
   test.AddAttribute("blocksize", blocksize);
-  const int64_t N = 2, C = 3, H = 3, W = 6;
+  constexpr int64_t N = 2, C = 3, H = 3, W = 6;
   const std::vector<float> X = {
       0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.,
       11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21.,
@@ -104,10 +104,10 @@ TEST(TensorOpTest, SpaceToDepthTest_2) {
 
 TEST(TensorOpTest, DepthToSpaceTest_1) {
   OpTester test("DepthToSpace", 7);  // create an opset 7 model
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
 
-  const int64_t N = 1, C = 8, H = 1, W = 2;
+  constexpr int64_t N = 1, C = 8, H = 1, W = 2;
   const std::vector<float> X = {
       0.0f, 0.2f,
       2.0f, 2.2f,
@@ -135,10 +135,10 @@ TEST(TensorOpTest, DepthToSpaceTest_1) {
 
 TEST(TensorOpTest, DepthToSpaceTest_1_double) {
   OpTester test("DepthToSpace", 7);  // create an opset 7 model
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
 
-  const int64_t N = 1, C = 8, H = 1, W = 2;
+  constexpr int64_t N = 1, C = 8, H = 1, W = 2;
   const std::vector<double> X = {
       0.0, 0.2,
       2.0, 2.2,
@@ -165,10 +165,10 @@ TEST(TensorOpTest, DepthToSpaceTest_1_double) {
 }
 TEST(TensorOpTest, DepthToSpaceTest_2) {
   OpTester test("DepthToSpace", 7);  // create an opset 7 model
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
 
-  const int64_t N = 2, C = 12, H = 3, W = 2;
+  constexpr int64_t N = 2, C = 12, H = 3, W = 2;
   const std::vector<float> X = {
       0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.,
       11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21.,
@@ -208,10 +208,10 @@ TEST(TensorOpTest, DepthToSpaceTest_2) {
 
 TEST(TensorOpTest, DepthToSpaceTest_3) {
   OpTester test("DepthToSpace", 11);  // create an opset 11 model with missing default attribute
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
 
-  const int64_t N = 2, C = 12, H = 3, W = 2;
+  constexpr int64_t N = 2, C = 12, H = 3, W = 2;
   const std::vector<float> X = {
       0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.,
       11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21.,
@@ -251,11 +251,11 @@ TEST(TensorOpTest, DepthToSpaceTest_3) {
 
 TEST(TensorOpTest, DepthToSpaceTest_4) {
   OpTester test("DepthToSpace", 11);  // create an opset 11 model with attribute present = "DCR" mode
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
   test.AddAttribute("mode", "DCR");
 
-  const int64_t N = 2, C = 12, H = 3, W = 2;
+  constexpr int64_t N = 2, C = 12, H = 3, W = 2;
   const std::vector<float> X = {
       0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.,
       11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21.,
@@ -295,11 +295,11 @@ TEST(TensorOpTest, DepthToSpaceTest_4) {
 
 TEST(TensorOpTest, DepthToSpaceTest_5) {
   OpTester test("DepthToSpace", 11);  // create an opset 11 model with attribute present = "CRD" mode
-  const int64_t blocksize = 2;
+  constexpr int64_t blocksize = 2;
   test.AddAttribute("blocksize", blocksize);
   test.AddAttribute("mode", "CRD");
 
-  const int64_t N = 1, C = 4, H = 2, W = 3;
+  constexpr int64_t N = 1, C = 4, H = 2, W = 3;
   const std::vector<float> X = {0., 1., 2.,
                                 3., 4., 5.,
                                 9., 10., 11.,

--- a/onnxruntime/test/providers/cpu/tensor/upsample_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/upsample_op_test.cc
@@ -18,7 +18,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -49,7 +49,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_int32) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<int32_t> X = {1, 3,
                             3, 5,
 
@@ -80,7 +80,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_uint8) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<uint8_t> X = {1, 3,
                             3, 5,
 
@@ -111,7 +111,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest2XTest) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -142,7 +142,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest222XTest) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -183,7 +183,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest15XTest) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -214,7 +214,7 @@ TEST(UpsampleOpTest, UpsampleOpNearestTest_NoScale) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -240,7 +240,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest2XTest_int32) {
   test.AddAttribute("mode", "nearest");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<int32_t> X = {1, 3,
                             3, 5,
 
@@ -271,7 +271,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 2, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 2, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -302,7 +302,7 @@ TEST(UpsampleOpTest, UpsampleOp2DBilinearTest) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("scales", scales);
 
-  const int64_t H = 2, W = 2;
+  constexpr int64_t H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f};
 
@@ -325,7 +325,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_ScalesNoOp) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 2, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 2, C = 1, H = 2, W = 2;
   std::vector<float> X = {1.0f, 3.0f,
                           3.0f, 5.0f,
 
@@ -351,7 +351,7 @@ TEST(UpsampleOpTest, UpsampleOp4DBilinearTest_int32) {
   test.AddAttribute("mode", "linear");
   test.AddAttribute("scales", scales);
 
-  const int64_t N = 2, C = 1, H = 2, W = 2;
+  constexpr int64_t N = 2, C = 1, H = 2, W = 2;
   std::vector<int32_t> X = {1, 3,
                             3, 5,
 
@@ -403,7 +403,7 @@ TEST(UpsampleOpTest, UpsampleOpNearest2XTest_opset9) {
   std::vector<float> scales{1.0f, 1.0f, 2.0f, 2.0f};
   test.AddAttribute("mode", "nearest");
 
-  const int64_t N = 1, C = 2, H = 2, W = 2;
+  constexpr int64_t N = 1, C = 2, H = 2, W = 2;
   std::vector<int32_t> X = {1, 3,
                             3, 5,
 

--- a/onnxruntime/test/providers/internal_testing/internal_testing_partitioning_tests.cc
+++ b/onnxruntime/test/providers/internal_testing/internal_testing_partitioning_tests.cc
@@ -319,7 +319,7 @@ TEST(InternalTestingEP, DISABLED_TestNnapiPartitioningMlPerfModels) {
       }
       std::cout << std::endl;
 
-      const bool debug_output = false;
+      constexpr bool debug_output = false;
       PartitionStats stats{}, stop_at_nms_stats{}, slice_stats{};
 
       // arbitrary examples of running different combinations to test what partitioning results

--- a/onnxruntime/test/quantization/quantization_test.cc
+++ b/onnxruntime/test/quantization/quantization_test.cc
@@ -141,7 +141,7 @@ TEST(Quantization, CreateQuantizationParamsFromTensors) {
 //
 
 TEST(Quantization, QuantizeFloat_Int8) {
-  const float x = 2.34f;
+  constexpr float x = 2.34f;
   quantization::Params<int8_t> params(/*scale=*/0.0872204f, /*zero_point=*/0);
   EXPECT_EQ(quantization::Quantize(x, params), 27);
 }
@@ -155,8 +155,8 @@ TEST(Quantization, QuantizeFloatValues_Int8) {
 
 TEST(Quantization, QuantizeLinear_Int8) {
   std::vector<float> values = {-3.412f, -12.42f, 1.032f, 2.32f, 9.8212f};
-  const float expected_scale = 0.0872204f;
-  const int8_t expected_zero_point = 15;
+  constexpr float expected_scale = 0.0872204f;
+  constexpr int8_t expected_zero_point = 15;
   std::vector<int8_t> expected_values = {-24, -127, 27, 41, 127};
 
   TestQuantizeLinearVectorAndValues(values,
@@ -166,7 +166,7 @@ TEST(Quantization, QuantizeLinear_Int8) {
 }
 
 TEST(Quantization, Dequantize_Int8) {
-  const int8_t x_i8 = 12;
+  constexpr int8_t x_i8 = 12;
   quantization::Params<int8_t> params(/*scale=*/0.0124f, /*zero_point=*/-1);
   EXPECT_NEAR(quantization::Dequantize(x_i8, params), 0.1612f, kEpsilon);
 }
@@ -185,7 +185,7 @@ TEST(Quantization, DequantizeValues_Int8) {
 //
 
 TEST(Quantization, QuantizeFloat_UInt8) {
-  const float x = 1.25f;
+  constexpr float x = 1.25f;
   quantization::Params<uint8_t> params(/*scale=*/0.0117647f, /*zero_point=*/85);
   EXPECT_EQ(quantization::Quantize(x, params), 191);
 }
@@ -200,8 +200,8 @@ TEST(Quantization, QuantizeFloatValues_UInt8) {
 
 TEST(Quantization, QuantizeLinear_UInt8) {
   std::vector<float> values = {-3.412f, -12.42f, 1.032f, 2.32f, 9.8212f};
-  const float expected_scale = 0.0872203931f;
-  const uint8_t expected_zero_point = 142;
+  constexpr float expected_scale = 0.0872203931f;
+  constexpr uint8_t expected_zero_point = 142;
   std::vector<uint8_t> expected_values = {103, 0, 154, 169, 255};
 
   TestQuantizeLinearVectorAndValues(values,
@@ -211,7 +211,7 @@ TEST(Quantization, QuantizeLinear_UInt8) {
 }
 
 TEST(Quantization, Dequantize_UInt8) {
-  const uint8_t x_u8 = 200;
+  constexpr uint8_t x_u8 = 200;
   quantization::Params<uint8_t> params(/*scale=*/0.0124f, /*zero_point=*/127);
   EXPECT_NEAR(quantization::Dequantize(x_u8, params), 0.9052f, kEpsilon);
 }

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1633,9 +1633,9 @@ TEST(CApiTest, TestSharingOfInitializerAndItsPrepackedVersion) {
   Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
   // These values are different from the actual initializer values in the model
   float data[] = {2.0f, 1.0f};
-  const int data_len = sizeof(data) / sizeof(data[0]);
+  constexpr int data_len = sizeof(data) / sizeof(data[0]);
   const int64_t shape[] = {2, 1};
-  const size_t shape_len = sizeof(shape) / sizeof(shape[0]);
+  constexpr size_t shape_len = sizeof(shape) / sizeof(shape[0]);
   Ort::Value val = Ort::Value::CreateTensor<float>(mem_info, data, data_len, shape, shape_len);
   session_options.AddInitializer("W", val);
 
@@ -1676,9 +1676,9 @@ TEST(CApiTest, TestIncorrectInputTypeToModel_Tensors) {
   Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
   double data[] = {2., 1., 4., 3., 6., 5.};
-  const int data_len = sizeof(data) / sizeof(data[0]);
+  constexpr int data_len = sizeof(data) / sizeof(data[0]);
   const int64_t shape[] = {3, 2};
-  const size_t shape_len = sizeof(shape) / sizeof(shape[0]);
+  constexpr size_t shape_len = sizeof(shape) / sizeof(shape[0]);
   Ort::Value val = Ort::Value::CreateTensor<double>(mem_info, data, data_len, shape, shape_len);
 
   std::vector<const char*> input_names{"X"};
@@ -1703,9 +1703,9 @@ TEST(CApiTest, TestIncorrectInputTypeToModel_SequenceTensors) {
   Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
   double data[] = {2., 1., 4., 3., 6., 5.};
-  const int data_len = sizeof(data) / sizeof(data[0]);
+  constexpr int data_len = sizeof(data) / sizeof(data[0]);
   const int64_t shape[] = {2, 3};
-  const size_t shape_len = sizeof(shape) / sizeof(shape[0]);
+  constexpr size_t shape_len = sizeof(shape) / sizeof(shape[0]);
   Ort::Value val = Ort::Value::CreateTensor<double>(mem_info, data, data_len, shape, shape_len);
 
   std::vector<Ort::Value> seq;
@@ -1870,7 +1870,7 @@ void JoinThreadCustomized(OrtCustomThreadHandle handle) {
 }
 
 TEST(CApiTest, TestPerSessionCustomThreadPoolHooks) {
-  const int32_t thread_count = 3;
+  constexpr int32_t thread_count = 3;
   Ort::SessionOptions session_options;
   // test both intra and inter op thread pool
   session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
@@ -1892,7 +1892,7 @@ TEST(CApiTest, TestPerSessionCustomThreadPoolHooks) {
 TEST(CApiTest, crop_and_resize) {
   std::vector<float> input_value_0;
   input_value_0.resize(2 * 36 * 36 * 3);
-  for (int i = 0; i < 36 * 36 * 3; ++i) {
+  for (ptrdiff_t i = 0; i < 36 * 36 * 3; ++i) {
     input_value_0[i] = 1.f;
     input_value_0[i + 36 * 36 * 3] = 2.f;
   }

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -36,8 +36,8 @@ TEST(CApiTest, CreateGetVectorOfMapsInt64Float) {  // support zipmap output type
   auto default_allocator = std::make_unique<MockedOrtAllocator>();
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
 
-  const size_t N = 3;
-  const int NUM_KV_PAIRS = 4;
+  constexpr size_t N = 3;
+  constexpr int NUM_KV_PAIRS = 4;
   std::vector<Ort::Value> in;
   std::vector<int64_t> keys{3, 1, 2, 0};
   std::vector<int64_t> dims = {4};
@@ -100,8 +100,8 @@ TEST(CApiTest, CreateGetVectorOfMapsStringFloat) {  // support zipmap output typ
   auto default_allocator = std::make_unique<MockedOrtAllocator>();
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
 
-  const size_t N = 3;
-  const int64_t NUM_KV_PAIRS = 4;
+  constexpr size_t N = 3;
+  constexpr int64_t NUM_KV_PAIRS = 4;
   std::vector<Ort::Value> in;
   const char* keys_arr[NUM_KV_PAIRS] = {"abc", "def", "ghi", "jkl"};
   std::vector<std::string> keys{keys_arr, keys_arr + NUM_KV_PAIRS};
@@ -166,7 +166,7 @@ TEST(CApiTest, TypeInfoMap) {
   auto default_allocator = std::make_unique<MockedOrtAllocator>();
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
 
-  const int64_t NUM_KV_PAIRS = 4;
+  constexpr int64_t NUM_KV_PAIRS = 4;
   std::vector<int64_t> keys{0, 1, 2, 3};
   std::vector<int64_t> dims = {NUM_KV_PAIRS};
   std::vector<float> values{3.0f, 1.0f, 2.f, 0.f};
@@ -220,7 +220,7 @@ TEST(CApiTest, CreateGetSeqTensors) {
   std::vector<Ort::Value> in;
   std::vector<int64_t> vals{3, 1, 2, 0};
   std::vector<int64_t> dims{1, 4};
-  const int N = 2;
+  constexpr int N = 2;
   for (int i = 0; i < N; ++i) {
     // create tensor
     Ort::Value tensor = Ort::Value::CreateTensor(info, vals.data(), vals.size() * sizeof(int64_t),
@@ -246,7 +246,7 @@ TEST(CApiTest, CreateGetSeqStringTensors) {
 
   std::vector<Ort::Value> in;
   const char* string_input_data[] = {"abs", "def"};
-  const int N = 2;
+  constexpr int N = 2;
   for (int i = 0; i < N; ++i) {
     // create tensor
     std::vector<int64_t> shape{2};
@@ -287,7 +287,7 @@ TEST(CApiTest, TypeInfoSequence) {
   std::vector<Ort::Value> in;
   std::vector<int64_t> vals{3, 1, 2, 0};
   std::vector<int64_t> dims{1, 4};
-  const int N = 2;
+  constexpr int N = 2;
   for (int i = 0; i < N; ++i) {
     // create tensor
     Ort::Value tensor = Ort::Value::CreateTensor(info, vals.data(), vals.size() * sizeof(int64_t),

--- a/onnxruntime/test/testdata/custom_execution_provider_library/my_allocator.cc
+++ b/onnxruntime/test/testdata/custom_execution_provider_library/my_allocator.cc
@@ -9,7 +9,9 @@ MyEPAllocator::MyEPAllocator(OrtDevice::DeviceId device_id)
     : IAllocator(OrtMemoryInfo(MyEP, OrtAllocatorType::OrtArenaAllocator,
                                OrtDevice(MyEPDevice, OrtDevice::MemType::DEFAULT, device_id))) {
 }
-
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 void* MyEPAllocator::Alloc(size_t size) {
   void* device_address = new (std::nothrow) uint8_t[size];
   return device_address;

--- a/onnxruntime/test/testdata/custom_execution_provider_library/my_allocator.h
+++ b/onnxruntime/test/testdata/custom_execution_provider_library/my_allocator.h
@@ -7,7 +7,7 @@
 
 namespace onnxruntime {
 constexpr const char* MyEP = "MyEP";
-static const OrtDevice::DeviceType MyEPDevice = 11;
+static constexpr OrtDevice::DeviceType MyEPDevice = 11;
 }  // namespace onnxruntime
 
 namespace onnxruntime {

--- a/onnxruntime/test/util/include/file_util.h
+++ b/onnxruntime/test/util/include/file_util.h
@@ -16,8 +16,8 @@ class ScopedFileDeleter {
  public:
   ScopedFileDeleter() = default;
   ScopedFileDeleter(const PathString& path) : path_{path} {}
-  ScopedFileDeleter(ScopedFileDeleter&& other) { *this = std::move(other); }
-  ScopedFileDeleter& operator=(ScopedFileDeleter&& other) {
+  ScopedFileDeleter(ScopedFileDeleter&& other) noexcept { *this = std::move(other); }
+  ScopedFileDeleter& operator=(ScopedFileDeleter&& other) noexcept {
     CleanUp();
     path_ = std::move(other.path_);
     other.path_.clear();

--- a/onnxruntime/test/util/test_allocator.cc
+++ b/onnxruntime/test/util/test_allocator.cc
@@ -15,7 +15,9 @@ MockedOrtAllocator::MockedOrtAllocator() {
 MockedOrtAllocator::~MockedOrtAllocator() {
   Ort::GetApi().ReleaseMemoryInfo(cpu_memory_info);
 }
-
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(disable : 26400)
+#endif
 void* MockedOrtAllocator::Alloc(size_t size) {
   constexpr size_t extra_len = sizeof(size_t);
   memory_inuse.fetch_add(size += extra_len);

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -36,7 +36,7 @@ static void VerifyOutputs(const std::vector<std::string>& output_names,
             << " mismatch for " << output_names[i];
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {
-        const float abs_err = float(1e-5);
+        constexpr float abs_err = 1e-5f;
 
         EXPECT_THAT(ltensor.DataAsSpan<float>(),
                     ::testing::Pointwise(::testing::FloatNear(abs_err), rtensor.DataAsSpan<float>()));


### PR DESCRIPTION
**Description**: 


Change some const to constexpr.

This PR only touches unit test code.  I will have another one to fix the warnings in the other places.


**Motivation and Context**
- Why is this change required? What problem does it solve?

One of the C++ Core Guidelines checker warnings.

- If it fixes an open issue, please link to the issue here.
