### PR TITLE
[DmlEP] Added OnRunEnd and Sync method in dml ExecutionProvider

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -97,6 +97,12 @@ namespace Dml
     {
         m_context->Close();
     }
+
+    void ExecutionProviderImpl::WaitForOutstandingWork() 
+    {
+        Flush();
+        m_context->GetCurrentCompletionEvent().WaitForSignal();
+    }
     
     HRESULT __stdcall ExecutionProviderImpl::AllocatePooledResource(
         size_t size, 


### PR DESCRIPTION
Context:
See [issue:9962](https://github.com/microsoft/onnxruntime/issues/9962).

Added `onnxruntime::IExecutionProvider::common::Status::OnRunEnd()` and `onnxruntime::IExecutionProvider::common::Status::Sync()` method to `Dml::ExecutionProvider`, which will flush command list to GPU.