### PR TITLE
Optimize cuComputePartGradGammaBeta kernel for MI100

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
@@ -89,7 +89,7 @@ Status LayerNormGrad<T, U, simplified>::ComputeInternal(OpKernelContext* p_op_ke
     bias_grad_data = reinterpret_cast<CudaT*>(bias_grad->template MutableData<T>());
   }
 
-  #ifndef __HIP_PLATFORM_HCC__
+  #ifndef USE_ROCM
   const int part_size = 16;
   #else
   // Optimization for ROCm MI100

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
@@ -143,7 +143,7 @@ Status InvertibleLayerNormGrad<T, U>::ComputeInternal(OpKernelContext* p_op_kern
   auto scale_grad_data = reinterpret_cast<CudaT*>(scale_grad->template MutableData<T>());
   auto bias_grad_data = reinterpret_cast<CudaT*>(bias_grad->template MutableData<T>());
 
-  #ifndef __HIP_PLATFORM_HCC__
+  #ifndef USE_ROCM
   const int part_size = 16;
   #else
   // Optimization for ROCm MI100

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
@@ -89,7 +89,12 @@ Status LayerNormGrad<T, U, simplified>::ComputeInternal(OpKernelContext* p_op_ke
     bias_grad_data = reinterpret_cast<CudaT*>(bias_grad->template MutableData<T>());
   }
 
+  #ifndef __HIP_PLATFORM_HCC__
   const int part_size = 16;
+  #else
+  // Optimization for ROCm MI100
+  const int part_size = 64;
+  #endif
   auto part_grad_gamma = GetScratchBuffer<CudaU>(part_size * n2);
   auto part_grad_beta = GetScratchBuffer<CudaU>(part_size * n2);
 
@@ -138,7 +143,12 @@ Status InvertibleLayerNormGrad<T, U>::ComputeInternal(OpKernelContext* p_op_kern
   auto scale_grad_data = reinterpret_cast<CudaT*>(scale_grad->template MutableData<T>());
   auto bias_grad_data = reinterpret_cast<CudaT*>(bias_grad->template MutableData<T>());
 
+  #ifndef __HIP_PLATFORM_HCC__
   const int part_size = 16;
+  #else
+  // Optimization for ROCm MI100
+  const int part_size = 64;
+  #endif
   auto part_grad_gamma = GetScratchBuffer<CudaU>(part_size * n2);
   auto part_grad_beta = GetScratchBuffer<CudaU>(part_size * n2);
 


### PR DESCRIPTION
**Description**:
Optimized "part_size" on MI100 for layerNorm implementation (specifically for cuComputePartGradGammaBeta and cuComputeGradGammaBeta)

**Motivation and Context**
- Why is this change required? What problem does it solve?
https://ontrack.amd.com/browse/MSRCHA-161 : layer normalization forward & backward kernels slower on MI100 than on V100. It is ported from an Apex PR here: https://github.com/ROCmSoftwarePlatform/apex/pull/66

- If it fixes an open issue, please link to the issue here.





