### PR TITLE
Enhance TRT EP unit tests

### DIFF
--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -5,38 +5,6 @@
 #include <unordered_map>
 #include "flatbuffers/idl.h"
 
-/*
-* Seralize engine profile
-* The profile contains min/max shape ranges of dynamic shape dimensions of each input tensor
-* For example, assume tensor_a has two dynamic shape dimensions: dim_0 and dim_2, and tensor_b
-* has one dynamic shape dimension: dim_1. The data in profile will be,
-* key: tensor_a, value: dim_0 min_shape max_shape dim_2 min_shape max_shape
-* key: tensor_b, value: dim_1 min_shape max_shape
-*/
-void SerializeProfile(const std::string& file_name, std::unordered_map<std::string, std::unordered_map<size_t, std::pair<int64_t, int64_t>>>& shape_ranges) {
-  // Serialize profile
-  flexbuffers::Builder builder;
-  auto profile_start = builder.StartMap();
-  for (auto outer_it = shape_ranges.begin(); outer_it != shape_ranges.end(); ++outer_it) {
-    builder.TypedVector(outer_it->first.c_str(), [&] {
-      for (auto inner_it = outer_it->second.begin(); inner_it != outer_it->second.end(); ++inner_it) {
-        builder.Int(inner_it->first);
-        builder.Int(inner_it->second.first);
-        builder.Int(inner_it->second.second);
-      }
-    });
-  }
-  builder.EndMap(profile_start);
-  builder.Finish();
-
-  // Save flexbuffer
-  std::ofstream file(file_name, std::ios::binary | std::ios::out);
-  auto buf = builder.GetBuffer();
-  size_t size = builder.GetSize();
-  file.write(reinterpret_cast<const char*>(&buf[0]), size);
-  file.close();
-}
-
 // Deserialize engine profile
 std::unordered_map<std::string, std::unordered_map<size_t, std::pair<int64_t, int64_t>>> DeserializeProfile(std::ifstream& infile) {
   // Load flexbuffer

--- a/include/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/include/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <fstream>
+#include <unordered_map>
+#include "flatbuffers/idl.h"
+
+/*
+* Seralize engine profile
+* The profile contains min/max shape ranges of dynamic shape dimensions of each input tensor
+* For example, assume tensor_a has two dynamic shape dimensions: dim_0 and dim_2, and tensor_b
+* has one dynamic shape dimension: dim_1. The data in profile will be,
+* key: tensor_a, value: dim_0 min_shape max_shape dim_2 min_shape max_shape
+* key: tensor_b, value: dim_1 min_shape max_shape
+*/
+void SerializeProfile(const std::string& file_name, std::unordered_map<std::string, std::unordered_map<size_t, std::pair<int64_t, int64_t>>>& shape_ranges) {
+  // Serialize profile
+  flexbuffers::Builder builder;
+  auto profile_start = builder.StartMap();
+  for (auto outer_it = shape_ranges.begin(); outer_it != shape_ranges.end(); ++outer_it) {
+    builder.TypedVector(outer_it->first.c_str(), [&] {
+      for (auto inner_it = outer_it->second.begin(); inner_it != outer_it->second.end(); ++inner_it) {
+        builder.Int(inner_it->first);
+        builder.Int(inner_it->second.first);
+        builder.Int(inner_it->second.second);
+      }
+    });
+  }
+  builder.EndMap(profile_start);
+  builder.Finish();
+
+  // Save flexbuffer
+  std::ofstream file(file_name, std::ios::binary | std::ios::out);
+  auto buf = builder.GetBuffer();
+  size_t size = builder.GetSize();
+  file.write(reinterpret_cast<const char*>(&buf[0]), size);
+  file.close();
+}
+
+// Deserialize engine profile
+std::unordered_map<std::string, std::unordered_map<size_t, std::pair<int64_t, int64_t>>> DeserializeProfile(std::ifstream& infile) {
+  // Load flexbuffer
+  infile.seekg(0, std::ios::end);
+  size_t length = infile.tellg();
+  infile.seekg(0, std::ios::beg);
+  std::unique_ptr<char[]> data{new char[length]};
+  infile.read((char*)data.get(), length);
+  infile.close();
+
+  // Deserialize profile
+  std::unordered_map<std::string, std::unordered_map<size_t, std::pair<int64_t, int64_t>>> shape_ranges;
+  auto tensors_range_entries = flexbuffers::GetRoot((const uint8_t*)data.get(), length).AsMap();
+  auto keys = tensors_range_entries.Keys();
+  auto values = tensors_range_entries.Values();
+  for (size_t i = 0, end = keys.size(); i < end; ++i) {
+    auto dim_range_vectors = values[i].AsTypedVector();
+    std::unordered_map<size_t, std::pair<int64_t, int64_t>> inner_map;
+    for (size_t j = 0, end = dim_range_vectors.size() / 3; j < end; ++j) {
+      size_t idx = 3 * j;
+      inner_map[dim_range_vectors[idx].AsInt64()] = std::make_pair(dim_range_vectors[idx + 1].AsInt64(), dim_range_vectors[idx + 2].AsInt64());
+    }
+    shape_ranges[keys[i].AsString().c_str()] = inner_map;
+  }
+  return shape_ranges;
+}

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -7,6 +7,12 @@
 #include "gtest/gtest.h"
 #include "test/util/include/default_providers.h"
 #include "test/util/include/scoped_env_vars.h"
+#include "core/providers/tensorrt/tensorrt_provider_options.h"
+#include "core/providers/tensorrt/tensorrt_execution_provider_utils.h"
+#include <string>
+#include <iostream>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 using namespace std;
 using namespace ONNX_NAMESPACE;
@@ -15,6 +21,8 @@ using namespace ::onnxruntime::logging;
 namespace onnxruntime {
 
 namespace test {
+class TensorrtExecutionProviderCacheTest: public testing::TestWithParam<std::string> {};
+
 template <typename T>
 void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64_t>& expected_dims,
                    const std::vector<T>& expected_values) {
@@ -26,11 +34,54 @@ void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64
   ASSERT_EQ(expected_values, found);
 }
 
-TEST(TensorrtExecutionProviderTest, EngineCachingTest) {
-  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
-      {"ORT_TENSORRT_ENGINE_CACHE_ENABLE", {"1"}},
-  }};
-  onnxruntime::Model model("enginecachingtest", false, DefaultLoggingManager().DefaultLogger());
+bool IsTensorRTCacheExisted(std::string path, std::string file_extension) {
+  for (const auto & entry : fs::directory_iterator(path)) {
+      if (fs::path(file_extension) == fs::path(entry).extension()) {
+          return true;
+      }
+  }
+  return false;
+}
+
+void RemoveTensorRTCache(std::string path, std::string file_extension) {
+  for (const auto & entry : fs::directory_iterator(path)) {
+      if (fs::path(file_extension) == fs::path(entry).extension()) {
+          fs::remove(entry);
+      }
+  }
+}
+
+std::vector<fs::path> GetTensorRTCache(std::string path, std::string file_extension) {
+  std::vector<fs::path> cache_files;
+  for (const auto & entry : fs::directory_iterator(path)) {
+      if (fs::path(file_extension) == fs::path(entry).extension()) {
+        cache_files.push_back(fs::path(entry));
+      }
+  }
+  return cache_files;
+}
+
+/**
+ * Create a simple model with dynamic or non-dynamic input shape.
+ * \param model_name - model name
+ * \param graph_name - graph name
+ * \params dims - specify dimensions 
+ *
+ * input: "X", "Y" and "Z"
+ *        you can specify input dimension, for example (1, 3, 2), (1, 2) or (1, -1, -1)). Note: -1 means the dimension is dynamic
+ * output: "M"
+ *
+ *      "X"  "Y"
+ *        \  /
+ *    "Z"  Add
+ *      \  / 
+ *       Add
+ *       / 
+ *     "M"
+ *
+ */
+void CreateBaseModel(std::string model_name, std::string graph_name, std::vector<int> dims) {
+  onnxruntime::Model model(graph_name, false, DefaultLoggingManager().DefaultLogger());
   auto& graph = model.MainGraph();
   std::vector<onnxruntime::NodeArg*> inputs;
   std::vector<onnxruntime::NodeArg*> outputs;
@@ -38,9 +89,10 @@ TEST(TensorrtExecutionProviderTest, EngineCachingTest) {
   // FLOAT tensor
   ONNX_NAMESPACE::TypeProto float_tensor;
   float_tensor.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-  float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
-  float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_param("sym1");
-  float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_param("sym2");
+
+  for (auto dim: dims) {
+    float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(dim);
+  }
 
   auto& input_arg_1 = graph.GetOrCreateNodeArg("X", &float_tensor);
   auto& input_arg_2 = graph.GetOrCreateNodeArg("Y", &float_tensor);
@@ -61,11 +113,31 @@ TEST(TensorrtExecutionProviderTest, EngineCachingTest) {
 
   auto status = graph.Resolve();
   ASSERT_TRUE(status.IsOK());
-  std::string model_file_name = "trt_execution_provider_enginecaching_test.onnx";
-  status = onnxruntime::Model::Save(model, model_file_name);
+  status = onnxruntime::Model::Save(model, model_name);
+}
+
+TEST_P(TensorrtExecutionProviderCacheTest, Run) {
+  // GetParam() returns the parameter of following format:
+  // ##cache type##_##input shape type##
+  std::string param = GetParam();
+  size_t pos = param.find("_");
+  std::string input_type = param.substr(pos + 1);
+  ASSERT_NE(pos, std::string::npos);
+  std::string cache_type = ToUTF8String(param.substr(0, pos));
+
+  std::string model_name = "trt_execution_provider_" + cache_type + "caching_test_" + input_type + ".onnx";
+  std::vector<int> dims;
+  if (input_type.compare("dynamic") == 0) {
+    dims = {1, -1, -1}; //dynamic shape input
+  }
+  else {
+    dims = {1, 3, 2};
+  }
+
+  CreateBaseModel(model_name, cache_type + "cachingtest", dims);
 
   SessionOptions so;
-  so.session_logid = "TensorrtExecutionProviderTest.EngineCachingTest";
+  so.session_logid = "TensorrtExecutionProvider" + cache_type + "cacheTest";
   RunOptions run_options;
   run_options.run_tag = so.session_logid;
   InferenceSession session_object{so, GetEnvironment()};
@@ -73,12 +145,6 @@ TEST(TensorrtExecutionProviderTest, EngineCachingTest) {
   auto cuda_provider = DefaultCudaExecutionProvider();
   cuda_provider->RegisterAllocator(allocator_manager);
   auto cpu_allocator = cuda_provider->GetAllocator(0, OrtMemTypeCPU);
-  // First run with input shape {1, 3, 2}
-  // TRT engine and profile will be created and cached
-  // Data in profile,
-  // X: 1, 3, 3, 2, 2, 2
-  // Y: 1, 3, 3, 2, 2, 2
-  // Z: 1, 3, 3, 2, 2, 2
   std::vector<int64_t> dims_mul_x = {1, 3, 2};
   std::vector<float> values_mul_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
   OrtValue ml_value_x;
@@ -101,44 +167,158 @@ TEST(TensorrtExecutionProviderTest, EngineCachingTest) {
   std::vector<int64_t> expected_dims_mul_m = {1, 3, 2};
   std::vector<float> expected_values_mul_m = {3.0f, 6.0f, 9.0f, 12.0f, 15.0f, 18.0f};
 
-  std::unique_ptr<IExecutionProvider> execution_provider = DefaultTensorrtExecutionProvider();
-  EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
-  status = session_object.Load(model_file_name);
-  ASSERT_TRUE(status.IsOK());
-  status = session_object.Initialize();
-  ASSERT_TRUE(status.IsOK());
+  OrtTensorRTProviderOptionsV2 params{
+      0,
+      0,
+      nullptr,
+      1000,
+      1,
+      1 << 30,
+      0,
+      0,
+      nullptr,
+      0,
+      0,
+      0,
+      0,
+      0,
+      nullptr,
+      0,
+      nullptr,
+      0};
 
-  // Now run
-  status = session_object.Run(run_options, feeds, output_names, &fetches);
-  ASSERT_TRUE(status.IsOK());
-  VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+  if (cache_type.compare("engine") == 0) {
 
-  // Second run with input shape {1, 1, 6}
-  // TRT engine and profile will be updated
-  // Data in profile,
-  // X: 1, 1, 3, 2, 2, 6
-  // Y: 1, 1, 3, 2, 2, 6
-  // Z: 1, 1, 3, 2, 2, 6
-  dims_mul_x = {1, 1, 6};
-  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_x);
-  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_y);
-  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_z);
-  feeds.clear();
-  feeds.insert(std::make_pair("X", ml_value_x));
-  feeds.insert(std::make_pair("Y", ml_value_y));
-  feeds.insert(std::make_pair("Z", ml_value_z));
+    /* Following code block will test the functionality of engine and optimization profile of ORT TRT, including:
+     * - engine cache serialization/de-serialization
+     * - profile cache serialization/de-serialization
+     * - engine/profile cache should be updated when the input shape changes
+     * - min/max shape ranges of dynamic shape dimensions saved in profile cache
+     * - read corrupted profile cache #TODO
+     *
+     */
 
-  // prepare outputs
-  fetches.clear();
+    params.trt_engine_cache_enable = 1;
+    std::unique_ptr<IExecutionProvider> execution_provider = TensorrtExecutionProviderWithOptions(&params);
+    EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
+    auto status = session_object.Load(model_name);
+    ASSERT_TRUE(status.IsOK());
+    status = session_object.Initialize();
+    ASSERT_TRUE(status.IsOK());
 
-  // prepare expected inputs and outputs
-  expected_dims_mul_m = {1, 1, 6};
+    // run inference
+    // TRT engine will be created and cached
+    // TRT profile will be created and cached only for dynamic input shape
+    // Data in profile,
+    // X: 1, 3, 3, 2, 2, 2
+    // Y: 1, 3, 3, 2, 2, 2
+    // Z: 1, 3, 3, 2, 2, 2
+    status = session_object.Run(run_options, feeds, output_names, &fetches);
+    ASSERT_TRUE(status.IsOK());
+    VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+    ASSERT_TRUE(IsTensorRTCacheExisted("./", ".engine"));
 
-  // Now run
-  status = session_object.Run(run_options, feeds, output_names, &fetches);
-  ASSERT_TRUE(status.IsOK());
-  VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+    std::vector<fs::path> profile_files;
+
+    // profile cache only being generated for dynamic input shape
+    if (input_type.compare("dynamic") == 0) {
+      ASSERT_TRUE(IsTensorRTCacheExisted("./", ".profile"));
+
+      profile_files = GetTensorRTCache("./", ".profile");
+      ASSERT_EQ(profile_files.size(), 1);
+      std::ifstream profile_file(profile_files[0], std::ios::binary | std::ios::in);
+      auto shape_ranges = DeserializeProfile(profile_file);
+
+      // check min/max shape ranges of dynamic shape dimensions
+      for(auto it = shape_ranges.cbegin(); it != shape_ranges.cend(); ++it) {
+        auto ranges = it->second;  
+        for (auto it2 = ranges.cbegin(); it2 != ranges.cend(); ++it2) {
+          if (it2->first == 1) {
+            ASSERT_EQ(it2->second.first, 3);
+            ASSERT_EQ(it2->second.second, 3);
+          } else if (it2->first == 2) {
+            ASSERT_EQ(it2->second.first, 2);
+            ASSERT_EQ(it2->second.second, 2);
+          }
+        }
+      }
+    }
+    else {
+      ASSERT_TRUE(!IsTensorRTCacheExisted("./", ".profile"));
+    }
+
+    // inference run with input shape {1, 1, 6}
+    // TRT engine and profile will be updated
+    // Data in profile,
+    // X: 1, 1, 3, 2, 2, 6
+    // Y: 1, 1, 3, 2, 2, 6
+    // Z: 1, 1, 3, 2, 2, 6
+    dims_mul_x = {1, 1, 6};
+    CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_x);
+    CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_y);
+    CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_z);
+    feeds.clear();
+    feeds.insert(std::make_pair("X", ml_value_x));
+    feeds.insert(std::make_pair("Y", ml_value_y));
+    feeds.insert(std::make_pair("Z", ml_value_z));
+
+    // prepare outputs
+    fetches.clear();
+
+    // prepare expected inputs and outputs
+    expected_dims_mul_m = {1, 1, 6};
+
+    status = session_object.Run(run_options, feeds, output_names, &fetches);
+
+    if (input_type.compare("dynamic") == 0) {
+      ASSERT_TRUE(status.IsOK());
+      VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+
+      profile_files = GetTensorRTCache("./", ".profile");
+      ASSERT_EQ(profile_files.size(), 1);
+      std::ifstream profile_file2(profile_files[0], std::ios::binary | std::ios::in);
+      auto shape_ranges2 = DeserializeProfile(profile_file2);
+
+      // check min/max shape ranges of dynamic shape dimensions
+      for(auto it = shape_ranges2.cbegin(); it != shape_ranges2.cend(); ++it) {
+        auto ranges = it->second;  
+        for (auto it2 = ranges.cbegin(); it2 != ranges.cend(); ++it2) {
+          if (it2->first == 1) {
+            ASSERT_EQ(it2->second.first, 1);
+            ASSERT_EQ(it2->second.second, 3);
+          } else if (it2->first == 2) {
+            ASSERT_EQ(it2->second.first, 2);
+            ASSERT_EQ(it2->second.second, 6);
+          }
+        }
+      }
+    } else {
+      // Can't run inference since input shape changes and the engine is static 
+      ASSERT_FALSE(status.IsOK());
+    }
+  } else if (cache_type.compare("timing") == 0) {
+     // add test code here
+  }
+
+  // clean up caches
+  RemoveTensorRTCache("./", ".engine");
+  RemoveTensorRTCache("./", ".profile");
 }
