### PR TITLE
update tensorrt multi gpu pipeline to tensorrt 8.2

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -1,8 +1,8 @@
-# Tag: nvcr.io/nvidia/tensorrt:21.07-py3
-# Label: com.nvidia.cuda.version: 11.4.0
-# Label: com.nvidia.cudnn.version: 8.2.2.26
+# Tag: nvcr.io/nvidia/tensorrt:21.12-py3
+# Label: com.nvidia.cuda.version: 11.5.0
+# Label: com.nvidia.cudnn.version: 8.3.1.22
 # Ubuntu 20.04
-FROM nvcr.io/nvidia/tensorrt:21.07-py3
+FROM nvcr.io/nvidia/tensorrt:21.12-py3
 
 ARG PYTHON_VERSION=3.8
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tools/ci_build/github/linux/run_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_dockerbuild.sh
@@ -100,8 +100,8 @@ elif [[ $BUILD_DEVICE = "tensorrt"* ]]; then
             IMAGE="$BUILD_OS-cuda11.0-cudnn8.0-tensorrt7.1"
             DOCKER_FILE=Dockerfile.ubuntu_tensorrt7_1
         else
-            # TensorRT container release 21.07
-            IMAGE="$BUILD_OS-cuda11.4-cudnn8.2-tensorrt8.0"
+            # TensorRT container release 21.12
+            IMAGE="$BUILD_OS-cuda11.5-cudnn8.3-tensorrt8.2"
             DOCKER_FILE=Dockerfile.ubuntu_tensorrt
         fi
         $GET_DOCKER_IMAGE_CMD --repository "onnxruntime-$IMAGE" \


### PR DESCRIPTION
update tensorrt multi gpu pipeline to tensorrt 8.2 - it uses nvidia ngc container , which only recently published 21.12 based on tensorrt 8.2