### PR TITLE
[NNAPI QDQ] Add nnapi qdq softmax op support

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -34,6 +34,7 @@ static const OpVersionsAndSelector::OpVersionsMap GetMiscOpVersionsMap() { retur
                                                                                    {"Resize", {}}}; }
 
 static const OpVersionsAndSelector::OpVersionsMap GetUnaryOpVersionsMap() { return {{"AveragePool", {}},
+                                                                                    {"Softmax", {}},
                                                                                     {"LeakyRelu", {}}}; }
 static const OpVersionsAndSelector::OpVersionsMap GetBinaryOpVersionsMap() { return {{"Add", {}},
                                                                                      {"Mul", {}}}; }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.cc
@@ -82,6 +82,8 @@ QuantizedOpType GetQuantizedOpType(const NodeUnit& node_unit) {
       return QuantizedOpType::QDQTranspose;
     else if (op_type == "Reshape")
       return QuantizedOpType::QDQReshape;
+    else if (op_type == "Softmax")
+      return QuantizedOpType::QDQSoftmax;
   } else {
     // throw?
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/helper.h
@@ -92,6 +92,7 @@ enum class QuantizedOpType : uint8_t {
   QDQMul,
   QDQTranspose,
   QDQReshape,
+  QDQSoftmax,
   // TODO, add other QDQ NodeUnit types
 };
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -1608,9 +1608,24 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 #pragma region op_softmax
 
 class SoftMaxOpBuilder : public BaseOpBuilder {
+ public:
+  void AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const override;
+
  private:
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const NodeUnit& node_unit) const override;
+  bool IsQuantizedOp(const NodeUnit& node_unit) const override;
 };
+
+bool SoftMaxOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) const {
+  return GetQuantizedOpType(node_unit) == QuantizedOpType::QDQSoftmax;
+}
+
+void SoftMaxOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
+  if (IsQuantizedOp(node_unit)) {
+    AddQuantizationScaleAndZeroPointToSkip(model_builder, *node_unit.Inputs()[0].quant_param);   // x_scale, x_zp
+    AddQuantizationScaleAndZeroPointToSkip(model_builder, *node_unit.Outputs()[0].quant_param);  // y_scale, y_zp
+  }
+}
 
 Status SoftMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
   auto& shaper(model_builder.GetShaper());
@@ -1636,6 +1651,21 @@ Status SoftMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
     axis = axis_nchw_to_nhwc[axis];
   }
 
+  // Check if the quantization scale and ZP are correct
+  float x_scale = 0.0f;
+  int32_t x_zero_point = 0;
+  float y_scale = 0.0f;
+  int32_t y_zero_point = 0;
+  if (IsQuantizedOp(node_unit)) {
+    ORT_RETURN_IF_ERROR(GetQuantizationScaleAndZeroPoint(
+        model_builder.GetInitializerTensors(), node_unit.Inputs()[0], node_unit.ModelPath(),
+        x_scale, x_zero_point));
+
+    ORT_RETURN_IF_ERROR(IsValidInputQuantizedType(model_builder, input, x_scale, x_zero_point));
+
+    y_scale = 1.f / 256;
+  }
+
   const auto& output = node_unit.Outputs()[0].node_arg.Name();
   float beta = 1.f;
   std::vector<uint32_t> input_indices;
@@ -1648,7 +1678,7 @@ Status SoftMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
   }
 
   ORT_RETURN_IF_ERROR(shaper.Identity(input, output));
-  const OperandType output_operand_type(operand_types.at(input).type, shaper[output]);
+  const OperandType output_operand_type(operand_types.at(input).type, shaper[output], y_scale, y_zero_point);
   ORT_RETURN_IF_ERROR(model_builder.AddOperation(ANEURALNETWORKS_SOFTMAX, input_indices,
                                                  {output}, {output_operand_type}, {output_is_nhwc}));
   return Status::OK();

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -268,6 +268,42 @@ static bool IsQuantizedIOSupported(const InitializedTensorSet& initializers, con
   return true;
 }
 
