### PR TITLE
Vish/beam search prefix matching

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -153,12 +153,14 @@ class BeamSearchImpl {
   Status GenerateNextToken(const OrtValue& logits,
                            gsl::span<int64_t>& beam_next_tokens,
                            gsl::span<int64_t>& beam_indices,
-                           BeamSearchState<T>& beam_state);
+                           BeamSearchState<T>& beam_state,
+                           int counter);
 
   // Calculate scores from logits, then apply filtering and select next token for each beam.
   Status ProcessLogits(const OrtValue& logits,  // logits output of subgraph
                        BeamSearchState<T>& beam_state,
-                       AllocatorPtr& allocator);
+                       AllocatorPtr& allocator,
+                       int counter);
 
   OpKernelContextInternal& context_;
 
@@ -292,6 +294,25 @@ Status BeamSearchImpl<T>::CheckInputs(const OpKernelContextInternal& context) {
     parameters_->vocab_mask = vocab_mask->DataAsSpan<int32_t>();
   }
 
+  const Tensor* prefix_vocab_mask = context.Input<Tensor>(9);
+  if (prefix_vocab_mask != nullptr) {
+    // prefix_vocab_mask is optional
+    const auto& vocab_mask_dims = prefix_vocab_mask->Shape().GetDims();
+    if (vocab_mask_dims.size() != 1) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'prefix_vocab_mask' is expected to have 1 dimension, got ",
+                             vocab_mask_dims.size());
+    }
+
+    // There is dependency on vocab_size parameter, which shall be set before calling this function.
+    if (static_cast<int>(vocab_mask_dims[0]) != parameters_->vocab_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'prefix_vocab_mask' shape does not match with vocab_size, got ",
+                             vocab_mask_dims[0]);
+    }
+
+    // store prefix vocab mask in parameters.
+    parameters_->prefix_vocab_mask = prefix_vocab_mask->DataAsSpan<int32_t>();
+  }
+
   return Status::OK();
 }
 
