### PR TITLE
[NNAPI QDQ] Add QDQ Resize support

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -68,6 +68,8 @@ QuantizedOpType GetQuantizedOpType(const NodeUnit& node_unit) {
   } else if (node_unit.UnitType() == NodeUnit::Type::QDQGroup) {
     if (op_type == "Conv")
       return QuantizedOpType::QDQConv;
+    else if (op_type == "Resize")
+      return QuantizedOpType::QDQResize;
   } else {
     // throw?
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -86,6 +86,7 @@ enum class QuantizedOpType : uint8_t {
   // QLinearMul,
   // QLinearReduceMean,
   QDQConv,
+  QDQResize,
   // TODO, add other QDQ NodeUnit types
 };
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2262,9 +2262,7 @@ class ResizeOpBuilder : public BaseOpBuilder {
 };
 
 /* static */ bool ResizeOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) {
-  static bool is_quant_op_type =
-      GetQuantizedOpType(node_unit) == QuantizedOpType::QDQResize;
-  return is_quant_op_type;
+  return GetQuantizedOpType(node_unit) == QuantizedOpType::QDQResize;
 }
 
 void ResizeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2258,10 +2258,22 @@ class ResizeOpBuilder : public BaseOpBuilder {
 
  private:
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const NodeUnit& node_unit) const override;
+  static bool IsQuantizedOp(const NodeUnit& node_unit) ORT_MUST_USE_RESULT;  // TODO, see if we want to move this to BaseOpBuilder
 };
+
+/* static */ bool ResizeOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) {
+  static bool is_quant_op_type =
+      GetQuantizedOpType(node_unit) == QuantizedOpType::QDQResize;
+  return is_quant_op_type;
+}
 
 void ResizeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
   const auto& inputs = node_unit.Inputs();
+  if (IsQuantizedOp(node_unit)) {
+    AddQuantizationScaleAndZeroPointToSkip(model_builder, *inputs[0].quant_param);               // x_scale, x_zp
+    AddQuantizationScaleAndZeroPointToSkip(model_builder, *node_unit.Outputs()[0].quant_param);  // y_scale, y_zp
+  }
+
   // We don't really use ROI here, so add them to skipped list
   model_builder.AddInitializerToSkip(inputs[1].node_arg.Name());  // ROI
 
@@ -2294,6 +2306,15 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
     if (!input_is_nhwc) {
       ORT_RETURN_IF_ERROR(GetNHWCInput(model_builder, node_unit, 0, input));
     }
+  }
+
+  // Check if the quantization scale and ZP is correct
+  if (IsQuantizedOp(node_unit)) {
+    float x_scale = 0.0f;
+    int32_t x_zero_point = 0;
+    ORT_RETURN_IF_ERROR(GetQuantizationScaleAndZeroPoint(
+        initializers, node_unit.Inputs()[0], node_unit.ModelPath(), x_scale, x_zero_point));
+    ORT_RETURN_IF_ERROR(IsValidInputQuantizedType(model_builder, input, x_scale, x_zero_point));
   }
 
   bool is_linear_resize = helper.Get("mode", "nearest") == "linear";

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -1471,9 +1471,7 @@ class ResizeOpSupportChecker : public BaseOpSupportChecker {
 };
 
 /* static */ bool ResizeOpSupportChecker::IsQuantizedOp(const NodeUnit& node_unit) {
-  static bool is_quant_op_type =
-      GetQuantizedOpType(node_unit) == QuantizedOpType::QDQResize;
-  return is_quant_op_type;
+  return GetQuantizedOpType(node_unit) == QuantizedOpType::QDQResize;
 }
 
 bool ResizeOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
