### PR TITLE
quantization tools: change num_bins default value

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -654,7 +654,7 @@ def create_calibrator(model,
         return MinMaxCalibrater(model, op_types_to_calibrate, augmented_model_path)
     elif calibrate_method == CalibrationMethod.Entropy:
         # default settings for entropy algorithm
-        num_bins = 128 if 'num_bins' not in extra_options else extra_options['num_bins']
+        num_bins = 2048 if 'num_bins' not in extra_options else extra_options['num_bins']
         num_quantized_bins = 128 if 'num_quantized_bins' not in extra_options else extra_options['num_quantized_bins']
         return EntropyCalibrater(model, op_types_to_calibrate, augmented_model_path, num_bins=num_bins, num_quantized_bins=num_quantized_bins)
     elif calibrate_method == CalibrationMethod.Percentile:


### PR DESCRIPTION
If you set `num_bins = 128` in `create_calibrator`,  then in `get_entropy_threshold` method, 

```
def get_entropy_threshold(self, histogram, num_quantized_bins):
       # both num_half_quantized_bin and zero_bin_index will equals to 64, this loop will execute only once, which is incorrect
        for i in range(num_half_quantized_bin, zero_bin_index + 1, num_half_quantized_bin):

```