### PR TITLE
Fix link error in dnnl

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.h
@@ -132,9 +132,5 @@ inline std::ostream& operator<<(std::ostream& os, const gsl::span<int64_t>& span
   return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const TensorShape& shape) {
-  return os << shape.GetDims();
-}
-
 }  // namespace onnxruntime
 


### PR DESCRIPTION
**Description**: A duplicate symbol was accidentally added in a previous change, this removes it and uses the shared provider library version.

**Motivation and Context**
Fixes a build break of dnnl (verified locally), from an issue pointed out by a user:
https://github.com/microsoft/onnxruntime/issues/10580