@@ -1598,6 +1596,8 @@ bool ResizeOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
 
   if (IsQuantizedOp(node_unit)) {
     // For QDQResize, we only support uint8 output now
+    // TODO, add int8 support to NNAPI, and maybe move all the output type check into a virtual function
+    // similar to HasSupportedInputsImpl
     int32_t output_type;
     if (!GetType(node_unit.Outputs()[0].node_arg, output_type))
       return false;

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -31,6 +31,8 @@ GetQDQTestCaseFn BuildQDQResizeTestCase(
 #ifdef USE_NNAPI
     resize_node.AddAttribute("mode", "linear");
     resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
+#else
+    ORT_UNUSED_PARAMETER(resize_node);
 #endif
     // add Q
     builder.AddQuantizeLinearNode<uint8_t>(resize_output, .003f, 1, output_arg);

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "qdq_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+GetQDQTestCaseFn BuildQDQResizeTestCase(
+    const std::vector<int64_t>& input_shape,
+    const std::vector<int64_t>& sizes_data) {
+  return [input_shape, sizes_data](ModelTestBuilder& builder) {
+    auto* input1_arg = builder.MakeInput<uint8_t>(input_shape,
+                                                  std::numeric_limits<uint8_t>::min(),
+                                                  std::numeric_limits<uint8_t>::max());
+    auto* roi = builder.MakeInitializer<float>({0}, {});
+    auto* scales = builder.MakeInitializer<float>({0}, {});
+    auto* sizes = builder.Make1DInitializer<int64_t>(sizes_data);
+    auto* output_arg = builder.MakeOutput();
+
+    // add DQ
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(input1_arg, .003f, 1, dq_output);
+
+    // add Resize
+    auto* resize_output = builder.MakeIntermediate();
+    Node& resize_node = builder.AddNode("Resize", {dq_output, roi, scales, sizes}, {resize_output});
+
+// NNAPI EP does not support the default setting of Resize Op
+// Use bi-linear and asymmetric for NNAPI EP only
+#ifdef USE_NNAPI
+    resize_node.AddAttribute("mode", "linear");
+    resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
+#endif
+    // add Q
+    builder.AddQuantizeLinearNode<uint8_t>(resize_output, .003f, 1, output_arg);
+  };
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 #include "graph_transform_test_builder.h"
 
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
@@ -12,7 +14,7 @@
 namespace onnxruntime {
 namespace test {
 
-using GetQDQConvTestCaseFn = std::function<void(ModelTestBuilder& builder)>;
+using GetQDQTestCaseFn = std::function<void(ModelTestBuilder& builder)>;
 
 template <typename T>
 typename std::enable_if<IsTypeQuantLinearCompatible<T>::value, NodeArg*>::type
@@ -24,10 +26,8 @@ AddQDQNodePair(ModelTestBuilder& builder, NodeArg* q_input, float scale, T zp = 
   return dq_output;
 }
 
-// TODO: for now it just builds a conv qdq graph.
-// can be modified and made it shared among different qdq test graphs associated with other operators
 template <typename InputType, typename WeightType, typename BiasType, typename OutputType>
-GetQDQConvTestCaseFn BuildQDQConvTestCase(const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape) {
+GetQDQTestCaseFn BuildQDQConvTestCase(const std::vector<int64_t>& input_shape, const std::vector<int64_t>& weights_shape) {
   return [input_shape, weights_shape](ModelTestBuilder& builder) {
     auto* input_arg = builder.MakeInput<float>(input_shape, -1.f, 1.f);
     auto* output_arg = builder.MakeOutput();
@@ -77,6 +77,8 @@ GetQDQConvTestCaseFn BuildQDQConvTestCase(const std::vector<int64_t>& input_shap
                                                 output_arg);
   };
 }
+
+GetQDQTestCaseFn BuildQDQResizeTestCase(const std::vector<int64_t>& input_shape, const std::vector<int64_t>& sizes_data);
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -78,7 +78,10 @@ GetQDQTestCaseFn BuildQDQConvTestCase(const std::vector<int64_t>& input_shape, c
   };
 }
 
-GetQDQTestCaseFn BuildQDQResizeTestCase(const std::vector<int64_t>& input_shape, const std::vector<int64_t>& sizes_data);
+GetQDQTestCaseFn BuildQDQResizeTestCase(const std::vector<int64_t>& input_shape,
+                                        const std::vector<int64_t>& sizes_data,
+                                        const std::string& mode = "nearest",
+                                        const std::string& coordinate_transformation_mode = "half_pixel");
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -278,8 +278,12 @@ TEST(NnapiExecutionProviderTest, TestQDQConv) {
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQResize) {
+  // NNAPI EP does not support the default setting of Resize Op
+  // Use bi-linear and asymmetric for NNAPI EP only
   RunQDQModelTest(BuildQDQResizeTestCase({1, 3, 64, 64} /* input_shape */,
-                                         {1, 3, 32, 32} /* sizes_data */),
+                                         {1, 3, 32, 32} /* sizes_data */,
+                                         "linear" /* mode */,
+                                         "asymmetric" /* coordinate_transformation_mode */),
                   "nnapi_qdq_test_graph_resize");
 }
 

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -35,6 +35,10 @@ static void VerifyOutputs(const std::vector<std::string>& output_names,
         EXPECT_THAT(ltensor.DataAsSpan<int64_t>(), ::testing::ContainerEq(rtensor.DataAsSpan<int64_t>()))
             << " mismatch for " << output_names[i];
         break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+        EXPECT_THAT(ltensor.DataAsSpan<uint8_t>(), ::testing::ContainerEq(rtensor.DataAsSpan<uint8_t>()))
+            << " mismatch for " << output_names[i];
+        break;
       case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {
         constexpr float abs_err = 1e-5f;
 


### PR DESCRIPTION
**Description**: [NNAPI QDQ] Add QDQ Conv support

**Motivation and Context**
- To avoid excessively large PR, the NNAPI QDQ integration is splitted into the following small tasks
- [x] 1. Add shared NodeUnit class (#10052[merged])
- [x] 2. Move NNAPI EP to use NodeUnitIODef for non-QDQ ops (#10237[merged])
- [x] 3. Add shared QDQ selectors (#10178[merged])
- [x] 4. Hookup NNAPI GetCapability/Compile with shared QDQ selectors (#10347[merged])
- [ ] 5. Enable QDQ for ops with QLinear version (QLinear[Conv/Matmul/Pool/...])(this PR)
- [ ] 6. Enable QDQ for ops without QLinear Version

This is part of task 6, to add support of QDQ Resize which does not have `QLinear` version

