### PR TITLE
add python binding for RunOptions config entry

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1237,7 +1237,27 @@ RunOptions instance. The individual calls will exit gracefully and return an err
                      R"pbdoc(Choose to run in training or inferencing mode)pbdoc")
 #endif
       .def_readwrite("only_execute_path_to_fetches", &RunOptions::only_execute_path_to_fetches,
-                     R"pbdoc(Only execute the nodes needed by fetch list)pbdoc");
+                     R"pbdoc(Only execute the nodes needed by fetch list)pbdoc")
+      .def(
+          "add_run_config_entry",
+          [](RunOptions* options, const char* config_key, const char* config_value) -> void {
+            //config_key and config_value will be copied
+            const Status status = options->config_options.AddConfigEntry(config_key, config_value);
+            if (!status.IsOK())
+              throw std::runtime_error(status.ErrorMessage());
+          },
+          R"pbdoc(Set a single run configuration entry as a pair of strings.)pbdoc")
+      .def(
+          "get_run_config_entry",
+          [](const RunOptions* options, const char* config_key) -> std::string {
+            const std::string key(config_key);
+            std::string value;
+            if (!options->config_options.TryGetConfigEntry(key, value))
+              throw std::runtime_error("RunOptions does not have configuration with key: " + key);
+
+            return value;
+          },
+          R"pbdoc(Get a single run configuration value using the given configuration key.)pbdoc");
 
   py::class_<ModelMetadata>(m, "ModelMetadata", R"pbdoc(Pre-defined and custom metadata about the model.
 It is usually used to identify the model used to run the prediction and

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1056,6 +1056,29 @@ class TestInferenceSession(unittest.TestCase):
         so2.log_severity_level = 1
         onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so2, providers=onnxrt.get_available_providers())
 
+    def testMemoryArenaShrinkage(self):
+        x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+
+        sess1 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
+        input_name = sess1.get_inputs()[0].name
+
+        # Shrink CPU memory after execution
+        ro1 = onnxrt.RunOptions()
+        ro1.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
+        self.assertEqual(ro1.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0")
+        sess1.run([], {input_name: x}, ro1)
+
+        available_providers = onnxrt.get_available_providers()
+        if 'CUDAExecutionProvider' in available_providers:
+            sess2 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=available_providers)
+            input_name = sess2.get_inputs()[0].name
+
+            # Shrink CPU and GPU memory after execution
+            ro2 = onnxrt.RunOptions()
+            ro2.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0;gpu:0")
+            self.assertEqual(ro2.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0;gpu:0")
+            sess2.run([], {input_name: x}, ro2)
+
     def testCheckAndNormalizeProviderArgs(self):
         from onnxruntime.capi.onnxruntime_inference_collection import check_and_normalize_provider_args
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1057,27 +1057,31 @@ class TestInferenceSession(unittest.TestCase):
         onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so2, providers=onnxrt.get_available_providers())
 
     def testMemoryArenaShrinkage(self):
-        x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+        if platform.architecture()[0] == '32bit':
+            # on x86 builds, the CPU allocator does not use an arena
+            print("Skipping testMemoryArenaShrinkage in 32bit platform.")
+        else:
+            x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
 
-        sess1 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
-        input_name = sess1.get_inputs()[0].name
+            sess1 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=['CPUExecutionProvider'])
+            input_name = sess1.get_inputs()[0].name
 
-        # Shrink CPU memory after execution
-        ro1 = onnxrt.RunOptions()
-        ro1.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
-        self.assertEqual(ro1.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0")
-        sess1.run([], {input_name: x}, ro1)
+            # Shrink CPU memory after execution
+            ro1 = onnxrt.RunOptions()
+            ro1.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
+            self.assertEqual(ro1.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0")
+            sess1.run([], {input_name: x}, ro1)
 
-        available_providers = onnxrt.get_available_providers()
-        if 'CUDAExecutionProvider' in available_providers:
-            sess2 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=available_providers)
-            input_name = sess2.get_inputs()[0].name
+            available_providers = onnxrt.get_available_providers()
+            if 'CUDAExecutionProvider' in available_providers:
+                sess2 = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=available_providers)
+                input_name = sess2.get_inputs()[0].name
 
-            # Shrink CPU and GPU memory after execution
-            ro2 = onnxrt.RunOptions()
-            ro2.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0;gpu:0")
-            self.assertEqual(ro2.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0;gpu:0")
-            sess2.run([], {input_name: x}, ro2)
+                # Shrink CPU and GPU memory after execution
+                ro2 = onnxrt.RunOptions()
+                ro2.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0;gpu:0")
+                self.assertEqual(ro2.get_run_config_entry("memory.enable_memory_arena_shrinkage"), "cpu:0;gpu:0")
+                sess2.run([], {input_name: x}, ro2)
 
     def testCheckAndNormalizeProviderArgs(self):
         from onnxruntime.capi.onnxruntime_inference_collection import check_and_normalize_provider_args


### PR DESCRIPTION
**Description**: Add python binding for `RunOptions.config_options.AddConfigEntry` / `RunOptions.config_options.TryGetConfigEntry`

**Motivation and Context**
- enable memory arena shrinkage from python

