### PR TITLE
Update Cuda to 11.4.2, update architectures, support Ubuntu 20.04

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 
 FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 COPY --from=0 /code/build/Linux/Release/dist /root
 COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -6,7 +6,6 @@
 
 # nVidia cuda 11.4 Base Image
 FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-devel-ubuntu20.04
-#FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
 ENV	    DEBIAN_FRONTEND=nonintercative
 MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
@@ -17,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 
 FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
-#FROM nvidia/cuda:11.4.2-devel-ubuntu18.04
 ENV	    DEBIAN_FRONTEND=nonintercative
 COPY --from=0 /code/build/Linux/Release/dist /root
 COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt

--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -6,7 +6,7 @@
 
 # nVidia cuda 11.4 Base Image
 FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-devel-ubuntu20.04
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 


### PR DESCRIPTION
This PR updates CUDA to 11.4.2, updates architectures to support 30 series GPUs, and migrates to Ubuntu 20.04 for compatibility / future proofing.

- Why is this change required? What problem does it solve?

* provides newer CUDA support, wider architecture support and a new Ubuntu release for security and future proofing.

That's it :) 