### PR TITLE
Update unit test GraphConstruction_VerifyNodeAndOpMatch

### DIFF
--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -696,7 +696,8 @@ TEST_F(GraphTest, GraphConstruction_VerifyNodeAndOpMatch) {
   graph.AddNode("node_1", "OpNotExist", "node 1", inputs, outputs);
   auto status = graph.Resolve();
   EXPECT_FALSE(status.IsOK());
-  EXPECT_EQ(0u, status.ErrorMessage().find_first_of("This is an invalid model. No Schema registered for OpNotExist"));
+  size_t pos = status.ErrorMessage().find("This is an invalid model. No Schema registered for OpNotExist");
+  EXPECT_NE(std::string::npos, pos);
 }
 
 TEST_F(GraphTest, GraphConstruction_CheckIsAcyclic) {


### PR DESCRIPTION
**Description**: 

std::find_first_of is not the right function to be used here.
find_first_of  searches through a string for the first character that matches **any element** of a specified string.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
