### PR TITLE
[js/web] fix lint error when run without ort-web TS types

### DIFF
--- a/js/web/lib/wasm/proxy-worker/main.ts
+++ b/js/web/lib/wasm/proxy-worker/main.ts
@@ -10,7 +10,7 @@ import {initializeWebAssembly} from '../wasm-factory';
 self.onmessage = (ev: MessageEvent<OrtWasmMessage>): void => {
   switch (ev.data.type) {
     case 'init-wasm':
-      initializeWebAssembly(ev.data.in!)
+      initializeWebAssembly(ev.data.in)
           .then(
               () => postMessage({type: 'init-wasm'} as OrtWasmMessage),
               err => postMessage({type: 'init-wasm', err} as OrtWasmMessage));

--- a/js/web/script/build.ts
+++ b/js/web/script/build.ts
@@ -99,7 +99,7 @@ if (WASM) {
     }
 
     fs.writeFileSync(WASM_BINDING_THREADED_MIN_JS_PATH, terser.stdout);
-    fs.writeFileSync(WASM_THREADED_JS_PATH, COPYRIGHT_BANNER + terser.stdout);
+    fs.writeFileSync(WASM_THREADED_JS_PATH, `${COPYRIGHT_BANNER}${terser.stdout}`);
 
     validateFile(WASM_BINDING_THREADED_MIN_JS_PATH);
     validateFile(WASM_THREADED_JS_PATH);
@@ -124,7 +124,7 @@ if (WASM) {
     }
 
     fs.writeFileSync(WASM_BINDING_THREADED_MIN_WORKER_JS_PATH, terser.stdout);
-    fs.writeFileSync(WASM_THREADED_WORKER_JS_PATH, COPYRIGHT_BANNER + terser.stdout);
+    fs.writeFileSync(WASM_THREADED_WORKER_JS_PATH, `${COPYRIGHT_BANNER}${terser.stdout}`);
 
     validateFile(WASM_BINDING_THREADED_MIN_WORKER_JS_PATH);
     validateFile(WASM_THREADED_WORKER_JS_PATH);

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -73,6 +73,10 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js'
     displayName: 'npm ci /js/'
   - script: |
+     npm run lint
+    workingDirectory: '$(Build.SourcesDirectory)\js'
+    displayName: 'run ESLint without TS type populated'
+  - script: |
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)\js\common'
     displayName: 'npm ci /js/common/'
@@ -83,7 +87,7 @@ jobs:
   - script: |
      npm run lint
     workingDirectory: '$(Build.SourcesDirectory)\js'
-    displayName: 'ESLint'
+    displayName: 'run ESLint'
   - script: |
      npm run format
     workingDirectory: '$(Build.SourcesDirectory)\js'


### PR DESCRIPTION
**Description**: currently linter will fail if run before `npm ci` under /js/web.