### PR TITLE
Return a Status instead of throw an exception in GetAttrs

### DIFF
--- a/onnxruntime/core/framework/op_node_proto_helper.cc
+++ b/onnxruntime/core/framework/op_node_proto_helper.cc
@@ -90,34 +90,38 @@ inline constexpr int ArrayTypeToAttributeType<std::string>() {
     }                                                                                              \
   }
 
-#define ORT_DEFINE_GET_ATTRS(IMPL_T, T, list)                                      \
-  template <>                                                                      \
-  template <>                                                                      \
-  Status OpNodeProtoHelper<IMPL_T>::GetAttrs<T>(                                   \
-      const std::string& name, std::vector<T>& values) const {                     \
-    const AttributeProto* attr = TryGetAttribute(name);                            \
-    if (!attr) {                                                                   \
-      return Status(ONNXRUNTIME, FAIL, "No attribute with this name is defined."); \
-    }                                                                              \
-    values.reserve(attr->list##_size());                                           \
-    for (int i = 0; i < attr->list##_size(); ++i) {                                \
-      values.push_back(static_cast<T>(attr->list(i)));                             \
-    }                                                                              \
-    return Status::OK();                                                           \
-  }                                                                                \
-  template <>                                                                      \
-  template <>                                                                      \
-  Status OpNodeProtoHelper<IMPL_T>::GetAttrs<T>(                                   \
-      const std::string& name, gsl::span<T> values) const {                        \
-    const AttributeProto* attr = TryGetAttribute(name);                            \
-    if (!attr) {                                                                   \
-      return Status(ONNXRUNTIME, FAIL, "No attribute with this name is defined."); \
-    }                                                                              \
-    ORT_ENFORCE(values.size() == static_cast<size_t>(attr->list##_size()));        \
-    for (int i = 0; i < attr->list##_size(); ++i) {                                \
-      values[i] = static_cast<T>(attr->list(i));                                   \
-    }                                                                              \
-    return Status::OK();                                                           \
+#define ORT_DEFINE_GET_ATTRS(IMPL_T, T, list)                                                                \
+  template <>                                                                                                \
+  template <>                                                                                                \
+  Status OpNodeProtoHelper<IMPL_T>::GetAttrs<T>(                                                             \
+      const std::string& name, std::vector<T>& values) const {                                               \
+    const AttributeProto* attr = TryGetAttribute(name);                                                      \
+    if (!attr) {                                                                                             \
+      return Status(ONNXRUNTIME, FAIL, "No attribute with this name is defined.");                           \
+    }                                                                                                        \
+    values.reserve(attr->list##_size());                                                                     \
+    for (int i = 0; i < attr->list##_size(); ++i) {                                                          \
+      values.push_back(static_cast<T>(attr->list(i)));                                                       \
+    }                                                                                                        \
+    return Status::OK();                                                                                     \
+  }                                                                                                          \
+  template <>                                                                                                \
+  template <>                                                                                                \
+  Status OpNodeProtoHelper<IMPL_T>::GetAttrs<T>(                                                             \
+      const std::string& name, gsl::span<T> values) const {                                                  \
+    const AttributeProto* attr = TryGetAttribute(name);                                                      \
+    if (!attr) {                                                                                             \
+      return Status(ONNXRUNTIME, FAIL, "No attribute with this name is defined.");                           \
+    }                                                                                                        \
+    if (values.size() != static_cast<size_t>(attr->list##_size())) {                                         \
+      std::ostringstream oss;                                                                                \
+      oss << "GetAttrs failed. Expect values.size()=" << (attr->list##_size()) << ", got " << values.size(); \
+      return Status(ONNXRUNTIME, FAIL, oss.str());                                                           \
+    }                                                                                                        \
+    for (int i = 0; i < attr->list##_size(); ++i) {                                                          \
+      values[i] = static_cast<T>(attr->list(i));                                                             \
+    }                                                                                                        \
+    return Status::OK();                                                                                     \
   }
 
 // Will not work for std::strings

--- a/onnxruntime/core/framework/op_node_proto_helper.cc
+++ b/onnxruntime/core/framework/op_node_proto_helper.cc
@@ -113,11 +113,8 @@ inline constexpr int ArrayTypeToAttributeType<std::string>() {
     if (!attr) {                                                                                             \
       return Status(ONNXRUNTIME, FAIL, "No attribute with this name is defined.");                           \
     }                                                                                                        \
-    if (values.size() != static_cast<size_t>(attr->list##_size())) {                                         \
-      std::ostringstream oss;                                                                                \
-      oss << "GetAttrs failed. Expect values.size()=" << (attr->list##_size()) << ", got " << values.size(); \
-      return Status(ONNXRUNTIME, FAIL, oss.str());                                                           \
-    }                                                                                                        \
+    ORT_RETURN_IF(values.size() != static_cast<size_t>(attr->list##_size()),                                 \
+       "GetAttrs failed. Expect values.size()=" , (attr->list##_size()) , ", got " , values.size());         \
     for (int i = 0; i < attr->list##_size(); ++i) {                                                          \
       values[i] = static_cast<T>(attr->list(i));                                                             \
     }                                                                                                        \


### PR DESCRIPTION
**Description**:

The return type of GetAttrs is Status, so it is better to return a Status instead of throwing an exception when errors happen. 

It's very tricky that if you want to read a tensor shape from attrs, you can either use a std::vector or TensorShapeVector to store the data. However, if you use TensorShapeVector you must pre-compute the number of dimension before calling GetAttrs and resize the vector to the right size. std::vector doesn't have the restriction. 

**Motivation and Context**
- Why is this change required? What problem does it solve?

Make error message more readable. 

- If it fixes an open issue, please link to the issue here.
