### PR TITLE
Optimize BinaryElementWise and BiasGeluGrad kernels for AMD

### DIFF
--- a/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
@@ -189,22 +189,16 @@ void BinaryElementWiseNoBroadcastImpl(
   if (count == 0)  // special case where there's a dim value of 0 in the output shape
     return;
   
-  int num_elements_per_thread = GridDim::maxElementsPerThread;
-  int num_threads_per_block = GridDim::maxThreadsPerBlock;
   #ifdef USE_ROCM
-  num_elements_per_thread = 2;
-  num_threads_per_block = 512;
+  const int num_elements_per_thread = 2;
+  const int num_threads_per_block = 512;
+  #else
+  const int num_elements_per_thread = GridDim::maxElementsPerThread;
+  const int num_threads_per_block = GridDim::maxThreadsPerBlock;
   #endif
+
   int blocksPerGrid = static_cast<int>(CeilDiv(count, num_threads_per_block * num_elements_per_thread));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
-  /*
-  _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
-      lhs_data,
-      rhs_data,
-      output_data,
-      func,
-      N);
-  */
   _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
       lhs_data,
       rhs_data,
@@ -231,12 +225,14 @@ void BinaryElementWiseImpl(
   if (count == 0)  // special case where there's a dim value of 0 in the output shape
     return;
 
-  int num_elements_per_thread = GridDim::maxElementsPerThread;
-  int num_threads_per_block = GridDim::maxThreadsPerBlock;
   #ifdef USE_ROCM
-  num_elements_per_thread = 2;
-  num_threads_per_block = 512;
+  const int num_elements_per_thread = 2;
+  const int num_threads_per_block = 512;
+  #else
+  const int num_elements_per_thread = GridDim::maxElementsPerThread;
+  const int num_threads_per_block = GridDim::maxThreadsPerBlock;
   #endif
+
   int blocksPerGrid = static_cast<int>(CeilDiv(count, num_threads_per_block * num_elements_per_thread));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
   if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::NoBroadcast)) {

--- a/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
@@ -188,9 +188,14 @@ void BinaryElementWiseNoBroadcastImpl(
     size_t count) {
   if (count == 0)  // special case where there's a dim value of 0 in the output shape
     return;
-
-  //int blocksPerGrid = static_cast<int>(CeilDiv(count, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
-  int blocksPerGrid = static_cast<int>(CeilDiv(count, 512 * 2));
+  
+  int num_elements_per_thread = GridDim::maxElementsPerThread;
+  int num_threads_per_block = GridDim::maxThreadsPerBlock;
+  #ifdef USE_ROCM
+  num_elements_per_thread = 2;
+  num_threads_per_block = 512;
+  #endif
+  int blocksPerGrid = static_cast<int>(CeilDiv(count, num_threads_per_block * num_elements_per_thread));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
   /*
   _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
@@ -200,7 +205,7 @@ void BinaryElementWiseNoBroadcastImpl(
       func,
       N);
   */
-  _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+  _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
       lhs_data,
       rhs_data,
       output_data,
@@ -226,31 +231,37 @@ void BinaryElementWiseImpl(
   if (count == 0)  // special case where there's a dim value of 0 in the output shape
     return;
 
-  int blocksPerGrid = static_cast<int>(CeilDiv(count, 512 * 2));
+  int num_elements_per_thread = GridDim::maxElementsPerThread;
+  int num_threads_per_block = GridDim::maxThreadsPerBlock;
+  #ifdef USE_ROCM
+  num_elements_per_thread = 2;
+  num_threads_per_block = 512;
+  #endif
+  int blocksPerGrid = static_cast<int>(CeilDiv(count, num_threads_per_block * num_elements_per_thread));
   CUDA_LONG N = static_cast<CUDA_LONG>(count);
   if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::NoBroadcast)) {
-    _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+    _BinaryElementWiseSimple<true, true, T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
         lhs_data,
         rhs_data,
         output_data,
         func,
         N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::LeftScalar)) {
-    _BinaryElementWiseSimple<false, true, T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+    _BinaryElementWiseSimple<false, true, T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
         lhs_data,
         rhs_data,
         output_data,
         func,
         N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightScalar)) {
-    _BinaryElementWiseSimple<true, false, T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+    _BinaryElementWiseSimple<true, false, T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
         lhs_data,
         rhs_data,
         output_data,
         func,
         N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightPerChannelBatch1)) {
-    _BinaryElementWiseRhsPerChannelBatch1<T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+    _BinaryElementWiseRhsPerChannelBatch1<T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
         lhs_data,
         rhs_data,
         fdm_H,
@@ -258,7 +269,7 @@ void BinaryElementWiseImpl(
         func,
         N);
   } else if (output_rank_or_simple_broadcast == static_cast<int32_t>(SimpleBroadcast::RightPerChannelBatchN)) {
-    _BinaryElementWiseRhsPerChannelBatchN<T, T1, T2, FuncT, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+    _BinaryElementWiseRhsPerChannelBatchN<T, T1, T2, FuncT, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
         lhs_data,
         rhs_data,
         fdm_H,
@@ -268,7 +279,7 @@ void BinaryElementWiseImpl(
         N);
   } else {
     if (lhs_padded_strides && rhs_padded_strides && lhs_padded_strides->Size() && rhs_padded_strides->Size())
-      _BinaryElementWise<T, T1, T2, FuncT, true, true, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+      _BinaryElementWise<T, T1, T2, FuncT, true, true, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
           output_rank_or_simple_broadcast,
           *lhs_padded_strides,
           lhs_data,
@@ -279,7 +290,7 @@ void BinaryElementWiseImpl(
           func,
           N);
     else if (lhs_padded_strides && lhs_padded_strides->Size())
-      _BinaryElementWise<T, T1, T2, FuncT, true, false, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+      _BinaryElementWise<T, T1, T2, FuncT, true, false, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
           output_rank_or_simple_broadcast,
           *lhs_padded_strides,
           lhs_data,
@@ -290,7 +301,7 @@ void BinaryElementWiseImpl(
           func,
           N);
     else if (rhs_padded_strides && rhs_padded_strides->Size())
-      _BinaryElementWise<T, T1, T2, FuncT, false, true, 512, 2><<<blocksPerGrid, 512, 0, stream>>>(
+      _BinaryElementWise<T, T1, T2, FuncT, false, true, num_threads_per_block, num_elements_per_thread><<<blocksPerGrid, num_threads_per_block, 0, stream>>>(
           output_rank_or_simple_broadcast,
           TArray<int64_t>(), // lhs is not computed, so no need to deference lhs_padded_strides
           lhs_data,

--- a/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad_impl.cu
@@ -62,9 +62,24 @@ void LaunchBiasGeluGradDxKernel(
   // given a 2D grid of blocks:
   // each grid row handles bias_size elements
   // there are input_size / bias_size rows
-  constexpr int num_elements_per_thread = GridDim::maxElementsPerThread;
+  //constexpr int num_elements_per_thread = GridDim::maxElementsPerThread;
+  /* 
+  int num_elements_per_thread = GridDim::maxElementsPerThread;
+  int threads_per_block = GridDim::maxThreadsPerBlock;
+  #ifdef __HIP_PLATFORM_HCC__
+  // Optimization for ROCm MI100
+  num_elements_per_thread = 2;
+  threads_per_block = 512;
+  #endif
+
   const int num_threads_per_block =
-      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(GridDim::maxThreadsPerBlock));
+      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(threads_per_block));
+  */
+  
+  constexpr int num_elements_per_thread = num_elements_per_thread;
+  const int num_threads_per_block =
+      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(512));
+  
   const auto grid_width = CeilDiv(bias_size, num_elements_per_thread * num_threads_per_block);
   const auto grid_height = input_size / bias_size;
 

--- a/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/activation/bias_gelu_grad_impl.cu
@@ -62,24 +62,16 @@ void LaunchBiasGeluGradDxKernel(
   // given a 2D grid of blocks:
   // each grid row handles bias_size elements
   // there are input_size / bias_size rows
-  //constexpr int num_elements_per_thread = GridDim::maxElementsPerThread;
-  /* 
-  int num_elements_per_thread = GridDim::maxElementsPerThread;
-  int threads_per_block = GridDim::maxThreadsPerBlock;
-  #ifdef __HIP_PLATFORM_HCC__
+  
+  const int num_elements_per_thread = GridDim::maxElementsPerThread;
+  int max_threads_per_block = GridDim::maxThreadsPerBlock;
+  #ifdef USE_ROCM
   // Optimization for ROCm MI100
-  num_elements_per_thread = 2;
-  threads_per_block = 512;
+  max_threads_per_block = 512;
   #endif
-
-  const int num_threads_per_block =
-      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(threads_per_block));
-  */
   
-  constexpr int num_elements_per_thread = num_elements_per_thread;
-  const int num_threads_per_block =
-      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(512));
-  
+  int num_threads_per_block =
+      std::min<int>(static_cast<int>(CeilDiv(bias_size, num_elements_per_thread)), static_cast<int>(max_threads_per_block));
   const auto grid_width = CeilDiv(bias_size, num_elements_per_thread * num_threads_per_block);
   const auto grid_height = input_size / bias_size;
 


### PR DESCRIPTION
**Description:**
Optimized _BinaryElementWise, _BinaryElementWiseRhsPerChannelBatchN, and BiasGeluGradDxKernel for AMD GPUs.

**Motivation and Context**

- Why is this change required? What problem does it solve?

The 4% runtime difference is observed in TNLRv4 on MI100 vs. V100. The cause of discrepancy is from the following three kernels: `_BinaryElementWise`, `_BinaryElementWiseRhsPerChannelBatchN`, and `BiasGeluGradDxKernel`. Given by the reproducer, we are able to see the performance improvement in terms of original sub-optimal kernels by 15.94%, 19.28%, and 27.97%, respectively.
