### PR TITLE
Fuse Clip->Q to Q

### DIFF
--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -5,72 +5,11 @@
 #include "core/graph/graph_utils.h"
 #include "core/optimizer/conv_activation_fusion.h"
 #include "core/optimizer/initializer.h"
+#include "core/optimizer/utils.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;
 namespace onnxruntime {
-
-namespace {
-// get min/max values from Clip if they are constant. Returns false if mutable and cannot be used
-static bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, float& max) {
-  min = std::numeric_limits<float>::lowest();
-  max = std::numeric_limits<float>::max();
-
-  // Clip opset 6 has min and max as attributes. they're inputs from opset 11 on.
-  bool min_max_are_attributes = graph_utils::IsSupportedOptypeVersionAndDomain(node, "Clip", {6});
-  bool min_max_are_constant_values = true;
-
-  if (min_max_are_attributes) {
-    min = graph_utils::GetNodeAttribute(node, "min")->f();
-    max = graph_utils::GetNodeAttribute(node, "max")->f();
-  } else {
-    // update min/max if provided via a constant initializer
-    // return true if value is default or coming from a constant initializer and update 'value'
-    // return false if value is mutable
-    auto update_if_constant_value = [&graph](const Node& node, size_t input_idx, float& value) {
-      const auto& input_defs = node.InputDefs();
-      const NodeArg* input = (input_defs.size() > input_idx) ? input_defs[input_idx] : nullptr;
-
-      if (input == nullptr || !input->Exists()) {
-        // optional input not specified so using default value
-        return true;
-      }
-
-      bool is_constant = true;
-      const ONNX_NAMESPACE::TensorProto* initializer = graph_utils::GetConstantInitializer(graph, input->Name());
-      if (initializer) {
-        Initializer i(*initializer, graph.ModelPath());
-        switch (initializer->data_type()) {
-          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
-            value = *i.data<float>();
-            break;
-          // double isn't currently supported
-          //case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
-          //  value = static_cast<float>(*i.data<double>());
-          //  break;
-          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
-            value = math::halfToFloat(i.data<MLFloat16>()->val);
-            break;
-          default:
-            ORT_THROW("Unexpected data type for Clip input of ", initializer->data_type());
-        }
-      } else {
-        is_constant = false;
-      }
-
-      return is_constant;
-    };
-
-    // 'min' is input 1, 'max' is input 2. both are optional.
-    // if the input is constant, 'min' or 'max' is updated by the call to get_if_constant_value
-    min_max_are_constant_values = update_if_constant_value(node, 1, min) &&
-                                  update_if_constant_value(node, 2, max);
-  }
-
-  return min_max_are_constant_values;
-}
-
-}  // namespace
 
 Status ConvActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   GraphViewer graph_viewer(graph);
