### PR TITLE
Check size of ThreadOptions.affinity vector

### DIFF
--- a/onnxruntime/core/util/thread_utils.cc
+++ b/onnxruntime/core/util/thread_utils.cc
@@ -26,6 +26,7 @@ CreateThreadPoolHelper(Env* env, OrtThreadPoolParams options) {
     if (options.auto_set_affinity)
       to.affinity = cpu_list;
   }
+  ORT_ENFORCE(to.affinity.empty() || to.affinity.size() == options.thread_pool_size, "length of thread affinity vector must match thread pool size");
   to.set_denormal_as_zero = options.set_denormal_as_zero;
 
   // set custom thread management members


### PR DESCRIPTION
**Description**:
This checks the size of the `ThreadOptions.affinity` vector to be either zero or match the number of threads in the thread pool. The thread pool implementations in `onnxruntime/core/platform/windows/env.cc` and `onnxruntime/core/platform/posix/env.cc` depend on the correct size:

https://github.com/microsoft/onnxruntime/blob/05d20343ee04990a7082ccb162faab9dd9a8305c/onnxruntime/core/platform/windows/env.cc#L103

and 

https://github.com/microsoft/onnxruntime/blob/05d20343ee04990a7082ccb162faab9dd9a8305c/onnxruntime/core/platform/posix/env.cc#L179

**Motivation and Context**
Might fix https://github.com/microsoft/onnxruntime/issues/10113.
