### PR TITLE
Initializing name string with an empty string rather than a null pointer

### DIFF
--- a/include/onnxruntime/core/framework/ortmemoryinfo.h
+++ b/include/onnxruntime/core/framework/ortmemoryinfo.h
@@ -7,7 +7,7 @@ struct OrtMemoryInfo {
   OrtMemoryInfo() = default;  // to allow default construction of Tensor
 
   // use string for name, so we could have customized allocator in execution provider.
-  const char* name = "";
+  const char* name = nullptr;
   int id = -1;
   OrtMemType mem_type = OrtMemTypeDefault;
   OrtAllocatorType alloc_type = OrtInvalidAllocator;
@@ -41,7 +41,7 @@ struct OrtMemoryInfo {
   std::string ToString() const {
     std::ostringstream ostr;
     ostr << "OrtMemoryInfo:["
-         << "name:" << name
+         << "name:" << (name ? name : "")
          << " id:" << id
          << " OrtMemType:" << mem_type
          << " OrtAllocatorType:" << alloc_type


### PR DESCRIPTION
**Description**: The name member variable of the struct OrtMemoryInfo is currently initialized with a nullptr. Using C/C++ string manipulation APIs on the "name" member variable on the default struct instance can lead to memory violation errors. Hence changing the initialization step to an empty string.