### PR TITLE
Add ability to save calibration augmented models through external data

### DIFF
--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -216,7 +216,13 @@ def quantize_static(model_input,
     model = load_model(Path(model_input), optimize_model, False)
 
     calib_extra_options = {} if 'CalibTensorRangeSymmetric' not in extra_options else {'symmetric': extra_options['CalibTensorRangeSymmetric']} 
-    calibrator = create_calibrator(model, op_types_to_quantize, calibrate_method=calibrate_method, extra_options=calib_extra_options)
+    calibrator = create_calibrator(
+        model,
+        op_types_to_quantize,
+        calibrate_method=calibrate_method,
+        use_external_data_format=use_external_data_format,
+        extra_options=calib_extra_options
+    )
     calibrator.collect_data(calibration_data_reader)
     tensors_range = calibrator.compute_range()
 


### PR DESCRIPTION
This PR aims to provide the ability to quantize models which size exceeds 2Gb.

Currently, the `augment_model` method from `CalibraterBase` and inherited uses `onnx.save(..)` which exports with external data format by default.

This PR exposes:
- `use_external_data_format: bool = False` as constructor parameter for each calibrator implementation and leverages this value within the `augment_model` when saving the ONNX graph.
- `use_externdal_data_format: bool = False` as an additional parameter for the `create_calibrator` method to forward to targeted calibrator constructor accordingly.