### PR TITLE
extend ADP task ComponentDetection timeout

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/component-governance-component-detection-steps.yml
@@ -4,6 +4,10 @@ parameters:
   type: string
   default: 'succeeded' # could be 'ci_only', 'always', 'succeeded'
 
+variables:
+  # change component detection timeout to 15 min
+  ComponentDetection.Timeout: 900
+
 steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'


### PR DESCRIPTION
**Description**: extend ADP task ComponentDetection timeout to 15 min.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  - recently there are several build failures caused by timeout of task ComponentDetection. This change extends the timeout from 6min to 15 min to reduce the failure rate.