### PR TITLE
Fix an error when compiling with ACL: conversion from gsl::span<const long int> to non-scalar type std::vector<long int>

### DIFF
--- a/onnxruntime/core/providers/acl/tensor/concat.cc
+++ b/onnxruntime/core/providers/acl/tensor/concat.cc
@@ -32,7 +32,7 @@ Status Concat<T>::Compute(OpKernelContext* ctx) const {
     input_tensors.push_back(ctx->Input<Tensor>(i));
   }
 
-  std::vector<int64_t> output_dims = input_tensors[0]->Shape().GetDimsAsVector();
+  std::vector<int64_t> output_dims = input_tensors[0]->Shape().AsShapeVector();
 
   // 'Concat' mode
   if (!is_stack_) {

--- a/onnxruntime/core/providers/acl/tensor/concat.cc
+++ b/onnxruntime/core/providers/acl/tensor/concat.cc
@@ -32,7 +32,7 @@ Status Concat<T>::Compute(OpKernelContext* ctx) const {
     input_tensors.push_back(ctx->Input<Tensor>(i));
   }
 
-  std::vector<int64_t> output_dims = input_tensors[0]->Shape().GetDims();
+  std::vector<int64_t> output_dims = input_tensors[0]->Shape()..GetDimsAsVector();
 
   // 'Concat' mode
   if (!is_stack_) {

--- a/onnxruntime/core/providers/acl/tensor/concat.cc
+++ b/onnxruntime/core/providers/acl/tensor/concat.cc
@@ -32,7 +32,7 @@ Status Concat<T>::Compute(OpKernelContext* ctx) const {
     input_tensors.push_back(ctx->Input<Tensor>(i));
   }
 
-  std::vector<int64_t> output_dims = input_tensors[0]->Shape()..GetDimsAsVector();
+  std::vector<int64_t> output_dims = input_tensors[0]->Shape().GetDimsAsVector();
 
   // 'Concat' mode
   if (!is_stack_) {


### PR DESCRIPTION
**Description**: Same as https://github.com/microsoft/onnxruntime/issues/9893. Credit to the author of the issue.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  - It fixes the error when compiling with ACL: `conversion from gsl::span<const long int> to non-scalar type std::vector<long int>`
- If it fixes an open issue, please link to the issue here.
  - https://github.com/microsoft/onnxruntime/issues/9893