### PR TITLE
Add `.git` suffix to github URL.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/google/benchmark.git
 [submodule "cmake/external/onnx"]
 	path = cmake/external/onnx
-	url = https://github.com/onnx/onnx
+	url = https://github.com/onnx/onnx.git
 [submodule "cmake/external/tvm"]
 	path = cmake/external/tvm
 	url = https://github.com/microsoft/onnxruntime-tvm.git
@@ -18,7 +18,7 @@
 	url = https://github.com/HowardHinnant/date.git
 [submodule "cmake/external/nsync"]
 	path = cmake/external/nsync
-	url = https://github.com/google/nsync
+	url = https://github.com/google/nsync.git
 [submodule "cmake/external/re2"]
 	path = cmake/external/re2
 	url = https://github.com/google/re2.git
@@ -39,10 +39,10 @@
 	url = https://github.com/NVlabs/cub.git
 [submodule "cmake/external/wil"]
 	path = cmake/external/wil
-	url = https://github.com/microsoft/wil
+	url = https://github.com/microsoft/wil.git
 [submodule "cmake/external/json"]
 	path = cmake/external/json
-	url = https://github.com/nlohmann/json
+	url = https://github.com/nlohmann/json.git
 [submodule "server/external/spdlog"]
 	path = server/external/spdlog
 	url = https://github.com/gabime/spdlog.git

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -285,7 +285,7 @@ if (onnxruntime_BUILD_CSHARP)
 endif()
 
 if (NOT WIN32)
-  #TODO: On Linux we may try https://github.com/microsoft/TraceLogging
+  #TODO: On Linux we may try https://github.com/microsoft/TraceLogging.git
   if (onnxruntime_ENABLE_INSTRUMENT)
     message(WARNING "Instrument is only supported on Windows now")
     set(onnxruntime_ENABLE_INSTRUMENT OFF)

--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -1,6 +1,6 @@
 include (ExternalProject)
 
-set(DNNL_URL https://github.com/oneapi-src/onednn)
+set(DNNL_URL https://github.com/oneapi-src/onednn.git)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
 set(DNNL_TAG v2.4.4)
 

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -1,7 +1,7 @@
 include (ExternalProject)
 
 set(zlib_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/zlib_archive)
-set(ZLIB_URL https://github.com/madler/zlib)
+set(ZLIB_URL https://github.com/madler/zlib.git)
 set(ZLIB_BUILD ${CMAKE_CURRENT_BINARY_DIR}/zlib/src/zlib)
 set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
 set(ZLIB_TAG 50893291621658f355bc5b4d450a8d06a563053d)


### PR DESCRIPTION
Although github works with both, this is more precise.
Having an extension also makes it easy to match with regex, when we want to inject code to reroute traffic to our own git mirror.