### PR TITLE
Fix a use-after-free error

### DIFF
--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -396,6 +396,9 @@ class SessionState {
   // KernelCreateInfo for each node so we do kernel lookup once
   KernelCreateInfoMap kernel_create_info_map_;
 
+  //fused_funcs_mgr_ must live longer than the session_kernels_, becaues a kernel could be created from this manager
+  FuncManager fused_funcs_mgr_;
+
   // If we compile kernels in a minimal build we need a way to find the kernel using the hash.
   // We populate this map when doing the kernel compilation in GraphPartitioner, and use it in LoadFromOrtFormat.
   std::unordered_map<std::string, HashValue> compiled_kernel_hashes_;
@@ -485,7 +488,6 @@ class SessionState {
   concurrency::ThreadPool* const inter_op_thread_pool_{};
 
   bool export_fused_dll_ = false;
-  FuncManager fused_funcs_mgr_;
   const DataTransferManager& data_transfer_mgr_;
 
   bool use_deterministic_compute_;


### PR DESCRIPTION
**Description**: 

You may think the func manager as a memory arena, and the kernels as tensors. A arena holds the memory of the tensors, so it must live longer than the tensors. The similar to function manager, which holds the code of the kernels

The bug was found by @[yuslepukhin](https://github.com/yuslepukhin)

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
