### PR TITLE
Update C/C++ API docs automation to create a PR (instead of push to publish branch)

### DIFF
--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -26,6 +26,7 @@ jobs:
           author_name: Nat Kershaw
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
+          branch-mode: create
           message: 'Update C++ docs to commit ${GITHUB_SHA}'
           add: '*.html'          
 #      OLD

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,11 +20,20 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
-      - name: Publish
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7
         with:
-          BRANCH: gh-pages
-          FOLDER: build/doxygen/html
-          TARGET_FOLDER: docs/api/c
-          CLEAN_EXCLUDE: '["_config.yml"]'    
+          author_name: Nat Kershaw
+          author_email: nakersha@microsoft.com
+          branch: gh-pages-pr
+          message: 'Update C++ docs to commit ${GITHUB_SHA}'
+          add: '*.html'          
+#      OLD
+#      - name: Publish
+#        uses: JamesIves/github-pages-deploy-action@releases/v3
+#        with:
+#          BRANCH: gh-pages
+#          FOLDER: build/doxygen/html
+#          TARGET_FOLDER: docs/api/c
+#          CLEAN_EXCLUDE: '["_config.yml"]'    
  

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -28,8 +28,9 @@ jobs:
           ref: gh-pages
           clean: false    
       - name: Move API docs into target area
