### PR TITLE
Update c-api-cpu.yml: change nuget linux arm64 RID

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -529,7 +529,7 @@ jobs:
       PackageType: 'nuget'
       PackagePath: '$(Build.ArtifactStagingDirectory)'
       PackageName: 'Microsoft.ML.OnnxRuntime.*nupkg'
-      PlatformsSupported: 'win-x64,win-x86,linux-x64,linux-aarch64,osx.10.14-x64'
+      PlatformsSupported: 'win-x64,win-x86,linux-x64,linux-arm64,osx.10.14-x64'
       VerifyNugetSigning: false
 
   - task: PublishPipelineArtifact@0


### PR DESCRIPTION
**Description**: 

Update c-api-cpu.yml: change nuget linux arm64 RID


**Motivation and Context**
- Why is this change required? What problem does it solve?

A follow-up of #10637 #10624



- If it fixes an open issue, please link to the issue here.
