### PR TITLE
Remove python 3.6 from our python packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -62,8 +62,6 @@ stages:
       pool: Linux-CPU
       strategy:
         matrix:
-          Python36:
-            PythonVersion: '3.6'
           Python37:
             PythonVersion: '3.7'
           Python38:
@@ -193,8 +191,6 @@ stages:
       pool: Onnxruntime-Linux-GPU
       strategy:
         matrix:
-          Python36:
-            PythonVersion: '3.6'
           Python37:
             PythonVersion: '3.7'
           Python38:
@@ -333,10 +329,6 @@ stages:
       - ROCm_build_environment
       strategy:
         matrix:
-          Python36 Torch1100 Rocm42:
-            PythonVersion: '3.6'
-            TorchVersion: '1.10.0'
-            RocmVersion: '4.2'
           Python37 Torch1100 Rocm42:
             PythonVersion: '3.7'
             TorchVersion: '1.10.0'
@@ -349,10 +341,6 @@ stages:
             PythonVersion: '3.9'
             TorchVersion: '1.10.0'
             RocmVersion: '4.2'
-          Python36 Torch1100 Rocm431:
-            PythonVersion: '3.6'
-            TorchVersion: '1.10.0'
-            RocmVersion: '4.3.1'
           Python37 Torch1100 Rocm431:
             PythonVersion: '3.7'
             TorchVersion: '1.10.0'
@@ -602,10 +590,6 @@ stages:
       pool: 'Win-CPU-2021'
       strategy:
         matrix:
-          Python36_x64:
-            PythonVersion: '3.6'
-            MsbuildPlatform: x64
-            buildArch: x64
           Python37_x64:
             PythonVersion: '3.7'
             MsbuildPlatform: x64
@@ -618,10 +602,6 @@ stages:
             PythonVersion: '3.9'
             MsbuildPlatform: x64
             buildArch: x64
-          Python36_x86:
-            PythonVersion: '3.6'
-            MsbuildPlatform: Win32
-            buildArch: x86
           Python37_x86:
             PythonVersion: '3.7'
             MsbuildPlatform: Win32
@@ -810,11 +790,6 @@ stages:
         buildArch: x64
       strategy:
         matrix:
-          Python36_GPU:
-            PythonVersion: '3.6'
-            EpBuildFlags: --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.2.1.8.Windows10.x86_64.cuda-11.4.cudnn8.2" --cuda_version=$(CUDA_VERSION) --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$(CUDA_VERSION)" --cudnn_home="C:\local\cudnn-$(CUDA_VERSION)-windows-x64-v8.2.2.26\cuda" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80"
-            EnvSetupScript: setup_env_gpu.bat
-            EP_NAME: gpu
           Python37_GPU:
             PythonVersion: '3.7'
             EpBuildFlags: --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.2.1.8.Windows10.x86_64.cuda-11.4.cudnn8.2" --cuda_version=$(CUDA_VERSION) --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$(CUDA_VERSION)" --cudnn_home="C:\local\cudnn-$(CUDA_VERSION)-windows-x64-v8.2.2.26\cuda" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80"
@@ -830,11 +805,6 @@ stages:
             EpBuildFlags: --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.2.1.8.Windows10.x86_64.cuda-11.4.cudnn8.2" --cuda_version=$(CUDA_VERSION) --cuda_home="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$(CUDA_VERSION)" --cudnn_home="C:\local\cudnn-$(CUDA_VERSION)-windows-x64-v8.2.2.26\cuda" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80"
             EnvSetupScript: setup_env_gpu.bat
             EP_NAME: gpu
-          Python36_dml:
-            PythonVersion: '3.6'
-            EpBuildFlags: --use_dml --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0 --enable_wcos
-            EP_NAME: directml
-            EnvSetupScript: setup_env.bat
           Python37_dml:
             PythonVersion: '3.7'
             EpBuildFlags: --use_dml --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0 --enable_wcos

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -1051,9 +1051,6 @@ stages:
           ARM64_Py37:
             PYTHON_EXE: '/opt/python/cp37-cp37m/bin/python3'
             Image: 'manylinux2014_aarch64'
-          ARM64_Py36:
-            PYTHON_EXE: '/opt/python/cp36-cp36m/bin/python3'
-            Image: 'manylinux2014_aarch64'
           # Uncomment the following lines to generate packages for PowerPC
           # POWERPC_Py39:
           #   PYTHON_EXE: '/opt/python/cp39-cp39/bin/python3'
@@ -1063,9 +1060,6 @@ stages:
           #   Image: 'manylinux2014_ppc64le'
           # POWERPC_Py37:
           #   PYTHON_EXE: '/opt/python/cp37-cp37m/bin/python3'
-          #   Image: 'manylinux2014_ppc64le'
-          # POWERPC_Py36:
-          #   PYTHON_EXE: '/opt/python/cp36-cp36m/bin/python3'
           #   Image: 'manylinux2014_ppc64le'
       steps:
       - checkout: self


### PR DESCRIPTION
**Description**: 

Remove python 3.6 from our python packaging pipeline


**Motivation and Context**
- Why is this change required? What problem does it solve?

In the last release we have announced this change: https://github.com/microsoft/onnxruntime/releases/tag/v1.10.0

And two weeks ago @faxu reminded me finishing this.

- If it fixes an open issue, please link to the issue here.
