### PR TITLE
fix bugs in cpuid_info

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/common/cpuid_info.h"
+
 #if defined(CPUIDINFO_ARCH_X86)
 #include <memory>
 #if defined(_MSC_VER)
@@ -22,7 +24,6 @@
 #endif
 
 #include <mutex>
-#include "core/common/cpuid_info.h"
 
 #if _WIN32
 #define HAS_WINDOWS_DESKTOP WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)

--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #include "core/common/cpuid_info.h"
+#include "core/common/logging/logging.h"
+#include "core/common/logging/severity.h"
 
 #if defined(CPUIDINFO_ARCH_X86)
 #include <memory>
@@ -60,8 +62,9 @@ static inline int XGETBV() {
 CPUIDInfo::CPUIDInfo() {
 #if (defined(CPUIDINFO_ARCH_X86) || defined(CPUIDINFO_ARCH_ARM)) && defined(CPUINFO_SUPPORTED)
   pytorch_cpuinfo_init_ = cpuinfo_initialize();
-  // Note: Failing to init pytorch cpuinfo library may cause CPU EP performance degradation due to undetected CPU features.
-  // TODO: Default logger is not set up yet at this time. Refine the logger logic to support to log here.
+  if (!pytorch_cpuinfo_init_) {
+    LOGS_DEFAULT(WARNING) << "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
+  }
 #endif
 
 #if defined(CPUIDINFO_ARCH_X86)

--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__i386__) || defined(__x86_64__)
-#define CPUIDINFO_ARCH_X86
-#endif
-
-#if defined(_M_ARM64) || defined(__aarch64__) || defined(_M_ARM) || defined(__arm__)
-#define CPUIDINFO_ARCH_ARM
-#endif
-
 #if defined(CPUIDINFO_ARCH_X86)
 #include <memory>
 #if defined(_MSC_VER)
@@ -31,8 +23,6 @@
 
 #include <mutex>
 #include "core/common/cpuid_info.h"
-#include "core/common/logging/logging.h"
-#include "core/common/logging/severity.h"
 
 #if _WIN32
 #define HAS_WINDOWS_DESKTOP WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
@@ -65,15 +55,12 @@ static inline int XGETBV() {
 }
 #endif  // CPUIDINFO_ARCH_X86
 
-CPUIDInfo CPUIDInfo::instance_;
-
 
 CPUIDInfo::CPUIDInfo() {
 #if (defined(CPUIDINFO_ARCH_X86) || defined(CPUIDINFO_ARCH_ARM)) && defined(CPUINFO_SUPPORTED)
   pytorch_cpuinfo_init_ = cpuinfo_initialize();
-  if (!pytorch_cpuinfo_init_) {
-    LOGS_DEFAULT(WARNING) << "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
-  }
+  // Note: Failing to init pytorch cpuinfo library may cause CPU EP performance degradation due to undetected CPU features.
+  // TODO: Default logger is not set up yet at this time. Refine the logger logic to support to log here.
 #endif
 
 #if defined(CPUIDINFO_ARCH_X86)

--- a/onnxruntime/core/common/cpuid_info.h
+++ b/onnxruntime/core/common/cpuid_info.h
@@ -5,6 +5,14 @@
 
 #include "core/common/common.h"
 
+#if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__i386__) || defined(__x86_64__)
+#define CPUIDINFO_ARCH_X86
+#endif
+
+#if defined(_M_ARM64) || defined(__aarch64__) || defined(_M_ARM) || defined(__arm__)
+#define CPUIDINFO_ARCH_ARM
+#endif
+
 namespace onnxruntime {
 
 class CPUIDInfo {
@@ -41,8 +49,6 @@ class CPUIDInfo {
   bool pytorch_cpuinfo_init_{false};
 #endif
   bool has_arm_neon_dot_{false};
-
-  static CPUIDInfo instance_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/compute.cpp
+++ b/onnxruntime/core/mlas/lib/compute.cpp
@@ -271,7 +271,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.ComputeExpF32Kernel(Input, Output, N);
+    GetMlasPlatform().ComputeExpF32Kernel(Input, Output, N);
 #else
     MlasComputeExpF32Kernel(Input, Output, N);
 #endif
@@ -850,7 +850,7 @@ Return Value:
         //
 
 #if defined(MLAS_TARGET_AMD64)
-        float Maximum = MlasPlatform.ReduceMaximumF32Kernel(Input, D);
+        float Maximum = GetMlasPlatform().ReduceMaximumF32Kernel(Input, D);
 #else
         float Maximum = MlasReduceMaximumF32Kernel(Input, D);
 #endif
@@ -863,7 +863,7 @@ Return Value:
             //
 
 #if defined(MLAS_TARGET_AMD64)
-            float Accumulation = MlasPlatform.ComputeSumExpF32Kernel(Input, nullptr, D, &NegativeMaximum);
+            float Accumulation = GetMlasPlatform().ComputeSumExpF32Kernel(Input, nullptr, D, &NegativeMaximum);
 #else
             float Accumulation = MlasComputeSumExpF32Kernel(Input, nullptr, D, &NegativeMaximum);
 #endif
@@ -875,7 +875,7 @@ Return Value:
             float Parameters[] = { NegativeMaximum, std::log(Accumulation)};
 
 #if defined(MLAS_TARGET_AMD64)
-            MlasPlatform.ComputeLogSoftmaxOutputF32Kernel(Input, Output, D, Parameters);
+            GetMlasPlatform().ComputeLogSoftmaxOutputF32Kernel(Input, Output, D, Parameters);
 #else
             MlasComputeLogSoftmaxOutputF32Kernel(Input, Output, D, Parameters);
 #endif
@@ -888,7 +888,7 @@ Return Value:
             //
 
 #if defined(MLAS_TARGET_AMD64)
-            float Accumulation = MlasPlatform.ComputeSumExpF32Kernel(Input, Output, D, &NegativeMaximum);
+            float Accumulation = GetMlasPlatform().ComputeSumExpF32Kernel(Input, Output, D, &NegativeMaximum);
 #else
             float Accumulation = MlasComputeSumExpF32Kernel(Input, Output, D, &NegativeMaximum);
 #endif
@@ -900,7 +900,7 @@ Return Value:
             float Parameters[] = { 1.0f / Accumulation };
 
 #if defined(MLAS_TARGET_AMD64)
-            MlasPlatform.ComputeSoftmaxOutputF32Kernel(Output, D, Parameters);
+            GetMlasPlatform().ComputeSoftmaxOutputF32Kernel(Output, D, Parameters);
 #else
             MlasComputeSoftmaxOutputF32Kernel(Output, D, Parameters);
 #endif

--- a/onnxruntime/core/mlas/lib/convsym.cpp
+++ b/onnxruntime/core/mlas/lib/convsym.cpp
@@ -205,7 +205,7 @@ MLAS_FORCEINLINE
 const
 MLAS_CONV_SYM_DISPATCH*
 GetConvSymDispatch(bool InputIsSigned){
-    return InputIsSigned ? MlasPlatform.ConvSymS8S8Dispatch : MlasPlatform.ConvSymU8S8Dispatch;
+    return InputIsSigned ? GetMlasPlatform().ConvSymS8S8Dispatch : GetMlasPlatform().ConvSymU8S8Dispatch;
 }
 
 size_t

--- a/onnxruntime/core/mlas/lib/dgemm.cpp
+++ b/onnxruntime/core/mlas/lib/dgemm.cpp
@@ -531,7 +531,7 @@ Return Value:
         size_t RowsHandled;
 
 #if defined(MLAS_TARGET_AMD64_IX86) || defined (MLAS_TARGET_POWER)
-        RowsHandled = MlasPlatform.GemmDoubleKernel(A, B, C, CountK, CountM, CountN, lda, ldc, alpha, ZeroMode);
+        RowsHandled = GetMlasPlatform().GemmDoubleKernel(A, B, C, CountK, CountM, CountN, lda, ldc, alpha, ZeroMode);
 #else
         if (ZeroMode) {
             RowsHandled = MlasDgemmKernelZero(A, B, C, CountK, CountM, CountN, lda, ldc, alpha);
@@ -830,10 +830,10 @@ MlasGemmBatch(
 
     ptrdiff_t TargetThreadCount;
 
-    if (Complexity < double(MLAS_DGEMM_THREAD_COMPLEXITY * MlasPlatform.MaximumThreadCount)) {
+    if (Complexity < double(MLAS_DGEMM_THREAD_COMPLEXITY * GetMlasPlatform().MaximumThreadCount)) {
         TargetThreadCount = ptrdiff_t(Complexity / double(MLAS_DGEMM_THREAD_COMPLEXITY)) + 1;
     } else {
-        TargetThreadCount = MlasPlatform.MaximumThreadCount;
+        TargetThreadCount = GetMlasPlatform().MaximumThreadCount;
     }
 
     ptrdiff_t MaximumThreadCount = MlasGetMaximumThreadCount(ThreadPool);

--- a/onnxruntime/core/mlas/lib/erf.cpp
+++ b/onnxruntime/core/mlas/lib/erf.cpp
@@ -262,7 +262,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.ErfKernelRoutine(Input, Output, N);
+    GetMlasPlatform().ErfKernelRoutine(Input, Output, N);
 #else
     MlasErfKernel(Input, Output, N);
 #endif

--- a/onnxruntime/core/mlas/lib/logistic.cpp
+++ b/onnxruntime/core/mlas/lib/logistic.cpp
@@ -179,7 +179,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.LogisticKernelRoutine(Input, Output, N);
+    GetMlasPlatform().LogisticKernelRoutine(Input, Output, N);
 #else
     MlasLogisticKernel(Input, Output, N);
 #endif

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -841,7 +841,11 @@ struct MLAS_PLATFORM {
 
 };
 
-extern MLAS_PLATFORM MlasPlatform;
+inline
+MLAS_PLATFORM& GetMlasPlatform(){
+    static MLAS_PLATFORM MlasPlatform;
+    return MlasPlatform;
+}
 
 //
 // Threading support.

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -43,12 +43,6 @@ MLASCPUIDInfo::MLASCPUIDInfo() { has_arm_neon_dot_ = ((getauxval(AT_HWCAP) & HWC
 #endif
 #endif // MLAS_TARGET_ARM64
 
-//
-// Stores the platform information.
-//
-
-MLAS_PLATFORM MlasPlatform;
-
 #ifdef MLAS_TARGET_AMD64_IX86
 
 //
@@ -422,7 +416,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    return MlasPlatform.PreferredBufferAlignment;
+    return GetMlasPlatform().PreferredBufferAlignment;
 #else
     return MLAS_DEFAULT_PREFERRED_BUFFER_ALIGNMENT;
 #endif

--- a/onnxruntime/core/mlas/lib/qdwconv.cpp
+++ b/onnxruntime/core/mlas/lib/qdwconv.cpp
@@ -288,14 +288,14 @@ Return Value:
     if (InputIsSigned) {
         if (FilterIsSigned) {
 
-            MlasPlatform.ConvDepthwiseS8S8Kernel(
+            GetMlasPlatform().ConvDepthwiseS8S8Kernel(
                 reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
                 reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
                 Output, Channels, OutputCount, KernelSize
                 );
         } else {
 
-            MlasPlatform.ConvDepthwiseS8U8Kernel(
+            GetMlasPlatform().ConvDepthwiseS8U8Kernel(
                 reinterpret_cast<const int8_t* const*>(Input), static_cast<int8_t>(InputZeroPoint),
                 reinterpret_cast<const uint8_t*>(Filter), static_cast<uint8_t>(FilterZeroPoint),
                 Output, Channels, OutputCount, KernelSize
@@ -304,14 +304,14 @@ Return Value:
     } else {
         if (FilterIsSigned) {
 
-            MlasPlatform.ConvDepthwiseU8S8Kernel(
+            GetMlasPlatform().ConvDepthwiseU8S8Kernel(
                 reinterpret_cast<const uint8_t* const*>(Input), static_cast<uint8_t>(InputZeroPoint),
                 reinterpret_cast<const int8_t*>(Filter), static_cast<int8_t>(FilterZeroPoint),
                 Output, Channels, OutputCount, KernelSize
                 );
         } else {
 
-            MlasPlatform.ConvDepthwiseU8U8Kernel(
+            GetMlasPlatform().ConvDepthwiseU8U8Kernel(
                 reinterpret_cast<const uint8_t* const*>(Input), static_cast<uint8_t>(InputZeroPoint),
                 reinterpret_cast<const uint8_t*>(Filter), static_cast<uint8_t>(FilterZeroPoint),
                 Output, Channels, OutputCount, KernelSize

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -165,10 +165,10 @@ MlasGemmBatch(
 
     ptrdiff_t TargetThreadCount;
 
-    if (Complexity < double(MLAS_QGEMM_THREAD_COMPLEXITY * MlasPlatform.MaximumThreadCount)) {
+    if (Complexity < double(MLAS_QGEMM_THREAD_COMPLEXITY * GetMlasPlatform().MaximumThreadCount)) {
         TargetThreadCount = ptrdiff_t(Complexity / double(MLAS_QGEMM_THREAD_COMPLEXITY)) + 1;
     } else {
-        TargetThreadCount = MlasPlatform.MaximumThreadCount;
+        TargetThreadCount = GetMlasPlatform().MaximumThreadCount;
     }
 
     ptrdiff_t MaximumThreadCount = MlasGetMaximumThreadCount(ThreadPool);

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -710,21 +710,21 @@ MlasGemmQuantGetDispatch(
 #if defined(MLAS_TARGET_AMD64_IX86)
     if (!AIsSigned) {
         if (BIsSigned) {
-            GemmQuantDispatch = MlasPlatform.GemmU8S8Dispatch;
+            GemmQuantDispatch = GetMlasPlatform().GemmU8S8Dispatch;
         }
         else {
-            GemmQuantDispatch = MlasPlatform.GemmU8U8Dispatch;
+            GemmQuantDispatch = GetMlasPlatform().GemmU8U8Dispatch;
         }
     }
 #elif defined(MLAS_TARGET_ARM64)
     if(BIsSigned) {
-        if(MlasPlatform.GemmU8X8Dispatch == &MlasGemmU8X8DispatchNeon) {
+        if(GetMlasPlatform().GemmU8X8Dispatch == &MlasGemmU8X8DispatchNeon) {
             GemmQuantDispatch = &MlasGemmX8S8DispatchNeon;
         } else {
             GemmQuantDispatch = AIsSigned? &MlasGemmS8S8DispatchSdot : &MlasGemmU8X8DispatchUdot;
         }
     } else if(!AIsSigned) {
-        GemmQuantDispatch = MlasPlatform.GemmU8X8Dispatch;
+        GemmQuantDispatch = GetMlasPlatform().GemmU8X8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64EC) || (defined(MLAS_TARGET_ARM) && !defined(_MSC_VER))
     if(BIsSigned || !AIsSigned) {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_avx2.cpp
@@ -107,7 +107,7 @@ MlasGemmQuantTryGemvKernel<MLAS_GEMM_U8S8_KERNEL_AVX2>(
     )
 {
     if (!AIsSigned && BIsSigned) {
-        MlasPlatform.GemvU8S8Kernel(A, B, C, CountK, CountN, ldb);
+        GetMlasPlatform().GemvU8S8Kernel(A, B, C, CountK, CountN, ldb);
         return true;
     }
 
@@ -179,8 +179,8 @@ MlasGemmQuantKernel<MLAS_GEMM_U8S8_KERNEL_AVX2>(
     bool ZeroMode
     )
 {
-    return MlasPlatform.GemmU8S8Kernel(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                       RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
+    return GetMlasPlatform().GemmU8S8Kernel(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                            RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
 }
 
 const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchAvx2 = {
@@ -260,8 +260,8 @@ MlasGemmQuantKernel<MLAS_GEMM_U8U8_KERNEL_AVX2>(
     bool ZeroMode
     )
 {
-    return MlasPlatform.GemmU8U8Kernel(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                       RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
+    return GetMlasPlatform().GemmU8U8Kernel(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                            RowSumBuffer, ColumnSumBuffer, ZeroPointB, ZeroMode);
 }
 
 const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8U8DispatchAvx2 = {

--- a/onnxruntime/core/mlas/lib/qladd.cpp
+++ b/onnxruntime/core/mlas/lib/qladd.cpp
@@ -520,7 +520,7 @@ MlasQLinearAdd<int8_t>(
     )
 {
 #if defined(MLAS_TARGET_AMD64)
-        MlasPlatform.QLinearAddS8Kernel(
+        GetMlasPlatform().QLinearAddS8Kernel(
 #else
         MlasQLinearAddKernel<int8_t>(
 #endif
@@ -545,7 +545,7 @@ MlasQLinearAdd<uint8_t>(
     )
 {
 #if defined(MLAS_TARGET_AMD64)
-        MlasPlatform.QLinearAddU8Kernel(
+        GetMlasPlatform().QLinearAddU8Kernel(
 #else
         MlasQLinearAddKernel<uint8_t>(
 #endif

--- a/onnxruntime/core/mlas/lib/quantize.cpp
+++ b/onnxruntime/core/mlas/lib/quantize.cpp
@@ -248,7 +248,7 @@ MlasQuantizeLinear<int8_t>(
     )
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.QuantizeLinearS8Kernel(
+    GetMlasPlatform().QuantizeLinearS8Kernel(
 #else
     MlasQuantizeLinearS8Kernel(
 #endif
@@ -267,7 +267,7 @@ MlasQuantizeLinear<uint8_t>(
     )
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.QuantizeLinearU8Kernel(
+    GetMlasPlatform().QuantizeLinearU8Kernel(
 #else
     MlasQuantizeLinearU8Kernel(
 #endif
@@ -989,7 +989,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.ReduceMinimumMaximumF32Kernel(Input, Min, Max, N);
+    GetMlasPlatform().ReduceMinimumMaximumF32Kernel(Input, Min, Max, N);
 #else
     MlasReduceMinimumMaximumF32Kernel(Input, Min, Max, N);
 #endif

--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -475,7 +475,7 @@ Return Value:
 #if defined(MLAS_TARGET_AMD64)
 
         MLAS_SGEMM_TRANSPOSE_PACKB_BLOCK_ROUTINE* SgemmTransposePackB16x4Routine =
-            MlasPlatform.TransposePackB16x4Routine;
+            GetMlasPlatform().TransposePackB16x4Routine;
 
         while (x >= 4) {
 
@@ -1062,7 +1062,7 @@ Return Value:
         size_t RowsHandled;
 
 #if defined(MLAS_TARGET_AMD64_IX86) || defined(MLAS_TARGET_POWER)
-        RowsHandled = MlasPlatform.GemmFloatKernel(A, B, C, CountK, CountM, CountN, lda, ldc, alpha, ZeroMode);
+        RowsHandled = GetMlasPlatform().GemmFloatKernel(A, B, C, CountK, CountM, CountN, lda, ldc, alpha, ZeroMode);
 #else
         if (ZeroMode) {
             RowsHandled = MlasSgemmKernelZero(A, B, C, CountK, CountM, CountN, lda, ldc, alpha);
@@ -1163,9 +1163,9 @@ Return Value:
         MLAS_SGEMM_KERNEL_M1_ROUTINE* SgemmKernelM1Routine;
 
         if (TransB == CblasNoTrans) {
-            SgemmKernelM1Routine = MlasPlatform.KernelM1Routine;
+            SgemmKernelM1Routine = GetMlasPlatform().KernelM1Routine;
         } else {
-            SgemmKernelM1Routine = MlasPlatform.KernelM1TransposeBRoutine;
+            SgemmKernelM1Routine = GetMlasPlatform().KernelM1TransposeBRoutine;
         }
 
         if (SgemmKernelM1Routine != nullptr) {
@@ -1198,9 +1198,9 @@ Return Value:
         MLAS_SGEMM_KERNEL_M1_ROUTINE* SgemmKernelM1Routine;
 
         if (TransA == CblasNoTrans) {
-            SgemmKernelM1Routine = MlasPlatform.KernelM1TransposeBRoutine;
+            SgemmKernelM1Routine = GetMlasPlatform().KernelM1TransposeBRoutine;
         } else {
-            SgemmKernelM1Routine = MlasPlatform.KernelM1Routine;
+            SgemmKernelM1Routine = GetMlasPlatform().KernelM1Routine;
         }
 
         if (SgemmKernelM1Routine != nullptr) {
@@ -1580,10 +1580,10 @@ MlasGemmBatch(
 
     ptrdiff_t TargetThreadCount;
 
-    if (Complexity < double(MLAS_SGEMM_THREAD_COMPLEXITY * MlasPlatform.MaximumThreadCount)) {
+    if (Complexity < double(MLAS_SGEMM_THREAD_COMPLEXITY * GetMlasPlatform().MaximumThreadCount)) {
         TargetThreadCount = ptrdiff_t(Complexity / double(MLAS_SGEMM_THREAD_COMPLEXITY)) + 1;
     } else {
-        TargetThreadCount = MlasPlatform.MaximumThreadCount;
+        TargetThreadCount = GetMlasPlatform().MaximumThreadCount;
     }
 
     ptrdiff_t MaximumThreadCount = MlasGetMaximumThreadCount(ThreadPool);

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -102,7 +102,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    return MlasPlatform.NchwcBlockSize;
+    return GetMlasPlatform().NchwcBlockSize;
 #else
     return 1;
 #endif
@@ -675,7 +675,7 @@ struct MLAS_NCHWC_CONV_NCHWC_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
 #if defined(MLAS_TARGET_AMD64)
-        MLAS_CONV_FLOAT_KERNEL* Kernel = MlasPlatform.ConvNchwcFloatKernel;
+        MLAS_CONV_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvNchwcFloatKernel;
 #else
         MLAS_CONV_FLOAT_KERNEL* Kernel = MlasConvNchwcFloatKernel;
 #endif
@@ -785,7 +785,7 @@ struct MLAS_NCHWC_CONV_NCHW_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
 #if defined(MLAS_TARGET_AMD64)
-        MLAS_CONV_FLOAT_KERNEL* Kernel = MlasPlatform.ConvNchwFloatKernel;
+        MLAS_CONV_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvNchwFloatKernel;
 #else
         MLAS_CONV_FLOAT_KERNEL* Kernel = MlasConvNchwFloatKernel;
 #endif
@@ -880,7 +880,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         const size_t OutputStrideBytes = BlockSize * OutputSize * sizeof(float);
 
 #if defined(MLAS_TARGET_AMD64)
-        MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = MlasPlatform.ConvPointwiseFloatKernel;
+        MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvPointwiseFloatKernel;
 #else
         MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = MlasConvPointwiseFloatKernel;
 #endif
@@ -1017,7 +1017,7 @@ struct MLAS_NCHWC_CONV_DEPTHWISE_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
         const size_t BlockedOutputWidth = BlockSize * OutputWidth;
 
 #if defined(MLAS_TARGET_AMD64)
-        MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* Kernel = MlasPlatform.ConvDepthwiseFloatKernel;
+        MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvDepthwiseFloatKernel;
 #else
         MLAS_CONV_DEPTHWISE_FLOAT_KERNEL* Kernel = MlasConvDepthwiseFloatKernel;
 #endif
@@ -1132,7 +1132,7 @@ struct MLAS_NCHWC_POOL_ALGORITHM : MLAS_NCHWC_NN_ALGORITHM
         const size_t InputStrideBytes = DilatedInputWidthBytes - KernelWidth * DilationWidthBytes;
 
 #if defined(MLAS_TARGET_AMD64)
-        MLAS_POOL_FLOAT_KERNEL* Kernel = MlasPlatform.PoolFloatKernel[WorkBlock->PoolingKind];
+        MLAS_POOL_FLOAT_KERNEL* Kernel = GetMlasPlatform().PoolFloatKernel[WorkBlock->PoolingKind];
 #else
         MLAS_POOL_FLOAT_KERNEL* Kernel = PoolKernels[WorkBlock->PoolingKind];
 #endif

--- a/onnxruntime/core/mlas/lib/tanh.cpp
+++ b/onnxruntime/core/mlas/lib/tanh.cpp
@@ -177,7 +177,7 @@ Return Value:
 --*/
 {
 #if defined(MLAS_TARGET_AMD64)
-    MlasPlatform.TanhKernelRoutine(Input, Output, N);
+    GetMlasPlatform().TanhKernelRoutine(Input, Output, N);
 #else
     MlasTanhKernel(Input, Output, N);
 #endif


### PR DESCRIPTION
**Description**: Describe your changes.
Fix following bugs in cpuid_info component:
1. CPUIDINFO_ARCH_X86 and CPUIDINFO_ARCH_ARM should be defined in header file instead of .cc file. This causes very tricky issue. Both macros are used to determine if pytorch_cpuinfo_init_ is a member of CPUIDInfo in the cpuid_info.h.
    pytorch_cpuinfo_init_ is a member of CPUIDInfo in cpuid_info.cc file on x86 and arm because those 2 macros are defined in cpuid_info.cc. 
    cpuid_info.h is also referred in platform.cc file.  pytorch_cpuinfo_init_ is determined not a member of CPUIDInfo in platform.cc file because those 2 macros are not defined there. It results that symbol has_arm_neon_dot_ uses the value of pytorch_cpuinfo_init_ in platform.cc. 

2. DefaultLogger is not initialized at the time of construction of CPUIDInfo.

3. Unused CPUIDInfo instance_. 
