### PR TITLE
Fix Reshape with allowzero=1 and unknown dimension

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
@@ -17,9 +17,6 @@ class ReshapeHelper {
     for (size_t i = 0; i < nDims; ++i) {
       ORT_ENFORCE(requested_shape[i] >= -1, "A dimension cannot be less than -1, got ", requested_shape[i]);
       if (requested_shape[i] == -1) {
-        ORT_ENFORCE(!allow_zero,
-                    "The input tensor cannot be reshaped to the requested shape. Input shape:",
-                    input_shape, ", requested shape:", TensorShape(requested_shape));
         ORT_ENFORCE(unknown_dim == -1, "At most one dimension can be -1.");
         unknown_dim = i;
       } else {

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -101,7 +101,7 @@ TEST(TensorOpTest, Reshape_WithAllowZero) {
            {kNupharExecutionProvider, kTensorrtExecutionProvider});
 }
 
-TEST(TensorOpTest, Reshape_EmptyInputWihtoutAllowZero) {
+TEST(TensorOpTest, Reshape_EmptyInputWithoutAllowZero) {
   OpTester test("Reshape");
 
   test.AddInput<float>("data", {0, 3, 4}, std::vector<float>());
@@ -114,7 +114,7 @@ TEST(TensorOpTest, Reshape_EmptyInputWihtoutAllowZero) {
            {kNupharExecutionProvider, kTensorrtExecutionProvider});
 }
 
-TEST(TensorOpTest, Reshape_EmptyInputWihtAllowZero) {
+TEST(TensorOpTest, Reshape_EmptyInputWithAllowZero) {
   OpTester test("Reshape", 14);
 
   test.AddInput<float>("data", {0, 3, 4}, std::vector<float>());
@@ -125,6 +125,25 @@ TEST(TensorOpTest, Reshape_EmptyInputWihtAllowZero) {
   // TensorRT doesn't support dynamic shape tensor for now
   // Nuphar only supports reshape shape from initializer
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kNupharExecutionProvider, kTensorrtExecutionProvider});
+}
+
+TEST(TensorOpTest, Reshape_UnknownDimWithoutAllowZero) {
+  OpTester test("Reshape");
+
+  test.AddInput<float>("data", {2, 3}, std::vector<float>(6, 1.0f));
+  test.AddInput<int64_t>("shape", {2}, {-1, 6});
+  test.AddOutput<float>("reshaped", {1, 6}, std::vector<float>(6, 1.0f));
+  test.Run();
+}
+
+TEST(TensorOpTest, Reshape_UnknownDimWithAllowZero) {
+  OpTester test("Reshape", 14);
+
+  test.AddInput<float>("data", {2, 3}, std::vector<float>(6, 1.0f));
+  test.AddInput<int64_t>("shape", {2}, {-1, 6});
+  test.AddAttribute<int64_t>("allowzero", 1);
+  test.AddOutput<float>("reshaped", {1, 6}, std::vector<float>(6, 1.0f));
+  test.Run();
 }
 
 TEST(TensorOpTest, ShapeTest2D) {


### PR DESCRIPTION
**Description**: 
Remove check that throws at valid use cases.
The correct check should enforce unknown dimension and `0` does not appear at the same time, when `allowzero=1`. This in fact is already enforced at https://github.com/microsoft/onnxruntime/blob/7660eeef3eff9a58b4d807dd951a34bafcb03ac0/onnxruntime/core/providers/cpu/tensor/reshape_helper.h#L38, since existence of `0` will push `size` to be 0, and be caught by this check.

**Motivation and Context**
Fix #10664 that could cause all pytorch model that has reshape node and unknown dimension to fail in ORT starting from opset 14.
