### PR TITLE
Fix building DNNL EP with clang

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc
@@ -44,7 +44,7 @@ void DnnlSqueeze::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
     if ((j < axes_data.size() && axes_data[j] == static_cast<int64_t>(i)) ||
         (axes_data.size() == 0 && data_dims[i] == 1)) {
       ORT_ENFORCE(data_dims[i] == 1, "Dimension of input ", i, " must be 1 instead of ", data_dims[i],
-                  ". shape=", data_dims);
+                  ". shape=", TensorShape(data_dims));
       ++j;
       continue;
     }


### PR DESCRIPTION
**Description**: Describe your changes.

Before this change, building DNNL EP from onnxruntime 1.10.0 with clang fails with:
```
In file included from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc:4:
In file included from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.h:5:
In file included from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h:10:
In file included from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:19:
In file included from /build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/common.h:36:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
  ss << t;
     ^
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<std::vector<long>>' requested here
  MakeStringImpl(ss, args...);
  ^
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, std::vector<long>>' requested here
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<long, const char *, std::vector<long>>' requested here
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, long, const char *, std::vector<long>>' requested here
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<unsigned long, const char *, long, const char *, std::vector<long>>' requested here
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:46:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, unsigned long, const char *, long, const char *, std::vector<long>>' requested here
  MakeStringImpl(ss, args...);
  ^
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:93:18: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, unsigned long, const char *, long, const char *, std::vector<long>>' requested here
  return detail::MakeStringImpl(detail::if_char_array_make_ptr_t<Args const&>(args)...);
                 ^
/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc:46:7: note: in instantiation of function template specialization 'onnxruntime::MakeString<char [20], unsigned long, char [23], long, char [9], std::vector<long>>' requested here
      ORT_ENFORCE(data_dims[i] == 1, "Dimension of input ", i, " must be 1 instead of ", data_dims[i],
      ^
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/common.h:184:64: note: expanded from macro 'ORT_ENFORCE'
                                                ::onnxruntime::MakeString(__VA_ARGS__)); \
                                                               ^
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/framework/tensor_shape.h:147:15: note: 'operator<<' should be declared prior to the call site
std::ostream& operator<<(std::ostream& out, const TensorShape& shape);
              ^
1 error generated.
make[2]: *** [CMakeFiles/onnxruntime_providers_dnnl.dir/build.make:384: CMakeFiles/onnxruntime_providers_dnnl.dir/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_squeeze.cc.o] Error 1
```
Two-phase lookups fail as:

1. visible in the template definition - fails as `std::ostream& operator<<(std::ostream& out, const TensorShape& shape)` (from include/onnxruntime/core/framework/tensor_shape.h) is defined after `template <typename... Args> std::string MakeString(const Args&... args)` (from include/onnxruntime/core/common/make_string.h) as per `clang++ -E`
2. argument-dependent lookup - fails as the argument data_dims has type `std::vector<long>` (via typedef in dnnl.hpp), while `std::ostream& operator<<(std::ostream& out, const TensorShape& shape)` is in namespace onnxruntime instead of std

There are several possible fixes:

* Make operator<< appear before MakeString by adjust the order of header files - I consider it fragile
* Also define operator<< in namespace std - may results in namespace pollution
* Use an argument of a class in onnxruntime namespace - this commit

**Motivation and Context**

Allow onnxruntime to build with clang

