### PR TITLE
Fix Reshape issue when shape size is -1

### DIFF
--- a/orttraining/orttraining/eager/ort_ops.cpp
+++ b/orttraining/orttraining/eager/ort_ops.cpp
@@ -12,7 +12,6 @@ namespace eager {
 void copy(onnxruntime::ORTInvoker& invoker,
           const OrtValue& src, OrtValue& dst){
   auto& ort_ep = invoker.GetCurrentExecutionProvider();
-
   const auto& src_tensor = src.Get<onnxruntime::Tensor>();
   auto* dst_tensor = dst.GetMutable<onnxruntime::Tensor>();
   if (!dst_tensor)

--- a/orttraining/orttraining/eager/ort_ops.cpp
+++ b/orttraining/orttraining/eager/ort_ops.cpp
@@ -4,14 +4,15 @@
 #include "ort_ops.h"
 #include "ort_util.h"
 #include "ort_log.h"
+#include "core/providers/cpu/tensor/reshape_helper.h"
 
 namespace torch_ort {
 namespace eager {
 
-void copy(onnxruntime::ORTInvoker& invoker, 
+void copy(onnxruntime::ORTInvoker& invoker,
           const OrtValue& src, OrtValue& dst){
   auto& ort_ep = invoker.GetCurrentExecutionProvider();
-  
+
   const auto& src_tensor = src.Get<onnxruntime::Tensor>();
   auto* dst_tensor = dst.GetMutable<onnxruntime::Tensor>();
   if (!dst_tensor)
@@ -25,16 +26,18 @@ void createInplaceOutputValue(OrtValue& input, V<int64_t> shape, OrtValue* p_mlv
   // the ort TensorShape class only accept std::vector, so have to conversion.
   std::vector<int64_t> new_shape;
   new_shape.assign(shape.begin(), shape.end());
+  onnxruntime::ReshapeHelper helper(input.Get<onnxruntime::Tensor>().Shape(), new_shape);
   CreateMLValue(input_ort_tensor->MutableDataRaw(),
                 input_ort_tensor->DataType(), new_shape, p_mlvalue);
 }
 
-template <typename T> 
+template <typename T>
 using Vector = std::vector<T, std::allocator<T>>;
 
 template <>
 void createInplaceOutputValue<Vector>(OrtValue& input, Vector<int64_t> shape, OrtValue* p_mlvalue){
   auto* input_ort_tensor = input.GetMutable<onnxruntime::Tensor>();
+  onnxruntime::ReshapeHelper helper(input.Get<onnxruntime::Tensor>().Shape(), shape);
   CreateMLValue(input_ort_tensor->MutableDataRaw(),
                 input_ort_tensor->DataType(), shape, p_mlvalue);
 }

--- a/orttraining/orttraining/eager/test/ort_tensor.py
+++ b/orttraining/orttraining/eager/test/ort_tensor.py
@@ -19,19 +19,25 @@ class OrtTensorTests(unittest.TestCase):
     ort_ones = cpu_ones.to('ort')
     assert ort_ones.is_ort
     assert torch.allclose(cpu_ones, ort_ones.cpu())
-  
+
   def test_reshape(self):
     cpu_ones = torch.ones(10, 10)
     ort_ones = cpu_ones.to('ort')
     y = ort_ones.reshape(-1)
     assert len(y.size()) == 1
     assert y.size()[0] == 100
-  
+
   def test_view(self):
     cpu_ones = torch.ones(2048)
     ort_ones = cpu_ones.to('ort')
     y = ort_ones.view(4, 512)
     assert y.size() == (4, 512)
+
+  def test_view_neg1(self):
+    cpu_ones = torch.ones(784, 256)
+    ort_ones = cpu_ones.to('ort')
+    y = ort_ones.view(-1)
+    assert y.size()[0] == 200704
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
**Description**: 
When torch_ort::eager::reshape_invoke is invoked with shape size -1 and in_place=true, expecting a special handling for -1, but it fails at createInplaceOutputValue(input, shape, &result[0]) trying to do Tensor::Init with size=-1.
This PR address this issue.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