+// Some Quantized NNAPI operations have required output scale and zero point
+// e.g. Softmax (uint8) requires output scale be 1.f/256 and zp be 0
+// This helper function checks if the given io_def has required scale and zp
+static bool HasRequiredScaleAndZeroPoint(const InitializedTensorSet& initializers,
+                                         const std::string& op_desc,
+                                         const NodeUnitIODef& io_def,
+                                         const Path& path,
+                                         float required_scale, int32_t required_zp) {
+  float scale = 0.0f;
+  int32_t zp = 0;
+  auto status = GetQuantizationScaleAndZeroPoint(initializers, io_def, path,
+                                                 scale, zp);
+  if (!status.IsOK()) {
+    LOGS_DEFAULT(ERROR) << op_desc
+                        << " GetQuantizationScaleAndZeroPoint failed, message: "
+                        << status.ErrorMessage();
+    return false;
+  }
+
+  if (scale != required_scale) {
+    LOGS_DEFAULT(VERBOSE) << op_desc
+                          << " scale can only be [" << required_scale
+                          << "], actual scale: " << scale;
+    return false;
+  }
+
+  if (zp != required_zp) {
+    LOGS_DEFAULT(VERBOSE) << op_desc
+                          << "] zero point can only be [" << required_zp
+                          << "], actual zero point: " << scale;
+    return false;
+  }
+
+  return true;
+}
+
 #pragma endregion helpers
 
 #pragma region op_base
@@ -1138,7 +1174,18 @@ class SoftMaxOpSupportChecker : public BaseOpSupportChecker {
                                            const OpSupportCheckParams& /* params */) const override {
     return ANEURALNETWORKS_FEATURE_LEVEL_2;
   }
+  bool HasSupportedInputOutputsImpl(
+      const InitializedTensorSet& initializers, const NodeUnit& node_unit,
+      const OpSupportCheckParams& params) const override;
+
+  bool IsNodeUnitTypeSupported(const NodeUnit& /* node_unit */) const override { return true; }
+
+  bool IsQuantizedOp(const NodeUnit& node_unit) const override;
 };
+
+bool SoftMaxOpSupportChecker::IsQuantizedOp(const NodeUnit& node_unit) const {
+  return GetQuantizedOpType(node_unit) == QuantizedOpType::QDQSoftmax;
+}
 
 bool SoftMaxOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const NodeUnit& node_unit,
                                                 const OpSupportCheckParams& params) const {
@@ -1162,6 +1209,32 @@ bool SoftMaxOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /* i
           << " input axis: " << axis;
       return false;
     }
+  }
+
+  return true;
+}
+
+bool SoftMaxOpSupportChecker::HasSupportedInputOutputsImpl(
+    const InitializedTensorSet& initializers, const NodeUnit& node_unit,
+    const OpSupportCheckParams& params) const {
+  if (!IsQuantizedOp(node_unit)) {
+    return BaseOpSupportChecker::HasSupportedInputOutputsImpl(initializers, node_unit, params);
+  }
+
+  if (!IsQuantizedIOSupported(initializers, node_unit, {0}, params, IOKind::Input)) {
+    return false;
+  }
+
+  if (!IsQuantizedIOSupported(initializers, node_unit, {0}, params, IOKind::Output)) {
+    return false;
+  }
+
+  // NNAPI requires the scale be 1.f/256 and zero point to be 0
+  if (!HasRequiredScaleAndZeroPoint(initializers,
+                                    MakeString("Op [", node_unit.OpType(), "] name [", node_unit.Name(), "]'s output 0 "),
+                                    node_unit.Outputs()[0], node_unit.ModelPath(),
+                                    1.f / 256 /* required_scale */, 0 /* required_zp */)) {
+    return false;
   }
 
   return true;
