### PR TITLE
ppc64le: optimizing the MlasQuantizeLinear() with VSX

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -308,8 +308,19 @@ else()
           ${MLAS_SRC_DIR}/power/SgemmKernelPower.cpp
           ${MLAS_SRC_DIR}/dgemm.cpp
           ${MLAS_SRC_DIR}/power/DgemmKernelPower.cpp
+          ${MLAS_SRC_DIR}/power/QuantizePower.cpp
         )
         set_source_files_properties(${MLAS_SRC_DIR}/power/SgemmKernelPower.cpp PROPERTIES COMPILE_FLAGS "-DSINGLE")
+
+        check_cxx_compiler_flag("-mcpu=power9" HAS_POWER9)
+        if (HAS_POWER9)
+          set(mlas_platform_srcs
+            ${mlas_platform_srcs}
+            ${MLAS_SRC_DIR}/power/QuantizePowerVSX.cpp
+          )
+          set_source_files_properties(${MLAS_SRC_DIR}/power/QuantizePowerVSX.cpp PROPERTIES COMPILE_FLAGS "-mcpu=power9")
+        endif()
+
         check_cxx_compiler_flag("-mcpu=power10" HAS_POWER10)
         if(HAS_POWER10)
           set(CMAKE_REQUIRED_FLAGS "-mcpu=power10")

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -536,6 +536,8 @@ extern "C" {
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelPOWER10;
     MLAS_GEMM_DOUBLE_KERNEL MlasDgemmKernel;
     MLAS_GEMM_DOUBLE_KERNEL MlasDgemmKernelPOWER10;
+    MLAS_QUANTIZE_LINEAR_S8_KERNEL MlasQuantizeLinearS8KernelVSX;
+    MLAS_QUANTIZE_LINEAR_U8_KERNEL MlasQuantizeLinearU8KernelVSX;
 #else
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelZero;
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelAdd;
@@ -851,6 +853,8 @@ struct MLAS_PLATFORM {
 #if defined(MLAS_TARGET_POWER)
     MLAS_GEMM_DOUBLE_KERNEL* GemmDoubleKernel;
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8X8Dispatch;
+    MLAS_QUANTIZE_LINEAR_S8_KERNEL* QuantizeLinearS8Kernel;
+    MLAS_QUANTIZE_LINEAR_U8_KERNEL* QuantizeLinearU8Kernel;
 #endif
 #if defined(MLAS_TARGET_AMD64)
     MLAS_SGEMM_KERNEL_M1_ROUTINE* KernelM1Routine;

--- a/onnxruntime/core/mlas/lib/power/QuantizePower.cpp
+++ b/onnxruntime/core/mlas/lib/power/QuantizePower.cpp
@@ -1,0 +1,126 @@
+#include "mlasi.h"
+#include <altivec.h>
+
+template<typename OutputType>
+void
+MLASCALL
+MlasQuantizeLinearKernel(
+    const float* Input,
+    OutputType* Output,
+    size_t N,
+    float Scale,
+    OutputType ZeroPoint
+    )
+/*++
+
+Routine Description:
+
+    This routine quantizes the input buffer using the supplied quantization
+    parameters.
+
+Arguments:
+
+    Input - Supplies the input buffer.
+
+    Output - Supplies the output buffer.
+
+    N - Supplies the number of elements to process.
+
+    Scale - Supplies the quantization scale.
+
+    ZeroPoint - Supplies the quantization zero point value.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    constexpr int32_t MinimumValue = std::numeric_limits<OutputType>::lowest();
+    constexpr int32_t MaximumValue = std::numeric_limits<OutputType>::max();
+
+    auto ScaleVector = vec_splats(Scale);
+    auto MinimumValueVector = vec_splats(float(MinimumValue));
+    auto MaximumValueVector = vec_splats(float(MaximumValue));
+    auto ZeroPointVector = vec_splats(float(ZeroPoint));
+
+    while (N >= 16) {
+        auto FloatVector0 = vec_xl(0, Input);
+        auto FloatVector1 = vec_xl(0, Input + 4);
+        auto FloatVector2 = vec_xl(0, Input + 8);
+        auto FloatVector3 = vec_xl(0, Input + 12);
+
+        FloatVector0 = vec_div(FloatVector0, ScaleVector);
+        FloatVector1 = vec_div(FloatVector1, ScaleVector);
+        FloatVector2 = vec_div(FloatVector2, ScaleVector);
+        FloatVector3 = vec_div(FloatVector3, ScaleVector);
+
+        FloatVector0 = vec_round(FloatVector0);
+        FloatVector1 = vec_round(FloatVector1);
+        FloatVector2 = vec_round(FloatVector2);
+        FloatVector3 = vec_round(FloatVector3);
+
+        FloatVector0 = vec_add(FloatVector0, ZeroPointVector);
+        FloatVector1 = vec_add(FloatVector1, ZeroPointVector);
+        FloatVector2 = vec_add(FloatVector2, ZeroPointVector);
+        FloatVector3 = vec_add(FloatVector3, ZeroPointVector);
+
+        FloatVector0 = vec_max(FloatVector0, MinimumValueVector);
+        FloatVector1 = vec_max(FloatVector1, MinimumValueVector);
+        FloatVector2 = vec_max(FloatVector2, MinimumValueVector);
+        FloatVector3 = vec_max(FloatVector3, MinimumValueVector);
+
+        FloatVector0 = vec_min(FloatVector0, MaximumValueVector);
+        FloatVector1 = vec_min(FloatVector1, MaximumValueVector);
+        FloatVector2 = vec_min(FloatVector2, MaximumValueVector);
+        FloatVector3 = vec_min(FloatVector3, MaximumValueVector);
+
+        auto IntegerVector0 = vec_signed(FloatVector0);
+        auto IntegerVector1 = vec_signed(FloatVector1);
+        auto IntegerVector2 = vec_signed(FloatVector2);
+        auto IntegerVector3 = vec_signed(FloatVector3);
+
+        auto ShortVector0 = vec_pack(IntegerVector0, IntegerVector1);
+        auto ShortVector1 = vec_pack(IntegerVector2, IntegerVector3);
+        auto CharVector = vec_pack(ShortVector0, ShortVector1);
+        vec_xst(CharVector, 0, (int8_t *) Output);
+
+        Output += 16;
+        Input += 16;
+        N -= 16;
+    }
+
+    for (size_t n = 0; n < N; n++) {
+
+        float FloatValue = std::nearbyintf(Input[n] / Scale) + float(ZeroPoint);
+        FloatValue = std::max(FloatValue, float(MinimumValue));
+        FloatValue = std::min(FloatValue, float(MaximumValue));
+        Output[n] = (OutputType)(int32_t)FloatValue;
+    }
+}
+
+void
+MLASCALL
+MlasQuantizeLinearU8Kernel(
+    const float* Input,
+    uint8_t* Output,
+    size_t N,
+    float Scale,
+    uint8_t ZeroPoint
+    )
+{
+    MlasQuantizeLinearKernel<uint8_t>(Input, Output, N, Scale, ZeroPoint);
+}
+
+void
+MLASCALL
+MlasQuantizeLinearS8Kernel(
+    const float* Input,
+    int8_t* Output,
+    size_t N,
+    float Scale,
+    int8_t ZeroPoint
+    )
+{
+    MlasQuantizeLinearKernel<int8_t>(Input, Output, N, Scale, ZeroPoint);
+}

--- a/onnxruntime/core/mlas/lib/power/QuantizePowerVSX.cpp
+++ b/onnxruntime/core/mlas/lib/power/QuantizePowerVSX.cpp
@@ -1,0 +1,132 @@
+#include "mlasi.h"
+#include <altivec.h>
+
+template <typename OutputType>
+void
+MLASCALL
+MlasQuantizeLinearVSX(
+    const float* Input,
+    OutputType* Output,
+    size_t N,
+    float Scale,
+    OutputType ZeroPoint
+    )
+{
+    // Workaround for bad GCC warning that Scale is set but not used.
+    MLAS_UNREFERENCED_PARAMETER(Scale);
+
+    constexpr int32_t MinimumValue = std::numeric_limits<OutputType>::min();
+    constexpr int32_t MaximumValue = std::numeric_limits<OutputType>::max();
+
+    auto ScaleVector = vec_splats(Scale);
+    auto MinimumValueVector = vec_splats(float(MinimumValue));
+    auto MaximumValueVector = vec_splats(float(MaximumValue));
+    auto ZeroPointVector = vec_splats(float(ZeroPoint));
+
+    while (N >= 16) {
+        auto FloatVector0 = vec_xl(0, Input);
+        auto FloatVector1 = vec_xl(0, Input + 4);
+        auto FloatVector2 = vec_xl(0, Input + 8);
+        auto FloatVector3 = vec_xl(0, Input + 12);
+
+        FloatVector0 = vec_div(FloatVector0, ScaleVector);
+        FloatVector1 = vec_div(FloatVector1, ScaleVector);
+        FloatVector2 = vec_div(FloatVector2, ScaleVector);
+        FloatVector3 = vec_div(FloatVector3, ScaleVector);
+
+        FloatVector0 = vec_round(FloatVector0);
+        FloatVector1 = vec_round(FloatVector1);
+        FloatVector2 = vec_round(FloatVector2);
+        FloatVector3 = vec_round(FloatVector3);
+
+        FloatVector0 = vec_add(FloatVector0, ZeroPointVector);
+        FloatVector1 = vec_add(FloatVector1, ZeroPointVector);
+        FloatVector2 = vec_add(FloatVector2, ZeroPointVector);
+        FloatVector3 = vec_add(FloatVector3, ZeroPointVector);
+
+        FloatVector0 = vec_max(FloatVector0, MinimumValueVector);
+        FloatVector1 = vec_max(FloatVector1, MinimumValueVector);
+        FloatVector2 = vec_max(FloatVector2, MinimumValueVector);
+        FloatVector3 = vec_max(FloatVector3, MinimumValueVector);
+
+        FloatVector0 = vec_min(FloatVector0, MaximumValueVector);
+        FloatVector1 = vec_min(FloatVector1, MaximumValueVector);
+        FloatVector2 = vec_min(FloatVector2, MaximumValueVector);
+        FloatVector3 = vec_min(FloatVector3, MaximumValueVector);
+
+        auto IntegerVector0 = vec_signed(FloatVector0);
+        auto IntegerVector1 = vec_signed(FloatVector1);
+        auto IntegerVector2 = vec_signed(FloatVector2);
+        auto IntegerVector3 = vec_signed(FloatVector3);
+
+        auto ShortVector0 = vec_pack(IntegerVector0, IntegerVector1);
+        auto ShortVector1 = vec_pack(IntegerVector2, IntegerVector3);
+        auto CharVector = vec_pack(ShortVector0, ShortVector1);
+        vec_xst(CharVector, 0, (int8_t *) Output);
+
+        Output += 16;
+        Input += 16;
+        N -= 16;
+    }
+
+    while (N >= 4) {
+        auto FloatVector = vec_xl(0, Input);
+        FloatVector = vec_div(FloatVector, ScaleVector);
+        FloatVector = vec_round(FloatVector);
+        FloatVector = vec_add(FloatVector, ZeroPointVector);
+
+        FloatVector = vec_max(FloatVector, MinimumValueVector);
+        FloatVector = vec_min(FloatVector, MaximumValueVector);
+        auto IntegerVector = vec_signed(FloatVector);
+
+        auto ShortVector = vec_pack(IntegerVector, vec_splats((int32_t) 0));
+        auto CharVector = vec_pack(ShortVector, vec_splats((int16_t) 0));
+        vec_xst_len(CharVector, (int8_t *) Output, N);
+
+        Output += 4;
+        Input += 4;
+        N -= 4;
+    }
+
+    if (N > 0) {
+        auto FloatVector = vec_xl_len( const_cast<float*>(Input), 4*N);
+
+        FloatVector = vec_div(FloatVector, ScaleVector);
+        FloatVector = vec_round(FloatVector);
+        FloatVector = vec_add(FloatVector, ZeroPointVector);
+
+        FloatVector = vec_max(FloatVector, MinimumValueVector);
+        FloatVector = vec_min(FloatVector, MaximumValueVector);
+        auto IntegerVector = vec_signed(FloatVector);
+
+        auto ShortVector = vec_pack(IntegerVector, vec_splats((int32_t) 0));
+        auto CharVector = vec_pack(ShortVector, vec_splats((int16_t) 0));
+        vec_xst_len(CharVector, (int8_t *) Output, N);
+    }
+}
+
+void
+MLASCALL
+MlasQuantizeLinearU8KernelVSX(
+    const float* Input,
+    uint8_t* Output,
+    size_t N,
+    float Scale,
+    uint8_t ZeroPoint
+    )
+{
+    MlasQuantizeLinearVSX<uint8_t>(Input, Output, N, Scale, ZeroPoint);
+}
+
+void
+MLASCALL
+MlasQuantizeLinearS8KernelVSX(
+    const float* Input,
+    int8_t* Output,
+    size_t N,
+    float Scale,
+    int8_t ZeroPoint
+    )
+{
+    MlasQuantizeLinearVSX<int8_t>(Input, Output, N, Scale, ZeroPoint);
+}

--- a/onnxruntime/core/mlas/lib/quantize.cpp
+++ b/onnxruntime/core/mlas/lib/quantize.cpp
@@ -276,6 +276,38 @@ MlasQuantizeLinear<uint8_t>(
 
 #else
 
+#if defined(MLAS_TARGET_POWER)
+
+template<>
+void
+MLASCALL
+MlasQuantizeLinear<int8_t>(
+    const float* Input,
+    int8_t* Output,
+    size_t N,
+    float Scale,
+    int8_t ZeroPoint
+    )
+{
+    GetMlasPlatform().QuantizeLinearS8Kernel(Input, Output, N, Scale, ZeroPoint);
+}
+
+template<>
+void
+MLASCALL
+MlasQuantizeLinear<uint8_t>(
+    const float* Input,
+    uint8_t* Output,
+    size_t N,
+    float Scale,
+    uint8_t ZeroPoint
+    )
+{
+    GetMlasPlatform().QuantizeLinearU8Kernel(Input, Output, N, Scale, ZeroPoint);
+}
+
+#endif
+
 //
 // QuantizeLinear implementation using the C++ runtime.
 //
@@ -327,6 +359,7 @@ Return Value:
     }
 }
 
+#if !defined(MLAS_TARGET_POWER)
 template
 void
 MLASCALL
@@ -348,6 +381,8 @@ MlasQuantizeLinear<uint8_t>(
     float Scale,
     uint8_t ZeroPoint
     );
+#endif
+
 #endif
 
 #if defined(MLAS_SSE2_INTRINSICS)


### PR DESCRIPTION
This optimized code is valid only when -mcpu is set to utilize POWER9 technology or above.
A compatible code for POWER8 was created as well, but it was not tuned for performance.