### PR TITLE
Fix build with gcc 7.5

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -179,11 +179,10 @@ NnapiExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_view
                                             gen_metadef_name, NNAPI, kNnapiExecutionProvider);
 
   const auto num_of_partitions = result.size();
-  const auto num_of_supported_nodes = std::transform_reduce(
-      result.begin(), result.end(),
-      size_t{0}, std::plus<>{},
-      [](const auto& partition) -> size_t {
-        return partition && partition->sub_graph ? partition->sub_graph->nodes.size() : 0;
+  const auto num_of_supported_nodes = std::accumulate(
+      result.begin(), result.end(), size_t{0},
+      [](const auto& acc, const auto& partition) -> size_t {
+        return acc + (partition && partition->sub_graph ? partition->sub_graph->nodes.size() : 0);
       });
 
   const auto summary_msg = MakeString(


### PR DESCRIPTION
**Description**: Describe your changes.

gcc 7.5 supports c++17, however, the `transform_reduce` function is not implemented. Switch to `accumulate` to workaround the build issue here.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  gcc 7.5 is the default cpp compiler for Ubuntu 18.04, and is still widely used.