### PR TITLE
[FIX] register softmaxgrad_13/logsoftmaxgrad_13 for rocm

### DIFF
--- a/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc
@@ -179,5 +179,96 @@ TEST(CudaKernelTest, LogSoftmaxGrad_LargeTensor_AllAxis) {
   TestSoftmaxGrad(dY_dims, Y_dims, dX_dims, 1, true);
 }
 
+static void TestSoftmaxGrad_13(const std::vector<int64_t>& dY_dims,
+                            const std::vector<int64_t>& Y_dims,
+                            const std::vector<int64_t>& dX_dims,
+                            int axis = 1,
+                            bool is_log_softmax = false,
+                            double per_sample_tolerance = 1e-4,
+                            double relative_per_sample_tolerance = 1e-4) {  
+
+  const char* op = is_log_softmax? "LogSoftmaxGrad_13" : "SoftmaxGrad_13";
+  CompareOpTester test(op, 1, kMSDomain);
+  test.AddAttribute<int64_t>("axis", axis);
+
+  // create rand inputs
+  RandomValueGenerator random{};
+  std::vector<float> dY_data = random.Uniform<float>(dY_dims, 0.0f, 1.0f);
+  // Add 1e-2 for numerical stability to prevent zero probability.
+  std::vector<float> Y_data = random.Uniform<float>(Y_dims, 0.02f, 1.02f);
+
+  test.AddInput<float>("dY", dY_dims, dY_data);
+  test.AddInput<float>("Y", Y_dims, Y_data);
+
+  std::vector<float> dX_data = FillZeros<float>(dX_dims);
+  test.AddOutput<float>("dX", dX_dims, dX_data);
+
+  test.CompareWithCPU(kGpuExecutionProvider, per_sample_tolerance, relative_per_sample_tolerance);
+}
+
+// small tensor to check dispatch_softmax_backward
+TEST(CudaKernelTest, SoftmaxGrad_13_SmallTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 2);
+}
+
+TEST(CudaKernelTest, SoftmaxGrad_13_SmallTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 0);
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 1);
+}
+
+// large tensor to check cuda DNN softmax backward
+TEST(CudaKernelTest, SoftmaxGrad_13_LargeTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  std::vector<int64_t> dX_dims{8, 16, 2048};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 2);
+}
+
+// large tensor to check cuda DNN softmax backward
+TEST(CudaKernelTest, SoftmaxGrad_13_LargeTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
+  std::vector<int64_t> dX_dims{8, 16, 512};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 0);
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 1);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_13_SmallTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 2, true);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_13_SmallTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{4, 2, 128};
+  std::vector<int64_t> Y_dims{4, 2, 128};
+  std::vector<int64_t> dX_dims{4, 2, 128};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 0, true);
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 1, true);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_13_LargeTensor_LastAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 2048};
+  std::vector<int64_t> Y_dims{8, 16, 2048};
+  std::vector<int64_t> dX_dims{8, 16, 2048};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 2, true);
+}
+
+TEST(CudaKernelTest, LogSoftmaxGrad_13_LargeTensor_AllAxis) {
+  std::vector<int64_t> dY_dims{8, 16, 512};
+  std::vector<int64_t> Y_dims{8, 16, 512};
+  std::vector<int64_t> dX_dims{8, 16, 512};
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 0, true);
+  TestSoftmaxGrad_13(dY_dims, Y_dims, dX_dims, 1, true);
+}
+
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/rocm/math/softmax_grad.cc
+++ b/orttraining/orttraining/training_ops/rocm/math/softmax_grad.cc
@@ -7,6 +7,7 @@
 #include "core/providers/rocm/miopen_common.h"
 #include "core/providers/rocm/math/softmax.h"
 #include "core/providers/rocm/shared_inc/accumulation_type.h"
