### PR TITLE
Symbolic export for numpy_T 

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -201,6 +201,7 @@ class SymbolicShapeInference:
             'aten::avg_pool2d': self._infer_aten_pool2d,
             'aten::_adaptive_avg_pool2d': self._infer_aten_pool2d,
             'aten::binary_cross_entropy_with_logits': self._infer_aten_bce,
+            'aten::numpy_T': self._infer_Transpose,
         }
         self.run_ = True
         self.suggested_merge_ = {}

--- a/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
@@ -141,3 +141,10 @@ def binary_cross_entropy_with_logits_gradient():
         (('ATenOp', 'com.microsoft'), ['GO(0)', 'I(0)', 'I(1)', 'I(2)', 'I(3)', 'I(4)'], [
          'GI(0)'], {'name': {'value': 'aten::binary_cross_entropy_with_logits_backward', 'dtype': 'string'}}),
     ]
+
+@register_gradient('com.microsoft', 'ATenOp', 'aten::numpy_T', '')
+def numpy_T_gradient():
+    return [
+        (('ATenOp', 'com.microsoft'), ['GO(0)'], [
+         'GI(0)'], {'name': {'value': 'aten::numpy_T', 'dtype': 'string'}}),
+    ]

--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -140,7 +140,14 @@ def binary_cross_entropy_with_logits(g, self, target, weight, pos_weight, reduct
 def numpy_T(g, self):
     # Numpy-style `a.T`: returns the tensor
     # with dims reversed
-    return g.op("Transpose", self)
+    rank = sym_help._get_tensor_rank(self)
+    if rank is not None:
+        axes = list(reversed(range(rank)))
+        return g.op("Transpose", self, perm_i=axes)
+    else:
+        # if we don't have dim information we cannot
+        # output a permute so use ATen instead
+        return g.op("com.microsoft::ATenOp", self, name_s='aten::numpy_T')
 
 # For torch.einsum.
 def parse_equation(equation):

--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -136,6 +136,11 @@ def binary_cross_entropy_with_logits(g, self, target, weight, pos_weight, reduct
     from torch.onnx.symbolic_opset12 import binary_cross_entropy_with_logits as bce
     return bce(g, self, target, weight, pos_weight, reduction)
 
+@register_symbolic('numpy_T')
+def numpy_T(g, self):
+    # Numpy-style `a.T`: returns the tensor
+    # with dims reversed
+    return g.op("Transpose", self)
 
 # For torch.einsum.
 def parse_equation(equation):


### PR DESCRIPTION
This PR adds export support for numpy_T as onnx transpose if rank is available, and aten op otherwise.
