### PR TITLE
Remove file-scope non-constant static variables to support multiple inference sessions 

### DIFF
--- a/onnxruntime/core/optimizer/propagate_cast_ops.cc
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.cc
@@ -9,47 +9,47 @@
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 /*********************************************************************************************************************************
-* PropagateCastOps transformation tries to expand float16 computation regions in the graph by converting float operations to float16.
-* In order to perform the transformation, certain operations are considered FP16 safe, i.e. the computation may be performed
-* without effecting the numerical result, ex. transpose, shape, etc. The transformation supports three levels of optimization, 0, 1
-* and 2. Level 2 being the most aggressive, may consider moving float operations to float16 which may result in different numerical results
-* due to loss of precision. The user may choose level 0, whereby the user chooses the opcodes which are "FP16 Safe" instead of a list
-* predetermined opcodes as in levels 1 and 2.
-* Currently three strategies are available, None, InsertAndReduce and FloodFill.
-* None:
-*   Although no new cast operations are inserted or propagated using this strategy some optimizations are performed
-*   1. Remove back-to-back casts
-*   2. Fuse subgraphs
-*   3. Remove unnecessary casts
-* InsertAndReduce :
-*   This transformation converts all FP16 operations to float16. The transformation first
-*   1. Inserts float16 cast operation on all the float inputs
-*   2. Changes all float outputs to float16
-*   3. Inserts float cast operations on all float outputs as expected
-*   After inserting the FP16 and FP32 cast operation nodes around all the nodes with FP16 Safe opcodes, the transformation reduces the
-*   cast operations, using the following operations on the graph, iteratively until no more reduction is possible.
-*   1. Remove back-to-back casts
-*   2. Remove redundant casts
-*   3. Fuse sibling subgraphs with same cast operation
-* FloodFill:
-*   Operations are converted from float to float16 by propagating float16 cast operations up the graph or float cast operations down the
-*   graph. Using this strategy, for each pre-existing float/float16 cast operations the transformation first finds the possible expansion of
-*   float16 region up/down the graph using DFS/ReverseDFS and (TODO) identifies loss/gain by performing such expansion, considering
-*   the gain by reducing float operations lower precision and loss due to newly inserted cast operations (/TODO).
-*   In addition to propagating cast operations up/down the graph, in this strategy, the above mentioned cast op reduction functions
-*   are also used.
-* InsertAndReduce exhaustively inserts cast operations before and after all the nodes with the allowed opcodes whereas FloodFill only
-* propagates existing casts up or down the graph, inserting new casts as it expands the float16 regions.
-*********************************************************************************************************************************/
+ * PropagateCastOps transformation tries to expand float16 computation regions in the graph by converting float operations to float16.
+ * In order to perform the transformation, certain operations are considered FP16 safe, i.e. the computation may be performed
+ * without effecting the numerical result, ex. transpose, shape, etc. The transformation supports three levels of optimization, 0, 1
+ * and 2. Level 2 being the most aggressive, may consider moving float operations to float16 which may result in different numerical results
+ * due to loss of precision. The user may choose level 0, whereby the user chooses the opcodes which are "FP16 Safe" instead of a list
+ * predetermined opcodes as in levels 1 and 2.
+ * Currently three strategies are available, None, InsertAndReduce and FloodFill.
+ * None:
+ *   Although no new cast operations are inserted or propagated using this strategy some optimizations are performed
+ *   1. Remove back-to-back casts
+ *   2. Fuse subgraphs
+ *   3. Remove unnecessary casts
+ * InsertAndReduce :
+ *   This transformation converts all FP16 operations to float16. The transformation first
+ *   1. Inserts float16 cast operation on all the float inputs
+ *   2. Changes all float outputs to float16
+ *   3. Inserts float cast operations on all float outputs as expected
+ *   After inserting the FP16 and FP32 cast operation nodes around all the nodes with FP16 Safe opcodes, the transformation reduces the
+ *   cast operations, using the following operations on the graph, iteratively until no more reduction is possible.
+ *   1. Remove back-to-back casts
+ *   2. Remove redundant casts
+ *   3. Fuse sibling subgraphs with same cast operation
+ * FloodFill:
+ *   Operations are converted from float to float16 by propagating float16 cast operations up the graph or float cast operations down the
+ *   graph. Using this strategy, for each pre-existing float/float16 cast operations the transformation first finds the possible expansion of
+ *   float16 region up/down the graph using DFS/ReverseDFS and (TODO) identifies loss/gain by performing such expansion, considering
+ *   the gain by reducing float operations lower precision and loss due to newly inserted cast operations (/TODO).
+ *   In addition to propagating cast operations up/down the graph, in this strategy, the above mentioned cast op reduction functions
+ *   are also used.
+ * InsertAndReduce exhaustively inserts cast operations before and after all the nodes with the allowed opcodes whereas FloodFill only
+ * propagates existing casts up or down the graph, inserting new casts as it expands the float16 regions.
+ *********************************************************************************************************************************/
 namespace onnxruntime {
 // NodeArg to Select consumer node map.
 typedef std::unordered_map<NodeArg*, std::vector<Node*>> NodeArgToConsumerMap;
 
 /*
-* ConcatNames
-* Collects all the names from the pointers of the objects stores in the container class C
-* the class should have a member functions returning a string (or a ref).
-*/
+ * ConcatNames
+ * Collects all the names from the pointers of the objects stores in the container class C
+ * the class should have a member functions returning a string (or a ref).
+ */
 template <typename C, typename T = typename C::value_type>
 static std::string ConcatNames(
     C const& items, std::string (*f)(const T& n) = [](const T& n) { return n->Name(); }) {
@@ -64,11 +64,11 @@ static std::string GetName(const std::pair<const NodeArg*, std::vector<Node*>>& 
   return p.first->Name() + " feeding " + ConcatNames(p.second) + "; ";
 };
 /*
-* The collection fp16_allow_ops, specifies for a given propagate_cast_ops level, a vector of node op_types that
-* the code is allowed to propage Cast operations across. The user may specify a custom list of optypes using level 0.
-* The opcodes are split into multiple levels. Cast propagation is done based on the level. Level 2 op code
-* list includes Level 1 list also.
-*/
+ * The collection fp16_allow_ops, specifies for a given propagate_cast_ops level, a vector of node op_types that
+ * the code is allowed to propage Cast operations across. The user may specify a custom list of optypes using level 0.
+ * The opcodes are split into multiple levels. Cast propagation is done based on the level. Level 2 op code
+ * list includes Level 1 list also.
+ */
 using NodeIndices = std::unordered_set<NodeIndex>;
 using FP16AllowOps = PropagateCastOps::FP16AllowOps;
 static const FP16AllowOps default_fp16_allow_ops = {
@@ -77,11 +77,11 @@ static const FP16AllowOps default_fp16_allow_ops = {
     /* Level 2 */ {"Add", "BiasGelu", "Dropout", "FastGelu", "Gather", "Gelu", "LayerNormalization", "Where"}};
 
 /*
-*  The following two maps specify the opcode to input and opcode to output mappings to list the inputs/outputs to consider while propagating
-*  cast operations. All other inputs/outputs not listed in this table are not relevant for deciding whether an operation
-*  performed in float or float16. If an opcode is not listed in these tables, the code will look at all the inputs and outputs to validate
-*  transformation.
-*/
+ *  The following two maps specify the opcode to input and opcode to output mappings to list the inputs/outputs to consider while propagating
+ *  cast operations. All other inputs/outputs not listed in this table are not relevant for deciding whether an operation
+ *  performed in float or float16. If an opcode is not listed in these tables, the code will look at all the inputs and outputs to validate
+ *  transformation.
+ */
 static const std::unordered_map<std::string, std::vector<int>> opcode_to_input_map = {
     {"Gather", {0}},
     {"Reshape", {0}},
@@ -101,9 +101,9 @@ static const std::unordered_map<std::string, std::vector<int>> opcode_to_output_
     {"Unsqueeze", {0}}};
 
 /*
-*  Check if the input is relevant to consider for cast propagation for the given node.
-*  Return true if the opcode is not found in the opcode_to_input map.
-*/
+ *  Check if the input is relevant to consider for cast propagation for the given node.
+ *  Return true if the opcode is not found in the opcode_to_input map.
+ */
 static bool IsRelevantInput(const Node* node, const NodeArg* input) {
   if (opcode_to_input_map.find(node->OpType()) != opcode_to_input_map.cend()) {
     const std::vector<int>& selected_inputs = opcode_to_input_map.at(node->OpType());
@@ -114,9 +114,9 @@ static bool IsRelevantInput(const Node* node, const NodeArg* input) {
 }
 
 /*
-*  Check if the output is relevant to consider for cast propagation for the given node.
-*  Return true if the opcode is not found in the opcode_to_output map.
-*/
+ *  Check if the output is relevant to consider for cast propagation for the given node.
+ *  Return true if the opcode is not found in the opcode_to_output map.
+ */
 static bool IsRelevantOutput(const Node* node, const NodeArg* output) {
   if (opcode_to_output_map.find(node->OpType()) != opcode_to_output_map.cend()) {
     const std::vector<int>& selected_outputs = opcode_to_output_map.at(node->OpType());
@@ -155,28 +155,28 @@ static bool IsType(const NodeArg& node_arg, TensorProto_DataType data_type) {
 }
 
 /* InsertCastNodes
-* Insert a new Cast node after each NodeArg in the require_cast map, feeding the nodes (consumer) in the vector mapped to
-* the NodeArg. The other consumers of the NodeArg will not be changed. The cast node is FLOAT16 if is_fp16 is True
-* and FLOAT otherwise. This function fixes the graph edges in addition to inserting the cast nodes.
-*
-* In the following example only the first two consumers, Opcode0 and Opcode1 get casted and the third consumer Opcode2 does not.
-*
-*                Input0/NodeArg                                  Input/NodeArg
-*               ___ ____|________________                           |____________________
-*               |              |        |                           |                   |
-*               |              |        |                      _____V______             |
-*               |              |        |                      | CastFP16 |             |
-*               |              |   _____V_____                 |_or_FP32__|       ______V___
-*               |              |   | Opcode2 |                      |             | Opcode2|
-*               |              |   |_________|               _______|___________  |________|
-*               |              |                             |                 |
-*               |              |                ---\    _____V______      _____V_____
-*               |              |                ---/    | Opcode0  |      | Opcode1 |
-*          _____V_____    _____V______                  |__________|      |_________|
-*          | Opcode0 |    | Opcode1  |                       |                 |
-*          |_________|    |__________|
-*               |              |
-*/
+ * Insert a new Cast node after each NodeArg in the require_cast map, feeding the nodes (consumer) in the vector mapped to
+ * the NodeArg. The other consumers of the NodeArg will not be changed. The cast node is FLOAT16 if is_fp16 is True
+ * and FLOAT otherwise. This function fixes the graph edges in addition to inserting the cast nodes.
+ *
+ * In the following example only the first two consumers, Opcode0 and Opcode1 get casted and the third consumer Opcode2 does not.
+ *
+ *                Input0/NodeArg                                  Input/NodeArg
+ *               ___ ____|________________                           |____________________
+ *               |              |        |                           |                   |
+ *               |              |        |                      _____V______             |
+ *               |              |        |                      | CastFP16 |             |
+ *               |              |   _____V_____                 |_or_FP32__|       ______V___
+ *               |              |   | Opcode2 |                      |             | Opcode2|
+ *               |              |   |_________|               _______|___________  |________|
+ *               |              |                             |                 |
+ *               |              |                ---\    _____V______      _____V_____
+ *               |              |                ---/    | Opcode0  |      | Opcode1 |
+ *          _____V_____    _____V______                  |__________|      |_________|
+ *          | Opcode0 |    | Opcode1  |                       |                 |
+ *          |_________|    |__________|
+ *               |              |
+ */
 static Status InsertCastNodes(Graph& graph,
                               const NodeArgToConsumerMap& require_cast,
                               bool is_fp16,
@@ -279,46 +279,46 @@ static Status InsertCastNodes(Graph& graph,
 }
 
 /* RemoveCastNodesChain
-* Remove the cast nodes specified in casts vector and fix the graph edges accordingly. If the output of the cast
-* is also a graph output then insert an Identity node if the input of the cast node feeds other nodes. In the
-* trivial case the chain has only one cast node. The caller is responsible for the validity of removing casts.
-*
-*                         _____|______
-*                         | Opcode1  |
-*                         |__________|
-*                              |
-*                         _____V______                         ____________
-*                         |  Cast    |                         | Opcode 1 |
-*                         |__________|                         |__________|
-*                              |                                    |
-*                              .                                    |
-*                              .                  ---\         _____V______
-*                              .                  ---/         | Opcode2  |
-*                         _____V______                         |__________|
-*                         |  Cast    |                              |
-*                         |__________|                              V
-*                              |
-*                         _____V______
-*                         |  Opcode2 |
-*                         |__________|
-*                              |
-*                              V
-*
-*    OR
-*                         _____|______                         _____|_____
-*                         | Opcode1  |                         | Opcode1 |
-*                         |__________|                         |_________|
-*                              |                                    |
-*                         _____V______            ---\         _____V______
-*                         |  Cast    |            ---/         | Opcode 2 |
-*                         |__________|                         |__________|
-*                              |                                    |
-*                         _____V______                              V
-*                         |  Opcode2 |
-*                         |__________|
-*                              |
-*                              V
-*/
+ * Remove the cast nodes specified in casts vector and fix the graph edges accordingly. If the output of the cast
+ * is also a graph output then insert an Identity node if the input of the cast node feeds other nodes. In the
+ * trivial case the chain has only one cast node. The caller is responsible for the validity of removing casts.
+ *
+ *                         _____|______
+ *                         | Opcode1  |
+ *                         |__________|
+ *                              |
+ *                         _____V______                         ____________
+ *                         |  Cast    |                         | Opcode 1 |
+ *                         |__________|                         |__________|
+ *                              |                                    |
+ *                              .                                    |
+ *                              .                  ---\         _____V______
+ *                              .                  ---/         | Opcode2  |
+ *                         _____V______                         |__________|
+ *                         |  Cast    |                              |
+ *                         |__________|                              V
+ *                              |
+ *                         _____V______
+ *                         |  Opcode2 |
+ *                         |__________|
+ *                              |
+ *                              V
+ *
+ *    OR
+ *                         _____|______                         _____|_____
+ *                         | Opcode1  |                         | Opcode1 |
+ *                         |__________|                         |_________|
+ *                              |                                    |
+ *                         _____V______            ---\         _____V______
+ *                         |  Cast    |            ---/         | Opcode 2 |
+ *                         |__________|                         |__________|
+ *                              |                                    |
+ *                         _____V______                              V
+ *                         |  Opcode2 |
+ *                         |__________|
+ *                              |
+ *                              V
+ */
 
 static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, NodeIndices& removed_nodes) {
   ORT_ENFORCE(casts.size() > 0);
@@ -378,61 +378,61 @@ static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, NodeI
 }
 
 /*
-* RemoveBackToBackCasts
-* Remove FLOAT and FLOAT16 casts back-to-back, only if the parent cast is from FLOAT16 to FLOAT
-* and the child cast is from FLOAT to FLOAT16 or from FLOAT to FLOAT.
-* The trivial case is parent cast has only one output. A non-trivial case handled by this function
-* is, parent has multiple children and one or more child node output is also a graph output.
-* In the non-trivial case, when a child-cast nullifies the parent cast, the consumer nodes are moved
-* from the child-cast to the producer of the parent-cast input. The code handles cornercases such as
-* the child-cast output is also a graph output, in addition to possibly other nodes, and the
-* parent-cast has other output nodes. The first check CanRemoveNode rules-out the possibility of
-* parent-cast output also being the graph output.
-* The inputs is Cast to FLOAT16
-* With the possibility of child/parent cast feeding other nodes/graph-output, the transformation is either
-*                         _____|______
-*                         | Opcode1  |
-*                         |__________|
-*                              |
-*                         _____V______                         ____________
-*                         | Cast     |                         | Opcode 1 |
-*                         |FP16->FP32|                         |__________|
-*                         |__________|                              |
-*                              |                                    |
-*                              |                  ---\         _____V______
-*                              |                  ---/         | Opcode2  |
-*                         _____V______                         |__________|
-*                         | Cast     |
-*                         |FP32->Fp16|
-*                         |__________|
-*                              |
-*                         _____V______
-*                         |  Opcode2 |
-*                         |__________|
-*
-*   or
-*
-*                         _____|______
-*                         | Opcode1  |
-*                         |__________|
-*                              |
-*                         _____V______                         ____________
-*                         | Cast     |                         | Opcode 1 |
-*                         |FP16->FP32|                         |__________|
-*                         |__________|                              |
-*                              |                                    |
-*                              |                  ---\         _____V______
-*                              |                  ---/         | Cast FP32|
-*                         _____V______                         |__________|
-*                         | Cast     |                              |
-*                         |FP32->FP32|                              |
-*                         |__________|                         _____V______
-*                              |                               | Opcode2  |
-*                         _____V______                         |__________|
-*                         |  Opcode2 |                              |
-*                         |__________|
-*                              |
-*/
+ * RemoveBackToBackCasts
+ * Remove FLOAT and FLOAT16 casts back-to-back, only if the parent cast is from FLOAT16 to FLOAT
+ * and the child cast is from FLOAT to FLOAT16 or from FLOAT to FLOAT.
+ * The trivial case is parent cast has only one output. A non-trivial case handled by this function
+ * is, parent has multiple children and one or more child node output is also a graph output.
+ * In the non-trivial case, when a child-cast nullifies the parent cast, the consumer nodes are moved
+ * from the child-cast to the producer of the parent-cast input. The code handles cornercases such as
+ * the child-cast output is also a graph output, in addition to possibly other nodes, and the
+ * parent-cast has other output nodes. The first check CanRemoveNode rules-out the possibility of
+ * parent-cast output also being the graph output.
+ * The inputs is Cast to FLOAT16
+ * With the possibility of child/parent cast feeding other nodes/graph-output, the transformation is either
+ *                         _____|______
+ *                         | Opcode1  |
+ *                         |__________|
+ *                              |
+ *                         _____V______                         ____________
+ *                         | Cast     |                         | Opcode 1 |
+ *                         |FP16->FP32|                         |__________|
+ *                         |__________|                              |
+ *                              |                                    |
+ *                              |                  ---\         _____V______
+ *                              |                  ---/         | Opcode2  |
+ *                         _____V______                         |__________|
+ *                         | Cast     |
+ *                         |FP32->Fp16|
+ *                         |__________|
+ *                              |
+ *                         _____V______
+ *                         |  Opcode2 |
+ *                         |__________|
+ *
+ *   or
+ *
+ *                         _____|______
+ *                         | Opcode1  |
+ *                         |__________|
+ *                              |
+ *                         _____V______                         ____________
+ *                         | Cast     |                         | Opcode 1 |
+ *                         |FP16->FP32|                         |__________|
+ *                         |__________|                              |
+ *                              |                                    |
+ *                              |                  ---\         _____V______
+ *                              |                  ---/         | Cast FP32|
+ *                         _____V______                         |__________|
+ *                         | Cast     |                              |
+ *                         |FP32->FP32|                              |
+ *                         |__________|                         _____V______
+ *                              |                               | Opcode2  |
+ *                         _____V______                         |__________|
+ *                         |  Opcode2 |                              |
+ *                         |__________|
+ *                              |
+ */
 static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
                                   NodeIndices& removed_nodes,
                                   const logging::Logger& logger) {
@@ -519,14 +519,14 @@ static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
 }
 
 /*
-*  SearchUpstream:
-*  ReverseDFS, traverse bottom-up, the graph upstream collecting all the NodeArgs that require a cast
-*  in order to move an FP16 Cast operation up the graph.
-*  Visited float NodeArgs are either in require_cast or require_type_change so that the same
-*  nodearg is traversed not more than once.
-*  If the level is 2, the functions traverses up the graph identifying required FP32 casts even if
-*  multiple consumers for the node outputs are found while level 0 or 1 quit traversing up.
-*/
+ *  SearchUpstream:
+ *  ReverseDFS, traverse bottom-up, the graph upstream collecting all the NodeArgs that require a cast
+ *  in order to move an FP16 Cast operation up the graph.
+ *  Visited float NodeArgs are either in require_cast or require_type_change so that the same
+ *  nodearg is traversed not more than once.
+ *  If the level is 2, the functions traverses up the graph identifying required FP32 casts even if
+ *  multiple consumers for the node outputs are found while level 0 or 1 quit traversing up.
+ */
 static void SearchUpstream(Graph& graph, NodeArg* node_arg, Node* dst_node,
                            NodeArgToConsumerMap& require_cast,
                            NodeArgToConsumerMap& require_cast_fp32,
@@ -603,11 +603,11 @@ static void SearchUpstream(Graph& graph, NodeArg* node_arg, Node* dst_node,
 }
 
 /*
-*  SearchDownstream:
-*  Recursively DFS traverse the graph downstream collecting all the NodeArgs that require a cast
-*  in order to remove an FP32 Cast operation up the graph. Also collect the NodeArgs that need to
-*  be converted from float to float16 along the way.
-*/
+ *  SearchDownstream:
+ *  Recursively DFS traverse the graph downstream collecting all the NodeArgs that require a cast
+ *  in order to remove an FP32 Cast operation up the graph. Also collect the NodeArgs that need to
+ *  be converted from float to float16 along the way.
+ */
 static void SearchDownstream(Graph& graph, NodeArg* node_arg,
                              NodeArgToConsumerMap& require_cast,
                              NodeArgToConsumerMap& require_cast_fp16,
@@ -690,16 +690,16 @@ static void ChangeTypeToFP16(Graph& graph, std::unordered_set<NodeArg*>& require
 }
 
 /*
-* PropagateForwards
-* Propagate FP32 Cast operations forwards (downstream)
-* Using SearchDownStream search the graph for Cast FP16 safe/allowed operations to expand
-* the float16 computation region.
-* The required_cast vector is the collection of nodes that require float cast.
-* All nodeargs on a path down to any of the
-* frontier nodes require type change from FLOAT to FLOAT16.
-* require_type_change consists of such nodes.  All the frontier nodes require fp32 cast
-* The input node is expected to be non-nullptr
-*/
+ * PropagateForwards
+ * Propagate FP32 Cast operations forwards (downstream)
+ * Using SearchDownStream search the graph for Cast FP16 safe/allowed operations to expand
+ * the float16 computation region.
+ * The required_cast vector is the collection of nodes that require float cast.
+ * All nodeargs on a path down to any of the
+ * frontier nodes require type change from FLOAT to FLOAT16.
+ * require_type_change consists of such nodes.  All the frontier nodes require fp32 cast
+ * The input node is expected to be non-nullptr
+ */
 static bool PropagateForwards(Graph& graph, Node* node,
                               NodeIndices& removed_nodes,
                               size_t level,
@@ -732,17 +732,17 @@ static bool PropagateForwards(Graph& graph, Node* node,
   return modified;
 }
 /*
-*  PropagateBackwards
-*  Propagate FP16 Cast operations backwards (upstream)
-*  Using SearchUpstream search the graph for Cast FP16 safe/allowed operations and expand
-*  float16 computation regsion and
-*  find the frontiers of the float16 computation region.
-*  The required_cast or require_cast_fp32 vector is a collection of
-*  FP16-cast-frontiers of the cast node. All node-args on the path from any of the
-*  frontier nodes to the cast node require type change from  FLOAT to FLOAT16.
-*  Each of the frontier nodes requires an fp16 cast or fp32 cast.
-*  The input node is expected be non-nullptr.
-*/
+ *  PropagateBackwards
+ *  Propagate FP16 Cast operations backwards (upstream)
+ *  Using SearchUpstream search the graph for Cast FP16 safe/allowed operations and expand
+ *  float16 computation regsion and
+ *  find the frontiers of the float16 computation region.
+ *  The required_cast or require_cast_fp32 vector is a collection of
+ *  FP16-cast-frontiers of the cast node. All node-args on the path from any of the
+ *  frontier nodes to the cast node require type change from  FLOAT to FLOAT16.
+ *  Each of the frontier nodes requires an fp16 cast or fp32 cast.
+ *  The input node is expected be non-nullptr.
+ */
 static bool PropagateBackwards(Graph& graph, Node* node,
                                NodeIndices& removed_nodes,
                                size_t level,
@@ -782,27 +782,27 @@ static bool PropagateBackwards(Graph& graph, Node* node,
 }
 
 /*
-* FuseNodes
-* Fuse all (cast) nodes, and replace with a single (cast) node.
-* Assumptions:
-* 1. all nodes are Cast ops and are of the same Cast type
-* 2. all the nodes have the same input
-*                Input0/NodeArg
-*               ___ ____|______                               Input0/NodeArg
-*               |             |                                     |
-*          _____V____    _____V______                          _____V______
-*          |Cast FP16|    | Cast FP16|                         | CastFP16 |
-*          |or_FP32__|    |_or_FP32 _|                         |_or_FP32__|
-*               |              |                                    |
-*               |              |                             _______|___________
-*               |              |                             |                 |
-*               |              |                ---\    _____V______      _____V_____
-*               |              |                ---/    | Opcode0  |      | Opcode1 |
-*          _____V_____    _____V______                  |__________|      |_________|
-*          | Opcode0 |    | Opcode1  |                       |                 |
-*          |_________|    |__________|
-*               |              |
-*/
+ * FuseNodes
+ * Fuse all (cast) nodes, and replace with a single (cast) node.
+ * Assumptions:
+ * 1. all nodes are Cast ops and are of the same Cast type
+ * 2. all the nodes have the same input
+ *                Input0/NodeArg
+ *               ___ ____|______                               Input0/NodeArg
+ *               |             |                                     |
+ *          _____V____    _____V______                          _____V______
+ *          |Cast FP16|    | Cast FP16|                         | CastFP16 |
+ *          |or_FP32__|    |_or_FP32 _|                         |_or_FP32__|
+ *               |              |                                    |
+ *               |              |                             _______|___________
+ *               |              |                             |                 |
+ *               |              |                ---\    _____V______      _____V_____
+ *               |              |                ---/    | Opcode0  |      | Opcode1 |
+ *          _____V_____    _____V______                  |__________|      |_________|
+ *          | Opcode0 |    | Opcode1  |                       |                 |
+ *          |_________|    |__________|
+ *               |              |
+ */
 static void FuseNodes(Graph& graph, const NodeArg* input, std::vector<Node*> nodes,
                       NodeIndices& removed_nodes,
                       NodeIndices& inserted_nodes) {
@@ -915,43 +915,43 @@ static bool RemoveUnnecessaryCasts(Graph& graph, Node* node,
 }
 
 /*
-* PropagateFP32CastsFromInputsToOutputs
-* This non-recursive fusion, checks whether the given node is fp16 safe op and
-* whether all floatingpoint inputs are cast to fp32
-* and propagates cast op to the floatingpoint outputs.
-* Convert the following graph
-*
-*        Input0/NodeArg  Input1/NodeArg
-*               |             |
-*          _____V____    _____V______
-*          |Cast FP32|   | Cast FP32|
-*          |_________|   |__________|
-*               |              |
-*             __V______________V___
-*            |       Opcode        |
-*            |(operation performed |
-*            |    in float32)      |
-*            |_____________________|
-*              |             |
-*              |             |
-*
-*  and produce the following output
-*
-*          Input0/NodeArg  Input1/NodeArg
-*                |               |
-*              __V_______________V___
-*             |       Opcode        |
-*             |(operation performed |
-*             |    in float16)      |
-*             |_____________________|
-*               |             |
-*          _____V____    _____V______
-*          |Cast FP32|   | Cast FP32|
-*          |_________|   |__________|
-*               |              |
-*
-*
-*/
+ * PropagateFP32CastsFromInputsToOutputs
+ * This non-recursive fusion, checks whether the given node is fp16 safe op and
+ * whether all floatingpoint inputs are cast to fp32
+ * and propagates cast op to the floatingpoint outputs.
+ * Convert the following graph
+ *
+ *        Input0/NodeArg  Input1/NodeArg
+ *               |             |
+ *          _____V____    _____V______
+ *          |Cast FP32|   | Cast FP32|
+ *          |_________|   |__________|
+ *               |              |
+ *             __V______________V___
+ *            |       Opcode        |
+ *            |(operation performed |
+ *            |    in float32)      |
+ *            |_____________________|
+ *              |             |
+ *              |             |
+ *
+ *  and produce the following output
+ *
+ *          Input0/NodeArg  Input1/NodeArg
+ *                |               |
+ *              __V_______________V___
+ *             |       Opcode        |
+ *             |(operation performed |
+ *             |    in float16)      |
+ *             |_____________________|
+ *               |             |
+ *          _____V____    _____V______
+ *          |Cast FP32|   | Cast FP32|
+ *          |_________|   |__________|
+ *               |              |
+ *
+ *
+ */
 static bool PropagateFP32CastsFromInputsToOutputs(Graph& graph, Node* node,
                                                   NodeIndices& removed_nodes,
                                                   size_t level,
@@ -1023,43 +1023,43 @@ static bool PropagateFP32CastsFromInputsToOutputs(Graph& graph, Node* node,
   return modified;
 }
 /*
-* PropagateFP16CastsFromOutputsToInputs
-* This non-recursive fusion, checks whether the given node is fp16 safe op and
-* whether all floatingpoint outputs are cast to fp16
-* and propagates cast op to the floatingpoint inputs.
-* Convert the following graph
-*
-*        Input0/NodeArg  Input1/NodeArg
-*               |             |
-*             __V______________V___
-*            |       Opcode        |
-*            |(operation performed |
-*            |    in float32)      |
-*            |_____________________|
-*               |             |
-*          _____V____    _____V______
-*          |Cast FP16|   | Cast FP16|
-*          |_________|   |__________|
-*               |              |
-*               |              |
-*               V              V
-*
-*  and produce the following output
-*
-*        Input0/NodeArg   Input1/NodeArg
-*               |               |
-*          _____V____      _____V______
-*          |Cast FP16|     | Cast FP16|
-*          |_________|     |__________|
-*                |              |
-*              __V______________V___
-*             |       Opcode        |
-*             |(operation performed |
-*             |    in float16)      |
-*             |_____________________|
-*                 |             |
-*                 V             V
-*/
+ * PropagateFP16CastsFromOutputsToInputs
+ * This non-recursive fusion, checks whether the given node is fp16 safe op and
+ * whether all floatingpoint outputs are cast to fp16
+ * and propagates cast op to the floatingpoint inputs.
+ * Convert the following graph
+ *
+ *        Input0/NodeArg  Input1/NodeArg
+ *               |             |
+ *             __V______________V___
+ *            |       Opcode        |
+ *            |(operation performed |
+ *            |    in float32)      |
+ *            |_____________________|
+ *               |             |
+ *          _____V____    _____V______
+ *          |Cast FP16|   | Cast FP16|
+ *          |_________|   |__________|
+ *               |              |
+ *               |              |
+ *               V              V
+ *
+ *  and produce the following output
+ *
+ *        Input0/NodeArg   Input1/NodeArg
+ *               |               |
+ *          _____V____      _____V______
+ *          |Cast FP16|     | Cast FP16|
+ *          |_________|     |__________|
+ *                |              |
+ *              __V______________V___
+ *             |       Opcode        |
+ *             |(operation performed |
+ *             |    in float16)      |
+ *             |_____________________|
+ *                 |             |
+ *                 V             V
+ */
 static bool PropagateFP16CastsFromOutputsToInputs(Graph& graph, Node* node,
                                                   NodeIndices& removed_nodes,
                                                   size_t level,
@@ -1130,11 +1130,11 @@ static bool PropagateFP16CastsFromOutputsToInputs(Graph& graph, Node* node,
 }
 
 /*
-*  CreateCast
-*  Create a cast node based on the node_arg for the given data type. If the node_arg is a graph output is_graph_outut is set.
-*  If the node_arg is not a graph output then the node_arg is the input of the new cast node. Otherwise the node_arg is the output
-*  of the new cast node. This function is used by InsertFP16Cast or InsertFP32Casts.
-*/
+ *  CreateCast
+ *  Create a cast node based on the node_arg for the given data type. If the node_arg is a graph output is_graph_outut is set.
+ *  If the node_arg is not a graph output then the node_arg is the input of the new cast node. Otherwise the node_arg is the output
+ *  of the new cast node. This function is used by InsertFP16Cast or InsertFP32Casts.
+ */
 static Node& CreateCast(Graph& graph, NodeArg* node_arg, TensorProto_DataType data_type,
                         NodeIndices& inserted_nodes, bool is_graph_output = false) {
   TypeProto type_proto;
@@ -1159,36 +1159,36 @@ static Node& CreateCast(Graph& graph, NodeArg* node_arg, TensorProto_DataType da
   return node;
 }
 /* InsertFP16Cast
-* Insert a new cast input for the given float input for the give node. This function should be used with InsertFP32Casts
-* in order to compute FP16 allowed operations in 16 bit precision instead of 32 bit precision.
-*
-*        Input0/NodeArg  Input1/NodeArg
-*               |              |
-*             __V______________V___
-*            |       Opcode        |
-*            |(operation performed |
-*            |    in float32)      |
-*            |_____________________|
-*               |             |
-*               V             V
-*
-* Is eventually translated to the following, after all inputs are casted
-*
-*        Input0/NodeArg   Input1/NodeArg
-*               |               |
-*          _____V____      _____V______
-*          |Cast FP16|     | Cast FP16|
-*          |_________|     |__________|
-*                |              |
-*              __V______________V___
-*             |       Opcode        |
-*             |(operation performed |
-*             |    in float16)      |
-*             |_____________________|
-*                 |             |
-*                 V             V
-*
-*/
+ * Insert a new cast input for the given float input for the give node. This function should be used with InsertFP32Casts
+ * in order to compute FP16 allowed operations in 16 bit precision instead of 32 bit precision.
+ *
+ *        Input0/NodeArg  Input1/NodeArg
+ *               |              |
+ *             __V______________V___
+ *            |       Opcode        |
+ *            |(operation performed |
+ *            |    in float32)      |
+ *            |_____________________|
+ *               |             |
+ *               V             V
+ *
+ * Is eventually translated to the following, after all inputs are casted
+ *
+ *        Input0/NodeArg   Input1/NodeArg
+ *               |               |
+ *          _____V____      _____V______
+ *          |Cast FP16|     | Cast FP16|
+ *          |_________|     |__________|
+ *                |              |
+ *              __V______________V___
+ *             |       Opcode        |
+ *             |(operation performed |
+ *             |    in float16)      |
+ *             |_____________________|
+ *                 |             |
+ *                 V             V
+ *
+ */
 static void InsertFP16Cast(Graph& graph, NodeArg* input_arg, Node* node,
                            NodeIndices& inserted_nodes, const logging::Logger& logger) {
   Node& cast = CreateCast(graph, input_arg, TensorProto::FLOAT16, inserted_nodes);
@@ -1211,41 +1211,41 @@ static void InsertFP16Cast(Graph& graph, NodeArg* input_arg, Node* node,
 }
 
 /* InsertFP32Casts
-*  Insert float casts on the given output for each consumer.  This function should be used with InsertFP16Casts
-* in order to compute FP16 allowed operations in 16 bit precision instead of 32 bit precision.
-*
-*               |               |
-*             __V_______________V___
-*            |       Opcode        |
-*            |(operation performed |
-*            |    in float16)      |
-*            |_____________________|
-*               _______|_______
-*               |             |
-*          _____V____    _____V______
-*          |Consumer0|   |Consumer1 |
-*          |_________|   |__________|
-*               |              |
-*
-*  will be translated to the following
-*
-*               |               |
-*             __V_______________V___
-*            |       Opcode        |
-*            |(operation performed |
-*            |    in float16)      |
-*            |_____________________|
-*               _______|_______
-*               |             |
-*          _____V____    _____V______
-*          |Cast FP32|   | Cast FP32|
-*          |_________|   |__________|
-*               |             |
-*          _____V____    _____V______
-*          |Consumer0|   |Consumer1 |
-*          |_________|   |__________|
-*               |              |
-*/
+ *  Insert float casts on the given output for each consumer.  This function should be used with InsertFP16Casts
+ * in order to compute FP16 allowed operations in 16 bit precision instead of 32 bit precision.
+ *
+ *               |               |
+ *             __V_______________V___
+ *            |       Opcode        |
+ *            |(operation performed |
+ *            |    in float16)      |
+ *            |_____________________|
+ *               _______|_______
+ *               |             |
+ *          _____V____    _____V______
+ *          |Consumer0|   |Consumer1 |
+ *          |_________|   |__________|
+ *               |              |
+ *
+ *  will be translated to the following
+ *
+ *               |               |
+ *             __V_______________V___
+ *            |       Opcode        |
+ *            |(operation performed |
+ *            |    in float16)      |
+ *            |_____________________|
+ *               _______|_______
+ *               |             |
+ *          _____V____    _____V______
+ *          |Cast FP32|   | Cast FP32|
+ *          |_________|   |__________|
+ *               |             |
+ *          _____V____    _____V______
+ *          |Consumer0|   |Consumer1 |
+ *          |_________|   |__________|
+ *               |              |
+ */
 static void InsertFP32Casts(Graph& graph, NodeArg* output_arg,
                             NodeIndices& inserted_nodes, const logging::Logger& logger) {
   NodeArg* orig_output_arg = output_arg;
@@ -1291,18 +1291,18 @@ static void InsertFP32Casts(Graph& graph, NodeArg* output_arg,
   graph.UpdateConsumerNodes(output_arg->Name(), new_consumers);
 }
 /*
-*  Expand FP16 compute regions on the graph by example float16 compute nodes,
-*  propagating float32 Cast operation down the graph and propagating float16
-*  Cast operations up the graph. The following functions are performed
-*  1. Fuse subgraphs
-*  2. Propagate fp32 casts forwards
-*  3. Propagate fp16 casts back
-*  4. Insert casts before and after allowed operations (InsertAndReduce strategy)
-*  5. Remove back to back casts
-*  6. Remove redundant casts
-*  7. Move FP32 casts from inputs to outputs
-*  8. Move FP16 casts from outputs to inputs
-*/
+ *  Expand FP16 compute regions on the graph by example float16 compute nodes,
+ *  propagating float32 Cast operation down the graph and propagating float16
+ *  Cast operations up the graph. The following functions are performed
+ *  1. Fuse subgraphs
+ *  2. Propagate fp32 casts forwards
+ *  3. Propagate fp16 casts back
+ *  4. Insert casts before and after allowed operations (InsertAndReduce strategy)
+ *  5. Remove back to back casts
+ *  6. Remove redundant casts
+ *  7. Move FP32 casts from inputs to outputs
+ *  8. Move FP16 casts from outputs to inputs
+ */
 Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   bool local_modified = false;
   NodeIndices inserted_nodes;   // Names of the nodes inserted

--- a/onnxruntime/core/optimizer/propagate_cast_ops.cc
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.cc
@@ -183,7 +183,7 @@ static Status InsertCastNodes(Graph& graph,
                               const NodeIndices& removed_nodes,
                               NodeIndices& inserted_nodes) {
   // Create required new Cast nodes.
-  for (const std::pair<NodeArg*, std::vector<Node*>>& element : require_cast) {
+  for (const NodeArgToConsumerMap::value_type& element : require_cast) {
     NodeArg* node_arg = element.first;
     const std::vector<Node*>& nodes = element.second;
     if (!node_arg->Exists()) {

--- a/onnxruntime/core/optimizer/propagate_cast_ops.cc
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.cc
@@ -180,7 +180,7 @@ static bool IsType(const NodeArg& node_arg, TensorProto_DataType data_type) {
 static Status InsertCastNodes(Graph& graph,
                               const NodeArgToConsumerMap& require_cast,
                               bool is_fp16,
-                              std::deque<NodeIndex>& removed_nodes,
+                              const NodeIndices& removed_nodes,
                               NodeIndices& inserted_nodes) {
   // Create required new Cast nodes.
   for (std::pair<NodeArg*, std::vector<Node*>> element : require_cast) {
@@ -243,7 +243,7 @@ static Status InsertCastNodes(Graph& graph,
     // Update consumers of node_arg to use the output of the cast node
     int cast_output_index = optimizer_utils::IndexOfNodeOutput(cast, cast_output);
     for (Node* consumer : consumers) {
-      if (std::find(removed_nodes.begin(), removed_nodes.end(), consumer->Index()) == removed_nodes.end()) {
+      if (removed_nodes.find(consumer->Index()) == removed_nodes.end()) {
         if (std::find(nodes.begin(), nodes.end(), consumer) == nodes.end()) {
           // Consumers not getting casted need to replace input-def if the producer's output-def is changed
           if (is_node_arg_cast_output) {
@@ -320,7 +320,7 @@ static Status InsertCastNodes(Graph& graph,
 *                              V
 */
 
-static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, std::deque<NodeIndex>& removed_nodes) {
+static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, NodeIndices& removed_nodes) {
   ORT_ENFORCE(casts.size() > 0);
   Node* lead_cast = casts.front();
   Node* trail_cast = casts.back();
@@ -358,7 +358,7 @@ static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, std::
     int cast_output_index = optimizer_utils::IndexOfNodeOutput(*trail_cast, *cast_output);
     for (Node* consumer : consumers) {
       if (nullptr != consumer &&
-          std::find(removed_nodes.begin(), removed_nodes.end(), consumer->Index()) == removed_nodes.end()) {
+          removed_nodes.find(consumer->Index()) == removed_nodes.end()) {
         auto& consumer_inputs = consumer->MutableInputDefs();
         int input_index = optimizer_utils::IndexOfNodeInput(*consumer, *cast_output);
         graph.RemoveEdge(trail_cast->Index(), consumer->Index(), cast_output_index, input_index);
@@ -372,7 +372,7 @@ static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, std::
   }
   for (auto cast : casts) {
     graph_utils::RemoveNodeOutputEdges(graph, *cast);
-    removed_nodes.push_front(cast->Index());
+    removed_nodes.insert(cast->Index());
   }
   return Status::OK();
 }
@@ -434,7 +434,7 @@ static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, std::
 *                              |
 */
 static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
-                                  std::deque<NodeIndex>& removed_nodes,
+                                  NodeIndices& removed_nodes,
                                   const logging::Logger& logger) {
   ORT_ENFORCE(IsCastTo(parent, TensorProto::FLOAT));
   bool modified = false;
@@ -443,7 +443,7 @@ static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
     std::vector<Node*> children = graph.GetMutableConsumerNodes(cast_output->Name());
     if (children.size() == 1) {
       Node* child = children[0];
-      if (std::find(removed_nodes.begin(), removed_nodes.end(), child->Index()) == removed_nodes.end()) {
+      if (removed_nodes.find(child->Index()) == removed_nodes.end()) {
         if (IsCastTo(child, TensorProto::FLOAT16)) {
           // The parent and child cancell out
           LOGS(logger, VERBOSE) << "RemoveBackToBackCasts: Removed Cast nodes  " << parent->Name() << " and " << child->Name();
@@ -463,7 +463,7 @@ static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
       std::vector<Node*> new_consumers;
       size_t children_count = children.size();
       for (Node* child : children) {
-        if (std::find(removed_nodes.begin(), removed_nodes.end(), child->Index()) == removed_nodes.end()) {
+        if (removed_nodes.find(child->Index()) == removed_nodes.end()) {
           if (IsCastTo(child, TensorProto::FLOAT16)) {
             // The parent and child cancell out
             // Remove the child node without effecting the other nodes.
@@ -493,7 +493,7 @@ static bool RemoveBackToBackCasts(Graph& graph, Node* parent,
             }
             modified = true;
             graph.RemoveEdge(parent->Index(), child->Index(), 0, 0);
-            removed_nodes.push_front(child->Index());
+            removed_nodes.insert(child->Index());
             children_count--;
           } else if (IsCastTo(child, TensorProto::FLOAT)) {
             // Child is a duplicate of parent
@@ -531,7 +531,7 @@ static void SearchUpstream(Graph& graph, NodeArg* node_arg, Node* dst_node,
                            NodeArgToConsumerMap& require_cast,
                            NodeArgToConsumerMap& require_cast_fp32,
                            std::unordered_set<NodeArg*>& require_type_change,
-                           std::deque<NodeIndex>& removed_nodes,
+                           const NodeIndices& removed_nodes,
                            size_t level,
                            const FP16AllowOps& fp16_allow_ops) {
   Node* node = graph.GetMutableProducerNode(node_arg->Name());
@@ -550,7 +550,7 @@ static void SearchUpstream(Graph& graph, NodeArg* node_arg, Node* dst_node,
     if (IsType(*node_arg, TensorProto_DataType_FLOAT)) {
       require_cast[node_arg].push_back(dst_node);
     }
-  } else if (std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end()) {
+  } else if (removed_nodes.find(node->Index()) == removed_nodes.end()) {
     if (IsCastTo(node, TensorProto_DataType_FLOAT)) {
       // This Cast node and the Cast node that will be created later will cancel out
       require_cast[node_arg].push_back(dst_node);
@@ -578,7 +578,7 @@ static void SearchUpstream(Graph& graph, NodeArg* node_arg, Node* dst_node,
         if (level >= 2) {
           for (Node* consumer : graph.GetMutableConsumerNodes(node_arg->Name())) {
             if (nullptr != consumer && consumer != dst_node && consumer->OpType() != "Cast" &&
-                std::find(removed_nodes.begin(), removed_nodes.end(), consumer->Index()) == removed_nodes.end()) {
+                removed_nodes.find(consumer->Index()) == removed_nodes.end()) {
               require_cast_fp32[node_arg].push_back(consumer);
             }
           }
@@ -612,7 +612,6 @@ static void SearchDownstream(Graph& graph, NodeArg* node_arg,
                              NodeArgToConsumerMap& require_cast,
                              NodeArgToConsumerMap& require_cast_fp16,
                              std::unordered_set<NodeArg*>& require_type_change,
-                             std::deque<NodeIndex>& removed_nodes,
                              size_t level,
                              const FP16AllowOps& fp16_allow_ops) {
   for (Node* node : graph.GetMutableConsumerNodes(node_arg->Name())) {
@@ -646,7 +645,7 @@ static void SearchDownstream(Graph& graph, NodeArg* node_arg,
             if (IsRelevantOutput(node, node_output) && IsType(*node_output, TensorProto_DataType_FLOAT) &&
                 require_cast.find(node_output) == require_cast.end() &&
                 require_type_change.find(node_output) == require_type_change.end()) {
-              SearchDownstream(graph, node_output, require_cast, require_cast_fp16, require_type_change, removed_nodes, level, fp16_allow_ops);
+              SearchDownstream(graph, node_output, require_cast, require_cast_fp16, require_type_change, level, fp16_allow_ops);
               if (require_cast.find(node_output) == require_cast.end()) {
                 require_type_change.insert(node_output);
               }
@@ -664,7 +663,7 @@ static void SearchDownstream(Graph& graph, NodeArg* node_arg,
 // Change the elem_type of the given NodeArgs from FLOAT to FLOAT16.
 static void ChangeTypeToFP16(Graph& graph, std::unordered_set<NodeArg*>& require_type_change, bool is_forward,
                              NodeIndices& converted_nodes,
-                             NodeIndices& inserted_nodes,
+                             const NodeIndices& inserted_nodes,
                              const logging::Logger& logger) {
   ONNX_NAMESPACE::TypeProto type_proto;
   type_proto.mutable_tensor_type()->set_elem_type(TensorProto::FLOAT16);
@@ -702,7 +701,7 @@ static void ChangeTypeToFP16(Graph& graph, std::unordered_set<NodeArg*>& require
 * The input node is expected to be non-nullptr
 */
 static bool PropagateForwards(Graph& graph, Node* node,
-                              std::deque<NodeIndex>& removed_nodes,
+                              NodeIndices& removed_nodes,
                               size_t level,
                               const FP16AllowOps& fp16_allow_ops,
                               NodeIndices& converted_nodes,
@@ -714,7 +713,7 @@ static bool PropagateForwards(Graph& graph, Node* node,
   NodeArgToConsumerMap require_cast_fp16;
   std::unordered_set<NodeArg*> require_type_change;
   NodeArg* cast_output = node->MutableOutputDefs()[0];
-  SearchDownstream(graph, cast_output, require_cast, require_cast_fp16, require_type_change, removed_nodes, level, fp16_allow_ops);
+  SearchDownstream(graph, cast_output, require_cast, require_cast_fp16, require_type_change, level, fp16_allow_ops);
   if (require_cast.size() > 0 && require_cast.find(cast_output) == require_cast.end()) {
     if (require_cast_fp16.size() > 0) {
       ORT_THROW_IF_ERROR(InsertCastNodes(graph, require_cast_fp16, true, removed_nodes, inserted_nodes));
@@ -745,7 +744,7 @@ static bool PropagateForwards(Graph& graph, Node* node,
 *  The input node is expected be non-nullptr.
 */
 static bool PropagateBackwards(Graph& graph, Node* node,
-                               std::deque<NodeIndex>& removed_nodes,
+                               NodeIndices& removed_nodes,
                                size_t level,
                                const FP16AllowOps& fp16_allow_ops,
                                NodeIndices& converted_nodes,
@@ -805,7 +804,7 @@ static bool PropagateBackwards(Graph& graph, Node* node,
 *               |              |
 */
 static void FuseNodes(Graph& graph, const NodeArg* input, std::vector<Node*> nodes,
-                      std::deque<NodeIndex>& removed_nodes,
+                      NodeIndices& removed_nodes,
                       NodeIndices& inserted_nodes) {
   ORT_ENFORCE(nodes.size() > 0);
   Node* node = nodes[0];
@@ -845,14 +844,14 @@ static void FuseNodes(Graph& graph, const NodeArg* input, std::vector<Node*> nod
   graph.AddConsumerNode(input->Name(), &new_cast);
   graph.UpdateConsumerNodes(new_output.Name(), consumers);
   for (Node* n : nodes) {
-    removed_nodes.push_front(n->Index());
+    removed_nodes.insert(n->Index());
     graph_utils::RemoveNodeOutputEdges(graph, *n);
   }
 }
 
 // Traverse the graph recursively searching/collecting sibling Cast op nodes to fuse and call FuseNodes.
 static bool FuseSiblingCasts(Graph& graph, const NodeArg* node_arg,
-                             std::deque<NodeIndex>& removed_nodes,
+                             NodeIndices& removed_nodes,
                              NodeIndices& inserted_nodes,
                              const logging::Logger& logger) {
   bool modified = false;
@@ -861,7 +860,7 @@ static bool FuseSiblingCasts(Graph& graph, const NodeArg* node_arg,
   for (Node* node : graph.GetMutableConsumerNodes(node_arg->Name())) {
     // If a cast node feeds a graph output then it is not a candidate for fusion.
     if (nullptr == node || node->OpType() != "Cast" ||
-        std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) != removed_nodes.end() ||
+        removed_nodes.find(node->Index()) != removed_nodes.end() ||
         graph.IsOutput(node->OutputDefs()[0])) {
       continue;
     }
@@ -886,7 +885,7 @@ static bool FuseSiblingCasts(Graph& graph, const NodeArg* node_arg,
 
 // Overloaded function which goes through all the output args of a node and calls FuseSiblingCasts
 static bool FuseSiblingCasts(Graph& graph, const Node* parent,
-                             std::deque<NodeIndex>& removed_nodes,
+                             NodeIndices& removed_nodes,
                              NodeIndices& inserted_nodes,
                              const logging::Logger& logger) {
   bool modified = false;
@@ -899,7 +898,7 @@ static bool FuseSiblingCasts(Graph& graph, const Node* parent,
 // RemoveUnnecessaryCasts
 // Remove a cast if the input elem_type is same the required cast type.
 static bool RemoveUnnecessaryCasts(Graph& graph, Node* node,
-                                   std::deque<NodeIndex>& removed_nodes,
+                                   NodeIndices& removed_nodes,
                                    const logging::Logger& logger) {
   bool modified = false;
   if (node->InputDefs().size() == 1) {
@@ -954,7 +953,7 @@ static bool RemoveUnnecessaryCasts(Graph& graph, Node* node,
 *
 */
 static bool PropagateFP32CastsFromInputsToOutputs(Graph& graph, Node* node,
-                                                  std::deque<NodeIndex>& removed_nodes,
+                                                  NodeIndices& removed_nodes,
                                                   size_t level,
                                                   const FP16AllowOps& fp16_allow_ops,
                                                   NodeIndices& converted_nodes,
@@ -978,7 +977,7 @@ static bool PropagateFP32CastsFromInputsToOutputs(Graph& graph, Node* node,
       has_float_inputs = true;
       Node* producer = graph.GetMutableProducerNode(input->Name());
       if (nullptr != producer) {
-        if (std::find(removed_nodes.begin(), removed_nodes.end(), producer->Index()) == removed_nodes.end()) {
+        if (removed_nodes.find(producer->Index()) == removed_nodes.end()) {
           if (IsCastTo(producer, TensorProto::FLOAT) &&
               producer->GetOutputEdgesCount() == 1 &&
               !graph.IsOutput(input)) {
@@ -1062,7 +1061,7 @@ static bool PropagateFP32CastsFromInputsToOutputs(Graph& graph, Node* node,
 *                 V             V
 */
 static bool PropagateFP16CastsFromOutputsToInputs(Graph& graph, Node* node,
-                                                  std::deque<NodeIndex>& removed_nodes,
+                                                  NodeIndices& removed_nodes,
                                                   size_t level,
                                                   const FP16AllowOps& fp16_allow_ops,
                                                   NodeIndices& converted_nodes,
@@ -1086,7 +1085,7 @@ static bool PropagateFP16CastsFromOutputsToInputs(Graph& graph, Node* node,
       for (auto node_iter = consumers.begin(); node_iter != consumers.end() && (level >= 2 || all_float_outputs_have_casts); ++node_iter) {
         Node* consumer = *node_iter;
         if (nullptr != consumer &&
-            std::find(removed_nodes.begin(), removed_nodes.end(), consumer->Index()) == removed_nodes.end()) {
+            removed_nodes.find(consumer->Index()) == removed_nodes.end()) {
           if (IsCastTo(consumer, TensorProto::FLOAT16)) {
             casts.push_back(consumer);
           } else {
@@ -1345,11 +1344,11 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
       }
     }
   }
-  std::unordered_set<std::string> removed_node_names;
+  std::vector<std::string> removed_node_names;
   int pass = 0;
   do {
     LOGS(logger, VERBOSE) << "Propagate Cast Operations Pass " << pass << ":";
-    std::deque<NodeIndex> removed_nodes;
+    NodeIndices removed_nodes;
 
     if (local_modified) {
       ORT_RETURN_IF_ERROR(graph.Resolve());
@@ -1363,7 +1362,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
     for (auto node_index : node_topology_list) {
       Node* node = graph.GetNode(node_index);
       if (nullptr != node &&
-          std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end() &&
+          removed_nodes.find(node->Index()) == removed_nodes.end() &&
           node->OpType() == "Cast") {
         local_modified |= RemoveUnnecessaryCasts(graph, node, removed_nodes, logger);
       }
@@ -1373,7 +1372,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
     for (auto node_index : node_topology_list) {
       Node* node = graph.GetNode(node_index);
       if (nullptr != node &&
-          std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end()) {
+          removed_nodes.find(node->Index()) == removed_nodes.end()) {
         local_modified |= FuseSiblingCasts(graph, node, removed_nodes, inserted_nodes, logger);
       }
     }
@@ -1385,7 +1384,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
     for (auto node_index : node_topology_list) {
       Node* node = graph.GetNode(node_index);
       if (nullptr != node &&
-          std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end() &&
+          removed_nodes.find(node->Index()) == removed_nodes.end() &&
           IsCastTo(node, TensorProto::FLOAT)) {
         local_modified |= RemoveBackToBackCasts(graph, node, removed_nodes, logger);
       }
@@ -1397,7 +1396,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
       for (auto node_index : node_topology_list) {
         Node* node = graph.GetNode(node_index);
         if (nullptr != node &&
-            std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end()) {
+            removed_nodes.find(node->Index()) == removed_nodes.end()) {
           local_modified |= PropagateFP16CastsFromOutputsToInputs(graph, node, removed_nodes, level_, fp16_allow_ops_, converted_nodes, inserted_nodes, logger);
         }
       }
@@ -1406,7 +1405,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
       for (auto node_index : node_topology_list) {
         Node* node = graph.GetNode(node_index);
         if (nullptr != node &&
-            std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end()) {
+            removed_nodes.find(node->Index()) == removed_nodes.end()) {
           local_modified |= PropagateFP32CastsFromInputsToOutputs(graph, node, removed_nodes, level_, fp16_allow_ops_, converted_nodes, inserted_nodes, logger);
         }
       }
@@ -1415,7 +1414,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
       for (auto node_index : node_topology_list) {
         Node* node = graph.GetNode(node_index);
         if (nullptr != node &&
-            std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end() &&
+            removed_nodes.find(node->Index()) == removed_nodes.end() &&
             IsCastTo(node, TensorProto::FLOAT)) {
           local_modified |= PropagateForwards(graph, node, removed_nodes, level_, fp16_allow_ops_, converted_nodes, inserted_nodes, logger);
         }
@@ -1425,7 +1424,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
       for (auto node_index : node_topology_list) {
         Node* node = graph.GetNode(node_index);
         if (nullptr != node &&
-            std::find(removed_nodes.begin(), removed_nodes.end(), node->Index()) == removed_nodes.end() &&
+            removed_nodes.find(node->Index()) == removed_nodes.end() &&
             IsCastTo(node, TensorProto::FLOAT16)) {
           local_modified |= PropagateBackwards(graph, node, removed_nodes, level_, fp16_allow_ops_, converted_nodes, inserted_nodes, logger);
         }
@@ -1436,7 +1435,7 @@ Status PropagateCastOps::ApplyImpl(Graph& graph, bool& modified, int graph_level
     for (NodeIndex removed_node : removed_nodes) {
       auto it = inserted_nodes.find(removed_node);
       if (it == inserted_nodes.end()) {
-        removed_node_names.insert(graph.GetNode(removed_node)->Name());
+        removed_node_names.push_back(graph.GetNode(removed_node)->Name());
       } else {
         inserted_nodes.erase(it);
       }

--- a/onnxruntime/core/optimizer/propagate_cast_ops.cc
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.cc
@@ -183,9 +183,9 @@ static Status InsertCastNodes(Graph& graph,
                               const NodeIndices& removed_nodes,
                               NodeIndices& inserted_nodes) {
   // Create required new Cast nodes.
-  for (std::pair<NodeArg*, std::vector<Node*>> element : require_cast) {
+  for (const std::pair<NodeArg*, std::vector<Node*>>& element : require_cast) {
     NodeArg* node_arg = element.first;
-    std::vector<Node*> nodes = element.second;
+    const std::vector<Node*>& nodes = element.second;
     if (!node_arg->Exists()) {
       continue;
     }
@@ -320,7 +320,7 @@ static Status InsertCastNodes(Graph& graph,
  *                              V
  */
 
-static Status RemoveCastNodesChain(Graph& graph, std::vector<Node*> casts, NodeIndices& removed_nodes) {
+static Status RemoveCastNodesChain(Graph& graph, const std::vector<Node*>& casts, NodeIndices& removed_nodes) {
   ORT_ENFORCE(casts.size() > 0);
   Node* lead_cast = casts.front();
   Node* trail_cast = casts.back();

--- a/onnxruntime/core/optimizer/propagate_cast_ops.h
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.h
@@ -15,6 +15,8 @@ Propagate FP16 Cast operations up the graph and FP32 Cast operations down the gr
 */
 class PropagateCastOps : public GraphTransformer {
  public:
+  typedef std::vector<std::unordered_set<std::string>> FP16AllowOps;
+
   PropagateCastOps(GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy =
                        GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy::FloodFill,
                    size_t level = 0, const std::vector<std::string>& allow_list = {},
@@ -24,7 +26,7 @@ class PropagateCastOps : public GraphTransformer {
 
  private:
   size_t level_;
-  std::vector<std::string> allow_list_;
+  FP16AllowOps fp16_allow_ops_;
   GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy_;
 };
 

--- a/onnxruntime/core/optimizer/propagate_cast_ops.h
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.h
@@ -24,6 +24,7 @@ class PropagateCastOps : public GraphTransformer {
 
  private:
   size_t level_;
+  std::vector<std::string> allow_list_;
   GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy_;
 };
 

--- a/onnxruntime/core/optimizer/propagate_cast_ops.h
+++ b/onnxruntime/core/optimizer/propagate_cast_ops.h
@@ -15,6 +15,12 @@ Propagate FP16 Cast operations up the graph and FP32 Cast operations down the gr
 */
 class PropagateCastOps : public GraphTransformer {
  public:
+  /*
+   * The collection FP16AllowOps, specifies for a given propagate_cast_ops level, a collection of node op_types that
+   * the code is allowed to propage Cast operations across. The user may specify a custom list of optypes using level 0.
+   * The opcodes are split into multiple levels. Cast propagation is done based on the level. Level 2 op code
+   * list includes Level 1 list also.
+   */
   typedef std::vector<std::unordered_set<std::string>> FP16AllowOps;
 
   PropagateCastOps(GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy strategy =


### PR DESCRIPTION
**Description**: Describe your changes.
Remove non-constant file-scope static ("global static") variables.
The scope of this PR is **only** to enable multiple concurrent InferenceSession instances by removing non-constant static variables in the file-scope.
**Motivation and Context**
Make multiple concurrent InferenceSessions possible by encapsulating data in the class members.
- Why is this change required? What problem does it solve?
Enable using multiple inference sessions.
- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/10473