### PR TITLE
Change C# tests to use C# 5.0

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -4,7 +4,7 @@ REM Licensed under the MIT License.
 @ECHO ON
 SETLOCAL EnableDelayedExpansion
 
-SET TargetFramework=netcoreapp2.1
+SET TargetFramework=netcoreapp5.0
 SET TargetArch=x64
 SET dn="C:\Program Files\dotnet\dotnet"
 SET CurrentOnnxRuntimeVersion=""

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -71,7 +71,7 @@ jobs:
 
   - script: |
      @echo "Running Runtest.bat"
-     test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x64 $(NuGetPackageVersionNumber)
+     test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp5.0 x64 $(NuGetPackageVersionNumber)
     workingDirectory: '$(Build.SourcesDirectory)\csharp'
     displayName: 'Run End to End Test (C#) .Net Core x64'
     env:
@@ -80,7 +80,7 @@ jobs:
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
          @echo "Running Runtest.bat"
-         test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp2.1 x86 $(NuGetPackageVersionNumber)
+         test\Microsoft.ML.OnnxRuntime.EndToEndTests\runtest.bat $(Build.BinariesDirectory)\nuget-artifact netcoreapp5.0 x86 $(NuGetPackageVersionNumber)
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
         displayName: 'Run End to End Test (C#) .Net Core x86'
         env:


### PR DESCRIPTION
**Description**: 

.NET Core 2.1 has reached end of support on August 21, 2021. Use C# 5.0 instead. Our CI build machines do no have C# 6.0 yet. Later I will do it.

**Motivation and Context**
- Why is this change required? What problem does it solve?


- If it fixes an open issue, please link to the issue here.
