### PR TITLE
Remove coremltools submodule *security vulnerability*  and copy the coreml model schema 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,9 +56,6 @@
 [submodule "cmake/external/mp11"]
 	path = cmake/external/mp11
 	url = https://github.com/boostorg/mp11.git
-[submodule "cmake/external/coremltools"]
-	path = cmake/external/coremltools
-	url = https://github.com/apple/coremltools.git
 [submodule "cmake/external/dlpack"]
 	path = cmake/external/dlpack
 	url = https://github.com/dmlc/dlpack.git

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -114,16 +114,6 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "523d5e03d86c26267ee6bdf17dd20f6ce6bdadd7",
-          "repositoryUrl": "https://github.com/apple/coremltools.git"
-        },
-        "comments": "git submodule at cmake/external/coremltools"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "commitHash": "c3cceac115c072fb63df1836ff46d8c60d9eb304",
           "repositoryUrl": "https://github.com/NVlabs/cub.git"
         },
@@ -174,7 +164,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "a3d65c80d32c3e584b7aab41d516a0043b2a5e84",
+          "commitHash": "3acac70a551c321574732e5bfd67930244bb7151",
           "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
         },
         "comments": "git submodule at cmake/external/emsdk"
@@ -215,7 +205,7 @@
         "type": "git",
         "git": {
           "commitHash": "db78ac1d7716f56fc9f1b030b715f872f93964e4",
-          "repositoryUrl": "https://github.com/nlohmann/json"
+          "repositoryUrl": "https://github.com/nlohmann/json.git"
         },
         "comments": "git submodule at cmake/external/json"
       }
@@ -234,7 +224,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "2d54553b7a78c7c35620b827e7e5ab2228ecb495",
+          "commitHash": "f412df7a2b64421e1f1d61fde6055a6ea288e8f5",
           "repositoryUrl": "https://github.com/microsoft/mimalloc.git"
         },
         "comments": "git submodule at cmake/external/mimalloc"
@@ -255,7 +245,7 @@
         "type": "git",
         "git": {
           "commitHash": "436617053d0f39a1019a371c3a9aa599b3cb2cea",
-          "repositoryUrl": "https://github.com/google/nsync"
+          "repositoryUrl": "https://github.com/google/nsync.git"
         },
         "comments": "git submodule at cmake/external/nsync"
       }
@@ -265,7 +255,7 @@
         "type": "git",
         "git": {
           "commitHash": "be76ca7148396176784ba8733133b9fb1186ea0d",
-          "repositoryUrl": "https://github.com/onnx/onnx"
+          "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"
       }
@@ -294,7 +284,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "1f416bb462689f3ef9e3f1057a113d9c6aba6972",
+          "commitHash": "e9456d57605c883cdf985e634ab483e2c1500bb1",
           "repositoryUrl": "https://github.com/onnx/onnx-tensorrt.git"
         },
         "comments": "git submodule at cmake/external/onnx-tensorrt"
@@ -304,7 +294,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "553df22c67bee5f0fe6599cff60f1afc6748c635",
+          "commitHash": "994c6181247d7b419b28889fc57d5817e2089419",
           "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx-tensorrt/third_party/onnx"
@@ -324,20 +314,10 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "09f082940113661256310e3f4811aa7261a9fa05",
+          "commitHash": "59a2ac2745d8a57ac94c6accced73620d59fb844",
           "repositoryUrl": "https://github.com/pybind/pybind11.git"
         },
         "comments": "git submodule at cmake/external/onnx-tensorrt/third_party/onnx/third_party/pybind11"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "6a00cbc4a9b8e68b71caf7f774b3f9c753ae84d5",
-          "repositoryUrl": "https://github.com/wjakob/clang-cindex-python3"
-        },
-        "comments": "git submodule at cmake/external/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/clang"
       }
     },
     {
@@ -414,58 +394,8 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "9ec2b92d180dff8877e402018b97baa574031b8b",
-          "repositoryUrl": "https://github.com/microsoft/onnxruntime-tvm.git"
-        },
-        "comments": "git submodule at cmake/external/tvm"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "b257a9221ee1e5180d994b3488ddcc259b0ac157",
-          "repositoryUrl": "https://github.com/dmlc/HalideIR"
-        },
-        "comments": "git submodule at cmake/external/tvm/3rdparty/HalideIR"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "5c792cef3aee54ad8b7000111c9dc1797f327b59",
-          "repositoryUrl": "https://github.com/dmlc/dlpack"
-        },
-        "comments": "git submodule at cmake/external/tvm/3rdparty/dlpack"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "d07fb7a443b5db8a89d65a15a024af6a425615a5",
-          "repositoryUrl": "https://github.com/dmlc/dmlc-core"
-        },
-        "comments": "git submodule at cmake/external/tvm/3rdparty/dmlc-core"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "cabe04d6d6b05356fa8f9741704924788f0dd762",
-          "repositoryUrl": "https://github.com/agauniyal/rang"
-        },
-        "comments": "git submodule at cmake/external/tvm/3rdparty/rang"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "commitHash": "e8c599bca6c56c44b6730ad93f6abbc9ecd60fc1",
-          "repositoryUrl": "https://github.com/microsoft/wil"
+          "repositoryUrl": "https://github.com/microsoft/wil.git"
         },
         "comments": "git submodule at cmake/external/wil"
       }

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -784,7 +784,7 @@ if (onnxruntime_USE_COREML)
 
   # Compile CoreML proto definition to ${CMAKE_CURRENT_BINARY_DIR}/coreml
   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
-    set(COREML_PROTO_ROOT ${PROJECT_SOURCE_DIR}/external/coremltools/mlmodel/format)
+    set(COREML_PROTO_ROOT ${PROJECT_SOURCE_DIR}/../onnxruntime/core/providers/coreml/mlmodel_format)
     file(GLOB coreml_proto_srcs
       "${COREML_PROTO_ROOT}/*.proto"
     )

