### PR TITLE
[js/react_native] publish onnxruntime-common npm package as web and node do

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -12,9 +12,6 @@ parameters:
 variables:
   build_config: Release
   ${{ if eq(parameters.NpmPublish, 'nightly (@dev)') }}:
-    # 'dev' will skip generating onnxruntime-common package when it's not updated
-    # since react-native e2e always requires both onnxruntime-common and onnxruntime-react-native packages,
-    # use 'custom' type mode here.
     npm_packaging_mode: 'dev'
   ${{ if eq(parameters.NpmPublish, 'release candidate (@rc)') }}:
     npm_packaging_mode: 'rc'

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -198,6 +198,7 @@ jobs:
   # 'dev' npm_packaging_mode doesn't create npm package when onnxruntime-common is not changed.
   # since e2e requires onnxruntime-common package, it builds and move it to e2e directory.
   - script: |
+      rm -f $(Build.SourcesDirectory)/js/common/*.tgz
       if [ ! -f $(Build.SourcesDirectory)/js/common/*.tgz ]
       then
         pushd $(Build.SourcesDirectory)/js/common

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -15,7 +15,8 @@ variables:
     # 'dev' will skip generating onnxruntime-common package when it's not updated
     # since react-native e2e always requires both onnxruntime-common and onnxruntime-react-native packages,
     # use 'custom' type mode here.
-    npm_packaging_mode: '-dev.$(Get-Date -Format yyyyMMdd)-$(git rev-parse --short HEAD)'
+    #npm_packaging_mode: '-dev.$(Get-Date -Format yyyyMMdd)-$(git rev-parse --short HEAD)'
+    npm_packaging_mode: 'dev'
   ${{ if eq(parameters.NpmPublish, 'release candidate (@rc)') }}:
     npm_packaging_mode: 'rc'
   ${{ if eq(parameters.NpmPublish, 'production (@latest)') }}:
@@ -195,7 +196,15 @@ jobs:
       targetFolder: $(Build.SourcesDirectory)/js/react_native/e2e
     displayName: Copy onnxruntime-react-native npm package to React Native e2e directory
 
+  # 'dev' npm_packaging_mode doesn't create npm package when onnxruntime-common is not changed.
+  # since e2e requires onnxruntime-common package, it builds and move it to e2e directory.
   - script: |
+      if [ ! -f $(Build.SourcesDirectory)/js/common/*.tgz ]
+        pushd $(Build.SourcesDirectory)/js/common
+        npm pack
+        mv *.tgz $(Build.SourcesDirectory)/js/react_native/e2e
+        popd
+      fi
       mv onnxruntime-common*.tgz onnxruntime-common.tgz
       yarn add --no-lockfile file:./onnxruntime-common.tgz
       mv onnxruntime-react-native*.tgz onnxruntime-react-native.tgz
@@ -275,6 +284,13 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)/js/react_native'
     displayName: Restore git changes for e2e tests
 
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/js/common
+      contents: onnxruntime-common*.tgz
+      targetFolder: $(Build.ArtifactStagingDirectory)
+    displayName: 'Create Artifacts onnxruntime-common'
+  
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/js/react_native

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -198,7 +198,6 @@ jobs:
   # 'dev' npm_packaging_mode doesn't create npm package when onnxruntime-common is not changed.
   # since e2e requires onnxruntime-common package, it builds and move it to e2e directory.
   - script: |
-      rm -f $(Build.SourcesDirectory)/js/common/*.tgz
       if [ ! -f $(Build.SourcesDirectory)/js/common/*.tgz ]
       then
         pushd $(Build.SourcesDirectory)/js/common

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -15,7 +15,6 @@ variables:
     # 'dev' will skip generating onnxruntime-common package when it's not updated
     # since react-native e2e always requires both onnxruntime-common and onnxruntime-react-native packages,
     # use 'custom' type mode here.
-    #npm_packaging_mode: '-dev.$(Get-Date -Format yyyyMMdd)-$(git rev-parse --short HEAD)'
     npm_packaging_mode: 'dev'
   ${{ if eq(parameters.NpmPublish, 'release candidate (@rc)') }}:
     npm_packaging_mode: 'rc'
@@ -200,6 +199,7 @@ jobs:
   # since e2e requires onnxruntime-common package, it builds and move it to e2e directory.
   - script: |
       if [ ! -f $(Build.SourcesDirectory)/js/common/*.tgz ]
+      then
         pushd $(Build.SourcesDirectory)/js/common
         npm pack
         mv *.tgz $(Build.SourcesDirectory)/js/react_native/e2e


### PR DESCRIPTION
To align with web and node package release, react native pipeline must publish onnxruntime-common npm package if it's changed and use the same 'dev' mode to compare the latest onnxruntime-common package with a current commit.

Once this PR is merged, the same policy for web and node can be applied in release pipeline.