### PR TITLE
Exclude CETCOMPAT from Windows ARM build

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -188,7 +188,7 @@ if (APPLE)
     if (NOT CMAKE_OSX_ARCHITECTURES)
         message("Building ONNX Runtime for ${CMAKE_HOST_SYSTEM_PROCESSOR}")
     endif()
-else()
+elseif (NOT WIN32 AND NOT APPLE)
     message("Building ONNX Runtime for ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
@@ -1204,7 +1204,7 @@ function(onnxruntime_configure_target target_name)
   endif()
   
   # Keep BinSkim happy
-  if(MSVC)
+  if(MSVC AND NOT CMAKE_GENERATOR MATCHES "ARM")
     target_link_options(${target_name} PRIVATE "/CETCOMPAT")
   endif()
 endfunction()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -188,7 +188,7 @@ if (APPLE)
     if (NOT CMAKE_OSX_ARCHITECTURES)
         message("Building ONNX Runtime for ${CMAKE_HOST_SYSTEM_PROCESSOR}")
     endif()
-elseif (NOT WIN32 AND NOT APPLE)
+else()
     message("Building ONNX Runtime for ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1204,7 +1204,7 @@ function(onnxruntime_configure_target target_name)
   endif()
   
   # Keep BinSkim happy
-  if(MSVC AND NOT CMAKE_GENERATOR MATCHES "ARM")
+  if(MSVC AND NOT onnxruntime_target_platform MATCHES "ARM")
     target_link_options(${target_name} PRIVATE "/CETCOMPAT")
   endif()
 endfunction()


### PR DESCRIPTION
**Description**: 

Exclude CETCOMPAT from Windows ARM build

**Motivation and Context**
- Why is this change required? What problem does it solve?

ARM doesn't support it.

- If it fixes an open issue, please link to the issue here.
