### PR TITLE
Remove cbegin and cend calls which do not exist in std::span or gsl::span

### DIFF
--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -42,7 +42,7 @@ using InlinedShapeVectorT = absl::InlinedVector<T, kTensorShapeSmallBufferElemen
 inline TensorShapeVector ToShapeVector(const gsl::span<const int64_t>& span) {
   TensorShapeVector out;
   out.reserve(span.size());
-  out.assign(span.cbegin(), span.cend());
+  out.assign(span.begin(), span.end());
   return out;
 }
 

--- a/onnxruntime/core/framework/op_node_proto_helper.cc
+++ b/onnxruntime/core/framework/op_node_proto_helper.cc
@@ -186,7 +186,7 @@ MUST_USE_RESULT Status OpNodeProtoHelper<Impl_t>::GetAttrs(const std::string& na
   Status status = this->GetAttrsAsSpan<int64_t>(name, span);
   if (status.IsOK()) {
     out.reserve(span.size());
-    out.assign(span.cbegin(), span.cend());
+    out.assign(span.begin(), span.end());
   }
   return status;
 }


### PR DESCRIPTION
**Description**: Remove calls to `cbegin` and `cend` introduced in https://github.com/microsoft/onnxruntime/pull/10193 which are removed methods (see [#1](https://stackoverflow.com/questions/62757700/why-does-stdspan-lack-cbegin-and-cend-methods) [#2](https://cplusplus.github.io/LWG/issue3320)), not present on `std::span` or `gsl::span`. 

**Motivation and Context**
- *Why is this change required? What problem does it solve?* It breaks the WindowsAI build, conflicting because we use GSL's span, not GSL lite (which has the stale `cbegin`/`cend`). Plus, the iterators are already const anyway, given the function parameter is `gsl::span<const int64_t>`.
- *If it fixes an open issue, please link to the issue here.* NA