### PR TITLE
fix hardcoded type in create_ort_value

### DIFF
--- a/orttraining/orttraining/eager/ort_aten.h
+++ b/orttraining/orttraining/eager/ort_aten.h
@@ -51,7 +51,7 @@ OrtValue create_ort_value(
     {1,},
     &ort_val);
   auto* ort_tensor = ort_val.GetMutable<onnxruntime::Tensor>();
-  CopyVectorToTensor<int64_t>(invoker, &val, 1, *ort_tensor);
+  CopyVectorToTensor<T>(invoker, &val, 1, *ort_tensor);
   return ort_val;
 }
 


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?

The `create_ort_value` function hardcodes a template argument to `int64_t`, which does not work in the general case.

- If it fixes an open issue, please link to the issue here.
