### PR TITLE
Add C/C++ API interface to ORTInvoker.

### DIFF
--- a/cmake/onnxruntime_session.cmake
+++ b/cmake/onnxruntime_session.cmake
@@ -5,6 +5,8 @@ file(GLOB onnxruntime_session_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_INCLUDE_DIR}/core/session/*.h"
     "${ONNXRUNTIME_ROOT}/core/session/*.h"
     "${ONNXRUNTIME_ROOT}/core/session/*.cc"
+    "${ONNXRUNTIME_INCLUDE_DIR}/core/eager/ort_kernel_invoker.h"
+    "${ONNXRUNTIME_ROOT}/core/eager/ort_kernel_invoker.cc"
     )
 
 if (onnxruntime_MINIMAL_BUILD)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -364,6 +364,7 @@ set (onnxruntime_shared_lib_test_SRC
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_session_options.cc
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_run_options.cc
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_allocator.cc
+          ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_invoker.cc
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_nontensor_types.cc
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_model_loading.cc
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_ort_format_models.cc

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -257,6 +257,8 @@ ORT_RUNTIME_CLASS(ArenaCfg);
 ORT_RUNTIME_CLASS(PrepackedWeightsContainer);
 ORT_RUNTIME_CLASS(TensorRTProviderOptionsV2);
 ORT_RUNTIME_CLASS(CUDAProviderOptionsV2);
+ORT_RUNTIME_CLASS(Invoker);
+ORT_RUNTIME_CLASS(NodeAttributes);
 
 #ifdef _WIN32
 typedef _Return_type_success_(return == 0) OrtStatus* OrtStatusPtr;
@@ -3303,6 +3305,31 @@ struct OrtApi {
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_MIGraphX,
                   _In_ OrtSessionOptions* options, _In_ const OrtMIGraphXProviderOptions* migraphx_options);
+  ORT_API2_STATUS(CreateInvoker,
+                  _In_ const OrtEnv* env,
+                  _In_ const OrtSessionOptions* options,
+                  size_t provider_index,
+                  _Outptr_ OrtInvoker** invoker);
+  ORT_API2_STATUS(Invoker_Invoke,
+                  _Inout_ OrtInvoker* invoker,
+                  const char* op_name,
+                  _In_reads_(input_len) const OrtValue* const* inputs,
+                  size_t inputs_len,
+                  _Inout_updates_all_(output_names_len) OrtValue** outputs,
+                  size_t outputs_len,
+                  const OrtNodeAttributes* attributes,
+                  const char* domain,
+                  int version);
+  ORT_API2_STATUS(CreateNodeAttributes, _Outptr_ OrtNodeAttributes** attributes);
+  ORT_API2_STATUS(NodeAttributes_Set_float, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, float value);
+  ORT_API2_STATUS(NodeAttributes_Set_int64, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, int64_t value);
+  ORT_API2_STATUS(NodeAttributes_Set_string, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_ const char* value);
+  ORT_API2_STATUS(NodeAttributes_Set_tensor, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _Inout_ void* p_data, size_t p_data_len, _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type);
+  ORT_API2_STATUS(NodeAttributes_SetArray_float, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) float const* values, size_t values_len);
+  ORT_API2_STATUS(NodeAttributes_SetArray_int64, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) int64_t const* values, size_t values_len);
+  ORT_API2_STATUS(NodeAttributes_SetArray_string, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) const char* const* values, size_t values_len);
+  ORT_CLASS_RELEASE(Invoker);
+  ORT_CLASS_RELEASE(NodeAttributes);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -112,6 +112,8 @@ ORT_DEFINE_RELEASE(ModelMetadata);
 ORT_DEFINE_RELEASE(ThreadingOptions);
 ORT_DEFINE_RELEASE(IoBinding);
 ORT_DEFINE_RELEASE(ArenaCfg);
+ORT_DEFINE_RELEASE(Invoker);
+ORT_DEFINE_RELEASE(NodeAttributes);
 
 #undef ORT_DEFINE_RELEASE
 
@@ -931,6 +933,29 @@ struct ArenaCfg : Base<OrtArenaCfg> {
   * See docs/C_API.md for details on what the following parameters mean and how to choose these values
   */
   ArenaCfg(size_t max_mem, int arena_extend_strategy, int initial_chunk_size_bytes, int max_dead_bytes_per_chunk);
