### PR TITLE
Make model tests name clear

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -990,23 +990,23 @@ TEST_P(ModelTest, Run) {
   }
   return v;
 }
+INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()));
+//INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
+      //// use info.param here to generate the test suffix
+      //// remove the trailing '/model.onnx' of test name which is size of 11
+      //std::basic_string<ORTCHAR_T> name = info.param.substr(0, info.param.size() - 11);
 
-INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
-      // use info.param here to generate the test suffix
-      // remove the trailing '/model.onnx' of test name which is size of 11
-      std::basic_string<ORTCHAR_T> name = info.param.substr(0, info.param.size() - 11);
-
-      // replace '/' with '_' since '/' is not accept as test name
-      std::replace(name.begin(), name.end(), '/', '_');
+      //// replace '/' with '_' since '/' is not accept as test name
+      //std::replace(name.begin(), name.end(), '/', '_');
       
-      char chars[] = ".";
-      for (unsigned int i = 0; i < strlen(chars); ++i)
-      {
-         name.erase (std::remove(name.begin(), name.end(), chars[i]), name.end());
-      }
+      //char chars[] = ".";
+      //for (unsigned int i = 0; i < strlen(chars); ++i)
+      //{
+         //name.erase (std::remove(name.begin(), name.end(), chars[i]), name.end());
+      //}
 
-      return name;
-    });
+      //return name;
+    //});
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -990,23 +990,33 @@ TEST_P(ModelTest, Run) {
   }
   return v;
 }
-INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()));
-//INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
-      //// use info.param here to generate the test suffix
-      //// remove the trailing '/model.onnx' of test name which is size of 11
-      //std::basic_string<ORTCHAR_T> name = info.param.substr(0, info.param.size() - 11);
 
-      //// replace '/' with '_' since '/' is not accept as test name
-      //std::replace(name.begin(), name.end(), '/', '_');
+INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
+      // use info.param here to generate the test suffix
+      std::basic_string<ORTCHAR_T> name = info.param;
+     
+      // remove the trailing '/model.onnx' of test name which is size of 11
+      if (name.size() > 11 and name.substr(name.size() - 11) == ORT_TSTR("/model.onnx")) {
+        name = name.substr(0, info.param.size() - 11);
+      }
+
+      // remove the trailing '.onnx' of test name which is size of 5 
+      if (name.size() > 5 and name.substr(name.size() - 5) == ORT_TSTR(".onnx")) {
+        name = name.substr(0, info.param.size() - 5);
+      }
+
+      // replace '/' with '_' since '/' is not accept as test name
+      std::replace(name.begin(), name.end(), '/', '_');
       
-      //char chars[] = ".";
-      //for (unsigned int i = 0; i < strlen(chars); ++i)
-      //{
-         //name.erase (std::remove(name.begin(), name.end(), chars[i]), name.end());
-      //}
+      // remove '.' and '-'
+      char chars[] = ".-";
+      for (unsigned int i = 0; i < strlen(chars); ++i)
+      {
+         name.erase (std::remove(name.begin(), name.end(), chars[i]), name.end());
+      }
 
-      //return name;
-    //});
+      return name;
+    });
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -990,7 +990,13 @@ TEST_P(ModelTest, Run) {
   return v;
 }
 
-INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()));
+INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
+      // use info.param here to generate the test suffix
+      // remove the trailing '/model.onnx' of test name which is size of 11
+      std::basic_string<ORTCHAR_T> name = info.param.substr(0, info.param.size() - 11);
+      std::replace(name.begin(), name.end(), '/', '_');
+      return name;
+    });
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -653,6 +653,7 @@ TEST_P(ModelTest, Run) {
             const OrtValue* v = p.second;
             input.emplace(p.first, *v);
           }
+          EXPECT_TRUE(false) << model_path;
           ASSERT_STATUS_OK(session_object.Run(input, output_names, &output_values));
         }
 
@@ -994,7 +995,16 @@ INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterSt
       // use info.param here to generate the test suffix
       // remove the trailing '/model.onnx' of test name which is size of 11
       std::basic_string<ORTCHAR_T> name = info.param.substr(0, info.param.size() - 11);
+
+      // replace '/' with '_' since '/' is not accept as test name
       std::replace(name.begin(), name.end(), '/', '_');
