### PR TITLE
Move floatToHalf from onnxruntime_util.lib to onnxruntime_framework.lib

### DIFF
--- a/include/onnxruntime/core/framework/float16.h
+++ b/include/onnxruntime/core/framework/float16.h
@@ -16,7 +16,16 @@ namespace onnxruntime {
 #else
 #define ORT_HOST_DEVICE
 #endif
+namespace math {
+// Converts a float32 to a float16 value.
+uint16_t floatToHalf(float f);
 
+// Converts a double (float64) to a float16 value.
+uint16_t doubleToHalf(double f);
+
+// Converts a float16 to a float32 value.
+float halfToFloat(uint16_t h);
+}
 // MLFloat16
 struct MLFloat16 {
   uint16_t val;

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -4,6 +4,16 @@
 #include "core/framework/data_types.h"
 
 #include "boost/mp11.hpp"
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-result"
+#endif
+#include "Eigen/Core"
+#include "Eigen/src/Core/arch/Default/Half.h"
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "core/framework/data_types_internal.h"
 #include "core/framework/element_type_lists.h"
@@ -26,7 +36,19 @@
 using namespace ONNX_NAMESPACE;
 
 namespace onnxruntime {
+namespace math {
+uint16_t floatToHalf(float f) {
+  return Eigen::half_impl::float_to_half_rtne(f).x;
+}
 
+uint16_t doubleToHalf(double f) {
+  return Eigen::half_impl::float_to_half_rtne(static_cast<float>(f)).x;
+}
+
+float halfToFloat(uint16_t h) {
+  return Eigen::half_impl::half_to_float(Eigen::half_impl::raw_uint16_to_half(h));
+}
+}  // namespace math
 MLFloat16::MLFloat16(float f) : val{math::floatToHalf(f)} {}
 
 float MLFloat16::ToFloat() const {

--- a/onnxruntime/core/util/math.h
+++ b/onnxruntime/core/util/math.h
@@ -353,14 +353,5 @@ constexpr T roundUp(T a, T b) {
   return divUp<T>(a, b) * b;
 }
 
-// Converts a float32 to a float16 value.
-uint16_t floatToHalf(float f);
-
-// Converts a double (float64) to a float16 value.
-uint16_t doubleToHalf(double f);
-
-// Converts a float16 to a float32 value.
-float halfToFloat(uint16_t h);
-
 }  // namespace math
 }  // namespace onnxruntime

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -808,18 +808,6 @@ void Col2imNd<float, CPUMathUtil, StorageOrder::NCHW>(const float* data_col, con
 SPECIALIZED_COPYVECTOR(float)
 #undef SPECIALIZED_COPYVECTOR
 
-uint16_t floatToHalf(float f) {
-  return Eigen::half_impl::float_to_half_rtne(f).x;
-}
-
-uint16_t doubleToHalf(double f) {
-  return Eigen::half_impl::float_to_half_rtne(static_cast<float>(f)).x;
-}
-
-float halfToFloat(uint16_t h) {
-  return Eigen::half_impl::half_to_float(Eigen::half_impl::raw_uint16_to_half(h));
-}
-
 // AddToRow and AddToCol adds the corresponding row/col vector b to the matrix a
 // of shape M x N. The actual implementation uses eigen which is column major,
 // so notice the row/column swap in the actual implementation.


### PR DESCRIPTION
**Description**: 

Move floatToHalf from onnxruntime_util.lib to onnxruntime_framework.lib, to break the circular dependency between the two libs.

BTW, I'm surprised GCC didn't post an error on this.  See https://github.com/microsoft/onnxruntime/blob/master/docs/cmake_guideline.md#static-library-order-matters about why it shouldn't work.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
