### PR TITLE
Optimization Convolution op when using dnnl ep

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_conv.cc
@@ -21,10 +21,12 @@ void DnnlConv::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto conv_src_mem = sp.GetMemory(node.Input(IN_X));
   auto src_md = conv_src_mem.get_desc();
+  src_md.data.format_kind = dnnl_format_kind_t::dnnl_format_kind_any;
   auto src_dims = conv_src_mem.get_desc().dims();
 
   auto conv_weights_mem = sp.GetMemory(node.Input(IN_W));
   auto weight_md = conv_weights_mem.get_desc();
+  weight_md.data.format_kind = dnnl_format_kind_t::dnnl_format_kind_any;
   auto weight_dims_original = conv_weights_mem.get_desc().dims();
   dnnl::memory::dims weight_dims = weight_dims_original;
 


### PR DESCRIPTION
**Description**: 
If Group attr = 1 allow the OneDNN library to optimize the memory
layout for the device the Convolution operator is being run on.

Without this optimization, the default NCHW memory layout is used
on CPUs, the NCHW memory layout can result in a significant performance
decrease.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Using the default NCHW memory layout on CPU resulted in poor performance when running convolution models on CPU.
- If it fixes an open issue, please link to the issue here.
