### PR TITLE
Update rocm_ep and migraphx_ep to rocm4.5.2 and fix dockerfiles to build docker images correctly

### DIFF
--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -32,7 +32,7 @@ https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x8
 tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Install rbuild
-RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
+RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz numpy yapf==0.28.0
 
 ENV PATH /opt/miniconda/bin:/code/cmake-3.21.0-linux-x86_64/bin:${PATH}
 

--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -18,10 +18,16 @@ RUN update-locale LANG=en_US.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -r -f -g ${gid} scxiao && useradd -r -u ${uid} -g ${gid} -ms /bin/bash scxiao
+RUN usermod -aG sudo scxiao
+RUN mkdir -p /workspace && chown scxiao /workspace
+
 # Install rocm
 RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
+  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 RUN apt-get update &&\
     apt-get install -y sudo git bash build-essential rocm-dev libpython3.6-dev python3-pip miopen-hip \
@@ -39,17 +45,27 @@ ENV PATH /opt/miniconda/bin:/code/cmake-3.21.0-linux-x86_64/bin:${PATH}
 # Install MIGraphX from source
 RUN mkdir -p /migraphx
 RUN cd /migraphx && git clone --depth=1 --branch migraphx_for_ort https://github.com/ROCmSoftwarePlatform/AMDMIGraphX src