+#include "core/providers/rocm/tensor/transpose.h"
 
 namespace onnxruntime {
 namespace rocm {
@@ -101,16 +102,76 @@ Status SoftmaxGrad<T>::ComputeInternal(OpKernelContext* ctx) const {
   const TensorShape& input_shape{dY->Shape()};
   const Tensor* Y = ctx->Input<Tensor>(1);
   Tensor* dX = ctx->Output(0, input_shape);
+  
+  size_t rank = input_shape.NumDimensions();
+  const size_t axis = static_cast<size_t>(HandleNegativeAxis(axis_, rank));
+  bool is_transpose_required = opset_ >= 13 && axis != (rank - 1);
 
-  const T* dY_data = dY->template Data<T>();
-  const T* Y_data = Y->template Data<T>();
-  T* dX_data = dX->template MutableData<T>();
+  std::unique_ptr<Tensor> transposed_dY;
+  std::unique_ptr<Tensor> transposed_Y;
+  std::vector<int64_t> transposed_input_dims;
+  std::unique_ptr<Tensor> intermediate_output;  // output that the softmax implementation will write into while using transposed input
+  std::vector<size_t> permutation(rank);
 
-  if (log_softmax_) {
-    return SoftMaxGradComputeHelper<T, true>(Stream(), dY_data, input_shape, Y_data, dX_data, MiopenHandle(), axis_);
-  } else {
-    return SoftMaxGradComputeHelper<T, false>(Stream(), dY_data, input_shape, Y_data, dX_data, MiopenHandle(), axis_);
+  if (is_transpose_required) {
+    AllocatorPtr alloc;
+    auto status = ctx->GetTempSpaceAllocator(&alloc);
+    if (!status.IsOK())
+      return status;
+
+    std::iota(std::begin(permutation), std::end(permutation), 0);
+
+    // swap the innermost dim with the dim corresponding to axis
+    permutation[axis] = rank - 1;
+    permutation[rank - 1] = axis;
+
+    transposed_input_dims.reserve(rank);
+    for (auto e : permutation) {
+      transposed_input_dims.push_back(input_shape[e]);
+    }
+
+    // Allocate a temporary tensor to hold transposed input
+    auto temp_input0 = Tensor::Create(Y->DataType(), TensorShape(transposed_input_dims), alloc);
+
+    // Perform the transpose
+    ORT_RETURN_IF_ERROR(Transpose::DoTranspose(prop_,
+                                               Stream(),
+                                               RocblasHandle(),
+                                               permutation, *Y, *temp_input0));
+    transposed_Y = std::move(temp_input0);
+    auto temp_input1 = Tensor::Create(Y->DataType(), TensorShape(transposed_input_dims), alloc);
+    ORT_RETURN_IF_ERROR(Transpose::DoTranspose(prop_,
+                                               Stream(),
+                                               RocblasHandle(),
+                                               permutation, *dY, *temp_input1));
+    transposed_dY = std::move(temp_input1);
+
+    // Allocate memory for the intermediate output
+    intermediate_output = Tensor::Create(dX->DataType(), TensorShape(transposed_input_dims), alloc);
   }
+  const T* dY_data = is_transpose_required ? transposed_dY->template Data<T>() : dY->template Data<T>();
+  const T* Y_data = is_transpose_required ? transposed_Y->template Data<T>() : Y->template Data<T>();
+  T* dX_data = is_transpose_required ? intermediate_output->template MutableData<T>() : dX->template MutableData<T>();
+  const TensorShape* compute_input_shape = is_transpose_required ? &transposed_Y->Shape() : &input_shape;
+  Status status;
+  if (log_softmax_) {
+    status = SoftMaxGradComputeHelper<T, true>(Stream(), dY_data, *compute_input_shape, Y_data, dX_data, MiopenHandle(), is_transpose_required ? static_cast<int64_t>(rank) - 1 : axis);
+  } else {
+    status = SoftMaxGradComputeHelper<T, false>(Stream(), dY_data, *compute_input_shape, Y_data, dX_data, MiopenHandle(), is_transpose_required ? static_cast<int64_t>(rank) - 1 : axis);
+  }
+
+  if (!status.IsOK()) {
+    return status;
+  }
+
+  if (is_transpose_required) {
+    // Perform the transpose to get the axes back to the original ordering
+    ORT_RETURN_IF_ERROR(Transpose::DoTranspose(prop_,
+                                               Stream(),
+                                               RocblasHandle(),
+                                               permutation, *intermediate_output, *dX));
+  }
+  return Status::OK();
 }
 
 #define SPECIALIZED_GRADIENT(T)     \

--- a/orttraining/orttraining/training_ops/rocm/math/softmax_grad.cc
+++ b/orttraining/orttraining/training_ops/rocm/math/softmax_grad.cc
@@ -61,17 +61,33 @@ Status SoftMaxGradComputeHelper(
   return Status::OK();
 }
 
-#define REGISTER_GRADIENT_KERNEL_TYPED(T)                                       \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                \
-      SoftmaxGrad,                                                              \
-      kMSDomain,                                                                \
-      1,                                                                        \
-      T,                                                                        \
-      kRocmExecutionProvider,                                                   \
+#define REGISTER_GRADIENT_KERNEL_TYPED(T)                                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      SoftmaxGrad,                                                                         \
+      kMSDomain,                                                                           \
+      1,                                                                                   \
+      T,                                                                                   \
+      kRocmExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      SoftmaxGrad<T>);                                                                     \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      SoftmaxGrad_13,                                                                      \
+      kMSDomain,                                                                           \
+      1,                                                                                   \
+      T,                                                                                   \
+      kRocmExecutionProvider,                                                              \
       (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       SoftmaxGrad<T>);                                                                     \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
       LogSoftmaxGrad,                                                                      \
+      kMSDomain,                                                                           \
+      1,                                                                                   \
+      T,                                                                                   \
+      kRocmExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      SoftmaxGrad<T>);                                                                     \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      LogSoftmaxGrad_13,                                                                   \
       kMSDomain,                                                                           \
       1,                                                                                   \
       T,                                                                                   \

--- a/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
@@ -69,6 +69,12 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, LogSoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SoftmaxGrad_13);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, SoftmaxGrad_13);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SoftmaxGrad_13);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, LogSoftmaxGrad_13);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad_13);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad_13);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float_float_float, BatchNormalizationGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double_double_double, BatchNormalizationGrad);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16_MLFloat16_MLFloat16, BatchNormalizationGrad);
@@ -247,6 +253,12 @@ Status RegisterRocmTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, LogSoftmaxGrad)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SoftmaxGrad_13)>,
+    // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, SoftmaxGrad_13)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SoftmaxGrad_13)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, LogSoftmaxGrad_13)>,
+    // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, double, LogSoftmaxGrad_13)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, LogSoftmaxGrad_13)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 12, 12, float, int64_t, SoftmaxCrossEntropyLoss)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TWO_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 13, MLFloat16, int64_t, SoftmaxCrossEntropyLoss)>,


### PR DESCRIPTION
**Description**: 
1. register SoftmaxGrad_13 and logSoftmaxGrad_13 for rocm.

**Motivation and Context**
- Why is this change required? What problem does it solve?
when the opset version update to the 14, some kernels used in models not register for rocm and run on CPU, it may bring a lot of memcpy operators and make the ort training slow.
- If it fixes an open issue, please link to the issue here.
