### PR TITLE
support type promotion in binary poerators in eager mode

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen.py
+++ b/orttraining/orttraining/eager/opgen/opgen.py
@@ -22,7 +22,7 @@ parser.add_argument('--custom_ops', action='store_true', help='Whether we are ge
 args = parser.parse_args()
 ops_module = SourceFileLoader("opgen.customop", args.ops_module).load_module()
 
-ortgen = ORTGen(ops_module.ops, custom_ops=args.custom_ops)
+ortgen = ORTGen(ops_module.ops, type_promotion_ops=ops_module.type_promotion_ops, custom_ops=args.custom_ops)
 
 regdecs_path = args.header_file
 print(f"INFO: Using ATen RegistrationDeclations from: {regdecs_path}")

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -26,6 +26,7 @@ class GeluGrad(ONNXOp):
     self.domain = kMSDomain
 
 ops = {}
+type_promotion_ops = []
 
 for binary_op, onnx_op in {
   'add': Add('self', Mul('alpha', 'other')),
@@ -37,6 +38,7 @@ for binary_op, onnx_op in {
       name = f'aten::{binary_op}{variant}.{dtype}'
       if name not in ops:
         ops[f'aten::{binary_op}{variant}.{dtype}'] = deepcopy(onnx_op)
+        type_promotion_ops.append(f'aten::{binary_op}{variant}.{dtype}')
 
 for unary_op in [
   'abs','acos','acosh', 'asinh', 'atanh', 'asin', 'atan', 'ceil', 'cos',
@@ -92,3 +94,8 @@ hand_implemented = {
 }
 
 ops = {**ops, **hand_implemented} 
+# TODO: this is a temporary whitelist for ops need type promotion
+# Need to enhance the support for onnx type constrains to automatically
+# resolve whether the op need type promotion.
+# Will remove this list in the future.
+type_promotion_ops = (*type_promotion_ops, 'aten::gelu_backward')

--- a/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
@@ -13,3 +13,5 @@ from opgen.onnxops import *
 ops = {
     'gemm': Gemm('A', 'B', 'C', 'alpha', 'beta', 'transA', 'transB')
 }
+
+type_promotion_ops = {}

--- a/orttraining/orttraining/eager/ort_aten.h
+++ b/orttraining/orttraining/eager/ort_aten.h
@@ -118,5 +118,12 @@ bool IsSupportedType(c10::optional<int64_t> val, const std::vector<at::ScalarTyp
 
 bool IsSupportedType(at::TensorList tensors, const std::vector<at::ScalarType>& valid_types);
 
+c10::optional<at::ScalarType> PromoteScalarTypesWithCategory(
+    const std::vector<at::ScalarType>& typesFromTensors,
+    const std::vector<at::ScalarType>& typesFromScalars);
+
+ONNX_NAMESPACE::TensorProto_DataType GetONNXTensorProtoDataType(at::ScalarType dtype);
+
+OrtValue CastToType(onnxruntime::ORTInvoker& invoker, const OrtValue& input, at::ScalarType type);
 } // namespace eager
 } // namespace torch_ort

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -17,6 +17,16 @@ class OrtOpTests(unittest.TestCase):
     cpu_twos = cpu_ones + cpu_ones
     ort_twos = ort_ones + ort_ones
     assert torch.allclose(cpu_twos, ort_twos.cpu())
+  
+  def test_type_promotion_add(self):
+    device = self.get_device()
+    x = torch.ones(2, 5, dtype = torch.int64)
+    y = torch.ones(2, 5, dtype = torch.float32)
+    ort_x = x.to(device)
+    ort_y = y.to(device)
+    ort_z = ort_x + ort_y
+    assert ort_z.dtype == torch.float32
+    assert torch.allclose(ort_z.cpu(), (x + y))
 
   def test_add_alpha(self):
     device = self.get_device()


### PR DESCRIPTION
**Description**: Reuse pytorch's type promotion strategy to handle kernel invoke with different types in eager mode

currently we only enable it with a whitelist. will have another PR to parse the onnx type constrains to automatically resolve which arguments need type promotion.