@@ -173,7 +112,7 @@ Status ConvActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
           activation_params.push_back(graph_utils::GetNodeAttribute(next_node, "alpha")->f());
         } else if (graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "Clip", {6, 11, 12, 13})) {
           float min, max;
-          if (GetClipConstantMinMax(graph, next_node, min, max)) {
+          if (optimizer_utils::GetClipConstantMinMax(graph, next_node, min, max)) {
             activation_params.push_back(min);
             activation_params.push_back(max);
           } else {

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -44,6 +44,7 @@
 #include "core/optimizer/nhwc_transformer.h"
 #include "core/optimizer/noop_elimination.h"
 #include "core/optimizer/not_where_fusion.h"
+#include "core/optimizer/qdq_transformer/clip_quantizelinear.h"
 #include "core/optimizer/qdq_transformer/qdq_propagation.h"
 #include "core/optimizer/qdq_transformer/qdq_s8_to_u8.h"
 #include "core/optimizer/qdq_transformer/relu_quantizelinear.h"
@@ -99,6 +100,7 @@ std::vector<std::unique_ptr<RewriteRule>> GenerateRewriteRules(
       rules.push_back(std::make_unique<ConvAddFusion>());
       rules.push_back(std::make_unique<ConvMulFusion>());
       rules.push_back(std::make_unique<ConvBNFusion>());
+      rules.push_back(std::make_unique<ClipQuantFusion>());
       rules.push_back(std::make_unique<ReluQuantFusion>());
       break;
 

--- a/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
@@ -93,7 +93,8 @@ Status ClipQuantFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
     return Status::OK();
   }
 
-  if (lower < min || max < upper) {
+  constexpr float epsilon = std::numeric_limits<float>::epsilon();
+  if (epsilon < min - lower || epsilon < upper - max) {
     return Status::OK();
   }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/qdq_transformer/clip_quantizelinear.h"
+#include "core/optimizer/utils.h"
+#include "core/graph/graph_utils.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace onnxruntime::common;
+namespace onnxruntime {
+
+static bool GetQConstantLowerUpper(const Graph& graph, const Node& node, float& lower, float& upper) {
+  const auto& input_defs = node.InputDefs();
+
+  constexpr size_t input_cnt_required = 3;
+  if (input_defs.size() != input_cnt_required) {
+    return false;
+  }
+
+  constexpr size_t s_idx = 1;
+  const NodeArg* s_input = input_defs[s_idx];
+
+  const ONNX_NAMESPACE::TensorProto* s_tensor_proto = graph_utils::GetConstantInitializer(graph, s_input->Name());
+  if (!s_tensor_proto) {
+    return false;
+  }
+
+  Initializer s_initializer(*s_tensor_proto, graph.ModelPath());
+  if (s_initializer.dims().size() != 0 ||
+      s_initializer.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    return false;
+  }
+  const float scale = s_initializer.data<float>()[0];
+
+  constexpr size_t zp_idx = 2;
+  const NodeArg* zp_input = input_defs[zp_idx];
+
+  const ONNX_NAMESPACE::TensorProto* zp_tensor_proto = graph_utils::GetConstantInitializer(graph, zp_input->Name());
+  if (!zp_tensor_proto) {
+    return false;
+  }
+
+  Initializer zp_initializer(*zp_tensor_proto, graph.ModelPath());
+  if (zp_initializer.dims().size() != 0) {
+    return false;
+  }
+
+  switch (zp_initializer.data_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8: {
+      const int8_t zero_point = zp_initializer.data<int8_t>()[0];
+      lower = scale * (-128 - zero_point);
+      upper = scale * (127 - zero_point);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8: {
+      const uint8_t zero_point = zp_initializer.data<uint8_t>()[0];
+      lower = scale * (0 - zero_point);
+      upper = scale * (255 - zero_point);
+      break;
+    }
+    default:
+      ORT_THROW("Unexpected data type for QuantizeLinear input y_zero_point of ", zp_initializer.data_type());
+  }
+  return true;
+}
+
+bool ClipQuantFusion::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& /*logger*/) const {
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Clip", {1, 6, 11, 12, 13}) ||
+      !optimizer_utils::CheckOutputEdges(graph, node, 1)) {
+    return false;
+  }
+
+  // if Clip is followed by QuantizeLinear, it can be fused into QuantizeLinear potentially
+  const auto& next_node = *node.OutputNodesBegin();
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "QuantizeLinear", {10, 13})) {
+    return false;
+  }
+
+  return true;
+}
+
+Status ClipQuantFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
+  float min, max;
+  if (!optimizer_utils::GetClipConstantMinMax(graph, node, min, max)) {
+    return Status::OK();
+  }
+
+  const Node& q_node = *graph.GetNode(node.OutputNodesBegin()->Index());
+
+  float lower, upper;
+  if (!GetQConstantLowerUpper(graph, q_node, lower, upper)) {
+    return Status::OK();
+  }
+
+  if (lower < min || max < upper) {
+    return Status::OK();
+  }
+
+  if (graph_utils::RemoveNode(graph, node)) {
+    rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/rewrite_rule.h"
+
+namespace onnxruntime {
+
+/**
+    @Class ClipQuantFusion
+
+    Rewrite rule that fuses Clip into followed QuantizeLinear
+ */
+class ClipQuantFusion : public RewriteRule {
+ public:
+  ClipQuantFusion() noexcept : RewriteRule("ClipQuantRewrite") {}
+
+  std::vector<std::string> TargetOpTypes() const noexcept override {
+    return {"Clip"};
+  }
+
+ private:
+  bool SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const override;
+
+  Status Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -281,24 +281,9 @@ bool IsOperationDeterministic(const std::string& domain, const std::string& op) 
   if (domain.compare(kOnnxDomain) == 0) {
     auto iter = std::find(kOnnxDomainNonDeterministicOps.begin(), kOnnxDomainNonDeterministicOps.end(), op);
     return iter == kOnnxDomainNonDeterministicOps.end();
-  } 
-  // Unknown domain. Assume the op is not deterministic.
-  return false;  
-}
-
-#endif  // #if !defined(ORT_MINIMAL_BUILD)
-
-#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-
-bool IsScalar(const NodeArg& input_arg) {
-  auto shape = input_arg.Shape();
-  if (shape == nullptr) {
-    // shape inferencing wasn't able to populate shape information for this NodeArg
-    return false;
   }
-
-  auto dim_size = shape->dim_size();
-  return dim_size == 0 || (dim_size == 1 && shape->dim(0).has_dim_value() && shape->dim(0).dim_value() == 1);
+  // Unknown domain. Assume the op is not deterministic.
+  return false;
 }
 
 bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, float& max) {
@@ -358,6 +343,22 @@ bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, flo
 
   return min_max_are_constant_values;
 }
+
+#endif  // #if !defined(ORT_MINIMAL_BUILD)
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+bool IsScalar(const NodeArg& input_arg) {
+  auto shape = input_arg.Shape();
+  if (shape == nullptr) {
+    // shape inferencing wasn't able to populate shape information for this NodeArg
+    return false;
+  }
+
+  auto dim_size = shape->dim_size();
+  return dim_size == 0 || (dim_size == 1 && shape->dim(0).has_dim_value() && shape->dim(0).dim_value() == 1);
+}
+
 #endif  // #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
 }  // namespace optimizer_utils

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -301,6 +301,63 @@ bool IsScalar(const NodeArg& input_arg) {
   return dim_size == 0 || (dim_size == 1 && shape->dim(0).has_dim_value() && shape->dim(0).dim_value() == 1);
 }
 
+bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, float& max) {
+  min = std::numeric_limits<float>::lowest();
+  max = std::numeric_limits<float>::max();
+
+  // Clip opset 1 and 6 has min and max as attributes. they're inputs from opset 11 on.
+  bool min_max_are_attributes = graph_utils::IsSupportedOptypeVersionAndDomain(node, "Clip", {1, 6});
+  bool min_max_are_constant_values = true;
+
+  if (min_max_are_attributes) {
+    min = graph_utils::GetNodeAttribute(node, "min")->f();
+    max = graph_utils::GetNodeAttribute(node, "max")->f();
+  } else {
+    // update min/max if provided via a constant initializer
+    // return true if value is default or coming from a constant initializer and update 'value'
+    // return false if value is mutable
+    auto update_if_constant_value = [&graph](const Node& node, size_t input_idx, float& value) {
+      const auto& input_defs = node.InputDefs();
+      const NodeArg* input = (input_defs.size() > input_idx) ? input_defs[input_idx] : nullptr;
+
+      if (input == nullptr || !input->Exists()) {
+        // optional input not specified so using default value
+        return true;
+      }
+
+      bool is_constant = true;
+      const ONNX_NAMESPACE::TensorProto* initializer = graph_utils::GetConstantInitializer(graph, input->Name());
+      if (initializer) {
+        Initializer i(*initializer, graph.ModelPath());
+        switch (initializer->data_type()) {
+          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+            value = *i.data<float>();
+            break;
+          // double isn't currently supported
+          //case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+          //  value = static_cast<float>(*i.data<double>());
+          //  break;
+          case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+            value = math::halfToFloat(i.data<MLFloat16>()->val);
+            break;
+          default:
+            ORT_THROW("Unexpected data type for Clip input of ", initializer->data_type());
+        }
+      } else {
+        is_constant = false;
+      }
+
+      return is_constant;
+    };
+
+    // 'min' is input 1, 'max' is input 2. both are optional.
+    // if the input is constant, 'min' or 'max' is updated by the call to get_if_constant_value
+    min_max_are_constant_values = update_if_constant_value(node, 1, min) &&
+                                  update_if_constant_value(node, 2, max);
+  }
+
+  return min_max_are_constant_values;
+}
 #endif  // #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
 }  // namespace optimizer_utils

