### PR TITLE
Fix possible null pointer dereference.

### DIFF
--- a/onnxruntime/core/session/IOBinding.cc
+++ b/onnxruntime/core/session/IOBinding.cc
@@ -52,7 +52,7 @@ static common::Status SyncProviders(const SessionState::NameNodeInfoMapType& nod
   std::set<std::string> providers;
   for (auto& pair : node_info_map) {
     for (auto& node_info : pair.second) {
-      if (node_info.p_node->GetExecutionProviderType() != onnxruntime::kCpuExecutionProvider) {
+      if (node_info.p_node && node_info.p_node->GetExecutionProviderType() != onnxruntime::kCpuExecutionProvider) {
         providers.insert(node_info.p_node->GetExecutionProviderType());
       }
     }


### PR DESCRIPTION
**Description**
Fix possible null pointer dereference.

NodeInfo::p_node was used directly but it can be null from here:
https://github.com/microsoft/onnxruntime/blob/2afce4830c9ff48374ca11cf00b09afcc1ff2124/onnxruntime/core/framework/session_state_utils.cc#L381-L382

Add an additional check that it is not null before use.

**Motivation and Context**
Fix #10300