### PR TITLE
Fix build errors due to changes in warnings that VS 2022 17.1 produces.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -965,8 +965,6 @@ if (WIN32)
         # warning C4800: Implicit conversion from 'X' to bool. Possible information loss
         if (onnxruntime_USE_OPENVINO OR onnxruntime_ENABLE_EAGER_MODE)
            list(APPEND ORT_WARNING_FLAGS "/wd4800")
-        else()
-           list(APPEND ORT_WARNING_FLAGS "/w34800")
         endif()
         # operator 'operator-name': deprecated between enumerations of different types
         list(APPEND ORT_WARNING_FLAGS "/wd5054")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -756,12 +756,11 @@ add_dependencies(onnx_test_data_proto onnx_proto ${onnxruntime_EXTERNAL_DEPENDEN
 #onnx_proto target should mark this definition as public, instead of private
 target_compile_definitions(onnx_test_data_proto PRIVATE "-DONNX_API=")
 if(WIN32)
-  target_compile_options(onnx_test_data_proto PRIVATE "/wd4125" "/wd4456" "/wd4100" "/wd4267" "/wd6011" "/wd6387" "/wd28182")
+  target_compile_options(onnx_test_data_proto PRIVATE "/wd4100" "/wd4125" "/wd4127" "/wd4267" "/wd4456" "/wd4800" "/wd6011" "/wd6387" "/wd28182")
 else()
   #Once we upgrade protobuf to 3.17.3+, we can remove this
   target_compile_options(onnx_test_data_proto PRIVATE "-Wno-unused-parameter")
 endif()
-add_dependencies(onnx_test_data_proto onnx_proto ${onnxruntime_EXTERNAL_DEPENDENCIES})
 onnxruntime_add_include_to_target(onnx_test_data_proto onnx_proto)
 target_include_directories(onnx_test_data_proto PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(onnx_test_data_proto PROPERTIES FOLDER "ONNXRuntimeTest")

--- a/onnxruntime/core/framework/inlined_containers.h
+++ b/onnxruntime/core/framework/inlined_containers.h
@@ -8,8 +8,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // This file contains code and comments derived from llvm/ADT/SmallVector.h
-// 
-// Specifically CalculateInlinedVectorDefaultInlinedElements<T>() template is derived from 
+//
+// Specifically CalculateInlinedVectorDefaultInlinedElements<T>() template is derived from
 // CalculateSmallVectorDefaultInlinedElements<T>() and its comments.
 
 #pragma once
@@ -20,6 +20,9 @@
 #pragma warning(push)
 // C4127: conditional expression is constant
 #pragma warning(disable : 4127)
+// C4324: structure was padded due to alignment specifier
+// Usage of alignas causes some internal padding in places.
+#pragma warning(disable : 4324)
 #endif
 
 #include <absl/container/inlined_vector.h>
@@ -38,10 +41,10 @@ namespace onnxruntime {
 /// This produces the following on MSVC x64
 ///    int8_t  -> 41
 //     int16_t -> 21
-//     int32_t -> 11 
+//     int32_t -> 11
 //     int64_t -> 6
 //     std::string 40 -> 1
-template<typename T>
+template <typename T>
 struct CalculateInlinedVectorDefaultInlinedElements {
   // Parameter controlling the default number of inlined elements
   // for `InlinedVector<T>`.
@@ -91,7 +94,7 @@ struct CalculateInlinedVectorDefaultInlinedElements {
 // Use InlinedVector for small arrays that can fit on a stack with a default
 // value pre-calculated.
 // Use TensorShapeVector for shapes.
-template <typename T, 
+template <typename T,
           size_t N = CalculateInlinedVectorDefaultInlinedElements<T>::value,
           typename Allocator = std::allocator<T>>
 using InlinedVector = absl::InlinedVector<T, N, Allocator>;
@@ -101,7 +104,7 @@ using InlinedVector = absl::InlinedVector<T, N, Allocator>;
 // buckets array that is allocated in one shot. It eliminates
 // per-node new/delete calls. Always call reserve() on any hash set/map
 // when the number of items is known in advance
-template <typename T, 
+template <typename T,
           typename Hash = absl::container_internal::hash_default_hash<T>,
           typename Eq = absl::container_internal::hash_default_eq<T>,
           typename Allocator = std::allocator<T>>


### PR DESCRIPTION
**Description**: 

Disable warning about padding for abseil-cpp flat_hash_map.

Disable some warnings from compiling the test proto. This also required removing a line in CMakeList.txt where we move a level 4 warning 4800 to level 3 by adding `/w34800`. That ends up later on the command line (gets added to AdditionalOptions for some reason) and overrides the `/wd4800`. 

<img width="424" alt="image" src="https://user-images.githubusercontent.com/979079/155097238-69a19afa-1cca-4017-8c25-7c8197918688.png">

Couldn't find a way to handle that nicely. As we compile with `/W4` the value of moving 4800 to level 3 in dev mode is unclear so simplest was to remove that. Open to suggestions if there's a better way.

**Motivation and Context**
Fix build breaks.