### PR TITLE
Allow users to bind arbitrary memory using raw pointers

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Dictionary that represents overridableInitializers metadata
         /// </summary>
         private Dictionary<string, NodeMetadata> _overridableInitializerMetadata;
-		
+
         private SessionOptions _builtInSessionOptions = null;
         private RunOptions _builtInRunOptions = null;
         private ModelMetadata _modelMetadata = null;
@@ -998,9 +998,15 @@ namespace Microsoft.ML.OnnxRuntime
                 NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorElementType(tensorInfo, out el_type));
                 type = (TensorElementType)el_type;
             }
+
             Type dotnetType = null;
             int width = 0;
-            TensorElementTypeConverter.GetTypeAndWidth(type, out dotnetType, out width);
+            if (!TensorElementTypeConverter.GetTypeAndWidth(type, out dotnetType, out width))
+            {
+                throw new OnnxRuntimeException(ErrorCode.InvalidArgument,
+                    "Unable to query type information for data type: " + type.ToString());
+            }
+
             UIntPtr numDimensions;
             NativeApiStatus.VerifySuccess(NativeMethods.OrtGetDimensionsCount(tensorInfo, out numDimensions));
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.shared.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.OnnxRuntime
             // dispose managed state (managed objects).
             if (disposing)
             {
-                if(_disposables != null)
+                if (_disposables != null)
                 {
                     _disposables.Dispose();
                     _disposables = null;
@@ -106,10 +106,19 @@ namespace Microsoft.ML.OnnxRuntime
                     NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorElementType(typeAndShape, out el_type));
                     elemType = (TensorElementType)el_type;
                 }
-                TensorElementTypeConverter.GetTypeAndWidth(elemType, out type, out width);
+
+                if (!TensorElementTypeConverter.GetTypeAndWidth(elemType, out type, out width))
+                {
+                    throw new OnnxRuntimeException(ErrorCode.InvalidArgument,
+                        "Unable to query type information for data type: " + elemType.ToString());
+                }
 
                 if (typeof(T) != type)
-                    throw new NotSupportedException(nameof(NativeOnnxTensorMemory<T>) + " does not support T = " + nameof(T));
+                {
+                    var message = String.Format("The NativeOnnxTensorMemory<T> type being instantiated for T = : {0} while supplied OrtValue contains T = {1}",
+                        nameof(T), nameof(type));
+                    throw new OnnxRuntimeException(ErrorCode.InvalidArgument, message);
+                }
 
                 ElementType = elemType;
                 ElementWidth = width;
@@ -136,7 +145,7 @@ namespace Microsoft.ML.OnnxRuntime
                     Dimensions[i] = (int)shape[i];
                 }
 
-                if (typeof(T) != typeof(string))
+                if (elemType != TensorElementType.String)
                 {
                     NativeApiStatus.VerifySuccess(NativeMethods.OrtGetTensorMutableData(ortValue.Handle, out _dataBufferPointer));
                 }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxTensorMemory.shared.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.OnnxRuntime
                 if (typeof(T) != type)
                 {
                     var message = String.Format("The NativeOnnxTensorMemory<T> type being instantiated for T = : {0} while supplied OrtValue contains T = {1}",
-                        nameof(T), nameof(type));
+                        typeof(T), type);
                     throw new OnnxRuntimeException(ErrorCode.InvalidArgument, message);
                 }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxValueHelper.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeOnnxValueHelper.shared.cs
@@ -108,19 +108,22 @@ namespace Microsoft.ML.OnnxRuntime
 
     internal static class TensorElementTypeConverter
     {
-        public static void GetTypeAndWidth(TensorElementType elemType, out Type type, out int width)
+        public static bool GetTypeAndWidth(TensorElementType elemType, out Type type, out int width)
         {
-            TensorElementTypeInfo result = TensorBase.GetElementTypeInfo(elemType);
-            if(result != null)
+            bool result = true;
+            TensorElementTypeInfo typeInfo = TensorBase.GetElementTypeInfo(elemType);
+            if(typeInfo != null)
             {
-                type = result.TensorType;
-                width = result.TypeSize;
+                type = typeInfo.TensorType;
+                width = typeInfo.TypeSize;
             }
             else
             {
                 type = null;
                 width = 0;
+                result = false;
             }
+            return result;
         }
     }
 }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtAllocator.shared.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         #region SafeHandle
