### PR TITLE
[ortmodule] Ensure contiguous tensor into forward pass

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -52,6 +52,9 @@ class TrainingManager(GraphExecutionManager):
         forward_inputs = C.OrtValueVector()
         forward_inputs.reserve(len(inputs))
         for input in inputs:
+            # TODO: Non-contiguous tensor input in execution_session_run_forward, need tensor copy.
+            if not input.is_contiguous():
+                input = input.contiguous()
             if input.device.type == 'ort':
                 forward_inputs.push_back(C.aten_ort_tensor_to_ort_value(input))
             else:


### PR DESCRIPTION
**Description**: Ensure contiguous tensor input into `_utils._torch_tensor_to_dlpack(input)`.

**Motivation and Context**
- Why is this change required? What problem does it solve?
`_utils._torch_tensor_to_dlpack(input)` need contiguous tensor input. However, in hierarchical ortmodule, some pytorch submodules can have non-contiguous tensor output. So we need convert it to contiguous tensor into ort submodules. 
Actually I find the backward pass already have this conversion. So add this to forward pass here.