+};
+
+struct NodeAttributes : public Base<OrtNodeAttributes> {
+  explicit NodeAttributes(std::nullptr_t);
+  void Set_float(const char* name, float value);
+  void Set_int64(const char* name, int64_t value);
+  void Set_string(const char* name, const char* value);
+  void Set_tensor(const char* name, void* p_data, size_t p_data_len, const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type);
+  void SetArray_float(const char* name, float const* values, size_t values_len);
+  void SetArray_int64(const char* name, int64_t const* values, size_t values_len);
+  void SetArray_string(const char* name, const char* const* values, size_t values_len);
+};
+
+struct Invoker : public Base<OrtInvoker> {
+  Invoker(const Env& env, const SessionOptions& options, size_t provider_index);
+  void Invoke(const char* op_name,
+              const Value* inputs,
+              size_t inputs_len,
+              Value* outputs,
+              size_t outputs_len,
+              const NodeAttributes& attributes,
+              const char* domain,
+              int version);
 };
 
 //

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1020,6 +1020,48 @@ inline TensorTypeAndShapeInfo Value::GetTensorTypeAndShapeInfo() const {
   return TensorTypeAndShapeInfo{output};
 }
 
+inline NodeAttributes::NodeAttributes(std::nullptr_t) {
+  ThrowOnError(GetApi().CreateNodeAttributes(&p_));
+}
+
+inline void NodeAttributes::Set_float(const char* name, float value) {
+  ThrowOnError(GetApi().NodeAttributes_Set_float(p_, name, value));
+}
+inline void NodeAttributes::Set_int64(const char* name, int64_t value) {
+  ThrowOnError(GetApi().NodeAttributes_Set_int64(p_, name, value));
+}
+inline void NodeAttributes::Set_string(const char* name, const char* value) {
+  ThrowOnError(GetApi().NodeAttributes_Set_string(p_, name, value));
+}
+inline void NodeAttributes::Set_tensor(const char* name, void* p_data, size_t p_data_len, const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type) {
+  ThrowOnError(GetApi().NodeAttributes_Set_tensor(p_, name, p_data, p_data_len, shape, shape_len, type));
+}
+inline void NodeAttributes::SetArray_float(const char* name, float const* values, size_t values_len) {
+  ThrowOnError(GetApi().NodeAttributes_SetArray_float(p_, name, values, values_len));
+}
+inline void NodeAttributes::SetArray_int64(const char* name, int64_t const* values, size_t values_len) {
+  ThrowOnError(GetApi().NodeAttributes_SetArray_int64(p_, name, values, values_len));
+}
+inline void NodeAttributes::SetArray_string(const char* name, const char* const* values, size_t values_len) {
+  ThrowOnError(GetApi().NodeAttributes_SetArray_string(p_, name, values, values_len));
+}
+
+inline Invoker::Invoker(const Env& env, const SessionOptions& options, size_t provider_index) {
+  ThrowOnError(GetApi().CreateInvoker(env, options, provider_index, &p_));
+}
+inline void Invoker::Invoke(const char* op_name,
+                            const Value* inputs,
+                            size_t inputs_len,
+                            Value* outputs,
+                            size_t outputs_len,
+                            const NodeAttributes& attributes,
+                            const char* domain,
+                            int version) {
+  auto ort_input_values = reinterpret_cast<const OrtValue**>(const_cast<Value*>(inputs));
+  auto ort_output_values = reinterpret_cast<OrtValue**>(outputs);
+  ThrowOnError(GetApi().Invoker_Invoke(p_, op_name, ort_input_values, inputs_len, ort_output_values, outputs_len, attributes, domain, version));
+}
+
 //
 // Custom OP API Inlines
 //

