### PR TITLE
Incorrect output after GPU to GPU inference via VideoFrame and Gray8 models

### DIFF
--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -483,7 +483,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   PipelineStateCacheFormat formatFrom = PipelineStateCacheFormat::kBGR8;
   if (tensorDesc.channelType == kImageTensorChannelTypeRGB8) {
     formatFrom = PipelineStateCacheFormat::kRGB8;
-  } else if (inputDesc.Format == kImageTensorChannelTypeGRAY8 ||
+  } else if (inputDesc.Format == DXGI_FORMAT_R8_UNORM ||
              tensorDesc.channelType == kImageTensorChannelTypeGRAY8) {
     formatFrom = PipelineStateCacheFormat::kGRAY8;
   }

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -483,7 +483,8 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   PipelineStateCacheFormat formatFrom = PipelineStateCacheFormat::kBGR8;
   if (tensorDesc.channelType == kImageTensorChannelTypeRGB8) {
     formatFrom = PipelineStateCacheFormat::kRGB8;
-  } else if (inputDesc.Format == kImageTensorChannelTypeGRAY8) {
+  } else if (inputDesc.Format == kImageTensorChannelTypeGRAY8 ||
+             tensorDesc.channelType == kImageTensorChannelTypeGRAY8) {
     formatFrom = PipelineStateCacheFormat::kGRAY8;
   }
 


### PR DESCRIPTION
Issue: The detensorization pipeline incorrectly interpreted Gray8 outputs as BGR8 outputs, and so detensorization was calling into incorrect shaders for conversion back from NCHW to NHWC.

Related Issues:
https://github.com/microsoft/onnxruntime/issues/10410 : [WinML] [C++/WinRT] Empty output after GPU to GPU inference via VideoFrame
Models which produce 1 channel (Gray8) format outputs fail to produce correct output when binding output VideoFrames that are D3D11 backed surfaces.

Fix: When the output tensor is marked as Gray8, honor the format (which calls the appropriate shader later on).
