### PR TITLE
[TVM EP] Improved usability of TVM EP

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -44,17 +44,14 @@ try:
 except ImportError:
     pass
 
-if "StvmExecutionProvider" in get_available_providers():
-    try:
-        # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
-        # In order to use a Python function in C++ code, it must be registered in the global table of functions.
-        # Registration is carried out through the JIT interface, so it is necessary to call
-        # special functions for registration. To do this, we need to make the following import.
-        import onnxruntime.providers.stvm
-    except ImportError as e:
-        onnxruntime_validation.warnings.warn(
-            f"WARNING: Failed to register python functions to work with TVM EP. More details: {e}"
-        )
+try:
+    # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
+    # In order to use a Python function in C++ code, it must be registered in the global table of functions.
+    # Registration is carried out through the JIT interface, so it is necessary to call
+    # special functions for registration. To do this, we need to make the following import.
+    import onnxruntime.providers.stvm
+except ImportError:
+    pass
 
 from onnxruntime.capi.onnxruntime_validation import package_name, version, cuda_version
 if version:

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -44,6 +44,15 @@ try:
 except ImportError:
     pass
 
+try:
+    # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
+    # In order to use a Python function in C++ code, it must be registered in the global table of functions.
+    # Registration is carried out through the JIT interface, so it is necessary to call
+    # special functions for registration. To do this, we need to make the following import.
+    import onnxruntime.providers.stvm
+except ImportError:
+    pass
+
 from onnxruntime.capi.onnxruntime_validation import package_name, version, cuda_version
 if version:
     __version__ = version

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -44,15 +44,6 @@ try:
 except ImportError:
     pass
 
-try:
-    # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
-    # In order to use a Python function in C++ code, it must be registered in the global table of functions.
-    # Registration is carried out through the JIT interface, so it is necessary to call
-    # special functions for registration. To do this, we need to make the following import.
-    import onnxruntime.providers.stvm
-except ImportError:
-    pass
-
 from onnxruntime.capi.onnxruntime_validation import package_name, version, cuda_version
 if version:
     __version__ = version

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -44,14 +44,17 @@ try:
 except ImportError:
     pass
 
-try:
-    # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
-    # In order to use a Python function in C++ code, it must be registered in the global table of functions.
-    # Registration is carried out through the JIT interface, so it is necessary to call
-    # special functions for registration. To do this, we need to make the following import.
-    import onnxruntime.providers.stvm
-except ImportError:
-    pass
+if "StvmExecutionProvider" in get_available_providers():
+    try:
+        # Working between the C++ and Python parts in TVM EP is done using the PackedFunc and Registry classes.
+        # In order to use a Python function in C++ code, it must be registered in the global table of functions.
+        # Registration is carried out through the JIT interface, so it is necessary to call
+        # special functions for registration. To do this, we need to make the following import.
+        import onnxruntime.providers.stvm
+    except ImportError as e:
+        onnxruntime_validation.warnings.warn(
+            f"WARNING: Failed to register python functions to work with TVM EP. More details: {e}"
+        )
 
 from onnxruntime.capi.onnxruntime_validation import package_name, version, cuda_version
 if version:


### PR DESCRIPTION
Working between the C++ and Python parts in `TVM EP` is done using the `PackedFunc` and `Registry` classes. In order to use a Python function in C++ code, it must be registered in the global table of functions.
Registration is carried out through the JIT interface, so it is necessary to call special functions for registration. To do this, we need to make the following import:
```python
import onnxruntime.providers.stvm # nessesary to register tvm_onnx_import_and_compile and others
```
In order not to write this line at the beginning of every script where `TVM EP` is required, it was moved to `__init__.py`.
Thus, only one import needs to be called:
```python
import onnxruntime
```