### PR TITLE
Symmetric QGEMM 

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -57,6 +57,7 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/arm64/QgemmS8S8KernelSdot.asm
         ${MLAS_SRC_DIR}/arm64/SgemmKernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/SgemvKernelNeon.asm
+        ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelNeon.asm
       )
     else()
       target_sources(onnxruntime_mlas PRIVATE

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -281,6 +281,7 @@ else()
           ${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSdot.S
           ${MLAS_SRC_DIR}/aarch64/SgemmKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SgemvKernelNeon.S
+          ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelNeon.S
           ${MLAS_SRC_DIR}/qgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -283,7 +283,7 @@ else()
           ${MLAS_SRC_DIR}/aarch64/SgemmKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SgemvKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelNeon.S
-          ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelSDot.S
+          ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelSdot.S
           ${MLAS_SRC_DIR}/qgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -58,6 +58,7 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/arm64/SgemmKernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/SgemvKernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelNeon.asm
+        ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelSDot.asm
       )
     else()
       target_sources(onnxruntime_mlas PRIVATE
@@ -282,6 +283,7 @@ else()
           ${MLAS_SRC_DIR}/aarch64/SgemmKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SgemvKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelNeon.S
+          ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelSDot.S
           ${MLAS_SRC_DIR}/qgemm_kernel_neon.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
           ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -43,6 +43,7 @@ bool IAllocator::CalcMemSizeForArrayWithAlignment(size_t nmemb, size_t size, siz
 void* AllocatorDefaultAlloc(size_t size) {
   const size_t alignment = MlasGetPreferredBufferAlignment();
   if (size <= 0) return nullptr;
+  size += MLAS_SYMM_QGEMM_BUF_OVERRUN;
   void* p;
 #if defined(_MSC_VER)
   p = mi_malloc_aligned(size, alignment);
@@ -73,6 +74,7 @@ void AllocatorDefaultFree(void* p) {
 void* AllocatorDefaultAlloc(size_t size) {
   const size_t alignment = MlasGetPreferredBufferAlignment();
   if (size <= 0) return nullptr;
+  size += MLAS_SYMM_QGEMM_BUF_OVERRUN;
   void* p;
 #if _MSC_VER
   p = _aligned_malloc(size, alignment);

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -590,6 +590,65 @@ MlasGemmBatch(
     MLAS_THREADPOOL* ThreadPool
     );
 
+/**
+ * @brief Supply data parameters for symmetric quantized GEMM.
+ *        B matrix zero point must be zero, and it must be
+ *        pre-packed, with column sums scaled by (-ZeroPointA)
+*/
+struct MLAS_SYMM_QGEMM_DATA_PARAMS {
+    const void* A = nullptr;
+    size_t lda = 0;
+    const void* B = 0;
+    void* C = nullptr;
+    size_t ldc = 0;
+    // TODO!! add re-quantization parameters
+};
+
+/**
+ * @brief Whether symmetric quant gemm is supported.
+ * @param AIsSigned 
+ * @return 
+*/
+inline
+bool
+MLASCALL
+MlasSymmQgemmSupported(bool AIsSigned)
+{
+#ifndef MLAS_TARGET_ARM64
+
+    // Only have arm64 impl for now
+    return false;
+
+#else
+
+    // Only support s8s8 for now
+    return AIsSigned;
+
+#endif  // !MLAS_TARGET_ARM64
+}
+
+/**
+ * @brief   Batched QGEMM. Similar to MlasGemmBatch, but right hand side matrix
+ *          must be symmetrically quantized and prepacked.
+ *
+ * @param [IN] Shape        A single shape descriptor for all multiplicatons.
+                            Currently A and B must be signed, and accumulation
+                            mode not supported
+ * @param [IN] DataParams   Array of data descriptors, one for each mutliplication
+ *                          B must be prepacked
+ * @param [IN] BatchN       Number of multiplications
+ * @param [IN] ThreadPool 
+*/
+void
+MLASCALL
+MlasSymmQgemmBatch(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_SYMM_QGEMM_DATA_PARAMS* DataParams,
+    const size_t BatchN,
+    MLAS_THREADPOOL* ThreadPool
+    );
+
+
 //
 // Buffer packing routines.
 //
@@ -630,6 +689,18 @@ MlasGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
+    void* PackedB
+    );
+
+void
+MLASCALL
+MlasSymmQgemmPackB(
+    size_t N,
+    size_t K,
+    const int8_t* B,
+    size_t ldb,
+    bool AIsSigned,
+    int32_t ZeroPointA,
     void* PackedB
     );
 

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -592,6 +592,16 @@ MlasGemm(
     MlasGemmBatch(Shape, &DataParams, 1, ThreadPool);
 }
 
+//
+// Symmetric QGEMM has limited buffer overrun.
+// Currently only supported in ARM64
+//
+#if defined(MLAS_TARGET_ARM64)
+constexpr size_t MLAS_SYMM_QGEMM_BUF_OVERRUN = 15;
+#else
+constexpr size_t MLAS_SYMM_QGEMM_BUF_OVERRUN = 0;
+#endif
+
 /**
  * @brief Supply data parameters for symmetric quantized GEMM.
  *        B matrix zero point must be zero, and it must be

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -562,14 +562,6 @@ struct MLAS_GEMM_QUANT_DATA_PARAMS {
     const MLAS_QGEMM_OUTPUT_PROCESSOR* OutputProcessor = nullptr;
 };
 
-void
-MLASCALL
-MlasGemm(
-    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
-    const MLAS_GEMM_QUANT_DATA_PARAMS& DataParams,
-    MLAS_THREADPOOL* ThreadPool
-    );
-
 /**
  * @brief Batched GEMM, for multiplying multiple pairs of matrices.
  * Note:  We only support uniform batching, so shapes and types of the
@@ -589,6 +581,16 @@ MlasGemmBatch(
     const size_t BatchN,
     MLAS_THREADPOOL* ThreadPool
     );
+
+inline
+void
+MlasGemm(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS &Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS &DataParams,
+    MLAS_THREADPOOL *ThreadPool)
+{
+    MlasGemmBatch(Shape, &DataParams, 1, ThreadPool);
+}
 
 /**
  * @brief Supply data parameters for symmetric quantized GEMM.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -607,29 +607,6 @@ struct MLAS_SYMM_QGEMM_DATA_PARAMS {
 };
 
 /**
- * @brief Whether symmetric quant gemm is supported.
- * @param AIsSigned 
- * @return 
-*/
-inline
-bool
-MLASCALL
-MlasSymmQgemmSupported(bool AIsSigned)
-{
-#ifndef MLAS_TARGET_ARM64
-
-    // Only have arm64 impl for now
-    return false;
-
-#else
-
-    // Only support s8s8 for now
-    return AIsSigned;
-
-#endif  // !MLAS_TARGET_ARM64
-}
-
-/**
  * @brief   Batched QGEMM. Similar to MlasGemmBatch, but right hand side matrix
  *          must be symmetrically quantized and prepacked.
  *
@@ -692,6 +669,23 @@ MlasGemmPackB(
     bool AIsSigned,
     bool BIsSigned,
     void* PackedB
+    );
+
+/**
+ * @brief For symmetric quantized GEMM, returns size of the
+ *        packing buffer needed for right hand side        
+ * @param N              Number of columns 
+ * @param K              Number of rows
+ * @param AIsSigned      Whether left hand size is signed int8_t
+ * @return  size of the packing buffer,
+ *          0 if operation not supported
+*/
+size_t
+MLASCALL
+MlasSymmQgemmPackBSize(
+    size_t N,
+    size_t K, 
+    bool AIsSigned
     );
 
 void

--- a/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 
 Module Name:
 
-    SymQgemmS8KernelNeon.asm
+    SymQgemmS8KernelNeon.S
 
 Abstract:
 
@@ -20,17 +20,17 @@ Abstract:
 
 --*/
 
-#include "kxarm64.h"
+#include "asmmacro.h"
 
 //
 // Stack frame layout for the S8S8 kernel.
+// d8-d15, x19-x30 need to be preserved if used
 //
 
-#define  SQGemmS8Frame_SavedNeonRegisters     (8 * 8)
-#define  SQGemmS8Frame_SavedRegisters         SQGemmS8Frame_SavedNeonRegisters
-#define  SQGemmS8Frame_ColumnSumBuffer        0 + SQGemmS8Frame_SavedRegisters
+        .equ    .LSQGemmS8Frame_SavedRegisters,     (8 * 8)
+        .equ    .LSQGemmS8Frame_ColumnSumBuffer,    0 + .LSQGemmS8Frame_SavedRegisters
 
-        TEXTAREA
+        .text
 
 /*++
 
@@ -73,13 +73,13 @@ Return Value:
 
 --*/
 
-        NESTED_ENTRY MlasSymQgemmS8KernelNeon
+        FUNCTION_ENTRY MlasSymQgemmS8KernelNeon
 
-        PROLOG_SAVE_REG_PAIR d8,d9,#-SQGemmS8Frame_SavedRegisters!
-        PROLOG_SAVE_REG_PAIR d10,d11,#16
-        PROLOG_SAVE_REG_PAIR d12,d13,#32
-        PROLOG_SAVE_REG_PAIR d14,d15,#48
-        ldr     x13,[sp,#SQGemmS8Frame_ColumnSumBuffer]
+        stp     d8,d9,[sp,#-.LSQGemmS8Frame_SavedRegisters]!
+        stp     d10,d11,[sp,#16]
+        stp     d12,d13,[sp,#32]
+        stp     d14,d15,[sp,#48]
+        ldr     x13,[sp,#.LSQGemmS8Frame_ColumnSumBuffer]
         mov     x14,x0
         mov     x15,x3
         cmp     x4,#1                       // CountM == 1?
@@ -109,7 +109,7 @@ Return Value:
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 //
 
-M4_ProcessNextColumnLoop
+M4_ProcessNextColumnLoop:
         mov     x0,x14                      // reload matrix A0
         mov     x3,x15                      // reload PackedCountK
         ldr     d0,[x0],#8                  // Load A0
@@ -139,7 +139,7 @@ M4_ProcessNextColumnLoop
         movi    v31.4s,#0
         add     x11,x10,x7                  // A3
 
-M4_ComputeBlockLoop
+M4_ComputeBlockLoop:
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
@@ -200,7 +200,7 @@ M4_ComputeBlockLoop
         sadalp  v31.4s,v15.8h
         b       M4_ComputeBlockLoop
 
-M4_ComputeBlockLoopFinish
+M4_ComputeBlockLoopFinish:
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
@@ -245,7 +245,7 @@ M4_ComputeBlockLoopFinish
         add     v24.4s,v24.4s,v2.4s
         add     v28.4s,v28.4s,v2.4s
 
-M4_StoreOutput
+M4_StoreOutput:
         add     x10,x2,x6,lsl #2
         add     x11,x10,x6,lsl #2
         add     x12,x11,x6,lsl #2
@@ -257,17 +257,17 @@ M4_StoreOutput
         st1     {v28.4s},[x12]
         cbnz    x5,M4_ProcessNextColumnLoop
 
-M4_ExitKernel
+M4_ExitKernel:
         mov     x0,#4                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d14,d15,#48
-        EPILOG_RESTORE_REG_PAIR d12,d13,#32
-        EPILOG_RESTORE_REG_PAIR d10,d11,#16
-        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
-        EPILOG_RETURN
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#.LSQGemmS8Frame_SavedRegisters
+        ret
 
-M4_StoreOutputPartial
+M4_StoreOutputPartial:
 
-M4_StoreOutputPartial_ZeroMode
+M4_StoreOutputPartial_ZeroMode:
         tbz     x5,#1,M4_StoreOutputPartial1_ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
@@ -278,7 +278,7 @@ M4_StoreOutputPartial_ZeroMode
         st1     {v28.2s},[x12],#8
         dup     v28.4s,v28.s[2]
 
-M4_StoreOutputPartial1_ZeroMode
+M4_StoreOutputPartial1_ZeroMode:
         tbz     x5,#0,M4_ExitKernel
         st1     {v16.s}[0],[x2]
         st1     {v20.s}[0],[x10]
@@ -309,9 +309,9 @@ M4_StoreOutputPartial1_ZeroMode
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 
-M2_ProcessLoop
+M2_ProcessLoop:
 
-M2_ProcessNextColumnLoop
+M2_ProcessNextColumnLoop:
         ldp     d4,d24,[x1],#16             // B
         mov     x0,x14                      // reload matrix A
         mov     x3,x15                      // reload PackedCountK
@@ -330,7 +330,7 @@ M2_ProcessNextColumnLoop
         movi    v23.4s,#0
         ldp     d1,d3,[x9],#16              // Load A1
 
-M2_ComputeBlockLoop
+M2_ComputeBlockLoop:
         sub     x3,x3,#1
         smull   v28.8h,v0.8b,v4.8b
         smull   v29.8h,v0.8b,v5.8b
@@ -365,7 +365,7 @@ M2_ComputeBlockLoop
         sadalp  v23.4s,v31.8h
         b       M2_ComputeBlockLoop
 
-M2_ComputeBlockLoopFinish
+M2_ComputeBlockLoopFinish:
         ld1     {v0.4s},[x13],#16           // load ColumnSumBuffer[0]
         smlal   v28.8h,v2.8b,v24.8b
         smlal   v29.8h,v2.8b,v25.8b
@@ -398,7 +398,7 @@ M2_ComputeBlockLoopFinish
         add     v16.4s,v16.4s,v0.4s
         add     v20.4s,v20.4s,v0.4s
 
-M2_StoreOutput
+M2_StoreOutput:
         add     x10,x2,x6,lsl #2
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     M2_StoreOutputPartial
@@ -406,24 +406,24 @@ M2_StoreOutput
         st1     {v20.4s},[x10]
         cbnz    x5,M2_ProcessNextColumnLoop
 
-M2_ExitKernel
+M2_ExitKernel:
         mov     x0,#2                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d14,d15,#48
-        EPILOG_RESTORE_REG_PAIR d12,d13,#32
-        EPILOG_RESTORE_REG_PAIR d10,d11,#16
-        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
-        EPILOG_RETURN
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#.LSQGemmS8Frame_SavedRegisters
+        ret
 
-M2_StoreOutputPartial
+M2_StoreOutputPartial:
 
-M2_StoreOutputPartial_ZeroMode
+M2_StoreOutputPartial_ZeroMode:
         tbz     x5,#1,M2_StoreOutputPartial1_ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
         st1     {v20.2s},[x10],#8
         dup     v20.4s,v20.s[2]
 
-M2_StoreOutputPartial1_ZeroMode
+M2_StoreOutputPartial1_ZeroMode:
         tbz     x5,#0,M2_ExitKernel
         st1     {v16.s}[0],[x2]
         st1     {v20.s}[0],[x10]
@@ -451,9 +451,9 @@ M2_StoreOutputPartial1_ZeroMode
 // Accumulators are horizontally aggregated to the left most register
 // for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
 //
-M1_ProcessLoop
+M1_ProcessLoop:
 
-M1_ProcessNextColumnLoop
+M1_ProcessNextColumnLoop:
         ldp     d4,d24,[x1],#16             // B
         ldp     d5,d25,[x1],#16
         ldp     d6,d26,[x1],#16
@@ -466,7 +466,7 @@ M1_ProcessNextColumnLoop
         movi    v18.4s,#0
         movi    v19.4s,#0
 
-M1_ComputeBlockLoop
+M1_ComputeBlockLoop:
         sub     x3,x3,#1
         smull   v20.8h,v0.8b,v4.8b
         smull   v21.8h,v0.8b,v5.8b
@@ -488,7 +488,7 @@ M1_ComputeBlockLoop
         sadalp  v19.4s,v23.8h
         b       M1_ComputeBlockLoop
 
-M1_ComputeBlockLoopFinish
+M1_ComputeBlockLoopFinish:
         ld1     {v4.4s},[x13],#16           // load ColumnSumBuffer[0]
         smull   v22.8h,v0.8b,v6.8b
         smull   v23.8h,v0.8b,v7.8b
@@ -507,32 +507,30 @@ M1_ComputeBlockLoopFinish
         // accumulator += column sum B
         add     v16.4s,v16.4s,v4.4s
 
-M1_StoreOutput
+M1_StoreOutput:
         subs    x5,x5,#4                    // adjust CountN remaining
         blo     M1_StoreOutputPartial
         st1     {v16.4s},[x2],#16
         cbnz    x5,M1_ProcessNextColumnLoop
 
-M1_ExitKernel
+M1_ExitKernel:
         mov     x0,#1                       // return number of rows handled
-        EPILOG_RESTORE_REG_PAIR d14,d15,#48
-        EPILOG_RESTORE_REG_PAIR d12,d13,#32
-        EPILOG_RESTORE_REG_PAIR d10,d11,#16
-        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
-        EPILOG_RETURN
+        ldp     d14,d15,[sp,#48]
+        ldp     d12,d13,[sp,#32]
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#.LSQGemmS8Frame_SavedRegisters
+        ret
 
-M1_StoreOutputPartial
+M1_StoreOutputPartial:
 
-M1_StoreOutputPartial_ZeroMode
+M1_StoreOutputPartial_ZeroMode:
         tbz     x5,#1,M1_StoreOutputPartial1_ZeroMode
         st1     {v16.2s},[x2],#8
         dup     v16.4s,v16.s[2]             // shift remaining elements down
 
-M1_StoreOutputPartial1_ZeroMode
+M1_StoreOutputPartial1_ZeroMode:
         tbz     x5,#0,M1_ExitKernel
         st1     {v16.s}[0],[x2]
         b       M1_ExitKernel
 
-        NESTED_END MlasSymQgemmS8KernelNeon
-
-        END
+        .end

--- a/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelSdot.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelSdot.S
@@ -1,0 +1,388 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    SymQgemmS8KernelSdot.S
+
+Abstract:
+
+    This module implements the kernels for the quantized integer matrix/matrix
+    multiply operation (QGEMM), where the right hand side is symmetrically quantized,
+    i.e. zero point being zero.
+
+    This kernel only requires prepacking of the right hand side, which is usually
+    constant. When the packed right hand side is cached, we achieves higher performance
+    by avoid packing all together.
+
+--*/
+
+#include "asmmacro.h"
+#include "AssembleDotProduct.h"
+
+//
+// Stack frame layout for the symmetric convolution kernel.
+// d8-d15, x19-x30 need to be preserved if used
+//
+        .equ    .LGemmS8S8KernelFrame_SavedRegisters,   (4 * 8)
+        .equ    .LGemmS8S8KernelFrame_ColumnSumBuffer,  (0 + .LGemmS8S8KernelFrame_SavedRegisters)
+
+        .text
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>.
+
+    C (x2) - Supplies the address of matrix C.
+
+    PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
+        Packed K should be 16x
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    ldc (x6) - Supplies the first dimension of matrix C.
+
+    lda (x7) - Supplies the first dimension of matrix A.
+
+    ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+        by the zero point offset of matrix A. These values are accumulated into
+        every column of matrix C.
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        FUNCTION_ENTRY MlasSymQgemmS8KernelSdot
+
+        stp     d8,d9,[sp,#-.LGemmS8S8KernelFrame_SavedRegisters]!
+        ldr     x8,[sp,#.LGemmS8S8KernelFrame_ColumnSumBuffer]
+        stp     d10,d11,[sp,#16]
+
+        // compute C pointers: x2, x16, x17, x6
+        cmp     x4,#2                   // M < 2 ?
+        add     x16,x2,x6,lsl #2        // x16 -> C1
+        add     x17,x2,x6,lsl #3        // x17 -> C2
+        csel    x16,x2,x16,lo           // if M < 2  x16/C1 -> C0
+        csel    x17,x16,x17,ls          // if M <= 2  x17/C2 -> C1
+        cmp     x4,#4                   // M < 4 ?
+        mov     x12,#4                  // set max M to 4
+        add     x6,x16,x6,lsl #3        // x6 -> C3
+        mov     x9,x0                   // save A0
+        mov     x10,x3                  // save K
+        csel    x6,x17,x6,lo            // if M < 4  x6/C3 -> C2
+        csel    x4,x12,x4,hi            // if M > 4  M = 4;
+
+// Register Usage
+//                                            B (x1) -> 4x16
+//                        ----------------------------------------------------------------------------
+//                        |v4.b[0]..v4.b[12] v5.b[0]..v5.b[12]  v6.b[0]..v6.b[12]   v7.b[0]..v7.b[12]|
+//                        |  ...      ...     ...       ...       ...       ...       ...     ...    |
+//                        |v4.b[3]..v4.b[15] v5.b[3]..v5.b[15]  v6.b[3]..v6.b[15]   v7.b[3]..v7.b[15]|
+//            A 4x4       ----------------------------------------------------------------------------
+//     ------------------ ----------------------------------------------------------------------------
+// x0  |v0.b[0]..v0.b[3]| |v16.s[0]_v16.s[3] v20.s[0]_v20.s[3]  v24.s[0]_v24.s[3]   v28.s[0]_v28.s[3]| x2
+// x12 |v1.b[0]..v1.b[3]| |v17.s[0]_v17.s[3] v21.s[0]_v21.s[3]  v25.s[0]_v25.s[3]   v29.s[0]_v29.s[3]| x16
+// x13 |v2.b[0]..v2.b[3]| |v18.s[0]_v18.s[3] v22.s[0]_v22.s[3]  v26.s[0]_v26.s[3]   v30.s[0]_v30.s[3]| x17
+// x14 |v3.b[0]..v3.b[3]| |v19.s[0]_v19.s[3] v23.s[0]_v23.s[3]  v27.s[0]_v27.s[3]   v31.s[0]_v31.s[3]| x6
+//     ------------------ ----------------------------------------------------------------------------
+
+ProcessNextColumnLoop:
+        ldr     q16,[x8],#16            // Init accumulators with column sums
+        ldr     q20,[x8],#16
+        ldr     q24,[x8],#16
+        ldr     q28,[x8],#16
+        mov     x0,x9                   // reload A0
+        cmp     x4,#2                   // M < 2 ?
+        add     x12,x9,x7               // x12 -> A1
+        add     x13,x0,x7,lsl #1        // x13 -> A2
+        ldr     q4,[x1],#16             // Load B
+        csel    x12,x0,x12,lo           // if M < 2  A1 -> A0
+        csel    x13,x12,x13,ls          // if M <= 2  A2 -> A1
+        cmp     x4,4                    // M < 4 ?
+        add     x14,x12,x7,lsl #1       // x14 -> A3
+        ldr     q5,[x1],#16
+        csel    x14,x13,x14,lo          // if M < 4  A3 -> A2
+        ldr     d0,[x0],#8              // Load A0  1st/2nd block of 4
+        mov     v17.16b,v16.16b
+        mov     v18.16b,v16.16b
+        ldr     d1,[x12],#8             // Load A1
+        mov     v19.16b,v16.16b
+        mov     v21.16b,v20.16b
+        ldr     d2,[x13],#8             // Load A2
+        mov     v22.16b,v20.16b
+        mov     v23.16b,v20.16b
+        ldr     d3,[x14],#8             // Load A3
+        mov     v25.16b,v24.16b
+        mov     v26.16b,v24.16b
+        ldr     q6,[x1],#16
+        mov     v27.16b,v24.16b
+        mov     v29.16b,v28.16b
+        ldr     q7,[x1],#16
+        subs    x3,x10,#2               // one loop iteration and epilogue consume k = 32
+        mov     v30.16b,v28.16b
+        mov     v31.16b,v28.16b
+        b.lo    BlockLoopEpilogue       // Need 32 k for main loop
+
+BlockLoop:
+        SdotByElement    16, 4, 0,0
+        SdotByElement    17, 4, 1,0
+        ldr     d8,[x0],#8              // Load A0  3rd/4th block of 4
+        SdotByElement    18, 4, 2,0
+        SdotByElement    19, 4, 3,0
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 0,0
+        SdotByElement    21, 5, 1,0
+        ldr     d9,[x12],#8
+        SdotByElement    22, 5, 2,0
+        SdotByElement    23, 5, 3,0
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 0,0
+        SdotByElement    25, 6, 1,0
+        ldr     d10,[x13],#8
+        SdotByElement    26, 6, 2,0
+        SdotByElement    27, 6, 3,0
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 0,0
+        SdotByElement    29, 7, 1,0
+        ldr     d11,[x14],#8
+        SdotByElement    30, 7, 2,0
+        SdotByElement    31, 7, 3,0
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 0,1
+        SdotByElement    17, 4, 1,1
+        SdotByElement    18, 4, 2,1
+        SdotByElement    19, 4, 3,1
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 0,1
+        SdotByElement    21, 5, 1,1
+        SdotByElement    22, 5, 2,1
+        SdotByElement    23, 5, 3,1
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 0,1
+        SdotByElement    25, 6, 1,1
+        SdotByElement    26, 6, 2,1
+        SdotByElement    27, 6, 3,1
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 0,1
+        SdotByElement    29, 7, 1,1
+        SdotByElement    30, 7, 2,1
+        SdotByElement    31, 7, 3,1
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 8,0
+        SdotByElement    17, 4, 9,0
+        ldr     d0,[x0],#8
+        SdotByElement    18, 4,10,0
+        SdotByElement    19, 4,11,0
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 8,0
+        SdotByElement    21, 5, 9,0
+        ldr     d1,[x12],#8
+        SdotByElement    22, 5,10,0
+        SdotByElement    23, 5,11,0
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 8,0
+        SdotByElement    25, 6, 9,0
+        ldr     d2,[x13],#8
+        SdotByElement    26, 6,10,0
+        SdotByElement    27, 6,11,0
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 8,0
+        SdotByElement    29, 7, 9,0
+        ldr     d3,[x14],#8
+        SdotByElement    30, 7,10,0
+        SdotByElement    31, 7,11,0
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 8,1
+        SdotByElement    17, 4, 9,1
+        SdotByElement    18, 4,10,1
+        SdotByElement    19, 4,11,1
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 8,1
+        SdotByElement    21, 5, 9,1
+        SdotByElement    22, 5,10,1
+        SdotByElement    23, 5,11,1
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 8,1
+        SdotByElement    25, 6, 9,1
+        SdotByElement    26, 6,10,1
+        SdotByElement    27, 6,11,1
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 8,1
+        SdotByElement    29, 7, 9,1
+        subs    x3,x3,#1                // k -= 16
+        SdotByElement    30, 7,10,1
+        SdotByElement    31, 7,11,1
+        ldr     q7,[x1],#16
+        b.hs    BlockLoop
+
+BlockLoopEpilogue:
+        SdotByElement    16, 4, 0,0
+        SdotByElement    17, 4, 1,0
+        ldr     d8,[x0],#8
+        SdotByElement    18, 4, 2,0
+        SdotByElement    19, 4, 3,0
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 0,0
+        SdotByElement    21, 5, 1,0
+        ldr     d9,[x12],#8
+        SdotByElement    22, 5, 2,0
+        SdotByElement    23, 5, 3,0
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 0,0
+        SdotByElement    25, 6, 1,0
+        ldr     d10,[x13],#8
+        SdotByElement    26, 6, 2,0
+        SdotByElement    27, 6, 3,0
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 0,0
+        SdotByElement    29, 7, 1,0
+        ldr     d11,[x14],#8
+        SdotByElement    30, 7, 2,0
+        SdotByElement    31, 7, 3,0
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 0,1
+        SdotByElement    17, 4, 1,1
+        SdotByElement    18, 4, 2,1
+        SdotByElement    19, 4, 3,1
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 0,1
+        SdotByElement    21, 5, 1,1
+        SdotByElement    22, 5, 2,1
+        SdotByElement    23, 5, 3,1
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 0,1
+        SdotByElement    25, 6, 1,1
+        SdotByElement    26, 6, 2,1
+        SdotByElement    27, 6, 3,1
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 0,1
+        SdotByElement    29, 7, 1,1
+        SdotByElement    30, 7, 2,1
+        SdotByElement    31, 7, 3,1
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 8,0
+        SdotByElement    17, 4, 9,0
+        SdotByElement    18, 4,10,0
+        SdotByElement    19, 4,11,0
+        ldr     q4,[x1],#16
+        SdotByElement    20, 5, 8,0
+        SdotByElement    21, 5, 9,0
+        SdotByElement    22, 5,10,0
+        SdotByElement    23, 5,11,0
+        ldr     q5,[x1],#16
+        SdotByElement    24, 6, 8,0
+        SdotByElement    25, 6, 9,0
+        SdotByElement    26, 6,10,0
+        SdotByElement    27, 6,11,0
+        ldr     q6,[x1],#16
+        SdotByElement    28, 7, 8,0
+        SdotByElement    29, 7, 9,0
+        SdotByElement    30, 7,10,0
+        SdotByElement    31, 7,11,0
+        ldr     q7,[x1],#16
+        SdotByElement    16, 4, 8,1
+        SdotByElement    17, 4, 9,1
+        SdotByElement    18, 4,10,1
+        SdotByElement    19, 4,11,1
+        SdotByElement    20, 5, 8,1
+        SdotByElement    21, 5, 9,1
+        SdotByElement    22, 5,10,1
+        SdotByElement    23, 5,11,1
+        SdotByElement    24, 6, 8,1
+        SdotByElement    25, 6, 9,1
+        SdotByElement    26, 6,10,1
+        SdotByElement    27, 6,11,1
+        SdotByElement    28, 7, 8,1
+        SdotByElement    29, 7, 9,1
+        subs    x5,x5,#16               // adjust CountN remaining
+        SdotByElement    30, 7,10,1
+        SdotByElement    31, 7,11,1
+        blo     StoreOutputPartial
+        stp     q16,q20,[x2],#32
+        stp     q24,q28,[x2],#32
+        stp     q17,q21,[x16],#32
+        stp     q25,q29,[x16],#32
+        stp     q18,q22,[x17],#32
+        stp     q26,q30,[x17],#32
+        stp     q19,q23,[x6],#32
+        stp     q27,q31,[x6],#32
+        cbnz    x5,ProcessNextColumnLoop
+
+ExitKernel:
+        mov     x0,x4                   // return number of rows handled
+        ldp     d10,d11,[sp,#16]
+        ldp     d8,d9,[sp],#.LGemmS8S8KernelFrame_SavedRegisters
+        ret
+
+//
+// Store the partial 1 to 15 columns either overwriting the output matrix or
+// accumulating into the existing contents of the output matrix.
+//
+
+StoreOutputPartial:
+        tbz     x5,#3,StoreOutputPartial4
+        stp     q16,q20,[x2],#32
+        mov     v16.16b,v24.16b             // shift remaining elements down
+        mov     v20.16b,v28.16b
+        stp     q17,q21,[x16],#32
+        mov     v17.16b,v25.16b
+        mov     v21.16b,v29.16b
+        stp     q18,q22,[x17],#32
+        mov     v18.16b,v26.16b
+        mov     v22.16b,v30.16b
+        stp     q19,q23,[x6],#32
+        mov     v19.16b,v27.16b
+        mov     v23.16b,v31.16b
+
+StoreOutputPartial4:
+        tbz     x5,#2,StoreOutputPartial2
+        st1     {v16.4s},[x2],#16
+        mov     v16.16b,v20.16b             // shift remaining elements down
+        st1     {v17.4s},[x16],#16
+        mov     v17.16b,v21.16b
+        st1     {v18.4s},[x17],#16
+        mov     v18.16b,v22.16b
+        st1     {v19.4s},[x6],#16
+        mov     v19.16b,v23.16b
+
+StoreOutputPartial2:
+        tbz     x5,#1,StoreOutputPartial1
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v17.2s},[x16],#8
+        dup     v17.4s,v17.s[2]
+        st1     {v18.2s},[x17],#8
+        dup     v18.4s,v18.s[2]
+        st1     {v19.2s},[x6],#8
+        dup     v19.4s,v19.s[2]
+
+StoreOutputPartial1:
+        tbz     x5,#0,ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v17.s}[0],[x16]
+        st1     {v18.s}[0],[x17]
+        st1     {v19.s}[0],[x6]
+        b       ExitKernel
+
+        .end

--- a/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
@@ -1,0 +1,538 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    SymQgemmS8KernelNeon.asm
+
+Abstract:
+
+    This module implements the kernels for the quantized integer matrix/matrix
+    multiply operation (QGEMM), where the right hand side is symmetrically quantized,
+    i.e. zero point being zero.
+
+    This kernel only requires prepacking of the right hand side, which is usually
+    constant. When the packed right hand side is cached, we achieves higher performance
+    by avoid packing all together.
+
+--*/
+
+#include "kxarm64.h"
+
+//
+// Stack frame layout for the S8S8 kernel.
+//
+
+#define  SQGemmS8Frame_SavedNeonRegisters     (8 * 8)
+#define  SQGemmS8Frame_SavedRegisters         SQGemmS8Frame_SavedNeonRegisters
+#define  SQGemmS8Frame_ColumnSumBuffer        0 + SQGemmS8Frame_SavedRegisters
+
+        TEXTAREA
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>.
+
+    C (x2) - Supplies the address of matrix C.
+
+    PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    ldc (x6) - Supplies the first dimension of matrix C.
+
+    lda (x7) - Supplies the first dimension of matrix A.
+
+    ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+        by the zero point offset of matrix A. These values are accumulated into
+        every column of matrix C.
+
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        NESTED_ENTRY MlasSymQgemmS8KernelNeon
+
+        PROLOG_SAVE_REG_PAIR d8,d9,#-SQGemmS8Frame_SavedRegisters!
+        PROLOG_SAVE_REG_PAIR d10,d11,#16
+        PROLOG_SAVE_REG_PAIR d12,d13,#32
+        PROLOG_SAVE_REG_PAIR d14,d15,#48
+        ldr     x8,[sp,#SQGemmS8Frame_ColumnSumBuffer]
+        mov     x14,x0
+        mov     x15,x3
+        cmp     x4,#1                       // CountM == 1?
+        beq     M1_ProcessLoop
+        cmp     x4,#4                       // CountM < 4?
+        blo     M2_ProcessLoop
+
+//
+// Process 4 rows of the matrices.
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v8.b[0]   v9.b[0]   v10.b[0]  v11.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v8.b[7]   v9.b[7]   v10.b[7]  v11.b[7]|
+//            A 4x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v24.4s    v25.4s    v26.4s    v27.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v28.4s    v29.4s    v30.4s    v31.4s  |
+// -----------------------------------  ----------------------------------------
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+//
+
+M4_ProcessNextColumnLoop
+        mov     x0,x14                      // reload matrix A0
+        mov     x3,x15                      // reload PackedCountK
+        ldr     d0,[x0],#8                  // Load A0
+        add     x9,x14,x7                   // A1
+        ldr     d2,[x0],#8                  // Load A0
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        ldp     d4,d8,[x1],#64              // B
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        ldp     d5,d9,[x1,#-48]
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        ldp     d6,d10,[x1,#-32]
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+        ldp     d7,d11,[x1,#-16]
+        movi    v24.4s,#0
+        movi    v25.4s,#0
+        add     x10,x9,x7                   // A2
+        ldp     d1,d3,[x9],#16              // Load A1
+        movi    v26.4s,#0
+        movi    v27.4s,#0
+        movi    v28.4s,#0
+        movi    v29.4s,#0
+        movi    v30.4s,#0
+        movi    v31.4s,#0
+        add     x11,x10,x7                  // A3
+
+M4_ComputeBlockLoop
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x10],#16             // Load A2
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+        sub     x3,x3,#1
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d1,d3,[x11],#16             // Load A3
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+        cbz     x3,M4_ComputeBlockLoopFinish
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ldp     d0,d2,[x0],#16              // Load A0 next iter
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal   v12.8h,v3.8b,v8.8b
+        ldp     d4,d8,[x1],#64              // B
+        smlal   v13.8h,v3.8b,v9.8b
+        ldp     d5,d9,[x1,#-48]
+        smlal   v14.8h,v3.8b,v10.8b
+        ldp     d6,d10,[x1,#-32]
+        smlal   v15.8h,v3.8b,v11.8b
+        ldp     d7,d11,[x1,#-16]
+        sadalp  v28.4s,v12.8h
+        ldp     d1,d3,[x9],#16              // Load A1 next iter
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        b       M4_ComputeBlockLoop
+
+M4_ComputeBlockLoopFinish
+        smull   v12.8h,v0.8b,v4.8b
+        smull   v13.8h,v0.8b,v5.8b
+        smull   v14.8h,v0.8b,v6.8b
+        smull   v15.8h,v0.8b,v7.8b
+        smlal   v12.8h,v2.8b,v8.8b
+        smlal   v13.8h,v2.8b,v9.8b
+        smlal   v14.8h,v2.8b,v10.8b
+        smlal   v15.8h,v2.8b,v11.8b
+        ld1     {v2.4s},[x8],#16            // load ColumnSumBuffer[0]
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        smull   v12.8h,v1.8b,v4.8b
+        smull   v13.8h,v1.8b,v5.8b
+        smull   v14.8h,v1.8b,v6.8b
+        smull   v15.8h,v1.8b,v7.8b
+        smlal   v12.8h,v3.8b,v8.8b
+        smlal   v13.8h,v3.8b,v9.8b
+        smlal   v14.8h,v3.8b,v10.8b
+        smlal   v15.8h,v3.8b,v11.8b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+        addp    v24.4s,v24.4s,v25.4s
+        addp    v26.4s,v26.4s,v27.4s
+        addp    v28.4s,v28.4s,v29.4s
+        addp    v30.4s,v30.4s,v31.4s
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+        addp    v24.4s,v24.4s,v26.4s
+        addp    v28.4s,v28.4s,v30.4s
+
+        // accumulator += column sum B 
+        add     v16.4s,v16.4s,v2.4s
+        add     v20.4s,v20.4s,v2.4s
+        add     v24.4s,v24.4s,v2.4s
+        add     v28.4s,v28.4s,v2.4s
+
+M4_StoreOutput
+        add     x10,x2,x6,lsl #2
+        add     x11,x10,x6,lsl #2
+        add     x12,x11,x6,lsl #2
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     M4_StoreOutputPartial
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        st1     {v24.4s},[x11]
+        st1     {v28.4s},[x12]
+        cbnz    x5,M4_ProcessNextColumnLoop
+
+M4_ExitKernel
+        mov     x0,#4                       // return number of rows handled
+        EPILOG_RESTORE_REG_PAIR d14,d15,#48
+        EPILOG_RESTORE_REG_PAIR d12,d13,#32
+        EPILOG_RESTORE_REG_PAIR d10,d11,#16
+        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
+        EPILOG_RETURN
+
+M4_StoreOutputPartial
+
+M4_StoreOutputPartial_ZeroMode
+        tbz     x5,#1,M4_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+        st1     {v24.2s},[x11],#8
+        dup     v24.4s,v24.s[2]
+        st1     {v28.2s},[x12],#8
+        dup     v28.4s,v28.s[2]
+
+M4_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,M4_ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        st1     {v24.s}[0],[x11]
+        st1     {v28.s}[0],[x12]
+        b       M4_ExitKernel
+
+//
+// Process 2 rows of the matrices.
+//
+// Column Sum v2.s[0] v2.s[4]
+// Each row sum replicated to all 4 elements of a vector register 
+// v30 v31
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 2x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// |v1.b[0]..v1.b[7] v3.b[0]..v3.b[7]|  |v20.4s    v21.4s    v22.4s    v23.4s  |
+// -----------------------------------  ----------------------------------------
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+
+M2_ProcessLoop
+
+M2_ProcessNextColumnLoop
+        ldp     d4,d24,[x1],#16             // B
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // Load A0
+        add     x9,x14,x7                   // A1
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        ldp     d5,d25,[x1],#16
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+        ldp     d6,d26,[x1],#16
+        movi    v20.4s,#0
+        movi    v21.4s,#0
+        ldp     d7,d27,[x1],#16
+        movi    v22.4s,#0
+        movi    v23.4s,#0
+        ldp     d1,d3,[x9],#16              // Load A1
+
+M2_ComputeBlockLoop
+        sub     x3,x3,#1
+        smull   v28.8h,v0.8b,v4.8b
+        smull   v29.8h,v0.8b,v5.8b
+        smull   v30.8h,v0.8b,v6.8b
+        smull   v31.8h,v0.8b,v7.8b
+        cbz     x3,M2_ComputeBlockLoopFinish
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // Load A0
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v29.8h,v3.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v30.8h,v3.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v31.8h,v3.8b,v27.8b
+        ldp     d7,d27,[x1],#16
+        sadalp  v20.4s,v28.8h
+        ldp     d1,d3,[x9],#16              // Load A1
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        b       M2_ComputeBlockLoop
+
+M2_ComputeBlockLoopFinish
+        ld1     {v0.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smlal   v28.8h,v2.8b,v24.8b
+        smlal   v29.8h,v2.8b,v25.8b
+        smlal   v30.8h,v2.8b,v26.8b
+        smlal   v31.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        smull   v28.8h,v1.8b,v4.8b
+        smull   v29.8h,v1.8b,v5.8b
+        smull   v30.8h,v1.8b,v6.8b
+        smull   v31.8h,v1.8b,v7.8b
+        smlal   v28.8h,v3.8b,v24.8b
+        smlal   v29.8h,v3.8b,v25.8b
+        smlal   v30.8h,v3.8b,v26.8b
+        smlal   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v20.4s,v20.4s,v21.4s
+        addp    v22.4s,v22.4s,v23.4s
+        addp    v16.4s,v16.4s,v18.4s
+        addp    v20.4s,v20.4s,v22.4s
+
+        // accumulator = column sum B 
+        add     v16.4s,v16.4s,v0.4s
+        add     v20.4s,v20.4s,v0.4s
+
+M2_StoreOutput
+        add     x10,x2,x6,lsl #2
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     M2_StoreOutputPartial
+        st1     {v16.4s},[x2],#16
+        st1     {v20.4s},[x10]
+        cbnz    x5,M2_ProcessNextColumnLoop
+
+M2_ExitKernel
+        mov     x0,#2                       // return number of rows handled
+        EPILOG_RESTORE_REG_PAIR d14,d15,#48
+        EPILOG_RESTORE_REG_PAIR d12,d13,#32
+        EPILOG_RESTORE_REG_PAIR d10,d11,#16
+        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
+        EPILOG_RETURN
+
+M2_StoreOutputPartial
+
+M2_StoreOutputPartial_ZeroMode
+        tbz     x5,#1,M2_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v20.2s},[x10],#8
+        dup     v20.4s,v20.s[2]
+
+M2_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,M2_ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v20.s}[0],[x10]
+        b       M2_ExitKernel
+
+//
+// Process 1 row of the matrices.
+//
+// Column Sum v2.s[0] v2.s[4]
+// row sum replicated to all 4 elements of a vector register 
+// v31 
+//                                            B 16x4
+//                                      ----------------------------------------
+//                                      |v4.b[0]   v5.b[0]   v6.b[0]   v7.b[0] |
+//                                      |  ...      ...        ...      ...    |
+//                                      |v4.b[7]   v5.b[7]   v6.b[7]   v7.b[7] |
+//                                      |v24.b[0]  v25.b[0]  v26.b[0]  v27.b[0]|
+//                                      |  ...      ...       ...       ...    |
+//                                      |v24.b[7]  v25.b[7]  v26.b[7]  v27.b[7]|
+//            A 1x16                    ----------------------------------------
+// -----------------------------------  ----------------------------------------
+// |v0.b[0]..v0.b[7] v2.b[0]..v2.b[7]|  |v16.4s    v17.4s    v18.4s    v19.4s  |
+// -----------------------------------  ----------------------------------------
+//
+// Accumulators are horizontally aggregated to the left most register
+// for each row. e.g. (v16.s[0], v16.s[1], v16.s[2], v16.s[3]) <- (v16, v17, v18, v19)
+//
+M1_ProcessLoop
+
+M1_ProcessNextColumnLoop
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
+        mov     x0,x14                      // reload matrix A
+        mov     x3,x15                      // reload PackedCountK
+        ldp     d0,d2,[x0],#16              // A0
+        movi    v16.4s,#0
+        movi    v17.4s,#0
+        movi    v18.4s,#0
+        movi    v19.4s,#0
+
+M1_ComputeBlockLoop
+        sub     x3,x3,#1
+        smull   v20.8h,v0.8b,v4.8b
+        smull   v21.8h,v0.8b,v5.8b
+        cbz    x3,M1_ComputeBlockLoopFinish
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        ldp     d4,d24,[x1],#16             // B
+        smlal   v21.8h,v2.8b,v25.8b
+        ldp     d5,d25,[x1],#16
+        smlal   v22.8h,v2.8b,v26.8b
+        ldp     d6,d26,[x1],#16
+        smlal   v23.8h,v2.8b,v27.8b
+        ldp     d0,d2,[x0],#16              // A0
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        ldp     d7,d27,[x1],#16
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        b       M1_ComputeBlockLoop
+
+M1_ComputeBlockLoopFinish
+        ld1     {v4.4s},[x8],#16            // load ColumnSumBuffer[0]
+        smull   v22.8h,v0.8b,v6.8b
+        smull   v23.8h,v0.8b,v7.8b
+        smlal   v20.8h,v2.8b,v24.8b
+        smlal   v21.8h,v2.8b,v25.8b
+        smlal   v22.8h,v2.8b,v26.8b
+        smlal   v23.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        addp    v16.4s,v16.4s,v17.4s
+        addp    v18.4s,v18.4s,v19.4s
+        addp    v16.4s,v16.4s,v18.4s
+
+        // accumulator += column sum B
+        add     v16.4s,v16.4s,v4.4s
+
+M1_StoreOutput
+        subs    x5,x5,#4                    // adjust CountN remaining
+        blo     M1_StoreOutputPartial
+        st1     {v16.4s},[x2],#16
+        cbnz    x5,M1_ProcessNextColumnLoop
+
+M1_ExitKernel
+        mov     x0,#1                       // return number of rows handled
+        EPILOG_RESTORE_REG_PAIR d14,d15,#48
+        EPILOG_RESTORE_REG_PAIR d12,d13,#32
+        EPILOG_RESTORE_REG_PAIR d10,d11,#16
+        EPILOG_RESTORE_REG_PAIR d8,d9,#64!
+        EPILOG_RETURN
+
+M1_StoreOutputPartial
+
+M1_StoreOutputPartial_ZeroMode
+        tbz     x5,#1,M1_StoreOutputPartial1_ZeroMode
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+
+M1_StoreOutputPartial1_ZeroMode
+        tbz     x5,#0,M1_ExitKernel
+        st1     {v16.s}[0],[x2]
+        b       M1_ExitKernel
+
+        NESTED_END MlasSymQgemmS8KernelNeon
+
+        END

--- a/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelSdot.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelSdot.asm
@@ -1,0 +1,391 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    SymQgemmS8KernelSdot.asm
+
+Abstract:
+
+    This module implements the kernels for the quantized integer matrix/matrix
+    multiply operation (QGEMM), where the right hand side is symmetrically quantized,
+    i.e. zero point being zero.
+
+    This kernel only requires prepacking of the right hand side, which is usually
+    constant. When the packed right hand side is cached, we achieves higher performance
+    by avoid packing all together.
+
+--*/
+
+#include "kxarm64.h"
+#include "AssembleDotProduct.h"
+
+//
+// Stack frame layout for the S8S8 kernel.
+//
+
+
+#define GemmS8S8KernelFrame_SavedRegisters           (4 * 8)
+#define GemmS8S8KernelFrame_ColumnSumBuffer          (0 + GemmS8S8KernelFrame_SavedRegisters)
+
+        TEXTAREA
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>.
+
+    C (x2) - Supplies the address of matrix C.
+
+    PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+        the number of packed rows from matrix B to iterate over.
+        Packed K should be 16x
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    ldc (x6) - Supplies the first dimension of matrix C.
+
+    lda (x7) - Supplies the first dimension of matrix A.
+
+    ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+        by the zero point offset of matrix A. These values are accumulated into
+        every column of matrix C.
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        NESTED_ENTRY MlasSymQgemmS8KernelSdot
+
+        PROLOG_SAVE_REG_PAIR d8,d9,#-GemmS8S8KernelFrame_SavedRegisters!
+        PROLOG_NOP    ldr    x8,[sp,#GemmS8S8KernelFrame_ColumnSumBuffer]
+        PROLOG_SAVE_REG_PAIR d10,d11,#16
+
+        // compute C pointers: x2, x16, x17, x6
+        cmp     x4,#2                   // M < 2 ?
+        add     x16,x2,x6,lsl #2        // x16 -> C1
+        add     x17,x2,x6,lsl #3        // x17 -> C2
+        csel    x16,x2,x16,lo           // if M < 2  x16/C1 -> C0
+        csel    x17,x16,x17,ls          // if M <= 2  x17/C2 -> C1
+        cmp     x4,#4                   // M < 4 ?
+        mov     x12,#4                  // set max M to 4
+        add     x6,x16,x6,lsl #3        // x6 -> C3
+        mov     x9,x0                   // save A0
+        mov     x10,x3                  // save K
+        csel    x6,x17,x6,lo            // if M < 4  x6/C3 -> C2
+        csel    x4,x12,x4,hi            // if M > 4  M = 4;
+
+// Register Usage
+//                                            B (x1) -> 4x16
+//                        ----------------------------------------------------------------------------
+//                        |v4.b[0]..v4.b[12] v5.b[0]..v5.b[12]  v6.b[0]..v6.b[12]   v7.b[0]..v7.b[12]|
+//                        |  ...      ...     ...       ...       ...       ...       ...     ...    |
+//                        |v4.b[3]..v4.b[15] v5.b[3]..v5.b[15]  v6.b[3]..v6.b[15]   v7.b[3]..v7.b[15]|
+//            A 4x4       ----------------------------------------------------------------------------
+//     ------------------ ----------------------------------------------------------------------------
+// x0  |v0.b[0]..v0.b[3]| |v16.s[0]_v16.s[3] v20.s[0]_v20.s[3]  v24.s[0]_v24.s[3]   v28.s[0]_v28.s[3]| x2
+// x12 |v1.b[0]..v1.b[3]| |v17.s[0]_v17.s[3] v21.s[0]_v21.s[3]  v25.s[0]_v25.s[3]   v29.s[0]_v29.s[3]| x16
+// x13 |v2.b[0]..v2.b[3]| |v18.s[0]_v18.s[3] v22.s[0]_v22.s[3]  v26.s[0]_v26.s[3]   v30.s[0]_v30.s[3]| x17
+// x14 |v3.b[0]..v3.b[3]| |v19.s[0]_v19.s[3] v23.s[0]_v23.s[3]  v27.s[0]_v27.s[3]   v31.s[0]_v31.s[3]| x6
+//     ------------------ ----------------------------------------------------------------------------
+
+ProcessNextColumnLoop
+        ldr     q16,[x8],#16            // Init accumulators with column sums
+        ldr     q20,[x8],#16
+        ldr     q24,[x8],#16
+        ldr     q28,[x8],#16
+        mov     x0,x9                   // reload A0
+        cmp     x4,#2                   // M < 2 ?
+        add     x12,x9,x7               // x12 -> A1
+        add     x13,x0,x7,lsl #1        // x13 -> A2
+        ldr     q4,[x1],#16             // Load B
+        csel    x12,x0,x12,lo           // if M < 2  A1 -> A0
+        csel    x13,x12,x13,ls          // if M <= 2  A2 -> A1
+        cmp     x4,4                    // M < 4 ?
+        add     x14,x12,x7,lsl #1       // x14 -> A3
+        ldr     q5,[x1],#16
+        csel    x14,x13,x14,lo          // if M < 4  A3 -> A2
+        ldr     d0,[x0],#8              // Load A0  1st/2nd block of 4
+        mov     v17.16b,v16.16b
+        mov     v18.16b,v16.16b
+        ldr     d1,[x12],#8             // Load A1
+        mov     v19.16b,v16.16b
+        mov     v21.16b,v20.16b
+        ldr     d2,[x13],#8             // Load A2
+        mov     v22.16b,v20.16b
+        mov     v23.16b,v20.16b
+        ldr     d3,[x14],#8             // Load A3
+        mov     v25.16b,v24.16b
+        mov     v26.16b,v24.16b
+        ldr     q6,[x1],#16
+        mov     v27.16b,v24.16b
+        mov     v29.16b,v28.16b
+        ldr     q7,[x1],#16
+        subs    x3,x10,#2               // one loop iteration and epilogue consume k = 32
+        mov     v30.16b,v28.16b
+        mov     v31.16b,v28.16b
+        b.lo    BlockLoopEpilogue       // Need 32 k for main loop
+
+BlockLoop
+        sdot    v16.4s,v4.16b,v0.4b[0]
+        sdot    v17.4s,v4.16b,v1.4b[0]
+        ldr     d8,[x0],#8              // Load A0  3rd/4th block of 4
+        sdot    v18.4s,v4.16b,v2.4b[0]
+        sdot    v19.4s,v4.16b,v3.4b[0]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v0.4b[0]
+        sdot    v21.4s,v5.16b,v1.4b[0]
+        ldr     d9,[x12],#8
+        sdot    v22.4s,v5.16b,v2.4b[0]
+        sdot    v23.4s,v5.16b,v3.4b[0]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v0.4b[0]
+        sdot    v25.4s,v6.16b,v1.4b[0]
+        ldr     d10,[x13],#8
+        sdot    v26.4s,v6.16b,v2.4b[0]
+        sdot    v27.4s,v6.16b,v3.4b[0]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v0.4b[0]
+        sdot    v29.4s,v7.16b,v1.4b[0]
+        ldr     d11,[x14],#8
+        sdot    v30.4s,v7.16b,v2.4b[0]
+        sdot    v31.4s,v7.16b,v3.4b[0]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v0.4b[1]
+        sdot    v17.4s,v4.16b,v1.4b[1]
+        sdot    v18.4s,v4.16b,v2.4b[1]
+        sdot    v19.4s,v4.16b,v3.4b[1]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v0.4b[1]
+        sdot    v21.4s,v5.16b,v1.4b[1]
+        sdot    v22.4s,v5.16b,v2.4b[1]
+        sdot    v23.4s,v5.16b,v3.4b[1]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v0.4b[1]
+        sdot    v25.4s,v6.16b,v1.4b[1]
+        sdot    v26.4s,v6.16b,v2.4b[1]
+        sdot    v27.4s,v6.16b,v3.4b[1]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v0.4b[1]
+        sdot    v29.4s,v7.16b,v1.4b[1]
+        sdot    v30.4s,v7.16b,v2.4b[1]
+        sdot    v31.4s,v7.16b,v3.4b[1]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v8.4b[0]
+        sdot    v17.4s,v4.16b,v9.4b[0]
+        ldr     d0,[x0],#8
+        sdot    v18.4s,v4.16b,v10.4b[0]
+        sdot    v19.4s,v4.16b,v11.4b[0]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v8.4b[0]
+        sdot    v21.4s,v5.16b,v9.4b[0]
+        ldr     d1,[x12],#8
+        sdot    v22.4s,v5.16b,v10.4b[0]
+        sdot    v23.4s,v5.16b,v11.4b[0]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v8.4b[0]
+        sdot    v25.4s,v6.16b,v9.4b[0]
+        ldr     d2,[x13],#8
+        sdot    v26.4s,v6.16b,v10.4b[0]
+        sdot    v27.4s,v6.16b,v11.4b[0]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v8.4b[0]
+        sdot    v29.4s,v7.16b,v9.4b[0]
+        ldr     d3,[x14],#8
+        sdot    v30.4s,v7.16b,v10.4b[0]
+        sdot    v31.4s,v7.16b,v11.4b[0]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v8.4b[1]
+        sdot    v17.4s,v4.16b,v9.4b[1]
+        sdot    v18.4s,v4.16b,v10.4b[1]
+        sdot    v19.4s,v4.16b,v11.4b[1]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v8.4b[1]
+        sdot    v21.4s,v5.16b,v9.4b[1]
+        sdot    v22.4s,v5.16b,v10.4b[1]
+        sdot    v23.4s,v5.16b,v11.4b[1]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v8.4b[1]
+        sdot    v25.4s,v6.16b,v9.4b[1]
+        sdot    v26.4s,v6.16b,v10.4b[1]
+        sdot    v27.4s,v6.16b,v11.4b[1]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v8.4b[1]
+        sdot    v29.4s,v7.16b,v9.4b[1]
+        subs    x3,x3,#1                // k -= 16
+        sdot    v30.4s,v7.16b,v10.4b[1]
+        sdot    v31.4s,v7.16b,v11.4b[1]
+        ldr     q7,[x1],#16
+        b.hs    BlockLoop
+
+BlockLoopEpilogue
+        sdot    v16.4s,v4.16b,v0.4b[0]
+        sdot    v17.4s,v4.16b,v1.4b[0]
+        ldr     d8,[x0],#8
+        sdot    v18.4s,v4.16b,v2.4b[0]
+        sdot    v19.4s,v4.16b,v3.4b[0]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v0.4b[0]
+        sdot    v21.4s,v5.16b,v1.4b[0]
+        ldr     d9,[x12],#8
+        sdot    v22.4s,v5.16b,v2.4b[0]
+        sdot    v23.4s,v5.16b,v3.4b[0]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v0.4b[0]
+        sdot    v25.4s,v6.16b,v1.4b[0]
+        ldr     d10,[x13],#8
+        sdot    v26.4s,v6.16b,v2.4b[0]
+        sdot    v27.4s,v6.16b,v3.4b[0]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v0.4b[0]
+        sdot    v29.4s,v7.16b,v1.4b[0]
+        ldr     d11,[x14],#8
+        sdot    v30.4s,v7.16b,v2.4b[0]
+        sdot    v31.4s,v7.16b,v3.4b[0]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v0.4b[1]
+        sdot    v17.4s,v4.16b,v1.4b[1]
+        sdot    v18.4s,v4.16b,v2.4b[1]
+        sdot    v19.4s,v4.16b,v3.4b[1]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v0.4b[1]
+        sdot    v21.4s,v5.16b,v1.4b[1]
+        sdot    v22.4s,v5.16b,v2.4b[1]
+        sdot    v23.4s,v5.16b,v3.4b[1]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v0.4b[1]
+        sdot    v25.4s,v6.16b,v1.4b[1]
+        sdot    v26.4s,v6.16b,v2.4b[1]
+        sdot    v27.4s,v6.16b,v3.4b[1]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v0.4b[1]
+        sdot    v29.4s,v7.16b,v1.4b[1]
+        sdot    v30.4s,v7.16b,v2.4b[1]
+        sdot    v31.4s,v7.16b,v3.4b[1]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v8.4b[0]
+        sdot    v17.4s,v4.16b,v9.4b[0]
+        sdot    v18.4s,v4.16b,v10.4b[0]
+        sdot    v19.4s,v4.16b,v11.4b[0]
+        ldr     q4,[x1],#16
+        sdot    v20.4s,v5.16b,v8.4b[0]
+        sdot    v21.4s,v5.16b,v9.4b[0]
+        sdot    v22.4s,v5.16b,v10.4b[0]
+        sdot    v23.4s,v5.16b,v11.4b[0]
+        ldr     q5,[x1],#16
+        sdot    v24.4s,v6.16b,v8.4b[0]
+        sdot    v25.4s,v6.16b,v9.4b[0]
+        sdot    v26.4s,v6.16b,v10.4b[0]
+        sdot    v27.4s,v6.16b,v11.4b[0]
+        ldr     q6,[x1],#16
+        sdot    v28.4s,v7.16b,v8.4b[0]
+        sdot    v29.4s,v7.16b,v9.4b[0]
+        sdot    v30.4s,v7.16b,v10.4b[0]
+        sdot    v31.4s,v7.16b,v11.4b[0]
+        ldr     q7,[x1],#16
+        sdot    v16.4s,v4.16b,v8.4b[1]
+        sdot    v17.4s,v4.16b,v9.4b[1]
+        sdot    v18.4s,v4.16b,v10.4b[1]
+        sdot    v19.4s,v4.16b,v11.4b[1]
+        sdot    v20.4s,v5.16b,v8.4b[1]
+        sdot    v21.4s,v5.16b,v9.4b[1]
+        sdot    v22.4s,v5.16b,v10.4b[1]
+        sdot    v23.4s,v5.16b,v11.4b[1]
+        sdot    v24.4s,v6.16b,v8.4b[1]
+        sdot    v25.4s,v6.16b,v9.4b[1]
+        sdot    v26.4s,v6.16b,v10.4b[1]
+        sdot    v27.4s,v6.16b,v11.4b[1]
+        sdot    v28.4s,v7.16b,v8.4b[1]
+        sdot    v29.4s,v7.16b,v9.4b[1]
+        subs    x5,x5,#16               // adjust CountN remaining
+        sdot    v30.4s,v7.16b,v10.4b[1]
+        sdot    v31.4s,v7.16b,v11.4b[1]
+        blo     StoreOutputPartial
+        stp     q16,q20,[x2],#32
+        stp     q24,q28,[x2],#32
+        stp     q17,q21,[x16],#32
+        stp     q25,q29,[x16],#32
+        stp     q18,q22,[x17],#32
+        stp     q26,q30,[x17],#32
+        stp     q19,q23,[x6],#32
+        stp     q27,q31,[x6],#32
+        cbnz    x5,ProcessNextColumnLoop
+
+ExitKernel
+        mov     x0,x4                   // return number of rows handled
+        EPILOG_RESTORE_REG_PAIR d10,d11,#16
+        EPILOG_RESTORE_REG_PAIR d8,d9,#GemmS8S8KernelFrame_SavedRegisters!
+        EPILOG_RETURN
+
+//
+// Store the partial 1 to 15 columns either overwriting the output matrix or
+// accumulating into the existing contents of the output matrix.
+//
+
+StoreOutputPartial
+        tbz     x5,#3,StoreOutputPartial4
+        stp     q16,q20,[x2],#32
+        mov     v16.16b,v24.16b             // shift remaining elements down
+        mov     v20.16b,v28.16b
+        stp     q17,q21,[x16],#32
+        mov     v17.16b,v25.16b
+        mov     v21.16b,v29.16b
+        stp     q18,q22,[x17],#32
+        mov     v18.16b,v26.16b
+        mov     v22.16b,v30.16b
+        stp     q19,q23,[x6],#32
+        mov     v19.16b,v27.16b
+        mov     v23.16b,v31.16b
+
+StoreOutputPartial4
+        tbz     x5,#2,StoreOutputPartial2
+        st1     {v16.4s},[x2],#16
+        mov     v16.16b,v20.16b             // shift remaining elements down
+        st1     {v17.4s},[x16],#16
+        mov     v17.16b,v21.16b
+        st1     {v18.4s},[x17],#16
+        mov     v18.16b,v22.16b
+        st1     {v19.4s},[x6],#16
+        mov     v19.16b,v23.16b
+
+StoreOutputPartial2
+        tbz     x5,#1,StoreOutputPartial1
+        st1     {v16.2s},[x2],#8
+        dup     v16.4s,v16.s[2]             // shift remaining elements down
+        st1     {v17.2s},[x16],#8
+        dup     v17.4s,v17.s[2]
+        st1     {v18.2s},[x17],#8
+        dup     v18.4s,v18.s[2]
+        st1     {v19.2s},[x6],#8
+        dup     v19.4s,v19.s[2]
+
+StoreOutputPartial1
+        tbz     x5,#0,ExitKernel
+        st1     {v16.s}[0],[x2]
+        st1     {v17.s}[0],[x16]
+        st1     {v18.s}[0],[x17]
+        st1     {v19.s}[0],[x6]
+        b       ExitKernel
+
+        NESTED_END MlasSymQgemmS8KernelSdot
+
+        END

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -702,7 +702,8 @@ extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmQuantDispatchDefault;
 //
 struct MLAS_SYMM_QGEMM_DISPATCH;
 extern const MLAS_SYMM_QGEMM_DISPATCH MlasSymmQgemmS8DispatchNeon;
- 
+extern const MLAS_SYMM_QGEMM_DISPATCH MlasSymmQgemmS8DispatchSdot;
+
 //
 // Symmetric quantized integer convolution dispatch structure.
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -870,7 +870,7 @@ MlasExecuteThreaded(
     MLAS_THREADPOOL* ThreadPool
     );
 
-inline
+constexpr
 size_t
 MlasDivRoundup(size_t up, size_t down)
 {

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -698,6 +698,12 @@ extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchWasmSimd;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmQuantDispatchDefault;
 
 //
+// Symmetric quantized qgemm dispatch structure
+//
+struct MLAS_SYMM_QGEMM_DISPATCH;
+extern const MLAS_SYMM_QGEMM_DISPATCH MlasSymmQgemmS8DispatchNeon;
+ 
+//
 // Symmetric quantized integer convolution dispatch structure.
 //
 
@@ -792,6 +798,7 @@ struct MLAS_PLATFORM {
 #elif defined(MLAS_TARGET_ARM64)
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8X8Dispatch;
 #endif
+    const MLAS_SYMM_QGEMM_DISPATCH* SymmQgemmDispatch{nullptr};
 
     const MLAS_CONV_SYM_DISPATCH* ConvSymU8S8Dispatch{nullptr};
     const MLAS_CONV_SYM_DISPATCH* ConvSymS8S8Dispatch{nullptr};
@@ -861,6 +868,13 @@ MlasExecuteThreaded(
     ptrdiff_t Iterations,
     MLAS_THREADPOOL* ThreadPool
     );
+
+inline
+size_t
+MlasDivRoundup(size_t up, size_t down)
+{
+    return (up + down - 1) / down;
+}
 
 /**
  * @brief Distribute multiple iterations of work over a thread pool if supported

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -359,6 +359,7 @@ Return Value:
 
     this->GemmU8X8Dispatch = &MlasGemmU8X8DispatchNeon;
     this->ConvSymU8S8Dispatch = &MlasConvSymDispatchNeon;
+    this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchNeon;
 
     //
     // Check if the processor supports ASIMD dot product instructions.

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -378,6 +378,7 @@ Return Value:
     if (HasDotProductInstructions) {
         this->GemmU8X8Dispatch = &MlasGemmU8X8DispatchUdot;
         this->ConvSymU8S8Dispatch = &MlasConvSymDispatchDot;
+        this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchSdot;
     }
 
 #endif // MLAS_TARGET_ARM64

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -207,6 +207,18 @@ MlasSymmQgemmBatch(
     const size_t N = Shape.N;
     const size_t K = Shape.K;
 
+    if (ThreadPool == nullptr) {
+        // So our caller handles partition
+        const MLAS_SYMM_QGEMM_DISPATCH* dispatch = MlasPlatform.SymmQgemmDispatch;
+        MLAS_SYMM_QGEMM_OPERATION* operation = dispatch->Operation;
+
+        for (size_t gemm_i = 0; gemm_i < BatchN; gemm_i++) {
+            auto Data = &DataParams[gemm_i];
+            operation(&Shape, Data, 0, M, 0, N);
+        }
+        return;
+    }
+
     //
     // Compute the number of target threads given the complexity of the SGEMM
     // operation. Small requests should run using the single threaded path.

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -749,7 +749,7 @@ MlasSymmQGemmPackedOperation(
             pa, b, c, PackedCountK, RowsRemaining, RangeCountN, ldc, lda, PackedColumnSumBuffer);
 
         c += ldc * RowsHandled;
-        pa += KernelType::PackedK * PackedCountK * RowsHandled;
+        pa += lda * RowsHandled;
         RowsRemaining -= RowsHandled;
     }
 }

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -1204,7 +1204,8 @@ size_t MlasSymmQGemmKernel<MLAS_GEMM_X8S8_KERNEL_NEON>(
     const int32_t* ColumnSumVector
 )
 {
-    MlasSymQgemmS8KernelNeon(A, B, C, PackedCountK, CountM, CountN, ldc, lda, ColumnSumVector);
+    return MlasSymQgemmS8KernelNeon(A, B, C, PackedCountK, CountM, CountN, ldc, lda,
+                                    ColumnSumVector);
 }
 
 const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon = {
@@ -1213,6 +1214,13 @@ const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon = {
     MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>,
     MLAS_GEMM_X8S8_KERNEL_NEON::PackedK,
     MLAS_GEMM_X8S8_KERNEL_NEON::PackedStrides.K,
+};
+
+const MLAS_SYMM_QGEMM_DISPATCH MlasSymmQgemmS8DispatchNeon = {
+    MlasSymmQGemmPackedOperation<MLAS_GEMM_X8S8_KERNEL_NEON>,
+    MlasGemmQuantCopyPackB<MLAS_GEMM_X8S8_KERNEL_NEON>,
+    4,   // StrideM
+    MLAS_GEMM_X8S8_KERNEL_NEON::PackedK
 };
 
 #endif  //defined(MLAS_TARGET_ARM64)

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_neon.cpp
@@ -608,6 +608,21 @@ extern "C" {
         const int32_t* ZeroPointB,
         bool ZeroMode
         );
+
+    size_t
+    MLASCALL
+    MlasSymQgemmS8KernelNeon(
+        const int8_t* A,
+        const int8_t* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        size_t lda,
+        const int32_t* ColumnSumVector
+        );
+
 }
 
 struct MLAS_GEMM_X8S8_KERNEL_NEON {
@@ -1174,6 +1189,23 @@ MlasGemmQuantKernel<MLAS_GEMM_X8S8_KERNEL_NEON>(
         RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
 }
 
+ 
+template<>
+MLAS_FORCEINLINE
+size_t MlasSymmQGemmKernel<MLAS_GEMM_X8S8_KERNEL_NEON>(
+    const int8_t* A,
+    const int8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    size_t lda,
+    const int32_t* ColumnSumVector
+)
+{
+    MlasSymQgemmS8KernelNeon(A, B, C, PackedCountK, CountM, CountN, ldc, lda, ColumnSumVector);
+}
 
 const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon = {
     MlasGemmQuantOperation<MLAS_GEMM_X8S8_KERNEL_NEON>,

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
@@ -757,3 +757,280 @@ const MLAS_GEMM_QUANT_DISPATCH MlasGemmS8S8DispatchSdot = {
     MLAS_GEMM_S8S8_KERNEL_SDOT::PackedK,
     MLAS_GEMM_S8S8_KERNEL_SDOT::PackedStrides.K,
 };
+
+
+/**
+ * @brief Type parameter for symmetric qgemm
+ */
+struct MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT {
+    typedef uint8_t PackedAType;
+    typedef uint8_t PackedBType;
+    typedef int8_t OffsetAType;
+    typedef int8_t OffsetBType;
+
+    static constexpr size_t PackedK = 16;
+};
+
+constexpr size_t MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK;
+
+template<>
+void
+MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>(
+    MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedBType* Dst,
+    const uint8_t* B,
+    size_t ldb,
+    size_t CountN,
+    size_t CountK,
+    int32_t* ColumnSumBuffer,
+    bool BIsSigned
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(BIsSigned);
+    int8_t* D = reinterpret_cast<int8_t*>(Dst);
+    const int8x16_t ZeroVector = vmovq_n_s8(0);
+    int8x8_t BytesRow[4];
+
+    //  Kernel MlasSymQgemmS8KernelSdot code loads 4x16 B block like:
+    // 
+    //  |v4.b[0]..v4.b[12] v5.b[0]..v5.b[12]  v6.b[0]..v6.b[12]  v7.b[0]..v7.b[12]|
+    //  |  ...      ...     ...       ...       ...      ...       ...      ...   |
+    //  |v4.b[3]..v4.b[15] v5.b[3]..v5.b[15]  v6.b[3]..v6.b[15]  v7.b[3]..v7.b[15]|
+    //
+    // So we process B data similar with MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SDOT>
+    // But twice as wide and twice as deep:
+    //     16 CountN and 16 CountK
+    //
+    //      [ A0 A1 A2 A3 B0 B1 B2 B3 C0 C1 C2 C3 D0 D1 D2 D3 ]
+    //      [ E0 E1 E2 E3 F0 F1 F2 F3 G0 G1 G2 G3 H0 H1 H2 H3 ]
+    //      [ H4 H5 H6 H7 I4 I5 I6 I7 J4 J5 J6 J7 K4 K5 K6 K7 ]
+    //      [ L4 L5 L6 L7 M4 M5 M6 M7 N4 N5 N6 N7 O4 O5 O6 O7 ]
+    //      .... repeat 4 times on K dimension ....
+    //
+    // If CountK is not aligned to a multiple of 16, then the packed buffer
+    // is padded with zero vectors.
+    //
+    // If CountN is not aligned to a multiple of 16, then the extra columns
+    // are padded with zeroes.
+    //
+
+    while (CountN >= 16) {
+
+        const int8_t* b = reinterpret_cast<const int8_t*>(B);
+        size_t k = CountK;
+        int32x4_t ColumnSums0[2];
+        int32x4_t ColumnSums1[2];
+
+        ColumnSums0[0] = vmovq_n_s32(0);
+        ColumnSums0[1] = vmovq_n_s32(0);
+        ColumnSums1[0] = vmovq_n_s32(0);
+        ColumnSums1[1] = vmovq_n_s32(0);
+
+        //
+        // Interleave rows of matrix B and write to the packed buffer.
+        //
+
+        while (k >= 4) {
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0]);
+            BytesRow[1] = vld1_s8(&b[ldb * 1]);
+            BytesRow[2] = vld1_s8(&b[ldb * 2]);
+            BytesRow[3] = vld1_s8(&b[ldb * 3]);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums0);
+            D += 32;
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0 + 8]);
+            BytesRow[1] = vld1_s8(&b[ldb * 1 + 8]);
+            BytesRow[2] = vld1_s8(&b[ldb * 2 + 8]);
+            BytesRow[3] = vld1_s8(&b[ldb * 3 + 8]);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums1);
+            D += 32;
+
+            b += ldb * 4;
+            k -= 4;
+        }
+
+        if (k > 0) {
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0]);
+            BytesRow[1] = (k >= 2) ? vld1_s8(&b[ldb * 1]) : vget_low_s8(ZeroVector);
+            BytesRow[2] = (k > 2) ? vld1_s8(&b[ldb * 2]) : vget_low_s8(ZeroVector);
+            BytesRow[3] = vget_low_s8(ZeroVector);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums0);
+            D += 32;
+
+            BytesRow[0] = vld1_s8(&b[ldb * 0 + 8]);
+            BytesRow[1] = (k >= 2) ? vld1_s8(&b[ldb * 1 + 8]) : vget_low_s8(ZeroVector);
+            BytesRow[2] = (k > 2) ? vld1_s8(&b[ldb * 2 + 8]) : vget_low_s8(ZeroVector);
+            BytesRow[3] = vget_low_s8(ZeroVector);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums1);
+            D += 32;
+        }
+
+        //
+        // Zero pad the output buffer to a multiple of PackedK if the above
+        // processed an odd number of four row bundles.
+        //
+        constexpr size_t mask = MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - 1;
+        size_t remain = (MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - (CountK & mask)) & mask;
+        remain = remain >> 2; // divid by 4
+        for (; remain > 0; remain--) {
+            vst1q_s8(&D[0], ZeroVector);
+            vst1q_s8(&D[16], ZeroVector);
+            vst1q_s8(&D[32], ZeroVector);
+            vst1q_s8(&D[48], ZeroVector);
+            D += 64;
+        }
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums0[0]);
+        vst1q_s32(&ColumnSumBuffer[4], ColumnSums0[1]);
+        vst1q_s32(&ColumnSumBuffer[8], ColumnSums1[0]);
+        vst1q_s32(&ColumnSumBuffer[12], ColumnSums1[1]);
+        ColumnSumBuffer += 16;
+
+        B += 16;
+        CountN -= 16;
+    }
+
+    //
+    // Process the remaining columns of matrix B.
+    //
+
+    if (CountN > 0) {
+
+        const int8_t* b = reinterpret_cast<const int8_t*>(B);
+        size_t k = CountK;
+        int8_t PaddedMatrixBData[64];
+        int32x4_t ColumnSums0[2];
+        int32x4_t ColumnSums1[2];
+
+        vst1q_s8(&PaddedMatrixBData[0], ZeroVector);
+        vst1q_s8(&PaddedMatrixBData[16], ZeroVector);
+        vst1q_s8(&PaddedMatrixBData[32], ZeroVector);
+        vst1q_s8(&PaddedMatrixBData[48], ZeroVector);
+
+        ColumnSums0[0] = vmovq_n_s32(0);
+        ColumnSums0[1] = vmovq_n_s32(0);
+        ColumnSums1[0] = vmovq_n_s32(0);
+        ColumnSums1[1] = vmovq_n_s32(0);
+
+        //
+        // Interleave rows of matrix B using an intermediate zero padded stack
+        // buffer and write to the packed buffer.
+        //
+
+        while (k > 0) {
+
+            const int8_t* bcopy0 = &b[ldb * 0];
+            const int8_t* bcopy1 = &b[ldb * 1];
+            const int8_t* bcopy2 = &b[ldb * 2];
+            const int8_t* bcopy3 = &b[ldb * 3];
+
+            if (k >= 4) {
+
+                b += ldb * 4;
+                k -= 4;
+
+            } else {
+
+                vst1q_s8(&PaddedMatrixBData[0], ZeroVector);
+                vst1q_s8(&PaddedMatrixBData[16], ZeroVector);
+                vst1q_s8(&PaddedMatrixBData[32], ZeroVector);
+                vst1q_s8(&PaddedMatrixBData[48], ZeroVector);
+
+                bcopy1 = (k >= 2) ? bcopy1 : &PaddedMatrixBData[48];
+                bcopy2 = (k > 2) ? bcopy2 : &PaddedMatrixBData[48];
+                bcopy3 = &PaddedMatrixBData[48];
+
+                k = 0;
+            }
+
+            int8_t* padded = PaddedMatrixBData;
+            int8_t* padded_end = padded + CountN;
+
+            do {
+                padded[0] = *bcopy0++;
+                padded[16] = *bcopy1++;
+                padded[32] = *bcopy2++;
+                padded[48] = *bcopy3++;
+            } while (++padded < padded_end);
+
+            BytesRow[0] = vld1_s8(&PaddedMatrixBData[0]);
+            BytesRow[1] = vld1_s8(&PaddedMatrixBData[16]);
+            BytesRow[2] = vld1_s8(&PaddedMatrixBData[32]);
+            BytesRow[3] = vld1_s8(&PaddedMatrixBData[48]);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums0);
+            D += 32;
+
+            BytesRow[0] = vld1_s8(&PaddedMatrixBData[8]);
+            BytesRow[1] = vld1_s8(&PaddedMatrixBData[24]);
+            BytesRow[2] = vld1_s8(&PaddedMatrixBData[40]);
+            BytesRow[3] = vld1_s8(&PaddedMatrixBData[56]);
+            MlasGemmS8S8CopyPackBProcessSDot(D, BytesRow, ColumnSums1);
+            D += 32;
+        }
+
+        //
+        // Zero pad the output buffer to a multiple of PackedK if the above
+        // processed an odd number of four row bundles.
+        //
+        constexpr size_t mask = MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - 1;
+        size_t remain = (MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - (CountK & mask)) & mask;
+        remain = remain >> 2;  // divid by 4
+        for (; remain > 0; remain--) {
+            vst1q_s8(&D[0], ZeroVector);
+            vst1q_s8(&D[16], ZeroVector);
+            vst1q_s8(&D[32], ZeroVector);
+            vst1q_s8(&D[48], ZeroVector);
+            D += 64;
+        }
+
+        vst1q_s32(&ColumnSumBuffer[0], ColumnSums0[0]);
+        vst1q_s32(&ColumnSumBuffer[4], ColumnSums0[1]);
+        vst1q_s32(&ColumnSumBuffer[8], ColumnSums1[0]);
+        vst1q_s32(&ColumnSumBuffer[12], ColumnSums1[1]);
+    }
+}
+
+extern "C" {
+    // Prototype of SDOT symmetric qgemm kernel in assembly
+
+    size_t
+    MLASCALL
+    MlasSymQgemmS8KernelSdot(
+        const int8_t* A,
+        const int8_t* B,
+        int32_t* C,
+        size_t PackedCountK,
+        size_t CountM,
+        size_t CountN,
+        size_t ldc,
+        size_t lda,
+        const int32_t* ColumnSumVector
+        );
+
+}
+
+template<>
+MLAS_FORCEINLINE
+size_t MlasSymmQGemmKernel<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>(
+    const int8_t* A,
+    const int8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    size_t lda,
+    const int32_t* ColumnSumVector
+)
+{
+    return MlasSymQgemmS8KernelSdot(A, B, C, PackedCountK, CountM, CountN, ldc, lda,
+                                    ColumnSumVector);
+}
+
+const MLAS_SYMM_QGEMM_DISPATCH MlasSymmQgemmS8DispatchSdot = {
+    MlasSymmQGemmPackedOperation<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>,
+    MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>,
+    4,  // StrideM
+    MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK
+};

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_sdot.cpp
@@ -802,8 +802,8 @@ MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>(
     //
     //      [ A0 A1 A2 A3 B0 B1 B2 B3 C0 C1 C2 C3 D0 D1 D2 D3 ]
     //      [ E0 E1 E2 E3 F0 F1 F2 F3 G0 G1 G2 G3 H0 H1 H2 H3 ]
-    //      [ H4 H5 H6 H7 I4 I5 I6 I7 J4 J5 J6 J7 K4 K5 K6 K7 ]
-    //      [ L4 L5 L6 L7 M4 M5 M6 M7 N4 N5 N6 N7 O4 O5 O6 O7 ]
+    //      [ I4 I5 I6 I7 J4 J5 J6 J7 K4 K5 K6 K7 L4 L5 L6 L7 ]
+    //      [ M4 M5 M6 M7 N4 N5 N6 N7 O4 O5 O6 O7 P4 P5 P6 P7 ]
     //      .... repeat 4 times on K dimension ....
     //
     // If CountK is not aligned to a multiple of 16, then the packed buffer
@@ -867,8 +867,7 @@ MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>(
         }
 
         //
-        // Zero pad the output buffer to a multiple of PackedK if the above
-        // processed an odd number of four row bundles.
+        // Zero pad the output buffer to a multiple of PackedK
         //
         constexpr size_t mask = MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - 1;
         size_t remain = (MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - (CountK & mask)) & mask;
@@ -970,8 +969,7 @@ MlasGemmQuantCopyPackB<MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT>(
         }
 
         //
-        // Zero pad the output buffer to a multiple of PackedK if the above
-        // processed an odd number of four row bundles.
+        // Zero pad the output buffer to a multiple of PackedK
         //
         constexpr size_t mask = MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - 1;
         size_t remain = (MLAS_SYMM_GEMM_S8S8_KERNEL_SDOT::PackedK - (CountK & mask)) & mask;

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -195,13 +195,9 @@ class QLinearConv : public OpKernel {
     // Don't pack the filter buffer if the MlasConvDepthwise path is used.
     if (group_input_channels != 1 || group_output_channels != 1) {
       const size_t kernel_dim = group_input_channels * kernel_size;
-      packed_W_size_ = 0;
-      if (MlasSymmQgemmSupported(std::is_same<ActType, int8_t>::value)) {
-        packed_W_size_ = MlasGemmPackBSize(group_output_channels,
-                                           kernel_dim,
-                                           std::is_same<ActType, int8_t>::value,
-                                           is_W_signed_);
-      }
+      packed_W_size_ = MlasSymmQgemmPackBSize(group_output_channels,
+                                              kernel_dim,
+                                              std::is_same<ActType, int8_t>::value);
       
       if (packed_W_size_ != 0) {
         size_t packed_W_data_size = SafeInt<size_t>(group_count) * packed_W_size_;

--- a/onnxruntime/test/mlas/bench/bench_symm_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_symm_qgemm.cpp
@@ -21,8 +21,6 @@ void SYMMQGEMM(benchmark::State& state, bool a_signed) {
   if (state.range(3) <= 0) throw std::invalid_argument("Batch must greater than 0!");
   if (state.range(4) <= 0) throw std::invalid_argument("Threads must greater than 0!");
 
-  if (!MlasSymmQgemmSupported(a_signed)) throw std::invalid_argument("Symmetric Qgemm not supported for int8_t activations on this platform!");
-
   const size_t M = static_cast<size_t>(state.range(0));
   const size_t N = static_cast<size_t>(state.range(1));
   const size_t K = static_cast<size_t>(state.range(2));

--- a/onnxruntime/test/mlas/bench/bench_symm_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_symm_qgemm.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "mlas.h"
+#include "bench_util.h"
+#include "core/util/thread_utils.h"
+
+#include <stdexcept>
+#include <memory>
+#include <numeric>
+#include <algorithm>
+
+static const std::vector<std::string> qgemm_arg_names = {"M", "N", "K", "Batch", "Threads"};
+
+void SYMMQGEMM(benchmark::State& state, bool a_signed) {
+  const int8_t a_zero_point = 29;
+
+  if (state.range(0) <= 0) throw std::invalid_argument("M must greater than 0!");
+  if (state.range(1) <= 0) throw std::invalid_argument("N must greater than 0!");
+  if (state.range(2) <= 0) throw std::invalid_argument("K must greater than 0!");
+  if (state.range(3) <= 0) throw std::invalid_argument("Batch must greater than 0!");
+  if (state.range(4) <= 0) throw std::invalid_argument("Threads must greater than 0!");
+
+  if (!MlasSymmQgemmSupported(a_signed)) throw std::invalid_argument("Symmetric Qgemm not supported for int8_t activations on this platform!");
+
+  const size_t M = static_cast<size_t>(state.range(0));
+  const size_t N = static_cast<size_t>(state.range(1));
+  const size_t K = static_cast<size_t>(state.range(2));
+
+  const size_t batch = static_cast<size_t>(state.range(3));
+  const size_t threads = static_cast<size_t>(state.range(4));
+  
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = int(threads);
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+      tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
+  auto A_holder = RandomVectorUniform<int8_t>(static_cast<size_t>(M * K * batch) + 16, int8_t(-120), int8_t(120));
+  auto B_holder = RandomVectorUniform<int8_t>(static_cast<size_t>(N * K * batch), int8_t(-122), int8_t(122));
+  std::vector<int32_t> C_holder(static_cast<size_t>(M * N * batch));
+  std::vector<uint8_t> pack_b_holder;
+
+  size_t packed_b_size  = MlasGemmPackBSize(N, K, a_signed, true);
+  pack_b_holder.resize(packed_b_size * batch);
+
+  MLAS_GEMM_QUANT_SHAPE_PARAMS gemm_shape;
+
+  gemm_shape.M = static_cast<size_t>(M);
+  gemm_shape.N = static_cast<size_t>(N);
+  gemm_shape.K = static_cast<size_t>(K);
+  gemm_shape.AIsSigned = true;
+  gemm_shape.BIsSigned = true;
+
+  std::vector<MLAS_SYMM_QGEMM_DATA_PARAMS> gemm_data_vec(batch);
+  for (size_t i = 0; i < batch; i++) {
+    auto& gemm_params = gemm_data_vec[i];
+    gemm_params.lda = gemm_shape.K;
+    gemm_params.ldc = gemm_shape.N;
+    gemm_params.A = A_holder.data() + M * K * i;
+    gemm_params.C = C_holder.data() + M * N * i;
+
+    MlasSymmQgemmPackB(N, K, (const int8_t*)gemm_params.B, N, a_signed, a_zero_point, (void*)(pack_b_holder.data() + packed_b_size * i));
+    gemm_params.B = (void*)(pack_b_holder.data() + packed_b_size * i);
+  }
+  for (auto _ : state) {
+    MlasSymmQgemmBatch(gemm_shape, gemm_data_vec.data(), batch, tp.get());
+  }
+}
+
+static void SymmQGemmSize(benchmark::internal::Benchmark* b) {
+  b->ArgNames(qgemm_arg_names);
+  // Args for  "M", "N", "K", "Batch",
+
+  b->Args({512, 32128, 768, 1, 1});
+  b->Args({512, 32128, 768, 1, 4});
+  b->Args({512, 32128, 768, 1, 6});
+
+  b->Args({512, 3072, 768, 1, 1});
+  b->Args({512, 3072, 768, 1, 4});
+  b->Args({512, 3072, 768, 1, 6});
+
+  b->Args({512, 768, 3072, 1, 1});
+  b->Args({512, 768, 3072, 1, 4});
+  b->Args({512, 768, 3072, 1, 6});
+
+  b->Args({512, 768, 768, 1, 1});
+  b->Args({512, 768, 768, 1, 4});
+  b->Args({512, 768, 768, 1, 6});
+
+  b->Args({512, 64, 512, 1, 1});
+  b->Args({512, 64, 512, 1, 4});
+  b->Args({512, 64, 512, 1, 6});
+
+  b->Args({512, 512, 64, 12, 1});
+  b->Args({512, 512, 64, 12, 4});
+  b->Args({512, 512, 64, 12, 6});
+
+  b->Args({512, 64, 512, 12, 1});
+  b->Args({512, 64, 512, 12, 4});
+  b->Args({512, 64, 512, 12, 6});
+}
+
+BENCHMARK_CAPTURE(SYMMQGEMM, SignedActivation, true)->Apply(SymmQGemmSize)->UseRealTime();

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
@@ -1,0 +1,36 @@
+#include "test_symm_qgemm_fixture.h"
+
+template <> MlasSymmQgemmTest<int8_t, int32_t, false>* MlasTestFixture<MlasSymmQgemmTest<int8_t, int32_t, false>>::mlas_tester(nullptr);
+template <> MlasSymmQgemmTest<int8_t, int32_t, true>* MlasTestFixture<MlasSymmQgemmTest<int8_t, int32_t, true>>::mlas_tester(nullptr);
+
+static size_t SymmQgemmRegistLongExecute() {
+  size_t count = 0;
+
+  if (MlasSymmQgemmSupported(true)) {
+    count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, false>>::RegisterLongExecute();
+
+    if (GetMlasThreadPool() != nullptr) {
+      count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, true>>::RegisterLongExecute();
+    }
+  }
+
+  return count;
+}
+
+static size_t SymmQgemmRegistShortExecute() {
+  size_t count = 0;
+
+  if (MlasSymmQgemmSupported(true)) {
+    count += SymmQgemmShortExecuteTest<int8_t, int32_t, false>::RegisterShortExecuteTests();
+
+    if (GetMlasThreadPool() != nullptr) {
+      count += SymmQgemmShortExecuteTest<int8_t, int32_t, true>::RegisterShortExecuteTests();
+    }
+  }
+
+  return count;
+}
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
+  return is_short_execute ? SymmQgemmRegistShortExecute() : SymmQgemmRegistLongExecute();
+});

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
@@ -6,12 +6,10 @@ template <> MlasSymmQgemmTest<int8_t, int32_t, true>* MlasTestFixture<MlasSymmQg
 static size_t SymmQgemmRegistLongExecute() {
   size_t count = 0;
 
-  if (MlasSymmQgemmSupported(true)) {
-    count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, false>>::RegisterLongExecute();
+  count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, false>>::RegisterLongExecute();
 
-    if (GetMlasThreadPool() != nullptr) {
-      count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, true>>::RegisterLongExecute();
-    }
+  if (GetMlasThreadPool() != nullptr) {
+    count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, true>>::RegisterLongExecute();
   }
 
   return count;
@@ -20,12 +18,10 @@ static size_t SymmQgemmRegistLongExecute() {
 static size_t SymmQgemmRegistShortExecute() {
   size_t count = 0;
 
-  if (MlasSymmQgemmSupported(true)) {
-    count += SymmQgemmShortExecuteTest<int8_t, int32_t, false>::RegisterShortExecuteTests();
+  count += SymmQgemmShortExecuteTest<int8_t, int32_t, false>::RegisterShortExecuteTests();
 
-    if (GetMlasThreadPool() != nullptr) {
-      count += SymmQgemmShortExecuteTest<int8_t, int32_t, true>::RegisterShortExecuteTests();
-    }
+  if (GetMlasThreadPool() != nullptr) {
+    count += SymmQgemmShortExecuteTest<int8_t, int32_t, true>::RegisterShortExecuteTests();
   }
 
   return count;

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm.cpp
@@ -4,9 +4,11 @@ template <> MlasSymmQgemmTest<int8_t, int32_t, false>* MlasTestFixture<MlasSymmQ
 template <> MlasSymmQgemmTest<int8_t, int32_t, true>* MlasTestFixture<MlasSymmQgemmTest<int8_t, int32_t, true>>::mlas_tester(nullptr);
 
 static size_t SymmQgemmRegistLongExecute() {
-  size_t count = 0;
+  if (MlasSymmQgemmPackBSize(16, 16, true) == 0) {
+    return 0;
+  }
 
-  count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, false>>::RegisterLongExecute();
+  size_t count = MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, false>>::RegisterLongExecute();
 
   if (GetMlasThreadPool() != nullptr) {
     count += MlasLongExecuteTests<MlasSymmQgemmTest<int8_t, int32_t, true>>::RegisterLongExecute();
@@ -16,9 +18,11 @@ static size_t SymmQgemmRegistLongExecute() {
 }
 
 static size_t SymmQgemmRegistShortExecute() {
-  size_t count = 0;
+  if (MlasSymmQgemmPackBSize(16, 16, true) == 0) {
+    return 0;
+  }
 
-  count += SymmQgemmShortExecuteTest<int8_t, int32_t, false>::RegisterShortExecuteTests();
+  size_t count = SymmQgemmShortExecuteTest<int8_t, int32_t, false>::RegisterShortExecuteTests();
 
   if (GetMlasThreadPool() != nullptr) {
     count += SymmQgemmShortExecuteTest<int8_t, int32_t, true>::RegisterShortExecuteTests();

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm.h
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "test_util.h"
+
+template <bool Threaded>
+class MlasSymmQgemmTestBase : public MlasTestBase {
+
+ protected:
+  MLAS_THREADPOOL* threadpool_;
+
+  MlasSymmQgemmTestBase() : threadpool_(Threaded ? GetMlasThreadPool() : nullptr) {}
+
+  void TestGemm(size_t M,
+                size_t N,
+                size_t K,
+                size_t BatchSize,
+                const uint8_t* A,
+                size_t lda,
+                int32_t offa,
+                bool AIsSigned,
+                const int8_t* B,
+                size_t ldb,
+                int32_t* C,
+                size_t ldc) {
+    MLAS_GEMM_QUANT_SHAPE_PARAMS GemmShape;
+    GemmShape.M = M;
+    GemmShape.N = N;
+    GemmShape.K = K;
+    GemmShape.AIsSigned = AIsSigned;
+    GemmShape.BIsSigned = true;
+
+    size_t PackedBSize = MlasGemmPackBSize(N, K, AIsSigned, true);
+    int8_t* PackedB = (int8_t*)BufferBPacked.GetBuffer(PackedBSize * BatchSize);
+
+    std::vector<MLAS_SYMM_QGEMM_DATA_PARAMS> GemmParameters(BatchSize);
+
+    for (size_t i = 0; i < GemmParameters.size(); i++) {
+      auto& params = GemmParameters[i];
+      params.A = A + (M * K * i);
+      params.lda = lda;
+      params.C = C + (M * N * i);
+      params.ldc = ldc;
+
+      MlasSymmQgemmPackB(N, K, B + (K * N * i), ldb, AIsSigned, offa, PackedB + PackedBSize * i);
+      params.B = PackedB + PackedBSize * i;
+    }
+
+    MlasSymmQgemmBatch(GemmShape, GemmParameters.data(), BatchSize, threadpool_);
+  }
+
+ private:
+  MatrixGuardBuffer<uint8_t> BufferBPacked;
+};
+
+template <typename AType, typename OutputType, bool Threaded>
+class MlasSymmQgemmTest;
+
+template <typename AType, bool Threaded>
+class MlasSymmQgemmTest<AType, int32_t, Threaded> : public MlasSymmQgemmTestBase<Threaded> {
+ public:
+
+  void Test(size_t M, size_t N, size_t K, size_t BatchSize, int32_t offa) {
+    // Symmetric kernel will have limited buffer overrun when reading the input buffer
+    constexpr size_t OVERRUN = 15;
+    const uint8_t* A = BufferA.GetBuffer(K * M * BatchSize + OVERRUN);
+    const int8_t* B = BufferB.GetBuffer(N * K * BatchSize);
+    int32_t* C = BufferC.GetBuffer(N * M * BatchSize);
+    int32_t* CReference = BufferCReference.GetBuffer(N * M * BatchSize);
+
+    Test(M, N, K, BatchSize, A, K, offa, B, N, C, CReference, N);
+  }
+
+  void Test(size_t M,
+            size_t N,
+            size_t K,
+            size_t BatchSize,
+            const uint8_t* A,
+            size_t lda,
+            int32_t offa,
+            const int8_t* B,
+            size_t ldb,
+            int32_t* C,
+            int32_t* CReference,
+            size_t ldc) {
+    std::fill_n(C, M * N * BatchSize, -1);
+    std::fill_n(CReference, M * N * BatchSize, -1);
+
+    this->TestGemm(M, N, K, BatchSize, A, lda, offa, std::is_signed<AType>::value, B, ldb, C, ldc);
+    ReferenceQgemm(M, N, K, BatchSize, (const AType*)A, lda, (AType)offa, B, ldb, (const int8_t)0, CReference, ldc);
+
+    for (size_t batch = 0, f = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++, f++) {
+          ASSERT_EQ(C[f], CReference[f]) << "@[" << batch << "x" << m << "x" << n << "], "
+                                         << "Batch=" << BatchSize << "M=" << M << ", N=" << N << ", K=" << K
+                                         << ", offa=" << offa << ", offb=--";
+        }
+      }
+    }
+  }
+
+ private:
+  void ReferenceQgemm(size_t M,
+                      size_t N,
+                      size_t K,
+                      size_t BatchSize,
+                      const AType* A,
+                      size_t lda,
+                      AType offa,
+                      const int8_t* B,
+                      size_t ldb,
+                      int8_t offb,
+                      int32_t* C,
+                      size_t ldc) {
+    for (size_t batch = 0; batch < BatchSize; batch++) {
+      for (size_t m = 0; m < M; m++) {
+        for (size_t n = 0; n < N; n++) {
+          const AType* a = A + (M * K * batch) + (m * lda);
+          const int8_t* b = B + (K * N * batch) + n;
+          int32_t* c = C + (M * N * batch) + (m * ldc) + n;
+          int32_t sum = 0;
+
+          for (size_t k = 0; k < K; k++) {
+            sum += ((int32_t(*b) - offb) * (int32_t(*a) - offa));
+            b += ldb;
+            a += 1;
+          }
+
+          *c = sum;
+        }
+      }
+    }
+  }
+
+  MatrixGuardBuffer<uint8_t> BufferA;
+  MatrixGuardBuffer<int8_t> BufferB;
+  MatrixGuardBuffer<int32_t> BufferC;
+  MatrixGuardBuffer<int32_t> BufferCReference;
+
+ public:
+  static const char* GetTestSuiteName() {
+    static std::string suite_name = std::string("SymmQgemm") +
+                                    (std::is_signed<AType>::value ? "S8" : "U8") +
+                                    "_Int32" +
+                                    (Threaded ? "_Threaded" : "_SingleThread");
+    return suite_name.c_str();
+  }
+
+  void ExecuteLong(void) override {
+    static const int32_t zero_points[] = {-18, 124};
+
+    for (size_t a = 0; a < _countof(zero_points); a++) {
+      int32_t offa = zero_points[a];
+
+      for (size_t M = 16; M < 160; M += 32) {
+        for (size_t N = 16; N < 160; N += 32) {
+          static const size_t ks[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 20, 32, 48, 64, 118, 119, 120, 121, 122, 160, 240, 320};
+          for (size_t k = 0; k < _countof(ks); k++) {
+            size_t K = ks[k];
+
+            Test(M, N, K, 1, offa);
+            Test(M + 1, N, K, 1, offa);
+            Test(M, N + 1, K, 1, offa);
+            Test(M + 1, N + 1, K, 1, offa);
+            Test(M + 3, N + 2, K, 1, offa);
+            Test(M + 4, N, K, 1, offa);
+            Test(M, N + 4, K, 1, offa);
+            Test(M + 4, N + 4, K, 1, offa);
+            Test(M + 3, N + 7, K, 1, offa);
+            Test(M + 8, N, K, 1, offa);
+            Test(M, N + 8, K, 1, offa);
+            Test(M + 12, N + 12, K, 1, offa);
+            Test(M + 13, N, K, 1, offa);
+            Test(M, N + 15, K, 1, offa);
+            Test(M + 15, N + 15, K, 1, offa);
+            Test(M, N, K, 7 + a, offa);
+            Test(M + 3, N, K, 7 + a, offa);
+            Test(M, N + 1, K, 7 + a, offa);
+            Test(M + 12, N, K, 7 + a, offa);
+            Test(M, N + 15, K, 7 + a, offa);
+            Test(M + 15, N + 15, K, 7 + a, offa);
+          }
+        }
+        printf("a %zd/%zd b %zd M %zd\n", a, _countof(zero_points), _countof(zero_points), M);
+      }
+    }
+
+    for (size_t M = 1; M < 160; M++) {
+      for (size_t N = 1; N < 160; N++) {
+        for (size_t K = 1; K < 160; K++) {
+          Test(M, N, K, 1, 18);
+        }
+      }
+      printf("M %zd\n", M);
+    }
+
+    for (size_t M = 160; M < 320; M += 24) {
+      for (size_t N = 112; N < 320; N += 24) {
+        for (size_t K = 1; K < 16; K++) {
+          Test(M, N, K, 1, 1);
+        }
+        for (size_t K = 16; K < 160; K += 32) {
+          Test(M, N, K, 1, -5);
+        }
+      }
+      printf("M %zd\n", M);
+    }
+  }
+};
+

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm.h
@@ -32,7 +32,7 @@ class MlasSymmQgemmTestBase : public MlasTestBase {
     GemmShape.AIsSigned = AIsSigned;
     GemmShape.BIsSigned = true;
 
-    size_t PackedBSize = MlasGemmPackBSize(N, K, AIsSigned, true);
+    size_t PackedBSize = MlasSymmQgemmPackBSize(N, K, AIsSigned);
     int8_t* PackedB = (int8_t*)BufferBPacked.GetBuffer(PackedBSize * BatchSize);
 
     std::vector<MLAS_SYMM_QGEMM_DATA_PARAMS> GemmParameters(BatchSize);

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
@@ -47,7 +47,6 @@ class SymmQgemmShortExecuteTest<AType, int32_t, Threaded> : public MlasTestFixtu
 
   static size_t RegisterShortExecuteTests() {
     size_t test_registered = 0;
-    test_registered += RegisterSingleTest(9, 16, 36, 1, 21);
 
     for (size_t b = 1; b < 16; b++) {
       test_registered += RegisterSingleTest(b, b, b, 1, 21);
@@ -70,7 +69,8 @@ class SymmQgemmShortExecuteTest<AType, int32_t, Threaded> : public MlasTestFixtu
       test_registered += RegisterSingleTest(1, 32, b, 5, 0);      
     }
     test_registered += RegisterSingleTest(43, 500, 401, 7, 113);
-    test_registered += RegisterSingleTest(1023, 1023, 1023, 3, -5);
+    test_registered += RegisterSingleTest(2003, 212, 1020, 3, -5);
+    test_registered += RegisterSingleTest(202, 2003, 1023, 3, 15);
 
     return test_registered;
   }

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
@@ -1,0 +1,81 @@
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "test_symm_qgemm.h"
+
+//
+// Short Execute() test helper to register each test seperately by all parameters.
+//
+template <typename AType, typename OutputType, bool Threaded>
+class SymmQgemmShortExecuteTest;
+
+template <typename AType, bool Threaded>
+class SymmQgemmShortExecuteTest<AType, int32_t, Threaded> : public MlasTestFixture<MlasSymmQgemmTest<AType, int32_t, Threaded>> {
+ public:
+  explicit SymmQgemmShortExecuteTest(size_t M, size_t N, size_t K, size_t Batch, int32_t offa)
+      : M_(M), N_(N), K_(K), Batch_(Batch), offa_(offa) {
+  }
+
+  void TestBody() override {
+    MlasTestFixture<MlasSymmQgemmTest<AType, int32_t, Threaded>>::mlas_tester->Test(M_, N_, K_, Batch_, offa_);
+  }
+
+  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, size_t Batch, int32_t offa) {
+    std::stringstream ss;
+    ss << "Batch" << Batch << "/M" << M << "xN" << N << "xK" << K << "/"
+       << "offa" << offa;
+    auto test_name = ss.str();
+
+    testing::RegisterTest(
+        MlasSymmQgemmTest<AType, int32_t, Threaded>::GetTestSuiteName(),
+        test_name.c_str(),
+        nullptr,
+        test_name.c_str(),
+        __FILE__,
+        __LINE__,
+        // Important to use the fixture type as the return type here.
+        [=]() -> MlasTestFixture<MlasSymmQgemmTest<AType, int32_t, Threaded>>* {
+          return new SymmQgemmShortExecuteTest<AType, int32_t, Threaded>(
+              M, N, K, Batch, offa);
+        });
+
+    return 1;
+  }
+
+  static size_t RegisterShortExecuteTests() {
+    size_t test_registered = 0;
+
+    for (size_t b = 1; b < 16; b++) {
+      test_registered += RegisterSingleTest(b, b, b, 1, 21);
+      test_registered += RegisterSingleTest(b, b, b, 2 + b / 4, -21);
+    }
+    for (size_t b = 1; b < 16; b++) {
+      test_registered += RegisterSingleTest(b, b, b, 1, 17);
+    }
+    for (size_t b = 16; b <= 256; b <<= 1) {
+      test_registered += RegisterSingleTest(b, b, b, 1, -1);
+    }
+    for (size_t b = 256; b < 320; b += 32) {
+      test_registered += RegisterSingleTest(b, b, b, 1, 85);
+    }
+    for (size_t b = 1; b < 96; b++) {
+      test_registered += RegisterSingleTest(1, b, 32, 1, 0);
+      test_registered += RegisterSingleTest(1, 32, b, 1, 0);
+      test_registered += RegisterSingleTest(1, b, b, 1, 0);
+      test_registered += RegisterSingleTest(1, b, 32, 3, 0);
+      test_registered += RegisterSingleTest(1, 32, b, 5, 0);      
+    }
+    test_registered += RegisterSingleTest(43, 500, 401, 7, 113);
+    test_registered += RegisterSingleTest(1023, 1023, 1023, 3, -5);
+
+    return test_registered;
+  }
+
+ private:
+  size_t M_, N_, K_, Batch_;
+  int32_t offa_;
+};
+

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
@@ -47,6 +47,7 @@ class SymmQgemmShortExecuteTest<AType, int32_t, Threaded> : public MlasTestFixtu
 
   static size_t RegisterShortExecuteTests() {
     size_t test_registered = 0;
+    test_registered += RegisterSingleTest(9, 16, 36, 1, 21);
 
     for (size_t b = 1; b < 16; b++) {
       test_registered += RegisterSingleTest(b, b, b, 1, 21);


### PR DESCRIPTION
**Description**: 

Adding code for symmetric quantized matrix multiplication.  Used in quantized convolution, achieving significant perf gain.

TODO, use this in other operators


DOT kernel perf test:

Pixel 5a:

Cartoongan | 513.539 ms | 471.786 ms
-- | -- | --
Efficient | 57.5169 ms | 56.4174 ms
Edgetpu | 14.6673 ms | 13.5959 ms



NEON kernel perf test

Pixel 3a

Cartoongan | 1423.53 ms | 1069.92 ms
-- | -- | --
Efficient | 114.086 ms | 107.968 ms
Edgetpu | 39.2632 ms | 36.9839 ms


