### PR TITLE
Fix VLOG?_DEFAULT macros usability.

### DIFF
--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -143,6 +143,12 @@ class LoggingManager final {
   static void SetDefaultLoggerSeverity(Severity severity);
 
   /**
+     Change the maximum verbosity level for log messages to be output by the default logger.
+     @param vlog_level The verbosity level.
+  */
+  static void SetDefaultLoggerVerbosity(int vlog_level);
+
+  /**
      Logs a FATAL level message and creates an exception that can be thrown with error information.
      @param category The log category.
      @param location The location the log message was generated.
@@ -211,7 +217,7 @@ class Logger {
         id_{id},
         min_severity_{severity},
         filter_user_data_{filter_user_data},
-        max_vlog_level_{severity > Severity::kVERBOSE ? -1 : vlog_level} {  // disable unless logging VLOG messages
+        max_vlog_level_{vlog_level} {
   }
 
   /**
@@ -227,6 +233,12 @@ class Logger {
   void SetSeverity(Severity severity) noexcept { min_severity_ = severity; }
 
   /**
+     Change the maximum verbosity level for log messages to be output.
+     @param vlog_level The verbosity.
+  */
+  void SetVerbosity(int vlog_level) noexcept { max_vlog_level_ = vlog_level; }
+
+  /**
      Check if output is enabled for the provided LogSeverity and DataType values.
      @param severity The severity.
      @param data_type Type of the data.
@@ -237,10 +249,10 @@ class Logger {
   }
 
   /**
-     Return the maximum VLOG level allowed.
+     Return the maximum VLOG level allowed. Disabled unless logging VLOG messages
   */
   int VLOGMaxLevel() const noexcept {
-    return max_vlog_level_;
+    return min_severity_ > Severity::kVERBOSE ? -1 : max_vlog_level_;
   }
 
   /**
@@ -264,7 +276,7 @@ class Logger {
   const std::string id_;
   Severity min_severity_;
   const bool filter_user_data_;
-  const int max_vlog_level_;
+  int max_vlog_level_;
 };
 
 inline const Logger& LoggingManager::DefaultLogger() {
@@ -283,6 +295,15 @@ inline void LoggingManager::SetDefaultLoggerSeverity(Severity severity) {
   }
 
   s_default_logger_->SetSeverity(severity);
+}
+
+inline void LoggingManager::SetDefaultLoggerVerbosity(int vlog_level) {
+  if (s_default_logger_ == nullptr) {
+    // fail early for attempted misuse. don't use logging macros as we have no logger.
+    ORT_THROW("Attempt to use DefaultLogger but none has been registered.");
+  }
+
+  s_default_logger_->SetVerbosity(vlog_level);
 }
 
 inline Timestamp LoggingManager::GetTimestamp() const noexcept {

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -144,6 +144,8 @@ class LoggingManager final {
 
   /**
      Change the maximum verbosity level for log messages to be output by the default logger.
+     @remarks
+     To activate the verbose log, the logger severity must also be set to kVERBOSE.
      @param vlog_level The verbosity level.
   */
   static void SetDefaultLoggerVerbosity(int vlog_level);
@@ -234,6 +236,8 @@ class Logger {
 
   /**
      Change the maximum verbosity level for log messages to be output.
+     @remarks
+     To activate the verbose log, the logger severity must also be set to kVERBOSE.
      @param vlog_level The verbosity.
   */
   void SetVerbosity(int vlog_level) noexcept { max_vlog_level_ = vlog_level; }

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -21,7 +21,7 @@ __author__ = "Microsoft"
 # the saved exception is raised after device version validation.
 try:
     from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, set_seed, \
-        RunOptions, SessionOptions, set_default_logger_severity, enable_telemetry_events, disable_telemetry_events, \
+        RunOptions, SessionOptions, set_default_logger_severity, set_default_logger_verbosity, enable_telemetry_events, disable_telemetry_events, \
         NodeArg, ModelMetadata, GraphOptimizationLevel, ExecutionMode, ExecutionOrder, SessionIOBinding, \
         OrtAllocatorType, OrtMemType, OrtArenaCfg, OrtMemoryInfo, create_and_register_allocator,  OrtSparseFormat
     import_capi_exception = None

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -21,9 +21,10 @@ __author__ = "Microsoft"
 # the saved exception is raised after device version validation.
 try:
     from onnxruntime.capi._pybind_state import get_all_providers, get_available_providers, get_device, set_seed, \
-        RunOptions, SessionOptions, set_default_logger_severity, set_default_logger_verbosity, enable_telemetry_events, disable_telemetry_events, \
+        RunOptions, SessionOptions, set_default_logger_severity, enable_telemetry_events, disable_telemetry_events, \
         NodeArg, ModelMetadata, GraphOptimizationLevel, ExecutionMode, ExecutionOrder, SessionIOBinding, \
-        OrtAllocatorType, OrtMemType, OrtArenaCfg, OrtMemoryInfo, create_and_register_allocator,  OrtSparseFormat
+        OrtAllocatorType, OrtMemType, OrtArenaCfg, OrtMemoryInfo, create_and_register_allocator,  OrtSparseFormat, \
+        set_default_logger_verbosity
     import_capi_exception = None
 except Exception as e:
     import_capi_exception = e

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -888,6 +888,12 @@ void addGlobalMethods(py::module& m, Environment& env) {
       },
       "Sets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
   m.def(
+      "set_default_logger_verbosity", [&env](int vlog_level) {
+        logging::LoggingManager* default_logging_manager = env.GetLoggingManager();
+        default_logging_manager->SetDefaultLoggerVerbosity(vlog_level);
+      },
+      "Sets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
+  m.def(
       "get_all_providers", []() -> const std::vector<std::string>& { return GetAllExecutionProviderNames(); },
       "Return list of Execution Providers that this version of Onnxruntime can support. "
       "The order of elements represents the default priority order of Execution Providers "

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -892,7 +892,8 @@ void addGlobalMethods(py::module& m, Environment& env) {
         logging::LoggingManager* default_logging_manager = env.GetLoggingManager();
         default_logging_manager->SetDefaultLoggerVerbosity(vlog_level);
       },
-      "Sets the default logging severity. 0:Verbose, 1:Info, 2:Warning, 3:Error, 4:Fatal");
+      "Sets the default logging verbosity level. To activate the verbose log, "
+      "you need to set the default logging severity to 0:Verbose level.");
   m.def(
       "get_all_providers", []() -> const std::vector<std::string>& { return GetAllExecutionProviderNames(); },
       "Return list of Execution Providers that this version of Onnxruntime can support. "


### PR DESCRIPTION
**Description**: Describe your changes.

Currently `VLOGS_DEFAULT` and `VLOGF_DEFAULT` macros results no log in user code due to internal bug.

https://github.com/microsoft/onnxruntime/blob/7443edb0bfc0e147b660b8f43e0e73df8117a98a/onnxruntime/core/common/logging/logging.cc#L90
`default_max_vlog_level` has a default value at https://github.com/microsoft/onnxruntime/blob/7443edb0bfc0e147b660b8f43e0e73df8117a98a/include/onnxruntime/core/common/logging/logging.h#L107-L110

but no `LoggingManager` is created with that param, so ORT always have vlog level set to `-1`, that is effectly disabled, so it is changed to populate the value from environment variable.


Secondly, the `max_vlog_level_` in `logging.h` is changed to runtime check. Originally, is is checked on Logger creation time, however, the severity can be changed at runtime. This cause a bug. Also, the pybind create env with `kWARNING` by default. https://github.com/microsoft/onnxruntime/blob/7443edb0bfc0e147b660b8f43e0e73df8117a98a/onnxruntime/python/onnxruntime_pybind_state.cc#L1554-L1558
If we then change the log level via `ort.set_default_logger_severity(log_level)`, the `VLOG?_DEFAULT` will not be enabled again.
