### PR TITLE
Add _force_exportable_set and pass debug_options

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
@@ -7,6 +7,9 @@ from ... import ORTModule
 from .... import ortmodule
 from ...debug_options import DebugOptions
 
+# nn.Module's in this set are considered exportable to ONNX.
+# For other nn.Module's, torch.onnx.export is called to check if
+# they are exportable.
 _force_exportable_set = set([torch.nn.Linear, torch.nn.Identity,  torch.nn.modules.linear.NonDynamicallyQuantizableLinear])
 
 class HierarchicalORTModule(torch.nn.Module):

--- a/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
@@ -52,10 +52,7 @@ class HierarchicalORTModule(torch.nn.Module):
         self._initialized = False
         super(HierarchicalORTModule, self).__init__()
         self._original_module = module
-        if not debug_options:
-            self._debug_options = DebugOptions()
-        else:
-            self._debug_options = debug_options
+        self._debug_options = debug_options if debug_options else DebugOptions()
 
     def _initialize(self, *args, **kwargs):
         handle_pool = []

--- a/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
@@ -7,6 +7,7 @@ from ... import ORTModule
 from .... import ortmodule
 from ...debug_options import DebugOptions
 
+_force_exportable_set = set([torch.nn.Linear, torch.nn.Identity,  torch.nn.modules.linear.NonDynamicallyQuantizableLinear])
 
 class HierarchicalORTModule(torch.nn.Module):
     '''
@@ -50,6 +51,8 @@ class HierarchicalORTModule(torch.nn.Module):
         self._original_module = module
         if not debug_options:
             self._debug_options = DebugOptions()
+        else:
+            self._debug_options = debug_options
 
     def _initialize(self, *args, **kwargs):
         handle_pool = []
@@ -81,6 +84,10 @@ class HierarchicalORTModule(torch.nn.Module):
         # "module" can be wrapped as ORTModule. Otherwise, "module" is
         # not exportable to ONNX.
         def check_exportable(module):
+            # forward functions of classes in _force_exportable_set may not be called
+            # thus not in module_arg_pool
+            if type(module) in _force_exportable_set:
+                return True
             sub_dict = module._modules
             if not sub_dict:
                 # No sub-module exists, so this module is a leaf

--- a/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/experimental/hierarchical_ortmodule/_hierarchical_ortmodule.py
@@ -87,6 +87,7 @@ class HierarchicalORTModule(torch.nn.Module):
             # forward functions of classes in _force_exportable_set may not be called
             # thus not in module_arg_pool
             if type(module) in _force_exportable_set:
+                exportable_list[module] = True
                 return True
             sub_dict = module._modules
             if not sub_dict:


### PR DESCRIPTION
**Description**: This PR fixes 

- key error thrown from `for args in module_arg_pool[module]:`, due to forward function of classes in _force_exportable_set are not always called
- pass through debug_options

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
