### PR TITLE
Fixing optimizer failure due to missing provider list

### DIFF
--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -93,7 +93,9 @@ def optimize_by_onnxruntime(onnx_model_path: str,
                                                providers=['CPUExecutionProvider'],
                                                **kwargs)
     else:
-        session = onnxruntime.InferenceSession(onnx_model_path, sess_options, **kwargs)
+        session = onnxruntime.InferenceSession(onnx_model_path, sess_options,
+                                               providers=['CUDAExecutionProvider'],
+                                               **kwargs)
         assert 'CUDAExecutionProvider' in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)


### PR DESCRIPTION
Signed-off-by: Boris Fomitchev <bfomitchev@nvidia.com>

Added provider argument (which is now required), to onnxruntime.InferenceSession call, to prevent optimizer.py from failing with CUDA.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
