### PR TITLE
Add ability to customize ORT_CXX_API_THROW

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -56,8 +56,12 @@ struct Exception : std::exception {
     abort();                                  \
   } while (false)
 #else
+// The #ifndef is for the very special case where the user of this library wants to define their own way of handling errors.
+// NOTE: This header expects control flow to not continue after calling ORT_CXX_API_THROW
+#ifndef ORT_CXX_API_THROW
 #define ORT_CXX_API_THROW(string, code) \
   throw Ort::Exception(string, code)
+#endif
 #endif
 
 // This is used internally by the C++ API. This class holds the global variable that points to the OrtApi, it's in a template so that we can define a global variable in a header and make


### PR DESCRIPTION
**Description**: A user wants to use the C++ wrappers, but must compile with C++ exceptions disabled. This trivial change lets them implement their own custom error handling.

**Motivation and Context**
User's issue:
https://github.com/microsoft/onnxruntime/issues/10564