### PR TITLE
Optimize DivGrad

### DIFF
--- a/onnxruntime/core/providers/rocm/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/rocm/reduction/reduction_ops.cc
@@ -165,19 +165,26 @@ Status ReduceKernel<allow_multi_axes>::ReduceKernelShared(
 
   // Block of fast matrix reduction.
   if (fast_reduction_) {
+    ORT_ENFORCE(input_shape.NumDimensions() == output_dims.size());
+    std::vector<int64_t> axes;
+    for (size_t i = 0; i < output_dims.size(); ++i) {
+      if (input_shape[i] != output_dims[i]) {
+        axes.emplace_back(static_cast<int64_t>(i));
+      }
+    }
     int m{}, n{};
-    const auto applicable_matrix_reduction = get_applicable_matrix_reduction(
-        miopen_reduce_op, input_shape.GetDims(), axes_, m, n);
+    const auto applicable_matrix_reduction =
+        get_applicable_matrix_reduction(miopen_reduce_op, input_shape.GetDims(), axes, m, n);
     switch (applicable_matrix_reduction) {
       case ApplicableMatrixReduction::Rows: {
-        return reduce_matrix_rows(
-            Stream(),
-            reinterpret_cast<const HipT*>(X),
-            reinterpret_cast<HipOutT*>(Y),
-            m, n, false);
+        return reduce_matrix_rows(Stream(), reinterpret_cast<const HipT*>(X), reinterpret_cast<HipOutT*>(Y), m, n);
       }
-      case ApplicableMatrixReduction::Columns:
-      // don't call reduce_matrix_columns() since it will reset initial output data
+      case ApplicableMatrixReduction::Columns: {
+        const auto buffer_size_bytes = compute_reduce_matrix_columns_buffer_size<HipT>(m, n);
+        auto buffer = GetScratchBuffer<void>(buffer_size_bytes);
+        return reduce_matrix_columns(Stream(), reinterpret_cast<const HipT*>(X), reinterpret_cast<HipOutT*>(Y), m, n,
+                                     buffer.get(), buffer_size_bytes);
+      }
       default:
         break;
     }

--- a/orttraining/orttraining/training_ops/cuda/math/div_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/math/div_grad.h
@@ -12,7 +12,10 @@ template <typename T>
 class DivGrad : public ReduceKernel<true> {  // TODO: not to derive from ReduceKernel.
                                              // Use a cudnn reduce sum simple helper instead.
  public:
-  DivGrad(const OpKernelInfo& info) : ReduceKernel<true>(info, /*keep_dims_override*/ int64_t(0)) {}
+  DivGrad(const OpKernelInfo& info) : ReduceKernel<true>(info, /*keep_dims_override*/ int64_t(0)) {
+    fast_reduction_ = true;
+  }
+
   Status ComputeInternal(OpKernelContext*) const override;
 };
 }  // namespace cuda


### PR DESCRIPTION
Optimize DivGrad to use fast reduction for ReduceSum calculation. The PR also tries to coalesce dimensions before binary elementwise kernels to reduce calling fast_divmod for some cases.

Use Tensor[32,256,1024] / Tensor[32,256,1] as torch module to test this PR. For this module, the avg step time for PyTorch is 11.04ms. Before the change, ORT's avg step time is 14.10ms. After the change, ORT's avg step time is 9.68ms.