### PR TITLE
Correctly set thread affinity on Windows

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -98,9 +98,10 @@ class WindowsThread : public EnvThread {
 #pragma warning(disable : 6387)
   static unsigned __stdcall ThreadMain(void* param) {
     std::unique_ptr<Param> p((Param*)param);
-    // TODO: should I try to use SetThreadSelectedCpuSets?
-    if (!p->thread_options.affinity.empty())
-      SetThreadAffinityMask(GetCurrentThread(), p->thread_options.affinity[p->index]);
+    if (!p->thread_options.affinity.empty()) {
+      DWORD_PTR mask = static_cast<DWORD_PTR>(1) << p->thread_options.affinity[p->index];
+      SetThreadAffinityMask(GetCurrentThread(), mask);
+    }
 #if WINVER >= _WIN32_WINNT_WIN10
     constexpr SetThreadDescriptionFunc pSetThrDesc = SetThreadDescription;
 #elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)


### PR DESCRIPTION
**Description**:
This fixes an issue with how thread affinity was set on Windows. `SetThreadAffinityMask` requires a bit vector for the mask, see https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadaffinitymask and https://stackoverflow.com/questions/5919699/proper-usage-of-setthreadaffinitymask.
