### PR TITLE
Implementation of  QAttention for the DNNL execution provider

### DIFF
--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.3)
+set(DNNL_TAG v2.4.4)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.4.4)
+set(DNNL_TAG v2.5)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.5)
+set(DNNL_TAG v2.4.4)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
@@ -200,6 +200,9 @@ std::vector<std::unique_ptr<ComputeCapability>> DNNLExecutionProvider::GetCapabi
 
       for (const auto* input : node->InputDefs()) {
         // if the node input was not produced by this subgraph, add it to the subgraph inputs.
+        if (!input->Exists()) {
+          continue;
+        }
         if (node_outputs.count(input) == 0) {
           if (subgraph_inputs.count(input) == 0) {
             subgraph_inputs.insert(input);
@@ -210,6 +213,9 @@ std::vector<std::unique_ptr<ComputeCapability>> DNNLExecutionProvider::GetCapabi
 
       const auto& output_defs = node->OutputDefs();
       for (const auto* output_def : output_defs) {
+        if (!output_def->Exists()) {
+          continue;
+        }
         node_outputs.insert(output_def);
         // if output is overall graph output we need to produce it.
         if (graph_outputs.count(output_def) != 0) {

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -282,7 +282,7 @@ bool DnnlMatMulNodeCapability::IsDimensionSupported(const Node* node) const {
 bool DnnlMatMulIntegerNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
-  if (!IsDimensionSupported(node)) return false;
+  if (!IsDimensionSupported(node,graph_viewer)) return false;
 
   // if weight is u8, onednn doesn't support
   auto node_inputs = node->InputDefs();
@@ -297,14 +297,77 @@ bool DnnlMatMulIntegerNodeCapability::Supported(const Node* node, const GraphVie
   return true;
 }
 
-bool DnnlMatMulIntegerNodeCapability::IsDimensionSupported(const Node* node) const {
+//assume weight zp is s8 since u8 will get rejected and weight zp matches weight data type
+bool DnnlMatMulIntegerNodeCapability::IsWeightZeroPointConstantZero(const NodeArg* node_arg, const GraphViewer& graph_viewer) const {
+  const ONNX_NAMESPACE::TensorProto* tensor_proto = nullptr;
+  // if node_arg is not initializer
+  if (!graph_viewer.GetInitializedTensor(node_arg->Name(), tensor_proto)) {
+    return false;
+  }
+  // if node_arg is not initializer
+  if (tensor_proto == nullptr) {
+    return false;
+  }
+
+  const auto& dims = tensor_proto->dims();
+  auto dim_size = tensor_proto->dims_size();
+  int num_elements = 1;
+  for (int i = 0; i < dim_size; i++) {
+    num_elements *= int(dims[i]);
+  }
+
+  //check if weight zp is all zeros
+  bool all_zero = true;
+  std::vector<int8_t> unpacked_tensor;
+  //delibrately make a vector of 1s instead of 0s
+  unpacked_tensor.resize(num_elements, 1);
+  ORT_THROW_IF_ERROR(onnxruntime::utils::UnpackTensor(*tensor_proto, tensor_proto->has_raw_data() ? tensor_proto->raw_data().data() : nullptr, tensor_proto->has_raw_data() ? tensor_proto->raw_data().size() : 0, reinterpret_cast<int8_t*>(unpacked_tensor.data()), num_elements));
+
+  //check if the initializer zero point contains all zeros
+  for (const auto& val : unpacked_tensor) {
+    if (val != 0) {
+      all_zero = false;
+      break;
+    }
+  }
+
+  //if initializer zero point is not all zeros, reject it
+  //TODO: if initializer zero point is a vector of a unique value, we can still compute it
+  if (!all_zero) {
+    return false;
+  }
+  return true;
+}
+
+bool DnnlMatMulIntegerNodeCapability::IsDimensionSupported(const Node* node, const GraphViewer& graph_viewer) const {
   auto node_inputs = node->InputDefs();
 
-  //if shape nullptr, attempt to run it (no gaurantee)
+  //do not support other than single zero point (not per column)
+  if (node_inputs.size() > 2) {
+    if (node_inputs.size() >= 3 && node_inputs[2] && node_inputs[2]->Exists()) {
+      if (node_inputs[2]->Shape() != nullptr && node_inputs[2]->Shape()->dim_size() >= 1) {
+        return false;
+      }
+    }
+
+    if (node_inputs.size() >= 4 && node_inputs[3] && node_inputs[3]->Exists()) {
+      if (node_inputs[3]->Shape() != nullptr) {
+        auto dim_size = node_inputs[3]->Shape()->dim_size();
+        if (dim_size >= 1) {
+          // non scalar zero point, but if the weight zp is constant of 0s, still accept it and let the fusion rule remove the zero point
+          if (!IsWeightZeroPointConstantZero(node_inputs[3], graph_viewer)) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+
+  //if shape nullptr, not enough information to reject it. attempt to run it (no gaurantee)
   if (node_inputs[0]->Shape() == nullptr || node_inputs[1]->Shape() == nullptr) {
     return true;
   }
-
+  // if matmul src and weight have shape but have dim value of 0, reject it
   if ((node_inputs[0]->Shape() != nullptr && node_inputs[0]->Shape()->dim_size() >= 2) &&
       (node_inputs[1]->Shape() != nullptr && node_inputs[1]->Shape()->dim_size() >= 2)) {
     for (const auto& dim : node_inputs[0]->Shape()->dim()) {
@@ -319,21 +382,6 @@ bool DnnlMatMulIntegerNodeCapability::IsDimensionSupported(const Node* node) con
     }
   } else {
     return false;
-  }
-
-  //do not support other than single zero point (not per column)
-  if (node_inputs.size() > 2) {
-    if (node_inputs.size() >= 3 && node_inputs[2] && node_inputs[2]->Exists()) {
-      if (node_inputs[2]->Shape() != nullptr && node_inputs[2]->Shape()->dim_size() >= 1) {
-        return false;
-      }
-    }
-
-    if (node_inputs.size() >= 4 && node_inputs[3] && node_inputs[3]->Exists()) {
-      if (node_inputs[3]->Shape() != nullptr && node_inputs[3]->Shape()->dim_size() >= 1) {
-        return false;
-      }
-    }
   }
 
   return true;
@@ -793,6 +841,31 @@ bool DnnlQAttentionNodeCapability::Supported(const Node* node, const GraphViewer
   if (node_outputs.size() == 2 && node_outputs[1]->Exists()) {
     return false;
   }
+  //qattention doesn't support unidriectional
+  const NodeAttributes& attributes = node->GetAttributes();
+  auto attr = attributes.find("unidirectional");
+  if (attr != attributes.end()) {
+    if (attr->second().i() == 1) {
+      return false;
+    }
+  }
+  //only support scalar input scale and weight scale
+  if(!IsScalar(node_inputs[3]) || !IsScalar(node_inputs[4])){
+    return false;
+  }
+  //only support 2D raw mask
+  if(node_inputs.size() >= 6 && node_inputs[5]->Exists() && node_inputs[5]->Shape() != nullptr && node_inputs[5]->Shape()->dim_size() != 2){
+    return false;
+  }
+  //only support scalar input zero point
+  if(node_inputs.size() >= 7 && node_inputs[6]->Exists() && !IsScalar(node_inputs[6])){
+    return false;
+  }
+  //only support scalar weight zero point
+  if(node_inputs.size() >= 8 && node_inputs[7]->Exists() && !IsScalar(node_inputs[7])){
+    return false;
+  }
+
   //qattention is disabled on gpu due to the following onednn bugs
   //1. flipped zero points in int8 matmul
   //2. unsupported runtime input source0 scaling in binary

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -199,7 +199,8 @@ class DnnlMatMulIntegerNodeCapability : public DnnlDefaultNodeCapability {
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 
  private:
-  bool IsDimensionSupported(const Node* node) const;
+  bool IsDimensionSupported(const Node* node, const GraphViewer& graph_viewer) const;
+  bool IsWeightZeroPointConstantZero(const NodeArg* node, const GraphViewer& graph_viewer) const;
 };
 
 /**

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -329,4 +329,16 @@ class DnnlErfNodeCapability : public DnnlDefaultNodeCapability {
   DnnlBinaryNodeCapability _binary;
 };
 
+
+class DnnlQAttentionNodeCapability : public DnnlDefaultNodeCapability {
+ public:
+  DnnlQAttentionNodeCapability() : DnnlDefaultNodeCapability({type_float32,
+                                                              type_int8,
+                                                              type_uint8}) {}
+  bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
+
+ private:
+  bool IsDimensionSupported(const Node* node) const;
+};
+                                 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -30,6 +30,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("MaxPool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Mul", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Pow", std::unique_ptr<DnnlNodeCapability>(new DnnlPowNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("QAttention", std::unique_ptr<DnnlNodeCapability>(new DnnlQAttentionNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("ReduceMean", std::unique_ptr<DnnlNodeCapability>(new DnnlReduceMeanNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Relu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Reshape", std::unique_ptr<DnnlNodeCapability>(new DnnlReshapeNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.cc
@@ -1,0 +1,326 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_qattention.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+#include <cmath>
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+DnnlQAttention::DnnlQAttention() {}
+
+//compute a total scale memory from input and weight scale
+dnnl::memory DnnlQAttention::ComputeTotalScale(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto eng = sp.GetEngine();
+  bool has_input_scale = node.Input(INPUT_SCALE).Exists();
+  bool has_weights_scale = node.Input(WEIGHTS_SCALE).Exists();
+  auto input_scale_mem = has_input_scale ? sp.GetMemory(node.Input(INPUT_SCALE)) : dnnl::memory();
+  auto weights_scale_mem = has_weights_scale ? sp.GetMemory(node.Input(WEIGHTS_SCALE)) : dnnl::memory();
+
+  if (input_scale_mem && weights_scale_mem) {
+    //force descriptor to be 1 dim, will fail if product of dims not equal 1
+    auto src_0_md = input_scale_mem.get_desc().reshape({1});
+    auto src_1_md = weights_scale_mem.get_desc().reshape({1});
+    auto dst_md = src_1_md;
+    auto binary_d = dnnl::binary::desc(dnnl::algorithm::binary_mul, src_0_md, src_1_md, dst_md);
+    auto binary_pd = dnnl::binary::primitive_desc(binary_d, eng);
+
+    auto binary_src0_mem = sp.GetMemoryAndReshape(node.Input(INPUT_SCALE), binary_pd.src0_desc(), eng);
+    auto binary_src1_mem = sp.GetMemoryAndReshape(node.Input(WEIGHTS_SCALE), binary_pd.src1_desc(), eng);
+    auto binary_dst_mem = dnnl::memory(binary_pd.dst_desc(), eng);
+    auto binary_prim = dnnl::binary(binary_pd);
+    sp.AddPrimitive(binary_prim, {{DNNL_ARG_SRC_0, binary_src0_mem}, {DNNL_ARG_SRC_1, binary_src1_mem}, {DNNL_ARG_DST, binary_dst_mem}});
+    return binary_dst_mem;
+  } else if (input_scale_mem) {
+    return sp.GetMemoryAndReshape(node.Input(INPUT_SCALE), input_scale_mem.get_desc().reshape({1}), eng);
+  } else if (weights_scale_mem) {
+    return sp.GetMemoryAndReshape(node.Input(WEIGHTS_SCALE), weights_scale_mem.get_desc().reshape({1}), eng);
+  } else {
+    return dnnl::memory();
+  }
+}
+
+//obtain the number of heads for qattention node
+dnnl::memory::dim DnnlQAttention::GetNumHeads(DnnlNode& node) {
+  auto attr = node.Attributes().find("num_heads");
+  if (attr != node.Attributes().end()) {
+    return attr->second().i();
+  } else {
+    //num_heads should always exists as an attribute in qattention
+    ORT_THROW("NUM_HEADS NOT EXIST");
+  }
+}
+
+/*
+limitations
+  scalar input zp
+  scalar weight zp
+  scalar input scale
+  scalar weight scale
+  2D raw mask
+*/
+void DnnlQAttention::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto eng = sp.GetEngine();
+
+  dnnl::memory QKV_mem;
+  {
+    //prepare zero points for int8 matmul primitive
+    dnnl::primitive_attr matmul_attr;
+    bool has_input_zero_point = node.Input(INPUT_ZP).Exists();
+    bool has_weights_zero_point = node.Input(WEIGHTS_ZP).Exists();
+
+    // (i-izp)*(w-wzp)
+    {
+      //set input zp
+      if (has_input_zero_point) {
+        matmul_attr.set_zero_points(DNNL_ARG_SRC, 0, {DNNL_RUNTIME_S32_VAL});
+      }
+
+      //set weight zp
+      if (has_weights_zero_point) {
+        matmul_attr.set_zero_points(DNNL_ARG_WEIGHTS, 0, {DNNL_RUNTIME_S32_VAL});
+      }
+    }
+
+    dnnl::memory::desc input_md;
+    dnnl::memory::desc weights_md;
+
+    {
+      auto input_md_ori = sp.GetMemory(node.Input(INPUT)).get_desc();
+      auto weights_md_ori = sp.GetMemory(node.Input(WEIGHTS)).get_desc();
+
+      auto weights_dims = weights_md_ori.dims();
+      weights_dims.insert(weights_dims.begin(), 1);
+
+      input_md = dnnl::memory::desc(input_md_ori.dims(), input_md_ori.data_type(), dnnl::memory::format_tag::any);
+      weights_md = dnnl::memory::desc(weights_dims, weights_md_ori.data_type(), dnnl::memory::format_tag::any);
+    }
+
+    dnnl::memory::desc QKV_md;
+    {
+      //the output of int8 matmul is always 3 dims and consists of Q,K,V values
+      auto QKV_dims = input_md.dims();
+      QKV_dims[2] = weights_md.dims()[2];
+      //use format any for optimization
+      QKV_md = dnnl::memory::desc(QKV_dims, dnnl::memory::data_type::f32, dnnl::memory::format_tag::any);
+    }
+
+    auto matmul_d = dnnl::matmul::desc(input_md, weights_md, QKV_md);
+    auto matmul_pd = dnnl::matmul::primitive_desc(matmul_d, matmul_attr, eng);
+    // (input-input_zero_point)*(weight-weight_zero_point)
+    auto matmul_prim = dnnl::matmul(matmul_pd);
+
+    auto matmul_src_mem = sp.GetMemoryAndReshape(node.Input(INPUT), matmul_pd.src_desc(), eng);
+    auto matmul_weights_mem = sp.GetMemoryAndReshape(node.Input(WEIGHTS), matmul_pd.weights_desc(), eng);
+    QKV_mem = dnnl::memory(matmul_pd.dst_desc(), eng);
+
+    std::unordered_map<int, dnnl::memory> mem_map({{DNNL_ARG_SRC, matmul_src_mem},
+                                                   {DNNL_ARG_WEIGHTS, matmul_weights_mem},
+                                                   {DNNL_ARG_DST, QKV_mem}});
+
+    if (has_input_zero_point) {
+      auto zp_mem_desc = dnnl::memory::desc({1}, dnnl::memory::data_type::s32, {1});
+      auto tensor = node.Input(INPUT_ZP);
+      auto zp_mem = sp.GetMemoryAndReshape(tensor, zp_mem_desc, eng);
+      mem_map[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC] = zp_mem;
+    }
+
+    if (has_weights_zero_point) {
+      auto zp_mem_desc = dnnl::memory::desc({1}, dnnl::memory::data_type::s32, {1});
+      auto tensor = node.Input(WEIGHTS_ZP);
+      auto zp_mem = sp.GetMemoryAndReshape(tensor, zp_mem_desc, eng);
+      mem_map[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = zp_mem;
+    }
+
+    //(i-izp)*(w-wzp)
+    sp.AddPrimitive(matmul_prim, mem_map);
+  }
+
+  //in place binary add with source0 scaling
+  {
+    //compute a total scale from input scale and weight scale
+    //i_scale * w_scale if both exist
+    auto total_scale_mem = ComputeTotalScale(sp, node);
+
+    auto bias_md = sp.GetMemory(node.Input(BIAS)).get_desc();
+    bias_md = bias_md.reshape({1, 1, bias_md.dims()[0]});
+    auto QKV_desc = QKV_mem.get_desc();
+
+    //always broadcast from bias to QKV
+    auto binary_d = dnnl::binary::desc(dnnl::algorithm::binary_add, QKV_desc, bias_md, QKV_desc);
+
+    dnnl::primitive_attr binary_attr;
+    //scale source 0, matmul output
+    if (total_scale_mem) {
+      binary_attr.set_scales(DNNL_ARG_SRC_0, 0, {DNNL_RUNTIME_F32_VAL});
+    }
+
+    auto binary_pd = dnnl::binary::primitive_desc(binary_d, binary_attr, eng);
+    auto binary_prim = dnnl::binary(binary_pd);
+
+    auto bias_mem = sp.GetMemoryAndReshape(node.Input(BIAS), binary_pd.src1_desc(), eng);
+
+    std::unordered_map<int, dnnl::memory> binary_mem_map({{DNNL_ARG_SRC_0, QKV_mem},
+                                                          {DNNL_ARG_SRC_1, bias_mem},
+                                                          {DNNL_ARG_DST, QKV_mem}});
+
+    if (total_scale_mem) {
+      binary_mem_map[DNNL_ARG_ATTR_INPUT_SCALES | DNNL_ARG_SRC_0] = total_scale_mem;
+    }
+
+    sp.AddPrimitive(binary_prim, binary_mem_map);
+  }
+
+  //parse some dim information for permute and reshape
+  //eg, 8,512,2034 = 8,512,(3,12,64)
+  auto batch_size = QKV_mem.get_desc().dims()[0];
+  auto sequence_length = QKV_mem.get_desc().dims()[1];
+  auto num_heads = GetNumHeads(node);
+  auto hidden_size = QKV_mem.get_desc().dims()[2] / 3;
+  auto head_size = hidden_size / num_heads;
+
+  //slice QKV into submemories
+  auto Q_md = QKV_mem.get_desc().submemory_desc({batch_size, sequence_length, hidden_size}, {0, 0, 0});
+  auto K_md = QKV_mem.get_desc().submemory_desc({batch_size, sequence_length, hidden_size}, {0, 0, hidden_size});
+  auto V_md = QKV_mem.get_desc().submemory_desc({batch_size, sequence_length, hidden_size}, {0, 0, hidden_size * 2});
+
+  //split QKV last dim to num_heads, hidden_dim
+  Q_md = Q_md.reshape({batch_size, sequence_length, num_heads, head_size});
+  K_md = K_md.reshape({batch_size, sequence_length, num_heads, head_size});
+  V_md = V_md.reshape({batch_size, sequence_length, num_heads, head_size});
+
+  //permute K and QV
+  Q_md = Q_md.permute_axes({0, 2, 1, 3});
+  //K is different as it needs to be tranposed
+  K_md = K_md.permute_axes({0, 3, 1, 2});
+  V_md = V_md.permute_axes({0, 2, 1, 3});
+
+  bool has_mask_index = node.Input(MASK_INDEX).Exists();
+  auto mask_index_mem = dnnl::memory();  // mask_index will reside in this memory
+
+  //prepare mask for calculating attention probs
+  //batch_size, max_sequence_length
+  //need a reorder of data type from s32 to f32 to let mask to have the same data type as QK result
+  if (has_mask_index) {
+    auto mask_index_mem_desc = sp.GetMemory(node.Input(MASK_INDEX)).get_desc();
+
+    auto linear_d = dnnl::eltwise_forward::desc(dnnl::prop_kind::forward_inference, dnnl::algorithm::eltwise_linear, mask_index_mem_desc, 10000.0f, -10000.0f);
+    auto linear_pd = dnnl::eltwise_forward::primitive_desc(linear_d, eng);
+
+    auto mask_index_ori_mem = sp.GetMemoryAndReshape(node.Input(MASK_INDEX), linear_pd.src_desc(), eng);
+    assert(linear_pd.dst_desc().data_type() == dnnl::memory::data_type::s32);
+    auto mask_index_mem_unbroadcasted = dnnl::memory(linear_pd.dst_desc(), eng);
+
+    auto linear_prim = dnnl::eltwise_forward(linear_pd);
+    //mask = 10000*mask-10000
+    sp.AddPrimitive(linear_prim, {{DNNL_ARG_SRC, mask_index_ori_mem}, {DNNL_ARG_DST, mask_index_mem_unbroadcasted}});
+
+    dnnl::memory mask_index_mem_unbroadcasted_f32;
+    {
+      auto md = mask_index_mem_unbroadcasted.get_desc();
+      auto dims = md.dims();
+      auto strides = md.data.format_desc.blocking.strides;
+      dnnl::memory::dims strides_vec;
+      for (size_t i = 0; i < dims.size(); i++) {
+        strides_vec.push_back(strides[i]);
+      }
+      auto mask_index_md_unbroadcasted_f32 = dnnl::memory::desc(dims, dnnl::memory::data_type::f32, strides_vec);
+      mask_index_mem_unbroadcasted_f32 = dnnl::memory(mask_index_md_unbroadcasted_f32, eng);
+      sp.AddPrimitive(dnnl::reorder(mask_index_mem_unbroadcasted, mask_index_mem_unbroadcasted_f32), {{DNNL_ARG_FROM, mask_index_mem_unbroadcasted}, {DNNL_ARG_TO, mask_index_mem_unbroadcasted_f32}});
+    }
+
+    //unsqueeze the mem for broadcasting
+    auto mask_index_dims = mask_index_mem_unbroadcasted_f32.get_desc().dims();
+    //not symetric, simply broadcasting
+    //eg 8,512 -> 8,1,1,512
+    //eg 8,1,1,512 -> 8,12,512,512
+    mask_index_dims.insert(mask_index_dims.begin() + 1, 1);
+    mask_index_dims.insert(mask_index_dims.begin() + 2, 1);
+    auto mask_index_broadcasted_md = mask_index_mem_unbroadcasted_f32.get_desc().reshape(mask_index_dims);
+    //set mask_index_mem
+    mask_index_mem = dnnl::memory(mask_index_broadcasted_md, eng, nullptr);
+    dnnl::stream s(eng);
+    mask_index_mem.set_data_handle(mask_index_mem_unbroadcasted_f32.get_data_handle(), s);
+    s.wait();
+  }
+
+  dnnl::memory QK_mem;
+  //matmul Q and K (transpose) with mask as binary post op followed by binary div (normalization) and in place softmax.
+  //softmax((Q * K(T) + MASK ) / sqrt(head_dim))
+  {
+    dnnl::primitive_attr QK_attr;
+    {
+      auto scales = std::vector<float>({float(1 / std::sqrt(head_size))});
+      QK_attr.set_output_scales(0, scales);
+
+      if (mask_index_mem) {
+        dnnl::post_ops add_bias;
+        add_bias.append_binary(dnnl::algorithm::binary_add, mask_index_mem.get_desc());
+        QK_attr.set_post_ops(add_bias);
+      }
+    }
+
+    auto QK_md = dnnl::memory::desc({batch_size, num_heads, sequence_length, sequence_length}, dnnl::memory::data_type::f32, dnnl::memory::format_tag::any);
+    auto QK_d = dnnl::matmul::desc(Q_md, K_md, QK_md);
+    auto QK_pd = dnnl::matmul::primitive_desc(QK_d, QK_attr, eng);
+    auto QK_prim = dnnl::matmul(QK_pd);
+
+    QK_mem = dnnl::memory(QK_pd.dst_desc(), eng);
+    {
+      //QKV_mem is used as both input and weight but since matmul is defined on submemory, computation will be applied to correct submemory
+      std::unordered_map<int, dnnl::memory> QK_mem_map({{DNNL_ARG_SRC, QKV_mem},
+                                                        {DNNL_ARG_WEIGHTS, QKV_mem},
+                                                        {DNNL_ARG_DST, QK_mem}});
+      if (mask_index_mem) {
+        QK_mem_map[DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1] = mask_index_mem;
+      }
+      sp.AddPrimitive(QK_prim, QK_mem_map);
+    }
+
+    //apply softmax in place to produce attention prob
+    {
+      auto softmax_desc = dnnl::softmax_forward::desc(dnnl::prop_kind::forward_inference, QK_mem.get_desc(), 3);
+      auto softmax_pd = dnnl::softmax_forward::primitive_desc(softmax_desc, eng);
+      auto softmax_prim = dnnl::softmax_forward::primitive(softmax_pd);
+
+      //QK = softmax(QK) in place
+      sp.AddPrimitive(softmax_prim, {{DNNL_ARG_SRC, QK_mem}, {DNNL_ARG_DST, QK_mem}});
+    }
+  }
+
+  //matmul attention_probs with V to produce the final attended result
+  dnnl::memory QAttention_dst_mem;
+  {
+    //format acbd in order to work with subsequent permute and merge to produce ort format memory
+    auto QAttention_dst_md = dnnl::memory::desc({batch_size, num_heads, sequence_length, head_size}, dnnl::memory::data_type::f32, dnnl::memory::format_tag::acbd);
+
+    auto Prob_V_d = dnnl::matmul::desc(QK_mem.get_desc(), V_md, QAttention_dst_md);
+    auto Prob_V_pd = dnnl::matmul::primitive_desc(Prob_V_d, eng);
+    auto Prob_V_prim = dnnl::matmul(Prob_V_pd);
+
+    QAttention_dst_mem = dnnl::memory(Prob_V_pd.dst_desc(), eng);
+    std::unordered_map<int, dnnl::memory> Prob_V_mem_map({{DNNL_ARG_SRC, QK_mem},
+                                                          {DNNL_ARG_WEIGHTS, QKV_mem},
+                                                          {DNNL_ARG_DST, QAttention_dst_mem}});
+    //prob * V
+    sp.AddPrimitive(Prob_V_prim, Prob_V_mem_map);
+  }
+
+  //permute and merge axes through reshape
+  {
+    auto QAttention_dst_md_BNSH = QAttention_dst_mem.get_desc();
+    //swap axes
+    auto QAttention_dst_md_BSNH = QAttention_dst_md_BNSH.permute_axes({0, 2, 1, 3});
+    //merge axes
+    auto QAttention_dst_md_BSH = QAttention_dst_md_BSNH.reshape({batch_size, sequence_length, hidden_size});
+    auto QAttention_dst_mem_correct_shape = dnnl::memory(QAttention_dst_md_BSH, eng, nullptr);
+    sp.AddReshape(QAttention_dst_mem, QAttention_dst_mem_correct_shape);
+    //needs to copy if it outputs for subgraph
+    sp.SetMemory(node.Output(OUTPUT), QAttention_dst_mem_correct_shape, true);
+  }
+}
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.h
@@ -1,0 +1,39 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlQAttention {
+ public:
+  enum InputTensors : int {
+    INPUT = 0,
+    WEIGHTS = 1,
+    BIAS = 2,
+    INPUT_SCALE = 3,
+    WEIGHTS_SCALE = 4,
+    MASK_INDEX = 5,
+    INPUT_ZP = 6,
+    WEIGHTS_ZP = 7,
+    PAST = 8  // not suppoted
+  };
+
+  enum OutputTensors : int {
+    OUTPUT = 0,
+    PRESENT = 1  // not supported
+  };
+
+  DnnlQAttention();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+ private:
+  dnnl::memory ComputeTotalScale(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+  dnnl::memory::dim GetNumHeads(DnnlNode& node);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -506,6 +506,8 @@ dnnl::memory DnnlSubgraphPrimitive::GetMemoryAndReshape(const DnnlTensor& tensor
     auto mem_from_dims = mem_from.get_desc().dims();
     auto mem_to_dims = mem_to.get_desc().dims();
     if (Product(mem_from_dims) != Product(mem_to_dims)) {
+      LOGS_DEFAULT(ERROR) << mem_from_dims;
+      LOGS_DEFAULT(ERROR) << mem_to_dims;
       throw std::invalid_argument("not a valid reshape, inconsistent dim product");
     }
     //keep the same data type from mem_from but reshape the dims with mem_desc

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -15,6 +15,7 @@
 #include "dnnl_matmul_integer.h"
 #include "dnnl_pool.h"
 #include "dnnl_pow.h"
+#include "dnnl_qattention.h"
 #include "dnnl_reducemean.h"
 #include "dnnl_reshape.h"
 #include "dnnl_softmax.h"
@@ -30,12 +31,88 @@
 #include "dnnl_relugrad.h"
 #endif
 
+#include <inttypes.h>
+#include <stdio.h>
+
+
 namespace onnxruntime {
 namespace ort_dnnl {
 
 template <class Map, class Key>
 inline bool Contains(const Map& map, const Key& key) {
   return map.find(key) != map.end();
+}
+
+
+void DnnlSubgraphPrimitive::PrintMemory(const dnnl::memory& mem) {
+  auto md = mem.get_desc();
+  auto dt = md.data_type();
+  auto dims = md.dims();
+  if (Product(dims) > 50) {
+    printf("tensor too long ignore printing \n");
+    return;
+  }
+  dnnl::memory to_mem;
+  if (!IsMemoryInExpectedOrtFormat(md)|| mem.get_engine().get_kind() != dnnl::engine::kind::cpu) {
+    printf("\n print memory reorder started \n");
+    dnnl::memory::desc to_md = dnnl::memory::desc(md.dims(), md.data_type(), GetDnnlFormat(md.dims().size()));
+    to_mem = dnnl::memory(to_md, GetCPUEngine());
+    auto stream = dnnl::stream(mem.get_engine());
+    dnnl::reorder(mem, to_mem).execute(stream, {{DNNL_ARG_FROM, mem}, {DNNL_ARG_TO, to_mem}});
+    stream.wait();
+    printf("\n print memory reorder ended \n");
+  } else {
+    to_mem = mem;
+  }
+
+  if (dt == dnnl::memory::data_type::f32) {
+    std::vector<float> data_vec(Product(dims));
+    auto dh = to_mem.get_data_handle();
+    for (size_t i = 0; i < to_mem.get_desc().get_size(); ++i) {
+      ((char*)data_vec.data())[i] = ((char*)dh)[i];
+    }
+
+    for (auto& data : data_vec) {
+      printf("%.6f \n", data);
+    }
+    printf("\n");
+  }
+  else if (dt == dnnl::memory::data_type::u8) {
+    std::vector<uint8_t> data_vec(Product(dims));
+    auto dh = to_mem.get_data_handle();
+    for (size_t i = 0; i < to_mem.get_desc().get_size(); ++i) {
+      ((char*)data_vec.data())[i] = ((char*)dh)[i];
+    }
+
+    for (auto& data : data_vec) {
+      printf("%" PRIu8 "\n", data);
+    }
+    printf("\n");
+  } else if (dt == dnnl::memory::data_type::s8) {
+    std::vector<int8_t> data_vec(Product(dims));
+    auto dh = to_mem.get_data_handle();
+    for (size_t i = 0; i < to_mem.get_desc().get_size(); ++i) {
+      ((char*)data_vec.data())[i] = ((char*)dh)[i];
+    }
+
+    for (auto& data : data_vec) {
+      printf("%" PRIi8 "\n", data);
+    }
+    printf("\n");
+  } else if (dt == dnnl::memory::data_type::s32) {
+    std::vector<int32_t> data_vec(Product(dims));
+    auto dh = to_mem.get_data_handle();
+    for (size_t i = 0; i < to_mem.get_desc().get_size(); ++i) {
+    ((char*)data_vec.data())[i] = ((char*)dh)[i];
+    }
+
+    for (auto& data : data_vec) {
+      printf("%" PRIi32 "\n", data);
+    }
+    printf("\n");
+  } else {
+    ORT_THROW("Cannot print such data type");
+  }
 }
 
 int Product(dnnl::memory::dims d) {
@@ -79,6 +156,8 @@ void DnnlSubgraphPrimitive::AddKernels() {
       DnnlPool().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Pow") {
       DnnlPow().CreatePrimitive(*this, node);
+    } else if (node.OpType() == "QAttention") {
+      DnnlQAttention().CreatePrimitive(*this, node);
     } else if (node.OpType() == "ReduceMean") {
       DnnlReduceMean().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Reshape") {
@@ -429,10 +508,21 @@ dnnl::memory DnnlSubgraphPrimitive::GetMemoryAndReshape(const DnnlTensor& tensor
     if (Product(mem_from_dims) != Product(mem_to_dims)) {
       throw std::invalid_argument("not a valid reshape, inconsistent dim product");
     }
-    auto mem_from_reshape = dnnl::memory(mem_desc, mem_from.get_engine(), nullptr);
+    //keep the same data type from mem_from but reshape the dims with mem_desc
+    auto mem_from_reshape_md = mem_from.get_desc();
+    if (transpose) {  
+      //hard coded to transpose 2 dimensional matrix
+      //TODO: expand to arbitrary permutation or transpose on given 2 dims for higher dimensional tensors
+      mem_from_reshape_md = mem_from_reshape_md.permute_axes({1, 0});
+    }
+    mem_from_reshape_md = mem_from_reshape_md.reshape(mem_desc.dims());
+    auto mem_from_reshape = dnnl::memory(mem_from_reshape_md, mem_from.get_engine(), nullptr);
     if (is_constant) {  // if constant, do reshape now
       LOGS_DEFAULT(INFO) << "reshaped now";
-      mem_from_reshape.set_data_handle(mem_from.get_data_handle());
+      //use the stream as a hint to make sure data handle gets set
+      dnnl::stream s{eng};
+      mem_from_reshape.set_data_handle(mem_from.get_data_handle(),s);
+      s.wait();
     } else {
       AddReshape(mem_from, mem_from_reshape);
     }
@@ -506,34 +596,55 @@ void DnnlSubgraphPrimitive::AddReshape(dnnl::memory src, dnnl::memory dst) {
   reshapes_.push_back({src, dst});
 }
 
-void DnnlSubgraphPrimitive::AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map) {
+void DnnlSubgraphPrimitive::AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map, std::vector<int> items_to_print) {
   net_.push_back(prim);
   net_args_.push_back(mem_map);
+  for (auto e : items_to_print) {
+    items_to_print_.push_back({int(net_.size() - 1), e});
+  }
 }
 
 onnxruntime::common::Status DnnlSubgraphPrimitive::Predict(const std::unordered_map<std::string, OnnxTensorData>& inputs, const std::unordered_map<std::string, OnnxTensorData>& outputs) {
+
+  auto stream = GetStream();
+
   for (auto& input : inputs) {
     if (Contains(inputs_, input.first)) {
-      inputs_.at(input.first).set_data_handle(input.second.buffer);
+      inputs_.at(input.first).set_data_handle(input.second.buffer, stream);
+      stream.wait();
     }
   }
 
   for (auto& output : outputs) {
     if (Contains(outputs_, output.first)) {
-      outputs_.at(output.first).set_data_handle(output.second.buffer);
+      outputs_.at(output.first).set_data_handle(output.second.buffer, stream);
+      stream.wait();
     }
   }
 
   // reshapes (eg, unsqueeze)
   // it is safe to set data handle because all external data handles have been set and onednn managed memory data handles will not change
   for (auto& reshape_pair : reshapes_) {
-    reshape_pair.second.set_data_handle(reshape_pair.first.get_data_handle());
+    reshape_pair.second.set_data_handle(reshape_pair.first.get_data_handle(),stream);
+    stream.wait();
   }
 
-  auto stream = GetStream();
+  
   for (size_t i = 0; i < net_.size(); ++i) {
     net_.at(i).execute(stream, net_args_.at(i));
     stream.wait();
+    
+    //for debug memory purpose
+    /*
+    for (auto e : items_to_print_) {
+      auto net_index = e.first;
+      auto net_arg_index = e.second;
+      if (net_index == i) {
+        PrintMemory(net_args_.at(i)[net_arg_index]);
+      }
+    }
+    */
+    
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -48,7 +48,7 @@ class DnnlSubgraphPrimitive {
   //obtain a dnnl::memory with specified name, memory descriptor and engine, will perform extra reorder/reshape if necessary before returning
   dnnl::memory GetMemoryAndReshape(const DnnlTensor& tensor, dnnl::memory::desc mem_desc, dnnl::engine eng, bool transpose = false);
   //add dnnl primitive and memory map to subgraph primitive
-  void AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map);
+  void AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map, std::vector<int> items_to_print = {});
   //add a reshape (e.g. squeeze, unsqueeze) to subgraph primitive
   void AddReshape(dnnl::memory src, dnnl::memory dst);
   bool HasMemory(std::string memory_name, dnnl::memory::desc mem_desc, dnnl::engine eng);
@@ -106,6 +106,11 @@ class DnnlSubgraphPrimitive {
   dnnl::engine gpu_engine_;
 
   OrtMutex mutex_;
+
+  //for memory debug purpose
+  std::vector<std::pair<int,int>> items_to_print_;
+  void PrintMemory(const dnnl::memory& mem);
+  
 };
 
 }  // namespace ort_dnnl

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -48,6 +48,8 @@ class DnnlSubgraphPrimitive {
   //obtain a dnnl::memory with specified name, memory descriptor and engine, will perform extra reorder/reshape if necessary before returning
   dnnl::memory GetMemoryAndReshape(const DnnlTensor& tensor, dnnl::memory::desc mem_desc, dnnl::engine eng, bool transpose = false);
   //add dnnl primitive and memory map to subgraph primitive
+  //when you add primitive, you can optionally specify a vector of indexes to be printed in runtime for debug purpose
+  //eg, sp.AddPrimitve(prim,mem_map,{DNNL_ARG_SRC})
   void AddPrimitive(dnnl::primitive prim, std::unordered_map<int, dnnl::memory> mem_map, std::vector<int> items_to_print = {});
   //add a reshape (e.g. squeeze, unsqueeze) to subgraph primitive
   void AddReshape(dnnl::memory src, dnnl::memory dst);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.cc
@@ -758,7 +758,6 @@ void DnnlGraphTransformer::RemoveMatMulIntegerZP(DnnlSubgraph& subgraph) {
       continue;
     }
 
-    //auto matmulint_node = dnnl_node;
     //if B zero point exists
     if (!(dnnl_node->InputCount() >= 4 && dnnl_node->Input(3).Exists())) {
       continue;
@@ -766,7 +765,6 @@ void DnnlGraphTransformer::RemoveMatMulIntegerZP(DnnlSubgraph& subgraph) {
 
     auto b_zero_point = dnnl_node->Input(3);
     const ONNX_NAMESPACE::TensorProto* tensor_proto = nullptr;
-    //subgraph.GetInitializedTensor(b_zero_point.Name(), tensor_proto);
     if (!subgraph.GetInitializedTensor(b_zero_point.Name(), tensor_proto)) {
       continue;
     }
@@ -775,20 +773,6 @@ void DnnlGraphTransformer::RemoveMatMulIntegerZP(DnnlSubgraph& subgraph) {
       continue;
     }
 
-    //std::vector<uint8_t> unpacked_tensor;
-    //ORT_THROW_IF_ERROR(onnxruntime::utils::UnpackInitializerData(*tensor_proto, unpacked_tensor));
-
-    //if (unpacked_tensor.size() > 0) {
-    //  continue;
-    //}
-
-
-    //auto has_raw_data = tensor_proto->has_raw_data();
-    //if (!has_raw_data) {
-    //  continue;
-    //}
-
-    const auto data_type = b_zero_point.Type();
     const auto& dims = tensor_proto->dims();
     auto dim_size = tensor_proto->dims_size();
     int num_elements = 1;
@@ -796,7 +780,7 @@ void DnnlGraphTransformer::RemoveMatMulIntegerZP(DnnlSubgraph& subgraph) {
       num_elements *= int(dims[i]);
     }
 
-    //check if b_zp is all zeros
+    //check if b_zp is all zeros, assume data is s8 since only s8 weight is supported in onednn
     bool all_zero = true;
     std::vector<int8_t> unpacked_tensor;
     unpacked_tensor.resize(num_elements,1);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 #include "dnnl_subgraph_transformer.h"
+#include "core/providers/shared_library/provider_api.h"
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif
@@ -16,6 +17,7 @@ void DnnlGraphTransformer::Apply(DnnlSubgraph& subgraph) {
   MatMulAdd(subgraph);
   Gelu(subgraph);
   FastGelu(subgraph);
+  RemoveMatMulIntegerZP(subgraph);
 }
 
 //resolve a fusion by replacing old_indices nodes with a new_node
@@ -743,6 +745,81 @@ void DnnlGraphTransformer::MatMulAdd(DnnlSubgraph& subgraph) {
       LOGS_DEFAULT(ERROR) << "MatMulAdd fusion of [" << matmul_node->Name() << "] and [" << add_node->Name() << "]";
     }
     ResolveFusion(subgraph, {matmul_node->Index(), add_node->Index()}, std::move(fused_node));
+  }
+}
+
+void DnnlGraphTransformer::RemoveMatMulIntegerZP(DnnlSubgraph& subgraph) {
+  size_t max_index = subgraph.GetMaxNodeIndex();
+  for (size_t index = 0; index < max_index; index++) {
+    auto dnnl_node = subgraph.GetDnnlNode(index);
+
+    //look for matmulint
+    if (dnnl_node == nullptr || dnnl_node->OpType() != "MatMulInteger") {
+      continue;
+    }
+
+    //auto matmulint_node = dnnl_node;
+    //if B zero point exists
+    if (!(dnnl_node->InputCount() >= 4 && dnnl_node->Input(3).Exists())) {
+      continue;
+    }
+
+    auto b_zero_point = dnnl_node->Input(3);
+    const ONNX_NAMESPACE::TensorProto* tensor_proto = nullptr;
+    //subgraph.GetInitializedTensor(b_zero_point.Name(), tensor_proto);
+    if (!subgraph.GetInitializedTensor(b_zero_point.Name(), tensor_proto)) {
+      continue;
+    }
+
+    if (tensor_proto == nullptr) {
+      continue;
+    }
+
+    //std::vector<uint8_t> unpacked_tensor;
+    //ORT_THROW_IF_ERROR(onnxruntime::utils::UnpackInitializerData(*tensor_proto, unpacked_tensor));
+
+    //if (unpacked_tensor.size() > 0) {
+    //  continue;
+    //}
+
+
+    //auto has_raw_data = tensor_proto->has_raw_data();
+    //if (!has_raw_data) {
+    //  continue;
+    //}
+
+    const auto data_type = b_zero_point.Type();
+    const auto& dims = tensor_proto->dims();
+    auto dim_size = tensor_proto->dims_size();
+    int num_elements = 1;
+    for (int i = 0; i < dim_size; i++) {
+      num_elements *= int(dims[i]);
+    }
+
+    //check if b_zp is all zeros
+    bool all_zero = true;
+    std::vector<int8_t> unpacked_tensor;
+    unpacked_tensor.resize(num_elements,1);
+    ORT_THROW_IF_ERROR(onnxruntime::utils::UnpackTensor(*tensor_proto, tensor_proto->has_raw_data() ? tensor_proto->raw_data().data() : nullptr, tensor_proto->has_raw_data() ? tensor_proto->raw_data().size() : 0, reinterpret_cast<int8_t*>(unpacked_tensor.data()), num_elements));
+    for (const auto& val : unpacked_tensor) {
+      if (val != 0) {
+        all_zero = false;
+        break;
+      }
+    }
+    
+
+    if (!all_zero) {
+      continue;
+    }
+
+    if (debug_log_) {
+      LOGS_DEFAULT(ERROR) << "Remove weight ZP of [" << dnnl_node->Name() << "]";
+    }
+    //remove b_zero_point's consumer matmulint
+    b_zero_point.RemoveConsumer(DnnlNodeArg(dnnl_node, 3, false));
+    //detach b_zero_point from matmulint node
+    dnnl_node->Inputs()[3] = nullptr;
   }
 }
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_transformer.h
@@ -26,6 +26,7 @@ class DnnlGraphTransformer {
   bool IsInitilizedWithExpectedValue(DnnlSubgraph& subgraph, DnnlTensor& input_arg, float expected_value);
   void ConvRelu(DnnlSubgraph& subgraph);
   void MatMulAdd(DnnlSubgraph& subgraph);
+  void RemoveMatMulIntegerZP(DnnlSubgraph& subgraph);
   // This function checks a few things
   //   - the node in question has a single output
   //   - The output of the node is only consumed by a one other node

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -173,10 +173,6 @@ static void RunQAttentionDNNL(
     weights_quant_params.zero_point = 1;
   }
 
-  if (is_unidirectional) {
-    return;
-  }
-
   RunQAttention<uint8_t, int8_t, EP::DNNL>(
       input_data, weights_data, bias_data, mask_index_data, output_data, input_quant_params, weights_quant_params,
       batch_size, sequence_length, hidden_size, number_of_heads, is_unidirectional, false, input_hidden_size);
@@ -264,6 +260,7 @@ static void RunQAttentionAll(
                     use_special_quantize_parameter, is_unidirectional, input_hidden_size);
 }
 
+//ONEDNN EP only supports 2D raw mask
 #ifdef USE_DNNL
 TEST(QAttentionTest, QAttentionDNNLBatch1) {
   int batch_size = 1;
@@ -389,6 +386,7 @@ TEST(QAttentionTest, QAttentionBatch2) {
                    batch_size, sequence_length, hidden_size, number_of_heads);
 }
 
+//ONEDNN EP only support 2D raw mask
 #ifdef USE_DNNL
 TEST(QAttentionTest, QAttentionDNNLBatch2) {
   int batch_size = 2;
@@ -454,6 +452,7 @@ TEST(QAttentionTest, QAttentionMaskPartialSequence) {
                    batch_size, sequence_length, hidden_size, number_of_heads);
 }
 
+//oneDNN EP only supports 2D raw mask
 #ifdef USE_DNNL
 TEST(QAttentionTest, QAttentionDNNLMaskPartialSequence) {
   int batch_size = 1;
@@ -474,7 +473,6 @@ TEST(QAttentionTest, QAttentionDNNLMaskPartialSequence) {
   std::vector<float> bias_data = {
       -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
 
-  // Test mask_index < sequence_length
   std::vector<int32_t> mask_index_data = {1L, 0L};
 
   std::vector<float> output_data = {

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -56,10 +56,9 @@ void RunQAttention(const std::vector<float>& input_data,
   std::vector<int64_t> mask_index_dims = {batch_size};
   if constexpr (ep == EP::DNNL) {
     //onednn only supports raw mask
-    if (mask_index_data.size() != 0 && mask_index_data.size() != batch_size * sequence_length) {
-      return;
+    if (mask_index_data.size() == batch_size * sequence_length) {
+      mask_index_dims = {batch_size, sequence_length};
     }
-    mask_index_dims = {batch_size, sequence_length};
   }
   std::vector<int64_t> output_dims = {batch_size, sequence_length, hidden_size};
 

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -18,9 +18,9 @@ namespace test {
 
 enum class EP : char {
   CPU,
-  CUDA
+  CUDA,
+  DNNL
 };
-
 
 // input:      [batch_size, sequence_length, hidden_size]
 // weights:    [hidden_size, 3 * hidden_size]
@@ -54,6 +54,13 @@ void RunQAttention(const std::vector<float>& input_data,
   std::vector<int64_t> weights_dims = {input_hidden_size, static_cast<int64_t>(3 * hidden_size)};
   std::vector<int64_t> bias_dims = {static_cast<int64_t>(3 * hidden_size)};
   std::vector<int64_t> mask_index_dims = {batch_size};
+  if constexpr (ep == EP::DNNL) {
+    //onednn only supports raw mask
+    if (mask_index_data.size() != 0 && mask_index_data.size() != batch_size * sequence_length) {
+      return;
+    }
+    mask_index_dims = {batch_size, sequence_length};
+  }
   std::vector<int64_t> output_dims = {batch_size, sequence_length, hidden_size};
 
   if (input_quant_params.scale != 0.0f) {
@@ -103,9 +110,13 @@ void RunQAttention(const std::vector<float>& input_data,
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
     tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}, nullptr, &execution_providers);
-  } else {
+  } else if constexpr (ep == EP::CPU) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCpuExecutionProvider());
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}, nullptr, &execution_providers);
+  } else {  // onednn ep
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultDnnlExecutionProvider());
     tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider}, nullptr, &execution_providers);
   }
 }
@@ -138,6 +149,37 @@ static void RunQAttentionCUDA(
         input_data, weights_data, bias_data, mask_index_data, output_data, input_quant_params, weights_quant_params,
         batch_size, sequence_length, hidden_size, number_of_heads, is_unidirectional, use_float16, input_hidden_size);
   }
+}
+
+static void RunQAttentionDNNL(
+    const std::vector<float>& input_data,
+    const std::vector<float>& weights_data,
+    const std::vector<float>& bias_data,
+    const std::vector<int32_t>& mask_index_data,  // onednn only support raw mask data
+    const std::vector<float>& output_data,
+    int batch_size,
+    int sequence_length,
+    int hidden_size,
+    int number_of_heads,
+    bool use_special_quantize_parameter = true,
+    bool is_unidirectional = false,
+    int input_hidden_size = 0) {
+  quantization::Params<uint8_t> input_quant_params(/*scale=*/0.0f, /*zero_point=*/0);
+  quantization::Params<int8_t> weights_quant_params(/*scale=*/0.0f, /*zero_point=*/0);
+  if (use_special_quantize_parameter) {
+    input_quant_params.scale = 0.1f;
+    weights_quant_params.scale = 0.1f;
+    input_quant_params.zero_point = 128;
+    weights_quant_params.zero_point = 1;
+  }
+
+  if (is_unidirectional) {
+    return;
+  }
+
+  RunQAttention<uint8_t, int8_t, EP::DNNL>(
+      input_data, weights_data, bias_data, mask_index_data, output_data, input_quant_params, weights_quant_params,
+      batch_size, sequence_length, hidden_size, number_of_heads, is_unidirectional, false, input_hidden_size);
 }
 
 static void RunQAttentionU8U8(
@@ -217,7 +259,41 @@ static void RunQAttentionAll(
   RunQAttentionCUDA(input_data, weight_data, bias_data, mask_index_data, output_data,
                     batch_size, sequence_length, hidden_size, number_of_heads,
                     use_special_quantize_parameter, is_unidirectional, use_float16, input_hidden_size);
+  RunQAttentionDNNL(input_data, weight_data, bias_data, mask_index_data, output_data,
+                    batch_size, sequence_length, hidden_size, number_of_heads,
+                    use_special_quantize_parameter, is_unidirectional, input_hidden_size);
 }
+
+#ifdef USE_DNNL
+TEST(QAttentionTest, QAttentionDNNLBatch1) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int number_of_heads = 2;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+
+  std::vector<int32_t> mask_index_data = {1L, 1L};
+
+  std::vector<float> output_data = {
+      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
+      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f};
+
+  RunQAttentionDNNL(input_data, weight_data, bias_data, mask_index_data, output_data,
+                    batch_size, sequence_length, hidden_size, number_of_heads);
+}
+#endif  // USE_DNNL
 
 TEST(QAttentionTest, QAttentionBatch1) {
   int batch_size = 1;
@@ -313,6 +389,41 @@ TEST(QAttentionTest, QAttentionBatch2) {
                    batch_size, sequence_length, hidden_size, number_of_heads);
 }
 
+#ifdef USE_DNNL
+TEST(QAttentionTest, QAttentionDNNLBatch2) {
+  int batch_size = 2;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int number_of_heads = 2;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+
+  std::vector<int32_t> mask_index_data = {1L, 1L, 1L, 1L};
+
+  std::vector<float> output_data = {
+      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
+      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f,
+      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
+      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f};
+
+  RunQAttentionDNNL(input_data, weight_data, bias_data, mask_index_data, output_data,
+                    batch_size, sequence_length, hidden_size, number_of_heads);
+}
+#endif  // USE_DNNL
+
 TEST(QAttentionTest, QAttentionMaskPartialSequence) {
   int batch_size = 1;
   int sequence_length = 2;
@@ -342,6 +453,38 @@ TEST(QAttentionTest, QAttentionMaskPartialSequence) {
   RunQAttentionAll(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads);
 }
+
+#ifdef USE_DNNL
+TEST(QAttentionTest, QAttentionDNNLMaskPartialSequence) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int number_of_heads = 2;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+
+  // Test mask_index < sequence_length
+  std::vector<int32_t> mask_index_data = {1L, 0L};
+
+  std::vector<float> output_data = {
+      8.6899995803833008f, -0.13000002503395081f, 4.25f, 5.6499996185302734f,
+      8.6899995803833008f, -0.13000002503395081f, 4.2499995231628418f, 5.6499991416931152f};
+
+  RunQAttentionDNNL(input_data, weight_data, bias_data, mask_index_data, output_data,
+                    batch_size, sequence_length, hidden_size, number_of_heads);
+}
+#endif  // USE_DNNL
 
 TEST(QAttentionTest, QAttentionMaskExceedSequence) {
   int batch_size = 1;

--- a/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_attention_op_test.cc
@@ -56,7 +56,7 @@ void RunQAttention(const std::vector<float>& input_data,
   std::vector<int64_t> mask_index_dims = {batch_size};
   if constexpr (ep == EP::DNNL) {
     //onednn only supports raw mask
-    if (mask_index_data.size() == batch_size * sequence_length) {
+    if (mask_index_data.size() == static_cast<size_t>(batch_size * sequence_length)) {
       mask_index_dims = {batch_size, sequence_length};
     }
   }
@@ -163,6 +163,8 @@ static void RunQAttentionDNNL(
     bool use_special_quantize_parameter = true,
     bool is_unidirectional = false,
     int input_hidden_size = 0) {
+  // Return without running code if USE_DNNL is not defined
+#ifdef USE_DNNL
   quantization::Params<uint8_t> input_quant_params(/*scale=*/0.0f, /*zero_point=*/0);
   quantization::Params<int8_t> weights_quant_params(/*scale=*/0.0f, /*zero_point=*/0);
   if (use_special_quantize_parameter) {
@@ -175,6 +177,20 @@ static void RunQAttentionDNNL(
   RunQAttention<uint8_t, int8_t, EP::DNNL>(
       input_data, weights_data, bias_data, mask_index_data, output_data, input_quant_params, weights_quant_params,
       batch_size, sequence_length, hidden_size, number_of_heads, is_unidirectional, false, input_hidden_size);
+#else
+  ORT_UNUSED_PARAMETER(input_data);
+  ORT_UNUSED_PARAMETER(weights_data);
+  ORT_UNUSED_PARAMETER(bias_data);
+  ORT_UNUSED_PARAMETER(mask_index_data);
+  ORT_UNUSED_PARAMETER(output_data);
+  ORT_UNUSED_PARAMETER(batch_size);
+  ORT_UNUSED_PARAMETER(sequence_length);
+  ORT_UNUSED_PARAMETER(hidden_size);
+  ORT_UNUSED_PARAMETER(number_of_heads);
+  ORT_UNUSED_PARAMETER(use_special_quantize_parameter);
+  ORT_UNUSED_PARAMETER(is_unidirectional);
+  ORT_UNUSED_PARAMETER(input_hidden_size);
+#endif
 }
 
 static void RunQAttentionU8U8(


### PR DESCRIPTION
**Description**:
This is an implementation of the com.microsoft.QAttention contrib operator for the DNNL execution provider

https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md#com.microsoft.QAttention


**Motivation and Context**
- Why is this change required?
This is added to try and expand the dnnl eps coverage of ops.
-  What problem does it solve?
This adds the ability to run the contrib op QAttention in the DNNL execution provider
- If it fixes an open issue, please link to the issue here.
