### PR TITLE
remove hardcoded type from inplace reshape

### DIFF
--- a/orttraining/orttraining/eager/ort_ops.cpp
+++ b/orttraining/orttraining/eager/ort_ops.cpp
@@ -22,12 +22,11 @@ void copy(onnxruntime::ORTInvoker& invoker,
 template <template<class> class V>
 void createInplaceOutputValue(OrtValue& input, V<int64_t> shape, OrtValue* p_mlvalue){
   auto* input_ort_tensor = input.GetMutable<onnxruntime::Tensor>();
-  auto element_type = onnxruntime::DataTypeImpl::GetType<int64_t>();
   // the ort TensorShape class only accept std::vector, so have to conversion.
   std::vector<int64_t> new_shape;
   new_shape.assign(shape.begin(), shape.end());
   CreateMLValue(input_ort_tensor->MutableDataRaw(),
-                element_type, new_shape, p_mlvalue);
+                input_ort_tensor->DataType(), new_shape, p_mlvalue);
 }
 
 template <typename T> 
@@ -36,9 +35,8 @@ using Vector = std::vector<T, std::allocator<T>>;
 template <>
 void createInplaceOutputValue<Vector>(OrtValue& input, Vector<int64_t> shape, OrtValue* p_mlvalue){
   auto* input_ort_tensor = input.GetMutable<onnxruntime::Tensor>();
-  auto element_type = onnxruntime::DataTypeImpl::GetType<int64_t>();
   CreateMLValue(input_ort_tensor->MutableDataRaw(),
-                element_type, shape, p_mlvalue);
+                input_ort_tensor->DataType(), shape, p_mlvalue);
 }
 
 template void createInplaceOutputValue<c10::ArrayRef>(OrtValue& input, c10::ArrayRef<int64_t> shape, OrtValue* p_mlvalue);


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

This is required for invoking reshape on tensors of types that are not int64 (e.g `torch.float32`).
