### PR TITLE
Enable argument files in build.py.

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -125,9 +125,14 @@ def _openvino_verify_device_type(device_read):
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(
+    class Parser(argparse.ArgumentParser):
+        # override argument file line parsing behavior - allow multiple arguments per line and handle quotes
+        def convert_arg_line_to_args(self, arg_line):
+            return shlex.split(arg_line)
+
+    parser = Parser(
         description="ONNXRuntime CI build driver.",
-        usage="""  # noqa
+        usage="""
         Default behavior is --update --build --test for native architecture builds.
         Default behavior is --update --build for cross-compiled builds.
 
@@ -136,7 +141,10 @@ def parse_arguments():
         The Test phase will run all unit tests, and optionally the ONNX tests.
 
         Use the individual flags to only run the specified stages.
-        """)
+        """,
+        # files containing arguments can be specified on the command line with "@<filename>" and the arguments within
+        # will be included at that point
+        fromfile_prefix_chars="@")
     # Main arguments
     parser.add_argument(
         "--build_dir", required=True, help="Path to the build directory.")


### PR DESCRIPTION
**Description**
Python's argparse.ArgumentParser supports passing files containing arguments.
https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars

This change enables argument files for build.py as there are potentially many arguments and it can be easier to keep common ones in a file.

For example:
```
$ cat cuda_opts.txt
--build_dir /path/to/build/dir
--use_cuda --cuda_version 11.4
--cuda_home /path/to/cuda/home
--cudnn_home /path/to/cudnn/home

$ python tools/ci_build/build.py @cuda_opts.txt --update
```

**Motivation and Context**
Make it easier to manage build.py arguments.
