### PR TITLE
Fix the default provider related issue

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -323,6 +323,9 @@ class InferenceSession(Session):
         else:
             raise TypeError("Unable to load from type '{0}'".format(type(path_or_bytes)))
 
+        if providers is None:
+            providers = C.get_available_providers()
+
         self._sess_options = sess_options
         self._sess_options_initial = sess_options
         self._enable_fallback = True

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -286,8 +286,9 @@ class InferenceSession(Session):
         :param sess_options: session options
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then 'CPUExecutionProvider'
-            will used by default.
+            (provider name, options dict). If not provided, the session will fall
+            back to 'CPUExecutionProvider' by default. For using other providers,
+            please explicitly specify the providers.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -286,8 +286,8 @@ class InferenceSession(Session):
         :param sess_options: session options
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, then 'CPUExecutionProvider'
+            will used by default.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 
@@ -322,9 +322,6 @@ class InferenceSession(Session):
             self._model_bytes = path_or_bytes  # TODO: This is bad as we're holding the memory indefinitely
         else:
             raise TypeError("Unable to load from type '{0}'".format(type(path_or_bytes)))
-
-        if providers is None:
-            providers = C.get_available_providers()
 
         self._sess_options = sess_options
         self._sess_options_initial = sess_options

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -91,7 +91,10 @@ def optimize_by_onnxruntime(onnx_model_path: str,
                                                providers=['CPUExecutionProvider'],
                                                **kwargs)
     else:
-        session = onnxruntime.InferenceSession(onnx_model_path, sess_options, **kwargs)
+        session = onnxruntime.InferenceSession(onnx_model_path,
+                                               sess_options,
+                                               providers=['CUDAExecutionProvider'],
+                                               **kwargs)
         assert 'CUDAExecutionProvider' in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)


### PR DESCRIPTION
**Description**: If setting `providers` be be `None` for InferenceSession, will get the below message. This PR will make the behavior work as the doc `if not provided, then all available providers are used with the default precedence.`.

```
EP Error using None
Falling back to ['CPUExecutionProvider'] and retrying.
```

Also a related issue in the optimizer.py is fixed.