-        
+
         /// <summary>
         /// Overrides SafeHandle.IsInvalid
         /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.ML.OnnxRuntime
         public override bool Equals(object obj)
         {
             var other = obj as OrtMemoryInfo;
-            if(other == null)
+            if (other == null)
             {
                 return false;
             }
@@ -271,7 +271,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <returns>true if instances are equal according to OrtCompareMemoryInfo.</returns>
         public bool Equals(OrtMemoryInfo other)
         {
-            if(this == other)
+            if (this == other)
             {
                 return true;
             }
@@ -308,6 +308,46 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// This class represents an arbitrary buffer of memory
+    /// allocated and owned by the user. It can be either a CPU or GPU memory.
+    /// This is just a composite of the buffer related information.
+    /// </summary>
+    public class OrtExternalAllocation
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="memInfo">use to accurately describe a piece of memory that this is wrapping</param>
+        /// <param name="shape">shape of this buffer</param>
+        /// <param name="elementType">element type</param>
+        /// <param name="pointer">the actual pointer to memory</param>
+        public OrtExternalAllocation(OrtMemoryInfo memInfo, long[] shape, Tensors.TensorElementType elementType, IntPtr pointer)
+        {
+            Info = memInfo;
+            Shape = shape;
+            ElementType = elementType;
+            Pointer = pointer;
+        }
+
+        /// <summary>
+        /// OrtMemoryInfo
+        /// </summary>
+        public OrtMemoryInfo Info { get; private set; }
+        /// <summary>
+        /// Shape
+        /// </summary>
+        public long[] Shape { get; private set; }
+        /// <summary>
+        /// Data type
+        /// </summary>
+        public Tensors.TensorElementType ElementType { get; private set; }
+        /// <summary>
+        /// Actual memory ptr
+        /// </summary>
+        public IntPtr Pointer { get; private set; }
     }
 
     /// <summary>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
@@ -191,12 +191,11 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="isInput">whether this is an input or output</param>
         private void BindExternalAllocation(string name, OrtExternalAllocation allocation, bool isInput)
         {
-            var size = ArrayUtilities.GetSizeForShape(allocation.Shape);
             using (var ortValue = OrtValue.CreateTensorValueWithData(allocation.Info,
                                                         allocation.ElementType,
                                                         allocation.Shape,
                                                         allocation.Pointer,
-                                                        size))
+                                                        allocation.Size))
                 BindInputOrOutput(name, ortValue.Handle, isInput);
         }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
@@ -56,8 +56,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Bind a piece of pre-allocated native memory as a OrtValue Tensor with a given shape
         /// to an input with a given name. The model will read the specified input from that memory
         /// possibly avoiding the need to copy between devices. OrtMemoryAllocation continues to own
-        /// the chunk of native memory and should be alive until the end of execution.
-        /// The size of the allocation can not be less than required.
+        /// the chunk of native memory, and the allocation should be alive until the end of execution.
         /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">of the input</param>
@@ -70,7 +69,11 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Bind externally allocated memory as input
+        /// Bind externally (not from OrtAllocator) allocated memory as input.
+        /// The model will read the specified input from that memory
+        /// possibly avoiding the need to copy between devices. The user code continues to own
+        /// the chunk of externally allocated memory, and the allocation should be alive until the end of execution.
+        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">name</param>
         /// <param name="allocation">non ort allocated memory</param>
@@ -118,7 +121,11 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Bind externally allocated memory as output
+        /// Bind externally (not from OrtAllocator) allocated memory as output.
+        /// The model will read the specified input from that memory
+        /// possibly avoiding the need to copy between devices. The user code continues to own
+        /// the chunk of externally allocated memory, and the allocation should be alive until the end of execution.
+        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">name</param>
         /// <param name="allocation">non ort allocated memory</param>
@@ -184,7 +191,8 @@ namespace Microsoft.ML.OnnxRuntime
 
 
         /// <summary>
-        /// BindExternal allocation as input or output
+        /// Bind external allocation as input or output.
+        /// The allocation is owned by the user code.
         /// </summary>
         /// <param name="name">name </param>
         /// <param name="allocation">non ort allocated memory</param>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void SynchronizeBoundInputs()
         {
-            NativeMethods.OrtSynchronizeBoundInputs(handle);
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtSynchronizeBoundInputs(handle));
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void SynchronizeBoundOutputs()
         {
-            NativeMethods.OrtSynchronizeBoundOutputs(handle);
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtSynchronizeBoundOutputs(handle));
         }
 
         /// <summary>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
@@ -57,7 +57,6 @@ namespace Microsoft.ML.OnnxRuntime
         /// to an input with a given name. The model will read the specified input from that memory
         /// possibly avoiding the need to copy between devices. OrtMemoryAllocation continues to own
         /// the chunk of native memory, and the allocation should be alive until the end of execution.
-        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">of the input</param>
         /// <param name="elementType">Tensor element type</param>
@@ -73,7 +72,6 @@ namespace Microsoft.ML.OnnxRuntime
         /// The model will read the specified input from that memory
         /// possibly avoiding the need to copy between devices. The user code continues to own
         /// the chunk of externally allocated memory, and the allocation should be alive until the end of execution.
-        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">name</param>
         /// <param name="allocation">non ort allocated memory</param>
@@ -109,7 +107,6 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Bind model output to an OrtValue as Tensor with a given type and shape. An instance of OrtMemoryAllocaiton
         /// owns the memory and should be alive for the time of execution.The size of the allocation can not be less than required
