### PR TITLE
[NNAPI QDQ] Add QDQ Conv support

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -96,11 +96,15 @@ ConvType GetConvType(const NodeUnit& node_unit, const InitializedTensorSet& init
     return ConvType::Grouped;
 }
 
+bool IsQuantizedConv(QuantizedOpType quant_op_type) {
+  return (quant_op_type == QuantizedOpType::QLinearConv) ||
+         (quant_op_type == QuantizedOpType::QDQConv);
+}
+
 bool IsQuantizedBinaryOp(QuantizedOpType quant_op_type) {
-  return quant_op_type == QuantizedOpType::QLinearConv ||
-         quant_op_type == QuantizedOpType::QLinearMatMul ||
+  return quant_op_type == QuantizedOpType::QLinearMatMul ||
          quant_op_type == QuantizedOpType::QLinearAdd ||
-         quant_op_type == QuantizedOpType::QDQConv;
+         IsQuantizedConv(quant_op_type);
 }
 
 bool HasValidUnaryOpQuantizedInputs(const NodeUnit& node_unit) {
@@ -134,8 +138,7 @@ bool HasValidBinaryOpQuantizedInputs(const NodeUnit& node_unit) {
 
   // QlinearConv supports u8u8 or u8s8
   // QLinearMatMul/Add only support u8u8
-  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
-                       (quant_op_type == QuantizedOpType::QDQConv);
+  bool is_quant_conv = IsQuantizedConv(quant_op_type);
   bool has_valid_qlinear_conv_weight =
       (b_input_type == ONNX_NAMESPACE::TensorProto_DataType_UINT8 ||
        b_input_type == ONNX_NAMESPACE::TensorProto_DataType_INT8);
@@ -157,8 +160,7 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
                                 const std::vector<size_t>& indices, const OpSupportCheckParams& params, bool is_input) {
   const auto& op_type = node_unit.OpType();
   auto quant_op_type = GetQuantizedOpType(node_unit);
-  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
-                       (quant_op_type == QuantizedOpType::QDQConv);
+  bool is_quant_conv = IsQuantizedConv(quant_op_type);
   bool is_quant_matmul = (quant_op_type == QuantizedOpType::QLinearMatMul);
   const auto& io_defs = is_input ? node_unit.Inputs() : node_unit.Outputs();
   for (const auto idx : indices) {
@@ -232,8 +234,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
                                     const std::vector<size_t>& indices, bool is_input) {
   const auto& op_type = node_unit.OpType();
   auto quant_op_type = GetQuantizedOpType(node_unit);
-  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
-                       (quant_op_type == QuantizedOpType::QDQConv);
+  bool is_quant_conv = IsQuantizedConv(quant_op_type);
   bool is_quant_matmul = (quant_op_type == QuantizedOpType::QLinearMatMul);
 
   const auto& io_defs = is_input ? node_unit.Inputs() : node_unit.Outputs();

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -48,24 +48,31 @@ std::string GetErrorCause(int error_code) {
   }
 }
 
-QLinearOpType GetQLinearOpType(const onnxruntime::Node& node) {
-  const auto& op_type = node.OpType();
-  if (op_type == "DequantizeLinear")
-    return QLinearOpType::DequantizeLinear;
-  else if (op_type == "QuantizeLinear")
-    return QLinearOpType::QuantizeLinear;
-  else if (op_type == "QLinearConv")
-    return QLinearOpType::QLinearConv;
-  else if (op_type == "QLinearMatMul")
-    return QLinearOpType::QLinearMatMul;
-  else if (op_type == "QLinearAdd")
-    return QLinearOpType::QLinearAdd;
-  else if (op_type == "QLinearSigmoid")
-    return QLinearOpType::QLinearSigmoid;
-  else if (op_type == "QLinearAveragePool")
-    return QLinearOpType::QLinearAveragePool;
+QuantizedOpType GetQuantizedOpType(const NodeUnit& node_unit) {
+  const auto& op_type = node_unit.OpType();
+  if (node_unit.UnitType() == NodeUnit::Type::SingleNode) {
+    if (op_type == "DequantizeLinear")
+      return QuantizedOpType::DequantizeLinear;
+    else if (op_type == "QuantizeLinear")
+      return QuantizedOpType::QuantizeLinear;
+    else if (op_type == "QLinearConv")
+      return QuantizedOpType::QLinearConv;
+    else if (op_type == "QLinearMatMul")
+      return QuantizedOpType::QLinearMatMul;
+    else if (op_type == "QLinearAdd")
+      return QuantizedOpType::QLinearAdd;
+    else if (op_type == "QLinearSigmoid")
+      return QuantizedOpType::QLinearSigmoid;
+    else if (op_type == "QLinearAveragePool")
+      return QuantizedOpType::QLinearAveragePool;
+  } else if (node_unit.UnitType() == NodeUnit::Type::QDQGroup) {
+    if (op_type == "Conv")
+      return QuantizedOpType::QDQConv;
+  } else {
+    // throw?
+  }
 
-  return QLinearOpType::Unknown;
+  return QuantizedOpType::Unknown;
 }
 
 ConvType GetConvType(const NodeUnit& node_unit, const InitializedTensorSet& initializers) {
@@ -89,10 +96,11 @@ ConvType GetConvType(const NodeUnit& node_unit, const InitializedTensorSet& init
     return ConvType::Grouped;
 }
 
-bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type) {
-  return qlinear_op_type == QLinearOpType::QLinearConv ||
-         qlinear_op_type == QLinearOpType::QLinearMatMul ||
-         qlinear_op_type == QLinearOpType::QLinearAdd;
+bool IsQuantizedBinaryOp(QuantizedOpType quant_op_type) {
+  return quant_op_type == QuantizedOpType::QLinearConv ||
+         quant_op_type == QuantizedOpType::QLinearMatMul ||
+         quant_op_type == QuantizedOpType::QLinearAdd ||
+         quant_op_type == QuantizedOpType::QDQConv;
 }
 
 bool HasValidUnaryOpQuantizedInputs(const NodeUnit& node_unit) {
@@ -111,9 +119,9 @@ bool HasValidUnaryOpQuantizedInputs(const NodeUnit& node_unit) {
 }
 
 bool HasValidBinaryOpQuantizedInputs(const NodeUnit& node_unit) {
-  auto op_type = GetQLinearOpType(node_unit.GetNode());
+  auto quant_op_type = GetQuantizedOpType(node_unit);
   int32_t a_input_type, b_input_type;
-  if (!IsQLinearBinaryOp(op_type)) {
+  if (!IsQuantizedBinaryOp(quant_op_type)) {
     LOGS_DEFAULT(VERBOSE) << "[" << node_unit.OpType() << "] is not a binary qlinear op";
     return false;
   }
@@ -126,14 +134,15 @@ bool HasValidBinaryOpQuantizedInputs(const NodeUnit& node_unit) {
 
   // QlinearConv supports u8u8 or u8s8
   // QLinearMatMul/Add only support u8u8
-  bool is_qlinear_conv = op_type == QLinearOpType::QLinearConv;
+  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
+                       (quant_op_type == QuantizedOpType::QDQConv);
   bool has_valid_qlinear_conv_weight =
       (b_input_type == ONNX_NAMESPACE::TensorProto_DataType_UINT8 ||
        b_input_type == ONNX_NAMESPACE::TensorProto_DataType_INT8);
 
   if (a_input_type != ONNX_NAMESPACE::TensorProto_DataType_UINT8 ||
-      (!is_qlinear_conv && a_input_type != b_input_type) ||
-      (is_qlinear_conv && !has_valid_qlinear_conv_weight)) {
+      (!is_quant_conv && a_input_type != b_input_type) ||
+      (is_quant_conv && !has_valid_qlinear_conv_weight)) {
     LOGS_DEFAULT(VERBOSE) << "[" << node_unit.OpType()
                           << "] A Input type: [" << a_input_type
                           << "] B Input type: [" << b_input_type
@@ -147,9 +156,10 @@ bool HasValidBinaryOpQuantizedInputs(const NodeUnit& node_unit) {
 bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
                                 const std::vector<size_t>& indices, const OpSupportCheckParams& params, bool is_input) {
   const auto& op_type = node_unit.OpType();
-  auto qlinear_op_type = GetQLinearOpType(node_unit.GetNode());
-  bool is_qlinear_conv = (qlinear_op_type == QLinearOpType::QLinearConv);
-  bool is_qlinear_matmul = (qlinear_op_type == QLinearOpType::QLinearMatMul);
+  auto quant_op_type = GetQuantizedOpType(node_unit);
+  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
+                       (quant_op_type == QuantizedOpType::QDQConv);
+  bool is_quant_matmul = (quant_op_type == QuantizedOpType::QLinearMatMul);
   const auto& io_defs = is_input ? node_unit.Inputs() : node_unit.Outputs();
   for (const auto idx : indices) {
     if (idx >= io_defs.size()) {
@@ -174,7 +184,7 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
     }
 
     // If this op is Qlinear[Conv/MatMul], we want to check u8s8 support for weight tensor (or B tensor for QlinearMatMul)
-    bool is_conv_matmul_weight = is_input && (is_qlinear_conv || is_qlinear_matmul) && idx == 1;
+    bool is_conv_matmul_weight = is_input && (is_quant_conv || is_quant_matmul) && idx == 1;
     bool is_conv_matmul_u8s8_weight = false;
 
     if (is_conv_matmul_weight) {
@@ -194,7 +204,7 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
       // For u8s8 Qlinear[Conv/MatMul], we support
       // 1. Per-tensor, the weight will be transformed to uint8 later
       // 2. Per-channel, only from Android API level 29
-      if (is_qlinear_matmul) {
+      if (is_quant_matmul) {
         LOGS_DEFAULT(VERBOSE) << "QLinearMatMul does not support per-channel quantization";
         return false;
       }
@@ -221,9 +231,10 @@ bool HasValidQuantizationScales(const InitializedTensorSet& initializers, const 
 bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
                                     const std::vector<size_t>& indices, bool is_input) {
   const auto& op_type = node_unit.OpType();
-  auto qlinear_op_type = GetQLinearOpType(node_unit.GetNode());
-  bool is_qlinear_conv = (qlinear_op_type == QLinearOpType::QLinearConv);
-  bool is_qlinear_matmul = (qlinear_op_type == QLinearOpType::QLinearMatMul);
+  auto quant_op_type = GetQuantizedOpType(node_unit);
+  bool is_quant_conv = (quant_op_type == QuantizedOpType::QLinearConv) ||
+                       (quant_op_type == QuantizedOpType::QDQConv);
+  bool is_quant_matmul = (quant_op_type == QuantizedOpType::QLinearMatMul);
 
   const auto& io_defs = is_input ? node_unit.Inputs() : node_unit.Outputs();
   for (const auto idx : indices) {
@@ -251,7 +262,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
       return false;
     }
 
-    bool is_conv_matmul_weight = is_input && (is_qlinear_conv || is_qlinear_matmul) && idx == 1;
+    bool is_conv_matmul_weight = is_input && (is_quant_conv || is_quant_matmul) && idx == 1;
     bool is_conv_matmul_u8s8_weight = false;
 
     if (is_conv_matmul_weight) {
@@ -279,7 +290,7 @@ bool HasValidQuantizationZeroPoints(const InitializedTensorSet& initializers, co
       }
 
       if (zero_dim != 1) {
-        if (is_qlinear_matmul) {
+        if (is_quant_matmul) {
           LOGS_DEFAULT(VERBOSE) << "QLinearMatMul does not support per-channel quantization";
           return false;
         }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -73,8 +73,8 @@ struct OpSupportCheckParams;
 
 std::string GetErrorCause(int error_code);
 
-enum class QLinearOpType : uint8_t {
-  Unknown,  // Unknown or not a linear quantized op
+enum class QuantizedOpType : uint8_t {
+  Unknown,  // Unknown or not a quantized NodeUnit
   DequantizeLinear,
   QuantizeLinear,
   QLinearConv,
@@ -85,6 +85,8 @@ enum class QLinearOpType : uint8_t {
   // Not yet supported
   // QLinearMul,
   // QLinearReduceMean,
+  QDQConv,
+  // TODO, add other QDQ NodeUnit types
 };
 
 enum class ConvType : uint8_t {
@@ -93,15 +95,15 @@ enum class ConvType : uint8_t {
   Grouped,
 };
 
-QLinearOpType GetQLinearOpType(const onnxruntime::Node& node);
+QuantizedOpType GetQuantizedOpType(const NodeUnit& node_unit);
 
 // Return the type of the conv ops,
 // This function assumes the input is a 2d conv node
 ConvType GetConvType(const NodeUnit& node_unit, const InitializedTensorSet& initializers);
 
-// This qlinear op is an operator takes 2 inputs and produces 1 output
-// Such as QLinearConv, QLinearMatMul, QLinearAdd, ...
-bool IsQLinearBinaryOp(QLinearOpType qlinear_op_type);
+// This quantized op is an operator or qdq node unit takes 2 inputs and produces 1 output
+// Such as QLinearConv, QLinearMatMul, QLinearAdd, QDQConv,...
+bool IsQuantizedBinaryOp(QuantizedOpType quant_op_type);
 
 // Check if a qlinear unary op has valid inputs, Qlinear[Sigmoid/AveragePool]
 bool HasValidUnaryOpQuantizedInputs(const NodeUnit& node_unit);

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -101,6 +101,9 @@ QuantizedOpType GetQuantizedOpType(const NodeUnit& node_unit);
 // This function assumes the input is a 2d conv node
 ConvType GetConvType(const NodeUnit& node_unit, const InitializedTensorSet& initializers);
 
+// If this is a quantized Conv (QLinearConv or QDQConv)
+bool IsQuantizedConv(QuantizedOpType quant_op_type);
+
 // This quantized op is an operator or qdq node unit takes 2 inputs and produces 1 output
 // Such as QLinearConv, QLinearMatMul, QLinearAdd, QDQConv,...
 bool IsQuantizedBinaryOp(QuantizedOpType quant_op_type);

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -158,14 +158,10 @@ void ModelBuilder::PreprocessNodeUnits() {
 // Help to get all quantized operators' input and the NodeUnit(s) using the input
 void ModelBuilder::GetAllQuantizedOpInputs() {
   for (const auto& node_unit : node_unit_holder_) {
-    // TODO, hookup getting quantized inputs with QDQ NodeUnits and remove the ORT_ENFORCE
-    ORT_ENFORCE(node_unit->UnitType() == NodeUnit::Type::SingleNode, "QDQ NodeUnit is not yet implemented");
+    auto quant_op_type = GetQuantizedOpType(*node_unit);
 
-    auto qlinear_op_type = GetQLinearOpType(node_unit->GetNode());
-
-    // Not a qlinear op
-    // TODO, add handling for QDQ NodeUnit
-    if (qlinear_op_type == QLinearOpType::Unknown)
+    // Not a qlinear op or qdq node group
+    if (quant_op_type == QuantizedOpType::Unknown)
       continue;
 
     const auto add_quantized_input =
@@ -174,12 +170,12 @@ void ModelBuilder::GetAllQuantizedOpInputs() {
           all_quantized_op_inputs[input_name].push_back(&node_unit);
         };
 
-    // All qlinear ops EXCEPT QuantizeLinear has quantized input
-    if (qlinear_op_type != QLinearOpType::QuantizeLinear) {
+    // All quantized ops EXCEPT QuantizeLinear has quantized input
+    if (quant_op_type != QuantizedOpType::QuantizeLinear) {
       add_quantized_input(*node_unit, 0);
     }
 
-    if (IsQLinearBinaryOp(qlinear_op_type)) {
+    if (IsQuantizedBinaryOp(quant_op_type)) {
       add_quantized_input(*node_unit, 1);
     }
 
@@ -494,14 +490,13 @@ Status ModelBuilder::AddOperandFromPersistMemoryBuffer(
 
 Status ModelBuilder::AddOperations() {
   const auto& node_indices = graph_viewer_.GetNodesInTopologicalOrder();
-  std::unordered_set<const NodeUnit*> processed_node_units;
-  processed_node_units.reserve(node_unit_holder_.size());
-  for (size_t i = 0; i < node_indices.size(); i++) {
-    const auto* node(graph_viewer_.GetNode(node_indices[i]));
+  for (const auto node_idx : node_indices) {
+    LOGS_DEFAULT(VERBOSE) << "Adding node [" << node_idx << "]";
+    const auto* node(graph_viewer_.GetNode(node_idx));
     const NodeUnit& node_unit = GetNodeUnit(node);
 
-    // Since a NodeUnit may contain multiple nodes, avoid processing the same NodeUnit multiple times
-    if (Contains(processed_node_units, &node_unit))
+    // We only insert the NodeUnit once when we hit the target node
+    if (node != &node_unit.GetNode())
       continue;
 
     if (const auto* op_builder = GetOpBuilder(node_unit)) {
@@ -510,8 +505,6 @@ Status ModelBuilder::AddOperations() {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "Node [", node_unit.Name(), "], type [", node_unit.OpType(), "] is not supported");
     }
-
-    processed_node_units.insert(&node_unit);
   }
 
   return Status::OK();
@@ -535,6 +528,8 @@ Status ModelBuilder::AddOperation(int op, const std::vector<uint32_t>& input_ind
       "op = " + std::to_string(op));
 
   num_nnapi_ops_++;
+
+  LOGS_DEFAULT(VERBOSE) << "Added NNAPI Operation Type [" << op << "]";
   return Status::OK();
 }
 
@@ -640,8 +635,9 @@ int32_t ModelBuilder::FindActivation(const NodeUnit& node_unit) {
 
   // TODO, add support of activation fusion for quantized node group (qdq or qlinear)
   // We do not support activation fusion for quantized operators for now
-  auto qlinear_op_type = GetQLinearOpType(node_unit.GetNode());
-  if (qlinear_op_type != QLinearOpType::Unknown)
+  // (usually the activations are fused already in the quantization)
+  auto quant_op_type = GetQuantizedOpType(node_unit);
+  if (quant_op_type != QuantizedOpType::Unknown)
     return fuse_code;
 
   for (auto it = output_node.OutputEdgesBegin(), end = output_node.OutputEdgesEnd(); it != end; ++it) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -1260,9 +1260,7 @@ class ConvOpBuilder : public BaseOpBuilder {
 };
 
 /* static */ bool ConvOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) {
-  auto quant_op_type = GetQuantizedOpType(node_unit);
-  return (quant_op_type == QuantizedOpType::QLinearConv) ||
-         (quant_op_type == QuantizedOpType::QDQConv);
+  return IsQuantizedConv(GetQuantizedOpType(node_unit));
 }
 
 /* static */ void

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -1198,8 +1198,6 @@ int UnaryOpSupportChecker::GetMinSupportedOpSet(const NodeUnit& node_unit) const
   if (!HasValidQuantizationZeroPoints(initializers, node_unit, {0}, false /* is_input */))
     return false;
 
-  return false;
-
   // NNAPI requires the scale be 1.f/256 and zero point to be 0
   // See https://android.googlesource.com/platform/frameworks/ml/+/refs/heads/android10-c2f2-release/nn/common/operations/Activation.cpp#180
   float output_scale = 0.0f;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -743,9 +743,7 @@ class ConvOpSupportChecker : public BaseOpSupportChecker {
 }
 
 /* static */ bool ConvOpSupportChecker::IsQuantizedOp(const NodeUnit& node_unit) {
-  auto quant_op_type = GetQuantizedOpType(node_unit);
-  return (quant_op_type == QuantizedOpType::QLinearConv) ||
-         (quant_op_type == QuantizedOpType::QDQConv);
+  return IsQuantizedConv(GetQuantizedOpType(node_unit));
 }
 
 bool ConvOpSupportChecker::HasSupportedInputsImpl(const NodeUnit& node_unit) const {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -728,6 +728,8 @@ class ConvOpSupportChecker : public BaseOpSupportChecker {
   }
 
   bool HasSupportedInputsImpl(const NodeUnit& node_unit) const override;
+  bool IsNodeUnitTypeSupported(const NodeUnit& node_unit) const override { return true; }
+  static bool IsQuantizedOp(const NodeUnit& node_unit);
 };
 
 /* static */ void ConvOpSupportChecker::CreateSharedOpSupportChecker(
@@ -740,8 +742,14 @@ class ConvOpSupportChecker : public BaseOpSupportChecker {
       });
 }
 
+/* static */ bool ConvOpSupportChecker::IsQuantizedOp(const NodeUnit& node_unit) {
+  auto quant_op_type = GetQuantizedOpType(node_unit);
+  return (quant_op_type == QuantizedOpType::QLinearConv) ||
+         (quant_op_type == QuantizedOpType::QDQConv);
+}
+
 bool ConvOpSupportChecker::HasSupportedInputsImpl(const NodeUnit& node_unit) const {
-  if (node_unit.OpType() != "QLinearConv")
+  if (!IsQuantizedOp(node_unit))
     return BaseOpSupportChecker::HasSupportedInputsImpl(node_unit);
 
   // QLinearConv only supports input of uint8 for now
@@ -754,10 +762,10 @@ bool ConvOpSupportChecker::HasSupportedInputsImpl(const NodeUnit& node_unit) con
 bool ConvOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
                                              const OpSupportCheckParams& params) const {
   const auto& op_type = node_unit.OpType();
-  const bool is_qlinear_conv = (op_type == "QLinearConv");
+  bool is_quant_conv = IsQuantizedOp(node_unit);
 
   // We don't support nhwc com.microsoft.QLinearConv for now
-  if (is_qlinear_conv && node_unit.Domain() == kMSDomain) {
+  if (is_quant_conv && node_unit.Domain() == kMSDomain) {
     LOGS_DEFAULT(VERBOSE) << "com.microsoft.QLinearConv is not supported";
     return false;
   }
@@ -791,7 +799,7 @@ bool ConvOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initial
     return false;
   }
 
-  if (is_qlinear_conv) {
+  if (is_quant_conv) {
     // For QLinearConv, we only support uint8 output now
     int32_t output_type;
     if (!GetType(node_unit.Outputs()[0].node_arg, output_type))

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -728,7 +728,7 @@ class ConvOpSupportChecker : public BaseOpSupportChecker {
   }
 
   bool HasSupportedInputsImpl(const NodeUnit& node_unit) const override;
-  bool IsNodeUnitTypeSupported(const NodeUnit& node_unit) const override { return true; }
+  bool IsNodeUnitTypeSupported(const NodeUnit& /* node_unit */) const override { return true; }
   static bool IsQuantizedOp(const NodeUnit& node_unit);
 };
 

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -239,21 +239,6 @@ TEST(NnapiExecutionProviderTest, TestNoShapeInputModel) {
       << "No node should be taken by the NNAPI EP";
 }
 
-// For now since we don't support QDQ in NNAPI, even the infrastructure is there
-// Need to verify a model with QDQ groups only will not be supported by NNAPI at all
-// This may need to be changed when we gradually add support for different ops for QDQ
-TEST(NnapiExecutionProviderTest, TestQDQConvModel) {
-  const ORTCHAR_T* model_file_name = ORT_TSTR("testdata/transform/qdq_conv.onnx");
-  // test load only
-  SessionOptions so;
-  InferenceSessionWrapper session_object{so, GetEnvironment()};
-  ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::make_unique<NnapiExecutionProvider>(0)));
-  ASSERT_STATUS_OK(session_object.Load(model_file_name));
-  ASSERT_STATUS_OK(session_object.Initialize());
-  ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 0)
-      << "No nodes should have been taken by the NNAPI EP";
-}
-
 #if defined(__ANDROID__)
 TEST(NnapiExecutionProviderTest, TestQDQModel) {
   onnxruntime::Model model("nnapi_qdq_test_graph", false, DefaultLoggingManager().DefaultLogger());


### PR DESCRIPTION
**Description**: [NNAPI QDQ] Add QDQ Conv support

**Motivation and Context**
- To avoid excessively large PR, the NNAPI QDQ integration is splitted into the following small tasks
- [x] 1. Add shared NodeUnit class (#10052[merged])
- [x] 2. Move NNAPI EP to use NodeUnitIODef for non-QDQ ops (#10237[merged])
- [x] 3. Add shared QDQ selectors (#10178[merged])
- [x] 4. Hookup NNAPI GetCapability/Compile with shared QDQ selectors (#10347[merged])
- [ ] 5. Enable QDQ for ops with QLinear version (QLinear[Conv/Matmul/Pool/...])(this PR)
- [ ] 6. Enable QDQ for ops without QLinear Version

This is part of task 5, to move QDQ op with equivalent QLinear version, to add support of QDQ conv