+      
+      char chars[] = ".";
+      for (unsigned int i = 0; i < strlen(chars); ++i)
+      {
+         name.erase (std::remove(name.begin(), name.end(), chars[i]), name.end());
+      }
+
       return name;
     });
 

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -990,7 +990,7 @@ TEST_P(ModelTest, Run) {
   return v;
 }
 
-auto GenerateCustomTestName  = [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
+auto ExpandModelName  = [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
   // use info.param here to generate the test suffix
   std::basic_string<ORTCHAR_T> name = info.param;
 
@@ -1005,7 +1005,7 @@ auto GenerateCustomTestName  = [](const ::testing::TestParamInfo<ModelTest::Para
   }
 
   // Note: test name only accepts '_' and alphanumeric
-  // replace '/' with '_' since '_'
+  // replace '/' with '_'
   std::replace(name.begin(), name.end(), '/', '_');
 
   // Note: test name only accepts '_' and alphanumeric
@@ -1025,7 +1025,7 @@ auto GenerateCustomTestName  = [](const ::testing::TestParamInfo<ModelTest::Para
 // So, we don't provide custom test name on Windows now.
 INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()));
 #else
-INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), GenerateCustomTestName);
+INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), ExpandModelName);
 #endif
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -653,7 +653,6 @@ TEST_P(ModelTest, Run) {
             const OrtValue* v = p.second;
             input.emplace(p.first, *v);
           }
-          EXPECT_TRUE(false) << model_path;
           ASSERT_STATUS_OK(session_object.Run(input, output_names, &output_values));
         }
 

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -990,23 +990,28 @@ TEST_P(ModelTest, Run) {
   return v;
 }
 
+// The optional last argument is a function or functor that generates custom test name suffixes based on the test parameters.
+// Specify the last argument to make test name more meaningful and clear instead of just the sequential number.
 INSTANTIATE_TEST_SUITE_P(ModelTests, ModelTest, testing::ValuesIn(GetParameterStrings()), [](const ::testing::TestParamInfo<ModelTest::ParamType>& info) {
       // use info.param here to generate the test suffix
       std::basic_string<ORTCHAR_T> name = info.param;
      
-      // remove the trailing '/model.onnx' of test name which is size of 11
+      // the original name here is the combination of provider name and model path name
+      // remove the trailing 'xxxxxxx/model.onnx' of name
       if (name.size() > 11 and name.substr(name.size() - 11) == ORT_TSTR("/model.onnx")) {
         name = name.substr(0, info.param.size() - 11);
       }
 
-      // remove the trailing '.onnx' of test name which is size of 5 
+      // remove the trailing 'xxxxxx.onnx' of name
       if (name.size() > 5 and name.substr(name.size() - 5) == ORT_TSTR(".onnx")) {
         name = name.substr(0, info.param.size() - 5);
       }
 
-      // replace '/' with '_' since '/' is not accept as test name
+      // Note: test name only accepts '_' and alphanumeric
+      // replace '/' with '_' since '_'
       std::replace(name.begin(), name.end(), '/', '_');
       
+      // Note: test name only accepts '_' and alphanumeric
       // remove '.' and '-'
       char chars[] = ".-";
       for (unsigned int i = 0; i < strlen(chars); ++i)


### PR DESCRIPTION
This PR makes model tests show meaningful and clear test name instead of sequential number so user can quickly know which tests are being run. 

original test name: 

    ...
    1: [ RUN      ] ModelTests/ModelTest.Run/6990
    1: [       OK ] ModelTests/ModelTest.Run/6990 (0 ms)
    1: [ RUN      ] ModelTests/ModelTest.Run/6991
    1: [       OK ] ModelTests/ModelTest.Run/6991 (0 ms)
    1: [ RUN      ] ModelTests/ModelTest.Run/6992


new test name:

    ...
    1: [ RUN      ] ModelTests/ModelTest.Run/tensorrt__data_onnx_onnx123_node_test_hardmax_default_axis
    1: [       OK ] ModelTests/ModelTest.Run/tensorrt__data_onnx_onnx123_node_test_hardmax_default_axis (0 ms)
    1: [ RUN      ] ModelTests/ModelTest.Run/tensorrt__data_onnx_onnx123_node_test_averagepool_1d_default
    1: [       OK ] ModelTests/ModelTest.Run/tensorrt__data_onnx_onnx123_node_test_averagepool_1d_default (0 ms)

