### PR TITLE
Fix C# pipeline build error

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
             else
             {
-                throw new OnnxRuntimeException(ErrorCode.InvalidArgument, "Unable to get information for type: " + elemType.ToString());
+                throw new ArgumentException("Unable to get information for type: " + elemType.ToString());
             }
         }
 


### PR DESCRIPTION
**Description**: 
Can't use internal types in the external E2E test project. Throw standard C# exception instead.
Issue was introduced in https://github.com/microsoft/onnxruntime/pull/10428

Pipeline errors:
```
D:\a\_work\1\s\csharp\test\Microsoft.ML.OnnxRuntime.Tests.Common\TestDataLoader.cs(59,48): error CS0122: 'ErrorCode' is inaccessible due to its protection level [D:\a\_work\1\s\csharp\test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj]
D:\a\_work\1\s\csharp\test\Microsoft.ML.OnnxRuntime.Tests.Common\TestDataLoader.cs(59,27): error CS1729: 'OnnxRuntimeException' does not contain a constructor that takes 2 arguments [D:\a\_work\1\s\csharp\test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj]
```

**Motivation and Context**
Fix pipeline build error.