### PR TITLE
Add some more documentation for the C/C++ API tensor creation functions.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1149,8 +1149,8 @@ struct OrtApi {
   * Create a tensor using a supplied ::OrtAllocator
   *
   * \param[in] allocator
-  * \param[in] shape Tensor shape
-  * \param[in] shape_len Number of elements in `shape`
+  * \param[in] shape Pointer to the tensor shape dimensions.
+  * \param[in] shape_len The number of tensor shape dimensions.
   * \param[in] type
   * \param[out] out Returns newly created ::OrtValue. Must be freed with OrtApi::ReleaseValue
   *
@@ -1160,20 +1160,20 @@ struct OrtApi {
                   ONNXTensorElementDataType type, _Outptr_ OrtValue** out);
 
   /** \brief Create a tensor backed by a user supplied buffer
-   *
-   * Create a tensor with user's buffer. You can fill the buffer either before calling this function or after.
-   * p_data is owned by caller. ReleaseValue won't release p_data.
-   *
-   * \param[in] info Memory description of where the p_data buffer resides (CPU vs GPU etc).
-   * \param[in] p_data Pointer to the data buffer.
-   * \param[in] p_data_len The number of bytes in the data buffer.
-   * \param[in] shape Pointer to the tensor shape values.
-   * \param[in] shape_len The tensor shape length.
-   * \param[in] type The data type.
-   * \param[out] out Returns newly created ::OrtValue. Must be freed with OrtApi::ReleaseValue
+  *
+  * Create a tensor with user's buffer. You can fill the buffer either before calling this function or after.
+  * p_data is owned by caller. ReleaseValue won't release p_data.
+  *
+  * \param[in] info Memory description of where the p_data buffer resides (CPU vs GPU etc).
+  * \param[in] p_data Pointer to the data buffer.
+  * \param[in] p_data_len The number of bytes in the data buffer.
+  * \param[in] shape Pointer to the tensor shape dimensions.
+  * \param[in] shape_len The number of tensor shape dimensions.
+  * \param[in] type The data type.
+  * \param[out] out Returns newly created ::OrtValue. Must be freed with OrtApi::ReleaseValue
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
-   */
+  */
   ORT_API2_STATUS(CreateTensorWithDataAsOrtValue, _In_ const OrtMemoryInfo* info, _Inout_ void* p_data,
                   size_t p_data_len, _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type,
                   _Outptr_ OrtValue** out);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1164,12 +1164,12 @@ struct OrtApi {
    * Create a tensor with user's buffer. You can fill the buffer either before calling this function or after.
    * p_data is owned by caller. ReleaseValue won't release p_data.
    *
-   * \param[in] info
-   * \param[in] p_data
-   * \param[in] p_data_len
-   * \param[in] shape
-   * \param[in] shape_len
-   * \param[in] type
+   * \param[in] info Memory description of where the p_data buffer resides (CPU vs GPU etc).
+   * \param[in] p_data Pointer to the data buffer.
+   * \param[in] p_data_len The number of bytes in the data buffer.
+   * \param[in] shape Pointer to the tensor shape values.
+   * \param[in] shape_len The tensor shape length.
+   * \param[in] type The data type.
    * \param[out] out Returns newly created ::OrtValue. Must be freed with OrtApi::ReleaseValue
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -507,8 +507,8 @@ struct Value : Base<OrtValue> {
    * \param info Memory description of where the p_data buffer resides (CPU vs GPU etc).
    * \param p_data Pointer to the data buffer.
    * \param p_data_element_count The number of elements in the data buffer.
-   * \param shape Pointer to the tensor shape values.
-   * \param shape_len The tensor shape length.
+   * \param shape Pointer to the tensor shape dimensions.
+   * \param shape_len The number of tensor shape dimensions.
    */
   template <typename T>
   static Value CreateTensor(const OrtMemoryInfo* info, T* p_data, size_t p_data_element_count, const int64_t* shape, size_t shape_len);
@@ -517,8 +517,8 @@ struct Value : Base<OrtValue> {
    * \param info Memory description of where the p_data buffer resides (CPU vs GPU etc).
    * \param p_data Pointer to the data buffer.
    * \param p_data_byte_count The number of bytes in the data buffer.
-   * \param shape Pointer to the tensor shape values.
-   * \param shape_len The tensor shape length.
+   * \param shape Pointer to the tensor shape dimensions.
+   * \param shape_len The number of tensor shape dimensions.
    * \param type The data type.
    */
   static Value CreateTensor(const OrtMemoryInfo* info, void* p_data, size_t p_data_byte_count, const int64_t* shape, size_t shape_len,
@@ -595,16 +595,16 @@ struct Value : Base<OrtValue> {
   /** \brief Creates a tensor using a supplied OrtAllocator. Wraps OrtApi::CreateTensorAsOrtValue.
    * \tparam T The numeric datatype. This API is not suitable for strings.
    * \param allocator The allocator to use.
-   * \param shape Pointer to the tensor shape values.
-   * \param shape_len The tensor shape length.
+   * \param shape Pointer to the tensor shape dimensions.
+   * \param shape_len The number of tensor shape dimensions.
    */
   template <typename T>
   static Value CreateTensor(OrtAllocator* allocator, const int64_t* shape, size_t shape_len);
 
   /** \brief Creates a tensor using a supplied OrtAllocator. Wraps OrtApi::CreateTensorAsOrtValue.
    * \param allocator The allocator to use.
-   * \param shape Pointer to the tensor shape values.
-   * \param shape_len The tensor shape length.
+   * \param shape Pointer to the tensor shape dimensions.
+   * \param shape_len The number of tensor shape dimensions.
    * \param type The data type.
    */
   static Value CreateTensor(OrtAllocator* allocator, const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -502,10 +502,25 @@ struct Value : Base<OrtValue> {
     size_t shape_len;
   };
 
-  /// \brief Wraps OrtApi::CreateTensorWithDataAsOrtValue
+  /** \brief Creates a tensor with a user supplied buffer. Wraps OrtApi::CreateTensorWithDataAsOrtValue.
+   * \tparam T The numeric datatype. This API is not suitable for strings.
+   * \param info Memory description of where the p_data buffer resides (CPU vs GPU etc).
+   * \param p_data Pointer to the data buffer.
+   * \param p_data_element_count The number of elements in the data buffer.
+   * \param shape Pointer to the tensor shape values.
+   * \param shape_len The tensor shape length.
+   */
   template <typename T>
   static Value CreateTensor(const OrtMemoryInfo* info, T* p_data, size_t p_data_element_count, const int64_t* shape, size_t shape_len);
-  /// \brief Wraps OrtApi::CreateTensorWithDataAsOrtValue
+
+  /** \brief Creates a tensor with a user supplied buffer. Wraps OrtApi::CreateTensorWithDataAsOrtValue.
+   * \param info Memory description of where the p_data buffer resides (CPU vs GPU etc).
+   * \param p_data Pointer to the data buffer.
+   * \param p_data_byte_count The number of bytes in the data buffer.
+   * \param shape Pointer to the tensor shape values.
+   * \param shape_len The tensor shape length.
+   * \param type The data type.
+   */
   static Value CreateTensor(const OrtMemoryInfo* info, void* p_data, size_t p_data_byte_count, const int64_t* shape, size_t shape_len,
                             ONNXTensorElementDataType type);
 
@@ -577,10 +592,21 @@ struct Value : Base<OrtValue> {
 
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
-  // \brief Wraps OrtApi::CreateTensorAsOrtValue
+  /** \brief Creates a tensor using a supplied OrtAllocator. Wraps OrtApi::CreateTensorAsOrtValue.
+   * \tparam T The numeric datatype. This API is not suitable for strings.
+   * \param allocator The allocator to use.
+   * \param shape Pointer to the tensor shape values.
+   * \param shape_len The tensor shape length.
+   */
   template <typename T>
   static Value CreateTensor(OrtAllocator* allocator, const int64_t* shape, size_t shape_len);
-  // \brief Wraps OrtApi::CreateTensorAsOrtValue
+
+  /** \brief Creates a tensor using a supplied OrtAllocator. Wraps OrtApi::CreateTensorAsOrtValue.
+   * \param allocator The allocator to use.
+   * \param shape Pointer to the tensor shape values.
+   * \param shape_len The tensor shape length.
+   * \param type The data type.
+   */
   static Value CreateTensor(OrtAllocator* allocator, const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type);
 
 #if !defined(DISABLE_SPARSE_TENSORS)


### PR DESCRIPTION
**Description**
Add some more documentation for the C/C++ API tensor creation functions.

**Motivation and Context**
Clarify documentation.
Usage of OrtMemoryInfo parameter is not obvious.
#10323