### PR TITLE
Add Experimental API for setting model name

### DIFF
--- a/winml/adapter/winml_adapter_apis.h
+++ b/winml/adapter/winml_adapter_apis.h
@@ -24,6 +24,7 @@ ORT_API_STATUS(CreateModelFromData, _In_ void* data, _In_ size_t size, _Outptr_ 
 ORT_API_STATUS(CloneModel, _In_ const OrtModel* in, _Outptr_ OrtModel** out);
 ORT_API_STATUS(ModelGetAuthor, _In_ const OrtModel* model, _Out_ const char** const author, _Out_ size_t* len);
 ORT_API_STATUS(ModelGetName, _In_ const OrtModel* model, _Out_ const char** const name, _Out_ size_t* len);
+ORT_API_STATUS(ModelSetName, _In_ const OrtModel* model, _In_ const char* name);
 ORT_API_STATUS(ModelGetDomain, _In_ const OrtModel* model, _Out_ const char** const domain, _Out_ size_t* len);
 ORT_API_STATUS(ModelGetDescription, _In_ const OrtModel* model, _Out_ const char** const description, _Out_ size_t* len);
 ORT_API_STATUS(ModelGetVersion, _In_ const OrtModel* model, _Out_ int64_t* version);

--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -26,6 +26,7 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
     &winmla::CloneModel,
     &winmla::ModelGetAuthor,
     &winmla::ModelGetName,
+    &winmla::ModelSetName,
     &winmla::ModelGetDomain,
     &winmla::ModelGetDescription,
     &winmla::ModelGetVersion,

--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -103,6 +103,13 @@ struct WinmlAdapterApi {
   OrtStatus*(ORT_API_CALL* ModelGetName)(_In_ const OrtModel* model, _Out_ const char** const name, _Out_ size_t* len)NO_EXCEPTION;
 
   /**
+    * ModelSetName
+	* This api set the model name from the OrtModel.
+	* This is used by the Windows ML Samples Gallery to change the model name for telemetry.
+    */
+  OrtStatus*(ORT_API_CALL* ModelSetName)(_In_ const OrtModel* model, _In_ const char* name)NO_EXCEPTION;
+
+  /**
     * ModelGetDomain
 	 * This api gets the model domain from the OrtModel.
 	 * This is used by WinML to support model reflection APIs.

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -292,9 +292,6 @@ ORT_API_STATUS_IMPL(winmla::ModelGetName, _In_ const OrtModel* model, _Out_ cons
 
 ORT_API_STATUS_IMPL(winmla::ModelSetName, _In_ const OrtModel* model, _In_ const char* const name) {
   API_IMPL_BEGIN
-  //*name = model->UseModelInfo()->name_.c_str();
-  //*len = model->UseModelInfo()->name_.size();
-  //return nullptr;
   auto model_proto = model->UseModelProto();
   ONNX_NAMESPACE::GraphProto& graph = *model_proto->mutable_graph();
   graph.set_name(name);

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -290,6 +290,17 @@ ORT_API_STATUS_IMPL(winmla::ModelGetName, _In_ const OrtModel* model, _Out_ cons
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(winmla::ModelSetName, _In_ const OrtModel* model, _In_ const char* const name) {
+  API_IMPL_BEGIN
+  //*name = model->UseModelInfo()->name_.c_str();
+  //*len = model->UseModelInfo()->name_.size();
+  //return nullptr;
+  auto model_proto = model->UseModelProto();
+  ONNX_NAMESPACE::GraphProto& graph = *model_proto->mutable_graph();
+  graph.set_name(name);
+  API_IMPL_END
+}
+
 ORT_API_STATUS_IMPL(winmla::ModelGetDomain, _In_ const OrtModel* model, _Out_ const char** const domain, _Out_ size_t* len) {
   API_IMPL_BEGIN
   *domain = model->UseModelInfo()->domain_.c_str();

--- a/winml/adapter/winml_adapter_model.cpp
+++ b/winml/adapter/winml_adapter_model.cpp
@@ -298,6 +298,7 @@ ORT_API_STATUS_IMPL(winmla::ModelSetName, _In_ const OrtModel* model, _In_ const
   auto model_proto = model->UseModelProto();
   ONNX_NAMESPACE::GraphProto& graph = *model_proto->mutable_graph();
   graph.set_name(name);
+  return nullptr;
   API_IMPL_END
 }
 

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -142,7 +142,7 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
     //! The JoinModel fuses two models by linking  outputs from the first model, to inupts of the second. 
     ROOT_NS.AI.MachineLearning.LearningModel JoinModel(ROOT_NS.AI.MachineLearning.LearningModel other, LearningModelJoinOptions options);
 
-    //! The EditModelName function changes the model name to the specified string
+    //! The SetName function changes the model name to the specified string
     void SetName(String model_name);
   }
 

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -141,6 +141,9 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
 
     //! The JoinModel fuses two models by linking  outputs from the first model, to inupts of the second. 
     ROOT_NS.AI.MachineLearning.LearningModel JoinModel(ROOT_NS.AI.MachineLearning.LearningModel other, LearningModelJoinOptions options);
+
+    //! The EditModelName function changes the model name to the specified string
+    void EditModelName(String model_name);
   }
 
 }  // namespace Microsoft.AI.MachineLearning.Experimental

--- a/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
+++ b/winml/api/Microsoft.AI.MachineLearning.Experimental.idl
@@ -143,7 +143,7 @@ namespace ROOT_NS.AI.MachineLearning.Experimental {
     ROOT_NS.AI.MachineLearning.LearningModel JoinModel(ROOT_NS.AI.MachineLearning.LearningModel other, LearningModelJoinOptions options);
 
     //! The EditModelName function changes the model name to the specified string
-    void EditModelName(String model_name);
+    void SetName(String model_name);
   }
 
 }  // namespace Microsoft.AI.MachineLearning.Experimental

--- a/winml/lib/Api.Experimental/LearningModelExperimental.cpp
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.cpp
@@ -29,9 +29,9 @@ void LearningModelExperimental::Save(hstring const& file_name) {
     modelp->SaveToFile(file_name);
 }
 
-void LearningModelExperimental::EditModelName(hstring const& model_name) {
+void LearningModelExperimental::SetName(hstring const& model_name) {
   auto modelp = model_.as<winmlp::LearningModel>();
-  modelp->EditModelName(model_name);
+  modelp->SetName(model_name);
 }
 
 }

--- a/winml/lib/Api.Experimental/LearningModelExperimental.cpp
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.cpp
@@ -29,4 +29,9 @@ void LearningModelExperimental::Save(hstring const& file_name) {
     modelp->SaveToFile(file_name);
 }
 
+void LearningModelExperimental::EditModelName(hstring const& model_name) {
+  auto modelp = model_.as<winmlp::LearningModel>();
+  modelp->EditModelName(model_name);
+}
+
 }

--- a/winml/lib/Api.Experimental/LearningModelExperimental.h
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.h
@@ -12,7 +12,7 @@ struct LearningModelExperimental : LearningModelExperimentalT<LearningModelExper
 
     void Save(hstring const& file_name);
 
-    void EditModelName(hstring const& model_name);
+    void SetName(hstring const& model_name);
 
 private:
     Microsoft::AI::MachineLearning::LearningModel model_;

--- a/winml/lib/Api.Experimental/LearningModelExperimental.h
+++ b/winml/lib/Api.Experimental/LearningModelExperimental.h
@@ -12,6 +12,8 @@ struct LearningModelExperimental : LearningModelExperimentalT<LearningModelExper
 
     void Save(hstring const& file_name);
 
+    void EditModelName(hstring const& model_name);
+
 private:
     Microsoft::AI::MachineLearning::LearningModel model_;
 };

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -130,8 +130,8 @@ STDMETHODIMP ModelInfo::GetName(const char** out, size_t* len) {
   return S_OK;
 }
 
-STDMETHODIMP ModelInfo::SetName(std::string name) {
-  name_ = name;
+STDMETHODIMP ModelInfo::SetName(const char* name) {
+  name_ = std::string(name);
   return S_OK;
 }
 

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -130,7 +130,7 @@ STDMETHODIMP ModelInfo::GetName(const char** out, size_t* len) {
   return S_OK;
 }
 
-STDMETHODIMP ModelInfo::EditModelName(std::string name) {
+STDMETHODIMP ModelInfo::SetName(std::string name) {
   name_ = name;
   return S_OK;
 }

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -130,6 +130,11 @@ STDMETHODIMP ModelInfo::GetName(const char** out, size_t* len) {
   return S_OK;
 }
 
+STDMETHODIMP ModelInfo::EditModelName(std::string name) {
+  name_ = name;
+  return S_OK;
+}
+
 STDMETHODIMP ModelInfo::GetDomain(const char** out, size_t* len) {
   *out = domain_.c_str();
   *len = domain_.size();

--- a/winml/lib/Api.Ort/OnnxruntimeModel.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.cpp
@@ -247,6 +247,14 @@ STDMETHODIMP OnnruntimeModel::SaveModel(_In_ const wchar_t* const file_name, _In
   return S_OK;
 }
 
+STDMETHODIMP OnnruntimeModel::SetName(const char* name) {
+  auto winml_adapter_api = engine_factory_->UseWinmlAdapterApi();
+  RETURN_HR_IF_NOT_OK_MSG(winml_adapter_api->ModelSetName(ort_model_.get(), name),
+                          engine_factory_->UseOrtApi());
+  info_->SetName(name);
+  return S_OK;
+}
+
 STDMETHODIMP OnnruntimeModel::DetachOrtModel(OrtModel** model) {
   *model = ort_model_.release();
   return S_OK;

--- a/winml/lib/Api.Ort/OnnxruntimeModel.h
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.h
@@ -26,7 +26,7 @@ class ModelInfo : public Microsoft::WRL::RuntimeClass<
   (const char** out, size_t* len);
   STDMETHOD(GetName)
   (const char** out, size_t* len);
-  STDMETHOD(EditModelName)
+  STDMETHOD(SetName)
   (std::string name);
   STDMETHOD(GetDomain)
   (const char** out, size_t* len);

--- a/winml/lib/Api.Ort/OnnxruntimeModel.h
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.h
@@ -27,7 +27,7 @@ class ModelInfo : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(GetName)
   (const char** out, size_t* len);
   STDMETHOD(SetName)
-  (std::string name);
+  (const char* name);
   STDMETHOD(GetDomain)
   (const char** out, size_t* len);
   STDMETHOD(GetDescription)

--- a/winml/lib/Api.Ort/OnnxruntimeModel.h
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.h
@@ -70,6 +70,8 @@ class OnnruntimeModel : public Microsoft::WRL::RuntimeClass<
   STDMETHOD(SaveModel)
   (_In_ const wchar_t* const file_name,
    _In_ unsigned size);
+  STDMETHOD(SetName)
+  (const char* name);
   STDMETHOD(DetachOrtModel)
   (OrtModel** model);
 

--- a/winml/lib/Api.Ort/OnnxruntimeModel.h
+++ b/winml/lib/Api.Ort/OnnxruntimeModel.h
@@ -26,6 +26,8 @@ class ModelInfo : public Microsoft::WRL::RuntimeClass<
   (const char** out, size_t* len);
   STDMETHOD(GetName)
   (const char** out, size_t* len);
+  STDMETHOD(EditModelName)
+  (std::string name);
   STDMETHOD(GetDomain)
   (const char** out, size_t* len);
   STDMETHOD(GetDescription)

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -279,9 +279,9 @@ LearningModel::OutputFeatures() try {
 }
 WINML_CATCH_ALL
 
-void LearningModel::EditModelName(const hstring& name) try {
+void LearningModel::SetName(const hstring& name) try {
   auto name_str = _winml::Strings::UTF8FromHString(name);
-  WINML_THROW_IF_FAILED(model_info_->EditModelName(name_str));
+  WINML_THROW_IF_FAILED(model_info_->SetName(name_str));
 }
 WINML_CATCH_ALL
 

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -280,8 +280,9 @@ LearningModel::OutputFeatures() try {
 WINML_CATCH_ALL
 
 void LearningModel::SetName(const hstring& name) try {
-  auto name_str = _winml::Strings::UTF8FromHString(name);
-  WINML_THROW_IF_FAILED(model_info_->SetName(name_str));
+  auto name_std_str = _winml::Strings::UTF8FromHString(name);
+  auto name_c_str = name_std_str.c_str();
+  WINML_THROW_IF_FAILED(model_->SetName(name_c_str));
 }
 WINML_CATCH_ALL
 

--- a/winml/lib/Api/LearningModel.cpp
+++ b/winml/lib/Api/LearningModel.cpp
@@ -279,6 +279,12 @@ LearningModel::OutputFeatures() try {
 }
 WINML_CATCH_ALL
 
+void LearningModel::EditModelName(const hstring& name) try {
+  auto name_str = _winml::Strings::UTF8FromHString(name);
+  WINML_THROW_IF_FAILED(model_info_->EditModelName(name_str));
+}
+WINML_CATCH_ALL
+
 void LearningModel::Close() try {
   // close the model
   model_ = nullptr;

--- a/winml/lib/Api/LearningModel.h
+++ b/winml/lib/Api/LearningModel.h
@@ -59,6 +59,8 @@ struct LearningModel : LearningModelT<LearningModel> {
   wfc::IVectorView<winml::ILearningModelFeatureDescriptor>
   OutputFeatures();
 
+  void EditModelName(const hstring& name);
+
   /* IClosable methods. */
   void Close();
 

--- a/winml/lib/Api/LearningModel.h
+++ b/winml/lib/Api/LearningModel.h
@@ -59,7 +59,7 @@ struct LearningModel : LearningModelT<LearningModel> {
   wfc::IVectorView<winml::ILearningModelFeatureDescriptor>
   OutputFeatures();
 
-  void EditModelName(const hstring& name);
+  void SetName(const hstring& name);
 
   /* IClosable methods. */
   void Close();

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -66,6 +66,9 @@ IModelInfo : IUnknown {
   STDMETHOD(GetName)
   (const char** out, size_t* len) PURE;
 
+  STDMETHOD(EditModelName)
+  (std::string name) PURE;
+
   STDMETHOD(GetDomain)
   (const char** out, size_t* len) PURE;
 

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -103,6 +103,9 @@ IModel : IUnknown {
   (_In_ const wchar_t* const file_name,
    _In_ unsigned size) PURE;
 
+  STDMETHOD(SetName)
+  (const char* name) PURE;
+
   STDMETHOD(AddOperator)
   (_In_ const char* const op_type, _In_ const char* const op_name, _In_ const char* const op_domain,
    _In_ const char* const* op_input_names, _In_ const char* const* actual_input_names, size_t num_inputs,

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -66,7 +66,7 @@ IModelInfo : IUnknown {
   STDMETHOD(GetName)
   (const char** out, size_t* len) PURE;
 
-  STDMETHOD(EditModelName)
+  STDMETHOD(SetName)
   (std::string name) PURE;
 
   STDMETHOD(GetDomain)

--- a/winml/lib/Common/inc/iengine.h
+++ b/winml/lib/Common/inc/iengine.h
@@ -67,7 +67,7 @@ IModelInfo : IUnknown {
   (const char** out, size_t* len) PURE;
 
   STDMETHOD(SetName)
-  (std::string name) PURE;
+  (const char* name) PURE;
 
   STDMETHOD(GetDomain)
   (const char** out, size_t* len) PURE;

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1090,7 +1090,6 @@ static void SetIntraOpThreadSpinning() {
  }
 
  static void SetName() {
-#ifndef BUILD_INBOX
    // load the model with name 'squeezenet_old'
    LearningModel model = nullptr;
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", model));
@@ -1106,12 +1105,12 @@ static void SetIntraOpThreadSpinning() {
    WINML_EXPECT_EQUAL(model_name, new_name);
 
    // ensure the model protobuf was actually modified
-   experimental_model.Save(L"Debug/model_name_changed.onnx");
+   std::wstring path = FileHelpers::GetModulePath() + L"model_name_changed.onnx";
+   experimental_model.Save(path);
    LearningModel model_name_changed = nullptr;
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model_name_changed.onnx", model_name_changed));
    model_name = model_name_changed.Name();
    WINML_EXPECT_EQUAL(model_name, new_name);
-#endif
  }
 
 

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1089,6 +1089,20 @@ static void SetIntraOpThreadSpinning() {
     WINML_EXPECT_TRUE(allowSpinning);
  }
 
+ static void EditModelName() {
+   LearningModel model = nullptr;
+   WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", model));
+   auto model_name = model.Name();
+   auto squeezenet_old = to_hstring("squeezenet_old");
+   WINML_EXPECT_EQUAL(model_name, squeezenet_old);
+
+   auto experimental_model = winml_experimental::LearningModelExperimental(model);
+   auto new_name = to_hstring("new name");
+   experimental_model.EditModelName(new_name);
+   model_name = model.Name();
+   WINML_EXPECT_EQUAL(model_name, new_name);
+ }
+
 
 const LearningModelSessionAPITestsApi& getapi() {
   static LearningModelSessionAPITestsApi api =
@@ -1123,6 +1137,7 @@ const LearningModelSessionAPITestsApi& getapi() {
     ModelBuilding_STFT,
     ModelBuilding_MelSpectrogramOnThreeToneSignal,
     ModelBuilding_MelWeightMatrix,
+    EditModelName
   };
 
   if (SkipGpuTests()) {

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1090,6 +1090,7 @@ static void SetIntraOpThreadSpinning() {
  }
 
  static void SetName() {
+#ifndef BUILD_INBOX
    // load the model with name 'squeezenet_old'
    LearningModel model = nullptr;
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", model));
@@ -1110,6 +1111,7 @@ static void SetIntraOpThreadSpinning() {
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model_name_changed.onnx", model_name_changed));
    model_name = model_name_changed.Name();
    WINML_EXPECT_EQUAL(model_name, new_name);
+#endif
  }
 
 

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1090,16 +1090,25 @@ static void SetIntraOpThreadSpinning() {
  }
 
  static void SetName() {
+   // load the model with name 'squeezenet_old'
    LearningModel model = nullptr;
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", model));
    auto model_name = model.Name();
    auto squeezenet_old = to_hstring("squeezenet_old");
    WINML_EXPECT_EQUAL(model_name, squeezenet_old);
 
+   // ensure the model name can be changed to 'new name'
    auto experimental_model = winml_experimental::LearningModelExperimental(model);
    auto new_name = to_hstring("new name");
    experimental_model.SetName(new_name);
    model_name = model.Name();
+   WINML_EXPECT_EQUAL(model_name, new_name);
+
+   // ensure the model protobuf was actually modified
+   experimental_model.Save(L"Debug/model_name_changed.onnx");
+   LearningModel model_name_changed = nullptr;
+   WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model_name_changed.onnx", model_name_changed));
+   model_name = model_name_changed.Name();
    WINML_EXPECT_EQUAL(model_name, new_name);
  }
 

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -1089,7 +1089,7 @@ static void SetIntraOpThreadSpinning() {
     WINML_EXPECT_TRUE(allowSpinning);
  }
 
- static void EditModelName() {
+ static void SetName() {
    LearningModel model = nullptr;
    WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", model));
    auto model_name = model.Name();
@@ -1098,7 +1098,7 @@ static void SetIntraOpThreadSpinning() {
 
    auto experimental_model = winml_experimental::LearningModelExperimental(model);
    auto new_name = to_hstring("new name");
-   experimental_model.EditModelName(new_name);
+   experimental_model.SetName(new_name);
    model_name = model.Name();
    WINML_EXPECT_EQUAL(model_name, new_name);
  }
@@ -1137,7 +1137,7 @@ const LearningModelSessionAPITestsApi& getapi() {
     ModelBuilding_STFT,
     ModelBuilding_MelSpectrogramOnThreeToneSignal,
     ModelBuilding_MelWeightMatrix,
-    EditModelName
+    SetName
   };
 
   if (SkipGpuTests()) {

--- a/winml/test/api/LearningModelSessionAPITest.h
+++ b/winml/test/api/LearningModelSessionAPITest.h
@@ -34,6 +34,7 @@ struct LearningModelSessionAPITestsApi {
   VoidTest ModelBuilding_STFT;
   VoidTest ModelBuilding_MelSpectrogramOnThreeToneSignal;
   VoidTest ModelBuilding_MelWeightMatrix;
+  VoidTest EditModelName;
 };
 const LearningModelSessionAPITestsApi& getapi();
 
@@ -69,4 +70,5 @@ WINML_TEST(LearningModelSessionAPITests, ModelBuilding_BlackmanWindow)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_STFT)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_MelSpectrogramOnThreeToneSignal)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_MelWeightMatrix)
+WINML_TEST(LearningModelSessionAPITests, EditModelName)
 WINML_TEST_CLASS_END()

--- a/winml/test/api/LearningModelSessionAPITest.h
+++ b/winml/test/api/LearningModelSessionAPITest.h
@@ -34,7 +34,7 @@ struct LearningModelSessionAPITestsApi {
   VoidTest ModelBuilding_STFT;
   VoidTest ModelBuilding_MelSpectrogramOnThreeToneSignal;
   VoidTest ModelBuilding_MelWeightMatrix;
-  VoidTest EditModelName;
+  VoidTest SetName;
 };
 const LearningModelSessionAPITestsApi& getapi();
 
@@ -70,5 +70,5 @@ WINML_TEST(LearningModelSessionAPITests, ModelBuilding_BlackmanWindow)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_STFT)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_MelSpectrogramOnThreeToneSignal)
 WINML_TEST(LearningModelSessionAPITests, ModelBuilding_MelWeightMatrix)
-WINML_TEST(LearningModelSessionAPITests, EditModelName)
+WINML_TEST(LearningModelSessionAPITests, SetName)
 WINML_TEST_CLASS_END()


### PR DESCRIPTION
This change adds the SetName function to the LearningModelExperimental API
- Setting the model name will allow easier tracking of which models are in use through telemetry
- A test for the function is added to the LearningModelSessionAPTest