### PR TITLE
Fix Windows GPU CI

### DIFF
--- a/onnxruntime/core/providers/cuda/cudnn_common.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_common.cc
@@ -136,10 +136,12 @@ cudnnDataType_t CudnnTensor::GetDataType<half>() {
   return CUDNN_DATA_HALF;
 }
 
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 template <>
 cudnnDataType_t CudnnTensor::GetDataType<BFloat16>() {
   return CUDNN_DATA_BFLOAT16;
 }
+#endif
 
 template <>
 cudnnDataType_t CudnnTensor::GetDataType<int8_t>() {

--- a/onnxruntime/core/providers/cuda/cudnn_common.cc
+++ b/onnxruntime/core/providers/cuda/cudnn_common.cc
@@ -136,12 +136,17 @@ cudnnDataType_t CudnnTensor::GetDataType<half>() {
   return CUDNN_DATA_HALF;
 }
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 template <>
+
 cudnnDataType_t CudnnTensor::GetDataType<BFloat16>() {
+#if CUDNN_VERSION >= 8100
   return CUDNN_DATA_BFLOAT16;
-}
+#else
+  ORT_THROW("cuDNN version is too low to support BFloat16.");
+  // Not reachable but GCC complains
+  return CUDNN_DATA_FLOAT;
 #endif
+}
 
 template <>
 cudnnDataType_t CudnnTensor::GetDataType<int8_t>() {


### PR DESCRIPTION
**Description**: as titled

**Motivation and Context**
fix the build error introduced by BFloat16 support:

https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=578959&view=logs&j=0b152f07-0ecb-5c9e-6061-137550693cb9&t=9724ba1b-dec2-5907-f7db-76dd75eb9346

onnxruntime\core\providers\cuda\cudnn_common.cc(141,10): error C2065: 'CUDNN_DATA_BFLOAT16': undeclared identifier 
