### PR TITLE
Generate native resources for all supported MacOS versions, not just 10.14

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -65,7 +65,7 @@ def generate_file_list_for_ep(nuget_artifacts_dir, ep, files_list):
                     is_versioned_dylib = re.match(r'.*[\.\d+]+\.dylib$', child_file.name)
                     if child_file.is_file() and child_file.suffix == '.dylib' and not is_versioned_dylib:
                         files_list.append('<file src="' + str(child_file) +
-                                          '" target="runtimes/osx.10.14-%s/native"/>' % cpu_arch)
+                                          '" target="runtimes/osx-%s/native"/>' % cpu_arch)
         for cpu_arch in ['x64', 'aarch64']:
             if child.name == get_package_name('linux', cpu_arch, ep):
                 child = child / 'lib'


### PR DESCRIPTION
**Description**:

This changes the generated path for MacOS assets in the nuget package from `runtimes/osx.10.14-<arch>` to `/runtimes/osx-<arch>`, which allows users on more versions of MacOS to use the library. This brings the library back to parity with the layout of 1.8.1. This should fix #9707.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  - this change is required because the current package layout doesn't support as many MacOS versions as it used to. I'm unsure if this is by design or by accident. Without this change, MacOS consumers on versions other than 10.14 experience runtime errors instead of compile-time errors.
- If it fixes an open issue, please link to the issue here.
  - the fixed issue would be #9707.