@@ -1439,29 +1512,13 @@ int UnaryOpSupportChecker::GetMinSupportedOpSet(const NodeUnit& node_unit) const
     const InitializedTensorSet& initializers, const NodeUnit& node_unit, const OpSupportCheckParams& /* params */) {
   const auto& op_type = node_unit.OpType();
   ORT_ENFORCE(op_type == "QLinearSigmoid");
-  const auto& op_name = node_unit.Name();
 
   // NNAPI requires the scale be 1.f/256 and zero point to be 0
   // See https://android.googlesource.com/platform/frameworks/ml/+/refs/heads/android10-c2f2-release/nn/common/operations/Activation.cpp#180
-  float output_scale = 0.0f;
-  int32_t output_zp = 0;
-  auto status = GetQuantizationScaleAndZeroPoint(initializers, node_unit.Outputs()[0], node_unit.ModelPath(),
-                                                 output_scale, output_zp);
-  if (!status.IsOK()) {
-    LOGS_DEFAULT(ERROR) << "Op [" << op_type << "] name [" << op_name
-                        << "] GetQuantizationScaleAndZeroPoint failed, message: " << status.ErrorMessage();
-    return false;
-  }
-
-  if (output_scale != 1.f / 256) {
-    LOGS_DEFAULT(VERBOSE) << "Op [" << op_type << "] name [" << op_name
-                          << "] output scale can only be 1.f/256, actual scale: " << output_scale;
-    return false;
-  }
-
-  if (output_zp != 0) {
-    LOGS_DEFAULT(VERBOSE) << "Op [" << op_type << "] name [" << op_name
-                          << "] output zero point can only be 0, actual zero point: " << output_scale;
+  if (!HasRequiredScaleAndZeroPoint(initializers,
+                                    MakeString("Op [", op_type, "] name [", node_unit.Name(), "]'s output 0 "),
+                                    node_unit.Outputs()[0], node_unit.ModelPath(),
+                                    1.f / 256 /* required_scale */, 0 /* required_zp */)) {
     return false;
   }
 

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -58,28 +58,5 @@ GetQDQTestCaseFn BuildQDQReshapeTestCase(const std::vector<int64_t>& input_shape
   };
 }
 
-GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape) {
-  return [input_shape](ModelTestBuilder& builder) {
-    auto* input_arg = builder.MakeInput<uint8_t>(input_shape,
-                                                 std::numeric_limits<uint8_t>::min(),
-                                                 std::numeric_limits<uint8_t>::max());
-
-    auto* output_arg = builder.MakeOutput();
-
-    // add DQ
-    auto* dq_output = builder.MakeIntermediate();
-    builder.AddDequantizeLinearNode<uint8_t>(input_arg, 1.f / 256, 0, dq_output);
-
-    // add SoftMax
-    auto* softmax_output = builder.MakeIntermediate();
-    Node& softmax_node = builder.AddNode("SoftMax", {dq_output}, {softmax_output});
-
-    softmax_node.AddAttribute("axis", static_cast<int64_t>(1));
-
-    // add Q
-    builder.AddQuantizeLinearNode<uint8_t>(softmax_output, 1.f / 256, 0, output_arg);
-  };
-}
-
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -229,7 +229,7 @@ GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape
 
     // add DQ
     auto* dq_output = builder.MakeIntermediate();