-        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">of the output</param>
         /// <param name="elementType">tensor element type</param>
@@ -125,7 +122,6 @@ namespace Microsoft.ML.OnnxRuntime
         /// The model will read the specified input from that memory
         /// possibly avoiding the need to copy between devices. The user code continues to own
         /// the chunk of externally allocated memory, and the allocation should be alive until the end of execution.
-        /// by the Tensor of the given size.
         /// </summary>
         /// <param name="name">name</param>
         /// <param name="allocation">non ort allocated memory</param>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtIoBinding.shared.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.OnnxRuntime
 
         /// <summary>
         /// Bind model output to an OrtValue as Tensor with a given type and shape. An instance of OrtMemoryAllocaiton
-        /// owns the memory and should be alive for the time of execution.The size of the allocation can not be less than required
+        /// owns the memory and should be alive for the time of execution.
         /// </summary>
         /// <param name="name">of the output</param>
         /// <param name="elementType">tensor element type</param>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -94,16 +94,25 @@ namespace Microsoft.ML.OnnxRuntime
         {
             Type type;
             int width;
-            TensorElementTypeConverter.GetTypeAndWidth(elementType, out type, out width);
-            if(width < 1)
+            if (!TensorElementTypeConverter.GetTypeAndWidth(elementType, out type, out width))
             {
-                throw new OnnxRuntimeException(ErrorCode.InvalidArgument, "Unsupported data type (such as string)");
+                throw new OnnxRuntimeException(ErrorCode.InvalidArgument,
+                    "Unable to query type information for data type: " + elementType.ToString());
+            }
+
+            if (elementType == TensorElementType.String)
+            {
+                throw new OnnxRuntimeException(ErrorCode.InvalidArgument,
+                    "Can not use map managed strings buffer to native OrtValue");
             }
 
             var shapeSize = ArrayUtilities.GetSizeForShape(shape);
-            if((shapeSize * width) > bufferLength)
+            var requiredBufferSize = shapeSize * width;
+            if (requiredBufferSize > bufferLength)
             {
-                throw new OnnxRuntimeException(ErrorCode.InvalidArgument, "Can not bind the shape to smaller buffer");
+                var message = String.Format("Shape of: {0} elements requires a buffer of at least {1} bytes. Provided: {2} bytes",
+                    shapeSize, requiredBufferSize, bufferLength);
+                throw new OnnxRuntimeException(ErrorCode.InvalidArgument, message);
             }
 
             IntPtr ortValueHandle = IntPtr.Zero;

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.OnnxRuntime
             if (elementType == TensorElementType.String)
             {
                 throw new OnnxRuntimeException(ErrorCode.InvalidArgument,
-                    "Can not use map managed strings buffer to native OrtValue");
+                    "Cannot map managed strings buffer to native OrtValue");
             }
 
             var shapeSize = ArrayUtilities.GetSizeForShape(shape);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtIoBindingAllocationTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtIoBindingAllocationTest.cs
@@ -61,11 +61,14 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 var ortAllocationInput = allocator.Allocate((uint)inputData.Length * sizeof(float));
                 dispList.Add(ortAllocationInput);
                 var inputShape = Array.ConvertAll<int, long>(inputMeta[inputName].Dimensions, d => d);
+                var shapeSize = ArrayUtilities.GetSizeForShape(inputShape);
+                Assert.Equal(shapeSize, inputData.Length);
                 PopulateNativeBufferFloat(ortAllocationInput, inputData);
 
                 // Re-use ORT allocated CPU buffer to present this as external allocation
+                var sizeInBytes = shapeSize * sizeof(float);
                 var externalInputAllocation = new OrtExternalAllocation(ortAllocationInput.Info, inputShape,
-                    Tensors.TensorElementType.Float, ortAllocationInput.Pointer);
+                    Tensors.TensorElementType.Float, ortAllocationInput.Pointer, sizeInBytes);
 
                 var ortAllocationOutput = allocator.Allocate((uint)outputData.Length * sizeof(float));
                 dispList.Add(ortAllocationOutput);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
@@ -56,8 +56,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
             else
             {
-                type = null;
-                width = 0;
+                throw new OnnxRuntimeException(ErrorCode.InvalidArgument, "Unable to get information for type: " + elemType.ToString());
             }
         }
 


### PR DESCRIPTION
**Description**:
Introduce OrtExternalAllocation class that allows to supply type, shape and raw memory pointer for binding and other purposes. Introduce reasonable shape checks against the supplied size.

Could not find a suitable framework class that would give its memory back as a raw Ptr.

**Motivation and Context**
OrtIoBinding does not currently allow binding of raw native and/or device-based buffers that were user-allocated or potentially by another framework. Those are usually expressed by `IntPtr`.

Re: https://github.com/microsoft/onnxruntime/issues/10180