### PR TITLE
Bump winrt version

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="GoogleTestAdapter" version="0.17.1" targetFramework="net46" />
   <package id="Microsoft.AI.DirectML" version="1.8.0" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201113.7" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.201201.7" targetFramework="native" />
 </packages>


### PR DESCRIPTION
**Description**: Bump WinRT version. The newer version is required by some internal OS tools (https://microsoft.visualstudio.com/OS/_workitems/edit/37239556/)