-    builder.AddDequantizeLinearNode<InputType>(input_arg, 1.f / 256, 0, dq_output);
+    builder.AddDequantizeLinearNode<InputType>(input_arg, .003f, std::numeric_limits<InputType>::max() / 2, dq_output);
 
     // add SoftMax
     auto* softmax_output = builder.MakeIntermediate();

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -195,7 +195,7 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
   return [input_shape, perms](ModelTestBuilder& builder) {
     auto* input_arg = builder.MakeInput<InputType>(input_shape,
                                                    std::numeric_limits<InputType>::min(),
-                                                   std::numeric_limits<OutputType>::max());
+                                                   std::numeric_limits<InputType>::max());
     auto* output_arg = builder.MakeOutput();
 
     InputType dq_zp = std::numeric_limits<InputType>::max() / 2;

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -193,7 +193,9 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
     const std::vector<int64_t>& input_shape,
     const std::vector<int64_t>& perms) {
   return [input_shape, perms](ModelTestBuilder& builder) {
-    auto* input_arg = builder.MakeInput<InputType>(input_shape, -128, 127);
+    auto* input_arg = builder.MakeInput<InputType>(input_shape,
+                                                   std::numeric_limits<InputType>::min(),
+                                                   std::numeric_limits<OutputType>::max());
     auto* output_arg = builder.MakeOutput();
 
     InputType dq_zp = std::numeric_limits<InputType>::max() / 2;
@@ -216,6 +218,29 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
 GetQDQTestCaseFn BuildQDQReshapeTestCase(const std::vector<int64_t>& input_shape,
                                          const std::vector<int64_t>& reshape_shape);
 
-GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape);
+template <typename InputType, typename OutputType>
+GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape, const int64_t& axis = -1) {
+  return [input_shape, axis](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<InputType>(input_shape,
+                                                   std::numeric_limits<InputType>::min(),
+                                                   std::numeric_limits<InputType>::max());
+
+    auto* output_arg = builder.MakeOutput();
+
+    // add DQ
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<InputType>(input_arg, 1.f / 256, 0, dq_output);
+
+    // add SoftMax
+    auto* softmax_output = builder.MakeIntermediate();
+    Node& softmax_node = builder.AddNode("Softmax", {dq_output}, {softmax_output});
+
+    softmax_node.AddAttribute("axis", axis);
+
+    // add Q
+    builder.AddQuantizeLinearNode<OutputType>(softmax_output, 1.f / 256, 0, output_arg);
+  };
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -215,5 +215,7 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
 
 GetQDQTestCaseFn BuildQDQReshapeTestCase(const std::vector<int64_t>& input_shape,
                                          const std::vector<int64_t>& reshape_shape);
+
+GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape);
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -306,8 +306,8 @@ TEST(NnapiExecutionProviderTest, TestQDQConv) {
                                        uint8_t /* WeightType */,
                                        int32_t /* BiasType */,
                                        uint8_t /* OutputType */>(
-                      {1, 1, 5, 5} /*input_shape*/,
-                      {1, 1, 3, 3} /*weights_shape*/),
+                      {1, 1, 5, 5} /* input_shape */,
+                      {1, 1, 3, 3} /* weights_shape */),
                   "nnapi_qdq_test_graph_conv",
                   {true /* verify_entire_graph_use_ep */});
 }
@@ -374,6 +374,14 @@ TEST(NnapiExecutionProviderTest, TestQDQReshape) {
   RunQDQModelTest(BuildQDQReshapeTestCase({1, 3, 64, 64} /* input_shape */,
                                           {1, 64, 64, 3} /* reshape_shape */),
                   "nnapi_qdq_test_graph_reshape",
+                  {
+                      true /* verify_entire_graph_use_ep */
+                  });
+}
+
+TEST(NnapiExecutionProviderTest, TestQDQSoftMax) {
+  RunQDQModelTest(BuildQDQSoftMaxTestCase({1, 32} /* input_shape */),
+                  "nnapi_qdq_test_graph_softmax",
                   {
                       true /* verify_entire_graph_use_ep */
                   });

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -380,7 +380,9 @@ TEST(NnapiExecutionProviderTest, TestQDQReshape) {
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQSoftMax) {
-  RunQDQModelTest(BuildQDQSoftMaxTestCase({1, 32} /* input_shape */),
+  RunQDQModelTest(BuildQDQSoftMaxTestCase<uint8_t, uint8_t>(
+                      {1, 32} /* input_shape */,
+                      static_cast<int64_t>(1) /* axis */),
                   "nnapi_qdq_test_graph_softmax",
                   {
                       true /* verify_entire_graph_use_ep */


### PR DESCRIPTION
**Description**: Describe your changes.

[NNAPI QDQ] Add nnapi qdq softmax op support , last operator required for basic mobilenet-edgetpu model.

**Motivation and Context**

*softmax is only added in the shared qdq selectors registration for ep. For cpu qdq selectorsandactions, softmax op is not added for registration, as it does not have actions.