--- a/onnxruntime/core/providers/coreml/mlmodel_format/ArrayFeatureExtractor.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/ArrayFeatureExtractor.proto
@@ -1,0 +1,19 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * An array feature extractor.
+ *
+ * Given an index, extracts the value at that index from its array input.
+ * Indexes are zero-based.
+ */
+message ArrayFeatureExtractor {
+    repeated uint64 extractIndex = 1;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/BayesianProbitRegressor.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/BayesianProbitRegressor.proto
@@ -1,0 +1,139 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+* A Bayesian probit regressor.
+*
+* The probit regression model is superficially similar to the more commonly known
+* logistic regression, with sampling distribution of the model given by
+*
+*    P(y=+1|x,w) = Φ(<w,x>/β)
+*
+* where w are the set of weights,
+*       x are the set of features for the given event,
+*       β is a model hyper-parameter, and
+*       Φ is the link function, defined to be the CDF of the normal distribution.
+* The weights w[i,j] are Gaussian distributed, with mean μ[i,j] and precision 1/(σ[i,j])^2
+* (where i indexes over features and j indexes over the values for the feature).
+* The parameter β scales the steepness of the inverse link function.
+*
+* (see https://en.wikipedia.org/wiki/Probit_model and https://en.wikipedia.org/wiki/Logistic_regression
+* for more details on probit model and logistic regression, respectively)
+*
+* Input: X
+*   x represents a set of features, each taking on a discrete value (note that continuous values
+*   would first need to be discretized). x can be represented as a vector where the index i is
+*   the feature id and x[i] is the feature value. Alternatively, x can be represented as a matrix
+*   with 2 columns where the first column indicates the feature id and the second column contains
+*   the feature values, i.e. x[i,0] is the feature id and x[i,1] is the feature value.
+*
+*   additional input features:
+*   - "optimism": apply a mean shift to the probability, i.e. shift regression mean by o*stdev,
+*                 where o is the "optimism" parameter (see additional output features)
+*   - "samplingScale": for sampling from posterior, multiply standard deviation by this factor
+*   - "samplingTruncation": for sampling from posterior, truncate sampling distribution at given multiple of std from mean
+*
+* Output: Y
+*   probability P(y|x,w)
+*
+*   additional output features:
+*   - mean (regression output before applying link function)
+*   - variance (regression output variance before applying link function)
+*   - pessimistic probability: P(y|x,w) with a mean shift parameterized by "optimism" feature
+*   - sampled probability: p ~ P(y|x,w) with standard deviation scaling parametrized by "samplingScale" feature
+*                                       and distribution truncated at multiple of standard deviation,
+*                                       where multiple parameterized by "samplingTruncation" feature.
+*
+*/
+
+message BayesianProbitRegressor {
+
+    /*
+     * Parameterization of a Gaussian distribution
+     */
+    message Gaussian {
+        double mean = 1;
+        double precision = 2; // inverse of the variance
+    }
+
+    /*
+     * Weight for a specific feature value
+     * The weight is represented as a Gaussian distribution
+     * with a mean and precision (1/variance) to capture
+     * uncertainty in the weight
+     */
+    message FeatureValueWeight {
+        uint32 featureValue = 1;
+        Gaussian featureWeight = 2;
+    }
+
+    /*
+     * Feature with associated weights (for different values)
+     * Each feature has a set of weights for the (discrete) values
+     * it can take
+     */
+    message FeatureWeight {
+        uint32 featureId = 1;
+        repeated FeatureValueWeight weights = 2;
+    }
+
+    uint32 numberOfFeatures = 1;
+
+    Gaussian bias = 2;  // bias term
+
+    /*
+     * Set of features with associated weights
+     */
+    repeated FeatureWeight features = 3;  // feature weights
+
+    /*
+    * Set this name to be the same as input feature of type multi-array (1D)
+    * in the model description you want to use as the regression input
+    */
+    string regressionInputFeatureName = 10;
+
+    /*
+    * Set this name to be the same as optional input feature of type double
+    * in the model description you want to use as the optimism input
+    */
+    string optimismInputFeatureName = 11;
+
+    /*
+    * Set this name to be the same as optional input feature of type double
+    * in the model description you want to use as the samplingScale input
+    */
+    string samplingScaleInputFeatureName = 12;
+
+    /*
+    * Set this name to be the same as optional input feature of type double
+    * in the model description you want to use as the samplingBounds input
+    */
+    string samplingTruncationInputFeatureName = 13;
+
+    /*
+    * name of 'mean' output feature
+    */
+    string meanOutputFeatureName = 20;
+
+    /*
+    * name of 'variance' output feature
+    */
+    string varianceOutputFeatureName = 21;
+
+    /*
+    * name of 'pessimistic' output feature
+    */
+    string pessimisticProbabilityOutputFeatureName = 22;
+
+    /*
+    * name of 'sampled' output feature: samples from the scaled posterior probability distribuiton
+    */
+    string sampledProbabilityOutputFeatureName = 23;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/CategoricalMapping.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/CategoricalMapping.proto
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * A categorical mapping.
+ *
+ * This allows conversion from integers to strings, or from strings to integers.
+ */
+message CategoricalMapping {
+    oneof MappingType {
+        // Conversion from strings to integers
+        StringToInt64Map stringToInt64Map = 1;
+
+        // Conversion from integer to string
+        Int64ToStringMap int64ToStringMap = 2;
+    }
+
+    /**
+     * The value returned if an input is not contained in the map above.
+     * If one of these is not set, then an error is raised on an unknown input.
+     */
+    oneof ValueOnUnknown {
+        // Default output when converting from an integer to a string.
+        string strValue = 101;
+
+        // Default output when converting from a string to an integer.
+        int64 int64Value = 102;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/CustomModel.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/CustomModel.proto
@@ -1,0 +1,30 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+* A parameterized model whose function is defined in code
+*/
+message CustomModel {
+
+    message CustomModelParamValue {
+        oneof value {
+            double doubleValue = 10;
+            string stringValue = 20;
+            int32 intValue = 30;
+            int64 longValue = 40;
+            bool boolValue = 50;
+            bytes bytesValue = 60;
+        }
+    }
+
+    string className = 10; // The name of the class (conforming to MLCustomModel) corresponding to this model
+    map<string, CustomModelParamValue> parameters = 30;
+    string description = 40; // An (optional) description provided by the model creator. This information is displayed when viewing the model, but does not affect the model's execution on device.
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/DataStructures.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/DataStructures.proto
@@ -1,0 +1,95 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "FeatureTypes.proto";
+
+package CoreML.Specification;
+
+/**
+ * A mapping from a string
+ * to a 64-bit integer.
+ */
+message StringToInt64Map {
+    map<string, int64> map = 1;
+}
+
+/**
+ * A mapping from a 64-bit integer
+ * to a string.
+ */
+message Int64ToStringMap {
+    map<int64, string> map = 1;
+}
+
+/**
+ * A mapping from a string
+ * to a double-precision floating point number.
+ */
+message StringToDoubleMap {
+    map<string, double> map = 1;
+}
+
+/**
+ * A mapping from a 64-bit integer
+ * to a double-precision floating point number.
+ */
+message Int64ToDoubleMap {
+    map<int64, double> map = 1;
+}
+
+/**
+ * A vector of strings.
+ */
+message StringVector {
+    repeated string vector = 1;
+}
+
+/**
+ * A vector of 64-bit integers.
+ */
+message Int64Vector {
+    repeated int64 vector = 1;
+}
+
+/**
+ * A vector of floating point numbers.
+ */
+message FloatVector {
+    repeated float vector = 1;
+}
+
+/**
+ * A vector of double-precision floating point numbers.
+ */
+message DoubleVector {
+    repeated double vector = 1;
+}
+
+/**
+ * A range of int64 values
+ */
+message Int64Range {
+    int64 minValue = 1;
+    int64 maxValue = 2;
+}
+
+/**
+ * A set of int64 values
+ */
+message Int64Set {
+    repeated int64 values = 1;
+}
+
+/**
+ * A range of double values
+ */
+message DoubleRange {
+    double minValue = 1;
+    double maxValue = 2;
+}
+

--- a/onnxruntime/core/providers/coreml/mlmodel_format/DictVectorizer.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/DictVectorizer.proto
@@ -1,0 +1,36 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * Uses an index mapping to convert a dictionary to an array.
+ *
+ * The output array will be equal in length to the index mapping vector parameter.
+ * All keys in the input dictionary must be present in the index mapping vector.
+ *
+ * For each item in the input dictionary, insert its value in the output array.
+ * The position of the insertion is determined by the position of the item's key
+ * in the index mapping. Any keys not present in the input dictionary, will be
+ * zero in the output array.
+ *
+ * For example: if the ``stringToIndex`` parameter is set to ``["a", "c", "b", "z"]``,
+ * then an input of ``{"a": 4, "c": 8}`` will produce an output of ``[4, 8, 0, 0]``.
+ *
+ */
+message DictVectorizer {
+    oneof Map {
+        /// String keys to indexes
+        StringVector stringToIndex = 1;
+
+        /// Int keys to indexes
+        Int64Vector int64ToIndex = 2;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/FeatureTypes.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/FeatureTypes.proto
@@ -1,0 +1,224 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * The 64-bit integer feature type.
+ */
+message Int64FeatureType {}
+
+/**
+ * The double-precision floating point number feature type.
+ */
+message DoubleFeatureType {}
+
+/**
+ * The string feature type.
+ */
+message StringFeatureType {}
+
+
+message SizeRange {
+    uint64 lowerBound = 1;
+    int64 upperBound = 2; // negative value means unbound otherwise upperbound is included in range
+}
+
+/**
+ * The image feature type.
+ */
+message ImageFeatureType {
+    // Assumes raw (decompressed) format
+    enum ColorSpace {
+        INVALID_COLOR_SPACE = 0;
+        GRAYSCALE = 10; //  8 bits per pixel
+        RGB = 20;       // 32 bits per pixel: RGBA with A channel ignored
+        BGR = 30;       // 32 bits per pixel: BGRA with A channel ignored
+    }
+
+    message ImageSize {
+        uint64 width = 1;
+        uint64 height = 2;
+    }
+
+    message EnumeratedImageSizes {
+        repeated ImageSize sizes = 1;
+    }
+
+    message ImageSizeRange {
+        SizeRange widthRange = 1;
+        SizeRange heightRange = 2;
+    }
+
+    // The required or default image size is width x height
+    //
+    // If specificationVersion <= 2 or SizeFlexibility is empty,
+    // width x height is the required fixed image size
+    //
+    // If SizeFlexibility is present, width x height indicate a "default"
+    // image size which must be consistent with the flexibilty specified
+
+    int64 width = 1;
+    int64 height = 2;
+
+    // For specification version >= 3 you can specify image size flexibility.
+
+    oneof SizeFlexibility {
+
+        // Use enumeratedSizes for a set of distinct fixed sizes
+        // e.g. portrait or landscape: [80 x 100, 100 x 8]
+        //
+        // If the width x height fields above are specified then they must be
+        // one of the sizes listed.
+        //
+        // If width and height are not specified above then the default width
+        // and height will be enumeratedSizes[0]
+        //
+        // Must be non-empty
+
+        EnumeratedImageSizes enumeratedSizes = 21;
+
+        // Use imageSizeRange to allow for ranges of values
+        // e.g. any image greater than 10 x 20: [10..<max] x [20..<max]
+        //
+        // If width and height are specified above they must fall in the range
+        // specified in imageSizeRange. They will be treated as the default size.
+        //
+        // If width and height are not specified above then the default width
+        // and height will be imageSizeRange.widthRange.lowerBound x imageSizeRange.heightRange.lowerBound
+
+        ImageSizeRange imageSizeRange = 31;
+    }
+
+    ColorSpace colorSpace = 3;
+}
+
+/**
+ * The array feature type.
+ */
+message ArrayFeatureType {
+
+    enum ArrayDataType {
+        INVALID_ARRAY_DATA_TYPE = 0;
+        FLOAT32 = 65568; // 0x10000 | 32
+        DOUBLE = 65600;  // 0x10000 | 64
+        INT32 = 131104;  // 0x20000 | 32
+    }
+
+    // The required or default shape
+    //
+    // If specificationVersion <= 2 or ShapeFlexibility is empty,
+    // shape is the required fixed shape
+    //
+    // If ShapeFlexibility is present, shape indicate a "default"
+    // shape which must be consistent with the flexibilty specified
+
+    repeated int64 shape = 1;
+
+    ArrayDataType dataType = 2;
+
+    message Shape {
+        repeated int64 shape = 1;
+    }
+
+    message EnumeratedShapes {
+        repeated Shape shapes = 1;
+    }
+
+    message ShapeRange {
+        // sizeRanges.size() must be length 1 or 3
+        // sizeRanges[d] specifies the allowed range for dimension d
+        repeated SizeRange sizeRanges = 1;
+    }
+
+    // For specification version >= 3 you can specify image size flexibility.
+
+    oneof ShapeFlexibility {
+
+        // Use enumeratedShapes for a set of distinct fixed shapes
+        //
+        // If the shape field is specified then it must be
+        // one of the enumerated shapes.
+        ///
+        // If shape is not specifed, the "default" shape will be considered
+        // enumeratedShapes[0]
+        //
+        // Must be non-empty
+
+        EnumeratedShapes enumeratedShapes = 21;
+
+        // Use shapeRange to allow the size of each dimension vary within
+        // indpendently specified ranges
+        //
+        // If you specify shape above it must fall in the range
+        // specified in shapeRanges. It will be treated as the default shape.
+        //
+        // If you don't specify shape above then the default shape will
+        // have shape[d] = shapeRange.sizeRanges[d].lowerBound
+
+        ShapeRange shapeRange = 31;
+
+    }
+
+    oneof defaultOptionalValue {
+        int32 intDefaultValue = 41;
+        float floatDefaultValue = 51;
+        double doubleDefaultValue = 61;
+    }
+
+}
+
+/**
+ * The dictionary feature type.
+ */
+message DictionaryFeatureType {
+    /**
+     *  Key/value type tags, with the following restrictions:
+     *  - ``keyType`` must be a hashable type
+     *  - ``valueType`` is assumed to be a ``double``
+     */
+    oneof KeyType {
+        Int64FeatureType int64KeyType = 1;
+        StringFeatureType stringKeyType = 2;
+    }
+}
+
+/**
+ * The Sequence feature type.
+ */
+message SequenceFeatureType {
+
+    /**
+     * Currently only categorical int64 and String sequences are supported
+     */
+    oneof Type {
+        Int64FeatureType int64Type = 1;
+        StringFeatureType stringType = 3;
+    }
+
+    // Range of allowed size/length/count of sequence
+    SizeRange sizeRange = 101;
+}
+
+/**
+ * A feature, which may be optional.
+ */
+message FeatureType {
+    oneof Type {
+        Int64FeatureType int64Type = 1;
+        DoubleFeatureType doubleType = 2;
+        StringFeatureType stringType = 3;
+        ImageFeatureType imageType = 4;
+        ArrayFeatureType multiArrayType = 5;
+        DictionaryFeatureType dictionaryType = 6;
+        SequenceFeatureType sequenceType = 7;
+    }
+
+    bool isOptional = 1000;
+}
+

--- a/onnxruntime/core/providers/coreml/mlmodel_format/FeatureVectorizer.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/FeatureVectorizer.proto
@@ -1,0 +1,26 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * A FeatureVectorizer puts one or more features into a single array.
+ *
+ * The ordering of features in the output array is determined by
+ * ``inputList``.
+ *
+ * ``inputDimensions`` is a zero based index.
+ */
+message FeatureVectorizer {
+    message InputColumn {
+        string inputColumn = 1;
+        uint64 inputDimensions = 2;
+    }
+
+    repeated InputColumn inputList = 1;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/GLMClassifier.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/GLMClassifier.proto
@@ -1,0 +1,43 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * A generalized linear model classifier.
+ */
+message GLMClassifier {
+    message DoubleArray {
+        repeated double value = 1;
+    }
+
+    enum PostEvaluationTransform {
+        Logit = 0;
+        Probit = 1; /// Only binary classification is supported for probit
+    }
+
+    enum ClassEncoding {
+        ReferenceClass = 0; /// First class is the reference class
+        OneVsRest = 1; /// Also called One vs All
+    }
+
+    repeated DoubleArray weights = 1;
+    repeated double offset = 2;
+    PostEvaluationTransform postEvaluationTransform = 3;
+    ClassEncoding classEncoding = 4;
+
+    /**
+     * Required class label mapping.
+     */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/GLMRegressor.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/GLMRegressor.proto
@@ -1,0 +1,28 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * A generalized linear model regressor.
+ */
+message GLMRegressor {
+    message DoubleArray {
+        repeated double value = 1;
+    }
+
+    enum PostEvaluationTransform {
+        NoTransform = 0;
+        Logit = 1;
+        Probit = 2;
+    }
+
+    repeated DoubleArray weights = 1;
+    repeated double offset = 2;
+    PostEvaluationTransform postEvaluationTransform = 3;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Gazetteer.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Gazetteer.proto
@@ -1,0 +1,43 @@
+// Copyright (c) 2019, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which uses an efficient probabilistic representation
+* for assigning labels to a set of strings.
+*/
+message Gazetteer {
+
+    /*
+    * Stores the revision number for the model, revision 2 is available on
+    * iOS, tvOS 13.0+, macOS 10.15+
+    */
+    uint32 revision = 1;
+    
+    /*
+    * Stores the language of the model, as specified in BCP-47 format,
+    * e.g. "en-US". See https://tools.ietf.org/html/bcp47
+    */
+    string language = 10;
+
+    /*
+    * Natural Lanaguge framework's efficient representation of a gazetter.
+    */
+    bytes modelParameterData = 100;
+    
+    /*
+    * Stores the set of output class labels
+    */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 200;
+    }
+    
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Identity.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Identity.proto
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * An identity model.
+ *
+ * This model returns given inputs as outputs, unchanged.
+ * Intended to be used for testing purposes.
+ */
+message Identity {
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Imputer.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Imputer.proto
@@ -1,0 +1,43 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * A transformer that replaces missing values with a default value,
+ * such as a statistically-derived value.
+ *
+ * If ``ReplaceValue`` is set, then missing values of that type are
+ * replaced with the corresponding value.
+ *
+ * For example: if ``replaceDoubleValue`` is set to ``NaN``
+ * and a single ``NaN`` double value is provided as input,
+ * then it is replaced by ``imputedDoubleValue``. However
+ * if the input is an array of doubles, then any instances
+ * of ``NaN`` in the array is replaced with the corresponding
+ * value in ``imputedDoubleArray``.
+ */
+message Imputer {
+    oneof ImputedValue {
+        double imputedDoubleValue = 1;
+        int64 imputedInt64Value = 2;
+        string imputedStringValue = 3;
+        DoubleVector imputedDoubleArray = 4;
+        Int64Vector imputedInt64Array = 5;
+        StringToDoubleMap imputedStringDictionary = 6;
+        Int64ToDoubleMap imputedInt64Dictionary = 7;
+    }
+
+    oneof ReplaceValue {
+        double replaceDoubleValue = 11;
+        int64 replaceInt64Value = 12;
+        string replaceStringValue = 13;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/ItemSimilarityRecommender.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/ItemSimilarityRecommender.proto
@@ -1,0 +1,93 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * Each tree is a collection of nodes,
+ * each of which is identified by a unique identifier.
+ *
+ * Each node is either a branch or a leaf node.
+ * A branch node evaluates a value according to a behavior;
+ * if true, the node identified by ``true_child_node_id`` is evaluated next,
+ * if false, the node identified by ``false_child_node_id`` is evaluated next.
+ * A leaf node adds the evaluation value to the base prediction value
+ * to get the final prediction.
+ *
+ * A tree must have exactly one root node,
+ * which has no parent node.
+ * A tree must not terminate on a branch node.
+ * All leaf nodes must be accessible
+ * by evaluating one or more branch nodes in sequence,
+ * starting from the root node.
+ */
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+
+/**
+ * Item Similarity Recommender
+ *
+ *  The Item Similarity recommender takes as input a list of items and scores,
+ *  then uses that information and a table of item similarities to predict similarity
+ *  scores for all items.  By default, the items predicted are most similar to the given
+ *  items but not part of that item set.
+ *
+ *  The predicted score for a given item k is
+ *    sum_(i in observed items)   sim_(k,i) * (score_i - shift_k)
+ *
+ *  Because only the most similar scores for each item i are stored,
+ *  sim_(k,i) is often zero.
+ *
+ *  For many models, the score adjustment parameter shift_j is zero -- it's occasionally used
+ *  to counteract global biases for popular items.
+ *
+ *
+ *  References:
+ */
+message ItemSimilarityRecommender {
+
+    /** The items similar to a given base item.
+     */
+    message ConnectedItem {
+        uint64 itemId = 1;
+        double similarityScore = 2;
+    }
+
+    /**  The formula for the score of a given model as given above, with shift_k
+     *   parameter given by itemScoreAdjustment, and the similar item list filling in
+     *   all the known sim(k,i) scores for i given by itemID and k given by the itemID parameter in
+     *   the similarItemList.
+     */
+    message SimilarItems {
+        uint64 itemId = 1;
+        repeated ConnectedItem similarItemList = 2;
+        double itemScoreAdjustment = 3;
+    }
+
+    repeated SimilarItems itemItemSimilarities = 1;
+
+    /** One or none of these are given.  If none are given, then the items must number 0, 1, ..., num_items - 1.
+     *  If either is given, the length must be exactly num_items.
+     */
+    StringVector itemStringIds = 2;
+    Int64Vector itemInt64Ids = 3;
+
+    /** Input parameter names specifying different possible inputs to the recommender.
+     */
+    string itemInputFeatureName = 10;  /* Required */
+    string numRecommendationsInputFeatureName = 11;  /* Optional; defaults to all items if not given.*/
+    string itemRestrictionInputFeatureName = 12; /* Optional. */
+    string itemExclusionInputFeatureName = 13; /* Optional; defaults to input item list if not given. */
+
+    /** The predicted outputs.  At least one of these must be specified.
+     */
+    string recommendedItemListOutputFeatureName = 20;
+    string recommendedItemScoreOutputFeatureName = 21;
+
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/LinkedModel.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/LinkedModel.proto
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+import public "Parameters.proto";
+
+package CoreML.Specification;
+
+/**
+ * A model which wraps another (compiled) model external to this one
+ */
+message LinkedModel {
+
+    oneof LinkType {
+        // A model located via a file system path
+        LinkedModelFile linkedModelFile = 1;
+    }
+}
+
+// Model is referenced by a model file name and search path
+message LinkedModelFile {
+
+    // Model file name: e.g. "MyFetureExtractor.mlmodelc"
+    StringParameter linkedModelFileName = 1;
+
+    // Search path to find the linked model file
+    // Multiple paths can be searched using the unix-style path separator ":"
+    // Each path can be relative (to this model) or absolute
+    //
+    // An empty string is the same as teh relative search path "."
+    // which searches in the same location as this model file
+    //
+    // There are some special paths which start with $
+    // - $BUNDLE_MAIN - Indicates to look in the main bundle
+    // - $BUNDLE_IDENTIFIER(identifier) - Looks in Bunde with given identifer
+    StringParameter linkedModelSearchPath = 2;
+}
+
+

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Model.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Model.proto
@@ -1,0 +1,322 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * A Core ML model consists of a specification version
+ * and a model description,
+ * and can be any one of the following types:
+ *
+ * Neural Networks
+ *   - `NeuralNetwork`
+ *
+ * Regressors
+ *   - ``GLMRegressor``
+ *   - ``SupportVectorRegressor``
+ *   - ``TreeEnsembleRegressor``
+ *   - ``NeuralNetworkRegressor``
+ *   - ``BayesianProbitRegressor``
+ *
+ * Classifiers
+ *   - `NeuralNetworkClassifier`
+ *   - `TreeEnsembleClassifier`
+ *   - `GLMClassifier`
+ *   - `SupportVectorClassifier`
+ *   - `KNearestNeighborsClassifier`
+ *
+ * Other models
+ *   - `CustomModel`
+ *   - `TextClassifier`
+ *   - `WordTagger`
+ *   - `Gazetteer`
+ *   - `WordEmbedding`
+ *   - `VisionFeaturePrint`
+ *   - `LinkedModel`
+ *   - `SoundAnalysisPreprocessing`
+ *   - `ItemSimilarityRecommender`
+ *
+ * Feature Engineering
+ *   - `Imputer`
+ *   - `Scaler`
+ *   - `Normalizer`
+ *   - `OneHotEncoder`
+ *   - `CategoricalMapping`
+ *   - `FeatureVectorizer`
+ *   - `DictVectorizer`
+ *   - `ArrayFeatureExtractor`
+ *   - `NonMaximumSuppression`
+ *
+ * Pipelines
+ *   - `PipelineClassifier`
+ *   - `PipelineRegressor`
+ *   - `Pipeline`
+ *
+ * Simple Mathematical Functions
+ *   - `Identity`
+ */
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "VisionFeaturePrint.proto";
+import public "TextClassifier.proto";
+import public "WordTagger.proto";
+import public "Gazetteer.proto";
+import public "WordEmbedding.proto";
+import public "ArrayFeatureExtractor.proto";
+import public "BayesianProbitRegressor.proto";
+import public "CategoricalMapping.proto";
+import public "CustomModel.proto";
+import public "DictVectorizer.proto";
+import public "FeatureTypes.proto";
+import public "FeatureVectorizer.proto";
+import public "GLMRegressor.proto";
+import public "GLMClassifier.proto";
+import public "NearestNeighbors.proto";
+import public "Identity.proto";
+import public "Imputer.proto";
+import public "NeuralNetwork.proto";
+import public "Normalizer.proto";
+import public "OneHotEncoder.proto";
+import public "Scaler.proto";
+import public "NonMaximumSuppression.proto";
+import public "SVM.proto";
+import public "TreeEnsemble.proto";
+import public "Parameters.proto";
+import public "ItemSimilarityRecommender.proto";
+import public "SoundAnalysisPreprocessing.proto";
+import public "LinkedModel.proto";
+
+package CoreML.Specification;
+
+/**
+ * A pipeline consisting of one or more models.
+ */
+message Pipeline {
+    repeated Model models = 1;
+
+    // Optional names given for each model
+    // If not supplied it defaults to ["model0",..., "model"(models.size()-1)]
+    // These names can be used to disambiguate the scope / domain of a parameter
+    repeated string names = 2;
+}
+
+/**
+ * A classifier pipeline.
+ */
+message PipelineClassifier {
+    Pipeline pipeline = 1;
+}
+
+/**
+ * A regressor pipeline.
+ */
+message PipelineRegressor {
+    Pipeline pipeline = 1;
+}
+
+/**
+ * A feature description,
+ * consisting of a name, short description, and type.
+ */
+message FeatureDescription {
+    string name = 1;
+    string shortDescription = 2;
+    FeatureType type = 3;
+}
+
+/**
+ * Model metadata,
+ * consisting of a short description, a version string,
+ * an author, a license, and any other user defined
+ * key/value meta data.
+ */
+message Metadata {
+    string shortDescription = 1;
+    string versionString = 2;
+    string author = 3;
+    string license = 4;
+    map<string, string> userDefined = 100;
+}
+
+/**
+ * A description of a model,
+ * consisting of descriptions of its input and output features.
+ * Both regressor and classifier models require the name of the
+ * primary predicted output feature (``predictedFeatureName``).
+ * Classifier models can specify the output feature containing
+ * probabilities for the predicted classes
+ * (``predictedProbabilitiesName``).
+ */
+message ModelDescription {
+    repeated FeatureDescription input = 1;
+    repeated FeatureDescription output = 10;
+
+    // [Required for regressor and classifier models]: the name
+    // to give to an output feature containing the prediction.
+    string predictedFeatureName = 11;
+
+    // [Optional for classifier models]: the name to give to an
+    // output feature containing a dictionary mapping class
+    // labels to their predicted probabilities. If not specified,
+    // the dictionary will not be returned by the model.
+    string predictedProbabilitiesName = 12;
+
+    repeated FeatureDescription trainingInput = 50;
+
+    Metadata metadata = 100;
+}
+
+message SerializedModel {
+    // Identifier whose content describes the model type of the serialized protocol buffer message.
+    string identifier = 1;
+
+    // Must be a valid serialized protocol buffer of the above specified type.
+    bytes model = 2;
+}
+
+/**
+ * A Core ML model,
+ * consisting of a specification version,
+ * a model description, and a model type.
+ *
+ * Core ML model compatibility is indicated by
+ * a monotonically increasing specification version number,
+ * which is incremented anytime a backward-incompatible change is made
+ * (this is functionally equivalent to the MAJOR version number
+ * described by `Semantic Versioning 2.0.0 <http://semver.org/>`_).
+ *
+ * Specification Versions : OS Availability (Core ML Version)
+ *
+ * 1 : iOS 11, macOS 10.13, tvOS 11, watchOS 4 (Core ML 1)
+ * - Feedforward & Recurrent Neural Networks
+ * - General Linear Models
+ * - Tree Ensembles
+ * - Support Vector Machines
+ * - Pipelines
+ * - Feature Engineering
+ *
+ * 2 : iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 4.2 (Core ML 1.2)
+ * - Custom Layers for Neural Networks
+ * - Float 16 support for Neural Network layers
+ *
+ * 3 : iOS 12, macOS 10.14, tvOS 12, watchOS 5 (Core ML 2)
+ * - Flexible shapes and image sizes
+ * - Categorical sequences
+ * - Core ML Vision Feature Print, Text Classifier, Word Tagger
+ * - Non Max Suppression
+ * - Crop and Resize Bilinear NN layers
+ * - Custom Models
+ *
+ * 4 : iOS 13, macOS 10.15, tvOS 13, watchOS 6 (Core ML 3)
+ * - Updatable models
+ * - Exact shape / general rank mapping for neural networks
+ * - Large expansion of supported neural network layers
+ *   - Generalized operations
+ *   - Control flow
+ *   - Dynamic layers
+ *   - See NeuralNetwork.proto
+ * - Nearest Neighbor Classifier
+ * - Sound Analysis Prepreocessing
+ * - Recommender
+ * - Linked Model
+ * - NLP Gazeteer
+ * - NLP WordEmbedding
+ *
+ * 5 : iOS 14, macOS 11, tvOS 14, watchOS 7 (Core ML 4)
+ * - Model Deployment
+ * - Model Encryption
+ * - Unified converter API with PyTorch and Tensorflow 2 Support in coremltools 4
+ * - MIL builder for neural networks and composite ops in coremltools 4
+ * - New layers in neural network:
+ *      - CumSum
+ *      - OneHot
+ *      - ClampedReLu
+ *      - ArgSort
+ *      - SliceBySize
+ *      - Convolution3D
+ *      - Pool3D
+ *      - Bilinear Upsample with align corners and fractional factors
+ *      - PixelShuffle
+ *      - MatMul with int8 weights and int8 activations
+ *      - Concat interleave
+ *      - See NeuralNetwork.proto
+ * - Enhanced Xcode model view with interactive previews
+ * - Enhanced Xcode Playground support for Core ML models
+ *
+ */
+message Model {
+    int32 specificationVersion = 1;
+    ModelDescription description = 2;
+    
+    /*
+     * Following model types support on-device update:
+     *
+     * - NeuralNetworkClassifier
+     * - NeuralNetworkRegressor
+     * - NeuralNetwork
+     * - KNearestNeighborsClassifier
+     */
+    bool isUpdatable = 10;
+    
+    // start at 200 here
+    // model specific parameters:
+    oneof Type {
+        // pipeline starts at 200
+        PipelineClassifier pipelineClassifier = 200;
+        PipelineRegressor pipelineRegressor = 201;
+        Pipeline pipeline = 202;
+
+        // regressors start at 300
+        GLMRegressor glmRegressor = 300;
+        SupportVectorRegressor supportVectorRegressor = 301;
+        TreeEnsembleRegressor treeEnsembleRegressor = 302;
+        NeuralNetworkRegressor neuralNetworkRegressor = 303;
+        BayesianProbitRegressor bayesianProbitRegressor = 304;
+
+        // classifiers start at 400
+        GLMClassifier glmClassifier = 400;
+        SupportVectorClassifier supportVectorClassifier = 401;
+        TreeEnsembleClassifier treeEnsembleClassifier = 402;
+        NeuralNetworkClassifier neuralNetworkClassifier = 403;
+        KNearestNeighborsClassifier kNearestNeighborsClassifier = 404;
+
+        // generic models start at 500
+        NeuralNetwork neuralNetwork = 500;
+        ItemSimilarityRecommender itemSimilarityRecommender = 501;
+
+        // Custom and linked models
+        CustomModel customModel = 555;
+        LinkedModel linkedModel = 556;
+
+        // feature engineering starts at 600
+        OneHotEncoder oneHotEncoder = 600;
+        Imputer imputer = 601;
+        FeatureVectorizer featureVectorizer = 602;
+        DictVectorizer dictVectorizer = 603;
+        Scaler scaler = 604;
+        CategoricalMapping categoricalMapping = 606;
+        Normalizer normalizer = 607;
+        ArrayFeatureExtractor arrayFeatureExtractor = 609;
+        NonMaximumSuppression nonMaximumSuppression = 610;
+
+
+        // simple mathematical functions used for testing start at 900
+        Identity identity = 900;
+
+        // reserved until 1000
+
+        // CoreML provided models
+        CoreMLModels.TextClassifier textClassifier = 2000;
+        CoreMLModels.WordTagger wordTagger = 2001;
+        CoreMLModels.VisionFeaturePrint visionFeaturePrint = 2002;
+        CoreMLModels.SoundAnalysisPreprocessing soundAnalysisPreprocessing = 2003;
+        CoreMLModels.Gazetteer gazetteer = 2004;
+        CoreMLModels.WordEmbedding wordEmbedding = 2005;
+        
+        // Reserved private messages start at 3000
+        // These messages are subject to change with no notice or support.
+        SerializedModel serializedModel = 3000;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/NearestNeighbors.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/NearestNeighbors.proto
@@ -1,0 +1,132 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+import public "DataStructures.proto";
+import public "Parameters.proto";
+
+/**
+ * A k-Nearest-Neighbor classifier
+ */
+message KNearestNeighborsClassifier {
+
+    /**
+     * The "core" nearest neighbor model attributes.
+     */
+    NearestNeighborsIndex nearestNeighborsIndex = 1;
+
+    /**
+     * Number of neighbors to use for classification.
+     */
+    Int64Parameter numberOfNeighbors = 3;
+
+    /**
+     * Type of labels supported by the model. Currently supports String or Int64
+     * labels.
+     */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+
+	/**
+	 * Default value of class label (useful when prediction is called on an empty kNN classifier)
+	 */
+    oneof DefaultClassLabel {
+        string defaultStringLabel = 110;
+        int64 defaultInt64Label = 111;
+    }
+
+    /**
+     * Weighting scheme to be used when computing the majority label of a 
+     * new data point.
+     */
+    oneof WeightingScheme {
+        UniformWeighting uniformWeighting = 200;
+        InverseDistanceWeighting inverseDistanceWeighting = 210;
+    }
+}
+
+/**
+ * The "core" attributes of a Nearest Neighbors model.
+ */
+message NearestNeighborsIndex {
+
+    /** 
+     * Number of dimensions of the input data.
+     */
+    int32 numberOfDimensions = 1;
+
+    /**
+     * Vector of floating point data that makes up the model. Each data point must have 'numberOfDimensions'
+     * dimensions.
+     */
+    repeated FloatVector floatSamples = 2;
+
+    /** 
+     * Backing data structure for the Nearest Neighbors Index. Currently supports 
+     * a linear index or a kd-tree index.
+     */
+    oneof IndexType {
+        LinearIndex linearIndex = 100;
+        SingleKdTreeIndex singleKdTreeIndex = 110;
+    }
+
+    /** 
+     * Distance function to be used to find neighbors. Currently only Squared Euclidean
+     * Distance is supported.
+     */
+    oneof DistanceFunction {
+        SquaredEuclideanDistance squaredEuclideanDistance = 200;
+    }
+
+}
+
+/**
+ * Specifies a uniform weighting scheme (i.e. each neighbor receives equal
+ * voting power).
+ */
+message UniformWeighting {
+}
+
+
+/**
+ * Specifies a inverse-distance weighting scheme (i.e. closest neighbors receives higher
+ * voting power). A nearest neighbor with highest sum of (1 / distance) is picked.
+ */
+message InverseDistanceWeighting {
+}
+
+
+/**
+ * Specifies a flat index of data points to be searched by brute force.
+ */
+message LinearIndex {
+}
+
+
+/**
+ * Specifies a kd-tree backend for the nearest neighbors model.
+ */
+message SingleKdTreeIndex {
+
+    /**
+     * Number of data points contained within a leaf node of the kd-tree.
+     */
+    int32 leafSize = 1;
+
+}
+
+
+/**
+ * Specifies the Squared Euclidean Distance function.
+ */
+message SquaredEuclideanDistance {
+}
+

--- a/onnxruntime/core/providers/coreml/mlmodel_format/NeuralNetwork.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/NeuralNetwork.proto
@@ -1,0 +1,6531 @@
+// Copyright (c) 2017-2019, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * A neural network is defined through a collection of layers
+ * and represents a directed acyclic graph (DAG).
+ * Each layer has a name, a layer type,
+ * a list of input names, a list of output names,
+ * and a collection of parameters specific to the layer type.
+ *
+ * The graph structure and connectivity of the neural network
+ * is inferred from the input and output names.
+ * A neural network starts with the layer
+ * whose input name is equal to the value specified in
+ * ``Model.description.input.name``,
+ * and ends with the layer
+ * whose output name is equal to the value specified in
+ * ``Model.description.output.name``.
+ * Layers must have unique input and output names,
+ * and a layer may not have input or output names that
+ * refer to layers that are not yet defined.
+ *
+ * For Core ML specification version <=3,
+ * all inputs are mapped to static rank 5 tensors, with axis notations
+ * [Sequence, Batch, Channel, Height, Width].
+ *
+ * From specification version 4 onwards (iOS >= 13, macOS >= 10.15), more options are available
+ * (see enums ``NeuralNetworkMultiArrayShapeMapping``, ``NeuralNetworkImageShapeMapping``)
+ * to map inputs to generic N-Dimensional (or N rank) tensors, where N >= 1.
+ *
+ * Each layer type may have specific constraints on the ranks of its inputs and outputs.
+ *
+ * Some of the layers (such as softmax, reduce, etc) have parameters that have been described in
+ * terms of notational axis "Channel", "Height", "Width" or "Sequence". They can be re-interpreted easily in
+ * the general ND setting by using the following rule:
+ * "width" is same as axis = -1 (i.e. the last axis from the end)
+ * "height" is same as axis = -2 (i.e. the second last axis from the end)
+ * "channel" is same as axis = -3 (i.e. the third last axis from the end)
+ * "sequence" is same as axis = -5 (i.e. the fifth last axis from the end)
+ *
+ * Several layers are available in 3 different variations, with the names ending
+ * in identifiers: ``like``, ``static`` and ``dynamic``. For instance, ``FillLike``,
+ * ``FillStatic`` and ``FillDynamic``. The ``static`` variation generally will have
+ * a property corresponding to the shape of the output. For instance, if the
+ * output of the ``FillStatic`` layer is desired to be of shape (10, 4), the
+ * property ``targetShape`` will have to be set to [10, 4]. In the ``dynamic`` case,
+ * the shape is an input, hence it can be changed at runtime. For instance, for
+ * a ``FillDynamic`` layer, the input would have to be an array containing the
+ * values 10 and 4, if the desired output is of shape (10, 4). Whereas in the
+ * ``like`` case, the additional input's shape is used as the output shape, ignoring
+ * its values. For instance, for a ``FillLike`` layer, for an input with shape
+ * (10, 4), the output generated will also be of shape (10, 4), values of the
+ * input will be ignored.
+ */
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+import public "Parameters.proto";
+
+package CoreML.Specification;
+
+
+enum NeuralNetworkMultiArrayShapeMapping {
+
+    /*
+     * Describes how the MultiArray shape for the inputs,
+     * provided in Features Types proto via model description,
+     * is mapped to construct tensors that are fed into the Neural Network layers.
+     */
+
+    /*
+     * Default legacy value. Only supported for Core ML Specification version <= 3.
+     *
+     * The default legacy shape mapping resolves all input shapes to a rank 5 equivalent
+     * with axis notation of [Seq, Batch, Channel, Height, Width].
+     *
+     * When this enum value is selected,
+     * the repeated shape field in the message "ArrayFeatureType" in feature types proto,
+     * must be either length 1 or length 3.
+     *
+     * The following rule is used to map the values in the shape field to the actual tensor shape:
+     * rank 1 shape is mapped to shape [1,1,C,1,1]
+     * rank 3 shape is mapped to shape [1,1,C,H,W]
+     * At runtime, the first two dimensions (Seq or Batch) can be presented as well, with non-1 values.
+     *
+     * It is invalid to use this enum value if any of the layers added
+     * Specification version 4 (iOS >= 13, macOS >= 10.15) onwards are used in the network.
+     * Validator will raise an error in that case.
+     */
+    RANK5_ARRAY_MAPPING = 0;
+
+    /*
+     * The exact shape and rank (i.e. number of dimensions in the shape) of the input,
+     * as specified in the message "ArrayFeatureType", is passed through to the layers.
+     * Supported only for Specification version >= 4 (iOS >= 13, macOS >= 10.15).
+     */
+    EXACT_ARRAY_MAPPING = 1;
+
+}
+
+enum NeuralNetworkImageShapeMapping {
+
+    /*
+     * Describes how the shape of the input tensors is constructed from image inputs.
+     */
+
+    /*
+     * In this case, image input is mapped to a rank 5 tensor.
+     * For Color images, input tensor is shaped as [1,1,3,H,W].
+     * For Gray images, input tensor is shaped as [1,1,1,H,W].
+     */
+    RANK5_IMAGE_MAPPING = 0;
+
+    /*
+     * For Color images, input tensor is shaped as [1,3,H,W].
+     * For Gray images, input tensor is shaped as [1,1,H,W].
+     * Supported only for Specification version >= 4 (iOS >= 13, macOS >= 10.15).
+     */
+    RANK4_IMAGE_MAPPING = 1;
+
+}
+
+/**
+ A neural network.
+ */
+message NeuralNetwork {
+
+    repeated NeuralNetworkLayer layers = 1;
+    repeated NeuralNetworkPreprocessing preprocessing = 2;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for multiarray inputs
+    NeuralNetworkMultiArrayShapeMapping arrayInputShapeMapping = 5;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for image inputs
+    NeuralNetworkImageShapeMapping imageInputShapeMapping = 6;
+
+
+    NetworkUpdateParameters updateParams = 10;
+
+}
+
+/// Preprocessing
+/// -------------
+
+/**
+ * A neural network preprocessor that
+ * performs a scalar multiplication of an image
+ * followed by addition of scalar biases to the channels.
+ *
+ * Input: X
+ *    An image in BGR or RGB format with shape ``[3, H, W]``
+ *    or in grayscale format with shape ``[1, H, W]``.
+ * Output: Y
+ *    An image with format and shape corresponding to the input.
+ *
+ * If the input image is in BGR format:
+ *
+ * .. code::
+ *
+ *     Y[0, :, :] = channelScale * X[0, :, :] + blueBias
+ *     Y[1, :, :] = channelScale * X[1, :, :] + greenBias
+ *     Y[2, :, :] = channelScale * X[2, :, :] + redBias
+ *
+ * If the input image is in RGB format:
+ *
+ * .. code::
+ *
+ *     Y[0, :, :] = channelScale * X[0, :, :] + redBias
+ *     Y[1, :, :] = channelScale * X[1, :, :] + greenBias
+ *     Y[2, :, :] = channelScale * X[2, :, :] + blueBias
+ *
+ * If the input image is in grayscale format:
+ *
+ * .. code::
+ *
+ *     Y[0, :, :] = channelScale * X[0, :, :] + grayBias
+ */
+message NeuralNetworkImageScaler {
+
+    float channelScale = 10; ///Scalar to be multiplied.
+    float blueBias = 20; ///Scalar blue bias to be added.
+    float greenBias = 21; ///Scalar green bias to be added.
+    float redBias = 22; ///Scalar red bias to be added.
+    float grayBias = 30; ///Scalar bias to be added for grayscale images.
+
+}
+
+/**
+ * A neural network preprocessor that
+ * subtracts the provided mean image from the input image.
+ * The mean image is subtracted from the input named
+ * ``NeuralNetworkPreprocessing.featureName``.
+ */
+message NeuralNetworkMeanImage {
+
+    /**
+     * Mean image stored as a flattened array of floats,
+     * representing shape [Channel,Height,Width].
+     */
+    repeated float meanImage = 1;
+
+}
+
+/// Preprocessing parameters for image inputs.
+message NeuralNetworkPreprocessing {
+
+    string featureName = 1; /// must be equal to the input name to which the preprocessing is applied
+    oneof preprocessor {
+        NeuralNetworkImageScaler scaler = 10;
+        NeuralNetworkMeanImage meanImage = 11;
+    }
+
+}
+
+/// Activation Functions
+/// --------------------
+
+/**
+ * A rectified linear unit (ReLU) activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \text{max}(0, x)
+ */
+message ActivationReLU {
+
+}
+
+/**
+ * A leaky rectified linear unit (ReLU) activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \begin{cases}
+ *             x      & \text{if } x \geq 0 \\
+ *             \alpha x & \text{if } x < 0
+ *            \end{cases}
+ */
+message ActivationLeakyReLU {
+
+    float alpha = 1; //negative slope value for leakyReLU
+
+}
+
+/**
+ * A hyperbolic tangent activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \dfrac{1 - e^{-2x}}{1 + e^{-2x}}
+ */
+message ActivationTanh {
+
+}
+
+/**
+ * A scaled hyperbolic tangent activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \alpha \tanh(\beta x)
+ */
+message ActivationScaledTanh {
+
+    float alpha = 1;
+    float beta = 2;
+
+}
+
+/**
+ * A sigmoid activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \dfrac{1}{1 + e^{-x}}
+ */
+message ActivationSigmoid {
+
+}
+
+/**
+ * A linear activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \alpha x + \beta
+ */
+message ActivationLinear {
+
+    float alpha = 1;
+    float beta = 2;
+
+}
+
+/**
+ * A hard sigmoid activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \text{min}(\text{max}(\alpha x + \beta, 0), 1)
+ */
+message ActivationSigmoidHard {
+
+    float alpha = 1;
+    float beta = 2;
+
+}
+
+/**
+ * A parameterized rectified linear unit (PReLU) activation function.
+ * Input must be at least rank 3. Axis = -3 is denoted by "C", or channels.
+ * "alpha" parameter can be a vector of length C.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *    f(x_i) = \begin{cases}
+ *                 x_i          & \text{if } x_i \geq 0 \\
+ *                 \alpha_i x_i & \text{if } x_i < 0
+ *             \end{cases} \;,\;i=1,...,C
+ */
+message ActivationPReLU {
+
+    // parameter of length C or 1.
+    // If length is 1, same value is used for all channels
+    WeightParams alpha = 1;
+
+}
+
+/**
+ * An exponential linear unit (ELU) activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \begin{cases}
+ *             x              & \text{if } x \geq 0 \\
+ *             \alpha (e^x - 1) & \text{if } x < 0
+ *            \end{cases}
+ */
+message ActivationELU {
+
+    float alpha = 1;
+
+}
+
+/**
+ * A thresholded rectified linear unit (ReLU) activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \begin{cases}
+ *             x & \text{if } x \geq \alpha \\
+ *             0 & \text{if } x < \alpha
+ *            \end{cases}
+ */
+message ActivationThresholdedReLU {
+
+    float alpha = 1;
+
+}
+
+/**
+ * A softsign activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \dfrac{x}{1 + |x|}
+ */
+message ActivationSoftsign {
+
+}
+
+/**
+ * A softplus activation function.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \text{log}(1 + e^x)
+ */
+message ActivationSoftplus {
+
+}
+
+/**
+ * A parametric softplus activation function.
+ * Input must be at least rank 3. axis = -3 is denoted by "C", or channels.
+ * "alpha"/"beta" parameter can be a vector of length C.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x_i) = \alpha_i \text{log}(1 + e^{\beta_i x_i}) \;,\;i=1,...,C
+ */
+message ActivationParametricSoftplus {
+
+    // If length is 1, same value is used for all channels
+    WeightParams alpha = 1; //parameter of length C or 1
+    WeightParams beta = 2; //parameter of length C or 1
+
+}
+
+message ActivationParams {
+
+    oneof NonlinearityType {
+        ActivationLinear linear = 5;
+
+        ActivationReLU ReLU = 10;
+        ActivationLeakyReLU leakyReLU = 15;
+        ActivationThresholdedReLU thresholdedReLU = 20;
+        ActivationPReLU PReLU = 25;
+
+        ActivationTanh tanh = 30;
+        ActivationScaledTanh scaledTanh = 31;
+
+        ActivationSigmoid sigmoid = 40;
+        ActivationSigmoidHard sigmoidHard = 41;
+
+        ActivationELU ELU = 50;
+
+        ActivationSoftsign softsign = 60;
+        ActivationSoftplus softplus = 70;
+        ActivationParametricSoftplus parametricSoftplus = 71;
+    }
+
+}
+
+/**
+ * Representation of the intermediate tensors
+ */
+message Tensor {
+
+    // Number of dimensions in the tensor shape
+    uint32 rank = 1;
+    // actual value of the tensor shape.
+    // must be of length "rank". Can contain -1s for unknown dimensions.
+    repeated int64 dimValue = 2;
+
+}
+
+/**
+ * A single neural network layer.
+ */
+message NeuralNetworkLayer {
+
+    string name = 1; //descriptive name of the layer
+    repeated string input = 2;
+    repeated string output = 3;
+
+    repeated Tensor inputTensor = 4; // must be the same length as the "input" field
+    repeated Tensor outputTensor = 5; // must be the same length as the "output" field
+
+    // Must be set to true to mark the layer as updatable.
+    // If true, the weightParams in the layer's properties must also be set to updatable
+    // If false, the value of the isUpdatable parameter within the layer's weights are ignored
+    bool isUpdatable = 10;
+
+    oneof layer {
+
+        // Start at 100 here
+        ConvolutionLayerParams convolution = 100;
+
+        PoolingLayerParams pooling = 120;
+
+        ActivationParams activation = 130;
+
+        InnerProductLayerParams innerProduct = 140;
+        EmbeddingLayerParams embedding = 150;
+
+        // Normalization-related Layers
+        BatchnormLayerParams batchnorm = 160;
+        MeanVarianceNormalizeLayerParams mvn = 165;
+        L2NormalizeLayerParams l2normalize = 170;
+        SoftmaxLayerParams softmax = 175;
+        LRNLayerParams lrn = 180;
+
+        CropLayerParams crop = 190;
+        PaddingLayerParams padding = 200;
+        UpsampleLayerParams upsample = 210;
+
+        ResizeBilinearLayerParams resizeBilinear = 211;
+        CropResizeLayerParams cropResize = 212;
+
+        UnaryFunctionLayerParams unary = 220;
+
+        // Element-wise Operations
+        AddLayerParams add = 230;
+        MultiplyLayerParams multiply = 231;
+
+        AverageLayerParams average = 240;
+        ScaleLayerParams scale = 245;
+
+        BiasLayerParams bias = 250;
+        MaxLayerParams max = 260;
+        MinLayerParams min = 261;
+
+        DotProductLayerParams dot = 270;
+        ReduceLayerParams reduce = 280;
+        LoadConstantLayerParams loadConstant = 290;
+
+        // Data Reorganization
+        ReshapeLayerParams reshape = 300;
+        FlattenLayerParams flatten = 301;
+        PermuteLayerParams permute = 310;
+        ConcatLayerParams concat = 320;
+        SplitLayerParams split = 330;
+        SequenceRepeatLayerParams sequenceRepeat = 340;
+
+        ReorganizeDataLayerParams reorganizeData = 345;
+        SliceLayerParams slice = 350;
+
+        // Recurrent Layers
+        SimpleRecurrentLayerParams simpleRecurrent = 400;
+        GRULayerParams gru = 410;
+        UniDirectionalLSTMLayerParams uniDirectionalLSTM = 420;
+        BiDirectionalLSTMLayerParams biDirectionalLSTM = 430;
+
+        // Custom (user-implemented) Layer
+        CustomLayerParams custom = 500;
+
+        // Following layers are available only after Core ML Specification
+        // version >= 4 (iOS >= 13, macOS >= 10.15)
+
+        // Control Flow related Layers
+        CopyLayerParams copy = 600;
+        BranchLayerParams branch = 605;
+
+        LoopLayerParams loop = 615;
+        LoopBreakLayerParams loopBreak = 620;
+        LoopContinueLayerParams loopContinue = 625;
+
+        RangeStaticLayerParams rangeStatic = 635;
+        RangeDynamicLayerParams rangeDynamic = 640;
+
+        // Element-wise Unary Layers
+        ClipLayerParams clip = 660;
+        CeilLayerParams ceil = 665;
+        FloorLayerParams floor = 670;
+
+        SignLayerParams sign = 680;
+        RoundLayerParams round = 685;
+
+        Exp2LayerParams exp2 = 700;
+
+        SinLayerParams sin = 710;
+        CosLayerParams cos = 715;
+        TanLayerParams tan = 720;
+
+        AsinLayerParams asin = 730;
+        AcosLayerParams acos = 735;
+        AtanLayerParams atan = 740;
+
+        SinhLayerParams sinh = 750;
+        CoshLayerParams cosh = 755;
+        TanhLayerParams tanh = 760;
+
+        AsinhLayerParams asinh = 770;
+        AcoshLayerParams acosh = 775;
+        AtanhLayerParams atanh = 780;
+
+        ErfLayerParams erf = 790;
+        GeluLayerParams gelu = 795;
+
+        // Element-wise Binary with Broadcasting Support
+        EqualLayerParams equal = 815;
+        NotEqualLayerParams notEqual = 820;
+        LessThanLayerParams lessThan = 825;
+        LessEqualLayerParams lessEqual = 827;
+        GreaterThanLayerParams greaterThan = 830;
+        GreaterEqualLayerParams greaterEqual = 832;
+
+        LogicalOrLayerParams logicalOr = 840;
+        LogicalXorLayerParams logicalXor = 845;
+        LogicalNotLayerParams logicalNot = 850;
+        LogicalAndLayerParams logicalAnd = 855;
+
+        ModBroadcastableLayerParams modBroadcastable = 865;
+        MinBroadcastableLayerParams minBroadcastable = 870;
+        MaxBroadcastableLayerParams maxBroadcastable = 875;
+        AddBroadcastableLayerParams addBroadcastable = 880;
+        PowBroadcastableLayerParams powBroadcastable = 885;
+        DivideBroadcastableLayerParams divideBroadcastable = 890;
+        FloorDivBroadcastableLayerParams floorDivBroadcastable = 895;
+        MultiplyBroadcastableLayerParams multiplyBroadcastable = 900;
+        SubtractBroadcastableLayerParams subtractBroadcastable = 905;
+
+        // Tensor Manipulations
+        TileLayerParams tile = 920;
+        StackLayerParams stack = 925;
+        GatherLayerParams gather = 930;
+        ScatterLayerParams scatter = 935;
+        GatherNDLayerParams gatherND = 940;
+        ScatterNDLayerParams scatterND = 945;
+        SoftmaxNDLayerParams softmaxND = 950;
+        GatherAlongAxisLayerParams gatherAlongAxis = 952;
+        ScatterAlongAxisLayerParams scatterAlongAxis = 954;
+
+        ReverseLayerParams reverse = 960;
+        ReverseSeqLayerParams reverseSeq = 965;
+
+        SplitNDLayerParams splitND = 975;
+        ConcatNDLayerParams concatND = 980;
+        TransposeLayerParams transpose = 985;
+
+        SliceStaticLayerParams sliceStatic = 995;
+        SliceDynamicLayerParams sliceDynamic = 1000;
+        SlidingWindowsLayerParams slidingWindows = 1005;
+
+        TopKLayerParams topK = 1015;
+        ArgMinLayerParams argMin = 1020;
+        ArgMaxLayerParams argMax = 1025;
+
+        EmbeddingNDLayerParams embeddingND = 1040;
+        BatchedMatMulLayerParams batchedMatmul = 1045;
+
+        // Tensor Allocation / Reshape-related Operations
+        GetShapeLayerParams getShape = 1065;
+        LoadConstantNDLayerParams loadConstantND = 1070;
+
+        FillLikeLayerParams fillLike = 1080;
+        FillStaticLayerParams fillStatic = 1085;
+        FillDynamicLayerParams fillDynamic = 1090;
+
+        BroadcastToLikeLayerParams broadcastToLike = 1100;
+        BroadcastToStaticLayerParams broadcastToStatic = 1105;
+        BroadcastToDynamicLayerParams broadcastToDynamic = 1110;
+
+        SqueezeLayerParams squeeze = 1120;
+        ExpandDimsLayerParams expandDims = 1125;
+        FlattenTo2DLayerParams flattenTo2D = 1130;
+        ReshapeLikeLayerParams reshapeLike = 1135;
+        ReshapeStaticLayerParams reshapeStatic = 1140;
+        ReshapeDynamicLayerParams reshapeDynamic = 1145;
+        RankPreservingReshapeLayerParams rankPreservingReshape = 1150;
+
+        ConstantPaddingLayerParams constantPad = 1155;
+
+        // Random Distributions
+        RandomNormalLikeLayerParams randomNormalLike = 1170;
+        RandomNormalStaticLayerParams randomNormalStatic = 1175;
+        RandomNormalDynamicLayerParams randomNormalDynamic = 1180;
+
+        RandomUniformLikeLayerParams randomUniformLike = 1190;
+        RandomUniformStaticLayerParams randomUniformStatic = 1195;
+        RandomUniformDynamicLayerParams randomUniformDynamic = 1200;
+
+        RandomBernoulliLikeLayerParams randomBernoulliLike = 1210;
+        RandomBernoulliStaticLayerParams randomBernoulliStatic = 1215;
+        RandomBernoulliDynamicLayerParams randomBernoulliDynamic = 1220;
+
+        CategoricalDistributionLayerParams categoricalDistribution = 1230;
+
+        // Reduction-related Layers:
+        ReduceL1LayerParams reduceL1 = 1250;
+        ReduceL2LayerParams reduceL2 = 1255;
+        ReduceMaxLayerParams reduceMax = 1260;
+        ReduceMinLayerParams reduceMin = 1265;
+        ReduceSumLayerParams reduceSum = 1270;
+        ReduceProdLayerParams reduceProd = 1275;
+        ReduceMeanLayerParams reduceMean = 1280;
+        ReduceLogSumLayerParams reduceLogSum = 1285;
+        ReduceSumSquareLayerParams reduceSumSquare = 1290;
+        ReduceLogSumExpLayerParams reduceLogSumExp = 1295;
+
+        // Masking / Selection Layers
+        WhereNonZeroLayerParams whereNonZero = 1313;
+        MatrixBandPartLayerParams matrixBandPart = 1315;
+        LowerTriangularLayerParams lowerTriangular = 1320;
+        UpperTriangularLayerParams upperTriangular = 1325;
+        WhereBroadcastableLayerParams whereBroadcastable = 1330;
+
+        // Normalization Layers
+        LayerNormalizationLayerParams layerNormalization = 1350;
+
+        NonMaximumSuppressionLayerParams NonMaximumSuppression = 1400;
+
+        // Following layers are available only after Core ML Specification
+        // version >= 5 (iOS >= 14, macOS >= 11.0)
+        OneHotLayerParams oneHot = 1450;
+        CumSumLayerParams cumSum = 1455;
+        ClampedReLULayerParams clampedReLU = 1460;
+        ArgSortLayerParams argSort = 1461;
+        Pooling3DLayerParams pooling3d = 1465;
+        GlobalPooling3DLayerParams globalPooling3d = 1466;
+        SliceBySizeLayerParams sliceBySize = 1470;
+        Convolution3DLayerParams convolution3d = 1471;
+
+    }
+
+}
+
+/**
+ * Branching Layer
+ *
+ * A layer that provides the functionality of branching or an If-Else block.
+ *
+ * Must have 1 input. There are no outputs as the execution is transferred to either the
+ * if or the else branch based on the value of the input.
+ *
+ * Input is the condition predicate. Must be a scalar (length 1 tensor).
+ *
+ */
+message BranchLayerParams {
+
+    /**
+     * execute this graph if the absolute value of the input Tensor is greater than 1e-6
+     * This must be present.
+     */
+    NeuralNetwork ifBranch = 1;
+    /**
+     * execute this graph if the absolute value of the input Tensor is less than 1e-6
+     * This is optional.
+     */
+    NeuralNetwork elseBranch = 2;
+
+}
+
+/**
+ * Loop Layer
+ *
+ * A layer that provides the functionality of a "for" loop or a "while" loop.
+ *
+ * There are either no inputs or 1 input. When an input is present, it corresponds to the maximum loop count,
+ * in that case the value of the "maxLoopIterations" field is ignored. Input must be a scalar.
+ * (For description below, maxLoopIterations is assumed to be the value of the input, when its present)
+ *
+ * No outputs are produced. Blobs produced by the condition or the body network are visible in the scope of the overall network.
+ *
+ * "conditionNetwork" must produce a tensor with the name specified in the "conditionVar" field.
+ *
+ * There are 3 possible cases for determining the termination condition:
+ *
+ * Case 1:
+ *
+ * If there is no "conditionNetwork", in this case the layer corresponds to a pure for loop, which is run "maxLoopIterations" number of times.
+ * Equivalent pseudo-code:
+ *
+ * for loopIterator = 0 : maxLoopIterations
+ *      bodyNetwork()
+ *
+ *
+ * Case 2:
+ *
+ * "conditionNetwork" is present, and "maxLoopIterations" is 0 and there is no input,
+ * in this case the layer corresponds to a while loop. Equivalent pseudo-code:
+ *
+ * conditionVar = conditionNetwork()
+ * while conditionVar:
+ *      bodyNetwork()
+ *      conditionVar = conditionNetwork()
+ *
+ *
+ * Case 3:
+ *
+ * "conditionNetwork" is provided, and "maxLoopIterations" is positive or there is an input,
+ * in this case the layer corresponds to a while loop with a joint condition. Equivalent pseudo-code:
+ *
+ * loopIterator = 0
+ * conditionVar = conditionNetwork()
+ * while (conditionVar and loopIterator < maxLoopIterations):
+ *      bodyNetwork()
+ *      loopIterator = loopIterator + 1
+ *      conditionVar = conditionNetwork()
+ *
+ */
+message LoopLayerParams {
+
+    /**
+     * maximum number of iterations. Ignored if input is present.
+     */
+    uint64 maxLoopIterations = 1;
+    /**
+     * This field provides the name of the tensor which is produced by the conditionNetwork
+     * and whose value is checked to start/continue/terminate the loop. Value close to 0.0f is treated as False.
+     * This field is optional.
+     * Must be a non empty string if and only if "conditionNetwork" is present.
+     */
+    string conditionVar = 2;
+    /**
+     * Must generate a tensor with the name provided in the "conditionVar" field.
+     * This field is optional.
+     * Must be present if and only if "conditionVar" field is a non empty string.
+     */
+    NeuralNetwork conditionNetwork = 3;
+    /**
+     * Body of the loop.
+     * This field must be present.
+     */
+    NeuralNetwork bodyNetwork = 4;
+
+}
+
+/**
+ * Loop break Layer
+ *
+ * Terminate the loop that has this layer.
+ * If present, it should always reside in the "bodyNetwork" of the loop layer
+ *
+ * No inputs/outputs
+ *
+ */
+message LoopBreakLayerParams {
+
+}
+
+/**
+ * Loop Continue Layer
+ *
+ * Stop the current loop iteration and continue on the next iteration.
+ * If present, it should always reside in the "bodyNetwork" of the loop layer
+ *
+ * No inputs/outputs
+ *
+ */
+message LoopContinueLayerParams {
+
+}
+
+/**
+ * Copy Layer
+ *
+ * A layer that copies its input tensor to the output tensor.
+ * Must have 1 input and 1 output, with distinct names.
+ * This is the only layer that is allowed to re-generate an output that is already present in the neural network prior to this layer,
+ * in which case it will overwrite the output tensor.
+ *
+ */
+message CopyLayerParams {
+
+}
+
+/**
+ * GreaterThan Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise greater than operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 > x2
+ *          or
+ *      y = x1 > alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message GreaterThanLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 2;
+
+}
+
+/**
+ * GreaterEqual Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise greater equal operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 >= x2
+ *          or
+ *      y = x1 >= alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message GreaterEqualLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 2;
+
+}
+
+/**
+ * LessThan Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise less than operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 < x2
+ *          or
+ *      y = x1 < alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message LessThanLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 2;
+
+}
+
+/**
+ * LessEqual Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise less equal operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 <= x2
+ *          or
+ *      y = x1 <= alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message LessEqualLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 2;
+
+}
+
+/**
+ * Equal Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise equal operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 == x2
+ *          or
+ *      y = x1 == alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message EqualLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 1;
+
+}
+
+/**
+ * NotEqual Layer
+ *
+ * Either 1 or 2 inputs.
+ * Produces 1 output.
+ * Perform elementwise not equal operation.
+ *
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = x1 != x2
+ *          or
+ *      y = x1 != alpha, if only one input is provided
+ *
+ * Broadcasting is supported.
+ *
+ */
+message NotEqualLayerParams {
+
+    /**
+     * Compare to the scalar value provided here if there is 1 input
+     */
+    float alpha = 1;
+
+}
+
+/**
+ * LogicalAnd Layer
+ *
+ * Must have 2 inputs, produces 1 output.
+ * Perform elementwise logical AND operation.
+ *
+ * Input is considered False if equal to 0.0f otherwise True.
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = AND(x1, x2)
+ *
+ * Broadcasting is supported.
+ *
+ */
+message LogicalAndLayerParams {
+
+}
+
+/**
+ * LogicalOr Layer
+ *
+ * Must have 2 inputs, produces 1 output.
+ * Perform elementwise logical OR operation.
+ *
+ * Input is considered False if equal to 0.0f otherwise True.
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = OR(x1, x2)
+ *
+ * Broadcasting is supported.
+ *
+ */
+message LogicalOrLayerParams {
+
+}
+
+/**
+ * LogicalXor Layer
+ *
+ * Must have 2 inputs, produces 1 output.
+ * Perform elementwise logical XOR operation.
+ *
+ * Input is considered False if equal to 0.0f otherwise True.
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = XOR(x1, x2)
+ *
+ * Broadcasting is supported.
+ *
+ */
+message LogicalXorLayerParams {
+
+}
+
+/**
+ * LogicalNot Layer
+ *
+ * Must have 1 input, produces 1 output.
+ * Perform elementwise logical NOT operation.
+ *
+ * Input is considered False if equal to 0.0f otherwise True.
+ * Output is 1.0f if the condition is true otherwise 0.0f.
+ *
+ * .. code::
+ *
+ *      y = NOT(x)
+ *
+ *
+ */
+message LogicalNotLayerParams {
+
+}
+
+/// Border Amounts
+/// --------------
+
+/**
+ * Specifies the amount of spatial border to be either padded or cropped.
+ *
+ * For padding:
+ *
+ * .. code::
+ *
+ *     H_out = borderAmounts[0].startEdgeSize + H_in + borderAmounts[0].endEdgeSize
+ *     W_out = borderAmounts[1].startEdgeSize + W_in + borderAmounts[1].endEdgeSize
+ *
+ *     topPaddingAmount == Height startEdgeSize
+ *     bottomPaddingAmount == Height endEdgeSize
+ *     leftPaddingAmount == Width startEdgeSize
+ *     rightPaddingAmount == Width endEdgeSize
+ *
+ * For cropping:
+ *
+ * .. code::
+ *
+ *     H_out = (-borderAmounts[0].startEdgeSize) + H_in + (-borderAmounts[0].endEdgeSize)
+ *     W_out = (-borderAmounts[1].startEdgeSize) + W_in + (-borderAmounts[1].endEdgeSize)
+ *
+ *     topCropAmount == Height startEdgeSize
+ *     bottomCropAmount == Height endEdgeSize
+ *     leftCropAmount == Width startEdgeSize
+ *     rightCropAmount == Width endEdgeSize
+ */
+message BorderAmounts {
+
+    message EdgeSizes {
+        /**
+         * The amount to be padded or cropped from the beginning.
+         */
+        uint64 startEdgeSize = 1;
+
+        /**
+         * The amount to be padded or cropped from the end.
+         */
+        uint64 endEdgeSize = 2;
+    }
+
+    /**
+     * The border amounts.
+     * This must be length 2 in the order ``[H, W]``.
+     */
+    repeated EdgeSizes borderAmounts = 10;
+
+}
+
+/**
+ * Specifies the type of padding to be used with Convolution/Deconvolution and Pooling layers.
+ * After padding, input spatial shape: ``[H_in, W_in]``, gets modified to the
+ * output spatial shape ``[H_out, W_out]``.
+ *
+ * .. code::
+ *
+ *      topPaddingAmount == Height startEdgeSize == borderAmounts[0].startEdgeSize
+ *      bottomPaddingAmount == Height endEdgeSize == borderAmounts[0].endEdgeSize
+ *      leftPaddingAmount == Width startEdgeSize == borderAmounts[1].startEdgeSize
+ *      rightPaddingAmount == Width endEdgeSize == borderAmounts[1].endEdgeSize
+ *
+ * With Convolution or Pooling:
+ *
+ * .. code::
+ *
+ *    H_out = int_division_round_down((H_in + topPaddingAmount + bottomPaddingAmount - KernelSize[0]),stride[0]) + 1
+ *
+ * which is same as:
+ *
+ * .. code::
+ *
+ *    H_out = int_division_round_up((H_in + topPaddingAmount + bottomPaddingAmount - KernelSize[0] + 1),stride[0])
+ *
+ * With Deconvolution:
+ *
+ * .. code::
+ *
+ *    H_out = (H_in-1) * stride[0] + kernelSize[0] - (topPaddingAmount + bottomPaddingAmount)
+ *
+ *
+ * The equivalent expressions hold true for ``W_out`` as well.
+ *
+ *
+ * By default, the values of ``paddingAmounts`` are set to ``0``,
+ * which results in a "true" valid padding.
+ * If non-zero values are provided for ``paddingAmounts``,
+ * "valid" convolution/pooling is performed within the spatially expanded input.
+ *
+ */
+message ValidPadding {
+
+    BorderAmounts paddingAmounts = 1;
+
+}
+
+/**
+ * Specifies the type of padding to be used with Convolution/Deconvolution and pooling layers.
+ * After padding, input spatial shape: ``[H_in, W_in]``, gets modified to the
+ * output spatial shape ``[H_out, W_out]``.
+ * With Convolution or pooling:
+ *
+ * .. code::
+ *
+ *      H_out = int_division_round_up(H_in,stride[0])
+ *      W_out = int_division_round_up(W_in,stride[1])
+ *
+ * This is achieved by using the following padding amounts:
+ *
+ * .. code::
+ *
+ *     totalPaddingHeight = max(0,(H_out-1) * stride[0] + KernelSize[0] - Hin)
+ *     totalPaddingWidth = max(0,(W_out-1) * stride[1] + KernelSize[1] - Win)
+ *
+ * There are two modes of asymmetry:
+ * ``BOTTOM_RIGHT_HEAVY``, and ``TOP_LEFT_HEAVY``.
+ *
+ * If the mode is ``BOTTOM_RIGHT_HEAVY``:
+ *
+ * .. code::
+ *
+ *     topPaddingAmount = floor(totalPaddingHeight / 2)
+ *     bottomPaddingAmount = totalPaddingHeight - topPaddingAmount
+ *     leftPaddingAmount = floor(totalPaddingWidth / 2)
+ *     rightPaddingAmount = totalPaddingWidth - leftPaddingAmount
+ *
+ * If the mode is ``TOP_LEFT_HEAVY``:
+ *
+ * .. code::
+ *
+ *     bottomPaddingAmount = floor(totalPaddingHeight / 2)
+ *     topPaddingAmount = totalPaddingHeight - bottomPaddingAmount
+ *     rightPaddingAmount = floor(totalPaddingWidth / 2)
+ *     leftPaddingAmount = totalPaddingWidth - rightPaddingAmount
+ *
+ *
+ * With Deconvolution:
+ *
+ * .. code::
+ *
+ *    H_out = H_in * stride[0]
+ *    W_out = W_in * stride[1]
+ */
+message SamePadding {
+
+    enum SamePaddingMode {
+
+        BOTTOM_RIGHT_HEAVY = 0;
+        TOP_LEFT_HEAVY = 1;
+
+    }
+    SamePaddingMode asymmetryMode = 1;
+
+}
+
+/**
+ * Specifies how grid points are sampled from an interval.
+ * Without the loss of generality, assume the interval to be [0, X-1] from which N points are to be sampled.
+ * Here X may correspond to an input image's height or width.
+ * All the methods can be expressed in terms of numpy's linspace function, along with the constraint that grid points have to lie in the interval [0, X-1].
+ * Note: numpy.linspace(start = start, end = end, num = N, endpoint = True) corresponds to sampling
+ * N points uniformly from the interval [start, end], endpoints included.
+ * The methods vary in how the ``start`` and ``end`` values are computed.
+ */
+message SamplingMode {
+
+    enum Method {
+
+        /**
+         * start = 0, end = X-1
+         * grid points = numpy.linspace(start, end)
+         */
+        STRICT_ALIGN_ENDPOINTS_MODE = 0;
+
+        /**
+         * if N == 1: start = end = (X-1)/2
+         * otherwise, start = 0, end = X-1
+         * grid points = numpy.linspace(start, end)
+         */
+        ALIGN_ENDPOINTS_MODE = 1;
+
+        /**
+         * start = 0, end = X - X/N
+         * grid points = min(X-1, numpy.linspace(start, end))
+         * This is same as the mode used in the upsample layer in this specification, when used with bilinear interpolation. In that case N/X = upsample ratio.
+         */
+        UPSAMPLE_MODE = 2;
+
+        /**
+         * spacing = max(1, X-1)/N
+         * start = 0.5 * spacing
+         * end = start + (N-1) * spacing
+         * grid points = min(X-1, numpy.linspace(start, end))
+         */
+        ROI_ALIGN_MODE = 3;
+
+    }
+
+    Method samplingMethod = 1;
+
+}
+
+/**
+ * Specifies the convention used to specify four bounding box coordinates for an image of size (Height, Width).
+ * The (0,0) coordinate corresponds to the top-left corner of the image.
+ */
+message BoxCoordinatesMode {
+
+    enum Coordinates {
+
+        /**
+         * [h_start, w_start, h_end, w_end]
+         */
+        CORNERS_HEIGHT_FIRST = 0;
+
+        /**
+         * [w_start, h_start, w_end, h_end]
+         */
+        CORNERS_WIDTH_FIRST = 1;
+
+        /**
+         * [h_center, w_center, box_height, box_width]
+         */
+        CENTER_SIZE_HEIGHT_FIRST = 2;
+
+        /**
+         * [w_center, h_center, box_width, box_height]
+         */
+        CENTER_SIZE_WIDTH_FIRST = 3;
+
+    }
+
+    Coordinates boxMode = 1;
+
+}
+
+/**
+ * Weights for layer parameters.
+ * Weights are stored as repeated floating point numbers
+ * using row-major ordering
+ * and can represent 1-, 2-, 3-, or 4-dimensional data.
+ */
+message WeightParams {
+
+    /**
+     * Values specified in single / float / FP32 precision.
+     */
+    repeated float floatValue = 1;
+
+    /**
+     * Values in 16-bit half precision floating point.
+     */
+    bytes float16Value = 2;
+
+    /**
+     * Raw value specification for quantized lower precisions.
+     *
+     * This field is interpreted as uintN, where N is the number of bits in quantization.
+     * E.g. if n=8, the field is interpreted as an array of UINT8.
+     * Use this field for quantized parameters unless specifically noted to use
+     * int8RawValue.
+     */
+    bytes rawValue = 30;
+
+    /**
+     * Field to be used if int8DynamicQuantize is set in the parent layer.
+     * Cannot be set if rawValue is also set.
+     * The values in this field are interpreted as INT8.
+     *
+     * If this field is set, following conditions must hold true:
+     * * QuantizationType == LinearQuantizationParams, such that
+     *   * size of the "scale" field is 1 and "bias" field is empty in "LinearQuantizationParams"
+     */
+    bytes int8RawValue = 31;
+
+    /**
+     * Quantization related parameters.
+     */
+    QuantizationParams quantization = 40;
+
+    bool isUpdatable = 50;
+
+}
+
+/**
+ * Quantization parameters.
+ */
+message QuantizationParams {
+
+    uint64 numberOfBits = 1;
+    oneof QuantizationType {
+        LinearQuantizationParams linearQuantization = 101;
+        LookUpTableQuantizationParams lookupTableQuantization = 102;
+    }
+
+}
+
+message LinearQuantizationParams {
+
+    /**
+     * Stores scale and bias values corresponding to the quantized weights.
+     * Must be an array of 1 element, or an array of C elements, where C
+     * is number of output channels. For recurrent layers it is equal to
+     * the output vector size.
+     *
+     * Relationship between quantized weights, unquantized weights, scale and bias:
+     *
+     * W_unquantized = W_quantized * scale + bias
+     *
+     */
+    repeated float scale = 1;
+    repeated float bias = 2;
+
+}
+
+message LookUpTableQuantizationParams {
+
+    /* Stores look-up table quantization values. Must be an array of
+    (2^numberOfBits) Elements.
+    */
+    repeated float floatValue = 1;
+
+}
+
+/// Layers
+/// ------
+
+/**
+ * A layer that performs spatial convolution or deconvolution.
+ *
+ * .. code::
+ *
+ *      y = ConvolutionLayer(x)
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ *
+ * Input
+ *    First Input:
+ *      A blob with rank greater than or equal to 4.
+ *      Rank 4 blob represents [Batch, channels, height, width].
+ *      For ranks greater than 4, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ *     From Core ML specification version 4 onwards (iOS >= 13, macOS >= 10.15).
+ *     convolution layer can have 2 inputs, in which case the second input is
+ *     the blob representing the weights. This is allowed when "isDeconvolution" = False.
+ *     The weight blob should have shape
+ *     ``[outputChannels, kernelChannels, kernelHeight, kernelWidth]``,
+ *     where kernelChannels == inputChannels / nGroups.
+ *
+ * Output
+ *   Rank is same as the input. e.g.: for rank 4 input, output shape is [B, C_out, H_out, W_out]
+ *
+ *
+ * If ``dilationFactor`` is not 1, effective kernel size is
+ * modified as follows:
+ *
+ * .. code::
+ *
+ *      KernelSize[0] <-- (kernelSize[0]-1) * dilationFactor[0] + 1
+ *      KernelSize[1] <-- (kernelSize[1]-1) * dilationFactor[1] + 1
+ *
+ * Type of padding can be ``valid`` or ``same``. Output spatial dimensions depend on the
+ * the type of padding. For details, refer to the descriptions of the messages "ValidPadding"
+ * and "SamePadding". Padded values are all zeros.
+ *
+ * For Deconvolution, ``ConvolutionPaddingType`` (``valid`` or ``same``) is ignored when ``outputShape`` is set.
+ *
+ *
+ */
+message ConvolutionLayerParams {
+
+    /**
+     * The number of kernels.
+     * Same as ``C_out`` used in the layer description.
+     */
+    uint64 outputChannels = 1;
+
+    /**
+     * Channel dimension of the kernels.
+     * Must be equal to ``inputChannels / nGroups``, if isDeconvolution == False
+     * Must be equal to ``inputChannels``, if isDeconvolution == True
+     */
+    uint64 kernelChannels = 2;
+
+    /**
+     * Group convolution, i.e. weight reuse along channel axis.
+     * Input and kernels are divided into g groups
+     * and convolution / deconvolution is applied within the groups independently.
+     * If not set or 0, it is set to the default value 1.
+     */
+    uint64 nGroups = 10;
+
+    /**
+     * Must be length 2 in the order ``[H, W]``.
+     * If not set, default value ``[3, 3]`` is used.
+     */
+    repeated uint64 kernelSize = 20;
+
+    /**
+     * Must be length 2 in the order ``[H, W]``.
+     * If not set, default value ``[1, 1]`` is used.
+     */
+    repeated uint64 stride = 30;
+
+    /**
+     * Must be length 2 in order ``[H, W]``.
+     * If not set, default value ``[1, 1]`` is used.
+     * It is ignored if ``isDeconvolution == true``.
+     */
+    repeated uint64 dilationFactor = 40;
+
+    /**
+     * The type of padding.
+     */
+    oneof ConvolutionPaddingType {
+        ValidPadding valid = 50;
+        SamePadding same = 51;
+    }
+
+    /**
+     * Flag to specify whether it is a deconvolution layer.
+     */
+    bool isDeconvolution = 60;
+
+    /**
+     * Flag to specify whether a bias is to be added or not.
+     */
+    bool hasBias = 70;
+
+    /**
+     * Weights associated with this layer.
+     * If convolution (``isDeconvolution == false``), weights have the shape
+     * ``[outputChannels, kernelChannels, kernelHeight, kernelWidth]``, where kernelChannels == inputChannels / nGroups
+     * If deconvolution (``isDeconvolution == true``) weights have the shape
+     * ``[kernelChannels, outputChannels / nGroups, kernelHeight, kernelWidth]``, where kernelChannels == inputChannels
+     */
+    WeightParams weights = 90;
+    WeightParams bias = 91; /// Must be of size [outputChannels].
+
+    /**
+     * The output shape, which has length 2 ``[H_out, W_out]``.
+     * This is used only for deconvolution (``isDeconvolution == true``).
+     * If not set, the deconvolution output shape is calculated
+     * based on ``ConvolutionPaddingType``.
+     */
+    repeated uint64 outputShape = 100;
+
+}
+
+/**
+ * A layer that performs a 3-dimensional convolution.
+ *
+ * .. code::
+ *
+ *      y = Convolution3DLayer(x)
+ *
+ * Input
+ *    A blob of rank 5.
+ *    The input blob's shape should be ``[batch, channels, depth, height, width]``.
+ *
+ * Fields
+ *   The bias field, if set, should have shape of ``[channelsOut]``.
+ *
+ * Output
+ *   A blob of rank 5.
+ *   The output blob's shape is ``[batch, channelsOut, depthOut, heightOut, widthOut]``.
+ *
+ * Type of padding can be ``custom``, ``valid``, or ``same``. Padded values are all zeros.
+ * Output spatial dimensions depend on the the type of padding. For details, refer to the
+ * descriptions of the ``PaddingType`` field of this ``Convolution3DLayerParams`` message.
+ *
+ * Example
+ *   For example, given an input of size ``[1, 3, 3, 8, 8]``, a stride of 2 in each dimension,
+ *   a kernel of 3 in each dimension, 2 output channels, and ``same`` padding, this layer will
+ *   compute the total padding applied in the depth, height, and width dimensions to be 2, 1, and 1,
+ *   respectively. The depth padding is even and will be applied equally to both sides of the depth
+ *   dimension. Since the height and width padding values are odd, they'll be applied to the
+ *   bottom/right of the height/width dimensions. Thus, the padding applied to the input will be
+ *   ``[1, 1, 0, 1, 0, 1]`` (front, back, top, bottom, left, right). Finally, the output produced
+ *   will have size ``[1, 2, 2, 4, 4]``.
+ *
+ */
+message Convolution3DLayerParams {
+
+    /**
+     * The number of channels in the output (channelsOut). Must be a positive integer.
+     */
+    int32 outputChannels = 1;
+
+    /**
+     * The number of channels in the input (channels). Must be a positive integer.
+     */
+    int32 inputChannels = 2;
+
+    /**
+    * Group convolution, i.e., weight reuse along the channel axis.
+    * It must evenly divide both the number of input and output channels and be at most the number
+    * of input channels (a depthwise convolution).
+    * Input and kernels are divided into g groups and convolution is applied within the groups
+    * independently.
+    */
+    int32 nGroups = 10;
+
+    /* Depth of the convolution kernel. Must be a positive integer.
+     */
+    int32 kernelDepth = 20;
+
+    /* Height of the convolution kernel. Must be a positive integer.
+     */
+    int32 kernelHeight = 21;
+
+    /* Width of the convolution kernel. Must be a positive integer.
+     */
+    int32 kernelWidth = 22;
+
+    /* Stride along the depth direction. Must be a positive integer.
+     */
+    int32 strideDepth = 31;
+
+    /* Stride along the height direction. Must be a positive integer.
+     */
+    int32 strideHeight = 32;
+
+    /* Stride along the width direction. Must be a positive integer.
+     */
+    int32 strideWidth = 33;
+
+    /* Dilation along the depth direction. Must be a positive integer.
+     */
+    int32 dilationDepth = 40;
+
+    /* Dilation along the height direction. Must be a positive integer.
+     */
+    int32 dilationHeight = 41;
+
+    /* Dilation along the width direction. Must be a positive integer.
+     */
+    int32 dilationWidth = 42;
+
+    /**
+     * Flag to specify whether a bias is to be added or not.
+     * If false, then no bias is added.
+     */
+    bool hasBias = 50;
+
+    /**
+     * Weights associated with this layer.
+     * Weights have the shape
+     * if deconvolution == False
+     * ``[outputChannels, kernelChannels, kernelDepth, kernelHeight, kernelWidth]``, where
+     * kernelChannels == inputChannels / nGroups
+     * else if deconvolution == True
+     * ``[outputChannels / nGroups, kernelChannels, kernelDepth, kernelHeight, kernelWidth]``, where
+     */
+    WeightParams weights = 60;
+
+    /**
+     * Must be of size ``[outputChannels]``.
+     */
+    WeightParams bias = 61;
+
+
+    /**
+     * The type of padding.
+     * All padding types pad the input shape with zeros.
+     * CUSTOM padding will add the custom padding values specified below to their respective
+     * dimensions, e.g., `customPaddingFront` number of zeros will be added to one side of the
+     * input's depth dimension and `customPaddingBack` number of zeros will be added to the other
+     * side of the input's depth dimension.
+     * VALID padding adds no padding to any dimension. In this case, the last convolution along
+     * each dimension will be dropped if the input dimension and the kernel size, stride, and
+     * dilation do not match.
+     * SAME padding adds enough padding to each dimension such that the output of the convolution
+     * has size ``Ceiling(inputShape / stride)``. Padding is added evenly to both sides of each
+     * dimension unless the total padding to add is odd, in which case it is added to the
+     * back/bottom/right side of the respective dimension. For example, if the total padding needed
+     * in the depth dimension is 3, 1 zero will be added to the front side of the depth dimension
+     * and 2 zeros will be added to the back side.
+     */
+    enum PaddingType {
+        CUSTOM = 0;
+        VALID = 1;
+        SAME = 2;
+    }
+    PaddingType paddingType = 70;
+
+    /* Padding before the input in the depth direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingFront = 80;
+
+    /* Padding after the input in the depth direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingBack = 81;
+
+    /* Padding before the input in the height direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingTop = 82;
+
+    /* Padding after the input in the height direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingBottom = 83;
+
+    /* Padding before the input in the width direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingLeft = 84;
+
+    /* Padding after the input in the width direction. Must be zero or a positive integer.
+     * Used when the `PaddingType` is `CustomPadding`, otherwise ignored by other padding types.
+     */
+    int32 customPaddingRight = 85;
+    
+    /* Flag to specify if this is Convolution Transpose or not.
+     */
+    bool isDeconvolution = 86;
+    
+    /*
+     * The output shape, which has length 3 ``[D_out, H_out, W_out]``.
+     * This is used only for deconvolution (``isDeconvolution == true``).
+     * If not set, the deconvolution output shape is calculated
+     * based on ``PaddingType``.
+     */
+    repeated uint64 outputShape = 87;
+
+}
+
+/**
+ * A layer that performs a matrix-vector or matrix-matrix product.
+ * This is equivalent to a fully-connected, or dense layer.
+ * The weight parameters correspond to a matrix of dimensions (inputChannels, outputChannels) i.e. (C_in, C_out)
+ *
+ * .. code::
+ *
+ *      y = InnerProductLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *      Input can have rank 1 to rank 5. This is how it is reshaped in to the matrix (for rank > 1):
+ *      rank 1 (x1) : in this case, the layer corresponds to a matrix-vector product. x1 must be equal to C_in
+ *      rank 2 (x1, x2): x2 must be equal to C_in
+ *      rank 3 (x1, x2, x3) --> (x1 * x2, x3). x3 must be equal to C_in
+ *      rank 4 (x1, x2, x3, x4) ---> (x1, x2 * x3 * x4). x2 * x3 * x4 must be equal to C_in
+ *      rank 5 (x1, x2, x3, x4, x5) ---> (x1 * x2, x3 * x4 * x5). x3 * x4 * x5 must be equal to C_in
+ *
+ * Output
+ *      Output rank is same as the input rank
+ *      rank 1: (C_out)
+ *      rank 2: (x1, C_out)
+ *      rank 3: (x1, x2, C_out)
+ *      rank 4: (x1, C_out, 1, 1)
+ *      rank 5: (x1, x2, C_out, 1, 1)
+ *
+ */
+message InnerProductLayerParams {
+
+    uint64 inputChannels = 1; /// Input size: C_in.
+    uint64 outputChannels = 2; /// Output size: C_out.
+
+    bool hasBias = 10; /// Whether a bias is added or not.
+
+    WeightParams weights = 20; /// Weight matrix [C_out, C_in].
+    WeightParams bias = 21; /// Bias vector [C_out].
+
+    /**
+     * If set, this layer, at runtime, quantizes the floating point input blob to int8 before applying an
+     * inner product using INT8 weight matrix parameters, as provided in weights->int8RawValue. The
+     * result is then dequantized.
+     * Requires:
+     * * hasBias == false
+     * * QuantizationType == LinearQuantizationParams, such that
+     *   * size of the "scale" field is 1 and "bias" field is empty in "LinearQuantizationParams"
+     * * numberOfBits == 8
+     * * weights->rawValue_size to be empty
+     */
+    bool int8DynamicQuantize = 22;
+
+}
+
+/**
+ * A layer that performs a matrix lookup and optionally adds a bias.
+ * The weights matrix is stored with dimensions [outputChannels, inputDim].
+ *
+ * .. code::
+ *
+ *      y = EmbeddingLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     Input values must be in the range ``[0, inputDim - 1]``.
+ *
+ *     Input must have rank equal to 4 or 5, such that the last 3 dimensions are all 1.
+ *     rank 4: shape (x1, 1, 1, 1). x1 is effectively the batch/sequence length.
+ *     rank 5: shape (x1, x2 , 1, 1, 1). x1 * x2 is effectively the combined batch/sequence length.
+ *
+ * Output
+ *      Output rank is same as the input rank. Please see input description above.
+ *      rank 4: shape (x1, outputChannels, 1, 1)
+ *      rank 5: shape (x1, x2, outputChannels, 1, 1)
+ *
+ */
+message EmbeddingLayerParams {
+
+    uint64 inputDim = 1; /// Size of the input dictionary.
+    uint64 outputChannels = 2; /// Size of the output vectors.
+
+    bool hasBias = 10; /// Whether a bias is added or not.
+
+    WeightParams weights = 20; /// 2-D weights of dimensions [outputChannels, inputDim].
+    WeightParams bias = 21; /// Bias of size [outputChannels].
+
+}
+
+/**
+ * A layer that performs a matrix lookup and optionally adds a bias.
+ * The weights matrix is stored with dimensions [embeddingSize, vocabSize].
+ *
+ * .. code::
+ *
+ *      y = EmbeddingNDLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     Input values must be in the range ``[0, vocabSize - 1]``.
+ *     Input must have rank at least 2. The last dimension must always be 1.
+ *     rank 2: shape (x1, 1). x1 is the batch/sequence length.
+ *     rank 3: shape (x1, x2, 1). x1 * x2 is effectively the combined batch/sequence length.
+ *     rank 4: shape (x1, x2, x3, 1). x1 * x2 * x2 is effectively the combined batch/sequence length.
+ *     rank 5: shape (x1, x2 , x3, x4, 1). x1 * x2 * x3 * x4 is effectively the combined batch/sequence length.
+ *
+ * Output
+ *      Output rank is same as the input rank. Please see input description above.
+ *      rank 2: shape (x1, embeddingSize)
+ *      rank 3: shape (x1, x2, embeddingSize)
+ *      rank 4: shape (x1, x2, x3, embeddingSize)
+ *      rank 5: shape (x1, x2, x3, x4, embeddingSize)
+ *
+ */
+message EmbeddingNDLayerParams {
+
+    uint64 vocabSize = 1; /// Size of the input dictionary.
+    uint64 embeddingSize = 2; /// Size of the output vectors.
+    bool hasBias = 3; /// Whether a bias is added or not.
+    WeightParams weights = 20; /// 2-D weights of dimensions [embeddingSize, vocabSize].
+    WeightParams bias = 21; /// Bias of size [embeddingSize].
+
+}
+
+/**
+ * A layer that performs batch normalization,
+ * which is performed along axis = -3,
+ * and repeated along the other axes, if present.
+ *
+ * .. code::
+ *
+ *      y = BatchnormLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * This operation is described by the following formula:
+ *
+ * .. math::
+ *     y_i = \gamma_i \dfrac{ (x_i - \mu_i)}{\sqrt{\sigma_i^2 + \epsilon}} + \beta_i \;,\;i=1,....,C
+ *
+ * Input
+ *     A blob with rank greater than equal to 3.
+ *     Example: Rank 4 blob represents [Batch, channels, height, width]
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     A blob with the same shape as the input.
+ */
+message BatchnormLayerParams {
+
+    uint64 channels = 1; /// Size of the channel dimension in the input.
+
+    /**
+     * If ``computeMeanVar == true``,
+     * the mean and variance are calculated from either
+     * the single input instance, if ``instanceNormalization == true``,
+     * or the whole batch, if ``instanceNormalization = false``.
+     * and the values provided in parameters "mean" and "variance" are ignored.
+     */
+    bool computeMeanVar = 5;
+    bool instanceNormalization = 6;
+
+    /**
+     * A small constant to avoid division by 0 while normalizing by variance.
+     * Defaults to ``1e-5`` if not set or set to ``0``.
+     */
+    float epsilon = 10;
+
+    WeightParams gamma = 15; /// Parameter of length [channels]
+    WeightParams beta = 16; /// Parameter of length [channels]
+    WeightParams mean = 17; /// Parameter of length [channels]
+    WeightParams variance = 18; /// Parameter of length [channels]
+
+}
+
+/**
+ * A spatial pooling layer.
+ *
+ * .. code::
+ *
+ *      y = PoolingLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank greater than equal to 4.
+ *     Rank 4 blob represents [Batch, channels, height, width]
+ *     For ranks greater than 4, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     Rank is same as the input. e.g.: for rank 4 input, output shape is [B, C, H_out, W_out]
+ *
+ * Padding options are similar to ``ConvolutionLayerParams``
+ * with the additional option of ``ValidCompletePadding`` (``includeLastPixel``),
+ * which ensures that the last application of the kernel
+ * always includes the last pixel of the input image, if there is padding.
+ *
+ * .. code::
+ *
+ *     H_out = ceil(float(H_in + 2 * paddingAmounts[0] - kernelSize[0])/float(Stride[0])) + 1
+ *     if (paddingAmounts[0] > 0 or paddingAmounts[1] > 0)
+ *          if ((H_out - 1) * Stride >= H_in + paddingAmounts[0]) {
+ *              H_out = H_out - 1
+ *          }
+ *     }
+ *
+ * The equivalent expressions hold true for ``W_out`` as well.
+ * Only symmetric padding is supported with this option.
+ */
+message PoolingLayerParams {
+
+    enum PoolingType {
+
+        MAX = 0;
+        AVERAGE = 1;
+        L2 = 2;
+
+    }
+    PoolingType type = 1; /// Type of pooling operation.
+
+    /**
+     * Must be length 2 in the order ``[H, W]``.
+     * If not set, default value ``[3, 3]`` is used.
+     */
+    repeated uint64 kernelSize = 10;
+
+    /**
+     * Must be length 2 in the order ``[H, W]``.
+     * If not set, default value ``[1, 1]`` is used.
+     */
+    repeated uint64 stride = 20;
+
+    message ValidCompletePadding {
+
+        /**
+         * Must be length 2 in order ``[H, W]``.
+         * If not set, value ``[0, 0]`` is used.
+         */
+        repeated uint64 paddingAmounts = 10;
+
+    }
+
+    oneof PoolingPaddingType {
+        ValidPadding valid = 30;
+        SamePadding same = 31;
+        ValidCompletePadding includeLastPixel = 32;
+    }
+
+    /**
+     * If true, padded values are excluded from the count (denominator)
+     * when computing average pooling.
+     */
+    bool avgPoolExcludePadding = 50;
+
+    /**
+     * If true, global pooling is performed.
+     * Kernel size is inferred from the input data spatial dimensions.
+     */
+    bool globalPooling = 60;
+
+}
+
+/*
+ * A layer to pool three spatial dimensions
+ *
+ * Input
+ *      A blob with rank equal to 5, representing [Batch, channels, depth, height, width].
+ *
+ * Output
+ *      Rank is same as the input: A blob with rank equal to 5, representing [Batch, channels, depth, height, width].
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * For example, given an input of shape (1,1,2,3,3):
+ *        +----+----+----+
+ *      / | 10 | 11 | 12 |
+ *     /  +----+----+----+
+ *    /   | 13 | 14 | 15 |
+ *   /    +----+----+----+
+ *  /     | 16 | 17 | 18 |
+ * /      +----+----+----+
+ * +----+----+----+      /
+ * |  1 |  2 |  3 |     /
+ * +----+----+----+    /
+ * |  4 |  5 |  6 |   /
+ * +----+----+----+  /
+ * |  7 |  8 |  9 | /
+ * +----+----+----+
+ *
+ * And applying MAX pooling using:
+ *      Kernel: 2x2x2
+ *      Stride: 1x1x1
+ *      Valid Padding
+ * We expect to get an output with shape: (1,1,1,2,2) and value:
+ * +----+----+
+ * | 14 | 15 |
+ * +----+----+
+ * | 17 | 18 |
+ * +----+----+
+ */
+message Pooling3DLayerParams {
+    
+    enum PoolingType3D {
+        MAX = 0;
+        AVERAGE = 1;
+    }
+    
+    // Whether to use Max or Average
+    PoolingType3D type = 1;
+    
+    // Depth of the pooling region.
+    int32 kernelDepth = 2;
+    
+    // Height of the pooling region.
+    int32 kernelHeight = 3;
+    
+    // Width of the pooling region.
+    int32 kernelWidth = 4;
+    
+    // Stride along the depth direction
+    int32 strideDepth = 5;
+    
+    // Stride along the height direction
+    int32 strideHeight = 6;
+    
+    // Stride along the width direction
+    int32 strideWidth = 7;
+    
+    /**
+     * The type of padding.
+     * All padding types pad the input shape with zeros.
+     * CUSTOM padding will add the custom padding values specified below to their respective
+     * dimensions, e.g., `customPaddingFront` number of zeros will be added to one side of the
+     * input's depth dimension and `customPaddingBack` number of zeros will be added to the other
+     * side of the input's depth dimension.
+     * VALID padding adds no padding to any dimension. In this case, the last pool along
+     * each dimension will be dropped if the input dimension and the kernel size, and stride do not match.
+     * SAME padding adds enough padding to each dimension such that the output
+     * has the same spatial dimensions as the input. Padding is added evenly to both
+     * sides of each dimension unless the total padding to add is odd, in which case the extra padding
+     * is added to the back/bottom/right side of the respective dimension.  For example, if the the
+     * total horizontal padding is 3, then there will be 1 padding on the left, and 2 padding on the right.
+     */
+    enum Pooling3DPaddingType {
+        CUSTOM = 0;
+        VALID = 1;
+        SAME = 2;
+    }
+    Pooling3DPaddingType paddingType = 15;
+    
+    // Padding before the input in the depth direction.
+    int32 customPaddingFront = 8;
+    
+    // Padding after the input in the depth direction.
+    int32 customPaddingBack = 9;
+    
+    // Padding before the input in the height direction.
+    int32 customPaddingTop = 10;
+    
+    // Padding after the input in the height direction.
+    int32 customPaddingBottom = 11;
+    
+    // Padding before the input in the width direction.
+    int32 customPaddingLeft = 12;
+    
+    // Padding after the input in the width direction.
+    int32 customPaddingRight = 13;
+    
+    // If true, exclude zeros from padding in Average pooling.  Meaningless in Max Pooling.
+    bool countExcludePadding = 14;
+}
+
+/*
+ * A layer to pool three spatial dimensions down to one value.
+ * This behaves like a special case of Pooling3DLayerParams in which
+ * the Kernel is the size of the input and there is no padding.
+ *
+ * Input
+ *      A blob with rank equal to 5, representing [Batch, channels, depth, height, width].
+ *
+ * Output
+ *      Rank is same as the input: A blob with rank equal to 5, representing [Batch, channels, depth, height, width].
+ *      Depth, height, and width of the output will always be 1.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * For example, given an input of shape (1,1,2,3,3):
+ *        +----+----+----+
+ *      / | 10 | 11 | 12 |
+ *     /  +----+----+----+
+ *    /   | 13 | 14 | 15 |
+ *   /    +----+----+----+
+ *  /     | 16 | 17 | 18 |
+ * /      +----+----+----+
+ * +----+----+----+      /
+ * |  1 |  2 |  3 |     /
+ * +----+----+----+    /
+ * |  4 |  5 |  6 |   /
+ * +----+----+----+  /
+ * |  7 |  8 |  9 | /
+ * +----+----+----+
+ *
+ * And applying MAX global 3d pooling, we expect to get an output with shape: (1,1,1,1,1) and value:
+ * +----+
+ * | 18 |
+ * +----+
+ */
+message GlobalPooling3DLayerParams {
+    
+    enum GlobalPoolingType3D {
+        MAX = 0;
+        AVERAGE = 1;
+    }
+    
+    // Whether to use Max or Average
+    GlobalPoolingType3D type = 1;
+}
+
+/**
+ * A layer that performs padding along spatial dimensions.
+ *
+ * .. code::
+ *
+ *      y = PaddingLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 2.
+ *     e.g.: blob with shape ``[H_in, W_in]``.
+ *     For ranks greater than 2, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch
+ *     i.e. Padding is applied on last two dimensions.
+ *
+ * Output
+ *     Same rank as the input.
+ *     e.g.: blob with shape ``[H_out, W_out]``.
+ *
+ * Output dimensions are calculated as follows:
+ *
+ * .. code::
+ *
+ *     H_out = H_in + topPaddingAmount + bottomPaddingAmount
+ *     W_out = W_in + leftPaddingAmount + rightPaddingAmount
+ *
+ *     topPaddingAmount == Height startEdgeSize == borderAmounts[0].startEdgeSize
+ *     bottomPaddingAmount == Height endEdgeSize == borderAmounts[0].endEdgeSize
+ *     leftPaddingAmount == Width startEdgeSize == borderAmounts[1].startEdgeSize
+ *     rightPaddingAmount == Width endEdgeSize == borderAmounts[1].endEdgeSize
+ *
+ * There are three types of padding:
+ *
+ * - ``PaddingConstant``, which fills a constant value at the border.
+ * - ``PaddingReflection``, which reflects the values at the border.
+ * - ``PaddingReplication``, which replicates the values at the border.
+ *
+ * Given the following input:
+ *
+ * .. code::
+ *
+ *     [1, 3, 4]  :  1   2   3   4
+ *                   5   6   7   8
+ *                   9   10  11  12
+ *
+ * Here is the output of applying the padding
+ * ``(top=2, left=2, bottom=0, right=0)``
+ * with each of the supported types:
+ *
+ * - ``PaddingConstant`` (``value = 0``):
+ *   .. code::
+ *
+ *       [1, 5, 6]  :  0   0   0  0   0   0
+ *                     0   0   0  0   0   0
+ *                     0   0   1  2   3   4
+ *                     0   0   5  6   7   8
+ *                     0   0   9  10  11  12
+ *
+ * - ``PaddingReflection``:
+ *   .. code::
+ *
+ *       [1, 5, 6]  :  11  10  9  10  11  12
+ *                     7   6   5  6   7   8
+ *                     3   2   1  2   3   4
+ *                     7   6   5  6   7   8
+ *                     11  10  9  10  11  12
+ *
+ * - ``PaddingReplication``:
+ *   .. code::
+ *
+ *       [1, 5, 6]  :  1   1   1  2   3   4
+ *                     1   1   1  2   3   4
+ *                     1   1   1  2   3   4
+ *                     5   5   5  6   7   8
+ *                     9   9   9  10  11  12
+ */
+message PaddingLayerParams {
+
+    /**
+     * Fill a constant value in the padded region.
+     */
+    message PaddingConstant {
+        float value = 1;
+    }
+
+    /**
+     * Reflect the values at the border for padding.
+     */
+    message PaddingReflection {
+    }
+
+    /**
+     * Replicate the values at the border for padding.
+     */
+    message PaddingReplication {
+    }
+
+    oneof PaddingType {
+        PaddingConstant constant = 1;
+        PaddingReflection reflection = 2;
+        PaddingReplication replication = 3;
+    }
+
+    BorderAmounts paddingAmounts = 10; /// Amounts to be padded to the input.
+
+}
+
+/**
+ * A layer that concatenates along the axis = -3 or -5.
+ * For general concatenation along any axis, see ConcatNDLayer.
+ *
+ * .. code::
+ *
+ *      y = ConcatLayer(x1,x2,....)
+ *
+ * Requires more than 1 input and produces 1 output.
+ *
+ * Input
+ *   All input blobs must have same rank.
+ *   If "sequenceConcat" = False, rank must be greater than equal to 3. In this case concatenation is along axis = -3
+ *   If "sequenceConcat" = True, rank must be greater than equal to 5. In this case concatenation is along axis = -5
+ *
+ * Output
+ *   Same rank as the input.
+ *
+ */
+message ConcatLayerParams {
+
+    /**
+     * If true, concatenate along the axis = -5 instead of axis = -3.
+     */
+    bool sequenceConcat = 100;
+
+}
+
+/**
+ * A layer that performs local response normalization (LRN).
+ *
+ * .. code::
+ *
+ *      y = LRNLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank greater than equal to 3.
+ *     Example: Rank 4 blob represents [Batch, channels, height, width]
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     A blob with the same shape as the input.
+ *
+ * This layer is described by the following formula:
+ *
+ * .. math::
+ *     x_i \leftarrow  \dfrac{x_i}{\left ( k + \dfrac{\alpha}{C} \sum_j x_j^2 \right )^\beta}
+ *
+ * where the summation is done over a ``(localSize, 1, 1)`` neighborhood ---
+ * that is, over a window "across" channels in 1x1 spatial neighborhoods.
+ */
+message LRNLayerParams {
+
+    float alpha = 1;
+    float beta = 2;
+    uint64 localSize = 3; /// Number of channels in the normalization window.
+    float k = 4; /// Defaults to 1 if not set or 0. Must be strictly positive.
+
+}
+
+/**
+ * Softmax Normalization Layer
+ *
+ * A layer that performs softmax normalization.
+ * Normalization is applied along axis = -3 or N-3 (where N is the rank of the input)
+ * For softmax layer that can operate on any axis, see SoftmaxNDLayer.
+ *
+ *
+ * .. code::
+ *
+ *      y = SoftmaxLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     Must be a blob with rank >= 3.
+ * Output
+ *     A blob with the same shape as the input.
+ *
+ * This layer is described by the following formula:
+ *
+ * .. math::
+ *     x_i \leftarrow \dfrac{e^{x_i}}{\sum_i{e^{x_i}}}
+ */
+message SoftmaxLayerParams {
+
+}
+
+/**
+ * A layer that uniformly splits across axis = -3 to produce a specified number of outputs.
+ * For general split operation along any axis, see SplitNDLayer.
+ *
+ * .. code::
+ *
+ *      (y1,y2,...yN) = SplitLayer(x), where N = nOutputs
+ *
+ * Requires 1 input and produces multiple outputs.
+ *
+ * Input
+ *     A blob with rank at least 3.
+ *     e.g.: blob with shape ``[C, H, W]``
+ * Output
+ *     ``nOutputs`` blobs each with same rank as the input.
+ *     e.g.: For input that is of shape ``[C, H, W]``, output shapes will be ``[C/nOutputs, H, W]``
+ */
+message SplitLayerParams {
+
+    uint64 nOutputs = 1; /// The number of outputs.
+
+}
+
+/**
+ * A layer that performs elementwise addition.
+ * This layer has limited broadcasting support. For general broadcasting see AddBroadcastableLayer.
+ *
+ * .. code::
+ *
+ *      y = AddLayer(x1,x2,...)
+ *
+ * Requires 1 or more than 1 input and produces 1 output.
+ *
+ * Input
+ *     In general, there are no rank constraints.
+ *     However, only certain set of shapes are broadcastable. For example:
+ *     [B, 1, 1, 1], [B, C, 1, 1], [B, 1, H, W], [B, C, H, W]
+ * Output
+ *     A blob with shape equal to the input blob.
+ *
+ * If only one input is provided, scalar addition is performed:
+ *
+ * .. math::
+ *     y = x + \alpha
+ *
+ */
+message AddLayerParams {
+
+    /**
+     * Scalar to be added to the input.
+     * Only used if there is a single input.
+     */
+    float alpha = 1;
+
+}
+
+/**
+ * A layer that performs elementwise multiplication.
+ * This layer has limited broadcasting support. For general broadcasting see MultiplyBroadcastableLayer.
+ *
+ * .. code::
+ *
+ *      y = MultiplyLayer(x1,x2,...)
+ *
+ * Requires 1 or more than 1 input and produces 1 output.
+ *
+ * Input
+ *     In general, there are no rank constraints.
+ *     However, only certain set of shapes are broadcastable. For example:
+ *     [B, 1, 1, 1], [B, C, 1, 1], [B, 1, H, W], [B, C, H, W]
+ * Output
+ *     A blob with shape equal to the first input blob.
+ *
+ * If only one input is provided, scalar multiplication is performed:
+ *
+ * .. math::
+ *     y = \alpha x
+ *
+ */
+message MultiplyLayerParams {
+
+    /**
+     * Scalar to be multiplied with the input.
+     * Only used if there is a single input.
+     */
+    float alpha = 1;
+
+}
+
+/**
+ * A layer that applies a unary function.
+ *
+ * .. code::
+ *
+ *      y = UnaryFunctionLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with no rank constraints.
+ * Output
+ *     A blob with the same shape as the input.
+ *
+ * The input is first modified by shifting and scaling:
+ *
+ * .. math::
+ *     x \leftarrow \text{scale} \cdot x + \text{shift}
+ */
+message UnaryFunctionLayerParams {
+
+    /**
+     * A unary operator.
+     *
+     * The following functions are supported:
+     *
+     * ``SQRT``
+     *     .. math:: f(x) = \sqrt{x}
+     *
+     * ``RSQRT``
+     *     .. math:: f(x) = \dfrac{1}{\sqrt{x + \epsilon}}
+     *
+     * ``INVERSE``
+     *     .. math:: f(x) = \dfrac{1}{x + \epsilon}
+     *
+     * ``POWER``
+     *     .. math:: f(x) = x^\alpha
+     *
+     * ``EXP``
+     *     .. math:: f(x) = e^x
+     *
+     * ``LOG``
+     *     .. math:: f(x) = \log x
+     *
+     * ``ABS``
+     *     .. math:: f(x) = |x|
+     *
+     * ``THRESHOLD``
+     *     .. math:: f(x) = \text{max}(\alpha, x)
+     */
+    enum Operation {
+        SQRT = 0;
+        RSQRT = 1;
+        INVERSE = 2;
+        POWER = 3;
+        EXP = 4;
+        LOG = 5;
+        ABS = 6;
+        THRESHOLD = 7;
+    }
+    Operation type = 1; /// The type of unary function.
+
+    /**
+     * A constant used in ``POWER`` and ``THRESHOLD`` functions.
+     */
+    float alpha = 2;
+
+    /**
+     * A small constant to avoid division by 0 while normalizing variance.
+     * Defaults to ``1e-6`` if not set or set to ``0``.
+     */
+    float epsilon = 3;
+
+    /**
+     * Input is shifted by this amount
+     * before the unary function is applied.
+     * Defaults to ``0.0`` if not set.
+     */
+    float shift = 4;
+
+    /**
+     * Input is scaled by this amount
+     * before the unary function is applied.
+     * Defaults to ``1.0`` if not set or set to ``0``.
+     */
+    float scale = 5;
+
+}
+
+/**
+ * A layer that scales up spatial dimensions.
+ * It supports two modes: nearest neighbour (default) and bilinear.
+ *
+ * .. code::
+ *
+ *      y = UpsampleLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 3.
+ *     e.g.: blob with shape ``[C, H, W]``.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     Same rank as the input.
+ *     e.g.: blob with shape ``[C, scalingFactor[0] * H, scalingFactor[1] * W]``
+ */
+message UpsampleLayerParams {
+
+    /**
+     * Scaling Factor. Mutually exclusive with fractionalScalingFactor.
+     * Must be length 2 in order ``[H, W]``.
+     * If not set, default value ``[1, 1]`` is used.
+     */
+    repeated uint64 scalingFactor = 1;
+
+    /**
+     * Fractional scaling factor. Mutually exclusive with scalingFactor.
+     * Must be length 2 in order ``[H, W]``.
+     * If not set, default value ``[1.0, 1.0]`` is used.
+     */
+    repeated float fractionalScalingFactor = 7;
+
+    /*
+     * Overall mode for interpolating new elements when upsampling.
+     * NN - Nearest Neighbors - simply pick the nearest true value for interpolated values.
+     * BILINEAR - Use bilinear interpolation. See LinearUpsamplingMode for behavior.
+     */
+    enum InterpolationMode {
+
+        NN = 0; /// Nearest Neighbour
+        BILINEAR = 1; /// Bilinear
+
+    }
+
+    InterpolationMode mode = 5;
+
+    /**
+     * LinearUpsampleMode specifies the behavior for linear upsampling. Only valid when Interpolation Mode is BILINEAR.
+     * If input grid is [0, Xin-1] (corresponding to an input size of Xin), and if the output size is Xout,
+     * then the grid points are sampled in the following manner:
+     * DEFAULT:
+     *   spacing = (Xin-Xin/Xout) / (Xout-1)
+     *   grid_point[i] = min(Xin-1, max(0, i * spacing)), for i = 0,1,2,….,Xout-1
+     * ALIGN_CORNERS_TRUE:
+     *   spacing = (Xin-1) / (Xout-1)
+     *   grid_point[i] = min(Xin-1, max(0, i * spacing)), for i = 0,1,2,….,Xout-1
+     * ALIGN_CORNERS_FALSE:
+     *   spacing = Xin / Xout
+     *   grid_point[i] = min(Xin-1, max(0, i * spacing + 0.5 * spacing - 0.5)), for i = 0,1,2,….,Xout-1
+     */
+    enum LinearUpsampleMode {
+
+        DEFAULT = 0;
+        ALIGN_CORNERS_TRUE = 1;
+        ALIGN_CORNERS_FALSE = 2;
+
+    }
+
+    LinearUpsampleMode linearUpsampleMode = 6;
+
+}
+
+/**
+* A layer that resizes the input to a pre-specified spatial size using bilinear interpolation.
+*
+* .. code::
+*
+*      y = ResizeBilinearLayer(x)
+*
+* Requires 1 input and produces 1 output.
+*
+* Input
+*     A blob with rank at least 3.
+*     e.g.: blob with shape ``[C, H_in, W_in]``.
+*     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+*
+* Output
+*     Same rank as the input.
+*     e.g.: blob with shape ``[C, H_out, W_out]``.
+*
+*/
+message ResizeBilinearLayerParams {
+
+    /**
+     * Target Spatial Size.
+     * Must be length 2 in order ``[Height, Width]``, i.e. ``[H_out, W_out]``.
+     * If not set, default value ``[1, 1]`` is used.
+     */
+    repeated uint64 targetSize = 1;
+
+    /**
+     * Mode used to compute the grid on which the spatial output values are evaluated.
+     * Same mode is applied to both the height and width axes.
+     */
+    SamplingMode mode = 2;
+
+}
+
+/**
+* A layer that extracts cropped spatial patches or RoIs (regions of interest) from the input and resizes them to a pre-specified size using
+* bilinear interpolation.
+* Note that RoI Align layer can be implemented with this layer followed by a pooling layer.
+*
+* .. code::
+*
+*      y = CropResizeLayer(x)
+*
+* Requires 2 inputs and produces 1 output.
+*
+* Input
+*     There are two inputs.
+*     First input represents an image feature map.
+*     Second input represents the bounding box coordinates for N patches or RoIs (region of interest).
+*
+*     First input is rank 5: [1, Batch, C, H_in, W_in].
+*     Second input is rank 5. Its shape can be either [N, 1, 4, 1, 1] or [N, 1, 5, 1, 1].
+*
+*     N: number of patches/RoIs to be extracted
+*
+*     If RoI shape = ``[N, 1, 4, 1, 1]``
+*                    The axis=-3 corresponds to the four coordinates specifying the bounding box.
+*                    All the N RoIs are extracted from all the batches of the input.
+*
+*     If RoI shape = ``[N, 1, 5, 1, 1]``
+*                     The first element of the axis=-3 specifies the input batch id from which to extract the RoI and
+*                               must be in the interval ``[0, Batch - 1]``. That is, n-th RoI is extracted from the RoI[n,0,0,0,0]-th
+*                     input batch id. The last four elements of the axis=-3 specify the bounding box coordinates.
+*
+* Output
+*     A blob with rank 5.
+*           - Shape is [N, Batch, C, H_out, W_out] if input RoI shape is [N, 1, 4, 1, 1]
+*           - Shape is [N, 1, C, H_out, W_out] if input RoI shape is [N, 1, 5, 1, 1]
+*
+*/
+message CropResizeLayerParams {
+
+    /**
+     * Target Spatial Size.
+     * Must be length 2 in order ``[Height, Width]``, i.e. ``[H_out, W_out]``.
+     * If not set, default value ``[1, 1]`` is used.
+     */
+    repeated uint64 targetSize = 1;
+
+    /**
+     * If true the bounding box coordinates must be in the interval [0, 1].
+     * They are scaled by (H_in - 1), (W_in - 1), i.e. based on the input spatial dimensions.
+     * If false the bounding box coordinates must be in the interval
+     * [0, H_in -1] and [0, W_in - 1], respectively for height and width dimensions.
+     */
+    bool normalizedCoordinates = 2;
+
+    /**
+     * Mode used to compute the grid on which the spatial output values are evaluated.
+     * Same mode is applied to both the height and width axes.
+     */
+    SamplingMode mode = 3;
+
+    /**
+     * Representation used to express the bounding box coordinates.
+     * It determines how the values of the second input are interpreted.
+     */
+    BoxCoordinatesMode boxIndicesMode = 4;
+
+    /**
+     * Additional spatial scale that multiplies the bounding box coordinates.
+     * Generally used while implementing the RoI Align layer,
+     * which uses unnormalized RoI coordinates along with a spatial scale less than or equal to 1.
+     */
+    float spatialScale = 5;
+
+}
+
+/**
+ * A layer that performs elementwise addition of a bias,
+ * which is broadcasted to match the input shape.
+ *
+ * .. code::
+ *
+ *      y = BiasLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 3.
+ *     e.g.: blob with shape ``[C, H, W]``.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     A blob with the same shape as the input.
+ */
+message BiasLayerParams {
+
+    /**
+     * The shape of the bias.
+     * Must be one of the following:
+     * ``[1]``, ``[C]``, ``[1, H, W]`` or ``[C, H, W]``.
+     */
+    repeated uint64 shape = 1;
+
+    /**
+     * The bias values.
+     * The size must be equal to the product of the ``shape`` dimensions.
+     */
+    WeightParams bias = 2;
+
+}
+
+/**
+ * A layer that performs elmentwise multiplication by a scale factor
+ * and optionally adds a bias;
+ * both the scale and bias are broadcasted to match the input shape.
+ *
+ * .. code::
+ *
+ *      y = ScaleLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 3.
+ *     e.g.: blob with shape ``[C, H, W]``.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     A blob with the same shape as the input.
+ */
+message ScaleLayerParams {
+
+    /**
+     * The shape of the scale.
+     * Must be one of the following:
+     * ``[1]``, ``[C]``, ``[1, H, W]`` or ``[C, H, W]``.
+     */
+    repeated uint64 shapeScale = 1;
+
+    /**
+     * The scale values.
+     * The size must be equal to the product of the ``shape`` dimensions.
+     */
+    WeightParams scale = 2; /// Scale values. Size must be equal to the product of dimensions specified in shapeScale.
+
+    bool hasBias = 3; /// If true, a bias is added after scaling.
+
+    /**
+     * The shape of the bias.
+     * Must be one of the following:
+     * ``[1]``, ``[C]``, ``[1, H, W]`` or ``[C, H, W]``.
+     */
+    repeated uint64 shapeBias = 4;
+
+    /**
+     * The bias values.
+     * The size must be equal to the product of the ``shape`` dimensions.
+     */
+    WeightParams bias = 5;
+
+}
+
+/**
+ * A layer that loads data as a parameter and provides it as an output.
+ * The output is rank 5. For general rank, see LoadConstantNDLayer.
+ *
+ * .. code::
+ *
+ *      y = LoadConstantLayer()
+ *
+ * Requires no input and produces 1 output.
+ *
+ * Output:
+ *     A blob with rank 5 and shape ``[1, 1, C, H, W]``
+ */
+message LoadConstantLayerParams {
+
+    /**
+     * The shape of the constant to be loaded,
+     * which must be``[C, H, W]``, that is length 3.
+     */
+    repeated uint64 shape = 1;
+
+    /**
+     * The data values,
+     * of size ``C * H * W``.
+     */
+    WeightParams data = 2;
+
+}
+
+/**
+ * A layer that performs L2 normalization, i.e. divides by the
+ * the square root of the sum of squares of all elements of input.
+ *
+ * .. code::
+ *
+ *      y = L2NormalizeLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank greater than equal to 3.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     A blob with the same shape as the input.
+ *
+ * This layer is described by the following formula:
+ *
+ * .. math::
+ *     x_i \leftarrow \dfrac{x_i}{\sqrt{\sum{x_i^2} + \epsilon}}
+ */
+message L2NormalizeLayerParams {
+
+    /**
+     * A small constant to avoid division by 0 while normalizing variance.
+     * Defaults to ``1e-6`` if not set or set to ``0``.
+     */
+    float epsilon = 1;
+
+}
+
+/// Data Reorganization Layers
+/// --------------------------
+
+/**
+ * A layer that flattens the input.
+ *
+ * .. code::
+ *
+ *      y = FlattenLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank greater than equal to 3.
+ *     e.g.: Rank 4 blob represents [Batch, C, H, W]
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     Same rank as the input, such that last two dimensions are both 1.
+ *     e.g.: For rank 4 input, output shape is ``[Batch, C * H * W, 1, 1]``
+ *
+ * There are two X orders: ``CHANNEL_FIRST`` and ``CHANNEL_LAST``.
+ * ``CHANNEL_FIRST`` does not require data to be rearranged,
+ * because row major ordering is used by internal storage.
+ * ``CHANNEL_LAST`` requires data to be rearranged.
+ */
+message FlattenLayerParams {
+
+    enum FlattenOrder {
+
+        CHANNEL_FIRST = 0;
+        CHANNEL_LAST = 1;
+
+    }
+    FlattenOrder mode = 1;
+
+}
+
+/**
+ * A layer that recasts the input into a new shape.
+ *
+ * .. code::
+ *
+ *      y = ReshapeLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank 5.
+ *     e.g.: ``[1, 1, C, H, W]`` or ``[Seq, 1, C, H, W]``.
+ * Output
+ *     A blob with rank 5.
+ *     e.g.: ``[1, 1, C_out, H_out, W_out]`` or ``[Seq_out, 1, C_out, H_out, W_out]``.
+ *
+ * There are two reshape orders: ``CHANNEL_FIRST`` and ``CHANNEL_LAST``.
+ * ``CHANNEL_FIRST`` is equivalent to
+ * flattening the input to ``[Seq, 1, C * H * W, 1, 1]`` in channel first order
+ * and then reshaping it to the target shape;
+ * no data rearrangement is required.
+ * ``CHANNEL_LAST`` is equivalent to
+ * flattening the input to ``[Seq, 1, H * W * C, 1, 1]`` in channel last order,
+ * reshaping it to ``[Seq_out, 1, H_out, W_out, C_out]`` (it is now in "H_out-major"" order),
+ * and then permuting it to ``[C_out, H_out, W_out]``;
+ * both the flattening and permuting requires the data to be rearranged.
+ */
+message ReshapeLayerParams {
+
+    /**
+     * The shape of the output.
+     * Must be of length 3 or 4.
+     * If set to 3, ``targetShape`` is interpreted as
+     * ``[1, 1, C_out, H_out, W_out]``, and sequence length of the input is preserved.
+     * If set to 4, ``targetShape`` is interpreted as
+     * ``[Seq_out, 1, C_out, H_out, W_out]``,
+     * where ``Seq_out`` is the new sequence length.
+     */
+    repeated int64 targetShape = 1;
+
+    enum ReshapeOrder {
+
+        CHANNEL_FIRST = 0;
+        CHANNEL_LAST = 1;
+
+    }
+    ReshapeOrder mode = 2;
+
+}
+
+/**
+ * A layer that rearranges the dimensions and data of an input.
+ * For generic transpose/permute operation see TransposeLayer.
+ *
+ * .. code::
+ *
+ *      y = PermuteLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     Must be a rank 5 blob.
+ *     e.g.: shape ``[Seq, B, C, H, W]``.
+ * Output
+ *     Rank 5 blob. Transposed version of the input, such that dimensions at axis=1 or axis=-4 is unchanged.
+ *
+ *
+ * Examples:
+ *
+ *  Assume input shape is [Seq, B, C, H, W]
+ *
+ * - If ``axis`` is set to ``[0, 3, 1, 2]``,
+ *   then the output has shape ``[Seq, B, W, C, H]``
+ *
+ * - If ``axis`` is set to ``[3, 1, 2, 0]``,
+ *   then the output has shape ``[W, B, C, H, Seq]``
+ *
+ * - If ``axis`` is set to ``[0, 3, 2, 1]``,
+ *   then the output has shape ``[Seq, B, W, H, C]``
+ *
+ * - If ``axis`` is not set, or is set to ``[0, 1, 2, 3]``,
+ *   the output is the same as the input.
+ */
+message PermuteLayerParams {
+
+    /**
+     * The order in which to permute the dimensions.
+     * Must have length 4 and a permutation of ``[0, 1, 2, 3]``.
+     */
+    repeated uint64 axis = 1;
+
+}
+
+/**
+ * A layer that reorganizes data in the input in specific ways.
+ *
+ * .. code::
+ *
+ *      y = ReorganizeDataLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 3.
+ *     e.g.: blob with shape ``[C, H, W]``.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ * Output
+ *     Same rank as the input.
+ *     e.g.: blob with shape ``[C_out, H_out, W_out]``.
+ *
+ * mode == SPACE_TO_DEPTH
+ *  ``[C_out, H_out, W_out]`` : ``[C * blockSize * blockSize, H/blockSize, W/blockSize]``.
+ *  blockSize must divide H and W.
+ *  Data is moved from the spatial dimensions to the channel dimension. Input is spatially divided into
+ *  non-overlapping blocks of size blockSize X blockSize and data from each block is moved into the
+ *  channel dimension.
+ *
+ * mode == DEPTH_TO_SPACE
+ *  ``[C_out, H_out, W_out]`` : ``[C/(blockSize * blockSize), H * blockSize, W * blockSize]``.
+ *  Square of blockSize must divide C.
+ *  Reverse of SPACE_TO_DEPTH. Data is moved from the channel dimension to the spatial dimensions.
+ *
+ * mode == PIXEL_SHUFFLE
+ *  ``[C_out, H_out, W_out]`` : ``[C/(blockSize * blockSize), H * blockSize, W *  blockSize]``.
+ *  Square of blockSize must divide C.
+ *  Similar to DEPTH_TO_SPACE, but using the pixel-shuffle semantics for channel order in the output space.
+ *  In both modes, elements along the channel dimension are collapsed into
+ *  blocks in the spatial dimensions. The difference is in the arrangement of
+ *  the input-channels' data in the output space. See below example for more
+ *  detail.
+ *  (Only available in Core ML Specification >= 5 (iOS >= 14, macOS >= 11.0)
+ *
+ *
+ * Examples:
+ *
+ * Assume input is the following [C = 8, H = 1, W = 2] tensor:
+ *
+ * .. code::
+ *
+ *    [[[1 2]] [[3 4]] [[5 6]] [[7 8]] [[9 10]] [[11 12]] [[13 14]] [[15 16]]]
+ *
+ * If block_size == 2 and mode == DEPTH_TO_SPACE, output will be the following
+ * [C = 2, H = 2, W = 4] tensor:
+ *
+ * .. code::
+ *
+ *    [[[ 1  5  2  6]
+ *      [ 9 13 10 14]]
+ *
+ *     [[ 3  7  4  8]
+ *      [11 15 12 16]]]
+ *
+ * For mode == SPACE_TO_DEPTH, the behavior is the same as mode ==
+ * DEPTH_TO_SPACE, but with the input and output swapped.
+ *
+ * If block_size == 2 and mode == PIXEL_SHUFFLE, output will be the following
+ * [C = 2, H = 2, W = 4] tensor:
+ *
+ * .. code::
+ *
+ *    [[[ 1  3  2  4]
+ *      [ 5  7  6  8]]
+ *
+ *     [[ 9 11 10 12]
+ *      [13 15 14 16]]]
+ *
+ */
+message ReorganizeDataLayerParams {
+
+    enum ReorganizationType {
+
+        SPACE_TO_DEPTH = 0;
+        DEPTH_TO_SPACE = 1;
+        PIXEL_SHUFFLE = 2;
+
+    }
+    ReorganizationType mode = 1;
+    uint64 blockSize = 2; /// must be greater than 1
+
+}
+
+/**
+ * A layer that slices the input data along axis = -1 or -2 or -3.
+ * For general slice along any axis, please see SliceStaticLayer/SliceDynamicLayer.
+ *
+ * .. code::
+ *
+ *      y = SliceLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob that can, in general, have any rank. However, depending on the value of "axis" ,
+ *     there may be additional rank constraints.
+ * Output
+ *     A blob with the same rank as the input.
+ *
+ * Sliced section is taken from the interval ``[startIndex, endIndex)``, i.e.
+ * startIndex is inclusive while endIndex is exclusive.
+ * stride must be positive and represents the step size for slicing.
+ * Negative indexing is supported for startIndex and endIndex.
+ * -1 denotes N-1, -2 denotes N-2 and so on, where N is the length of the dimension to be sliced.
+ *
+ */
+message SliceLayerParams {
+
+    int64 startIndex = 1; /// start of the sliced section. Inclusive.
+    int64 endIndex = 2; /// end of sliced section. Exclusive.
+    uint64 stride = 3; /// The step size. Must be positive.
+
+    enum SliceAxis {
+
+        CHANNEL_AXIS = 0;
+        HEIGHT_AXIS = 1;
+        WIDTH_AXIS = 2;
+
+    }
+    // The following mapping is used for interpreting this parameter:
+    // CHANNEL_AXIS => axis = -3, input must have rank at least 3.
+    // HEIGHT_AXIS => axis = -2, input must have rank at least 2.
+    // WIDTH_AXIS => axis = -1
+    SliceAxis axis = 4;
+
+}
+
+/**
+ * A layer that reduces the input using a specified operation.
+ *
+ * .. code::
+ *
+ *      y = ReduceLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob that can, in general, have any rank. However, depending on the value of "axis" ,
+ *      there may be additional rank constraints.
+ * Output
+ *     A blob with the same rank as the input, which has 1s on the dimensions specified in the parameter "axis"
+ *
+ *     Values supported for axis are [-1], [-2], [-3], [-2,-1], [-3,-2,-1]
+ *     and the equivalent positive values (depending on the rank of the input)
+ *     For mode == 'ArgMax', axis must be [-1] or [-2] or [-3].
+ */
+message ReduceLayerParams {
+
+    /*
+     * The following reduction operations are supported
+     * and are applied on the specified axis of the input array:
+     *
+     * ``SUM``
+     *     Sum of all elements
+     *
+     *     .. math:: \sum{x_i}
+     *
+     * ``AVG``
+     *     Sum of all elements divided by the number of elements
+     *
+     *     .. math:: \dfrac{\sum^n{x_i}}{n}
+     *
+     * ``PROD``
+     *     Product of all elements
+     *
+     *     .. math:: \prod{x_i}
+     *
+     * ``LOGSUM``
+     *     Sum of the natural logarithm of all elements
+     *
+     *     .. math:: \sum{\ln{(x_i + \epsilon)}}
+     *
+     * ``SUMSQUARE``
+     *     Sum of squares of all elements
+     *
+     *     .. math:: \sum{x^2}
+     *
+     * ``L1``
+     *     L1 normalization of all elements
+     *
+     *     .. math:: ||x||_1 = \sum{|x_i|}
+     *
+     * ``L2``
+     *     L2 normalization of all elements
+     *
+     *     .. math:: ||x||_2 = \sqrt{\sum{x_i^2}}
+     *
+     * ``MAX``
+     *     Maximum of all elements
+     *
+     *     .. math:: \text{max}(x_i)
+     *
+     * ``MIN``
+     *     Minumum of all elements
+     *
+     *     .. math:: \text{min}(x_i)
+     *
+     * ``ARGMAX``
+     *     Argument of the maximum of all elements
+     *
+     *     .. math:: \text{argmax}(x_i)
+     *
+     */
+    enum ReduceOperation {
+
+        SUM = 0;
+        AVG = 1;
+        PROD = 2;
+        LOGSUM = 3;
+        SUMSQUARE = 4;
+        L1 = 5;
+        L2 = 6;
+        MAX = 7;
+        MIN = 8;
+        ARGMAX = 9; /// only supported with axis = C, H or W.
+
+    }
+    ReduceOperation mode = 1; /// Specifies function used to reduce.
+
+    /**
+     * Used if mode is ``LOGSUM``.
+     * Defaults to ``1e-6`` if not set or is set to ``0``.
+     */
+    float epsilon = 2;
+
+    enum ReduceAxis {
+
+        CHW = 0;
+        HW = 1;
+        C = 2;
+        H = 3;
+        W = 4;
+
+    }
+
+    // The following mapping is used for interpreting this parameter:
+    // CHW = axis [-3, -2, -1], input must have rank at least 3.
+    // HW = axis [-2, -1], input must have rank at least 2.
+    // C = axis [-3]
+    // H = axis [-2]
+    // W = axis [-1]
+    ReduceAxis axis = 3;
+
+}
+
+/**
+ * A layer that crops the spatial dimensions of an input.
+ * If two inputs are provided, the shape of the second input is used as the reference shape.
+ *
+ * .. code::
+ *
+ *      y = CropLayer(x1) or y = CropLayer(x1,x2)
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ *
+ * Input
+ *    1 or 2 tensors, each with rank at least 3, both inputs must have equal rank.
+ *    Example:
+ *     - 1 input case: A blob with shape ``[C, H_in, W_in]``.
+ *     - 2 input case: 1st blob with shape ``[C, H_in, W_in]``, 2nd blob with shape ``[C, H_out, W_out]``.
+ *
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     Same rank as the inputs.
+ *     e.g.: A blob with shape ``[C, H_out, W_out]``.
+ *
+ * If one input is used, output is computed as follows:
+ *
+ * .. code::
+ *
+ *      y = x1[:, topCropAmount:H_in - bottomCropAmount, leftCropAmount:W_in - rightCropAmount]
+ *
+ *      topCropAmount == Height startEdgeSize == borderAmounts[0].startEdgeSize
+ *      bottomCropAmount == Height endEdgeSize == borderAmounts[0].endEdgeSize
+ *      leftCropAmount == Width startEdgeSize == borderAmounts[1].startEdgeSize
+ *      rightCropAmount == Width endEdgeSize == borderAmounts[1].endEdgeSize
+ *
+ *      H_out = H_in - topCropAmount - bottomCropAmount
+ *      W_out = W_in - leftCropAmount - rightCropAmount
+ *
+ * If two inputs are used, output is computed as follows:
+ *
+ * .. code::
+ *
+ *      y = x1[:, offset[0]:offset[0] + H_out, offset[1]:offset[1] + W_out]
+ */
+message CropLayerParams {
+
+    /**
+     * The amounts to be cropped from the input.
+     * Used only if a single input is provided.
+     */
+    BorderAmounts cropAmounts = 1;
+
+    /**
+     * The offset amounts.
+     * Used only if two inputs are provided.
+     * Must be of length 2, in order ``[H, W]``.
+     */
+    repeated uint64 offset = 5;
+
+}
+
+/**
+ * A layer that computes the elementwise average of the inputs.
+ * This layer has limited broadcasting support. For general broadcasting see AddBroadcastableLayer.
+ *
+ * .. code::
+ *
+ *      y = AverageLayer(x1,x2,...)
+ *
+ * Requires multiple inputs and produces 1 output.
+ *
+ * Input
+ *     In general, there are no rank constraints.
+ *     However, only certain set of shapes are broadcastable. For example:
+ *     [B, 1, 1, 1], [B, C, 1, 1], [B, 1, H, W], [B, C, H, W]
+ * Output
+ *     A blob with the same shape as each input.
+ */
+message AverageLayerParams {
+
+}
+
+/**
+ * A layer that computes the elementwise maximum over the inputs.
+ *
+ * .. code::
+ *
+ *      y = MaxLayer(x1,x2,...)
+ *
+ * Requires multiple inputs and produces 1 output.
+ *
+ * Input
+ *     In general, there are no rank constraints.
+ *     However, only certain set of shapes are broadcastable. For example:
+ *     [B, C, 1, 1], [B, C, H, W]
+ * Output
+ *     A blob with the same shape as each input.
+ */
+message MaxLayerParams {
+
+}
+
+/**
+ * A layer that computes the elementwise minimum over the inputs.
+ *
+ * .. code::
+ *
+ *      y = MinLayer(x1,x2,...)
+ *
+ * Requires multiple inputs and produces 1 output.
+ *
+ * Input
+ *     In general, there are no rank constraints.
+ *     However, only certain set of shapes are broadcastable. For example:
+ *     [B, C, 1, 1], [B, C, H, W]
+ * Output
+ *     A blob with the same shape as each input.
+ */
+message MinLayerParams {
+
+}
+
+/**
+ * A layer that computes the dot product of two vectors.
+ *
+ * .. code::
+ *
+ *      y = DotProductLayer(x1,x2)
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * Input
+ *     Two blobs with rank at least 3, such that the last two dimensions must be 1.
+ *     e.g.: blobs with shape ``[B, C, 1, 1]``.
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     Same rank as the input.
+ *     e.g. for rank 4 inputs, output shape: [B, 1, 1, 1]
+ */
+message DotProductLayerParams {
+
+    /**
+     * If true, inputs are normalized first,
+     * thereby computing the cosine similarity.
+     */
+    bool cosineSimilarity = 1;
+
+}
+
+/**
+ * A layer that performs mean variance normalization, along axis = -3.
+ *
+ * .. code::
+ *
+ *      y = MeanVarianceNormalizeLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank greater than equal to 3.
+ *     Example: Rank 4 blob represents [Batch, channels, height, width]
+ *     For ranks greater than 3, the leading dimensions, starting from 0 to -4 (inclusive), are all treated as batch.
+ *
+ * Output
+ *     A blob with the same shape as the input.
+ *
+ * If ``acrossChannels == true``
+ * normalization is performed on flattened input, i.e. the input is reshaped to (Batch,C), where "Batch" contains
+ * all dimensions from 0 to -4 (inclusive), and C contains dimensions -1, -2, -3.
+ *
+ * If ``acrossChannels == false``
+ * normalization is performed within a channel,
+ * across spatial dimensions (i.e. last two dimensions).
+ */
+message MeanVarianceNormalizeLayerParams {
+
+    /**
+     * If true, mean and variance are computed across channels.
+     */
+    bool acrossChannels = 1;
+
+    /**
+     * If false, only mean is subtracted.
+     */
+    bool normalizeVariance = 2;
+
+    /**
+     * A small constant to avoid division by 0 while normalizing variance.
+     * Defaults to ``1e-6`` if not set or set to ``0``.
+     */
+    float epsilon = 3;
+
+}
+
+/**
+ * A layer that repeats a sequence or the dimension sitting at axis = -5
+ *
+ * .. code::
+ *
+ *      y = SequenceRepeatLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A blob with rank at least 5.
+ *     e.g: shape ``[Seq, B, C, H, W]``
+ * Output
+ *     A blob with the same rank as the input.
+ *     e.g.: for input shape ``[Seq, B, C, H, W]``, output shape is ``[nRepetitions * Seq, B, C, H, W]``.
+ */
+message SequenceRepeatLayerParams {
+
+    /**
+     * Number of repetitions.
+     * Defaults to ``1`` if not set or set to ``0``.
+     */
+    uint64 nRepetitions = 1;
+
+}
+
+/// Recurrent Layers
+/// ----------------
+
+/*
+ * The following activations are supported with recurrent layers:
+ * - Linear
+ * - Sigmoid
+ * - Tanh
+ * - ReLU
+ * - Scaled Hyperbolic Tangent: alpha * tanh(beta * x), currently only supported for alpha = 1.7159, beta = 2/3
+ * - Hard Sigmoid: min(max(alpha * x + beta, 0), 1), currently only supported for alpha = 0.2, beta = 0.5
+ */
+
+/**
+ * A simple recurrent layer.
+ *
+ * .. code::
+ *
+ *      y_t = SimpleRecurrentLayer(x_t, y_{t-1})
+ *
+ * Input
+ *    A blob of rank 5, with shape `[Seq, Batch, inputVectorSize, 1, 1]``.
+ *    This represents a sequence of vectors of size ``inputVectorSize``.
+ * Output
+ *    Same rank as the input.
+ *    Represents a vector of size ``outputVectorSize``. It is either the final output or a sequence of outputs at all time steps.
+ *
+ * - Output Shape: ``[1, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == false``
+ * - Output Shape: ``[Seq, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == true``
+ *
+ * This layer is described by the following equation:
+ *
+ * .. math::
+ *     \boldsymbol{y_t} = f(\mathrm{clip}(W \boldsymbol{x_t} + \
+ *                                        R \boldsymbol{y_{t-1}} + b))
+ *
+ * - ``W`` is a 2-dimensional weight matrix
+ *   (``[outputVectorSize, inputVectorSize]``, row-major)
+ * - ``R`` is a 2-dimensional recursion matrix
+ *   (``[outputVectorSize, outputVectorSize]``, row-major)
+ * - ``b`` is a 1-dimensional bias vector (``[outputVectorSize]``)
+ * - ``f()`` is an activation
+ * - ``clip()`` is a function that constrains values between ``[-50.0, 50.0]``
+ */
+message SimpleRecurrentLayerParams {
+
+    uint64 inputVectorSize = 1; /// The size of the input vectors.
+    uint64 outputVectorSize = 2; /// The size of the output vectors.
+
+    /**
+    * Activations supported are Linear, Sigmoid, Tanh, ReLU, Scaled Tanh (alpha = 1.71, beta = 2/3), Hard sigmoid (alpha = 0.2, beta = 0.5)
+    */
+    ActivationParams activation = 10; /// The activation function.
+
+    /**
+        If false output is just the result after final state update.
+        If true, output is a sequence, containing outputs at all time steps.
+    */
+    bool sequenceOutput = 15;
+
+    bool hasBiasVector = 20; /// If false, no bias is added.
+
+    WeightParams weightMatrix = 30; /// Weight matrix W.
+    WeightParams recursionMatrix = 31; /// Recursion Weight matrix R.
+    WeightParams biasVector = 32; /// Bias vector b.
+
+    bool reverseInput = 100;
+    // If true, then the node processes the input sequence from right to left
+
+}
+
+/**
+ * Gated-Recurrent Unit (GRU) Layer
+ *
+ * .. code::
+ *
+ *      y_t = GRULayer(x_t, y_{t-1})
+ *
+ * Input
+ *    A blob of rank 5, with shape `[Seq, Batch, inputVectorSize, 1, 1]``.
+ *    This represents a sequence of vectors of size ``inputVectorSize``.
+ * Output
+ *    Same rank as the input.
+ *    Represents a vector of size ``outputVectorSize``. It is either the final output or a sequence of outputs at all time steps.
+ *
+ * - Output Shape: ``[1, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == false``
+ * - Output Shape: ``[Seq, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == true``
+ *
+ * This layer is described by the following equations:
+ *
+ * Update Gate
+ *     .. math::
+ *         \boldsymbol{z_t} = \
+ *             f(\mathrm{clip}(W_z \boldsymbol{x_t} + \
+ *                             R_z \boldsymbol{y_{t-1}} + b_z)
+ *
+ * Reset Gate
+ *     .. math::
+ *         \boldsymbol{r_t} = \
+ *             f(\mathrm{clip}(W_r \boldsymbol{x_t} + \
+ *                             R_r \boldsymbol{y_{t-1}} + b_r))
+ *
+ * Cell Memory State
+ *     .. math::
+ *         \boldsymbol{c_t} = \
+ *             \boldsymbol{y_{t-1}} \odot \boldsymbol{r_t}
+ *
+ * Output Gate
+ *     .. math::
+ *         \boldsymbol{o_t} = \
+ *             g(\mathrm{clip}(W_o \boldsymbol{x_t} + \
+ *                             R_o \boldsymbol{c_t} + b_o))
+ *
+ * Output
+ *     .. math::
+ *         \boldsymbol{y_t} = \
+ *             (1 - \boldsymbol{z_t}) \odot \boldsymbol{o_t} + \
+ *              \boldsymbol{z_t} \odot \boldsymbol{y_{t-1}}
+ *
+ * - ``W_z``, ``W_r``, ``W_o`` are 2-dimensional input weight matrices
+ *   (``[outputVectorSize, inputVectorSize]``, row-major)
+ * - ``R_z``, ``R_r``, ``R_o`` are 2-dimensional recursion matrices
+ *   (``[outputVectorSize, outputVectorSize]``, row-major)
+ * - ``b_z``, ``b_r``, ``b_o`` are 1-dimensional bias vectors
+ *   (``[outputVectorSize]``)
+ * - ``f()``, ``g()`` are activations
+ * - ``clip()`` is a function that constrains values between ``[-50.0, 50.0]``
+ * - ``⊙`` denotes the elementwise product of matrices
+ */
+message GRULayerParams {
+
+    uint64 inputVectorSize = 1; /// Size of the input vectors.
+    uint64 outputVectorSize = 2; /// Size of the output vectors.
+
+    /**
+     * 2 element array representing activations [f(), g()] in that order.
+     * Typical values used = [sigmoid, tanh].
+     * Activations supported are Linear, Sigmoid, Tanh, ReLU, Scaled Tanh (alpha = 1.71, beta = 2/3), Hard sigmoid (alpha = 0.2, beta = 0.5)
+     */
+    repeated ActivationParams activations = 10;
+
+    /**
+     * If false output is just the result after final state update.
+     * If true, output is a sequence, containing outputs at all time steps.
+     */
+    bool sequenceOutput = 15;
+
+    /**
+     * If false, no biases (``b_z``, ``b_r``, ``b_o``) are added.
+     */
+    bool hasBiasVectors = 20;
+
+    WeightParams updateGateWeightMatrix = 30; /// Weight Matrix W_z.
+    WeightParams resetGateWeightMatrix = 31; /// Weight Matrix W_r.
+    WeightParams outputGateWeightMatrix = 32; /// Weight Matrix W_o.
+
+    WeightParams updateGateRecursionMatrix = 50; /// Recursion Weight Matrix R_z.
+    WeightParams resetGateRecursionMatrix = 51; /// Recursion Weight Matrix R_r.
+    WeightParams outputGateRecursionMatrix = 52; /// Recursion Weight Matrix R_o.
+
+    WeightParams updateGateBiasVector = 70; /// Bias vector b_z.
+    WeightParams resetGateBiasVector = 71; /// Bias vector b_r.
+    WeightParams outputGateBiasVector = 72; /// Bias vector b_o.
+
+    /// If true, then the node processes the input sequence from right to left
+    bool reverseInput = 100;
+
+}
+
+/**
+ * Long short-term memory (LSTM) parameters.
+ *
+ * This is described by the following equations:
+ *
+ * Input Gate
+ *     .. math::
+ *         \boldsymbol{i_t} = \
+ *             f(\mathrm{clip}(W_i \boldsymbol{x_t} + \
+ *                             R_i \boldsymbol{y_{t-1}} + \
+ *                             p_i \odot c_{t-1} + b_i))
+ *
+ * Forget Gate
+ *     .. math::
+ *         \boldsymbol{f_t} = \
+ *             f(\mathrm{clip}(W_f \boldsymbol{x_t} + \
+ *                             R_f \boldsymbol{y_{t-1}} + \
+ *                             p_f \odot c_{t-1} + b_f))
+ *
+ * Block Input
+ *     .. math::
+ *         \boldsymbol{z_t} = \
+ *             g(\mathrm{clip}(W_z \boldsymbol{x_t} + \
+ *                             R_z \boldsymbol{y_{t-1}} + b_z))
+ *
+ * Cell Memory State
+ *     .. math::
+ *         \boldsymbol{c_t} = \
+ *             \boldsymbol{c_{t-1}} \odot \boldsymbol{f_t} + \
+ *             \boldsymbol{i_t} \odot \boldsymbol{z_t}
+ *
+ * Output Gate
+ *     .. math::
+ *         \boldsymbol{o_t} = \
+ *             f(\mathrm{clip}(W_o \boldsymbol{x_t} + \
+ *                             R_o \boldsymbol{y_{t-1}} + \
+ *                             p_o \odot c_t + b_o))
+ *
+ * Output
+ *     .. math::
+ *         \boldsymbol{y_t} = \
+ *             h(\boldsymbol{c_t}) \odot \boldsymbol{o_t}
+ *
+ * - ``W_i``, ``W_f``, ``W_z``, ``W_o`` are 2-dimensional input weight matrices
+ *   (``[outputVectorSize, inputVectorSize]``, row-major)
+ * - ``R_i``, ``R_f``, ``R_z``, ``R_o`` are 2-dimensional recursion matrices
+ *   (``[outputVectorSize, outputVectorSize]``, row-major)
+ * - ``b_i``, ``b_f``, ``b_z``, ``b_o`` are 1-dimensional bias vectors
+ *   (``[outputVectorSize]``)
+ * - ``p_``, ``p_f``, ``p_o`` are 1-dimensional peephole vectors
+ *   (``[outputVectorSize]``)
+ * - ``f()``, ``g()``, ``h()`` are activations
+ * - ``clip()`` is a function that constrains values between ``[-50.0, 50.0]``
+ * - ``⊙`` denotes the elementwise product of matrices
+ */
+message LSTMParams {
+
+    /**
+     * If true, output is a sequence, containing outputs at all time steps.
+     * If false, output is just the result after final state update.
+     */
+    bool sequenceOutput = 10;
+
+    /**
+     * If false, no biases (``b_i``, ``b_f``, ``b_z``, ``b_o``) are added.
+     */
+    bool hasBiasVectors = 20;
+
+    /**
+     * If true, a vector of ``1`` values is added to ``b_f``.
+     */
+    bool forgetBias = 30;
+
+    /**
+     * If true, peephole vectors are included.
+     */
+    bool hasPeepholeVectors = 40;
+
+    /**
+     * If the coupled Input and Forget flag is on, the behaviour of
+     * ``c_t`` is changed to the following (i.e. forget gate is not used):
+     *
+     * .. math::
+     *     \boldsymbol{c_t} = \
+     *         \boldsymbol{c_{t-1}} \odot (1 - \boldsymbol{i_t}) + \
+     *         \boldsymbol{i_t} \odot \boldsymbol{z_t}
+     *
+     */
+    bool coupledInputAndForgetGate = 50;
+
+    /**
+     * Places a limit on the maximum and minimum values of ``c_t``.
+     * c_t = min(c_t, cellClipThreshold)
+     * c_t = max(c_t, -cellClipThreshold)
+     * If 0, it is set to its default value = 50.0.
+     */
+    float cellClipThreshold = 60;
+
+}
+
+/**
+ * Weights for long short-term memory (LSTM) layers
+ */
+message LSTMWeightParams {
+
+    WeightParams inputGateWeightMatrix = 1; /// Weight Matrix W_i.
+    WeightParams forgetGateWeightMatrix = 2; /// Weight Matrix W_f.
+    WeightParams blockInputWeightMatrix = 3; /// Weight Matrix W_z.
+    WeightParams outputGateWeightMatrix = 4; /// Weight Matrix W_o.
+
+    WeightParams inputGateRecursionMatrix = 20; /// Recursion Weight Matrix R_i.
+    WeightParams forgetGateRecursionMatrix = 21; /// Recursion Weight Matrix R_f.
+    WeightParams blockInputRecursionMatrix = 22; /// Recursion Weight Matrix R_z.
+    WeightParams outputGateRecursionMatrix = 23; /// Recursion Weight Matrix R_o.
+
+    //biases:
+    WeightParams inputGateBiasVector = 40; /// Bias vector b_i.
+    WeightParams forgetGateBiasVector = 41; /// Bias vector b_f.
+    WeightParams blockInputBiasVector = 42; /// Bias vector b_z.
+    WeightParams outputGateBiasVector = 43; /// Bias vector b_o.
+
+    //peepholes:
+    WeightParams inputGatePeepholeVector = 60; /// Peephole vector p_i.
+    WeightParams forgetGatePeepholeVector = 61; /// Peephole vector p_f.
+    WeightParams outputGatePeepholeVector = 62; /// Peephole vector p_o.
+
+}
+
+/**
+ * A unidirectional long short-term memory (LSTM) layer.
+ *
+ * .. code::
+ *
+ *      (y_t, c_t) = UniDirectionalLSTMLayer(x_t, y_{t-1}, c_{t-1})
+ *
+ * Input
+ *    A blob of rank 5, with shape `[Seq, Batch, inputVectorSize, 1, 1]``.
+ *    This represents a sequence of vectors of size ``inputVectorSize``.
+ * Output
+ *    Same rank as the input.
+ *    Represents a vector of size ``outputVectorSize``. It is either the final output or a sequence of outputs at all time steps.
+ *
+ * - Output Shape: ``[1, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == false``
+ * - Output Shape: ``[Seq, Batch, outputVectorSize, 1, 1]`` , if ``sequenceOutput == true``
+ *
+ */
+message UniDirectionalLSTMLayerParams {
+
+    uint64 inputVectorSize = 1; /// Size of the input vectors.
+    uint64 outputVectorSize = 2; /// Size of the output vectors.
+
+    /**
+     * 3 element array representing activations [f(),g(),h()] in that order.
+     * Typical values used = [sigmoid, tanh, tanh].
+     * Activations supported are Linear, Sigmoid, Tanh, ReLU, Scaled Tanh (alpha = 1.71, beta = 2/3), Hard sigmoid (alpha = 0.2, beta = 0.5)
+     */
+    repeated ActivationParams activations = 10;
+
+    LSTMParams params = 15;
+
+    LSTMWeightParams weightParams = 20; /// Weights, biases and peepholes.
+
+    /// If true, then the node processes the input sequence from right to left
+    bool reverseInput = 100;
+
+}
+
+/**
+ * Bidirectional long short-term memory (LSTM) layer
+ *
+ * .. code::
+ *
+ *      (y_t, c_t, y_t_reverse, c_t_reverse) = BiDirectionalLSTMLayer(x_t, y_{t-1}, c_{t-1}, y_{t-1}_reverse, c_{t-1}_reverse)
+ *
+ * Input
+ *    A blob of rank 5, with shape `[Seq, Batch, inputVectorSize, 1, 1]``.
+ *    This represents a sequence of vectors of size ``inputVectorSize``.
+ * Output
+ *    Same rank as the input.
+ *    Represents a vector of size ``2 * outputVectorSize``. It is either the final output or a sequence of outputs at all time steps.
+ *
+ * - Output Shape: ``[1, Batch, 2 * outputVectorSize, 1, 1]`` , if ``sequenceOutput == false``
+ * - Output Shape: ``[Seq, Batch, 2 * outputVectorSize, 1, 1]`` , if ``sequenceOutput == true``
+ *
+ *
+ * The first LSTM operates on the input sequence in the forward direction.
+ * The second LSTM operates on the input sequence in the reverse direction.
+ *
+ * Example: given the input sequence ``[x_1, x_2, x_3]``,
+ * where ``x_i`` are vectors at time index ``i``:
+ *
+ * The forward LSTM output is ``[yf_1, yf_2, yf_3]``,
+ *
+ * where ``yf_i`` are vectors of size ``outputVectorSize``:
+ *
+ * - ``yf_1`` is the output at the end of sequence {``x_1``}
+ * - ``yf_2`` is the output at the end of sequence {``x_1``, ``x_2``}
+ * - ``yf_3`` is the output at the end of sequence {``x_1``, ``x_2``, ``x_3``}
+ *
+ * The backward LSTM output: ``[yb_1, yb_2, yb_3]``,
+ *
+ * where ``yb_i`` are vectors of size ``outputVectorSize``:
+ *
+ * - ``yb_1`` is the output at the end of sequence {``x_3``}
+ * - ``yb_2`` is the output at the end of sequence {``x_3``, ``x_2``}
+ * - ``yb_3`` is the output at the end of sequence {``x_3``, ``x_2``, ``x_1``}
+ *
+ * Output of the bi-dir layer:
+ *
+ * - if ``sequenceOutput = True`` : { ``[yf_1, yb_3]``,  ``[yf_2, yb_2]``,  ``[yf_3, yb_1]`` }
+ * - if ``sequenceOutput = False`` : { ``[yf_3, yb_3]`` }
+ */
+message BiDirectionalLSTMLayerParams {
+
+    /**
+     * Size of the input vectors.
+     */
+    uint64 inputVectorSize = 1;
+    /**
+     * Size of the outputs vectors.
+     * It is same for both forward and backward LSTMs.
+     */
+    uint64 outputVectorSize = 2;
+
+    /**
+     * 3 element array representing activations [f(),g(),h()] in that order.
+     * Typical values used = [sigmoid, tanh, tanh].
+     * Activations supported are Linear, Sigmoid, Tanh, ReLU, Scaled Tanh (alpha = 1.71, beta = 2/3), Hard sigmoid (alpha = 0.2, beta = 0.5)
+     */
+    repeated ActivationParams activationsForwardLSTM = 10;
+    /**
+     * Currently, backward LSTM activations
+     * must be same as the ones for the forward LSTM.
+     */
+    repeated ActivationParams activationsBackwardLSTM = 11;
+
+    /**
+     * Common parameters shared by the forward and backward LSTMs.
+     */
+    LSTMParams params = 15;
+
+    /**
+     * Weights and biases.
+     * Must be a length 2 message,
+     * for the forward and backward LSTM respectively.
+     */
+    repeated LSTMWeightParams weightParams = 20;
+
+}
+
+message CustomLayerParams {
+
+    message CustomLayerParamValue {
+        oneof value {
+            double doubleValue = 10;
+            string stringValue = 20;
+            int32 intValue = 30;
+            int64 longValue = 40;
+            bool boolValue = 50;
+        }
+    }
+
+    string className = 10; // The name of the class (conforming to MLCustomLayer) corresponding to this layer
+    repeated WeightParams weights = 20; // Any weights -- these are serialized in binary format and memmapped at runtime
+    map<string, CustomLayerParamValue> parameters = 30; // these may be handled as strings, so this should not be large
+    string description = 40; // An (optional) description of the layer provided by the model creator. This information is displayed when viewing the model, but does not affect the model's execution on device.
+
+}
+
+/**
+ * A layer that rearranges the dimensions and data of an input.
+ *
+ * .. code::
+ *
+ *      y = TransposeLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     A N-Dimensional tensor.
+ * Output
+ *     A N-Dimensional tensor of the same rank but with dimensions and data permuted according to axes.
+ *     Shape: ``[InputShape[axis[0]], InputShape[axis[1]], ... , InputShape[axis[N-1]]]``
+ *
+ * Examples:
+ *
+ * - If ``axes`` is set to ``[3, 1, 2, 0]`` and the input shape is ``[6,7,8,9]``,
+ *   then the output has shape ``[9,7,8,6]``
+ */
+
+message TransposeLayerParams {
+
+    /**
+     * Length of "axes" should match the rank of input & output tensor
+     * "axes" should be a permutation of "[0,1,2,...,N-1]" where N is the rank.
+     */
+    repeated uint64 axes = 1; //
+
+}
+
+/**
+ * A layer that computes the matrix multiplication of two tensors with numpy-like broadcasting
+ * where the matrices reside in the last two indices of the tensor.
+ *
+ * .. code::
+ *
+ *      y = BatchedMatMul(a,b)
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ *
+ * The first tensor, "a", must be provided as an input. The second tensor can either be an input or provided as a weight matrix parameter.
+ *
+ * Input
+ *     - a: First N-Dimensional tensor
+ *     - b: Second N-Dimensional tensor (either a rank-N input or a matrix, i.e. N=2, provided as a layer parameter)
+ *
+ * Output
+ *     A tensor containing the matrix product of two tensors.
+ *     When there are two inputs: rank is max(2, rank(a), rank(b))
+ *     When there is one input: rank is same as that of the input.
+ *
+ * This operation behaves as following:
+ *
+ *  When there are two inputs:
+ *      - If N >= 2 for both tensors, it is treated as a batch of matrices residing in the last two indices.
+ *        All the indices, except for the last two, are broadcasted using conventional rules.
+ *      - If the first tensor is 1-D, it is converted to a 2-D tensor by prepending a 1 to its shape. Eg. (D) -> (1,D)
+ *      - If the second tensor is 1-D, it is converted to a 2-D tensor by appending a 1 to its shape. Eg. (D) -> (D,1)
+ *
+ *  When there is one input:
+ *      - The weight matrix corresponds to a matrix, of shape (X1, X2). Values of X1, X2 must be provided as layer parameters.
+ *      - The input, "a", is reshaped into a matrix by combining all the leading dimensions, except the last, into a batch dimension. eg:
+ *             - if "a" is rank 1 (X1,) -->  (1, X1). Output shape will be (X2,)
+ *             - if "a" is rank 2 (B1, X1) --> no need to reshape. Output shape will be (B1, X2)
+ *             - if "a" is rank 3 (B1, B2, X1) --> (B1 * B2, X1). Output shape will be (B1, B2, X2)
+ *             - etc
+ */
+message BatchedMatMulLayerParams {
+
+    /**
+     * If transposeA is true, it transposes the left matrix on the fly before matrix multiplication.
+     * (is ignored when there is one input)
+     */
+    bool transposeA = 1;
+    /**
+     * If transposeB is true, it transposes the right matrix on the fly before matrix multiplication.
+     * (is ignored when there is one input)
+     */
+    bool transposeB = 2;
+
+    /*
+     * Following parameters are ignored when there are two inputs.
+     */
+
+    uint64 weightMatrixFirstDimension = 5; /// X1: same as the last dimension of the input tensor
+    uint64 weightMatrixSecondDimension = 6; /// X2: same as the last dimension of the output tensor
+
+    bool hasBias = 7; /// Whether a bias is added or not. Supported only when there is one input.
+
+    /*
+     * Weight matrix representing shape [X1, X2].
+     * Values are however stored in column major order,
+     * in the "repeated float" or "bytes" fields of the message "WeightParams"
+     */
+    WeightParams weights = 8;
+    WeightParams bias = 9; /// Bias vector [X2]. Supported only when there is one input.
+
+    /**
+     * If set, this layer, at runtime, quantizes the floating point input blob to int8 before applying the
+     * matrix multiplication using the INT8 weight parameters provided in weights->int8RawValue. The
+     * result is then dequantized.
+     * Requires:
+     * * number of inputs to be 1
+     * * hasBias == false
+     * * QuantizationType == LinearQuantizationParams, such that
+     *   * size of the "scale" field is 1 and "bias" field is empty in "LinearQuantizationParams"
+     * * numberOfBits == 8
+     * * weights->rawValue_size to be empty
+     */
+    bool int8DynamicQuantize = 10;
+
+}
+
+/**
+ * A layer that concatenates a list of tensors along a specified axis.
+ *
+ * .. code::
+ *
+ *      y = ConcatNDLayer(x1,x2,....)
+ *
+ * Requires at least 2 input and produces 1 output.
+ *
+ * Input
+ *     The rank of the input tensors must match and all dimensions also must match, except for the dimension 'axis'.
+ *
+ *
+ * Output
+ *     Same rank as the input. The dimension along "axis", is the sum of the dimensions of the inputs.
+ *
+ * example:
+ *
+ * in1 : shape (3, 2), value = [[1, 2], [3, 4], [5, 6]]
+ * in2 : shape (3, 2), value = [[7, 8], [9, 10], [11, 12]]
+ * axis = 0
+ *
+ * if interleave = False (default)
+ * output : shape (6, 2)
+ * output[0:3, :] = in1
+ * output[3:6, :] = in2
+ * value = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]
+ *
+ * if interleave = True
+ * output : shape (6, 2)
+ * output[0::2, :] = in1
+ * output[1::2, :] = in2
+ * value = [[1, 2], [7, 8], [3, 4], [9, 10], [5, 6], [11, 12]]
+ *
+ */
+message ConcatNDLayerParams {
+
+    /**
+     * Dimension along which to concatenate. Supports negative values of the parameter 'axis'.
+     */
+    int64 axis = 1;
+    
+    /**
+     * (Only available in Core ML Specification >= 5 (iOS >= 14, macOS >= 11.0)
+     * Interleave option. If True, concatenation is done via interleaving the inputs.
+     * This requires all inputs to have the exact same shape.
+     */
+    bool interleave = 2;
+    
+
+}
+
+/**
+ * A layer that performs softmax normalization along a specified axis.
+ *
+ * .. code::
+ *
+ *      y = SoftmaxNDLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output shape is same as the input.
+ */
+message SoftmaxNDLayerParams {
+
+    /**
+     * Dimension on which the softmax would be performed. Supports negative values of the parameter 'axis'.
+     */
+    int64 axis = 1;
+
+}
+
+/**
+ * A layer that reverses specific dimensions of the input tensor.
+ * It is similar in functionality to the numpy.flip method.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ */
+message ReverseLayerParams {
+
+    /**
+     * Reverses each dimension of the input tensor for which corresponding reverseDim is set to True.
+     * Requires len(reverseDim) == rank(inputTensor)
+     */
+    repeated bool reverseDim = 1;
+
+}
+
+/**
+ * A layer that reverses variable length slices.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * 2 inputs, in order are denoted by "data", "seq_lengths".
+ * "seq_lenghts" must be a rank 1 tensor, i.e. seq_lengths.shape = (B,)
+ * which contains the lengths of the amount of sequence to be reversed, for each element of the batch.
+ * Dimension "batchAxis" in "data" must be equal to B, i.e,
+ * data.shape[batchAxis] = B.
+ *
+ * According to the batch axis, input "data" is first divided into a batch of B inputs,
+ * each of which is flipped along the dimension "sequenceAxis", by the amount specified in
+ * "seq_lengths", the second input.
+ *
+ * e.g.:
+ *
+ * data [shape = (2,4)]:
+ * [0 1 2 3]
+ * [4 5 6 7]
+ * seq_lengths [shape = (2,)]:
+ * [3, 0]
+ * batchAxis = 0
+ * sequenceAxis = 1
+ *
+ * output [shape = (2,4)]:
+ * [2 1 0 3]
+ * [4 5 6 7]
+ *
+ *
+ * data [shape = (2,3,2)]:
+ * [0 1]
+ * [2 3]
+ * [4 5] (slice = 0)
+ * [6 7]
+ * [8 9]
+ * [10 11] (slice = 1)
+ * seq_lengths [shape = (2,)]:
+ * [2, 3]
+ * batchAxis = 0
+ * sequenceAxis = 1
+ *
+ * output [shape = (2,3,2)]:
+ * [2 3]
+ * [0 1]
+ * [4 5] (slice = 0)
+ * [10 11]
+ * [8 9]
+ * [6 7] (slice = 1)
+ *
+ * Output shape is same as the input.
+ */
+message ReverseSeqLayerParams {
+
+    int64 batchAxis = 1; // batch axis has to be strictly less than seq_axis
+    int64 sequenceAxis = 2;
+
+}
+
+/**
+ * A layer that loads data as a parameter and provides it as an output.
+ *
+ * .. code::
+ *
+ *      y = LoadConstantNDLayer()
+ *
+ * Requires no input and produces 1 output.
+ *
+ * Output: A tensor with shape as provided in the parameter "shape"
+ */
+message LoadConstantNDLayerParams {
+
+    /**
+     * The shape of the constant to be loaded.
+     */
+    repeated uint64 shape = 1;
+    WeightParams data = 2;
+
+}
+
+/**
+ * A layer that generates an output tensor with a constant value.
+ * Input is only used to determine the shape of the output.
+ * This layer is used to allocate a tensor with a dynamic shape (that of the input) and constant value.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * .. code::
+ *
+ *      y = FillLikeLayer(x)
+ *
+ * Input
+ *     A N-Dimensional tensor, whose values are ignored. Only the shape is used to
+ *     infer the shape of the output.
+ *
+ * Output
+ *     A N-Dimensional tensor with the same shape as the input tensor.
+ *
+ */
+message FillLikeLayerParams {
+
+    float value = 1;
+
+}
+
+/**
+ * A layer that generates an output tensor with a constant value.
+ * This layer is used to allocate a tensor with a static shape and constant value.
+ *
+ * Requires no input and produces 1 output.
+ *
+ * .. code::
+ *
+ *      y = FillStaticLayer(x)
+ *
+ * Output
+ *     A N-Dimensional tensor of shape "targetShape".
+ *
+ */
+message FillStaticLayerParams {
+
+    float value = 1;
+    repeated uint64 targetShape = 2;
+
+}
+
+/**
+ * A layer that generates an output tensor with a constant value.
+ * This layer is used to allocate a tensor with a dynamic shape (as specified by the input) and constant value.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * .. code::
+ *
+ *      y = FillDynamicLayer(x)
+ *
+ * Input
+ *     A rank 1 tensor specifying the shape of the output
+ *
+ * Output
+ *     An N-Dimensional tensor with the shape specified by the values in the input tensor.
+ *
+ */
+message FillDynamicLayerParams {
+
+    float value = 1;
+
+}
+
+/**
+ * A layer that returns the elements either from tensor x or tensor y,
+ * depending on the value in the condition tensor.
+ * It is similar in functionality to the numpy.where method with 3 inputs.
+ *
+ * Requires 3 inputs and produces 1 output.
+ * Inputs, in order, are the condition tensor, x and y.
+ *
+ * for each vector index (i,...,j):
+ *    output[i,...,j] = x[i,...,j] if condition[i,...,j] = True
+ *                      y[i,...,j] if condition[i,...,j] = False
+ *
+ * All the 3 inputs are first broadcasted to a common shape.
+ * (the shapes must be broadcastable)
+ *
+ * output.rank = max(input[0].rank, input[1].rank, input[2].rank)
+ *
+ */
+message WhereBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric sine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = SinLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message SinLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric cosine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = CosLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message CosLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric tangent function.
+ *
+ *
+ * .. code::
+ *
+ *      y = TanLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message TanLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric arcsine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AsinLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AsinLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric arccosine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AcosLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AcosLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric arctangent function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AtanLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AtanLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic sine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = SinhLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message SinhLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic cosine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = CoshLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message CoshLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic tangent function.
+ *
+ *
+ * .. code::
+ *
+ *      y = TanhLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message TanhLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic arcsine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AsinhLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AsinhLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic arccosine function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AcoshLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AcoshLayerParams {
+
+}
+
+/**
+ * A layer that computes elementwise trigonometric hyperbolic arctangent function.
+ *
+ *
+ * .. code::
+ *
+ *      y = AtanhLayer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message AtanhLayerParams {
+
+}
+/**
+ * A layer that raises each element in first tensor to the power of
+ * corresponding element in the second tensor.
+ * Supports conventional numpy-like broadcasting.
+ *
+ * .. code::
+ *
+ *      y = PowBroadcastableLayer(x)
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * Input
+ *     - First N-Dimensional tensor
+ *     - Second N-Dimensional tensor
+ *
+ * Output
+ *     An N-Dimensional tensor with the broadcast shape.
+ *
+ */
+message PowBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that computes the exponential of all elements in the input tensor, with the base 2.
+ *
+ *
+ * .. code::
+ *
+ *      y = Exp2Layer(x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message Exp2LayerParams {
+
+}
+
+/**
+ * A layer that returns a tensor containing the indices of all non-zero
+ * elements of input tensor.
+ * It is similar in functionality to the numpy.where method with 1 input.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output is of rank 2, of shape (N,R),
+ * where N is the number of non-zero elements in the input and R is the rank of the input.
+ *
+ * Output contains indices represented in the multi-index form
+ *
+ * e.g.:
+ * input {shape = (4,)}:
+ * [0 1 0 2]
+ * output {shape = (2,1)}:
+ * [1]
+ * [3]
+ *
+ *
+ * input {shape = (3, 3)}:
+ * [1 2 1]
+ * [0 2 2]
+ * [2 1 0]
+ * output {shape = (7,1)}:
+ * [0. 0.]
+ * [0. 1.]
+ * [0. 2.]
+ * [1. 1.]
+ * [1. 2.]
+ * [2. 0.]
+ * [2. 1.]
+ *
+ */
+message WhereNonZeroLayerParams {
+
+}
+
+/**
+ * A layer that copies a tensor setting everything outside a central band in
+ * each inner-most matrix to zero.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters for matrix_band_part layer
+ * band(m, n) = (num_lower < 0 || (m-n) <= num_lower) && (num_upper < 0 || (n-m) <= num_upper).
+ * output[i, j, k, ..., m, n] = band(m, n) * input[i, j, k, ..., m, n]
+ *
+ *
+ * Output shape is same as the input shape.
+ * Rank of the input must be at least 2.
+ * For rank higher than 2, the last 2 dimensions are treated as the matrix, while the rest are treated as batch.
+ */
+message MatrixBandPartLayerParams {
+
+    int64 numLower = 1;
+    int64 numUpper = 2;
+
+}
+
+/**
+ * A layer that copies a tensor setting everything outside upper triangular to zero.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output shape is same as the input shape.
+ * Rank of the input must be at least 2.
+ * For rank higher than 2, the last 2 dimensions are treated as the matrix, while the rest are treated as batch.
+ */
+message UpperTriangularLayerParams {
+
+    int64 k = 1; // Diagonal below which to zero elements. k = 0 (the default) is the main diagonal, k < 0 is below it and k > 0 is above
+
+}
+
+/**
+ * A layer that copies a tensor setting everything outside lower triangular to zero.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output shape is same as the input shape.
+ * Rank of the input must be at least 2.
+ * For rank higher than 2, the last 2 dimensions are treated as the matrix, while the rest are treated as batch.
+ */
+message LowerTriangularLayerParams {
+
+    int64 k = 1; // Diagonal above which to zero elements. k = 0 (the default) is the main diagonal, k < 0 is below it and k > 0 is above
+
+}
+
+/**
+ *
+ * A layer that broadcasts a tensor to a new shape.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * First input is broadcast to produce the output, while the second input is only
+ * used to determine the shape of the output. Values of second input are not used.
+ *
+ * Output is a tensor with the same shape as the second input.
+ *
+ */
+message BroadcastToLikeLayerParams {
+
+}
+
+/**
+ *
+ * A layer that broadcasts a tensor to a new shape.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output tensor is the broadcasted version of the input and has shape as specified in the
+ * parameter "targetShape".
+ */
+message BroadcastToStaticLayerParams {
+
+    repeated uint64 targetShape = 1;
+
+}
+
+/**
+ *
+ * A layer that broadcasts a tensor to a new shape.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * First input is the one that is broadcasted to produce the output.
+ * Second input is a rank 1 tensor specifying the shape of the output.
+ * Output tensor has shape as specified by the values in the 2nd input tensor.
+ */
+message BroadcastToDynamicLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise addition operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message AddBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise maximum operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message MaxBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise minimum operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message MinBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise modular operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message ModBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise floor division operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message FloorDivBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise subtract operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message SubtractBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise multiply operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message MultiplyBroadcastableLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise division operation with broadcast support.
+ *
+ * Requires 2 inputs and produces 1 output.
+ */
+message DivideBroadcastableLayerParams {
+
+}
+
+/**
+ * Gather layer that gathers elements from the first input, along a specified axis,
+ * at indices specified in the second input.
+ * It is similar in functionality to the numpy.take method.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * Given two inputs, 'data' and 'indices', gather the slices of 'data'
+ * and store into output.
+ * e.g.
+ * for i in [0, length(indices) - 1]
+ *    output[i] = data[indices[i]]  (1-D case, axis=0)
+ *
+ * if axis = 0:
+ * for each vector index (i,...,j)
+ *    output[i,...,j,:,..,:] = data[indices[i,...,j],:,..,:]
+ *
+ * output.rank = (data.rank - 1) + indices.rank
+ *
+ * Negative indices and negative axis are supported.
+ *
+ * e.g:
+ *
+ * data shape = (2, 3)
+ * indices shape = (6, 8)
+ * axis = 0
+ * output shape = (6, 8) + (3,) = (6, 8, 3)
+ *
+ * data shape = (2, 3, 5)
+ * indices shape = (6, 8)
+ * axis = 1
+ * output shape = (2,) + (6, 8) + (5,) =  (2, 6, 8, 5)
+ *
+ */
+message GatherLayerParams {
+
+    int64 axis = 1;
+
+}
+
+/*
+ * Scatter accumulation mode.
+ */
+enum ScatterMode {
+
+    SCATTER_UPDATE = 0;
+    SCATTER_ADD = 1; /// add
+    SCATTER_SUB = 2; /// subtract
+    SCATTER_MUL = 3; /// multiply
+    SCATTER_DIV = 4; /// divide
+    SCATTER_MAX = 5; /// maximum
+    SCATTER_MIN = 6; /// minimum
+
+}
+
+/*
+ * A layer that scatters data into a new tensor according to indices from the input.
+ * This is the inverse operation of Gather.
+ *
+ * Requires 3 inputs and produces 1 output.
+ *
+ * Output is initialized with the first input.
+ * Then updated with the values in the third input, at indices specified by the second input.
+ *
+ * An example when axis=0:
+ * Given three inputs, in order, "container", "indices", "updates", where
+ *
+ * - "container" is a rank R+1 tensor of shape [D_0, D_1, ..., D_R], which
+ *   contains D_0 number of tensors, each with shape [D_1, ..., D_R].
+ *
+ * - "indices" is a rank 1 tensor with shape [N], where N is the number of updates.
+ *   The values in this tensor must be in the range [0, D_0 - 1]. (negative indexing is supported)
+ *
+ * - "updates" is a rank R+1 tensor with shape [N, D_1, ..., D_R], which represents
+ *   a total number of N tensors, each of shape [D_1, ..., D_R].
+ *
+ * The effect of this operation is as follows:
+ *
+ * output = container;
+ * For each i in 0, ..., N - 1
+ *    output[indices[i], :, ..., :] = updates[i, :, ..., :] // if mode == "SCATTER_UPDATE"
+ *
+ * or
+ * For each i in 0, ..., N - 1
+ *    output[indices[i], :, ..., :] += updates[i, :, ..., :] // if mode == "SCATTER_ADD"
+ *
+ * etc
+ *
+ * When "indices" is a tensor of rank greater than 1, the equation becomes (for axis=0):
+ * For each vector index (i,...,j)
+ *   output[indices[i,...,j],...] -= updates[i,...,j,...] // if mode == "SCATTER_SUB"
+ *
+ *
+ * The output has the same shape as the first input.
+ * "indices" input must have rank less than or equal to the "updates" input and its shape
+ * must be a subset of the the shape of the "updates" input.
+ *
+ * e.g:
+ *
+ * container shape = (4, 3)
+ * indices shape = (5, 2, 3)
+ * updates shape = (4, 5, 2, 3)
+ * axis = 1
+ * output shape = (4, 3)
+ *
+ * container shape = (4, 4, 3)
+ * indices shape = (6,)
+ * updates shape = (4, 6, 3)
+ * axis = -2
+ * output shape = (4, 4, 3)
+ *
+ * container shape = (5,)
+ * indices shape = (5, 7, 5, 6)
+ * updates shape = (5, 7, 5, 6)
+ * axis = -1
+ * output shape = (5,)
+ */
+
+message ScatterLayerParams {
+
+    int64 axis = 1;
+    ScatterMode mode = 2; /// mode of accumulation.
+
+}
+
+/**
+ * A layer that gathers elements from the first input, 'params', at the multi-indices specified
+ * by the second input, 'indices'.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * 'params' = input[0], 'indices' = input[1]
+ *
+ * 'indices' is a rank K+1 tensor of shape [I_0, I_1, .., I_(K-1), I_K] which is viewed as a collection of
+ * indices of (I_0 * I_1 * ... * I_(K-1)) points in the I_K dimensional space. For instance, the multi-index of the first point
+ * is indices[0,0,...,0,:].
+ *
+ * Here is how the output is constructed:
+ *
+ * for i = 0,1,...,(I_0-1)
+ *   ...
+ *     for j = 0,1,....,(I_(K-1)-1)
+ *          output[i,....,j,:,:,..,:] = params[indices[i,...,j,:], :,:,..,:]
+ *
+ * Hence, output shape is [I_0, I_1,...,I(K-1)] + params.shape[I_K:]
+ *
+ * output.rank = indices.rank - 1 + params.rank - indices.shape[-1]
+ *
+ * e.g:
+ *
+ * input[0] shape = (4, 2, 3, 4)
+ * input[1] shape = (6, 2)
+ * output shape = (6,) + (3, 4) = (6, 3, 4)
+ *
+ * input[0] shape = (3, 3, 3, 4, 7)
+ * input[1] shape = (3, 5)
+ * output shape = (3,) + () = (3,)
+ *
+ * input[0] shape = (5, 3, 2, 5)
+ * input[1] shape = (2, 7, 3, 2)
+ * output shape = (2, 7, 3) + (2, 5) = (2, 7, 3, 2, 5)
+ *
+ */
+message GatherNDLayerParams {
+
+}
+
+/*
+ * A layer that scatters data into a new tensor according to multi-indices from the input.
+ * This is the inverse operation of GatherND.
+ *
+ * Requires 3 inputs and produces 1 output.
+ * 3 inputs, in order are denoted as "container", "indices", "updates".
+ *
+ * 'indices' is a rank K+1 tensor of shape [I_0, I_1, .., I_(K-1), I_K] which is viewed as a collection of
+ * indices of (I_0 * I_1 * ... * I_(K-1)) points in the I_K dimensional space. For instance, the multi-index of the first point
+ * is indices[0,0,...,0,:].
+ *
+ * container.rank >= I_K
+ * updates.rank = K + (container.rank - I_K)
+ * shape of 'updates' = [I_0, I_1,...,I(K-1)] + container.shape[I_K:]
+ *
+ * output = container
+ * For each vector index (i,...,j) s.t. 0<=i<I_0,..., 0<=j<I_K
+ *   output[indices[i,...,j,:], :,:,..,:] = updates[i,....,j,:,:,..,:] // if mode == "SCATTER_UPDATE"
+ *
+ * The output has the same shape as the first input.
+ *
+ * e.g:
+ *
+ * container shape = (3, 2)
+ * indices shape = (4, 2)
+ * updates shape = (4,)
+ * output shape = (3, 2)
+ *
+ * container shape = (7, 6)
+ * indices shape = (4, 7, 2, 5, 1)
+ * updates shape = (4, 7, 2, 5, 6)
+ * output shape = (7, 6)
+ *
+ */
+message ScatterNDLayerParams {
+
+    ScatterMode mode = 1; /// mode of accumulation.
+
+}
+
+/**
+ * Gather layer that gathers elements from the first input, along a specified axis,
+ * at indices specified in the second input.
+ * It is similar in functionality to the numpy.take_along_axis method.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * Given two inputs, 'data' and 'indices', gather the slices of 'data'
+ * and store into output.
+ *
+ * Both inputs and output have the same rank.
+ * Output shape is same as the shape of 'indices'
+ * Shapes of 'indices' and 'data' match, except at the 'axis' dimension.
+ *
+ * This operation performs the following operation for axis=0:
+ * for each vector index (i,j,....,k)
+ *    output[i,j,....,k] = data[index[i,j,....,k],j,....,k]
+ *
+ * Negative indices and negative axis are supported.
+ *
+ * e.g:
+ *
+ * data shape = (4, 4, 7)
+ * indices shape = (4, 5, 7)
+ * axis = 1
+ * output shape = (4, 5, 7)
+ *
+ */
+message GatherAlongAxisLayerParams {
+
+    int64 axis = 1;
+
+}
+
+/**
+ * A layer that scatters data into a new tensor according to indices from
+ * the input along the given axis into the output tensor.
+ * This is the inverse operation of GatherAlongAxis.
+ * It is similar in functionality to the numpy.put_along_axis method.
+ *
+ * Requires 3 inputs and produces 1 output.
+ * 3 inputs, in order are denoted as "container", "indices", "updates".
+ *
+ * All inputs and output have the same rank.
+ * Output shape is same as the shape of 'container'
+ * Shapes of 'indices' and 'updates' match, which is same as the shape of 'container' except at the 'axis' dimension.
+ *
+ * Negative indices and negative axis are supported.
+ *
+ * This operation performs the following operation for axis=0:
+ * output = container
+ * for each vector index (i,j,....,k)
+ *    output[index[i,j,....,k],j,....,k] = updates[i,j,....,k]
+ *
+ * e.g.:
+ *
+ * container shape = (2, 5, 6)
+ * indices shape = (2, 2, 6)
+ * updates shape = (2, 2, 6)
+ * axis = -2
+ * output shape = (2, 5, 6)
+ *
+ */
+message ScatterAlongAxisLayerParams {
+
+    int64 axis = 1;
+    ScatterMode mode = 2; /// mode of accumulation.
+
+}
+
+/**
+ * A layer that stacks the input tensors along the given axis.
+ * It is similar in functionality to the numpy.stack method.
+ *
+ * Requires at least 2 inputs and produces 1 output.
+ * All inputs must have the same shape.
+ * Rank of the output is 1 greater than the rank of the inputs.
+ *
+ * Negative indexing is supported for the "axis" parameter.
+ *
+ * e.g.:
+ *
+ * input shape = (2, 4, 2)
+ * number of inputs = 5
+ * axis = 3
+ * output shape = (2, 4, 2, 5)
+ *
+ * input shape = (2, 4, 2)
+ * number of inputs = 5
+ * axis = -2
+ * output shape = (2, 4, 5, 2)
+ */
+message StackLayerParams {
+
+    int64 axis = 1;
+
+}
+
+/**
+ * A layer that reshapes a tensor that does not alter the rank of the input.
+ * Order of the data is left unchanged.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * e.g:
+ *
+ * input shape = (20,10)
+ * targetShape = (5,-1)
+ * output shape = (5,40)
+ *
+ * input shape = (20,10,5)
+ * targetShape = (0,2,25)
+ * output shape = (20,2,25)
+ *
+ * input shape = (10,3,5)
+ * targetShape = (25,0,-1)
+ * output shape = (25,3,2)
+ */
+message RankPreservingReshapeLayerParams {
+
+    /**
+     * Length of this field must be same as the input/output rank.
+     * It can have 0's, in which case the corresponding input dimension is kept intact.
+     * At most one element can be -1, in which case the output dimension is calculated from rest of the shape.
+     */
+    repeated int64 targetShape = 1;
+
+}
+
+/**
+ * Constant padding layer.
+ * Pad the input array with a constant value, either along a single given axis or along a set of axes.
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ * The amount of padding can be either set as a parameter ("padAmounts") or provided as a second input.
+ *
+ * Output rank is same as the rank of the first input.
+ *
+ * when "padToGivenOutputSizeMode" is False:
+ *
+ * output_shape[i] = input_shape[i] + padAmounts[2*i] + padAmounts[2*i+1], i=0,...,rank-1
+ *
+ * Examples:
+ *
+ * input shape = (20,10)
+ * padAmounts = [0,1,4,0]
+ * output shape = (21,14)
+ *
+ * input shape = (20,10,5)
+ * padAmounts = [0,0,3,4,0,9]
+ * output shape = (20,17,14)
+ *
+ *
+ * when "padToGivenOutputSizeMode" is True
+ *
+ * output_shape[i] = max(input_shape[i], max(padAmounts[2*i] + padAmounts[2*i+1])), i=0,...,rank-1
+ *
+ * input shape = (20,10)
+ * padAmounts = [0,21,14,0]
+ * output shape = (21,14)
+ *
+ * input shape = (20,10,5)
+ * padAmounts = [0,0,17,0,0,14]
+ * output shape = (20,17,14)
+ */
+message ConstantPaddingLayerParams {
+    /**
+     * The value to be used for padding.
+     */
+    float value = 1;
+
+    /**
+     * Length of this repeated field must be twice the rank of the first input.
+     * 2*i-th and (2*i+1)-th values represent the amount of padding to be applied to the the i-th input
+     * dimension, "before" and "after" the input values, respectively.
+     */
+    repeated uint64 padAmounts = 2;
+
+    /**
+     * When this is True, positive values in "padAmounts" are equivalent to the output shape.
+     * In that case only one of padAmounts[2*i] and padAmounts[2*i+1] can be non zero, for i=0,..,rank-1.
+     */
+    bool padToGivenOutputSizeMode = 3;
+}
+
+/**
+ * A layer that returns a tensor filled with values from the normal distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the normal distribution.
+ *     mean: mean of the normal distribution.
+ *     stdDev: standard deviation of the normal distribution.
+ *
+ * Input
+ *     An N-Dimensional tensor, whose values are ignored. Only the shape is used to
+ *     infer the shape of the output.
+ *
+ * Output
+ *     An N-Dimensional tensor with the same shape as the input tensor.
+ *
+ */
+message RandomNormalLikeLayerParams {
+
+    int64 seed = 1;
+    float mean = 2;
+    float stdDev = 3;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the normal distribution.
+ *
+ * Requires no input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the normal distribution.
+ *     mean: mean of the normal distribution.
+ *     stdDev: standard deviation of the normal distribution.
+ *     outputShape: shape of the output tensor.
+ *
+ * Output
+ *     An N-Dimensional tensor of shape "outputShape".
+ *
+ */
+message RandomNormalStaticLayerParams {
+
+    int64 seed = 1;
+    float mean = 2;
+    float stdDev = 3;
+    repeated uint64 outputShape = 4;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the normal distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *     seed: seed used for the normal distribution.
+ *     mean: mean of the normal distribution.
+ *     stdDev: standard deviation of the normal distribution.
+ *
+ * Input
+ *     A rank 1 tensor specifying the shape of the output
+ *
+ * Output
+ *     An N-Dimensional tensor with the shape specified by the values in the input tensor.
+ */
+message RandomNormalDynamicLayerParams {
+
+    int64 seed = 1;
+    float mean = 2;
+    float stdDev = 3;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the uniform distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the uniform distribution.
+ *     minVal: lower bound on the range of random values for the uniform distribution.
+ *     maxVal: upper bound on the range of random values for the uniform distribution.
+ *
+ * Input
+ *     An N-Dimensional tensor, whose values are ignored. Only the shape is used to
+ *     infer the shape of the output.
+ *
+ * Output
+ *     An N-Dimensional tensor with the same shape as the input tensor.
+ *
+ */
+message RandomUniformLikeLayerParams {
+
+    int64 seed = 1;
+    float minVal = 2;
+    float maxVal = 3;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the uniform distribution.
+ *
+ * Requires no input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the uniform distribution.
+ *     minVal: lower bound on the range of random values for the uniform distribution.
+ *     maxVal: upper bound on the range of random values for the uniform distribution.
+ *     outputShape: shape of the output tensor.
+ *
+ * Output
+ *     An N-Dimensional tensor of shape "outputShape".
+ *
+ */
+message RandomUniformStaticLayerParams {
+
+    int64 seed = 1;
+    float minVal = 2;
+    float maxVal = 3;
+    repeated uint64 outputShape = 4;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the uniform distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *     seed: seed used for the uniform distribution.
+ *     minVal: lower bound on the range of random values for the uniform distribution.
+ *     maxVal: upper bound on the range of random values for the uniform distribution.
+ *
+ * Input
+ *     A rank 1 tensor specifying the shape of the output
+ *
+ * Output
+ *     An N-Dimensional tensor with the shape specified by the values in the input tensor.
+ *
+ */
+message RandomUniformDynamicLayerParams {
+
+    int64 seed = 1;
+    float minVal = 2;
+    float maxVal = 3;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the Bernoulli distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the Bernoulli distribution.
+ *     prob: probability of a 1 event.
+ *
+ * Input
+ *     An N-Dimensional tensor, whose values are ignored. Only the shape is used to
+ *     infer the shape of the output.
+ *
+ * Output
+ *     An N-Dimensional tensor with the same shape as the input tensor.
+ *
+ */
+message RandomBernoulliLikeLayerParams {
+
+    int64 seed = 1;
+    float prob = 2;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the Bernoulli distribution.
+ *
+ * Requires no input and produces 1 output.
+ *
+ * Parameters
+ *     seed: seed used for the Bernoulli distribution.
+ *     prob: probability of a 1 event.
+ *     outputShape: shape of the output tensor.
+ *
+ * Output
+ *     An N-Dimensional tensor of shape "outputShape".
+ */
+message RandomBernoulliStaticLayerParams {
+
+    int64 seed = 1;
+    float prob = 2;
+    repeated uint64 outputShape = 3;
+
+}
+
+/**
+ * A layer that returns a tensor filled with values from the Bernoulli distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *     seed: seed used for the Bernoulli distribution.
+ *     prob: probability of a 1 event.
+ *
+ * Input
+ *     A rank 1 tensor specifying the shape of the output
+ *
+ * Output
+ *     An N-Dimensional tensor with the shape specified by the values in the input tensor.
+ */
+message RandomBernoulliDynamicLayerParams {
+
+    int64 seed = 1;
+    float prob = 2;
+
+}
+
+/**
+ * A layer that returns a tensor of the specified shape filled with values from the categorical distribution.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameter:
+ *     seed: seed used for the categorical distribution.
+ *     numSamples: number of samples to draw.
+ *     isLogits: true if the inputs are logits, false if the inputs are probabilities.
+ *     eps: default value is 1e-10.
+ *     temperature: default value is 1.0.
+ *
+ * Input tensor shape = [D_1, D_2, ... , D_(R-1), D_R] (Rank = R)
+ * Then the shape of the output is [D_1, D_2, ... , D_(R-1), numSamples] (Rank = R)
+ *
+ */
+message CategoricalDistributionLayerParams {
+
+    int64 seed = 1;
+    int64 numSamples = 2;
+    bool isLogits = 3;
+    float eps = 4;
+    float temperature = 5;
+}
+
+/**
+ * A layer that performs reduction with L1 normalization operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceL1LayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with L2 normalization operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceL2LayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with max operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceMaxLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with min operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceMinLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with sum operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceSumLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with prod operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceProdLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with mean operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceMeanLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with logSum operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceLogSumLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with logSumExp operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceSumSquareLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that performs reduction with logSumExp operation.
+ *
+ * Negative indexing is supported.
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameters:
+ *    axes: dimensions along which to perform reduction
+ *    keepDims: if True, keep the reduced dimensions (value will be 1), otherwise, reduced dimensions are squeezed
+ *    reduceAll: ignore the "axes" parameter, perform reduction along all axes
+ *
+ */
+message ReduceLogSumExpLayerParams {
+
+    repeated int64 axes = 1;
+    bool keepDims = 2;
+    bool reduceAll = 3;
+
+}
+
+/**
+ * A layer that increases the rank of the input tensor by adding unit dimensions.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * e.g.:
+ *
+ * input shape = (10,5)
+ * axes = (0,1)
+ * output shape = (1,1,10,5)
+ *
+ * input shape = (10,5)
+ * axes = (0,2)
+ * output shape = (1,10,1,5)
+ *
+ * input shape = (10,5)
+ * axes = (-2,-1)
+ * output shape = (10,5,1,1)
+ *
+ */
+message ExpandDimsLayerParams {
+
+    /**
+     * Axis values provided here get dimension 1 in the output tensor.
+     * Negative indexing is supported.
+     */
+    repeated int64 axes = 1;
+
+}
+
+/**
+ * A layer that flattens the input tensor into a 2-dimensional matrix.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output tensor is always rank 2.
+ *
+ * First dimension of output is the product of all the dimensions in input[:axis] ("axis" is exclusive)
+ * Second dimension of output is the product of all the dimensions in input[axis:] ("axis" is inclusive)
+ *
+ * e.g.:
+ * input shape:  (3,)
+ * axis:  -1
+ * output shape:  (1, 3)
+ *
+ * input shape:  (3,)
+ * axis:  1
+ * output shape:  (3, 1)
+ *
+ * input shape:  (4, 3)
+ * axis:  -1
+ * output shape:  (4, 3)
+ *
+ * input shape:  (5, 2)
+ * axis:  0
+ * output shape:  (1, 10)
+ *
+ * input shape:  (5, 5, 3)
+ * axis:  -2
+ * output shape:  (5, 15)
+ *
+ * input shape:  (2, 3, 2)
+ * axis:  -1
+ * output shape:  (6, 2)
+ *
+ */
+message FlattenTo2DLayerParams {
+
+    int64 axis = 1;
+
+}
+
+/**
+ * A layer that reshapes a tensor.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output tensor is the reshaped version of the input and has shape as specified in the
+ * parameter "targetShape".
+ *
+ */
+message ReshapeStaticLayerParams {
+
+    repeated int64 targetShape = 1;
+
+}
+
+/**
+ * A layer that reshapes a tensor.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * First input is reshaped to produce the output, while the second input is only
+ * used to determine the shape of the output. Values of the second input are not used.
+ *
+ * Output is a tensor with the same shape as the second input.
+ *
+ */
+message ReshapeLikeLayerParams {
+
+}
+
+/**
+ * A layer that reshapes a tensor.
+ *
+ * Requires 2 inputs and produces 1 output.
+ *
+ * First input is the one that is reshaped to produce the output.
+ * Second input is a rank 1 tensor specifying the shape of the output.
+ * Output tensor has shape as specified by the values in the 2nd input tensor.
+ */
+message ReshapeDynamicLayerParams {
+
+}
+
+/**
+ * A layer that decreases the rank of the input tensor by removing unit dimensions.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Output rank is one less than input rank, if input rank is more than 1.
+ * If input rank is 1, output rank is also 1.
+ *
+ * e.g.:
+ *
+ * input shape = (1,1,10,5)
+ * axes = (0,1)
+ * output shape = (10,5)
+ *
+ * input shape = (1,10,5,1)
+ * axes = (0,3)
+ * output shape = (10,5)
+ *
+ * input shape = (10,5,1,1)
+ * axes = (-2,-1)
+ * output shape = (10,5)
+ *
+ * input shape = (1,)
+ * axes = (0)
+ * output shape = (1,)
+ *
+ */
+message SqueezeLayerParams {
+
+    /**
+     * Axis values provided here get removed from the input tensor.
+     * Negative indexing is supported.
+     */
+    repeated int64 axes = 1;
+    bool squeezeAll = 2; // if true squeeze all dimensions that are 1.
+
+}
+
+/**
+ * A layer that returns top K (or bottom K) values and the corresponding indices
+ * of the input along a given axis.
+ *
+ * Requires 1 or 2 inputs and produces 2 outputs.
+ *
+ * The second input is the value of the K, and is optional.
+ * If there is only one input, value of K that is specified in the layer parameter is used.
+ *
+ * Both outputs have the same rank as the first input.
+ * Second input must correspond to a scalar tensor.
+ *
+ * e.g.:
+ *
+ * first input's shape = (45, 34, 10, 5)
+ * axis = 1
+ * output shape, for both outputs = (45, K, 10, 5)
+ *
+ */
+message TopKLayerParams {
+
+    int64 axis = 1; ///  negative indexing is supported
+    uint64 K = 2; /// is ignored if a second input is present.
+    bool useBottomK = 3; /// if true, bottom K (values, indices) are returned instead
+
+}
+
+/**
+ * A layer that returns the indices of the maximum value along a specified axis in a tensor.
+ *
+ * Requires 1 input and produces 1 output. Negative indexing is supported.
+ *
+ * Output has the same rank as the input if "removeDim" is False (default).
+ * Output has rank one less than the input if "removeDim" is True and input rank is more than 1.
+ *
+ * e.g.:
+ *
+ * input shape = (45, 34, 10, 5)
+ * axis = -2
+ * output shape = (45, 1, 10, 5), if removeDim = False (default)
+ * output shape = (45, 10, 5), if removeDim = True
+ *
+ * input shape = (5,)
+ * axis = 0
+ * output shape = (1,), if removeDim = False or True
+ *
+ */
+message ArgMaxLayerParams {
+
+    int64 axis = 1;
+    bool removeDim = 2;
+
+}
+
+/**
+* A layer that returns the indices of the minimum value along a specified axis in a tensor.
+*
+* Requires 1 input and produces 1 output. Negative indexing is supported.
+*
+* Output has the same rank as the input if "removeDim" is False (default).
+* Output has rank one less than the input if "removeDim" is True and input rank is more than 1.
+*
+* e.g.:
+*
+* input shape = (45, 34, 10, 5)
+* axis = -2
+* output shape = (45, 1, 10, 5), if removeDim = False (default)
+* output shape = (45, 10, 5), if removeDim = True
+*
+* input shape = (5,)
+* axis = 0
+* output shape = (1,), if removeDim = False or True
+*
+*/
+message ArgMinLayerParams {
+
+    int64 axis = 1;
+    bool removeDim = 2;
+
+}
+
+/**
+ * A layer layer that splits the input tensor into multiple output tensors,
+ * along the specified axis.
+ *
+ * The layer either uniformly splits the input tensor into ``num_splits`` tensors, or
+ * splits according to the given split sizes in ``split_sizes``.
+ * Supports unequal splits and negative indexing.
+ *
+ * Requires 1 input and produces at least 2 outputs.
+ * Rank of all the outputs is same as that of the input.
+ *
+ * If parameter "splitSizes" is provided, value of the parameter "numSplits" is ignored, since in that case
+ * "numSplits" is automatically inferred to be the length of "splitSizes".
+ *
+ *
+ * e.g.:
+ * input shape:  (5, 3, 4)
+ * axis = -3, split_sizes = [3, 2]
+ * output shape:  (3, 3, 4)
+ * output shape:  (2, 3, 4)
+ */
+message SplitNDLayerParams {
+
+    int64 axis = 1;
+    uint64 numSplits = 2;
+    repeated uint64 splitSizes = 3;
+
+}
+
+/**
+ * A layer that performs element-wise ceil operation on the input tensor that
+ * rounds the value to the smallest integer not less than x.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message CeilLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise round operation on the input tensor
+ * that rounds the value to the nearest integer.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message RoundLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise floor operation on the input tensor
+ * that rounds the value to the largest integer not greater than x.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message FloorLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise sign operation (+1 for positive values,
+ * -1 for negative values, 0 for zeros).
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message SignLayerParams {
+
+}
+
+/**
+ * A layer that performs element-wise clip operation. Clip the values in the
+ * input tensor to the threshold values [min_value, max_value].
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Parameter minVal: the minimum threshold.
+ * Parameter maxVal: the maximum threshold.
+ *
+ * output =  min(max(input, minVal), maxVal)
+ *
+ * Output shape is same as the input.
+ */
+message ClipLayerParams {
+
+    float minVal = 1;
+    float maxVal = 2;
+
+}
+
+/**
+ * A layer that extracts a slice of size ``(end - begin) / stride``
+ * from the given input tensor.
+ * Support negative indexing and negative strides.
+ *
+ * Requires 1 input and produces 1 output.
+ * Output rank is same as the input rank.
+ *
+ * Value of beginIds, beginMasks, endIds, endMasks, strides are required parameters.
+ * Lengths of all the parameters must equal the rank of the input.
+ *
+ * i-th element of "beginIds" is ignored and assumed to be 0 if the i-th element of
+ * "beginMasks" is True
+ *
+ * i-th element of "endIds" is ignored and assumed to be -1 if the i-th element of
+ * "endMasks" is True
+ *
+ * e.g.:
+ * if i-th element of "squeezeMasks" is set to True, only beginIds[i] would be sliced
+ * out, and all other masks and inputs are ignored.
+ *
+ * e.g. (without squeezeMasks):
+ * input shape:  (5, 5, 5)
+ * beginIds:  [1, 2, 3]
+ * beginMasks:  [True, False, True]
+ * endIds:  [3, -3, 2]
+ * endMasks:  [False, True, True]
+ * strides:  [2, 2, 2]
+ * SqueezeMasks:  [False, False, False]
+ * output shape:  (2, 2, 3)
+ * This is equivalent to input[:3:2, 2::2, ::2]
+ *
+ * e.g. (with squeezeMasks):
+ * input shape:  (5, 5, 5)
+ * beginIds:  [1, 2, 3]
+ * beginMasks:  [True, False, True]
+ * endIds:  [3, -3, 2]
+ * endMasks:  [False, True, True]
+ * strides:  [2, 2, 2]
+ * SqueezeMasks:  [False, True, False]
+ * output shape:  (2, 3)
+ * This is equivalent to input[:3:2, 2, ::2]
+ *
+ */
+message SliceStaticLayerParams {
+
+    repeated int64 beginIds = 1;
+    repeated bool beginMasks = 2;
+    repeated int64 endIds = 3;
+    repeated bool endMasks = 4;
+    repeated int64 strides = 5;
+    repeated bool squeezeMasks = 6;
+
+
+}
+
+/**
+ * A layer that extracts a slice of size ``(end - begin) / stride``
+ * from the given input tensor.
+ * Support negative indexing and negative strides.
+ * See "SliceStaticLayerParams" for the description and an example of the functionality of the layer.
+ *
+ * Requires 2 to 7 inputs and produces 1 output.
+ * Rank of the output is same as the rank of the first input unless squeezeMask is set.
+ *
+ * Value of beginIds, beginMasks, endIds, endMasks, strides can be passed in either
+ * as dynamic inputs or as static parameters.
+ * Lengths of all the parameters or inputs from 2-6 must equal the rank of the first input.
+ *
+ * The 2nd input represents the "beginIds".
+ * The 3rd input, if present, corresponds to "endIds". In this case the value of the "endIds" parameter is ignored.
+ * The 4th input, if present, corresponds to "strides". In this case the value of the "strides" parameter is ignored.
+ * The 5th input, if present, corresponds to "beginMasks". In this case the value of the "beginMasks" parameter is ignored.
+ * The 6th input, if present, corresponds to "endMasks". In this case the value of the "endMasks" parameter is ignored.
+ * The 7th input, if present, corresponds to "squeezeMasks". In this case the value of the "squeezeMasks" parameter is ignored.
+ *
+ */
+message SliceDynamicLayerParams {
+
+    repeated bool beginMasks = 2;
+    repeated int64 endIds = 3;
+    repeated bool endMasks = 4;
+    repeated int64 strides = 5;
+    repeated bool squeezeMasks = 6;
+
+}
+
+/**
+ * A layer that constructs a tensor by repeating the input tensor multiple
+ * number of times.
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ * Output rank is same as the input rank.
+ *
+ * If two inputs are provided, second input is used as "reps"
+ * and "reps" parameter is ignored.
+ *
+ * If only one input is provided,
+ * length of the "reps" parameter must be at least 1 and
+ * not greater than the rank of the input.
+ * If it is less than the input rank, it is made equal to the input rank by prepending 1's to it.
+ *
+ * e.g.:
+ *
+ * input shape = (2, 4, 2)
+ * reps = (1, 2, 6)
+ * output shape = (2, 8, 12)
+ *
+ * input shape = (2, 4, 2)
+ * reps = (6)
+ * reps after prepending ones = (1, 1, 6)
+ * output shape = (2, 4, 12)
+ *
+ * input shape = (2, 4, 2)
+ * second input = [1, 2, 6] -> shape: (3,)
+ * reps = N/A [Ignored]
+ * output shape = (2, 8, 12)
+ *
+ */
+message TileLayerParams {
+
+    repeated uint64 reps = 1;
+
+}
+
+/**
+ * A layer that returns the shape of an input tensor.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input: a tensor.
+ * Output: a vector of length R, where R is the rank of the input tensor
+ * Output is always a rank 1 tensor.
+ */
+message GetShapeLayerParams {
+
+}
+
+/**
+ * A layer that computes the Gauss error function,
+ * which is defined as:
+ *
+ * .. math::
+ *     f(x) = \dfrac{1}{\sqrt{\pi}}\int_{-x}^{x}{e^{-t^2}dt}
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ */
+message ErfLayerParams {
+
+}
+
+/**
+ * A layer that evaluates the Gaussian Error Linear Unit (GELU) activation.
+ * Following equations are used to compute the activation based on the value of the "mode" parameter:
+ *
+ * mode == 'EXACT':
+ * .. math::
+ *     f(x) = 0.5x\left ( 1+\rm{erf}\left ( \frac{x}{\sqrt{2}} \right ) \right )
+ *
+ * mode == 'TANH_APPROXIMATION':
+ * .. math::
+ *     f(x) = 0.5x\left ( 1+\rm{tanh}\left ( \sqrt{2/\pi}\left ( x + 0.044715x^3 \right ) \right ) \right )
+ *
+ * mode == 'SIGMOID_APPROXIMATION':
+ * .. math::
+ *     f(x) = x*\rm{sigmoid}(1.702x)
+ *
+ * Requires 1 input and produces 1 output.
+ * Output shape is same as the input.
+ *
+ */
+message GeluLayerParams {
+
+    enum GeluMode {
+
+        EXACT = 0;
+        TANH_APPROXIMATION = 1;
+        SIGMOID_APPROXIMATION = 2;
+
+    }
+
+    GeluMode mode = 1; /// mode of GELU operation.
+
+}
+
+/**
+ * RangeStatic layer that returns a tensor that contains evenly spaced values.
+ * It is similar in functionality to the numpy.arange method.
+ *
+ * Requires no input and produces 1 output.
+ * Output is a rank 1 tensor.
+ */
+message RangeStaticLayerParams {
+
+    float endValue = 1;
+    float startValue = 2;
+    float stepSizeValue = 3;
+
+}
+
+/**
+ * A layer that returns a tensor that contains evenly spaced values.
+ * Its functionality is similar to the numpy.arange method.
+ *
+ * Requires at least 1 input, up to a maximum of 3 inputs.
+ * Produces 1 output, which is a rank 1 tensor.
+ *
+ * Each input must be a scalar, or rank 1 and shape (1,).
+ *
+ * The first input represents the "endValue".
+ * The second input, if present, corresponds to "startValue". In this case the value of the "startValue" parameter is ignored.
+ * The third input, if present, corresponds to "stepSizeValue". In this case the value of the "stepSizeValue" parameter is ignored.
+ *
+ */
+message RangeDynamicLayerParams {
+
+    float startValue = 2;
+    float stepSizeValue = 3;
+
+}
+
+/**
+ * A layer that returns a tensor containing all windows of size ``windowSize``
+ * separated by ``step`` along the dimension ``axis``.
+ *
+ * .. code::
+ *
+ *      y = SlidingWindows(x)
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * Input
+ *     An N-Dimensional tensor.
+ *
+ * Output
+ *     An (N+1)-Dimensional tensor.
+ *
+ * This operation behaves as following:
+ *      - if axis = 0 & input is rank 1 (L,). Output shape will be (M, W).
+ *      - if axis = 1 & input is rank 3 (B1, L, C1). Output shape will be (B1, M, W, C1)
+ *      - if axis = 2 & input is rank 5 (B1, B2, L, C1, C2) --> (B1 * B2, L, C1 * C2) --> (B1 * B2, M, W, C1 * C2). Output shape will be (B1, B2, M, W, C1, C2)
+ *      - etc.
+ * where
+ *      - L, C, B refer to input length, feature dimension length & batch size respectively
+ *      - W is the window size.
+ *      - M is the number of windows/slices calculated as M = (L - W) / step + 1
+ */
+message SlidingWindowsLayerParams {
+
+    int64 axis = 1;
+    uint64 windowSize = 2;
+    uint64 step = 3;
+
+}
+
+/**
+ * A layer that applies layer normalization over the input tensor.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * output = gamma * (input - computed_mean) / (sqrt(computed_variance + eps)) + beta
+ *
+ * Parameters
+ *     normalizedShape: subset of the input shape, along with layer norm is performed, rest of the input shape is treated as the batch dimension. The mean and variance are computed for the input, over the last few dimensions as specified by the normalizedShape parameter.
+ *     gamma: must have shape = "normalizedShape"
+ *     beta: must have shape = "normalizedShape"
+ *     eps: small constant to avoid division by 0
+ *
+ * Output shape is same as the input.
+ *
+ * e.g.:
+ * input shape = (10,5)
+ * normalized shape = (5,) or (10,5)
+ *
+ * input shape = (10,5,6,7)
+ * normalized shape = (7,) or (6,7) or (5,6,7) or (10,5,6,7)
+ */
+message LayerNormalizationLayerParams {
+
+    repeated int64 normalizedShape = 1;
+    float eps = 2;
+    WeightParams gamma = 3;
+    WeightParams beta = 4;
+
+}
+
+/**
+ * Non maximum suppression (NMS) layer.
+ * Applies the non maximum suppression algorithm to input bounding box coordinates.
+ * The effect of this layer is similar to the functionality of the "NonMaximumSuppression"
+ * model type (for details please see NonMaximumSuppression.proto) with a couple of differences.
+ * One, this is a layer in a neural network model, whereas that is a different model type. Second,
+ * this layer supports a batch of bounding boxes.
+ *
+ * The NMS layer requires at least 2 inputs, and up to a maximum of 5 inputs. It produces 4 outputs.
+ * Following is the description of inputs and outputs:
+ *
+ * input 1, shape (B,N,4): coordinates of N boxes, for a batch size B.
+ * input 2, shape (B,N,C): class scores for each box. C can be 1 when there is only 1 score per box, i.e., no class specific score.
+ *
+ * input 3, optional, shape (1,): IoU threshold. When present, it overwrites the value provided in layer parameter "iouThreshold".
+ * input 4, optional, shape (1,): Score threshold. When present, it overwrites the value provided in layer parameter "scoreThreshold".
+ * input 5, optional, shape (1,): Maximum number of boxes. When present, it overwrites the value provided in layer parameter "maxBoxes".
+ *
+ * output 1, shape (B,maxBoxes,4): box coordinates, corresponding to the surviving boxes.
+ * output 2, shape (B,maxBoxes,C): box scores, corresponding to the surviving boxes.
+ * output 3, shape (B,maxBoxes): indices of the surviving boxes. Hence it will have values in the range [0,N-1], except for padding.
+ * output 4, shape (B,): number of boxes selected after the NMS algorithm, for each batch.
+ *
+ * When surviving boxes are less than "maxBoxes", the first 3 outputs are padded.
+ * For the first two outputs, the padding is done using values 0, whereas for the third output the
+ * padding value used is -1, since the output values represent indices.
+ *
+ * If no box survives, that is, all the scores are below the "scoreThreshold",
+ * then for that batch, number of boxes (value of the fourth output) will be 1. The first 3 outputs will
+ * correspond to the box with the highest score. This is to avoid generating an "empty" output.
+ *
+ * The four values that describe the box dimensions are (in order):
+ *
+ *  - x (center location of the box along the horizontal axis)
+ *  - y (center location of the box along the vertical axis)
+ *  - width (size of box along the horizontal axis)
+ *  - height (size of box on along the vertical axis)
+ *
+ * In each batch,
+ * the N scores for N boxes, used for suppression, are generated by taking the max of the matrix (N,C)
+ * along the columns.
+ * If "perClassSuppression" flag is false, suppression happens across all classes.
+ * If "perClassSuppression" flag is true, each box is assigned to the class with the highest
+ * score and then the suppression happens separately for boxes within the same class.
+ *
+ * Note that the 4th output can be used to dynamically slice the first 3 outputs, in case
+ * the padded outputs are not required.
+ *
+ */
+message NonMaximumSuppressionLayerParams {
+    /**
+     * The intersection over union (IoU) threshold over which boxes are suppressed.
+     */
+    float iouThreshold = 1;
+
+    /**
+     * Before IoU suppression is performed, boxes with class scores below this threshold are rejected.
+     */
+    float scoreThreshold = 2;
+
+    /**
+     * The maximum number of boxes to be given out as output.
+     * If the number of surviving boxes are less, output is padded up to this number.
+     */
+    uint64 maxBoxes = 3;
+
+    /**
+     * If true, suppression is performed independently within boxes of each class.
+     */
+    bool perClassSuppression = 4;
+}
+
+/**
+ * A layer that performs element-wise clamped ReLU operation.
+ *
+ * Requires 1 input and produces 1 output.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = \begin{cases}
+ *               \text{min}(\text{beta},x) \;\; \text{if} \;\; x \geq 0\\
+ *               \text{min}(\text{beta} ,\text{alpha}\cdot x) \;\; \text{if} \;\; x<0
+ *            \end{cases}
+ *
+ * Output shape is same as the input.
+ *
+ * Available (iOS >= 14, macOS >= 11.0, watchOS >= 7)
+ */
+message ClampedReLULayerParams {
+
+    float alpha = 1;
+    float beta = 2;
+
+}
+
+/**
+* A layer that returns the indices that would sort the input tensor, along a specified axis.
+*
+* Requires 1 input and produces 1 output.
+*
+* Output has the same rank and shape as the input.
+*
+* Value of "axis" must be positive and less than the rank of the input.
+*
+* e.g.:
+*
+* input shape = (5,)
+* axis = 0
+* input values = [3.1, 5.4, 32.9, 3.2, 77.0]
+* output shape = (5,)
+* output values = [0, 3, 1, 2, 4], descending = False
+* output values = [4, 2, 1, 3, 0], descending = True
+*
+* input shape = (2,3)
+* axis = 1
+* input values = [[3, 5, 32], [3, 77, 6]]
+* output shape = (2,3)
+* output values = [[0, 1, 2], [0, 2, 1]], descending = False
+* output values = [[2, 1, 0], [1, 2, 0]], descending = True
+*
+*/
+message ArgSortLayerParams {
+
+    int64 axis = 1; /// must be between [0, input_rank - 1]
+    bool descending = 2;
+
+}
+
+/**
+ * A layer that does slice operation by providing size to be extracted 
+ * from the given input tensor.
+ *
+ * Requires 2 inputs and produces 1 output.
+ * Rank of the output is same as the rank of the first input.
+ *
+ * The 1st input represents the tensor to be sliced.
+ * The 2nd input represents the beginning index to be sliced from.
+ *
+ * Example:
+ * Input 1: x (x.shape = (2, 3, 4))
+ * Input 2: begin
+ * size: 2
+ * axis: 1
+ *
+ * Output: x[:, begin:begin+2, :]
+ *
+ */
+message SliceBySizeLayerParams {
+
+    int64 size = 2;
+    int64 axis = 3;
+
+}
+
+
+/// Neural Network Specializations
+/// ------------------------------
+
+/**
+ * A neural network specialized as a classifier.
+ */
+message NeuralNetworkClassifier {
+
+    repeated NeuralNetworkLayer layers = 1;
+    repeated NeuralNetworkPreprocessing preprocessing = 2;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for multiarray inputs
+    NeuralNetworkMultiArrayShapeMapping arrayInputShapeMapping = 5;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for image inputs
+    NeuralNetworkImageShapeMapping imageInputShapeMapping = 6;
+
+    NetworkUpdateParameters updateParams = 10;
+
+    // The set of labels for every possible class.
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+
+    // The name of the output blob containing the probability of each class.
+    // In other words, the score vector. Must be a 1-D tensor with the same
+    // number and order of elements as ClassLabels.
+    string labelProbabilityLayerName = 200;
+}
+
+
+/**
+ * A layer that computes the one hot representation of the input.
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ * Rank of the output is one more than the first input.
+ * If the second input is present, it is used to determine the value of "oneHotVectorSize" and the parameter "oneHotVectorSize" is ignored.
+ *
+ * Input values correspond to indices and should typically be in the range [0,"oneHotVectorSize" -1]. If it is outside this range, a vector of all "offValue" will be chosen.
+ *
+ * Typically one hot vectors contain 0s everywhere, except 1 at the index that the input corresponds to.
+ * However, instead of 0, any float value could be generated by using the "offValue" parameter.
+ * Similarly, instead of 1, any other value can be used by employing the "onValue" parameter.
+ *
+ * e.g.:
+ * input shape: (10,), "oneHotVectorSize" : 32, axis=-1, then output shape will be (10,32)
+ * input shape: (10,23), "oneHotVectorSize" : 32, axis=1, then output shape will be (10,32,23)
+ * input shape: (10,), "oneHotVectorSize" : 32, axis=0, then output shape will be (32,10)
+ *
+ * input shape: (2,), "oneHotVectorSize" : 4, axis=-1, then output shape will be (2,4)
+ * say input values = [2, 0], and "onValue" = 5, and "offValue" = -1, then output will be:
+ * [-1, -1, 5, -1
+ *  5, -1, -1, -1]
+ *
+ *  say input values = [2, -1], and "onValue" = 5, and "offValue" = -1, then output will be:
+ * [-1, -1, 5, -1
+ *  -1, -1, -1, -1]
+ *
+ * Available (iOS >= 14, macOS >= 11.0, watchOS >= 7)
+ */
+
+message OneHotLayerParams {
+
+    uint64 oneHotVectorSize = 1; /// size of the one hot vector
+    int64 axis = 2; ///  negative indexing is supported. It refers to the axis in the output tensor.
+    float onValue = 3;
+    float offValue = 4;
+}
+
+
+/**
+ * A layer that computes the cumsum values of the input along a given axis.
+ *
+ * Requires 1 or 2 inputs and produces 1 output.
+ *
+ * Output shape and rank is same as the first input.
+ * If the second input is present, it is used to determine the value of "axis" and the parameter "axis" is ignored.
+ *
+ * e.g.:
+ * Input shape = (3,), values it has:  [4, 6, 7]
+ *
+ * Then output values will be:
+ *
+ * if "excludeFinalSum" = False and "reverse" = False:
+ * output values : [4, 10, 17]
+ *
+ * if "excludeFinalSum" = True and "reverse" = False:
+ * output values : [0, 4, 10]
+ *
+ * if "excludeFinalSum" = False and "reverse" = True:
+ * output values : [17, 13, 7]
+ *
+ * if "excludeFinalSum" = True and "reverse" = True:
+ * output values : [13, 7, 0]
+ *
+ *
+ * Available (iOS >= 14, macOS >= 11.0, watchOS >= 7)
+ */
+
+
+message CumSumLayerParams {
+
+    int64 axis = 1; ///  negative indexing is supported
+
+    /// if true, the first element of the output is 0, and the last element contains the sum of the input up to the penultimate value
+    /// if false, the first element of the output is same as the input and the last element is the sum of all the input values
+    /// (this behavior is reversed when "reverse" flag is True)
+    bool excludeFinalSum = 2;
+
+    bool reverse = 3; /// if true, cumsum is performed in the opposite direction
+}
+
+
+/**
+ * A neural network specialized as a regressor.
+ */
+message NeuralNetworkRegressor {
+
+    repeated NeuralNetworkLayer layers = 1;
+    repeated NeuralNetworkPreprocessing preprocessing = 2;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for multiarray inputs
+    NeuralNetworkMultiArrayShapeMapping arrayInputShapeMapping = 5;
+
+    // use this enum value to determine the input tensor shapes to the neural network, for image inputs
+    NeuralNetworkImageShapeMapping imageInputShapeMapping = 6;
+
+    NetworkUpdateParameters updateParams = 10;
+
+}
+
+/// ---------------------------------------------------------
+/// On-device Training related messages
+/// ---------------------------------------------------------
+
+/**
+ * Details on how the network will be updated
+ */
+message NetworkUpdateParameters {
+
+    repeated LossLayer lossLayers = 1;
+    Optimizer optimizer = 2;
+    Int64Parameter epochs = 3;
+
+    /**
+     * Describes whether to shuffle the batch of data between epochs.
+     */
+    BoolParameter shuffle = 10;
+
+    /**
+     * The seed to be used in an associated random number generator.
+     */
+    Int64Parameter seed = 20;
+}
+
+/**
+ * Loss layer - categorical cross entropy and mean squared error are the only supported loss functions currently
+ */
+message LossLayer {
+
+    string name = 1;
+    oneof LossLayerType {
+
+        CategoricalCrossEntropyLossLayer categoricalCrossEntropyLossLayer = 10;
+        MeanSquaredErrorLossLayer meanSquaredErrorLossLayer = 11;
+
+    }
+
+}
+
+/**
+ * Categorical cross entropy loss layer
+ * Categorical cross entropy is used for single label categorization (only one category is applicable for each data point).
+ *
+ * The input is a vector of length N representing the distribution over N categories.  It must be the output of a softmax.
+ *
+ * The target is a single value representing the true category or class label. If the target is the predictedFeatureName of a neural network classifier it will be inverse mapped to the corresponding categorical index for you.
+ *
+ * math:
+ * Loss_{CCE}(input, target) = -\sum_{i=1}^{N} (target == i) log( input[i] ) = - log (input[target])
+ */
+message CategoricalCrossEntropyLossLayer {
+
+    string input = 1;
+    string target = 2;
+
+}
+
+/**
+ * Mean squared error loss layer,
+ * specifying input and target
+ */
+message MeanSquaredErrorLossLayer {
+
+    string input = 1;
+    string target = 2;
+
+}
+
+/**
+ * Optimizer - stochastic gradient descent and adam are the only supported optimizers currently
+ */
+message Optimizer {
+
+    oneof OptimizerType {
+
+        SGDOptimizer sgdOptimizer = 10;
+        AdamOptimizer adamOptimizer = 11;
+
+    }
+
+}
+
+/**
+ * Stochastic gradient descent optimizer,
+ * specifying configurable learning rate, mini batch size, and momentum
+ */
+message SGDOptimizer {
+
+    DoubleParameter learningRate = 1;
+    Int64Parameter miniBatchSize = 2;
+    DoubleParameter momentum = 3;
+
+}
+
+/**
+ * Adam optimizer,
+ * specifying configurable learning rate, mini batch size, betas, and eps
+ */
+message AdamOptimizer {
+
+    DoubleParameter learningRate = 1;
+    Int64Parameter miniBatchSize = 2;
+    DoubleParameter beta1 = 3;
+    DoubleParameter beta2 = 4;
+    DoubleParameter eps = 5;
+
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/NonMaximumSuppression.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/NonMaximumSuppression.proto
@@ -1,0 +1,187 @@
+// Copyright (c) 2018, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/*
+* Non-maximum suppression of axis-aligned bounding boxes.
+*
+* This is used primarily for object detectors that tend to produce multiple
+* boxes around a single object.  This is a byproduct of the detector's
+* robustness to spatial translation. If there are two or more bounding boxes
+* that are very similar to one another, the algorithm should return only a
+* single representative.
+*
+* Similarity between two bounding boxes is measured by intersection-over-union
+* (IOU), the fraction between the area of intersection and area of the union.
+* Here is an example where the areas can be calculated by hand by counting glyphs::
+*
+*     +-------+                            +-------+
+*     |       |                            |       |
+*     |    +------+          +--+          |       +---+
+*     |    |  |   |          |  |          |           |
+*     +-------+   |          +--+          +----+      |
+*          |      |                             |      |
+*          +------+                             +------+
+*                        Intersection         Union
+*      IOU: 0.16      =       12       /       73
+*
+* All IOU scores are fractions betwen 0.0 (fully disjoint) and 1.0 (perfect
+* overlap). The standard algorithm (PickTop) is defined as follows:
+*
+*  1. Sort boxes by descending order of confidence
+*  2. Take the top one and mark it as keep
+*  3. Suppress (mark it as discard) all boxes within a fixed IOU radius of the
+*     keep box
+*  4. Go to 2 and repeat on the subset of boxes not already kept or discarded
+*  5. When all boxes are processed, output only the ones marked as keep
+*
+* Before the algorithm, boxes that fall below the confidence threshold are
+* discarded.
+*/
+message NonMaximumSuppression {
+    // Suppression methods:
+    /*
+    * Pick the bounding box of the top confidence, suppress all within a radius.
+    */
+    message PickTop {
+        /*
+        * Suppression is only done among predictions with the same label
+        * (argmax of the confidence).
+        */
+        bool perClass = 1;
+    }
+
+    /*
+    * Choose which underlying suppression method to use
+    */
+    oneof SuppressionMethod {
+        PickTop pickTop = 1;
+    }
+
+    /*
+    * Optional class label mapping.
+    */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+
+    /*
+    * This defines the radius of suppression. A box is considered to be within
+    * the radius of another box if their IOU score is less than this value.
+    */
+    double iouThreshold = 110;
+
+    /*
+    * Remove bounding boxes below this threshold.  The algorithm run-time is
+    * proportional to the square of the number of incoming bounding boxes
+    * (O(N^2)). This threshold is a way to reduce N to make the algorithm
+    * faster. The confidence threshold can be any non-negative value. Negative
+    * confidences are not allowed, since if the output shape is specified to be
+    * larger than boxes after suppression, the unused boxes are filled with
+    * zero confidence. If the prediction is handled by Core Vision, it is also
+    * important that confidences are defined with the following semantics:
+    * 
+    *   1. Confidences should be between 0 and 1
+    *   2. The sum of the confidences for a prediction should not exceed 1, but is
+    *      allowed to be less than 1
+    *   3. The sum of the confidences will be interpreted as the confidence of
+    *      any object (e.g. if the confidences for two classes are 0.2 and 0.4,
+           it means there is a 60% (0.2 + 0.4) confidence that an object is
+           present)
+    */
+    double confidenceThreshold = 111;
+
+    /*
+    * Set the name of the confidence input.
+    *
+    * The input should be a multi-array of type double and shape N x C. N is
+    * the number of boxes and C the number of classes. Each row describes the
+    * confidences of each object category being present at that particular
+    * location. Confidences should be nonnegative, where 0.0 means the highest
+    * certainty the object is not present.
+    *
+    * Specifying shape is optional.
+    */
+    string confidenceInputFeatureName = 200;
+
+    /*
+    * Set the name of the coordinates input.
+    *
+    * The input should be a multi-array of type double and shape N x 4. The
+    * rows correspond to the rows of the confidence matrix. The four values
+    * describe (in order):
+    *
+    *  - x (center location of the box along the horizontal axis)
+    *  - y (center location of the box along the vertical axis)
+    *  - width (size of box along the horizontal axis)
+    *  - height (size of box on along the vertical axis)
+    *
+    * Specifying shape is optional.
+    */
+    string coordinatesInputFeatureName = 201;
+
+    /*
+    * The iouThreshold can be optionally overridden by specifying this string
+    * and providing a corresponding input of type double. This allows changing
+    * the value of the parameter during run-time.
+    *
+    * The input should be a scalar double between 0.0 and 1.0. Setting it to 1.0
+    * means there will be no suppression based on IOU.
+    */
+    string iouThresholdInputFeatureName = 202;
+
+    /*
+    * The confidenceThreshold can be optionally overridden by specifying this
+    * string and providing a corresponding input. This allows changing the
+    * value of the parameter during run-time, which can aid setting it just
+    * right for a particular use case.
+    *
+    * The input should be a scalar double with nonnegative value.
+    */
+    string confidenceThresholdInputFeatureName = 203;
+
+    /*
+    * Set the name of the confidence output. The output will be the same type
+    * and shape as the corresponding input. The only difference is that the
+    * number of rows may have been reduced.
+    *
+    * Specifying shape is optional. One reason to specify shape is to limit
+    * the number of output boxes. This can be done is several ways:
+    *
+    * Fixed shape:
+    * The output can be pinned to a fixed set of boxes. If this number is larger
+    * than the number of boxes that would have been returned, the output is padded
+    * with zeros for both confidence and coordinates. Specifying a fixed shape
+    * can be done by setting either shape (deprecated) or allowedShapes set to
+    * fixedsize.
+    *
+    * Min/max:
+    * It is also possible to set both a minimum and a maximum. The same zero-padding
+    * as for fixed shape is applied when necessary. Setting min/max is done by defining
+    * two allowedShapes, where the first dimension uses a rangeofsizes defining lowerbound
+    * and upperbound.
+    */
+    string confidenceOutputFeatureName = 210;
+
+    /*
+    * Set the name of the coordinates output. The output will be the same type
+    * and shape as the corresponding input. The only difference is that the
+    * number of rows may have been reduced.
+    *
+    * Specifying shape is optional. See confidence output for a more detailed
+    * description. Note that to achieve either fixed shape output or a
+    * constraint range of boxes, only one of confidence or coordinates need to
+    * set a shape. Both shapes are allowed to be defined, but in such case they
+    * have to be consistent along dimension 0.
+    */
+    string coordinatesOutputFeatureName = 211;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Normalizer.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Normalizer.proto
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * A normalization preprocessor.
+ */
+message Normalizer {
+    /**
+     * There are three normalization modes,
+     * which have the corresponding formulas:
+     *
+     * Max
+     *     .. math::
+     *         max(x_i)
+     *
+     * L1
+     *     .. math::
+     *         z = ||x||_1 = \sum_{i=1}^{n} |x_i|
+     *
+     * L2
+     *     .. math::
+     *         z = ||x||_2 = \sqrt{\sum_{i=1}^{n} x_i^2}
+     */
+    enum NormType {
+        LMax = 0;
+        L1 = 1;
+        L2 = 2;
+    }
+
+    NormType normType = 1;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/OneHotEncoder.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/OneHotEncoder.proto
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * Transforms a categorical feature into an array. The array will be all
+ * zeros expect a single entry of one.
+ *
+ * Each categorical value will map to an index, this mapping is given by
+ * either the ``stringCategories`` parameter or the ``int64Categories``
+ * parameter.
+ */
+message OneHotEncoder {
+    enum HandleUnknown {
+        ErrorOnUnknown = 0;
+        IgnoreUnknown = 1;   // Output will be all zeros for unknown values.
+    }
+
+    /**
+     * Mapping to be used for the encoding. The position of the category in
+     * the below vector determines where the single one entry will be in the
+     * output.
+     */
+    oneof CategoryType {
+        StringVector stringCategories = 1;
+        Int64Vector int64Categories = 2;
+    }
+
+    // Output can be a dictionary with only one entry, instead of an array.
+    bool outputSparse = 10;
+
+    HandleUnknown handleUnknown = 11;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Parameters.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Parameters.proto
@@ -1,0 +1,52 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * Int64 parameter,
+ * consisting of a default int64 value, and allowed range or set of values
+ * value is unbounded if AllowedValues is not set.
+ */
+message Int64Parameter {
+    int64 defaultValue = 1;
+    oneof AllowedValues {
+        Int64Range range = 10;
+        Int64Set set = 11;
+    }
+}
+
+/**
+ * Double parameter,
+ * consisting of a default double value, and allowed range of values
+ * value is unbounded if AllowedValues is not set.
+ */
+message DoubleParameter {
+    double defaultValue = 1;
+    oneof AllowedValues {
+        DoubleRange range = 10;
+    }
+}
+
+/**
+ * String parameter,
+ * A default string value must be provided
+ */
+message StringParameter {
+    string defaultValue = 1;
+}
+
+/**
+ * String parameter,
+ * A default bool value must be provided
+ */
+message BoolParameter {
+    bool defaultValue = 1;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/README.md
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/README.md
@@ -1,0 +1,16 @@
+# Core ML Model Format Specification
+This directory contains the protobuf message definitions that comprise the Core ML model document (``.mlmodel``) format.
+
+The top-level message is ``Model``, which is defined in ``Model.proto``.
+Other message types describe data structures, feature types, feature engineering model types, and predictive model types.
+
+# Update the Core ML Model Format Specification
+Please do not modify protobuf message definitions, they are copied directly from [Core ML Tools](https://github.com/apple/coremltools) repository.
+
+To update the Core ML Model Format Schema schema files to a more recent version:
+1. Delete all the protobuf message definitions (`.proto`) from this directory.
+2. Copy the new version of protobuf message definitions (`.proto`) from the `mlmodel/format/` directory of preferred coremltools release branch.
+
+# Core ML Model Format Schema version history
+## [coremltools 4.0](https://github.com/apple/coremltools/releases/tag/4.0)
+[Core ML Model Format Specification](https://github.com/apple/coremltools/tree/4.0/mlmodel/format)

--- a/onnxruntime/core/providers/coreml/mlmodel_format/SVM.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/SVM.proto
@@ -1,0 +1,195 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/// Kernel Definitions
+/// ------------------
+
+/**
+ * A linear kernel.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     K(\boldsymbol{x}, \boldsymbol{x'}) = \boldsymbol{x}^T \boldsymbol{x'}
+ */
+message LinearKernel {
+}
+
+/**
+ * A Gaussian radial basis function (RBF) kernel.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     K(\boldsymbol{x}, \boldsymbol{x'}) = \
+ *          \exp(-\gamma || \boldsymbol{x} - \boldsymbol{x'} ||^2 )
+ *
+ */
+message RBFKernel {
+    double gamma = 1;
+}
+
+/**
+ * A polynomial kernel.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     K(\boldsymbol{x}, \boldsymbol{x'}) = \
+ *           (\gamma \boldsymbol{x}^T \boldsymbol{x'} + c)^{degree}
+ */
+message PolyKernel {
+    int32 degree = 1;
+    double c = 2;
+    double gamma = 3;
+}
+
+/**
+ * A sigmoid kernel.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     K(\boldsymbol{x}, \boldsymbol{x'}) = \
+ *           \tanh(\gamma \boldsymbol{x}^T \boldsymbol{x'} + c)
+ */
+message SigmoidKernel {
+    double gamma = 1;
+    double c = 2;
+}
+
+/**
+ * A kernel.
+ */
+message Kernel {
+    oneof kernel {
+        LinearKernel linearKernel = 1;
+        RBFKernel rbfKernel = 2;
+        PolyKernel polyKernel = 3;
+        SigmoidKernel sigmoidKernel = 4;
+    }
+}
+
+
+/// Support Vector Definitions
+/// --------------------------
+
+/**
+ * A sparse node.
+ */
+message SparseNode {
+    int32 index = 1; // 1-based indexes, like libsvm
+    double value = 2;
+}
+
+/**
+ * A sparse vector.
+ */
+message SparseVector {
+    repeated SparseNode nodes = 1;
+}
+
+/**
+ * One or more sparse support vectors.
+ */
+message SparseSupportVectors {
+    repeated SparseVector vectors = 1;
+}
+
+/**
+ * A dense vector.
+ */
+message DenseVector {
+    repeated double values = 1;
+}
+
+/**
+ * One or more dense support vectors.
+ */
+message DenseSupportVectors {
+    repeated DenseVector vectors = 1;
+}
+
+/**
+ * One or more coefficients.
+ */
+message Coefficients {
+    repeated double alpha = 1;
+}
+
+/**
+ * A support vector regressor.
+ */
+message SupportVectorRegressor {
+    Kernel kernel = 1;
+
+    // Support vectors, either sparse or dense format
+    oneof supportVectors {
+        SparseSupportVectors sparseSupportVectors = 2;
+        DenseSupportVectors denseSupportVectors = 3;
+    }
+
+    // Coefficients, one for each support vector
+    Coefficients coefficients = 4;
+
+    double rho = 5;
+}
+
+/**
+ * A support vector classifier
+ */
+message SupportVectorClassifier {
+    Kernel kernel = 1;
+
+    /**
+     * The number of support vectors for each class.
+     */
+    repeated int32 numberOfSupportVectorsPerClass = 2;
+
+    /**
+     * The support vectors, in either sparse or dense format.
+     */
+    oneof supportVectors {
+        SparseSupportVectors sparseSupportVectors = 3;
+        DenseSupportVectors denseSupportVectors = 4;
+    }
+
+    /**
+     * The coefficients, essentially a two dimensional array of
+     * size: (numberOfClasses-1) by (total number of support vectors)
+     */
+    repeated Coefficients coefficients = 5;
+
+    /**
+     * Constants for decision function,
+     * with K*(K-1) / 2 elements,
+     * where K is the number of classes.
+     */
+    repeated double rho = 6;
+
+    /**
+     * Pairwise probability information for A vs B classifier.
+     * Total of K*(K-1)/2 elements where K is the number of classes.
+     * These fields are optional,
+     * and only required if you want probabilities or multi class predictions.
+     */
+    repeated double probA = 7;
+    repeated double probB = 8;
+
+    /**
+     * Class label mapping.
+     */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/Scaler.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/Scaler.proto
@@ -1,0 +1,34 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification;
+
+/**
+ * A scaling operation.
+ *
+ * This function has the following formula:
+ *
+ * .. math::
+ *     f(x) = scaleValue \cdot (x + shiftValue)
+ *
+ * If the ``scaleValue`` is not given, the default value 1 is used.
+ * If the ``shiftValue`` is not given, the default value 0 is used.
+ *
+ * If ``scaleValue`` and ``shiftValue`` are each a single value
+ * and the input is an array, then the scale and shift are applied
+ * to each element of the array.
+ *
+ * If the input is an integer, then it is converted to a double to
+ * perform the scaling operation. If the output type is an integer,
+ * then it is cast to an integer. If that cast is lossy, then an
+ * error is generated.
+ */
+message Scaler {
+    repeated double shiftValue = 1;
+    repeated double scaleValue = 2;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/SoundAnalysisPreprocessing.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/SoundAnalysisPreprocessing.proto
@@ -1,0 +1,60 @@
+// Copyright (c) 2019, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which takes audio signal samples as input and outputs an array of
+* preprocessed samples according to the specified preprocessing types
+*/
+message SoundAnalysisPreprocessing {
+
+    // Specific preprocessing types for sound analysis
+
+    /* Vggish preprocesses input audio samples and makes them ready to
+       be fed to Vggish feature extractor.
+       c.f. https://arxiv.org/pdf/1609.09430.pdf
+
+       The preprocessing takes input a single channel (monophonic) audio samples
+       975 miliseconds long, sampled at 16KHz, i.e., 15600 samples 1D multiarray
+       and produces preprocessed samples in multiarray of shape [1, 96, 64]
+
+     (1) Splits the input audio samples into overlapping frames, where each
+         frame is 25 milliseconds long and hops forward by 10 milliseconds.
+         Any partial frames at the end are dropped.
+
+     (2) Hann window: apply a periodic Hann with a window_length of
+         25 milliseconds, which translates to 400 samples in 16KHz sampling rate
+
+         w(n) = 0.5 - 0.5 * cos(2*pi*n/window_length_sample),
+         where 0 <= n <= window_lenth_samples - 1 and window_lenth_samples = 400
+
+         Then, the Hann window is applied to each frame as below
+
+         windowed_frame(n) = frame(n) * w(n)
+         where 0 <= n <= window_lenth_samples - 1 and window_lenth_samples = 400
+
+     (3) Power spectrum: calculate short-time Fourier transfor magnitude, with
+         an FFT length of 512
+
+     (4) Log Mel filter bank: calculates a log magnitude mel-frequency
+         spectrogram minimum frequency of 125Hz and maximum frequency of 7500Hz,
+         number of mel bins is 64, log_offset is 0.01, number of spectrum bins
+         is 64.
+    */
+
+    message Vggish {
+        // no specific parameter
+    }
+
+    // Vision feature print type
+    oneof SoundAnalysisPreprocessingType {
+        Vggish vggish = 20;
+    }
+
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/TextClassifier.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/TextClassifier.proto
@@ -1,0 +1,43 @@
+// Copyright (c) 2018, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which takes a single input string and outputs a
+* label for the input.
+*/
+message TextClassifier {
+
+    /*
+    * Stores the resivion number for the model, revision 1 is available on
+    * iOS, tvOS 12.0+, macoOS 10.14+
+    */
+    uint32 revision = 1;
+    
+    /*
+    * Stores the language of the model, as specified in BCP-47 format,
+    * e.g. "en-US". See https://tools.ietf.org/html/bcp47
+    */
+    string language = 10;
+
+    /*
+    * Stores the byte representation of learned model parameters
+    */
+    bytes modelParameterData = 100;
+    
+    /*
+    * Stores the set of output class labels
+    */
+    oneof ClassLabels {
+        StringVector stringClassLabels = 200;
+    }
+    
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/TreeEnsemble.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/TreeEnsemble.proto
@@ -1,0 +1,161 @@
+// Copyright (c) 2017, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * Each tree is a collection of nodes,
+ * each of which is identified by a unique identifier.
+ *
+ * Each node is either a branch or a leaf node.
+ * A branch node evaluates a value according to a behavior;
+ * if true, the node identified by ``true_child_node_id`` is evaluated next,
+ * if false, the node identified by ``false_child_node_id`` is evaluated next.
+ * A leaf node adds the evaluation value to the base prediction value
+ * to get the final prediction.
+ *
+ * A tree must have exactly one root node,
+ * which has no parent node.
+ * A tree must not terminate on a branch node.
+ * All leaf nodes must be accessible
+ * by evaluating one or more branch nodes in sequence,
+ * starting from the root node.
+ */
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification;
+
+/**
+ * A tree ensemble post-evaluation transform.
+ */
+enum TreeEnsemblePostEvaluationTransform {
+    NoTransform = 0;
+    Classification_SoftMax = 1;
+    Regression_Logistic = 2;
+    Classification_SoftMaxWithZeroClassReference = 3;
+}
+
+/**
+ * Tree ensemble parameters.
+ */
+message TreeEnsembleParameters {
+    message TreeNode {
+        uint64 treeId = 1;
+        uint64 nodeId = 2;
+
+        enum TreeNodeBehavior {
+            BranchOnValueLessThanEqual = 0;
+            BranchOnValueLessThan = 1;
+            BranchOnValueGreaterThanEqual = 2;
+            BranchOnValueGreaterThan = 3;
+            BranchOnValueEqual = 4;
+            BranchOnValueNotEqual = 5;
+            LeafNode = 6;
+        }
+
+        /**
+         * The branch mode parameters.
+         *
+         * If branch is false,
+         * then the parameters in this section must be filled in
+         * to determine how the branching functions.
+         */
+        TreeNodeBehavior nodeBehavior = 3;
+
+        /**
+         * If the node behavior mode is a branch mode,
+         * then these values must be filled in.
+         */
+        uint64 branchFeatureIndex = 10;
+        double branchFeatureValue = 11;
+        uint64 trueChildNodeId = 12;
+        uint64 falseChildNodeId = 13;
+        bool missingValueTracksTrueChild = 14;
+
+        /**
+         * The leaf mode.
+         *
+         * If ``nodeBahavior`` == ``LeafNode``,
+         * then the evaluationValue is added to the base prediction value
+         * in order to get the final prediction.
+         * To support multiclass classification
+         * as well as regression and binary classification,
+         * the evaluation value is encoded here as a sparse vector,
+         * with evaluationIndex being the index of the base vector
+         * that evaluation value is added to.
+         * In the single class case,
+         * it is expected that evaluationIndex is exactly 0.
+         */
+        message EvaluationInfo {
+           uint64 evaluationIndex = 1;
+           double evaluationValue = 2;
+        }
+
+        repeated EvaluationInfo evaluationInfo = 20;
+
+        /**
+         * The relative hit rate of a node for optimization purposes.
+         *
+         * This value has no effect on the accuracy of the result;
+         * it allows the tree to optimize for frequent branches.
+         * The value is relative,
+         * compared to the hit rates of other branch nodes.
+         *
+         * You typically use a proportion of training samples
+         * that reached this node
+         * or some similar metric to derive this value.
+         */
+        double relativeHitRate = 30;
+    }
+
+    repeated TreeNode nodes = 1;
+
+    /**
+     * The number of prediction dimensions or classes in the model.
+     *
+     * All instances of ``evaluationIndex`` in a leaf node
+     * must be less than this value,
+     * and the number of values in the ``basePredictionValue`` field
+     * must be equal to this value.
+     *
+     * For regression,
+     * this is the dimension of the prediction.
+     * For classification,
+     * this is the number of classes.
+     */
+    uint64 numPredictionDimensions = 2;
+
+    /**
+     * The base prediction value.
+     *
+     * The number of values in this must match
+     * the default values of the tree model.
+     */
+    repeated double basePredictionValue = 3;
+}
+
+/**
+ * A tree ensemble classifier.
+ */
+message TreeEnsembleClassifier {
+    TreeEnsembleParameters treeEnsemble = 1;
+    TreeEnsemblePostEvaluationTransform postEvaluationTransform = 2;
+
+    // Required class label mapping
+    oneof ClassLabels {
+        StringVector stringClassLabels = 100;
+        Int64Vector int64ClassLabels = 101;
+    }
+}
+
+/**
+ * A tree ensemble regressor.
+ */
+message TreeEnsembleRegressor {
+    TreeEnsembleParameters treeEnsemble = 1;
+    TreeEnsemblePostEvaluationTransform postEvaluationTransform = 2;
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/VisionFeaturePrint.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/VisionFeaturePrint.proto
@@ -1,0 +1,63 @@
+// Copyright (c) 2018, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which takes an input image and outputs array(s) of features
+* according to the specified feature types
+*/
+message VisionFeaturePrint {
+
+    // Specific vision feature print types
+   
+    // Scene extracts features useful for identifying contents of natural images
+    // in both indoor and outdoor environments
+    message Scene {
+        enum SceneVersion {
+            SCENE_VERSION_INVALID = 0;
+            // VERSION_1 is available on iOS,tvOS 12.0+, macOS 10.14+
+            // It uses a 299x299 input image and yields a 2048 float feature vector
+            SCENE_VERSION_1 = 1;
+        }
+        
+        SceneVersion version = 1;
+    }
+
+    // Objects extracts features useful for identifying and localizing
+    // objects in natural images
+    message Objects {
+        enum ObjectsVersion {
+            OBJECTS_VERSION_INVALID = 0;
+            // VERSION_1 is available on iOS,tvOS 14.0+, macOS 11.0+
+            // It uses a 299x299 input image and yields two multiarray
+            // features: one at high resolution of shape (288, 35, 35)
+            // the other at low resolution of shape (768, 17, 17)
+            OBJECTS_VERSION_1 = 1;
+        }
+
+        ObjectsVersion version = 1;
+
+        /*
+        * Stores the names of the output features according to the
+        * order of them being computed from the neural network, i.e.,
+        * the first element in the output is the earliest being
+        * computed, while the last is the latest being computed. In
+        * general, the order reflects the resolution of the feature.
+        * The earlier it is computed, the higher the feature resolution.
+        */
+        repeated string output = 100;
+    }
+
+    // Vision feature print type
+    oneof VisionFeaturePrintType {
+        Scene scene = 20;
+        Objects objects = 21;
+    }
+
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/WordEmbedding.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/WordEmbedding.proto
@@ -1,0 +1,35 @@
+// Copyright (c) 2019, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which maps a set of strings into a finite-dimensional real vector space.
+*/
+message WordEmbedding {
+
+    /*
+    * Stores the revision number for the model, revision 2 is available on
+    * iOS, tvOS 13.0+, macOS 10.15+
+    */
+    uint32 revision = 1;
+    
+    /*
+    * Stores the language of the model, as specified in BCP-47 format,
+    * e.g. "en-US". See https://tools.ietf.org/html/bcp47
+    */
+    string language = 10;
+
+    /*
+    * Stores efficient representation of emebedding as encoded by the Natural Language Framework
+    */
+    bytes modelParameterData = 100;
+    
+}

--- a/onnxruntime/core/providers/coreml/mlmodel_format/WordTagger.proto
+++ b/onnxruntime/core/providers/coreml/mlmodel_format/WordTagger.proto
@@ -1,0 +1,75 @@
+// Copyright (c) 2018, Apple Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-3-clause license that can be
+// found in LICENSE.txt or at https://opensource.org/licenses/BSD-3-Clause
+
+syntax = "proto3";
+option optimize_for = LITE_RUNTIME;
+
+import public "DataStructures.proto";
+
+package CoreML.Specification.CoreMLModels;
+
+/**
+* A model which takes a single input string and outputs a
+* sequence of tokens, tags for tokens, along with their
+* locations and lengths, in the original string.
+*/
+message WordTagger {
+
+    /*
+    * Stores the resivion number for the model, revision 1 is available on
+    * iOS, tvOS 12.0+, macoOS 10.14+
+    */
+    uint32 revision = 1;
+
+    /*
+    * Stores the language of the model, as specified in BCP-47 format,
+    * e.g. "en-US". See https://tools.ietf.org/html/bcp47
+    */
+    string language = 10;
+
+    /*
+    * Stores the name of tokens output. The output will be
+    * a sequence of strings that contains the tokens in the
+    * input string
+    */
+    string tokensOutputFeatureName = 20;
+
+    /*
+    * Stores the name of token tags output. The output will be
+    * a sequence of strings that contains the tags for each
+    * token in the input string
+    */
+    string tokenTagsOutputFeatureName = 21;
+
+    /*
+    * Stores the name of token locations output. The output will be
+    * a sequence of integers that contains the locations (indices)
+    * for each token in the input string, location starts from 0
+    */
+    string tokenLocationsOutputFeatureName = 22;
+
+    /*
+    * Stores the name of token lengths output. The output will be
+    * a sequence of integers that contains the lengths for each
+    * token in the input string
+    */
+    string tokenLengthsOutputFeatureName = 23;
+
+    /*
+    * Stores the byte representation of learned model parameters
+    */
+    bytes modelParameterData = 100;
+
+    /*
+    * Stores the set of output tags
+    */
+    oneof Tags {
+        StringVector stringTags = 200;
+    }
+
+
+    
+}
+


### PR DESCRIPTION
**Description**: Remove coremltools submodule and copy the coreml model schema 

**Motivation and Context**
- coremltools contains protobuf 3.3.0 (https://github.com/apple/coremltools/blob/main/deps/protobuf/js/package.json), which is marked as security vulnerability need to be address ASAP
- Although we don't use the javascript part of coremltools, there is no way we can partially sync the coremltools repo
- Since we are only using coreml model schemas, copied them into our repo and added a readme on how to update them
- Removed coremltools submodule