--- a/onnxruntime/core/session/invoker_abi_impl.cc
+++ b/onnxruntime/core/session/invoker_abi_impl.cc
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include <string>
+#include <iostream>
+
+#include "core/framework/error_code_helper.h"
+#include "core/framework/ort_value.h"
+#include "core/framework/execution_provider.h"
+#include "core/session/onnxruntime_c_api.h"
+#include "core/session/ort_apis.h"
+#include "core/eager/ort_kernel_invoker.h"
+#include "abi_session_options_impl.h"
+#include "core/session/ort_env.h"
+#include "core/graph/basic_types.h"
+
+namespace onnxruntime {
+struct OrtInvokerImpl {
+  IOnnxRuntimeOpSchemaRegistryList custom_schemas;
+  std::unique_ptr<onnxruntime::ORTInvoker> invoker;
+};
+}  // namespace onnxruntime
+
+ORT_API_STATUS_IMPL(OrtApis::CreateInvoker,
+                    _In_ const OrtEnv* env_,
+                    _In_ const OrtSessionOptions* options,
+                    size_t provider_index,
+                    _Outptr_ OrtInvoker** invoker_) {
+  API_IMPL_BEGIN
+  // Create the logger
+  const onnxruntime::logging::Logger& logger = env_->GetLoggingManager()->DefaultLogger();
+
+  // Create the provider
+  ORT_ENFORCE(provider_index < options->provider_factories.size(), "provider_index (" + std::to_string(provider_index) + ") must be less than the provider list size (" + std::to_string(options->provider_factories.size()) + ").");
+  std::shared_ptr<onnxruntime::IExecutionProvider> provider = options->provider_factories.at(provider_index)->CreateProvider();
+
+  // Create the invoker
+  onnxruntime::OrtInvokerImpl* invoker = new onnxruntime::OrtInvokerImpl;
+  invoker->invoker = std::make_unique<onnxruntime::ORTInvoker>(provider, logger, invoker->custom_schemas);
+  *invoker_ = reinterpret_cast<OrtInvoker*>(invoker);
+
+  return onnxruntime::ToOrtStatus(onnxruntime::common::Status::OK());
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::Invoker_Invoke,
+                    _Inout_ OrtInvoker* invoker_,
+                    const char* op_name_,
+                    _In_reads_(input_len) const OrtValue* const* inputs_,
+                    size_t inputs_len,
+                    _Inout_updates_all_(output_names_len) OrtValue** outputs_,
+                    size_t outputs_len,
+                    const OrtNodeAttributes* attributes_,
+                    const char* domain_,
+                    int version) {
+  API_IMPL_BEGIN
+  auto invoker = reinterpret_cast<onnxruntime::OrtInvokerImpl*>(invoker_);
+
+  std::vector<OrtValue> inputs;
+  for (size_t i = 0; i < inputs_len; i++) {
+    inputs.push_back(*inputs_[i]);
+  }
+  std::vector<OrtValue> outputs;
+  for (size_t i = 0; i < outputs_len; i++) {
+    outputs.push_back(*outputs_[i]);
+  }
+  const std::string op_name{op_name_};
+  const std::string domain{domain_};
+
+  const onnxruntime::NodeAttributes* attributes;
+  if (attributes_) {
+    attributes = reinterpret_cast<const onnxruntime::NodeAttributes*>(attributes_);
+  } else {
+    attributes = new onnxruntime::NodeAttributes;
+  }
+  auto status = invoker->invoker->Invoke(op_name, inputs, outputs, attributes, domain, version);
+  return onnxruntime::ToOrtStatus(status);
+
+  API_IMPL_END
+}
+
+ORT_API(void, OrtApis::ReleaseInvoker, _Frees_ptr_opt_ OrtInvoker* value) {
+  delete reinterpret_cast<onnxruntime::OrtInvokerImpl*>(value);
+}
+
+ORT_API(void, OrtApis::ReleaseNodeAttributes, _Frees_ptr_opt_ OrtNodeAttributes* value) {
+  delete reinterpret_cast<onnxruntime::NodeAttributes*>(value);
+}
+
+ORT_API_STATUS_IMPL(NodeAttributes_SetInt64, _Inout_ OrtNodeAttributes* attributes, int value);
+ORT_API_STATUS_IMPL(NodeAttributes_SetString, _Inout_ OrtNodeAttributes* attributes, const char* value);
+ORT_API_STATUS_IMPL(NodeAttributes_SetFloats, _Inout_ OrtNodeAttributes* attributes, const float* values, size_t values_len);
+ORT_API_STATUS_IMPL(NodeAttributes_SetInts, _Inout_ OrtNodeAttributes* attributes, const int* values, size_t values_len);
+ORT_API_STATUS_IMPL(NodeAttributes_SetStrings, _Inout_ OrtNodeAttributes* attributes, const char* const* values, size_t values_len);