-RUN cd /migraphx && rbuild package --cxx /opt/rocm-4.5.0/llvm/bin/clang++ -d /migraphx/deps -B /migraphx/build -S /migraphx/src/ -DPYTHON_EXECUTABLE=/usr/bin/python3
+RUN cd /migraphx && rbuild package --cxx /opt/rocm-4.5.2/llvm/bin/clang++ -d /migraphx/deps -B /migraphx/build -S /migraphx/src/ -DPYTHON_EXECUTABLE=/usr/bin/python3
 RUN dpkg -i /migraphx/build/*.deb
 RUN rm -rf /migraphx
+
+# Install rocm ep dependencies
+RUN apt-get update &&\
+    apt-get install -y rocrand rccl hipsparse hipfft hipcub hipblas rocthrust
 
 WORKDIR /code
 
 # Prepare onnxruntime repository & build onnxruntime
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cd onnxruntime &&\
-    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_migraphx &&\
-    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-    cd .. &&\
-    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
+    cd onnxruntime  &&\
+    /bin/sh ./build.sh --cmake_extra_defines ONNXRUNTIME_VERSION=`cat ./VERSION_NUMBER` --config Release --parallel \
+                       --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx &&\
+#    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_migraphx &&\
+#    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
+#    cd .. &&\
+#    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
+
+USER scxiao
+RUN ["/bin/bash"]
+

--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -54,6 +54,6 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
     cd onnxruntime  &&\
     /bin/sh ./build.sh --cmake_extra_defines ONNXRUNTIME_VERSION=`cat ./VERSION_NUMBER` --config Release --parallel \
-            --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx \&&
-   pip install /code/onnxruntime/build/Linux/Release/dist/*.whl
+            --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx &&\
+    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl
 

--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -18,12 +18,6 @@ RUN update-locale LANG=en_US.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
-ARG uid=1000
-ARG gid=1000
-RUN groupadd -r -f -g ${gid} scxiao && useradd -r -u ${uid} -g ${gid} -ms /bin/bash scxiao
-RUN usermod -aG sudo scxiao
-RUN mkdir -p /workspace && chown scxiao /workspace
-
 # Install rocm
 RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
@@ -60,12 +54,6 @@ RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXR
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
     cd onnxruntime  &&\
     /bin/sh ./build.sh --cmake_extra_defines ONNXRUNTIME_VERSION=`cat ./VERSION_NUMBER` --config Release --parallel \
-                       --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx &&\
-#    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_migraphx &&\
-#    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-#    cd .. &&\
-#    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
-
-USER scxiao
-RUN ["/bin/bash"]
+            --skip_tests --build_wheel --use_rocm --rocm_version=4.5.2 --rocm_home /opt/rocm --use_migraphx \&&
+   pip install /code/onnxruntime/build/Linux/Release/dist/*.whl
 

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && 
   sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends sudo git bash build-essential libelf1 rocm-dev libpython3.6-dev python3-pip miopen-hip rocblas libnuma-dev 
+    apt-get install -y sudo git bash build-essential rocm-dev libpython3.6-dev python3-pip miopen-hip rocblas half aria2 libnuma-dev 
 
 RUN aria2c -q -d /tmp -o cmake-3.20.0-linux-x86_64.tar.gz \
 https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz &&\

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -20,16 +20,20 @@ ENV LANG C.UTF-8
 # Install rocm
 RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.0/ xenial main > /etc/apt/sources.list.d/rocm.list'
+  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends sudo git bash build-essential cmake libelf1 rocm-dkms libpython3.6-dev python3-pip miopen-hip rocblas\
-    libnuma-dev kmod half hipsparse rocfft hipblas
+    apt-get install -y --no-install-recommends sudo git bash build-essential libelf1 rocm-dev libpython3.6-dev python3-pip miopen-hip rocblas\
+    libnuma-dev kmod half hipsparse rocfft hipblas aria2 rocblas
+
+RUN aria2c -q -d /tmp -o cmake-3.20.0-linux-x86_64.tar.gz \
+https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz &&\
+tar -zxf /tmp/cmake-3.20.0-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Install yapf
 RUN pip3 install yapf==0.28.0
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.21.0-linux-x86_64/bin:${PATH}
+ENV PATH /opt/miniconda/bin:/code/cmake-3.20.0-linux-x86_64/bin:${PATH}
 
 # Install dependencies
 COPY ./scripts/install_rocm_deps.sh /
@@ -40,10 +44,11 @@ WORKDIR /code
 # Prepare onnxruntime repository & build onnxruntime
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cd onnxruntime &&\
-    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
-    ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm &&\
-    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-    cd .. &&\
-    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
+    cd onnxruntime 
+#    &&\
+#    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
+#    ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm &&\
+#    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
+#    cd .. &&\
+#    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
 

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -23,8 +23,7 @@ RUN apt-get update && apt-get install -y gnupg2 --no-install-recommends curl && 
   sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.5.2/ ubuntu main > /etc/apt/sources.list.d/rocm.list'
 
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends sudo git bash build-essential libelf1 rocm-dev libpython3.6-dev python3-pip miopen-hip rocblas\
-    libnuma-dev kmod half hipsparse rocfft hipblas aria2 rocblas
+    apt-get install -y --no-install-recommends sudo git bash build-essential libelf1 rocm-dev libpython3.6-dev python3-pip miopen-hip rocblas libnuma-dev 
 
 RUN aria2c -q -d /tmp -o cmake-3.20.0-linux-x86_64.tar.gz \
 https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz &&\
@@ -36,19 +35,17 @@ RUN pip3 install yapf==0.28.0
 ENV PATH /opt/miniconda/bin:/code/cmake-3.20.0-linux-x86_64/bin:${PATH}
 
 # Install dependencies
-COPY ./scripts/install_rocm_deps.sh /
-RUN chmod +x /install_rocm_deps.sh && /install_rocm_deps.sh && rm /install_rocm_deps.sh
+RUN apt-get update &&\
+    apt-get install -y rocrand rccl hipsparse hipfft hipcub hipblas rocthrust
 
 WORKDIR /code
 
 # Prepare onnxruntime repository & build onnxruntime
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\
     /bin/sh onnxruntime/dockerfiles/scripts/install_common_deps.sh &&\
-    cd onnxruntime 
-#    &&\
-#    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
-#    ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm &&\
-#    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
-#    cd .. &&\
-#    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
+    cd onnxruntime &&\
+    /bin/sh ./build.sh --config Release --build_wheel --update --build --parallel --cmake_extra_defines\
+            ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --use_rocm --rocm_home=/opt/rocm &&\
+    pip install /code/onnxruntime/build/Linux/Release/dist/*.whl &&\
+    cd ..
 

--- a/dockerfiles/Dockerfile.rocm
+++ b/dockerfiles/Dockerfile.rocm
@@ -30,7 +30,7 @@ https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x8
 tar -zxf /tmp/cmake-3.20.0-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Install yapf
-RUN pip3 install yapf==0.28.0
+RUN pip3 install yapf==0.28.0 numpy
 
 ENV PATH /opt/miniconda/bin:/code/cmake-3.20.0-linux-x86_64/bin:${PATH}
 

--- a/dockerfiles/scripts/install_rocm_deps.sh
+++ b/dockerfiles/scripts/install_rocm_deps.sh
@@ -12,49 +12,53 @@ apt-get update && apt-get install -y --no-install-recommends \
         python3-dev
 
 # rocm-cmake
-wget --quiet https://github.com/RadeonOpenCompute/rocm-cmake/archive/rocm-3.8.0.tar.gz
-tar -xzvf rocm-3.8.0.tar.gz
-rm rocm-3.8.0.tar.gz
-cd rocm-cmake-rocm-3.8.0
+rocm_cmake_version=4.5.2
+wget --quiet https://github.com/RadeonOpenCompute/rocm-cmake/archive/refs/tags/rocm-${rocm_cmake_version}.tar.gz
+tar -xzvf rocm-${rocm_cmake_version}.tar.gz
+rm rocm-${rocm_cmake_version}.tar.gz
+cd rocm-cmake-rocm-${rocm_cmake_version}
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 make -j8
 make install
 cd ../..
-rm -rf rocm-cmake-rocm-3.8.0
+rm -rf rocm-cmake-rocm-${rocm_cmake_version}
 
 # rccl
-wget --quiet https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-4.0.0.tar.gz
-tar -xzvf rocm-4.0.0.tar.gz
-rm rocm-4.0.0.tar.gz
-cd rccl-rocm-4.0.0
+rccl_version=4.5.2
+wget --quiet https://github.com/ROCmSoftwarePlatform/rccl/archive/refs/tags/rocm-${rccl_version}.tar.gz
+tar -xzvf rocm-${rccl_version}.tar.gz
+rm rocm-${rccl_version}.tar.gz
+cd rccl-rocm-${rccl_version}
 mkdir build
 cd build
 CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 make -j8
 make install
 cd ../..
-rm -rf rccl-rocm-4.0.0
+rm -rf rccl-rocm-${rccl_version}
 
 #rocrand
-wget --quiet https://github.com/ROCmSoftwarePlatform/rocRAND/archive/rocm-4.0.0.tar.gz
-tar -xzvf rocm-4.0.0.tar.gz
-rm rocm-4.0.0.tar.gz
-cd rocRAND-rocm-4.0.0
+rocrand_version=4.5.2
+wget --quiet https://github.com/ROCmSoftwarePlatform/rocRAND/archive/refs/tags/rocm-${rocrand_version}.tar.gz
+tar -xzvf rocm-${rocrand_version}.tar.gz
+rm rocm-${rocrand_version}.tar.gz
+cd rocRAND-rocm-${rocrand_version}
 mkdir build
 cd build
 CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 make -j8
 make install
 cd ../..
-rm -rf rocRAND-rocm-4.0.0
+rm -rf rocRAND-rocm-${rocrand_version}
 
 #hipcub
-wget --quiet https://github.com/ROCmSoftwarePlatform/hipCUB/archive/rocm-4.0.0.tar.gz
-tar -xzvf rocm-4.0.0.tar.gz
-rm rocm-4.0.0.tar.gz
-cd hipCUB-rocm-4.0.0
+hipcub_version=4.5.2
+wget --quiet https://github.com/ROCmSoftwarePlatform/hipCUB/archive/refs/tags/rocm-${hipcub_version}.tar.gz
+tar -xzvf rocm-${hipcub_version}.tar.gz
+rm rocm-${hipcub_version}.tar.gz
+cd hipCUB-rocm-${hipcub_version}
 mkdir build
 cd build
 CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
@@ -62,18 +66,19 @@ make -j8
 make package
 make install
 cd ../..
-rm -rf hipCUB-rocm-4.0.0
+rm -rf hipCUB-rocm-${hipcub_version}
 
 #rocprim
-wget --quiet https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/rocm-4.0.0.tar.gz
-tar -xzvf rocm-4.0.0.tar.gz
-rm rocm-4.0.0.tar.gz
-cd rocPRIM-rocm-4.0.0
+rocprim_version=4.5.2
+wget --quiet https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/refs/tags/rocm-${rocprim_version}.tar.gz
+tar -xzvf rocm-${rocprim_version}.tar.gz
+rm rocm-${rocprim_version}.tar.gz
+cd rocPRIM-rocm-${rocprim_version}
 mkdir build
 cd build
 CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
 make -j8
 make install
 cd ../..
-rm -rf rocPRIM-rocm-4.0.0
+rm -rf rocPRIM-rocm-${rocprim_version}
 


### PR DESCRIPTION
**Description**: Describe your changes.
The dockerfile for rocm ep and migraphx ep needs update to fix some build errors.

**Motivation and Context**
Fix build errors in the dockerfile related to rocm  ep and migraphx ep.

- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