--- a/onnxruntime/core/optimizer/utils.h
+++ b/onnxruntime/core/optimizer/utils.h
@@ -102,7 +102,6 @@ bool CheckOutputEdges(const Graph& graph, const Node& node, size_t expected_outp
 
 bool IsOperationDeterministic(const std::string& domain, const std::string& op);
 
-
 /** Get min/max values from Clip if they are constant.
 @returns false if mutable and cannot be used.
 */

--- a/onnxruntime/core/optimizer/utils.h
+++ b/onnxruntime/core/optimizer/utils.h
@@ -102,6 +102,12 @@ bool CheckOutputEdges(const Graph& graph, const Node& node, size_t expected_outp
 
 bool IsOperationDeterministic(const std::string& domain, const std::string& op);
 
+
+/** Get min/max values from Clip if they are constant.
+@returns false if mutable and cannot be used.
+*/
+bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, float& max);
+
 #endif  // !#if !defined(ORT_MINIMAL_BUILD)
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -1487,7 +1487,7 @@ TEST(QDQTransformerTests, Clip) {
       if (opset_version >= 11) {
         auto* min_initializer = builder.MakeScalarInitializer<float>({min});
         auto* max_initializer = builder.MakeScalarInitializer<float>({max});
-        Node& argmax_node = builder.AddNode("Clip", {dq_output, min_initializer, max_initializer}, {clip_output});
+        builder.AddNode("Clip", {dq_output, min_initializer, max_initializer}, {clip_output});
       } else {
         Node& argmax_node = builder.AddNode("Clip", {dq_output}, {clip_output});
         argmax_node.AddAttribute("min", min);

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -1468,6 +1468,67 @@ TEST(QDQTransformerTests, DQForward_MutilpleSteps) {
   test_case({1, 13, 13, 23}, {30, 23, 3, 3}, {0, 3, 1, 2});
 }
 
+TEST(QDQTransformerTests, Clip) {
+  auto test_case = [&](float scale, auto zero_point, int clip_count, int opset_version = 12) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<int8_t>({1, 32, 112, 112},
+                                                  std::numeric_limits<int8_t>::min(),
+                                                  std::numeric_limits<int8_t>::max());
+      auto* output_arg = builder.MakeOutput();
+
+      // add DQ
+      auto* dq_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<int8_t>(input_arg, .0035f, 7, dq_output);
+
+      // add Clip
+      auto* clip_output = builder.MakeIntermediate();
+      constexpr float min = .0f;
+      constexpr float max = 6.0f;
+      if (opset_version >= 11) {
+        auto* min_initializer = builder.MakeScalarInitializer<float>({min});
+        auto* max_initializer = builder.MakeScalarInitializer<float>({max});
+        Node& argmax_node = builder.AddNode("Clip", {dq_output, min_initializer, max_initializer}, {clip_output});
+      } else {
+        Node& argmax_node = builder.AddNode("Clip", {dq_output}, {clip_output});
+        argmax_node.AddAttribute("min", min);
+        argmax_node.AddAttribute("max", max);
+      }
+
+      // add Q
+      builder.AddQuantizeLinearNode(clip_output, scale, zero_point, output_arg);
+    };
+
+    auto check_clip_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+      EXPECT_EQ(op_to_count["Clip"], clip_count);
+      EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
+    };
+
+    TransformerTester(build_test_case, check_clip_graph,
+                      TransformerLevel::Default,
+                      TransformerLevel::Level1,
+                      opset_version);
+  };
+
+  test_case(.0235294122248888f, static_cast<int8_t>(-128), 0);  // [0, 6]
+  test_case(.02f, static_cast<int8_t>(-128), 0);                // [0, 5.1]
+  test_case(.03f, static_cast<int8_t>(-128), 1);                // [0, 7.65]
+  test_case(.02f, static_cast<int8_t>(127), 1);                 // [-5.1 , 0]
+  test_case(.02f, static_cast<int8_t>(0), 1);                   // [-2.56, 2.54]
+  test_case(.04f, static_cast<int8_t>(-97), 1);                 // [-1.24, 8.96]
+  test_case(.02352941176f, static_cast<uint8_t>(0), 0);         // [0, 6]
+  test_case(.02f, static_cast<uint8_t>(0), 0);                  // [0, 5.1]
+  test_case(.03f, static_cast<uint8_t>(0), 1);                  // [0, 7.65]
+  test_case(.02f, static_cast<uint8_t>(255), 1);                // [-5.1, 0]
+  test_case(.02f, static_cast<uint8_t>(128), 1);                // [-2.56, 2.54]
+  test_case(.04f, static_cast<uint8_t>(31), 1);                 // [-1.24, 8.96]
+  test_case(.02f, static_cast<int8_t>(-128), 0, 10);            // [0, 5.1]
+  test_case(.03f, static_cast<int8_t>(-128), 1, 10);            // [0, 7.65]
+  test_case(.02f, static_cast<uint8_t>(0), 0, 10);              // [0, 5.1]
+  test_case(.03f, static_cast<uint8_t>(0), 1, 10);              // [0, 7.65]
+}
+
 TEST(QDQTransformerTests, Concat) {
   auto test_case = [&](const std::vector<std::vector<int64_t>>& input_shapes,
                        int64_t axis,

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -1485,8 +1485,8 @@ TEST(QDQTransformerTests, Clip) {
       constexpr float min = .0f;
       constexpr float max = 6.0f;
       if (opset_version >= 11) {
-        auto* min_initializer = builder.MakeScalarInitializer<float>({min});
-        auto* max_initializer = builder.MakeScalarInitializer<float>({max});
+        auto* min_initializer = builder.MakeScalarInitializer<float>(min);
+        auto* max_initializer = builder.MakeScalarInitializer<float>(max);
         builder.AddNode("Clip", {dq_output, min_initializer, max_initializer}, {clip_output});
       } else {
         Node& argmax_node = builder.AddNode("Clip", {dq_output}, {clip_output});


### PR DESCRIPTION
Implement a level 1 transformation ClipQuantFusion. It would check whether
Clip's range is larger than QuantizeLinear's, if it is, drop the Clip.

The range of QuantizeLinear is deducted according to following formulas:
* For int8_t zero_point: scale * [-128 - zero_point, 127 - zero_point]
* For uint8_t zero_point: scale * [0- zero_point, 255 - zero_point]

As GetClipConstantMinMax is used by transformations ClipQuantFusion and
ConvActivationFusion, move it to utils.h/utils.cc.