--- a/onnxruntime/core/session/node_attributes_abi_impl.cc
+++ b/onnxruntime/core/session/node_attributes_abi_impl.cc
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "core/common/status.h"
+#include "core/framework/error_code_helper.h"
+#include "core/session/ort_apis.h"
+#include "core/graph/basic_types.h"
+#include "core/framework/data_types.h"
+
+ORT_API_STATUS_IMPL(OrtApis::CreateNodeAttributes, _Outptr_ OrtNodeAttributes** attributes_) {
+  onnxruntime::NodeAttributes* attributes = new onnxruntime::NodeAttributes;
+  *attributes_ = reinterpret_cast<OrtNodeAttributes*>(attributes);
+  return onnxruntime::ToOrtStatus(onnxruntime::Status::OK());
+}
+
+#define ATTR_SETTER_IMPL(ctype, apiName, enumType, field)                                                  \
+  ORT_API_STATUS_IMPL(OrtApis::NodeAttributes_Set_##apiName,                                               \
+                      _Inout_ OrtNodeAttributes* attributes_,                                              \
+                      _In_ const char* name,                                                               \
+                      ctype value) {                                                                       \
+    API_IMPL_BEGIN                                                                                         \
+    ORT_ENFORCE(attributes_, "attributes must be non-null.");                                              \
+    onnxruntime::NodeAttributes* attributes = reinterpret_cast<onnxruntime::NodeAttributes*>(attributes_); \
+    ONNX_NAMESPACE::AttributeProto attribute_proto;                                                        \
+    attribute_proto.set_name(name);                                                                        \
+    attribute_proto.set_type(enumType);                                                                    \
+    attribute_proto.set_##field(value);                                                                    \
+    attributes->insert(std::make_pair(name, attribute_proto));                                             \
+    return onnxruntime::ToOrtStatus(onnxruntime::Status::OK());                                            \
+    API_IMPL_END                                                                                           \
+  }
+
+#define ARRAY_ATTR_SETTER_IMPL(ctype, apiName, enumType, field)                                            \
+  ORT_API_STATUS_IMPL(OrtApis::NodeAttributes_SetArray_##apiName,                                          \
+                      _Inout_ OrtNodeAttributes* attributes_,                                              \
+                      _In_ const char* name,                                                               \
+                      _In_ ctype const* values,                                                            \
+                      size_t num_values) {                                                                 \
+    API_IMPL_BEGIN                                                                                         \
+    ORT_ENFORCE(attributes_, "attributes must be non-null.");                                              \
+    onnxruntime::NodeAttributes* attributes = reinterpret_cast<onnxruntime::NodeAttributes*>(attributes_); \
+    ONNX_NAMESPACE::AttributeProto attribute_proto;                                                        \
+    attribute_proto.set_name(name);                                                                        \
+    attribute_proto.set_type(enumType);                                                                    \
+    for (size_t i = 0; i < num_values; i++) {                                                              \
+      attribute_proto.add_##field(values[i]);                                                              \
+    }                                                                                                      \
+    attributes->insert(std::make_pair(name, attribute_proto));                                             \
+    return onnxruntime::ToOrtStatus(onnxruntime::Status::OK());                                            \
+    API_IMPL_END                                                                                           \
+  }
+
+ATTR_SETTER_IMPL(const char*, string, ONNX_NAMESPACE::AttributeProto::STRING, s)
+ATTR_SETTER_IMPL(float, float, ONNX_NAMESPACE::AttributeProto::FLOAT, f)
+ATTR_SETTER_IMPL(int64_t, int64, ONNX_NAMESPACE::AttributeProto::INT, i)
+ARRAY_ATTR_SETTER_IMPL(float, float, ONNX_NAMESPACE::AttributeProto::FLOATS, floats)
+ARRAY_ATTR_SETTER_IMPL(int64_t, int64, ONNX_NAMESPACE::AttributeProto::INTS, ints)
+ARRAY_ATTR_SETTER_IMPL(const char*, string, ONNX_NAMESPACE::AttributeProto::STRINGS, strings)
+
+ORT_API_STATUS_IMPL(OrtApis::NodeAttributes_Set_tensor,
+                    _Inout_ OrtNodeAttributes* attributes_,
+                    _In_ const char* name,
+                    _Inout_ void* p_data,
+                    size_t p_data_len,
+                    _In_ const int64_t* shape,
+                    size_t shape_len,
+                    ONNXTensorElementDataType type) {
+  API_IMPL_BEGIN
+  ORT_ENFORCE(attributes_, "attributes must be non-null.");
+  onnxruntime::NodeAttributes* attributes = reinterpret_cast<onnxruntime::NodeAttributes*>(attributes_);
+
+  ONNX_NAMESPACE::AttributeProto attribute_proto;
+
+  attribute_proto.set_name(name);
+  attribute_proto.set_type(ONNX_NAMESPACE::AttributeProto::TENSOR);
+  ONNX_NAMESPACE::TensorProto* t = attribute_proto.mutable_t();
+
+  switch (type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::FLOAT);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::UINT8);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::INT8);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::UINT16);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::INT16);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::INT32);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::UINT32);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::INT64);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::UINT64);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::BOOL);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      t->set_data_type(ONNX_NAMESPACE::TensorProto::DOUBLE);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
+    default: {
+      std::ostringstream oss;
+      oss << "type " << type << " is not supported in this function";
+      std::string errmsg = oss.str();
+      return onnxruntime::ToOrtStatus(onnxruntime::Status(onnxruntime::common::ONNXRUNTIME, onnxruntime::common::NOT_IMPLEMENTED, errmsg));
+    }
+  }
+
+  for (size_t i = 0; i < shape_len; i++) {
+    t->add_dims(shape[i]);
+  }
+
+  for (size_t i = 0; i < p_data_len; i++) {
+    switch (type) {
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+        t->add_float_data(static_cast<float*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+        t->add_int32_data(static_cast<uint8_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+        t->add_int32_data(static_cast<int8_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+        t->add_int32_data(static_cast<uint16_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+        t->add_int32_data(static_cast<bool*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+        t->add_int32_data(static_cast<int16_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+        t->add_int32_data(static_cast<int32_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+        t->add_int64_data(static_cast<int64_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+        t->add_uint64_data(static_cast<uint32_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+        t->add_uint64_data(static_cast<uint64_t*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+        t->add_double_data(static_cast<double*>(p_data)[i]);
+        break;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
+      default: {
+        std::ostringstream oss;
+        oss << "type " << type << " is not supported in this function";
+        std::string errmsg = oss.str();
+        return onnxruntime::ToOrtStatus(onnxruntime::Status(onnxruntime::common::ONNXRUNTIME, onnxruntime::common::NOT_IMPLEMENTED, errmsg));
+      }
+    }
+  }
+
+  attributes->insert(std::make_pair(name, attribute_proto));
+  return onnxruntime::ToOrtStatus(onnxruntime::Status::OK());
+  API_IMPL_END
+}

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2522,6 +2522,18 @@ static constexpr OrtApi ort_api_1_to_11 = {
     &OrtApis::GetCUDAProviderOptionsAsString,
     &OrtApis::ReleaseCUDAProviderOptions,
     &OrtApis::SessionOptionsAppendExecutionProvider_MIGraphX,
+    &OrtApis::CreateInvoker,
+    &OrtApis::Invoker_Invoke,
+    &OrtApis::CreateNodeAttributes,
+    &OrtApis::NodeAttributes_Set_float,
+    &OrtApis::NodeAttributes_Set_int64,
+    &OrtApis::NodeAttributes_Set_string,
+    &OrtApis::NodeAttributes_Set_tensor,
+    &OrtApis::NodeAttributes_SetArray_float,
+    &OrtApis::NodeAttributes_SetArray_int64,
+    &OrtApis::NodeAttributes_SetArray_string,
+    &OrtApis::ReleaseInvoker,
+    &OrtApis::ReleaseNodeAttributes,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -339,4 +339,29 @@ ORT_API_STATUS_IMPL(UpdateCUDAProviderOptions, _Inout_ OrtCUDAProviderOptionsV2*
                     size_t num_keys);
 ORT_API_STATUS_IMPL(GetCUDAProviderOptionsAsString, _In_ const OrtCUDAProviderOptionsV2* cuda_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 ORT_API(void, ReleaseCUDAProviderOptions, _Frees_ptr_opt_ OrtCUDAProviderOptionsV2*);
+ORT_API_STATUS_IMPL(CreateInvoker,
+                    _In_ const OrtEnv* env,
+                    _In_ const OrtSessionOptions* options,
+                    size_t provider_index,
+                    _Outptr_ OrtInvoker** invoker);
+ORT_API_STATUS_IMPL(Invoker_Invoke,
+                    _Inout_ OrtInvoker* invoker,
+                    const char* op_name,
+                    _In_reads_(input_len) const OrtValue* const* inputs,
+                    size_t inputs_len,
+                    _Inout_updates_all_(output_names_len) OrtValue** outputs,
+                    size_t outputs_len,
+                    const OrtNodeAttributes* attributes,
+                    const char* domain,
+                    int version);
+ORT_API_STATUS_IMPL(CreateNodeAttributes, _Outptr_ OrtNodeAttributes** attributes);
+ORT_API_STATUS_IMPL(NodeAttributes_Set_float, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, float value);
+ORT_API_STATUS_IMPL(NodeAttributes_Set_int64, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, int64_t value);
+ORT_API_STATUS_IMPL(NodeAttributes_Set_string, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_ const char* value);
+ORT_API_STATUS_IMPL(NodeAttributes_Set_tensor, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _Inout_ void* p_data, size_t p_data_len, _In_ const int64_t* shape, size_t shape_len, ONNXTensorElementDataType type);
+ORT_API_STATUS_IMPL(NodeAttributes_SetArray_float, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) float const* values, size_t values_len);
+ORT_API_STATUS_IMPL(NodeAttributes_SetArray_int64, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) int64_t const* values, size_t values_len);
+ORT_API_STATUS_IMPL(NodeAttributes_SetArray_string, _Inout_ OrtNodeAttributes* attributes, _In_ const char* name, _In_reads_(values_len) const char* const* values, size_t values_len);
+ORT_API(void, ReleaseInvoker, _Frees_ptr_opt_ OrtInvoker*);
+ORT_API(void, ReleaseNodeAttributes, _Frees_ptr_opt_ OrtNodeAttributes*);
 }  // namespace OrtApis

--- a/onnxruntime/test/shared_lib/test_invoker.cc
+++ b/onnxruntime/test/shared_lib/test_invoker.cc
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/session/onnxruntime_cxx_api.h"
+#include <gtest/gtest.h>
+#include "core/providers/cpu/cpu_provider_factory.h"
+
+OrtValue* CreateOrtValue(OrtMemoryInfo* mem_info, std::vector<int64_t>& dims, std::vector<float>& values) {
+  OrtValue* value;
+  Ort::ThrowOnError(Ort::GetApi().CreateTensorWithDataAsOrtValue(mem_info,
+                                                                 values.data(),
+                                                                 values.size() * sizeof(float),
+                                                                 dims.data(),
+                                                                 dims.size(),
+                                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+                                                                 &value));
+  return value;
+}
+
+TEST(CApiTest, invoker) {
+  OrtEnv* env;
+  OrtSessionOptions* options;
+  OrtInvoker* invoker;
+  OrtMemoryInfo* mem_info;
+  Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &mem_info));
+  Ort::ThrowOnError(Ort::GetApi().CreateEnv(ORT_LOGGING_LEVEL_WARNING, "test", &env));
+  Ort::ThrowOnError(Ort::GetApi().CreateSessionOptions(&options));
+
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(options, /*use_arena=*/0));
+  Ort::ThrowOnError(Ort::GetApi().CreateInvoker(env, options, 0, &invoker));
+
+  std::vector<int64_t> input_node1_dims{2, 2};
+  std::vector<int64_t> input_node2_dims{2, 1};
+  std::vector<int64_t> output_node_dims{2, 2};
+
+  std::vector<float> input_node1_data{1, 2, 3, 4};
+  std::vector<float> input_node2_data{5, 6};
+  std::vector<float> output_node_data{0, 0, 0, 0};
+
+  OrtValue* input1 = CreateOrtValue(mem_info, input_node1_dims, input_node1_data);
+  OrtValue* input2 = CreateOrtValue(mem_info, input_node2_dims, input_node2_data);
+  std::array<OrtValue*, 2> inputs{input1, input2};
+  OrtValue* output = CreateOrtValue(mem_info, output_node_dims, output_node_data);
+
+  Ort::ThrowOnError(Ort::GetApi().Invoker_Invoke(invoker, "Add", inputs.data(), 2, &output, 1, nullptr, "", 13));
+
+  EXPECT_EQ(output_node_data[0], 6);
+  EXPECT_EQ(output_node_data[1], 7);
+  EXPECT_EQ(output_node_data[2], 9);
+  EXPECT_EQ(output_node_data[3], 10);
+
+  Ort::GetApi().ReleaseValue(input1);
+  Ort::GetApi().ReleaseValue(input2);
+  Ort::GetApi().ReleaseValue(output);
+  Ort::GetApi().ReleaseInvoker(invoker);
+  Ort::GetApi().ReleaseSessionOptions(options);
+  Ort::GetApi().ReleaseEnv(env);
+  Ort::GetApi().ReleaseMemoryInfo(mem_info);
+}
+
+TEST(CApiTest, invoker_attribute) {
+  OrtEnv* env;
+  OrtSessionOptions* options;
+  OrtInvoker* invoker;
+  OrtMemoryInfo* mem_info;
+  Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &mem_info));
+  Ort::ThrowOnError(Ort::GetApi().CreateEnv(ORT_LOGGING_LEVEL_WARNING, "test", &env));
+  Ort::ThrowOnError(Ort::GetApi().CreateSessionOptions(&options));
+
+  Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_CPU(options, /*use_arena=*/0));
+  Ort::ThrowOnError(Ort::GetApi().CreateInvoker(env, options, 0, &invoker));
+
+  std::vector<int64_t> input_node_dims = {2, 2, 2};
+  std::vector<int64_t> output_node_dims = {2};
+
+  std::vector<float> input_node_data = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<float> output_node_data = {0, 0};
+
+  OrtValue* input = CreateOrtValue(mem_info, input_node_dims, input_node_data);
+  OrtValue* output = CreateOrtValue(mem_info, output_node_dims, output_node_data);
+
+  OrtNodeAttributes* attributes;
+  Ort::ThrowOnError(Ort::GetApi().CreateNodeAttributes(&attributes));
+  std::vector<int64_t> axes{0, 2};
+  Ort::ThrowOnError(Ort::GetApi().NodeAttributes_SetArray_int64(attributes, "axes", axes.data(), axes.size()));
+  Ort::ThrowOnError(Ort::GetApi().NodeAttributes_Set_int64(attributes, "keepdims", 0));
+  Ort::ThrowOnError(Ort::GetApi().Invoker_Invoke(invoker, "ReduceMean", &input, 1, &output, 1, attributes, "", 13));
+
+  EXPECT_EQ(output_node_data[0], 3.5);
+  EXPECT_EQ(output_node_data[1], 5.5);
+
+  Ort::GetApi().ReleaseValue(input);
+  Ort::GetApi().ReleaseValue(output);
+  Ort::GetApi().ReleaseNodeAttributes(attributes);
+  Ort::GetApi().ReleaseInvoker(invoker);
+  Ort::GetApi().ReleaseSessionOptions(options);
+  Ort::GetApi().ReleaseEnv(env);
+  Ort::GetApi().ReleaseMemoryInfo(mem_info);
+}


### PR DESCRIPTION
**Description**: 
Exposes ORTInvoker via a C/C++ api.

**Motivation and Context**
This PR is an iteration on #4453. 
To minimize code size, it reuses the ORTInvoker. The API is also simplified.
Due to the nature of ORTInvoker, this PR has considerably higher latency. This could be fixed by saving the resolved graph, as was done in #4453. 

cc:
@tbennun @souptc @EmergentOrder @Craigacp @pranavsharma 

