### PR TITLE
Fix props file overwriting AdditionalIncludeDirectories

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/props.xml
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/props.xml
@@ -12,13 +12,13 @@
 
   <ItemDefinitionGroup Condition="'$(PlatformTarget)' == 'x64' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' != 'true')">
    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)../../runtimes/win-x64/native/onnxruntime.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)../../runtimes/win-x64/native/onnxruntime.lib;%(AdditionalDependencies)</AdditionalDependencies>
    </Link>
   </ItemDefinitionGroup>
 
   <ItemDefinitionGroup Condition="'$(PlatformTarget)' == 'x86' OR ('$(PlatformTarget)' == 'AnyCPU' AND '$(Prefer32Bit)' == 'true')">
    <Link>
-      <AdditionalDependencies>$(MSBuildThisFileDirectory)../../runtimes/win-x86/native/onnxruntime.lib</AdditionalDependencies>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)../../runtimes/win-x86/native/onnxruntime.lib;%(AdditionalDependencies)</AdditionalDependencies>
    </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
**Description**: In .props file, prepend to AdditionalIncludeDirectories variable instead of overwriting it.

**Motivation and Context**
- Fixes #9646
- Fixes #9924
