### PR TITLE
Remove duplicated constant initializer copies for TensorRT nodes

### DIFF
--- a/include/onnxruntime/core/graph/indexed_sub_graph.h
+++ b/include/onnxruntime/core/graph/indexed_sub_graph.h
@@ -39,6 +39,7 @@ struct IndexedSubGraph {
 
     std::vector<std::string> inputs;   ///< Inputs of customized SubGraph/FunctionProto.
     std::vector<std::string> outputs;  ///< Outputs of customized SubGraph/FunctionProto.
+    std::vector<std::string> constant_initializers;  ///< Constant initializers of customized SubGraph/FunctionProto.
     NodeAttributes attributes;         ///< Attributes of customized SubGraph/FunctionProto.
 
     std::string doc_string;  ///< Doc string of customized SubGraph/FunctionProto.

--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -459,12 +459,11 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
 
   for (const auto& constant_initializer : meta_def->constant_initializers) {
     const ONNX_NAMESPACE::TensorProto* initializer = graph.GetConstantInitializer(constant_initializer, true);
-    if (initializer) {
-       // meta_def->constant_initializers could have duplicates so make sure we only add once
-      const ONNX_NAMESPACE::TensorProto* subgraph_initializer = nullptr;
-      if (!function_body_graph.GetInitializedTensor(constant_initializer, subgraph_initializer)) {
-        function_body_graph.AddInitializedTensor(*initializer);
-      }
+    ORT_ENFORCE(initializer != nullptr, "Initializer " + constant_initializer + " is not found or is not constant initializer.");
+    // meta_def->constant_initializers could have duplicates so make sure we only add once
+    const ONNX_NAMESPACE::TensorProto* subgraph_initializer = nullptr;
+    if (!function_body_graph.GetInitializedTensor(constant_initializer, subgraph_initializer)) {
+      function_body_graph.AddInitializedTensor(*initializer);
     }
   }
 

--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -458,9 +458,9 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
   }
 
   for (const auto& constant_initializer : meta_def->constant_initializers) {
-    const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
-    if (graph.GetInitializedTensor(constant_initializer, initializer)) {
-      // meta_def->constant_initializer could have duplicates so make sure we only add once
+    const ONNX_NAMESPACE::TensorProto* initializer = graph.GetConstantInitializer(constant_initializer, true);
+    if (initializer) {
+       // meta_def->constant_initializers could have duplicates so make sure we only add once
       const ONNX_NAMESPACE::TensorProto* subgraph_initializer = nullptr;
       if (!function_body_graph.GetInitializedTensor(constant_initializer, subgraph_initializer)) {
         function_body_graph.AddInitializedTensor(*initializer);

--- a/onnxruntime/core/graph/function.cc
+++ b/onnxruntime/core/graph/function.cc
@@ -457,6 +457,17 @@ FunctionImpl::FunctionImpl(const onnxruntime::Graph& graph,
     }
   }
 
+  for (const auto& constant_initializer : meta_def->constant_initializers) {
+    const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
+    if (graph.GetInitializedTensor(constant_initializer, initializer)) {
+      // meta_def->constant_initializer could have duplicates so make sure we only add once
+      const ONNX_NAMESPACE::TensorProto* subgraph_initializer = nullptr;
+      if (!function_body_graph.GetInitializedTensor(constant_initializer, subgraph_initializer)) {
+        function_body_graph.AddInitializedTensor(*initializer);
+      }
+    }
+  }
+
   //TODO: if we reuse the nodes in parent graph, maybe we don't need to resolve it.
   auto status = function_body_graph.Resolve();
   ORT_ENFORCE(status.IsOK(), status.ErrorMessage());

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -429,6 +429,7 @@ struct ProviderHost {
   virtual ONNX_NAMESPACE::OperatorStatus& IndexedSubGraph_MetaDef__status(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::vector<std::string>& IndexedSubGraph_MetaDef__inputs(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::vector<std::string>& IndexedSubGraph_MetaDef__outputs(IndexedSubGraph_MetaDef* p) = 0;
+  virtual std::vector<std::string>& IndexedSubGraph_MetaDef__constant_initializers(IndexedSubGraph_MetaDef* p) = 0;
   virtual NodeAttributes& IndexedSubGraph_MetaDef__attributes(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::string& IndexedSubGraph_MetaDef__doc_string(IndexedSubGraph_MetaDef* p) = 0;
 

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -348,6 +348,8 @@ struct IndexedSubGraph_MetaDef final {
   const std::vector<std::string>& inputs() const { return g_host->IndexedSubGraph_MetaDef__inputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
   std::vector<std::string>& inputs() { return g_host->IndexedSubGraph_MetaDef__inputs(this); }
   const std::vector<std::string>& outputs() const { return g_host->IndexedSubGraph_MetaDef__outputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  const std::vector<std::string>& constant_initializers() const { return g_host->IndexedSubGraph_MetaDef__constant_initializers(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  std::vector<std::string>& constant_initializers() { return g_host->IndexedSubGraph_MetaDef__constant_initializers(this); }
   std::vector<std::string>& outputs() { return g_host->IndexedSubGraph_MetaDef__outputs(this); }
   NodeAttributes& attributes() { return g_host->IndexedSubGraph_MetaDef__attributes(this); }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -21,7 +21,6 @@
 #include <memory>
 #include "flatbuffers/idl.h"
 #include "ort_trt_int8_cal_table.fbs.h"
-#include <iostream>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -722,7 +721,6 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
     for (const auto& input : node->InputDefs()) {
       if (graph.IsConstantInitializer(input->Name(), true)) {
         initializers.push_back(input->Name());
-        std::cout << "node->InputDefs(): constant initializer: " << input->Name() << std::endl;
         continue;
       }
       const auto& it = fused_outputs.find(input);
@@ -738,7 +736,6 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
     for (const auto& input : node->ImplicitInputDefs()) {
       if (graph.IsConstantInitializer(input->Name(), true)) {
         initializers.push_back(input->Name());
-        std::cout << "node->ImplicitInputDefs: constant initializer: " << input->Name() << std::endl;
         continue;
       }
       const auto& it = fused_outputs.find(input);
@@ -816,14 +813,11 @@ std::unique_ptr<IndexedSubGraph> TensorrtExecutionProvider::GetSubGraph(SubGraph
   meta_def->name() = "TRTKernel_" + graph_type + "_" + graph.Name() + "_" + subgraph_id;
 
   // Assign inputs and outputs to subgraph's meta_def
-  std::cout << "TRT GetSubGraph inputs: " << std::endl;
   for (const auto& input : inputs) {
     if (input.second->Exists()) {
-      std::cout << input.second->Name() << ",";
       meta_def->inputs().push_back(input.second->Name());
     }
   }
-  std::cout << std::endl;
 
   for (const auto& initializer : initializers) {
     meta_def->constant_initializers().push_back(initializer);

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -507,6 +507,7 @@ struct ProviderHostImpl : ProviderHost {
   ONNX_NAMESPACE::OperatorStatus& IndexedSubGraph_MetaDef__status(IndexedSubGraph_MetaDef* p) override { return p->status; }
   std::vector<std::string>& IndexedSubGraph_MetaDef__inputs(IndexedSubGraph_MetaDef* p) override { return p->inputs; }
   std::vector<std::string>& IndexedSubGraph_MetaDef__outputs(IndexedSubGraph_MetaDef* p) override { return p->outputs; }
+  std::vector<std::string>& IndexedSubGraph_MetaDef__constant_initializers(IndexedSubGraph_MetaDef* p) override { return p->constant_initializers; }
   NodeAttributes& IndexedSubGraph_MetaDef__attributes(IndexedSubGraph_MetaDef* p) override { return p->attributes; }
   std::string& IndexedSubGraph_MetaDef__doc_string(IndexedSubGraph_MetaDef* p) override { return p->doc_string; }
 


### PR DESCRIPTION
When a subgraph is assigned to TensorRT EP, both ORT and TRT maintain a copy of the subgraph's constant initializers. This PR removes the ORT copy to save memory.
1. add constant_initializers field in MetaDef in order to differentiate constant initializers and overridable initializers in the (sub)graph input.
2. remove constant initializers from MetaDef input for TRT nodes, so that ORT can clean the constant initializers memory after partitioning.
