### PR TITLE
Enable binary ops for intel GPU when using dnnl ep

### DIFF
--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn.git)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.4.4)
+set(DNNL_TAG v2.5.2)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -433,10 +433,6 @@ bool DnnlBinaryNodeCapability::Supported(const Node* node, const GraphViewer& gr
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
   if (!IsDimensionSupported(node)) return false;
-  //gpu broadcast for source 0 not supported
-  if (dnnl_engine_get_count(dnnl_engine_kind_t::dnnl_gpu)) {
-    return false;
-  }
   return true;
 }
 

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -252,7 +252,7 @@ class DnnlPowNodeCapability : public DnnlDefaultMultiInputNodeCapability {
  public:
   DnnlPowNodeCapability()
     : DnnlDefaultMultiInputNodeCapability({/*T */{type_float32},
-                                           /*T1*/{type_uint8, type_int8, type_int32, type_float32}}) {}
+                                           /*T1*/{type_float32}}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
@@ -24,11 +24,14 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   }
 
   // GetMemory in OrtFormat. Broadcasting and mix format binary ops can result in computation failure
-  auto src_0_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_A), eng).get_desc();
-  auto src_1_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_B), eng).get_desc();
+  auto binary_src0_mem = sp.GetMemoryInOrtFormat(node.Input(IN_A), eng);
+  auto binary_src1_mem = sp.GetMemoryInOrtFormat(node.Input(IN_B), eng);
+  auto src_0_ori_md = binary_src0_mem.get_desc();
+  auto src_1_ori_md = binary_src1_mem.get_desc();
 
   auto src_0_dims = src_0_ori_md.dims();
   auto src_1_dims = src_1_ori_md.dims();
+
   if (src_0_dims.size() != src_1_dims.size()) {
     while (src_0_dims.size() < src_1_dims.size()) {
       src_0_dims.insert(src_0_dims.begin(), 1);
@@ -52,11 +55,6 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto binary_d = dnnl::binary::desc(algo, src_0_md, src_1_md, dst_md);
   auto binary_pd = dnnl::binary::primitive_desc(binary_d, eng);
-
-  auto binary_src0_mem = sp.GetMemoryAndReshape(node.Input(IN_A), binary_pd.src0_desc(), eng);
-  auto binary_src1_mem = sp.GetMemoryAndReshape(node.Input(IN_B), binary_pd.src1_desc(), eng);
-
-
 
   auto binary_dst_mem = dnnl::memory(binary_pd.dst_desc(), eng);
   auto binary_prim = dnnl::binary(binary_pd);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_pow.cc
@@ -21,19 +21,7 @@ void DnnlPow::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   float beta = 1.0;
   switch (node.Input(IN_Y).Type()) {
     case dnnl::memory::data_type::f32: {
-      beta = static_cast<float>(*(float*)exponent_src_mem.get_data_handle());
-      break;
-    }
-    case dnnl::memory::data_type::s32: {
-      beta = static_cast<float>(*(int32_t*)exponent_src_mem.get_data_handle());
-      break;
-    }
-    case dnnl::memory::data_type::s8: {
-      beta = static_cast<float>(*(int8_t*)exponent_src_mem.get_data_handle());
-      break;
-    }
-    case dnnl::memory::data_type::u8: {
-      beta = static_cast<float>(*(uint8_t*)exponent_src_mem.get_data_handle());
+      beta = *static_cast<float*>(exponent_src_mem.get_data_handle());
       break;
     }
     default:

--- a/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
@@ -35,36 +35,6 @@ TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_12) {
   test.AddOutput<float>("Z", dims, {1.0f, 4.0f, 9.0f});
   test.Run();
 }
-
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int32_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int32_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
-
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int8_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int8_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
-
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_uint8_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<uint8_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
 #endif  // USE_DNNL
 
 }  // namespace test


### PR DESCRIPTION
This updates OneDNN library to the latest version.

Removed some of the Pow capability that was only possible using
casting and caused issues with the latest version of OneDNN.

The binary ops were disabled due to an issue in the broadcasting
code. A fix for the broadcasting issue is part of OneDNN v2.5.x.

Signed-off-by: George Nash <george.nash@intel.com>

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
This increases the number of operators that can be run on intel GPUs
- If it fixes an open issue, please link to the issue here.
