### PR TITLE
[NNAPI] Fix bug in Reshape handling from NodeUnit change

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -1236,7 +1236,7 @@ class ConcatOpSupportChecker : public BaseOpSupportChecker {
 bool ConcatOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const NodeUnit& node_unit,
                                                const OpSupportCheckParams& /* params */) const {
   Shape input_shape;
-  if (GetShape(node_unit.Inputs()[0].node_arg, input_shape))
+  if (!GetShape(node_unit.Inputs()[0].node_arg, input_shape))
     return false;
 
   const auto input_size = input_shape.size();


### PR DESCRIPTION
**Description**: Fix bug in Reshape handling from NodeUnit change

**Motivation and Context**
- After NNAPI switch to NodeUnit, the `ReshapeOpBuilder::CanSkipReshape` may try to get a NodeUnit from a node which is not in the graph_viewer, and will throw, fix is to check if the output of a reshape NodeUnit is a graph output first
- Fixed a typo in `ConcatOpSupportChecker::IsOpSupportedImpl`
