### PR TITLE
Update OneDNN library to v2.5.2 for dnnl execution provider

### DIFF
--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn.git)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.4.4)
+set(DNNL_TAG v2.5.2)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -252,7 +252,7 @@ class DnnlPowNodeCapability : public DnnlDefaultMultiInputNodeCapability {
  public:
   DnnlPowNodeCapability()
     : DnnlDefaultMultiInputNodeCapability({/*T */{type_float32},
-                                           /*T1*/{type_uint8, type_int8, type_int32, type_float32}}) {}
+                                           /*T1*/{type_float32}}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
 

--- a/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_integer_test.cc
@@ -352,21 +352,37 @@ void RunMatMulIntegerU8X8Test(const int M, const int N, const int K, bool non_ze
 }
 
 void RunMatMulIntegerU8X8TestBatch(const int M, const int N, const int K) {
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " false,false,false\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, false /*non_zero_zp*/, false /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " false,true,false\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, false /*non_zero_zp*/, true /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " true,false,false\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, true /*non_zero_zp*/, false /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " true,true,false\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, true /*non_zero_zp*/, true /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " false,false,false\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, false /*non_zero_zp*/, false /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " false,true,false\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, false /*non_zero_zp*/, true /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " true,false,false\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, true /*non_zero_zp*/, false /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " true,true,false\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, true /*non_zero_zp*/, true /*B_is_initializer*/, false /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " false,false,true\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, false /*non_zero_zp*/, false /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " false,true,true\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, false /*non_zero_zp*/, true /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " true,false,true\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, true /*non_zero_zp*/, false /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: int8 " << M << "x" << N << "x" << K << " true,true,true\n";
   RunMatMulIntegerU8X8Test<int8_t>(M, N, K, true /*non_zero_zp*/, true /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " false,false,true\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, false /*non_zero_zp*/, false /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " false,true,true\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, false /*non_zero_zp*/, true /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " true,false,true\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, true /*non_zero_zp*/, false /*B_is_initializer*/, true /*per_column_zp*/);
+  std::cout << "RunMatMulIntegerU8X8Test: uint8 " << M << "x" << N << "x" << K << " true,true,true\n";
   RunMatMulIntegerU8X8Test<uint8_t>(M, N, K, true /*non_zero_zp*/, true /*B_is_initializer*/, true /*per_column_zp*/);
 }
 

--- a/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/dnnl/math/element_wise_ops_test.cc
@@ -36,35 +36,6 @@ TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_12) {
   test.Run();
 }
 
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int32_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int32_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
-
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_int8_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<int8_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
-
-TEST(MathOpTest, DNNL_Pow_Broadcast_Scalar1_float_uint8_12) {
-  OpTester test("Pow", 12);
-
-  std::vector<int64_t> dims{3};
-  test.AddInput<float>("X", dims, {1.0f, 2.0f, 3.0f});
-  test.AddInput<uint8_t>("Y", {}, {3}, true);
-  test.AddOutput<float>("Z", dims, {1.0f, 8.0f, 27.0f});
-  test.Run();
-}
 #endif  // USE_DNNL
 
 }  // namespace test


### PR DESCRIPTION
Disabled integer types for the Pow operator

Added some debug print statments to matmul_integer_test
to investigate some failures seen when running the
onnxruntime CI build. This should not be merged untill
the debug print statments are removed.

Signed-off-by: George Nash <george.nash@intel.com>

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
This PR is to investigate the CI build failures see in https://github.com/microsoft/onnxruntime/pull/10392

- If it fixes an open issue, please link to the issue here.
