### PR TITLE
Convert adam_w_mode to an int before passing it to the backend

### DIFF
--- a/orttraining/orttraining/python/training/optim/fused_adam.py
+++ b/orttraining/orttraining/python/training/optim/fused_adam.py
@@ -80,7 +80,7 @@ class FusedAdam(torch.optim.Optimizer):
                         eps=eps,
                         weight_decay=weight_decay)
         super(FusedAdam, self).__init__(params, defaults)
-        self._adam_w_mode = adam_w_mode
+        self._adam_w_mode = int(adam_w_mode) # backend expects the argument to be an int
         self._set_grad_none = set_grad_none
 
         # Skip buffer


### PR DESCRIPTION
`FusedAdam` accepts an `IntEnum` as an input for the `adam_w_mode` argument. This is passed into the backend which is expecting an `int` value. @jingyanwangms observed that this is causing an error for a user's model script and resulting in termination of execution.

This pull request converts the `IntEnum` value to an `int` value in the `FusedAdam` constructor.