### PR TITLE
Introduce load balancing dataset samplers

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -311,6 +311,9 @@ if (onnxruntime_ENABLE_TRAINING)
   file(GLOB onnxruntime_python_ortmodule_torch_cpp_ext_fused_ops_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/*"
   )
+  file(GLOB onnxruntime_python_utils_data_srcs CONFIGURE_DEPENDS
+  "${ORTTRAINING_SOURCE_DIR}/python/training/utils/data/*"
+  )
 else()
   file(GLOB onnxruntime_python_capi_training_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/python/training/*.py"
@@ -541,6 +544,7 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_capi_training_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/training/
@@ -579,6 +583,9 @@ if (onnxruntime_ENABLE_TRAINING)
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_ortmodule_torch_cpp_ext_fused_ops_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_utils_data_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/
   )
 endif()

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -586,7 +586,7 @@ if (onnxruntime_ENABLE_TRAINING)
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_utils_data_srcs}
-        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/
   )
 endif()
 

--- a/orttraining/orttraining/python/training/utils/data/__init__.py
+++ b/orttraining/orttraining/python/training/utils/data/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py
+
+from .sampler import LoadBalancingDistributedSampler, LoadBalancingDistributedBatchSampler

--- a/orttraining/orttraining/python/training/utils/data/sampler.py
+++ b/orttraining/orttraining/python/training/utils/data/sampler.py
@@ -1,0 +1,340 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# sampler.py
+
+import torch
+import math
+import torch.distributed as dist
+from torch.utils.data.sampler import Sampler
+from torch.utils.data.dataset import Dataset
+from typing import Optional, Iterator, Callable
+from collections import OrderedDict
+
+
+# Implementation is heavily derived from bagua/load_balancing_data_loader.py
+# https://github.com/BaguaSys/bagua/blob/01874a7c3f90904c37c5612a9db866b5d4b8b5ed/bagua/torch_api/contrib/load_balancing_data_loader.py#L12
+class LoadBalancingDistributedSampler:
+    r"""Sampler that balances the data load across workers based on the sample's complexity.
+    This sampler uses a :attr:`complexity_fn` to calculate each sample's computational
+    complexity and make each batch get similar computational complexity.
+    This is useful in scenarios like speech and NLP, where each batch has variable
+    length and distributed training suffers from straggler problem.
+    The usage is similar to `torch.utils.data.DistributedSampler <https://pytorch.org/docs/stable/data.html?highlight=distributedsampler#torch.utils.data.distributed.DistributedSampler>`_,
+    where each process loads a subset of the original dataset that is exclusive to it.
+    .. note::
+        Dataset is assumed to be of constant size (map-style dataset).
+    Args:
+        dataset: Dataset (map-style) used for sampling.
+        complexity_fn(Callable): A function whose input is a sample and output is an integer as a
+            measure of the computational complexity of the sample.
+        world_size (int, optional): Number of processes participating in
+            distributed training. By default, :attr:`world_size` is retrieved from the
+            current distributed group.
+        rank (int, optional): Rank of the current process within :attr:`world_size`.
+            By default, :attr:`rank` is retrieved from the current distributed
+            group.
+        shuffle (bool, optional): If ``True`` (default), sampler will shuffle the
+            indices within the dataset if :attr:`group_size` is None, else will
+            shuffle the groups if :attr:`group_size` is not None.
+        group_size (int, optional): If provided, the dataset will be broken down into
+            :attr:`group_size` sized groups. Indices will only be sorted within the groups
+            and not across the entire dataset. If :attr:`shuffle` is ```True``` and
+            :attr:`group_size` is not ```None```, the position of each group in the dataset
+            will be shuffled. Default: ```None```
+        seed (int, optional): random seed used to shuffle the sampler if
+            :attr:`shuffle=True`. This number should be identical across all
+            processes in the distributed group. Default: 0.
+        drop_last (bool, optional): if ``True``, then the sampler will drop the
+            tail of the data to make it evenly divisible across the number of
+            shards. If ``False``, the sampler will add extra indices to make
+            the data evenly divisible across the shards. Default: ``False``.
+        random_level (float, optional): A float varies from 0 and 1 that controls the extent
+            of load balance. 0 means the best load balance, while 1 means the opposite.
+    .. warning::
+        In distributed mode, calling the :meth:`set_epoch` method at
+        the beginning of each epoch **before** creating the `DataLoader <https://pytorch.org/docs/stable/data.html?highlight=dataloader#torch.utils.data.DataLoader>`_ iterator
+        is necessary to make shuffling work properly across multiple epochs. Otherwise,
+        the same ordering will be always used.
+    Example::
+        Define your :attr:`complexity_fn`, which accepts a dataset sample as its input and produces an integer
+        as the sample's computational complexity:
+        >>> dataset = torch.utils.data.TensorDataset(torch.randn(n, 2), torch.randperm(n))
+        >>> complexity_fn = lambda x: x[1]
+        Below is the usage of :class:`LoadBalancingDistributedSampler`
+        and `DataLoader <https://pytorch.org/docs/stable/data.html?highlight=dataloader#torch.utils.data.DataLoader>`_:
+        >>> sampler = bagua.torch_api.contrib.LoadBalancingDistributedSampler(
+        ...     dataset,
+        ...     complexity_fn=complexity_fn) if is_distributed else None
+        >>> loader = torch.utils.data.DataLoader(dataset,
+        ...     shuffle=(sampler is None),
+        ...     sampler=sampler)
+        >>>
+        >>> for epoch in range(start_epoch, n_epochs):
+        ...     if is_distributed:
+        ...         sampler.set_epoch(epoch)
+        ...     train(loader)
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        complexity_fn: Callable[..., int],
+        world_size: Optional[int] = None,
+        rank: Optional[int] = None,
+        shuffle: bool = True,
+        group_size: Optional[int] = None,
+        seed: int = 0,
+        drop_last: bool = False,
+        random_level: float = 0,
+    ) -> None:
+        if world_size is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            world_size = dist.get_world_size()
+        if rank is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            rank = dist.get_rank()
+        if rank >= world_size or rank < 0:
+            raise ValueError(
+                "Invalid rank {}, rank should be in the interval"
+                " [0, {}]".format(rank, world_size - 1)
+            )
+        self.dataset = dataset
+        self.world_size = world_size
+        self.rank = rank
+        self.epoch = 0
+        self.drop_last = drop_last
+        self.group_size = group_size
+
+        # If the dataset length is evenly divisible by number of shards, then there
+        # is no need to drop any data, since the dataset will be split equally.
+        dataset_len = len(self.dataset)
+        if self.drop_last and dataset_len % self.world_size != 0:
+            # Split to nearest available length that is evenly divisible.
+            # This is to ensure each rank receives the same amount of data when
+            # using this Sampler.
+            self.num_samples = dataset_len // self.world_size
+        else:
+            self.num_samples = math.ceil(dataset_len / self.world_size)
+        self.total_size = self.num_samples * self.world_size
+        self.shuffle = shuffle
+        self.seed = seed
+
+        self.sample_complexity_list = [None]*dataset_len
+        for sample_index in range(dataset_len):
+            self.sample_complexity_list[sample_index] = \
+                [sample_index, complexity_fn(self.dataset[sample_index])]
+
+        max_complexity = max(self.sample_complexity_list, key=lambda t: t[1])[1]
+        min_complexity = min(self.sample_complexity_list, key=lambda t: t[1])[1]
+
+        if random_level < 0.0 or random_level > 1.0:
+            raise ValueError(
+                "Invalid random level {}, shoule be in the range [0.0, 1.0]".format(
+                    random_level
+                )
+            )
+
+        self.random_number = int((max_complexity - min_complexity) * random_level + 1)
+
+    def _sort_shard_and_shuffle_dataset(self):
+        # This method returns a list of dataset sample indices after
+        # the dataset has been sorted, sharded and shuffled.
+        # The sorting of the dataset happens based on the group_size and complexities
+        # of each sample.
+        # Sharding happens across the number of workers.
+        # Shuffling is done either before sharding on the group indices (if group_size is provided)
+        # or on the dataset sample indices if the group_size is not provided.
+
+        def sort_in_groups(sample_complexity_list, group_size):
+            """Sort the dataset samples indices inside each group of size group_size."""
+            # If the group_size is None, the entire dataset is considered as a single group
+            if group_size is None:
+                group_size = len(sample_complexity_list)
+            # Sort the dataset samples inside each group of the dataset based on sample complexity.
+            for group_begin_index in range(0, len(sample_complexity_list), group_size):
+                group_end_index = min(group_begin_index + group_size, len(sample_complexity_list))
+                sample_complexity_list[group_begin_index:group_end_index] = \
+                    sorted(sample_complexity_list[group_begin_index:group_end_index], key=lambda t: t[1])
+            return sample_complexity_list
+
+        def chunks_wrap_padding(dataset_index_list, num_shards):
+            """Yield successive num_shards-sized chunks from dataset_index_list."""
+            num_samples = max(1, self.num_samples)
+            num_elements = num_samples * num_shards
+            current_lst = []
+            for i in range(num_elements):
+                current_lst.append(dataset_index_list[i % len(dataset_index_list)])
+                if len(current_lst) == num_shards:
+                    yield current_lst
+                    current_lst = []
+
+        sample_complexity_list = self.sample_complexity_list.copy()
+
+        # Control the degree of load balancing by modifying the complexities of
+        # all samples using the random_number.
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+
+        if self.random_number > 1:
+            complexity_random_ints = torch.randint(
+                self.random_number, (len(sample_complexity_list),), generator=g
+            ).tolist()
+
+            for index, random_int in enumerate(complexity_random_ints):
+                sample_complexity_list[index][1] += random_int
+
+        # Sort the data based on the computed complexities and group sizes.
+        ordered_sample_complexity_list = sort_in_groups(sample_complexity_list, self.group_size)
+
+        # If group_size is not None, shuffle the index of each group instead
+        # of shuffling the data indices.
+        if self.shuffle and self.group_size is not None:
+            num_groups = (len(self.sample_complexity_list) + self.group_size - 1) // self.group_size
+            group_order = torch.randperm(num_groups, generator=g).tolist()
+            end = 0
+            sample_complexity_list_copy = sample_complexity_list.copy()
+            for group_index in group_order:
+                original_list_begin_index = self.group_size*group_index
+                original_list_end_index = min(original_list_begin_index+self.group_size, len(sample_complexity_list))
+                begin = end
+                end = begin + (original_list_end_index - original_list_begin_index)
+                sample_complexity_list_copy[begin:end] = sample_complexity_list[original_list_begin_index:original_list_end_index]
+            ordered_sample_complexity_list = sample_complexity_list_copy
+
+        # Shard the data across the different workers.
+        index_chunks = list(
+            chunks_wrap_padding(
+                [index_complexity_tuple[0] for index_complexity_tuple in ordered_sample_complexity_list], self.world_size
+            )
+        )
+
+        # Shuffle the sharded data indices deterministically based on epoch and seed.
+        chunk_indices = list(range(len(index_chunks)))
+        if self.shuffle and self.group_size is None:
+            chunk_indices = torch.randperm(len(index_chunks), generator=g).tolist()
+
+        if not self.drop_last:
+            # Add extra samples to make it evenly divisible
+            padding_size = self.num_samples - len(chunk_indices)
+            if padding_size <= len(chunk_indices):
+                chunk_indices += chunk_indices[:padding_size]
+            else:
+                chunk_indices += (
+                    chunk_indices * math.ceil(padding_size / len(chunk_indices))
+                )[:padding_size]
+        else:
+            # Remove tail of data to make it evenly divisible.
+            chunk_indices = chunk_indices[: self.num_samples]
+
+        assert len(chunk_indices) == self.num_samples
+        return index_chunks, chunk_indices
+
+    def __iter__(self) -> Iterator:
+        index_chunks, chunk_indices = self._sort_shard_and_shuffle_dataset()
+        # Extract indices based on current rank.
+        indices = [index_chunks[i][self.rank] for i in chunk_indices]
+        assert len(indices) == self.num_samples
+
+        return iter(indices)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""Sets the epoch for this sampler.
+        When :attr:`shuffle=True`, this ensures all shards use a different
+        random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch
+
+
+class LoadBalancingDistributedBatchSampler(Sampler):
+    r"""Wraps another load balance sampler to yield variable sized mini-batches.
+    Args:
+        sampler (LoadBalancingDistributedSampler): Load balance sampler.
+        batch_fn (Callable): Callable to yield mini-batch indices.
+        drop_last (bool): If ``True``, the sampler will drop the last few batches exceeding
+            the least number of batches among replicas, otherwise, the number of batches
+            on each replica will be padded to the same.
+    :attr:`batch_fn` will have the signature of::
+        def batch_fn(indices: List[int]) -> List[List[int]]
+    Example::
+        >>> from bagua.torch_api.contrib import LoadBalancingDistributedSampler, \
+        ...     LoadBalancingDistributedBatchSampler
+        >>>
+        >>> sampler = LoadBalancingDistributedSampler(dataset, complexity_fn=complexity_fn)
+        >>> batch_sampler = LoadBalancingDistributedBatchSampler(sampler, batch_fn=batch_fn)
+        >>> loader = torch.utils.data.DataLoader(dataset, batch_sampler=batch_sampler)
+        >>>
+        >>> for epoch in range(start_epoch, n_epochs):
+        ...     batch_sampler.set_epoch(epoch)
+        ...     train(loader)
+    """
+
+    def __init__(
+        self,
+        sampler: LoadBalancingDistributedSampler,
+        batch_fn,
+        drop_last: bool = False,
+    ) -> None:
+        if not isinstance(sampler, LoadBalancingDistributedSampler):
+            raise ValueError(
+                "sampler should be of LoadBalancingDistributedSampler type."
+            )
+
+        if sampler.drop_last:
+            raise ValueError("drop_last of sampler should be False")
+
+        self.sampler = sampler
+        self.batch_fn = batch_fn
+        self.drop_last = drop_last
+
+        self.world_size = self.sampler.world_size
+        self.rank = self.sampler.rank
+
+        self.generate_batches()
+
+    def generate_batches(self):
+        index_chunks, chunk_indices = self.sampler._sort_shard_and_shuffle_dataset()
+
+        batches = []
+        for rank in range(self.world_size):
+            sub_indices = [index_chunks[i][rank] for i in chunk_indices]
+            batches.append(self.batch_fn(sub_indices))
+
+        self.total_batch = (
+            max([len(b) for b in batches])
+            if not self.drop_last
+            else min([len(b) for b in batches])
+        )
+
+        # here {len(batches[self.rank]) - self.total_batch} batches dropped for
+        # rank {self.rank}
+        if self.total_batch < len(batches[self.rank]):
+            pass
+
+        self.padded_batches = [
+            batch + batch[: self.total_batch - len(batch)] for batch in batches
+        ]
+
+    def __iter__(self):
+        return iter(self.padded_batches[self.rank])
+
+    def __len__(self):
+        return self.total_batch
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""
+        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.sampler.set_epoch(epoch)
+        self.generate_batches()

--- a/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
+++ b/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
@@ -121,6 +121,14 @@ def run_ortmodule_experimental_json_config_tests(cwd, log):
     run_subprocess(command, cwd=cwd, log=log).check_returncode()
 
 
+def run_data_sampler_tests(cwd, log):
+    log.debug('Running: Data sampler tests')
+
+    command = [sys.executable, '-m', 'pytest', '-sv', 'orttraining_test_sampler.py']
+
+    run_subprocess(command, cwd=cwd, log=log).check_returncode()
+
+
 def main():
     args = parse_arguments()
     cwd = args.cwd
@@ -149,7 +157,9 @@ def main():
 
     run_ortmodule_fallback_tests(cwd, log, args.transformers_cache)
 
-    run_ortmodule_hierarchical_ortmodule_tests(cwd, log,)
+    run_ortmodule_hierarchical_ortmodule_tests(cwd, log)
+
+    run_data_sampler_tests(cwd, log)
 
     return 0
 

--- a/orttraining/orttraining/test/python/orttraining_test_sampler.py
+++ b/orttraining/orttraining/test/python/orttraining_test_sampler.py
@@ -126,7 +126,7 @@ def test_load_balancing_data_sampler_sorts_and_shuffles_in_groups():
         len(samples_and_complexities)+group_size-1) // group_size,
         generator=torch.Generator().manual_seed(0)).tolist()
     end = 0
-    for original_group_index, group_index in enumerate(shuffled_group_order):
+    for group_index in shuffled_group_order:
         original_begin = group_index*group_size
         original_end = min(original_begin+group_size, len(samples_and_complexities))
         begin = end

--- a/orttraining/orttraining/test/python/orttraining_test_sampler.py
+++ b/orttraining/orttraining/test/python/orttraining_test_sampler.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# orttraining_test_sampler.py
+
+import torch
+from onnxruntime.training.utils.data import sampler
+import random
+
+class MyDataset(torch.utils.data.Dataset):
+    def __init__(self, samples):
+        self.samples = samples
+
+    def __getitem__(self, index):
+        return self.samples[index]
+
+    def __len__(self):
+        return len(self.samples)
+
+
+def test_load_balancing_data_sampler_balances_load():
+    samples_and_complexities = \
+        [(torch.FloatTensor([val]), torch.randint(0, 100, (1,)).item()) for val in range(100)]
+    dataset = MyDataset(samples_and_complexities)
+
+    def complexity_fn(sample):
+        return sample[1]
+
+    data_sampler0 = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=2,
+        rank=0,
+        shuffle=False)
+    data_sampler1 = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=2,
+        rank=1,
+        shuffle=False)
+
+    largest_complexity = -1
+    for index in data_sampler0:
+        assert samples_and_complexities[index][1] >= largest_complexity
+        largest_complexity = samples_and_complexities[index][1]
+
+    largest_complexity = -1
+    for index in data_sampler1:
+        assert samples_and_complexities[index][1] >= largest_complexity
+        largest_complexity = samples_and_complexities[index][1]
+
+def test_load_balancing_data_sampler_shuffles_and_balances_load():
+    complexities = []
+    for i in range(50):
+        c = torch.randint(0, 100, (1,)).item()
+        complexities.append(c)
+        complexities.append(c)
+    random.shuffle(complexities)
+
+    samples = \
+        [torch.FloatTensor([val]) for val in range(100)]
+    samples_and_complexities = list(zip(samples, complexities))
+    dataset = MyDataset(samples_and_complexities)
+
+    def complexity_fn(sample):
+        return sample[1]
+
+    data_sampler0 = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=2,
+        rank=0,
+        shuffle=True)
+    data_sampler1 = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=2,
+        rank=1,
+        shuffle=True)
+
+    for index0, index1 in zip(data_sampler0, data_sampler1):
+        assert samples_and_complexities[index0][1] == \
+            samples_and_complexities[index1][1]
+
+def test_load_balancing_data_sampler_sorts_in_groups():
+    samples_and_complexities = \
+        [(torch.FloatTensor([val]), torch.randint(0, 100, (1,)).item()) for val in range(100)]
+    dataset = MyDataset(samples_and_complexities)
+
+    def complexity_fn(sample):
+        return sample[1]
+
+    group_size = 8
+    samples_and_complexities_sorted = samples_and_complexities.copy()
+    for begin_index in range(0, len(samples_and_complexities), group_size):
+        end_index = min(begin_index+group_size, len(samples_and_complexities))
+        samples_and_complexities_sorted[begin_index:end_index] = sorted(samples_and_complexities_sorted[begin_index:end_index], key=lambda x: x[1])
+
+    data_sampler = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=1,
+        rank=0,
+        shuffle=False,
+        group_size=8)
+
+    for index, sorted_sample in zip(data_sampler, samples_and_complexities_sorted):
+        assert samples_and_complexities[index][1] == sorted_sample[1]
+
+def test_load_balancing_data_sampler_sorts_and_shuffles_in_groups():
+    samples_and_complexities = \
+        [(torch.FloatTensor([val]), torch.randint(0, 100, (1,)).item()) for val in range(100)]
+    dataset = MyDataset(samples_and_complexities)
+
+    def complexity_fn(sample):
+        return sample[1]
+
+    group_size = 8
+    samples_and_complexities_sorted = samples_and_complexities.copy()
+    for begin_index in range(0, len(samples_and_complexities), group_size):
+        end_index = min(begin_index+group_size, len(samples_and_complexities))
+        samples_and_complexities_sorted[begin_index:end_index] = \
+            sorted(samples_and_complexities_sorted[begin_index:end_index], key=lambda x: x[1])
+
+    samples_and_complexities_sorted_and_shuffled = samples_and_complexities_sorted.copy()
+    shuffled_group_order = torch.randperm((
+        len(samples_and_complexities)+group_size-1) // group_size,
+        generator=torch.Generator().manual_seed(0)).tolist()
+    end = 0
+    for original_group_index, group_index in enumerate(shuffled_group_order):
+        original_begin = group_index*group_size
+        original_end = min(original_begin+group_size, len(samples_and_complexities))
+        begin = end
+        end = begin + (original_end-original_begin)
+        samples_and_complexities_sorted_and_shuffled[begin:end] = \
+            samples_and_complexities_sorted[original_begin:original_end]
+
+    data_sampler = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=1,
+        rank=0,
+        shuffle=True,
+        group_size=8)
+
+    for index, sorted_and_shuffled_sample in zip(data_sampler, samples_and_complexities_sorted_and_shuffled):
+        assert samples_and_complexities[index][1] == sorted_and_shuffled_sample[1]
+
+def test_load_balancing_batch_sampler_uses_data_sampler():
+    samples_and_complexities = \
+        [(torch.FloatTensor([val]), torch.randint(0, 100, (1,)).item()) for val in range(100)]
+    dataset = MyDataset(samples_and_complexities)
+
+    def complexity_fn(sample):
+        return sample[1]
+
+    data_sampler = sampler.LoadBalancingDistributedSampler(
+        dataset,
+        complexity_fn=complexity_fn,
+        world_size=1,
+        rank=0,
+        shuffle=False)
+
+    batch_size = 12
+    def batch_fn(indices):
+        nonlocal batch_size
+        batches = []
+        for batch_index_begin in range(0, len(indices), batch_size):
+            batch_index_end = min(batch_index_begin+batch_size, len(indices))
+            batches.append(indices[batch_index_begin:batch_index_end])
+        return batches
+
+    batch_sampler = sampler.LoadBalancingDistributedBatchSampler(
+        data_sampler,
+        batch_fn
+    )
+
+    for batch in batch_sampler:
+        assert len(batch) == batch_size or \
+            len(batch) == len(samples_and_complexities) % batch_size

--- a/setup.py
+++ b/setup.py
@@ -397,7 +397,8 @@ if enable_training:
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.aten_op_executor',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.torch_interop_utils',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.torch_gpu_allocator',
-                     'onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.fused_ops'])
+                     'onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.fused_ops',
+                     'onnxruntime.training.utils.data'])
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.aten_op_executor'] = ['*.cc']
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.torch_interop_utils'] = ['*.cc']
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.torch_gpu_allocator'] = ['*.cc']


### PR DESCRIPTION
This pull request introduces the `LoadBalancingDistributedSampler` which helps with straggler problems observed in distributed training tasks where different workers work on data samples with varying complexity resulting in stragglers.
The data sampler does the following:
- Sorts the dataset based on sample complexities.
- Distributes the data across workers.
- Shuffles the data each worker sees deterministically in order to avoid working with data that is sorted purely in ascending order (which may result in convergence issues).

Here is an example of what the data sampler does:
- Assume the data sampler is working with dataset with complexities: `[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]` and the number of workers is 2.
- The sorted complexities will be: `[0 , 1, 2, 3, 4, 5, 6, 7, 8, 9]` and sorted dataset indices (sorted on complexities) will be `[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]`.
- Data is then distributed among workers. So the two workers will work with the indices `[9, 7, 5, 3, 1]` and `[8, 6, 4, 2, 0]` respectively.
- Indices seen by each worker is then shuffled deterministically. So, the indices seen by each worker may look like: `[5, 7, 3, 1, 9]` and `[4, 6, 2, 0, 8]` respectively.

In addition, the data sampler also provides a mechanism to control the degree of load balancing using the `random_level` argument. This argument modifies the sample complexities randomly so that the sorted dataset is not sorted purely in ascending order of complexities.

The data sampler also allows users to change the sorting and shuffling strategy slightly by working with groups within the dataset. This helps with decoupling any correlation that the sorting of the dataset might introduce with training loss.
- If the user provides the `group_size` argument, the dataset is grouped into `group_size` sized groups.
- The sorting of data samples based on complexities happens within each group as opposed to across the entire dataset.
- The shuffling happens on the group order and not on the dataset sample indices.

Here is an example of data sampler working with groups:
- Assume the data sampler is working with dataset with complexities: `[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]` and the number of workers is 2 and group size is 4.
- The sorted complexities will be: `[6, 7, 8, 9 | 2, 3, 4, 5 | 0, 1]` and sorted dataset indices (sorted on complexities) will be `[3, 2, 1, 0 | 7, 6, 5, 4 | 9, 8]`.
- The group order is then shuffled deterministically so that the indices could be: `[ 7, 6, 5, 4 | 9, 8 | 3, 2, 1, 0]`.
- The data is then distributed among the 2 workers. So each worker will see the data with indices `[7, 5, 9, 3, 1]` and `[6, 4, 8, 2, 0]` respectively.
