### PR TITLE
Refactor PropagateCastOps to remove global containers usage

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1119,7 +1119,7 @@ class Graph {
     return GetConsumerNodesImpl(*this, node_arg_name);
   }
 
-  void UpdateConsumerNodes(const std::string& node_arg_name, const std::vector<Node*>& nodes) {
+  void UpdateConsumerNodes(const std::string& node_arg_name, const gsl::span<Node* const>& nodes) {
     auto iter = node_arg_to_consumer_nodes_.find(node_arg_name);
     if (iter != node_arg_to_consumer_nodes_.end()) {
       node_arg_to_consumer_nodes_.erase(node_arg_name);
@@ -1127,6 +1127,10 @@ class Graph {
     for (Node* node : nodes) {
       node_arg_to_consumer_nodes_[node_arg_name].insert(node->Index());
     }
+  }
+
+  inline void UpdateConsumerNodes(const std::string& node_arg_name, std::initializer_list<Node*> nodes) {
+    UpdateConsumerNodes(node_arg_name, gsl::make_span(nodes.begin(), nodes.end()));
   }
 
   /** During constant folding it may become possible to infer the shape for a node.

--- a/onnxruntime/core/optimizer/propagate_cast_ops.cc
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.cc
@@ -1550,7 +1550,12 @@ PropagateCastOps::PropagateCastOps(GraphTransformerConfiguration::PropagateCastO
                                    size_t level, const gsl::span<const std::string>& allow_list,
                                    const std::unordered_set<std::string>& compatible_execution_providers)
     : GraphTransformer("PropagateCastOps", compatible_execution_providers),
-      impl_(std::make_unique<Impl>(strategy, level, allow_list)) {
+      impl_(new Impl(strategy, level, allow_list)) {
 }
+
+PropagateCastOps::~PropagateCastOps() noexcept {
+  delete impl_;
+}
+
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/propagate_cast_ops.h
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.h
@@ -21,12 +21,15 @@ class PropagateCastOps : public GraphTransformer {
                    size_t level = 0, const gsl::span<std::string const>& allow_list = {},
                    const std::unordered_set<std::string>& compatible_execution_providers = {});
 
+  ~PropagateCastOps() noexcept;
+
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
 
- private:
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(PropagateCastOps);
 
+ private:
   class Impl;
-  std::unique_ptr<Impl> impl_;
+  Impl* impl_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/propagate_cast_ops.h
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.h
@@ -5,6 +5,7 @@
 
 #include "core/optimizer/graph_transformer.h"
 #include "core/optimizer/graph_transformer_config.h"
+
 namespace onnxruntime {
 
 /**
@@ -17,14 +18,15 @@ class PropagateCastOps : public GraphTransformer {
  public:
   PropagateCastOps(GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy =
                        GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy::FloodFill,
-                   size_t level = 0, const std::vector<std::string>& allow_list = {},
-                   const std::unordered_set<std::string>& compatible_execution_providers = {}) noexcept;
+                   size_t level = 0, const gsl::span<std::string const>& allow_list = {},
+                   const std::unordered_set<std::string>& compatible_execution_providers = {});
 
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
 
  private:
-  size_t level_;
-  GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy_;
+
+  class Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**:
Global container usage creates race conditions between more than one model being loaded at the same time.

**Motivation and Context**
It is a bug.