### PR TITLE
Update protobuf java

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -19,7 +19,7 @@
       {
         "component": {
           "Type": "maven",
-          "maven": { "GroupId": "com.google.protobuf", "ArtifactId": "protobuf-java", "Version": "3.9.2" },
+          "maven": { "GroupId": "com.google.protobuf", "ArtifactId": "protobuf-java", "Version": "3.16.1" },
           "DevelopmentDependency": true
         }
       },

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -214,8 +214,8 @@ jobs:
         jar xf $(Build.BinariesDirectory)\final-jar\testing.jar
         popd
         powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -OutFile junit-platform-console-standalone-1.6.2.jar"
-        powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -OutFile protobuf-java-3.9.2.jar"
-        java -DUSE_CUDA=1 -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.9.2.jar;onnxruntime_gpu-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+        powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -OutFile protobuf-java-3.16.1.jar"
+        java -DUSE_CUDA=1 -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.16.1.jar;onnxruntime_gpu-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
       workingDirectory: '$(Build.BinariesDirectory)\final-jar'
 
   - template: templates/component-governance-component-detection-steps.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -960,8 +960,8 @@ jobs:
         jar xf $(Build.BinariesDirectory)\final-jar\testing.jar
         popd
         powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -OutFile junit-platform-console-standalone-1.6.2.jar"
-        powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -OutFile protobuf-java-3.9.2.jar"
-        java -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.9.2.jar;onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+        powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -OutFile protobuf-java-3.16.1.jar"
+        java -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.16.1.jar;onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
       workingDirectory: '$(Build.BinariesDirectory)\final-jar'
 
   - template: component-governance-component-detection-steps.yml
@@ -1000,9 +1000,9 @@ jobs:
         jar xf $(Build.BinariesDirectory)/final-jar/testing.jar
         popd
         wget https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -P ./
-        wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -P ./
+        wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -P ./
         LD_LIBRARY_PATH=./test:${LD_LIBRARY_PATH}
-        java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.9.2.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+        java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.16.1.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
       workingDirectory: '$(Build.BinariesDirectory)/final-jar'
 
   - template: component-governance-component-detection-steps.yml
@@ -1043,10 +1043,10 @@ jobs:
           jar xf $(Build.BinariesDirectory)/final-jar/testing.jar
           popd
           wget https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -P ./
-          wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -P ./
+          wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -P ./
           sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
           DYLD_LIBRARY_PATH=./test:${DYLD_LIBRARY_PATH}
-          java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.9.2.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
+          java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.16.1.jar:./onnxruntime-$(OnnxRuntimeVersion).jar --scan-class-path --fail-if-no-tests --disable-banner
         workingDirectory: '$(Build.BinariesDirectory)/final-jar'
 
   - template: component-governance-component-detection-steps.yml

--- a/tools/ci_build/github/azure-pipelines/templates/java-test-final-jar-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/java-test-final-jar-step.yml
@@ -27,8 +27,8 @@ parameters:
              jar xf $(Build.BinariesDirectory)/final-jar/testing.jar
              popd
              wget https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -P ./
-             wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -P ./
-             java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .;./test;./protobuf-java-3.9.2.jar;./onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
+             wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -P ./
+             java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .;./test;./protobuf-java-3.16.1.jar;./onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
            workingDirectory: '$(Build.BinariesDirectory)/final-jar'
 
 - job: Test_Final_Jar_MacOs
@@ -52,8 +52,8 @@ parameters:
              jar xf $(Build.BinariesDirectory)/final-jar/testing.jar
              popd
              wget https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -P ./
-             wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -P ./
-             java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .;./test;./protobuf-java-3.9.2.jar;./onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
+             wget https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -P ./
+             java -jar ./junit-platform-console-standalone-1.6.2.jar -cp .;./test;./protobuf-java-3.16.1.jar;./onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
            workingDirectory: '$(Build.BinariesDirectory)/final-jar'
 
 - job: Test_Final_Jar_Windows
@@ -75,6 +75,6 @@ parameters:
              jar xf $(Build.BinariesDirectory)\final-jar\testing.jar
              popd
              powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar -OutFile junit-platform-console-standalone-1.6.2.jar"
-             powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar -OutFile protobuf-java-3.9.2.jar"
-             java -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.9.2.jar;onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
+             powershell -Command "Invoke-WebRequest https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar -OutFile protobuf-java-3.16.1.jar"
+             java -jar junit-platform-console-standalone-1.6.2.jar -cp .;.\test;protobuf-java-3.16.1.jar;onnxruntime-${{parameters.version}}.jar --scan-class-path --fail-if-no-tests --disable-banner
            workingDirectory: '$(Build.BinariesDirectory)\final-jar'

--- a/tools/ci_build/github/linux/java_linux_final_test.sh
+++ b/tools/ci_build/github/linux/java_linux_final_test.sh
@@ -27,8 +27,8 @@ jar xf $BINARY_DIR/final-jar/testing.jar
 popd
 
 curl -O -sSL https://oss.sonatype.org/service/local/repositories/releases/content/org/junit/platform/junit-platform-console-standalone/1.6.2/junit-platform-console-standalone-1.6.2.jar
-curl -O -sSL https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.9.2/protobuf-java-3.9.2.jar
-java -DUSE_CUDA=1 -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.9.2.jar:./onnxruntime_gpu-${VERSION_NUMBER}.jar --scan-class-path --fail-if-no-tests --disable-banner
+curl -O -sSL https://oss.sonatype.org/service/local/repositories/google-releases/content/com/google/protobuf/protobuf-java/3.16.1/protobuf-java-3.16.1.jar
+java -DUSE_CUDA=1 -jar ./junit-platform-console-standalone-1.6.2.jar -cp .:./test:./protobuf-java-3.16.1.jar:./onnxruntime_gpu-${VERSION_NUMBER}.jar --scan-class-path --fail-if-no-tests --disable-banner
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
**Description**: 

Update protobuf java to new version.  This change only impact tests. It doesn't impact our packages.

The old one has CVE-2021-22569.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
