### PR TITLE
Remove wcos from normal windows build pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
     OrtNugetPackageId: 'Microsoft.ML.OnnxRuntime'
     AdditionalBuildFlags: ''
-    AdditionalWinBuildFlags: '--enable_onnx_tests --enable_wcos'
+    AdditionalWinBuildFlags: '--enable_onnx_tests'
     BuildVariant: 'default'
 
 - job: Linux_C_API_Packaging_GPU_x64
@@ -94,7 +94,7 @@ jobs:
     buildArch: x64
     msbuildPlatform: x64
     packageName: x64-cuda
-    buildparameter: --use_cuda --cuda_version=11.4 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4" --cudnn_home="C:\local\cudnn-11.4-windows-x64-v8.2.2.26\cuda" --enable_onnx_tests --enable_wcos --build_java --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;52;60;61;70;75;80"
+    buildparameter: --use_cuda --cuda_version=11.4 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4" --cudnn_home="C:\local\cudnn-11.4-windows-x64-v8.2.2.26\cuda" --enable_onnx_tests  --build_java --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;52;60;61;70;75;80"
     runTests: ${{ parameters.RunOnnxRuntimeTests }}
     buildJava: true
     java_artifact_id: onnxruntime_gpu
@@ -109,7 +109,7 @@ jobs:
     buildArch: x64
     msbuildPlatform: x64
     packageName: x64-tensorrt
-    buildparameter: --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.2.1.8.Windows10.x86_64.cuda-11.4.cudnn8.2" --cuda_version=11.4 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4" --cudnn_home="C:\local\cudnn-11.4-windows-x64-v8.2.2.26\cuda" --enable_onnx_tests --enable_wcos --build_java --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;52;60;61;70;75;80"
+    buildparameter: --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.2.1.8.Windows10.x86_64.cuda-11.4.cudnn8.2" --cuda_version=11.4 --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4" --cudnn_home="C:\local\cudnn-11.4-windows-x64-v8.2.2.26\cuda" --enable_onnx_tests --build_java --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;52;60;61;70;75;80"
     runTests: ${{ parameters.RunOnnxRuntimeTests }}
     buildJava: true
     java_artifact_id: onnxruntime_gpu

--- a/tools/ci_build/github/azure-pipelines/nodejs/cpu-esrp-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/cpu-esrp-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
   pool: 'Win-CPU-2021'
   variables:
     BuildConfig: 'RelWithDebInfo'
-    BuildCommand: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_nodejs --enable_onnx_tests --enable_wcos --use_telemetry --cmake_generator "Visual Studio 16 2019" --enable_lto'
+    BuildCommand: '--build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_nodejs --enable_onnx_tests --use_telemetry --cmake_generator "Visual Studio 16 2019" --enable_lto'
     msbuildPlatform: x64
   steps:
   - checkout: self

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -28,8 +28,8 @@ stages:
         BuildConfig: 'RelWithDebInfo'
         EnvSetupScript: setup_env.bat
         buildArch: x64
-        # Compare to our Nuget packaging pipeline, this job has "--build_wheel" but doesn't have "--enable_lto --disable_rtti --use_telemetry  --enable_wcos"
-        # Python bindings use typeid so I can't disable RTTI here. If it causes a problem, we will need to split this job to two jobs.
+        # Compare to our Nuget packaging pipeline, this job has "--build_wheel" but doesn't have "--enable_lto --disable_rtti --use_telemetry"
+        # Python bindings use typeid so I can't disable RTTI here. If it causes a problem, we will need to split this job to two jobs if it is a concern
         additionalBuildFlags: --build_wheel --build_java --build_nodejs
         msbuildPlatform: x64
         isX86: false


### PR DESCRIPTION
**Description**: 

Remove wcos from normal windows build pipelines. Keep it for WinML and DML build pipelines, remove it from the other places. Because wcos stands for Windows Core OS, it requires onecore and API Set. These two are only available starting from Windows 8. 

When we can drop the support for Windows 7/8/8.1, we can add it back.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Once the flag is used, the result binary can't run on Windows 7.

- If it fixes an open issue, please link to the issue here.