+
+/*
+ * The TensorrtExecutionProviderCacheTest aims to test the functionality of all the engine/profile/timing caches of ORT TRT.
+ * It uses value-parameterized test and the parameter in the test is a composite parameter which has following format:
+ * ##cache type##_##input shape type##
+ * - cache type       (could be engine cache or timing cache. Note: profile cache will be tested along with engine cache)
+ * - input shape type (could be dynamic input shape or static input shape)
+ *
+ * We have following test parameters:
+ * - engine_static: engine cache enabled with non-dynamic input shape
+ * - engine_dynamic: engine cache enabled with dynamic input shape
+ */
+INSTANTIATE_TEST_SUITE_P(TensorrtExecutionProviderCacheTests, TensorrtExecutionProviderCacheTest, testing::Values("engine_static",
+                                                                                                                  "engine_dynamic"),
+                                                                                                  [](const ::testing::TestParamInfo<TensorrtExecutionProviderCacheTest::ParamType>& info) {return info.param;});
 
 TEST(TensorrtExecutionProviderTest, FunctionTest) {
   onnxruntime::Model model("functiontest", false, DefaultLoggingManager().DefaultLogger());


### PR DESCRIPTION
Refactor current TRT EP cache unit test as well as adding more test cases on engine/profile/timing caches. Make the tests solid and cover more cases, so that later we refactor TRT EP, we can rely on these tests to see whether the functionality is correct.
