### PR TITLE
A small fix to allocators

### DIFF
--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -44,7 +44,7 @@ static common::Status AllocateBufferUsingDeviceAllocatorFromShapeAndType(const T
   if (shape_size > 0) {
     SafeInt<size_t> mem_size = 0;
 
-    if (!alloc->CalcMemSizeForArray(SafeInt<size_t>(shape_size), type->Size(), &mem_size)) {
+    if (!IAllocator::CalcMemSizeForArray(SafeInt<size_t>(shape_size), type->Size(), &mem_size)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed memory size calculation");
     }
 

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -29,7 +29,7 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
   void* p_data = nullptr;
   if (shape_size > 0) {
     SafeInt<size_t> len = 0;
-    if (!allocator->CalcMemSizeForArray(SafeInt<size_t>(shape_size), p_type->Size(), &len))
+    if (!IAllocator::CalcMemSizeForArray(SafeInt<size_t>(shape_size), p_type->Size(), &len))
       ORT_THROW("tensor failed memory size calculation");
 
     p_data = allocator->Alloc(len);


### PR DESCRIPTION
**Description**: 

CalcMemSizeForArray is a static function, it should be access from the class name, not pointers.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Fix a VC++ warning:

warning C6031: return value ignored: called-function could return unexpected value



- If it fixes an open issue, please link to the issue here.
