### PR TITLE
Fix edge case in GridSample border padding mode 

### DIFF
--- a/onnxruntime/contrib_ops/cpu/grid_sample.cc
+++ b/onnxruntime/contrib_ops/cpu/grid_sample.cc
@@ -205,11 +205,7 @@ Status GridSample<T>::Compute(OpKernelContext* context) const {
               }
 
               if (x < x_min || x > x_max || y < y_min || y > y_max) {  // out of bound
-                if (padding_mode_ == Border) {
-                  // use original border in both align_corner cases
-                  x = std::clamp(x, static_cast<T>(0), static_cast<T>(W_in - 1));
-                  y = std::clamp(y, static_cast<T>(0), static_cast<T>(H_in - 1));
-                } else if (padding_mode_ == Reflection) {
+                if (padding_mode_ == Reflection) {
                   x = GsReflect(x, x_min, x_max);
                   y = GsReflect(y, y_min, y_max);
                 }

--- a/onnxruntime/contrib_ops/cuda/grid_sample_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/grid_sample_impl.cu
@@ -146,10 +146,7 @@ __global__ void _GridSampleKernel(
     float border[] = {x_min, y_min, x_max, y_max};  // l-t-r-b
     if (grid_x_imgSpace < x_min || grid_x_imgSpace > x_max ||
         grid_y_imgSpace < y_min || grid_y_imgSpace > y_max) { // out of bound
-      if (padding_mode == 1) {  // border
-        grid_x_imgSpace = max(0.0f, min(grid_x_imgSpace, W_in - 1.0f));
-        grid_y_imgSpace = max(0.0f, min(grid_y_imgSpace, H_in - 1.0f));
-      } else if (padding_mode == 2) {  // reflection
+      if (padding_mode == 2) {  // reflection
         grid_x_imgSpace = GsReflect(grid_x_imgSpace, x_min, x_max);
         grid_y_imgSpace = GsReflect(grid_y_imgSpace, y_min, y_max);
       }

--- a/onnxruntime/test/contrib_ops/gridsample_test.cc
+++ b/onnxruntime/test/contrib_ops/gridsample_test.cc
@@ -128,6 +128,29 @@ TEST(GridsampleContribOpTest, gridsample_mode_bicubic) {
   test.Run();
 }
 
+TEST(GridsampleContribOpTest, gridsample_mode_bicubic_border) {
+  OpTester test("GridSample", 1, kMSDomain);
+  test.AddInput<float>("X", {1, 1, 3, 2}, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f});
+  test.AddInput<float>("Grid", {1, 4, 4, 2},
+                       {-1.0000f, -1.0000f, -0.5000f, -0.5000f,
+                        -0.2000f, -0.2000f, 0.0000f, 0.0000f,
+                        0.0000f, 0.0000f, -0.2000f, -0.2000f,
+                        0.5000f, 0.5000f, 1.0000f, 1.0000f,
+                        -1.100f, 0.4000f, -0.400f, -1.100f,
+                         1.100f, -0.400f, 0.400f, 1.100f,
+                        -10.000f,  0.000f, 10.000f, 0.000f,
+                        0.000f, -10.000f, 0.000f, 10.000f});
+  test.AddAttribute("mode", "bicubic");
+  test.AddAttribute("padding_mode", "border");
+  test.AddOutput<float>("Y", {1, 1, 4, 4},
+                       {-0.2812f, 0.3828f, 1.5005f, 2.5000f,
+                        2.5000f, 1.5005f, 4.6172f, 5.2812f,
+                        3.2960f, -0.0374f, 1.7040f, 5.0374f,
+                        2.0000f,  3.0000f, 0.5000f, 4.5000f});
+
+  test.Run();
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
**Bug fix**:   edge case in GridSample border padding mode 


In border padding mode, adjustment of grid point is not necessary.

This is the fix for issue https://github.com/microsoft/onnxruntime/issues/10607.
