### PR TITLE
Add "available since" message for C API additions since v1.10.0.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3220,7 +3220,7 @@ struct OrtApi {
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_CUDA_V2,
                   _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptionsV2* cuda_options);
@@ -3235,7 +3235,7 @@ struct OrtApi {
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   ORT_API2_STATUS(CreateCUDAProviderOptions, _Outptr_ OrtCUDAProviderOptionsV2** out);
 
@@ -3254,7 +3254,7 @@ struct OrtApi {
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   ORT_API2_STATUS(UpdateCUDAProviderOptions, _Inout_ OrtCUDAProviderOptionsV2* cuda_options,
                   _In_reads_(num_keys) const char* const* provider_options_keys,
@@ -3273,7 +3273,7 @@ struct OrtApi {
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   ORT_API2_STATUS(GetCUDAProviderOptionsAsString, _In_ const OrtCUDAProviderOptionsV2* cuda_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 
@@ -3281,7 +3281,7 @@ struct OrtApi {
   *
   * \note This is an exception in the naming convention of other Release* functions, as the name of the method does not have the V2 suffix, but the type does
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   void(ORT_API_CALL* ReleaseCUDAProviderOptions)(_Frees_ptr_opt_ OrtCUDAProviderOptionsV2* input);
 
@@ -3296,7 +3296,7 @@ struct OrtApi {
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
-  * \version New in version 1.11.
+  * \since Version 1.11.
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_MIGraphX,
                   _In_ OrtSessionOptions* options, _In_ const OrtMIGraphXProviderOptions* migraphx_options);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -267,7 +267,7 @@ typedef OrtStatus* OrtStatusPtr;
 /** \brief Memory allocation interface
 *
 * Structure of function pointers that defines a memory allocator. This can be created and filled in by the user for custom allocators.
-* 
+*
 * When an allocator is passed to any function, be sure that the allocator object is not destroyed until the last allocated object using it is freed.
 */
 typedef struct OrtAllocator {
@@ -376,7 +376,7 @@ typedef struct OrtCUDAProviderOptions {
   */
   int arena_extend_strategy;
 
-  /** \brief Flag indicating if copying needs to take place on the same stream as the compute stream in the CUDA EP   
+  /** \brief Flag indicating if copying needs to take place on the same stream as the compute stream in the CUDA EP
   *   0 = Use separate streams for copying and compute.
   *   1 = Use the same stream for copying and compute.
   *   Defaults to 1.
@@ -390,7 +390,7 @@ typedef struct OrtCUDAProviderOptions {
   */
   int has_user_compute_stream;
 
-  /** \brief User provided compute stream. 
+  /** \brief User provided compute stream.
   *   If provided, please set `has_user_compute_stream` to 1.
   */
   void* user_compute_stream;
@@ -434,7 +434,7 @@ typedef struct OrtROCMProviderOptions {
   */
   int arena_extend_strategy;
 
-  /** \brief Flag indicating if copying needs to take place on the same stream as the compute stream in the ROCM EP   
+  /** \brief Flag indicating if copying needs to take place on the same stream as the compute stream in the ROCM EP
   *   0 = Use separate streams for copying and compute.
   *   1 = Use the same stream for copying and compute.
   *   Defaults to 1.
@@ -448,7 +448,7 @@ typedef struct OrtROCMProviderOptions {
   */
   int has_user_compute_stream;
 
-  /** \brief User provided compute stream. 
+  /** \brief User provided compute stream.
   *   If provided, please set `has_user_compute_stream` to 1.
   */
   void* user_compute_stream;
@@ -3067,7 +3067,7 @@ struct OrtApi {
    * \brief Sets out to 1 iff an optional type OrtValue has an element, 0 otherwise (OrtValue is None)
    * Use this API to find if the optional type OrtValue is None or not.
    * If the optional type OrtValue is not None, use the OrtValue just like any other OrtValue.
-   * For example, if you get an OrtValue that corresponds to Optional(tensor) and 
+   * For example, if you get an OrtValue that corresponds to Optional(tensor) and
    * if HasValue() returns true, use it as tensor and so on.
 
    * \param[in] value Input OrtValue.
@@ -3079,7 +3079,7 @@ struct OrtApi {
   /// @}
   /// \name OrtKernelContext
   /// @{
-  /** \brief Used for custom operators, gets the GPU compute stream to use to launch the custom a GPU kernel     
+  /** \brief Used for custom operators, gets the GPU compute stream to use to launch the custom a GPU kernel
   *   \see ::OrtCustomOp
   * \param[in]  context OrtKernelContext instance
   * \param[out] out Returns pointer to a GPU compute stream that can be used to launch the custom GPU kernel.
@@ -3088,7 +3088,7 @@ struct OrtApi {
   *             Do not free or mutate the returned pointer as it refers to internal data owned by the underlying session.
   *             Only use it for custom kernel launching.
   *
-  * \snippet{doc} snippets.dox OrtStatus Return Value 
+  * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(KernelContext_GetGPUComputeStream, _In_ const OrtKernelContext* context, _Outptr_ void** out);
 
@@ -3107,7 +3107,7 @@ struct OrtApi {
   /// \name GetExecutionProviderApi
   /// @{
   /** \brief Get a pointer to the requested version of the Execution Provider specific
-   * API extensions to the OrtApi 
+   * API extensions to the OrtApi
    * \param[in] provider_name The name of the execution provider name. Currently only the following
    * values are supported: "DML".
    * \param[in] version Must be ::ORT_API_VERSION.
@@ -3126,16 +3126,16 @@ struct OrtApi {
   *
   * \param[in] options Session options
   * \param[in] ort_custom_create_thread_fn Custom thread creation function
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomCreateThreadFn, _Inout_ OrtSessionOptions* options, _In_ OrtCustomCreateThreadFn ort_custom_create_thread_fn);
 
-  /** \brief Set creation options for custom thread 
+  /** \brief Set creation options for custom thread
   *
   * \param[in] options Session options
   * \param[in] ort_custom_thread_creation_options Custom thread creation options (can be nullptr)
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomThreadCreationOptions, _Inout_ OrtSessionOptions* options, _In_ void* ort_custom_thread_creation_options);
@@ -3144,7 +3144,7 @@ struct OrtApi {
   *
   * \param[in] options Session options
   * \param[in] ort_custom_join_thread_fn Custom join thread function, must not be nullptr when ort_custom_create_thread_fn is set
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSessionOptions* options, _In_ OrtCustomJoinThreadFn ort_custom_join_thread_fn);
@@ -3156,7 +3156,7 @@ struct OrtApi {
   *
   * \param[inout] tp_options
   * \param[in] ort_custom_create_thread_fn Custom thread creation function
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomCreateThreadFn, _Inout_ OrtThreadingOptions* tp_options, _In_ OrtCustomCreateThreadFn ort_custom_create_thread_fn);
@@ -3165,7 +3165,7 @@ struct OrtApi {
   *
   * \param[inout] tp_options
   * \param[in] ort_custom_thread_creation_options Custom thread creation options (can be nullptr)
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomThreadCreationOptions, _Inout_ OrtThreadingOptions* tp_options, _In_ void* ort_custom_thread_creation_options);
@@ -3174,7 +3174,7 @@ struct OrtApi {
   *
   * \param[inout] tp_options
   * \param[in] ort_custom_join_thread_fn Custom thread join function, must not be nullptr when global ort_custom_create_thread_fn is set
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SetGlobalCustomJoinThreadFn, _Inout_ OrtThreadingOptions* tp_options, _In_ OrtCustomJoinThreadFn ort_custom_join_thread_fn);
@@ -3185,7 +3185,7 @@ struct OrtApi {
   *   operation is provider specific and could be a no-op.
   *
   * \param[inout] binding_ptr
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SynchronizeBoundInputs, _Inout_ OrtIoBinding* binding_ptr);
@@ -3195,7 +3195,7 @@ struct OrtApi {
   *   operation is provider specific and could be a no-op.
   *
   * \param[inout] binding_ptr
-  * 
+  *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   */
   ORT_API2_STATUS(SynchronizeBoundOutputs, _Inout_ OrtIoBinding* binding_ptr);
@@ -3219,6 +3219,8 @@ struct OrtApi {
   * \param[in] cuda_options
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  * \version New in version 1.11.
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_CUDA_V2,
                   _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptionsV2* cuda_options);
@@ -3232,6 +3234,8 @@ struct OrtApi {
   * \param[out] out Newly created ::OrtCUDAProviderOptionsV2. Must be released with OrtApi::ReleaseCudaProviderOptions
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  * \version New in version 1.11.
   */
   ORT_API2_STATUS(CreateCUDAProviderOptions, _Outptr_ OrtCUDAProviderOptionsV2** out);
 
@@ -3249,6 +3253,8 @@ struct OrtApi {
   * \param[in] num_keys Number of elements in the `provider_option_keys` and `provider_options_values` arrays
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  * \version New in version 1.11.
   */
   ORT_API2_STATUS(UpdateCUDAProviderOptions, _Inout_ OrtCUDAProviderOptionsV2* cuda_options,
                   _In_reads_(num_keys) const char* const* provider_options_keys,
@@ -3258,20 +3264,28 @@ struct OrtApi {
   /**
   * Get serialized CUDA provider options string.
   *
-  * For example, "device_id=0;arena_extend_strategy=0;......" 
+  * For example, "device_id=0;arena_extend_strategy=0;......"
   *
-  * \param cuda_options - OrtCUDAProviderOptionsV2 instance 
+  * \param cuda_options - OrtCUDAProviderOptionsV2 instance
   * \param allocator - a ptr to an instance of OrtAllocator obtained with CreateAllocator() or GetAllocatorWithDefaultOptions()
   *                      the specified allocator will be used to allocate continuous buffers for output strings and lengths.
   * \param ptr - is a UTF-8 null terminated string allocated using 'allocator'. The caller is responsible for using the same allocator to free it.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  * \version New in version 1.11.
   */
   ORT_API2_STATUS(GetCUDAProviderOptionsAsString, _In_ const OrtCUDAProviderOptionsV2* cuda_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 
   /** \brief Release an ::OrtCUDAProviderOptionsV2
   *
   * \note This is an exception in the naming convention of other Release* functions, as the name of the method does not have the V2 suffix, but the type does
+  *
+  * \version New in version 1.11.
   */
   void(ORT_API_CALL* ReleaseCUDAProviderOptions)(_Frees_ptr_opt_ OrtCUDAProviderOptionsV2* input);
+
+  /// @}
 
   /** \brief Append MIGraphX provider to session options
   *
@@ -3281,10 +3295,11 @@ struct OrtApi {
   * \param[in] migraphx_options
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  * \version New in version 1.11.
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_MIGraphX,
                   _In_ OrtSessionOptions* options, _In_ const OrtMIGraphXProviderOptions* migraphx_options);
-  /// @}
 };
 
 /*
@@ -3346,9 +3361,9 @@ struct OrtCustomOp {
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CUDA, _In_ OrtSessionOptions* options, int device_id);
 
 /*
- * This is the old way to add the MIGraphX provider to the session, please use 
+ * This is the old way to add the MIGraphX provider to the session, please use
  * SessionOptionsAppendExecutionProvider_MIGraphX above to access the latest functionality
- * This function always exists, but will only succeed if Onnxruntime was built with 
+ * This function always exists, but will only succeed if Onnxruntime was built with
  * HIP support and the MIGraphX provider shared library exists
  *
  * \param device_id HIP device id, starts from zero.

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -104,5 +104,5 @@ static const char* const kOrtSessionOptionsConfigNnapiEpPartitioningStopOps = "e
 // meaning the task will be distributed in smaller granularity for better parallelism.
 // For some models, it helps to reduce the variance of E2E inference latency and boost performance.
 // The feature will not function by default, specify any positive integer, e.g. "4", to enable it.
-// New in version 1.11.
+// Available since version 1.11.
 static const char* const kOrtSessionOptionsConfigDynamicBlockBase = "session.dynamic_block_base";

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -100,8 +100,9 @@ static const char* const kOrtSessionOptionsConfigNnapiEpPartitioningStopOps = "e
 // Enabling dynamic block-sizing for multithreading.
 // With a positive value, thread pool will split a task of N iterations to blocks of size starting from:
 // N / (num_of_threads * dynamic_block_base)
-// As execution progresses, the size will decrease according to the diminishing residual of N, 
+// As execution progresses, the size will decrease according to the diminishing residual of N,
 // meaning the task will be distributed in smaller granularity for better parallelism.
-// For some models, it helps to reduce the variance of E2E inference latency and boost performane.
+// For some models, it helps to reduce the variance of E2E inference latency and boost performance.
 // The feature will not function by default, specify any positive integer, e.g. "4", to enable it.
+// New in version 1.11.
 static const char* const kOrtSessionOptionsConfigDynamicBlockBase = "session.dynamic_block_base";


### PR DESCRIPTION
**Description**
Add "available since" message for C API additions since v1.10.0.

**Motivation and Context**
The C API docs may be updated with new APIs before they are available in a release. Adding a "new in version x" message indicates when they can be used.

#10298