### PR TITLE
cmake: disable 'attributes' error to fix the build with GCC < 9.x

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -491,6 +491,14 @@ if (onnxruntime_CROSS_COMPILING)
   endif()
 endif()
 
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+  check_cxx_compiler_flag(-Wno-error HAS_NOERROR)
+  if (HAS_NOERROR)
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-error=attributes")
+    string(APPEND CMAKE_C_FLAGS " -Wno-error=attributes")
+  endif()
+endif()
+
 # Mark symbols to be invisible, for macOS/iOS target only
 # Due to many dependencies have different symbol visibility settings, set global compile flags here.
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS")


### PR DESCRIPTION
This patch fixes the error "requested alignment X is larger than Y" in older GCC's. ARM Cross-Compiler already disables this 'attributes' error, but systems with GCC 8.x (like RHEL 8.x) cannot build ONNX-RT regardless of the architecture.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89357