### PR TITLE
Stop gradient edges for aten::argmax

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
@@ -133,6 +133,7 @@ def adaptive_avg_pool2d_gradient():
          'GI(0)'], {'name': {'value': 'aten::_adaptive_avg_pool2d_backward', 'dtype': 'string'}}),
     ]
 
+CustomGradientRegistry.register_custom_stop_gradient_edges([0], 'com.microsoft', 'ATenOp', 'aten::argmax', '')
 CustomGradientRegistry.register_custom_stop_gradient_edges([0], 'com.microsoft', 'ATenOp', 'aten::multinomial', '')
 
 @register_gradient('com.microsoft', 'ATenOp', 'aten::binary_cross_entropy_with_logits', '')


### PR DESCRIPTION
**Description**: As titled.

**Motivation and Context**
One internal customer has a model which exports to ATen: aten::argmax, and it fails while building gradients. In fact, aten::argmax should have a gradient, so we need stop the gradient edge. After this change, the backward pass works. 

We already have argmax in ortmodule test. Just make sure this change does not break existing tests.