### PR TITLE
fix ortmodule's output device info when it runs on ort device

### DIFF
--- a/orttraining/orttraining/eager/test/linux_only_ortmodule_eager_test.py
+++ b/orttraining/orttraining/eager/test/linux_only_ortmodule_eager_test.py
@@ -68,6 +68,8 @@ class OrtModuleEagerTest(unittest.TestCase):
         #reload initial state
         model.load_state_dict(initial_state)
         #run on ort with ORTModule and eager mode
+        #use device_idx 1 to test non-zero device
+        torch_ort_eager.set_device(1, 'CPUExecutionProvider', {'dummy':'dummy'})
         device = torch.device('ort', index=0)
         model.to(device)
         model = ORTModule(model)


### PR DESCRIPTION
**Description**: When run on ort device, we need decode the ort virtual device index to correct OrtDev structure. 