@@ -346,7 +367,8 @@ template <typename T>
 Status BeamSearchImpl<T>::ProcessLogits(
     const OrtValue& logits,
     BeamSearchState<T>& beam_state,
-    AllocatorPtr& allocator) {
+    AllocatorPtr& allocator,
+    int counter) {
   const int64_t batch_beam_size = static_cast<int64_t>(parameters_->BatchBeamSize());
   const int& vocab_size = parameters_->vocab_size;
 
@@ -394,7 +416,7 @@ Status BeamSearchImpl<T>::ProcessLogits(
 #endif
 
   // Apply all score processors that updates scores
-  logits_processors_.Process(&(beam_state.sequences), next_token_scores);
+  logits_processors_.Process(&(beam_state.sequences), next_token_scores, counter);
 
 #ifdef DEBUG_BEAM_SEARCH
   DumpTensor("next_token_scores after logits processor", next_token_scores.data(), parameters_->batch_size, parameters_->num_beams, vocab_size);
@@ -486,9 +508,10 @@ Status BeamSearchImpl<T>::GenerateNextToken(
     const OrtValue& logits,
     gsl::span<int64_t>& beam_next_tokens,
     gsl::span<int64_t>& beam_indices,
-    BeamSearchState<T>& beam_state) {
+    BeamSearchState<T>& beam_state,
+    int counter) {
   // Process logits to get next token scores
-  ORT_RETURN_IF_ERROR(ProcessLogits(logits, beam_state, allocator_));
+  ORT_RETURN_IF_ERROR(ProcessLogits(logits, beam_state, allocator_, counter));
 
   gsl::span<T>& beam_scores = beam_scorer_->GetNextScores();
   // It is optional to clone beam_scores. Change it to use same buffer also works:
@@ -587,7 +610,9 @@ Status BeamSearchImpl<T>::Execute(const FeedsFetchesManager& ffm) {
 #endif
 
   int current_length = parameters_->sequence_length;
+  int iteration_counter = 0;
   while (current_length < parameters_->max_length) {
+    iteration_counter++;
 #ifdef DEBUG_BEAM_SEARCH
     DumpString("***CurrentLength", std::to_string(current_length), true);
 #endif
@@ -600,7 +625,7 @@ Status BeamSearchImpl<T>::Execute(const FeedsFetchesManager& ffm) {
     const OrtValue& logits = fetches[0];
     gsl::span<int64_t> beam_next_tokens;
     gsl::span<int64_t> beam_indices;
-    ORT_RETURN_IF_ERROR(GenerateNextToken(logits, beam_next_tokens, beam_indices, beam_state));
+    ORT_RETURN_IF_ERROR(GenerateNextToken(logits, beam_next_tokens, beam_indices, beam_state, iteration_counter));
 
     // When all batches are finished, stop earlier to avoid wasting computation.
     if (beam_scorer_->IsDone()) {

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.h
@@ -28,7 +28,8 @@ struct BeamSearchParameters {
   int sequence_length;  // deduce from second dimension of input_ids
 
   gsl::span<const int32_t> vocab_mask;
-
+  gsl::span<const int32_t> prefix_vocab_mask;
+  
   // Parameters from outputs.
   bool output_scores;  // whether scores existed in output
 

--- a/onnxruntime/contrib_ops/cpu/transformers/dump_tensor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/dump_tensor.h
@@ -26,7 +26,8 @@ namespace transformers {
     continue;                                                                               \
   }
 
-#define SKIP_IF_TOO_MANY(row_or_column_size, i, new_line) SKIP_IF_MORE_THAN(row_or_column_size, i, MAX_ROW_OR_COLUMN, new_line)
+//#define SKIP_IF_TOO_MANY(row_or_column_size, i, new_line) SKIP_IF_MORE_THAN(row_or_column_size, i, MAX_ROW_OR_COLUMN, new_line)
+#define SKIP_IF_TOO_MANY(row_or_column_size, i, new_line)
 
 extern bool g_enable_tensor_dump;  // global variance to turn on/off dump
 

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
@@ -9,6 +9,8 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
+static int beam_search_iteration;
+
 template <typename T>
 gsl::span<T> NextTokenScores<T>::GetScores(int batch_beam_index) {
   assert(batch_beam_index >= 0 && batch_beam_index < batch_beam_size);
@@ -147,6 +149,35 @@ void VocabMaskLogitsProcessor<T>::Process(const ISequences* /*sequences*/,
 }
 
 template <typename T>
+PrefixVocabMaskLogitsProcessor<T>::PrefixVocabMaskLogitsProcessor(const gsl::span<const int32_t>& prefix_vocab_mask) : prefix_vocab_mask_(prefix_vocab_mask) {
+}
+
+template <typename T>
+void PrefixVocabMaskLogitsProcessor<T>::Process(const ISequences* /*sequences*/,
+                                          NextTokenScores<T>& next_token_scores) {  
+  assert(!prefix_vocab_mask_.empty());
+  if (beam_search_iteration > 1) {
+    return;
+  }
+
+  // Process vocabulary mask and set tokens with mask value 0 to -inf.
+  T* p = next_token_scores.scores.data();
+  // next_token_scores shape (batch_size * num_beams, vocab_size)
+  // vocab_mask shape (vocab_size). TODO: support shape (batch_size, vocab_size)
+  for (int i = 0; i < next_token_scores.batch_beam_size; i++) {
+    for (int j = 0; j < next_token_scores.vocab_size; j++, p++) {
+      if (prefix_vocab_mask_[j] == 0) {
+        *p = std::numeric_limits<T>::lowest();
+      }
+    }
+  }
+
+#ifdef DEBUG_BEAM_SEARCH
+  DumpScores("PrefixVocabMaskLogitsProcessor", next_token_scores.scores);
+#endif
+}
+
+template <typename T>
 void LogitsProcessorList<T>::Init(const BeamSearchParameters& parameters) {
   processor_list_.clear();
 
@@ -165,6 +196,11 @@ void LogitsProcessorList<T>::Init(const BeamSearchParameters& parameters) {
     processor_list_.push_back(vocab_mask_processor_.get());
   }
 
+  if (!parameters.prefix_vocab_mask.empty()) {
+    prefix_vocab_mask_processor_ = std::make_unique<PrefixVocabMaskLogitsProcessor<T>>(parameters.prefix_vocab_mask);
+    processor_list_.push_back(prefix_vocab_mask_processor_.get());
+  }
+
   if (parameters.min_length > 0) {
     min_length_processor_ = std::make_unique<MinLengthLogitsProcessor<T>>(parameters.min_length, parameters.eos_token_id);
     processor_list_.push_back(min_length_processor_.get());
@@ -176,8 +212,10 @@ void LogitsProcessorList<T>::Init(const BeamSearchParameters& parameters) {
 
 template <typename T>
 void LogitsProcessorList<T>::Process(const ISequences* sequences,
-                                     gsl::span<T>& next_token_scores) {
+                                     gsl::span<T>& next_token_scores,
+                                     int counter) {
   NextTokenScores<T> input_scores = {next_token_scores, batch_beam_size_, vocab_size_};
+  beam_search_iteration = counter;
   for (size_t i = 0; i < processor_list_.size(); i++) {
     processor_list_[i]->Process(sequences, input_scores);
   }
@@ -188,6 +226,7 @@ template class MinLengthLogitsProcessor<float>;
 template class RepetitionPenaltyLogitsProcessor<float>;
 template class NoRepeatNGramLogitsProcessor<float>;
 template class VocabMaskLogitsProcessor<float>;
+template class PrefixVocabMaskLogitsProcessor<float>;
 template class LogitsProcessorList<float>;
 
 }  // namespace transformers

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -77,11 +77,23 @@ class VocabMaskLogitsProcessor : public ILogitsProcessor<T> {
 };
 
 template <typename T>
+class PrefixVocabMaskLogitsProcessor : public ILogitsProcessor<T> {
+ public:
+  PrefixVocabMaskLogitsProcessor(const gsl::span<const int32_t>& vocab_mask);
+
+  void Process(const ISequences* sequences,
+               NextTokenScores<T>& next_token_scores) override;
+
+ private:
+  gsl::span<const int32_t> prefix_vocab_mask_;
+};
+
+template <typename T>
 class LogitsProcessorList {
 public:
     LogitsProcessorList() = default ;
     void Init(const BeamSearchParameters& parameters);
-    void Process(const ISequences* sequences, gsl::span<T>& next_token_scores);
+    void Process(const ISequences* sequences, gsl::span<T>& next_token_scores, int counter);
 
 private:
     int batch_beam_size_;
@@ -91,6 +103,7 @@ private:
     std::unique_ptr<RepetitionPenaltyLogitsProcessor<T>> repetition_penalty_processor_;
     std::unique_ptr<NoRepeatNGramLogitsProcessor<T>> no_repeat_ngram_processor_;
     std::unique_ptr<VocabMaskLogitsProcessor<T>> vocab_mask_processor_;
+    std::unique_ptr<PrefixVocabMaskLogitsProcessor<T>> prefix_vocab_mask_processor_;
     std::unique_ptr<MinLengthLogitsProcessor<T>> min_length_processor_;
 };
 

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -695,6 +695,7 @@ void RegisterTextGenerationSchemas() {
               "T", OpSchema::Optional)
         .Input(7, "repetition_penalty", "The parameter for repetition penalty. Default value 1.0 means no penalty. Accepts value > 0.0. Shape is (1)", "T", OpSchema::Optional)
         .Input(8, "vocab_mask", "Mask of vocabulary. Words that masked with 0 are not allowed to be generated, and 1 is allowed. Shape is (vacab_size)", "M", OpSchema::Optional)
+        .Input(9, "prefix_vocab_mask", "Mask of vocabulary for first step. Words that masked with 0 are not allowed to be generated, and 1 is allowed. Shape is (vacab_size)", "M", OpSchema::Optional)
         .Output(0, "sequences", "Word IDs of generated sequences. Shape is (batch_size, num_return_sequences, max_sequence_length)", "I")
         .Output(1, "sequences_scores", "Final beam score of the generated sequences. Shape is (batch_size, num_return_sequences)", "T", OpSchema::Optional)
         .Output(2, "scores",

--- a/onnxruntime/python/tools/transformers/convert_beam_search.py
+++ b/onnxruntime/python/tools/transformers/convert_beam_search.py
@@ -128,6 +128,17 @@ def parse_arguments(argv=None):
                                    default=1,
                                    help='Positive. >1 to penalize and <1 to encorage.')
 
+    beam_search_group.add_argument('--vocab_size',
+                                    type=int,
+                                    required=False,
+                                    help="Vocab_size of the underlying model")
+
+    beam_search_group.add_argument('--prefix_vocab_mask',
+                                    required=False,
+                                    action='store_true',
+                                    help="This vocab mask applies only to first iteration, enable if last work in query might need auto complete")
+    beam_search_group.set_defaults(prefix_vocab_mask=False)
+
     mixed_precision_option_group = parser.add_argument_group(
         "mixed precision conversion parameters that works when \"--precision fp16\" is specified")
 
@@ -236,6 +247,8 @@ def convert_model(args):
         "input_ids", "max_length", "min_length", "num_beams", "num_return_sequences", "temperature", "length_penalty",
         "repetition_penalty", "vocab_mask"
     ]
+    if args.prefix_vocab_mask:
+        inputs.append("prefix_vocab_mask")
 
     outputs = ["sequences"]
     if args.output_sequences_scores:
@@ -272,6 +285,10 @@ def convert_model(args):
         input_ids, max_length, min_length, num_beams, num_return_sequences, temperature, length_penalty,
         repetition_penalty, vocab_mask
     ]
+
+    if args.prefix_vocab_mask:
+        prefix_vocab_mask = helper.make_tensor_value_info('prefix_vocab_mask', TensorProto.INT32, [vocab_size])
+        graph_inputs.append(prefix_vocab_mask)
 
     # graph outputs
     sequences = helper.make_tensor_value_info('sequences', TensorProto.INT32,


### PR DESCRIPTION
**Description**: This PR targets required changes to allow prefix matching in beam search OP.

**Motivation and Context**
- Why is this change required? What problem does it solve?
In generative models, prefix of the last word needs to be matched with the first word being generated.

- If it fixes an open issue, please link to the issue here.
NA