-        run:
-          mv build/doxygen/html/* docs/api/c   
+        run: |
+          rm -rf docs/api/c
+          mv build/doxygen/html docs/api/c   
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -38,7 +38,7 @@ jobs:
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
           branch_mode: create
-          message: 'Update C++ docs to commit ${{GITHUB_SHA::7}}'
+          message: 'Update C++ docs to commit ${{GITHUB_SHA}}'
           add: '*.html'          
 #      OLD
 #      - name: Publish

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -36,20 +36,12 @@ jobs:
         run: |
           rm -rf docs/api/c
           mv build/doxygen/html docs/api/c   
-#      - name: Commit changes
-#        uses: EndBug/add-and-commit@v7
-#        with:
-#          author_name: Nat Kershaw
-#          author_email: nakersha@microsoft.com
-#          branch: gh-pages-pr
-#          branch_mode: create
-#          message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'
-#          add: '*.html'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           branch: gh-pages-pr
           base: gh-pages
-          commit-message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'      
+          title: '[Automated]: Update C/C++ API docs'
+          commit-message: 'Update C/C++ API docs to commit ${{ steps.vars.outputs.sha_short }}'      
 
  

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -36,19 +36,20 @@ jobs:
         run: |
           rm -rf docs/api/c
           mv build/doxygen/html docs/api/c   
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          author_name: Nat Kershaw
-          author_email: nakersha@microsoft.com
-          branch: gh-pages-pr
-          branch_mode: create
-          message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'
-          add: '*.html'
+#      - name: Commit changes
+#        uses: EndBug/add-and-commit@v7
+#        with:
+#          author_name: Nat Kershaw
+#          author_email: nakersha@microsoft.com
+#          branch: gh-pages-pr
+#          branch_mode: create
+#          message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'
+#          add: '*.html'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           branch: gh-pages-pr
-          base: gh-pages     
+          base: gh-pages
+          commit-message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'      
 
  

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,6 +20,9 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
+      - name: Debug
+        run:
+          git status    
       - uses: actions/checkout@v2
         with:
           ref: gh-pages    

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -15,20 +15,14 @@ jobs:
           sudo apt-get install libclang-cpp9
           wget https://www.doxygen.nl/files/doxygen-1.9.2.linux.bin.tar.gz
           tar xvzf doxygen-1.9.2.linux.bin.tar.gz
-      - name: Set vars
+      - name: Set commit ID
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Check outputs
-        run: echo ${{ steps.vars.outputs.sha_short }}
       - name: Run doxygen
         run: |
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
-      - name: Clean up
-        run:
-          rm -rf doxygen-1.9.2
-          rm doxygen-1.9.2.linux.bin.tar.gz
       - uses: actions/checkout@v2
         with:
           ref: gh-pages

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,9 +20,9 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
-      - name: Debug
+      - name: Clean up
         run:
-          git status    
+          rm -rf doxygen-1.9.2
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
@@ -38,7 +38,7 @@ jobs:
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
           branch_mode: create
-          message: 'Update C++ docs to commit ${GITHUB_SHA::7}'
+          message: 'Update C++ docs to commit ${{GITHUB_SHA::7}}'
           add: '*.html'          
 #      OLD
 #      - name: Publish

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -26,7 +26,7 @@ jobs:
           author_name: Nat Kershaw
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
-          branch-mode: create
+          branch_mode: create
           message: 'Update C++ docs to commit ${GITHUB_SHA}'
           add: '*.html'          
 #      OLD

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,6 +20,9 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages    
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:
@@ -27,7 +30,7 @@ jobs:
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
           branch_mode: create
-          message: 'Update C++ docs to commit ${GITHUB_SHA}'
+          message: 'Update C++ docs to commit ${GITHUB_SHA::7}'
           add: '*.html'          
 #      OLD
 #      - name: Publish

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -44,13 +44,11 @@ jobs:
           branch: gh-pages-pr
           branch_mode: create
           message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'
-          add: '*.html'          
-#      OLD
-#      - name: Publish
-#        uses: JamesIves/github-pages-deploy-action@releases/v3
-#        with:
-#          BRANCH: gh-pages
-#          FOLDER: build/doxygen/html
-#          TARGET_FOLDER: docs/api/c
-#          CLEAN_EXCLUDE: '["_config.yml"]'    
+          add: '*.html'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: gh-pages-pr
+          base: gh-pages     
+
  

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,12 +20,15 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
-      - name: Debug
+      - name: Debug 1
         run:
           git status    
       - uses: actions/checkout@v2
         with:
           ref: gh-pages    
+      - name: Debug 2
+        run:
+          git status    
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -20,16 +20,16 @@ jobs:
           mkdir -p build/doxygen
           cd docs/c_cxx
           ../../doxygen-1.9.2/bin/doxygen
-      - name: Debug 1
+      - name: Debug
         run:
           git status    
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
           clean: false    
-      - name: Debug 2
+      - name: Move API docs into target area
         run:
-          git status    
+          mv build/doxygen/html/* docs/api/c   
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -25,7 +25,8 @@ jobs:
           git status    
       - uses: actions/checkout@v2
         with:
-          ref: gh-pages    
+          ref: gh-pages
+          clean: false    
       - name: Debug 2
         run:
           git status    

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Clean up
         run:
           rm -rf doxygen-1.9.2
+          rm doxygen-1.9.2.linux.bin.tar.gz
       - uses: actions/checkout@v2
         with:
           ref: gh-pages
@@ -42,6 +43,7 @@ jobs:
           branch: gh-pages-pr
           base: gh-pages
           title: '[Automated]: Update C/C++ API docs'
-          commit-message: 'Update C/C++ API docs to commit ${{ steps.vars.outputs.sha_short }}'      
+          commit-message: 'Update C/C++ API docs to commit ${{ steps.vars.outputs.sha_short }}'   
+          add-paths: docs/api/c   
 
  

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -1,10 +1,10 @@
-name: Publish C/C++ API Docs
+name: Update C/C++ API Docs
 on:
   workflow_dispatch
 
 jobs:
   publish:
-    name: Publish C/C++ API docs
+    name: Generate C/C++ API docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -15,6 +15,11 @@ jobs:
           sudo apt-get install libclang-cpp9
           wget https://www.doxygen.nl/files/doxygen-1.9.2.linux.bin.tar.gz
           tar xvzf doxygen-1.9.2.linux.bin.tar.gz
+      - name: Set vars
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Check outputs
+        run: echo ${{ steps.vars.outputs.sha_short }}
       - name: Run doxygen
         run: |
           mkdir -p build/doxygen
@@ -38,7 +43,7 @@ jobs:
           author_email: nakersha@microsoft.com
           branch: gh-pages-pr
           branch_mode: create
-          message: 'Update C++ docs to commit ${{GITHUB_SHA}}'
+          message: 'Update C++ docs to commit ${{ steps.vars.outputs.sha_short }}'
           add: '*.html'          
 #      OLD
 #      - name: Publish

--- a/docs/c_cxx/README.md
+++ b/docs/c_cxx/README.md
@@ -1,13 +1,7 @@
-How to build the Doxygen HTML pages on Windows:
+# ONNX Runtime C/C++ docs source files
 
-* Install Doxygen (https://www.doxygen.nl/download.html)
-* Running from the command line:
-  * cd to (Repository Root)\docs\c_cxx
-  * Run "\Program Files\doxygen\bin\doxygen.exe" Doxyfile
-* Using the Doxygen GUI app:
-  * Launch Doxygen GUI (Doxywizard)
-  * File->Open (Repository Root)\docs\c_cxx\Doxyfile
-  * Switch to Run tab, click 'Run doxygen'
-* Generated docs are written to (Repository Root)\build\doxygen\html
+This directory contains doxygen configuration to generate the C/C++ API docs for ONNX Runtime.
 
-The generated documentation is online in the gh-pages branch of the project: https://github.com/microsoft/onnxruntime/tree/gh-pages/docs/api/c
+The actual generation is performed by a GitHub actions workflow: [publish-c-apidocs.yml](../../.github/workflows/publish-c-apidocs.yml).
+
+The workflow is currently manually triggered, and generates a PR to the gh-pages branch, for publication on https://onnxruntime.ai.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7,11 +7,11 @@
 *
 * <h1>C</h1>
 *
-* ::OrtApi - Click here to jump to the structure with all C API functions.
+* ::OrtApi - Click here to go to the structure with all C API functions.
 *
 * <h1>C++</h1>
 *
-* ::Ort - Click here to jump to the namespace holding all of the C++ wrapper classes
+* ::Ort - Click here to go to the namespace holding all of the C++ wrapper classes
 *
 * It is a set of header only wrapper classes around the C API. The goal is to turn the C style return value error codes into C++ exceptions, and to
 * automate memory management through standard C++ RAII principles.


### PR DESCRIPTION
See staged PR here: https://github.com/natke/onnxruntime/pull/15

This action creates a (or adds to an existing) PR to update the C/C++ API docs to the latest master. 

The original action failed because it is trying to commit to a protected branch (https://github.com/microsoft/onnxruntime/actions/runs/1565902647)