### PR TITLE
[Java] Support configuring CUDA and TensorRT execution providers

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -36,6 +36,8 @@ final class OnnxRuntime {
   private static final int ORT_API_VERSION_7 = 7;
   // Post 1.7 builds of the ORT API
   private static final int ORT_API_VERSION_8 = 8;
+  // Post 1.10 builds of the ORT API
+  private static final int ORT_API_VERSION_11 = 11;
 
   /**
    * The name of the system property which when set gives the path on disk where the ONNX Runtime
@@ -136,7 +138,7 @@ final class OnnxRuntime {
 
       load(ONNXRUNTIME_LIBRARY_NAME);
       load(ONNXRUNTIME_JNI_LIBRARY_NAME);
-      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_8);
+      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_11);
       providers = initialiseProviders(ortApiHandle);
       loaded = true;
     } finally {

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -6,110 +6,114 @@ package ai.onnxruntime;
 
 import java.io.IOException;
 
-/**
- * An abstract base class for execution provider options classes.
- */
-// Note this lives in ai.onnxruntime to allow subclasses to access the OnnxRuntime.ortApiHandle package private field.
+/** An abstract base class for execution provider options classes. */
+// Note this lives in ai.onnxruntime to allow subclasses to access the OnnxRuntime.ortApiHandle
+// package private field.
 public abstract class OrtProviderOptions implements AutoCloseable {
-    static {
-        try {
-            OnnxRuntime.init();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to load onnx-runtime library", e);
+  static {
+    try {
+      OnnxRuntime.init();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load onnx-runtime library", e);
+    }
+  }
+
+  protected final long nativeHandle;
+
+  /**
+   * Constructs a OrtProviderOptions wrapped around a native pointer.
+   *
+   * @param nativeHandle The native pointer.
+   */
+  protected OrtProviderOptions(long nativeHandle) {
+    this.nativeHandle = nativeHandle;
+  }
+
+  /**
+   * Allow access to the api handle pointer for subclasses.
+   *
+   * @return The api handle.
+   */
+  protected static long getApiHandle() {
+    return OnnxRuntime.ortApiHandle;
+  }
+
+  /**
+   * Gets the provider enum for this options instance.
+   *
+   * @return The provider enum.
+   */
+  public abstract OrtProvider getProvider();
+
+  @Override
+  public void close() {
+    close(OnnxRuntime.ortApiHandle, nativeHandle);
+  }
+
+  /**
+   * Native close method.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativePointer The native options pointer.
+   */
+  protected abstract void close(long apiHandle, long nativePointer);
+
+  /**
+   * Loads the provider's shared library (if necessary) and calls the create provider function.
+   *
+   * @param provider The OrtProvider for this options.
+   * @param createFunction The create function.
+   * @return The pointer to the native provider options object.
+   * @throws OrtException If either the library load or provider options create call failed.
+   */
+  protected static long loadLibraryAndCreate(
+      OrtProvider provider, OrtProviderSupplier createFunction) throws OrtException {
+    // Shared providers need their libraries loaded before options can be defined.
+    switch (provider) {
+      case CUDA:
+        if (!OnnxRuntime.extractCUDA()) {
+          throw new OrtException(
+              OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
         }
-    }
-
-    protected final long nativeHandle;
-
-    /**
-     * Constructs a OrtProviderOptions wrapped around a native pointer.
-     * @param nativeHandle The native pointer.
-     */
-    protected OrtProviderOptions(long nativeHandle) {
-        this.nativeHandle = nativeHandle;
-    }
-
-    /**
-     * Allow access to the api handle pointer for subclasses.
-     * @return The api handle.
-     */
-    protected static long getApiHandle() {
-        return OnnxRuntime.ortApiHandle;
-    }
-
-    /**
-     * Gets the provider enum for this options instance.
-     * @return The provider enum.
-     */
-    public abstract OrtProvider getProvider();
-
-    @Override
-    public void close() {
-        close(OnnxRuntime.ortApiHandle, nativeHandle);
-    }
-
-    /**
-     * Native close method.
-     * @param apiHandle The api pointer.
-     * @param nativePointer The native options pointer.
-     */
-    protected abstract void close(long apiHandle, long nativePointer);
-
-    /**
-     * Loads the provider's shared library (if necessary) and calls the create provider function.
-     * @param provider The OrtProvider for this options.
-     * @param createFunction The create function.
-     * @return The pointer to the native provider options object.
-     * @throws OrtException If either the library load or provider options create call failed.
-     */
-    protected static long loadLibraryAndCreate(OrtProvider provider, OrtProviderSupplier createFunction) throws OrtException {
-        // Shared providers need their libraries loaded before options can be defined.
-        switch (provider) {
-            case CUDA:
-                if (!OnnxRuntime.extractCUDA()) {
-                    throw new OrtException(
-                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
-                }
-                break;
-            case DNNL:
-                if (!OnnxRuntime.extractDNNL()) {
-                    throw new OrtException(
-                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find DNNL shared provider");
-                }
-                break;
-            case OPEN_VINO:
-                if (!OnnxRuntime.extractOpenVINO()) {
-                    throw new OrtException(
-                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find OpenVINO shared provider");
-                }
-                break;
-            case ROCM:
-                if (!OnnxRuntime.extractROCM()) {
-                    throw new OrtException(
-                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find ROCm shared provider");
-                }
-                break;
-            case TENSOR_RT:
-                if (!OnnxRuntime.extractTensorRT()) {
-                    throw new OrtException(
-                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
-                }
-                break;
+        break;
+      case DNNL:
+        if (!OnnxRuntime.extractDNNL()) {
+          throw new OrtException(
+              OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find DNNL shared provider");
         }
-
-        return createFunction.create();
+        break;
+      case OPEN_VINO:
+        if (!OnnxRuntime.extractOpenVINO()) {
+          throw new OrtException(
+              OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find OpenVINO shared provider");
+        }
+        break;
+      case ROCM:
+        if (!OnnxRuntime.extractROCM()) {
+          throw new OrtException(
+              OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find ROCm shared provider");
+        }
+        break;
+      case TENSOR_RT:
+        if (!OnnxRuntime.extractTensorRT()) {
+          throw new OrtException(
+              OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
+        }
+        break;
     }
 
+    return createFunction.create();
+  }
+
+  /** Functional interface mirroring a Java supplier, but can throw OrtException. */
+  @FunctionalInterface
+  public interface OrtProviderSupplier {
     /**
-     * Functional interface mirroring a Java supplier, but can throw OrtException.
+     * Calls the function to get the native pointer.
+     *
+     * @return The native pointer.
+     * @throws OrtException If the create call failed.
      */
-    @FunctionalInterface
-    public interface OrtProviderSupplier {
-        /**
-         * Calls the function to get the native pointer.
-         * @return The native pointer.
-         * @throws OrtException If the create call failed.
-         */
-        public long create() throws OrtException;
-    }
+    public long create() throws OrtException;
+  }
 }

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime;
+
+/**
+ * An abstract base class for execution provider options classes.
+ */
+// Note this lives in ai.onnxruntime to allow subclasses to access the OnnxRuntime.ortApiHandle package private field.
+public abstract class OrtProviderOptions implements AutoCloseable {
+
+    protected final long nativeHandle;
+
+    /**
+     * Constructs a OrtProviderOptions wrapped around a native pointer.
+     * @param nativeHandle The native pointer.
+     */
+    protected OrtProviderOptions(long nativeHandle) {
+        this.nativeHandle = nativeHandle;
+    }
+
+    /**
+     * Allow access to the api handle pointer for subclasses.
+     * @return The api handle.
+     */
+    protected static long getApiHandle() {
+        return OnnxRuntime.ortApiHandle;
+    }
+
+    @Override
+    public void close() {
+        close(OnnxRuntime.ortApiHandle, nativeHandle);
+    }
+
+    /**
+     * Native close method.
+     * @param apiHandle The api pointer.
+     * @param nativePointer The native options pointer.
+     */
+    protected abstract void close(long apiHandle, long nativePointer);
+}

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -4,11 +4,20 @@
  */
 package ai.onnxruntime;
 
+import java.io.IOException;
+
 /**
  * An abstract base class for execution provider options classes.
  */
 // Note this lives in ai.onnxruntime to allow subclasses to access the OnnxRuntime.ortApiHandle package private field.
 public abstract class OrtProviderOptions implements AutoCloseable {
+    static {
+        try {
+            OnnxRuntime.init();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load onnx-runtime library", e);
+        }
+    }
 
     protected final long nativeHandle;
 
@@ -28,6 +37,12 @@ public abstract class OrtProviderOptions implements AutoCloseable {
         return OnnxRuntime.ortApiHandle;
     }
 
+    /**
+     * Gets the provider enum for this options instance.
+     * @return The provider enum.
+     */
+    public abstract OrtProvider getProvider();
+
     @Override
     public void close() {
         close(OnnxRuntime.ortApiHandle, nativeHandle);
@@ -39,4 +54,62 @@ public abstract class OrtProviderOptions implements AutoCloseable {
      * @param nativePointer The native options pointer.
      */
     protected abstract void close(long apiHandle, long nativePointer);
+
+    /**
+     * Loads the provider's shared library (if necessary) and calls the create provider function.
+     * @param provider The OrtProvider for this options.
+     * @param createFunction The create function.
+     * @return The pointer to the native provider options object.
+     * @throws OrtException If either the library load or provider options create call failed.
+     */
+    protected static long loadLibraryAndCreate(OrtProvider provider, OrtProviderSupplier createFunction) throws OrtException {
+        // Shared providers need their libraries loaded before options can be defined.
+        switch (provider) {
+            case CUDA:
+                if (!OnnxRuntime.extractCUDA()) {
+                    throw new OrtException(
+                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
+                }
+                break;
+            case DNNL:
+                if (!OnnxRuntime.extractDNNL()) {
+                    throw new OrtException(
+                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find DNNL shared provider");
+                }
+                break;
+            case OPEN_VINO:
+                if (!OnnxRuntime.extractOpenVINO()) {
+                    throw new OrtException(
+                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find OpenVINO shared provider");
+                }
+                break;
+            case ROCM:
+                if (!OnnxRuntime.extractROCM()) {
+                    throw new OrtException(
+                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find ROCm shared provider");
+                }
+                break;
+            case TENSOR_RT:
+                if (!OnnxRuntime.extractTensorRT()) {
+                    throw new OrtException(
+                            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
+                }
+                break;
+        }
+
+        return createFunction.create();
+    }
+
+    /**
+     * Functional interface mirroring a Java supplier, but can throw OrtException.
+     */
+    @FunctionalInterface
+    public interface OrtProviderSupplier {
+        /**
+         * Calls the function to get the native pointer.
+         * @return The native pointer.
+         * @throws OrtException If the create call failed.
+         */
+        public long create() throws OrtException;
+    }
 }

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -54,9 +54,9 @@ public abstract class OrtProviderOptions implements AutoCloseable {
    * Native close method.
    *
    * @param apiHandle The api pointer.
-   * @param nativePointer The native options pointer.
+   * @param nativeHandle The native options pointer.
    */
-  protected abstract void close(long apiHandle, long nativePointer);
+  protected abstract void close(long apiHandle, long nativeHandle);
 
   /**
    * Loads the provider's shared library (if necessary) and calls the create provider function.

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
 
 import ai.onnxruntime.providers.CoreMLFlags;
 import ai.onnxruntime.providers.NNAPIFlags;
+import ai.onnxruntime.providers.OrtCUDAProviderOptions;
 import ai.onnxruntime.providers.OrtFlags;
+import ai.onnxruntime.providers.OrtTensorRTProviderOptions;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -771,6 +774,21 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Adds CUDA as an execution backend, using the specified CUDA options.
+     * @param cudaOpts The CUDA execution provider options.
+     * @throws OrtException If there was an error in the native code.
+     */
+    public void addCUDA(OrtCUDAProviderOptions cudaOpts) throws OrtException {
+      checkClosed();
+      if (OnnxRuntime.extractCUDA()) {
+        addCUDAV2(OnnxRuntime.ortApiHandle, nativeHandle, cudaOpts.nativeHandle);
+      } else {
+        throw new OrtException(
+                OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
+      }
+    }
+
+    /**
      * Add ROCM as an execution backend, using device 0.
      *
      * @throws OrtException If there was an error in native code.
@@ -851,6 +869,22 @@ public class OrtSession implements AutoCloseable {
       checkClosed();
       if (OnnxRuntime.extractTensorRT()) {
         addTensorrt(OnnxRuntime.ortApiHandle, nativeHandle, deviceNum);
+      } else {
+        throw new OrtException(
+                OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
+      }
+    }
+
+    /**
+     * Adds Nvidia's TensorRT as an execution backend.
+     *
+     * @param tensorRTOpts The configuration parameters for TensorRT.
+     * @throws OrtException If there was an error in native code.
+     */
+    public void addTensorrt(OrtTensorRTProviderOptions tensorRTOpts) throws OrtException {
+      checkClosed();
+      if (OnnxRuntime.extractTensorRT()) {
+        addTensorrtV2(OnnxRuntime.ortApiHandle, nativeHandle, tensorRTOpts.nativeHandle);
       } else {
         throw new OrtException(
             OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
@@ -1024,6 +1058,9 @@ public class OrtSession implements AutoCloseable {
     private native void addCPU(long apiHandle, long nativeHandle, int useArena) throws OrtException;
 
     private native void addCUDA(long apiHandle, long nativeHandle, int deviceNum)
+            throws OrtException;
+
+    private native void addCUDAV2(long apiHandle, long nativeHandle, long cudaOptsHandle)
         throws OrtException;
 
     private native void addROCM(long apiHandle, long nativeHandle, int deviceNum)
@@ -1036,6 +1073,9 @@ public class OrtSession implements AutoCloseable {
         throws OrtException;
 
     private native void addTensorrt(long apiHandle, long nativeHandle, int deviceNum)
+            throws OrtException;
+
+    private native void addTensorrtV2(long apiHandle, long nativeHandle, long tensorrtOptsHandle)
         throws OrtException;
 
     private native void addNnapi(long apiHandle, long nativeHandle, int nnapiFlags)

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -9,7 +9,6 @@ import ai.onnxruntime.providers.NNAPIFlags;
 import ai.onnxruntime.providers.OrtCUDAProviderOptions;
 import ai.onnxruntime.providers.OrtFlags;
 import ai.onnxruntime.providers.OrtTensorRTProviderOptions;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -775,6 +774,7 @@ public class OrtSession implements AutoCloseable {
 
     /**
      * Adds CUDA as an execution backend, using the specified CUDA options.
+     *
      * @param cudaOpts The CUDA execution provider options.
      * @throws OrtException If there was an error in the native code.
      */
@@ -784,7 +784,7 @@ public class OrtSession implements AutoCloseable {
         addCUDAV2(OnnxRuntime.ortApiHandle, nativeHandle, cudaOpts.nativeHandle);
       } else {
         throw new OrtException(
-                OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
+            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find CUDA shared provider");
       }
     }
 
@@ -871,7 +871,7 @@ public class OrtSession implements AutoCloseable {
         addTensorrt(OnnxRuntime.ortApiHandle, nativeHandle, deviceNum);
       } else {
         throw new OrtException(
-                OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
+            OrtException.OrtErrorCode.ORT_EP_FAIL, "Failed to find TensorRT shared provider");
       }
     }
 
@@ -1058,7 +1058,7 @@ public class OrtSession implements AutoCloseable {
     private native void addCPU(long apiHandle, long nativeHandle, int useArena) throws OrtException;
 
     private native void addCUDA(long apiHandle, long nativeHandle, int deviceNum)
-            throws OrtException;
+        throws OrtException;
 
     private native void addCUDAV2(long apiHandle, long nativeHandle, long cudaOptsHandle)
         throws OrtException;
@@ -1073,7 +1073,7 @@ public class OrtSession implements AutoCloseable {
         throws OrtException;
 
     private native void addTensorrt(long apiHandle, long nativeHandle, int deviceNum)
-            throws OrtException;
+        throws OrtException;
 
     private native void addTensorrtV2(long apiHandle, long nativeHandle, long tensorrtOptsHandle)
         throws OrtException;

--- a/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime.providers;
+
+import ai.onnxruntime.OrtException;
+
+/**
+ * Options for configuring the CUDA execution provider.
+ *
+ * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#configuration-options">ORT website</a>.
+ */
+public final class OrtCUDAProviderOptions extends StringConfigProviderOptions {
+
+    /**
+     * Constructs CUDA execution provider options for device 0.
+     * @throws OrtException If CUDA is unavailable.
+     */
+    public OrtCUDAProviderOptions() throws OrtException {
+        this(0);
+    }
+
+    /**
+     * Constructs CUDA execution provider options for the specified non-negative device id.
+     * @param deviceId The device id.
+     * @throws OrtException If CUDA is unavailable.
+     */
+    public OrtCUDAProviderOptions(int deviceId) throws OrtException {
+        super(create(getApiHandle()));
+        if (deviceId < 0) {
+            close();
+            throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
+        }
+
+        String id = "" + deviceId;
+        this.options.put("device_id",id);
+        add(getApiHandle(),this.nativeHandle,"device_id", id);
+    }
+
+    /**
+     * Creates a native OrtCUDAProviderOptionsV2.
+     * @param apiHandle The ONNX Runtime api handle.
+     * @return A pointer to a new OrtCUDAProviderOptionsV2.
+     * @throws OrtException If the creation failed (usually due to CUDA being unavailable).
+     */
+    private static native long create(long apiHandle) throws OrtException;
+
+    /**
+     * Adds an option to this options instance.
+     * @param apiHandle The api pointer.
+     * @param nativeHandle The native options pointer.
+     * @param key The option key.
+     * @param value The option value.
+     * @throws OrtException If the addition failed.
+     */
+    @Override
+    protected native void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
+
+    /**
+     * Closes this options instance.
+     * @param apiHandle The api pointer.
+     * @param nativeHandle The native options pointer.
+     */
+    @Override
+    protected native void close(long apiHandle, long nativeHandle);
+}

--- a/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
@@ -5,6 +5,7 @@
 package ai.onnxruntime.providers;
 
 import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtProvider;
 
 /**
  * Options for configuring the CUDA execution provider.
@@ -12,6 +13,7 @@ import ai.onnxruntime.OrtException;
  * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#configuration-options">ORT website</a>.
  */
 public final class OrtCUDAProviderOptions extends StringConfigProviderOptions {
+    private static final OrtProvider PROVIDER = OrtProvider.CUDA;
 
     /**
      * Constructs CUDA execution provider options for device 0.
@@ -27,7 +29,7 @@ public final class OrtCUDAProviderOptions extends StringConfigProviderOptions {
      * @throws OrtException If CUDA is unavailable.
      */
     public OrtCUDAProviderOptions(int deviceId) throws OrtException {
-        super(create(getApiHandle()));
+        super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
         if (deviceId < 0) {
             close();
             throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
@@ -36,6 +38,11 @@ public final class OrtCUDAProviderOptions extends StringConfigProviderOptions {
         String id = "" + deviceId;
         this.options.put("device_id",id);
         add(getApiHandle(),this.nativeHandle,"device_id", id);
+    }
+
+    @Override
+    public OrtProvider getProvider() {
+        return PROVIDER;
     }
 
     /**

--- a/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtCUDAProviderOptions.java
@@ -10,65 +10,73 @@ import ai.onnxruntime.OrtProvider;
 /**
  * Options for configuring the CUDA execution provider.
  *
- * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#configuration-options">ORT website</a>.
+ * <p>Supported options are listed on the <a
+ * href="https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#configuration-options">ORT
+ * website</a>.
  */
 public final class OrtCUDAProviderOptions extends StringConfigProviderOptions {
-    private static final OrtProvider PROVIDER = OrtProvider.CUDA;
+  private static final OrtProvider PROVIDER = OrtProvider.CUDA;
 
-    /**
-     * Constructs CUDA execution provider options for device 0.
-     * @throws OrtException If CUDA is unavailable.
-     */
-    public OrtCUDAProviderOptions() throws OrtException {
-        this(0);
+  /**
+   * Constructs CUDA execution provider options for device 0.
+   *
+   * @throws OrtException If CUDA is unavailable.
+   */
+  public OrtCUDAProviderOptions() throws OrtException {
+    this(0);
+  }
+
+  /**
+   * Constructs CUDA execution provider options for the specified non-negative device id.
+   *
+   * @param deviceId The device id.
+   * @throws OrtException If CUDA is unavailable.
+   */
+  public OrtCUDAProviderOptions(int deviceId) throws OrtException {
+    super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
+    if (deviceId < 0) {
+      close();
+      throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
     }
 
-    /**
-     * Constructs CUDA execution provider options for the specified non-negative device id.
-     * @param deviceId The device id.
-     * @throws OrtException If CUDA is unavailable.
-     */
-    public OrtCUDAProviderOptions(int deviceId) throws OrtException {
-        super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
-        if (deviceId < 0) {
-            close();
-            throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
-        }
+    String id = "" + deviceId;
+    this.options.put("device_id", id);
+    add(getApiHandle(), this.nativeHandle, "device_id", id);
+  }
 
-        String id = "" + deviceId;
-        this.options.put("device_id",id);
-        add(getApiHandle(),this.nativeHandle,"device_id", id);
-    }
+  @Override
+  public OrtProvider getProvider() {
+    return PROVIDER;
+  }
 
-    @Override
-    public OrtProvider getProvider() {
-        return PROVIDER;
-    }
+  /**
+   * Creates a native OrtCUDAProviderOptionsV2.
+   *
+   * @param apiHandle The ONNX Runtime api handle.
+   * @return A pointer to a new OrtCUDAProviderOptionsV2.
+   * @throws OrtException If the creation failed (usually due to CUDA being unavailable).
+   */
+  private static native long create(long apiHandle) throws OrtException;
 
-    /**
-     * Creates a native OrtCUDAProviderOptionsV2.
-     * @param apiHandle The ONNX Runtime api handle.
-     * @return A pointer to a new OrtCUDAProviderOptionsV2.
-     * @throws OrtException If the creation failed (usually due to CUDA being unavailable).
-     */
-    private static native long create(long apiHandle) throws OrtException;
+  /**
+   * Adds an option to this options instance.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativeHandle The native options pointer.
+   * @param key The option key.
+   * @param value The option value.
+   * @throws OrtException If the addition failed.
+   */
+  @Override
+  protected native void add(long apiHandle, long nativeHandle, String key, String value)
+      throws OrtException;
 
-    /**
-     * Adds an option to this options instance.
-     * @param apiHandle The api pointer.
-     * @param nativeHandle The native options pointer.
-     * @param key The option key.
-     * @param value The option value.
-     * @throws OrtException If the addition failed.
-     */
-    @Override
-    protected native void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
-
-    /**
-     * Closes this options instance.
-     * @param apiHandle The api pointer.
-     * @param nativeHandle The native options pointer.
-     */
-    @Override
-    protected native void close(long apiHandle, long nativeHandle);
+  /**
+   * Closes this options instance.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativeHandle The native options pointer.
+   */
+  @Override
+  protected native void close(long apiHandle, long nativeHandle);
 }

--- a/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
@@ -5,6 +5,7 @@
 package ai.onnxruntime.providers;
 
 import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtProvider;
 
 /**
  * Options for configuring the TensorRT execution provider.
@@ -12,6 +13,7 @@ import ai.onnxruntime.OrtException;
  * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options">ORT website</a>.
  */
 public final class OrtTensorRTProviderOptions extends StringConfigProviderOptions {
+    private static final OrtProvider PROVIDER = OrtProvider.TENSOR_RT;
 
     /**
      * Constructs TensorRT execution provider options for device 0.
@@ -27,7 +29,7 @@ public final class OrtTensorRTProviderOptions extends StringConfigProviderOption
      * @throws OrtException If TensorRT is unavailable.
      */
     public OrtTensorRTProviderOptions(int deviceId) throws OrtException {
-        super(create(getApiHandle()));
+        super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
         if (deviceId < 0) {
             close();
             throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
@@ -36,6 +38,11 @@ public final class OrtTensorRTProviderOptions extends StringConfigProviderOption
         String id = "" + deviceId;
         this.options.put("device_id",id);
         add(getApiHandle(),this.nativeHandle,"device_id", id);
+    }
+
+    @Override
+    public OrtProvider getProvider() {
+        return PROVIDER;
     }
 
     /**

--- a/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
@@ -10,65 +10,73 @@ import ai.onnxruntime.OrtProvider;
 /**
  * Options for configuring the TensorRT execution provider.
  *
- * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options">ORT website</a>.
+ * <p>Supported options are listed on the <a
+ * href="https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options">ORT
+ * website</a>.
  */
 public final class OrtTensorRTProviderOptions extends StringConfigProviderOptions {
-    private static final OrtProvider PROVIDER = OrtProvider.TENSOR_RT;
+  private static final OrtProvider PROVIDER = OrtProvider.TENSOR_RT;
 
-    /**
-     * Constructs TensorRT execution provider options for device 0.
-     * @throws OrtException If TensorRT is unavailable.
-     */
-    public OrtTensorRTProviderOptions() throws OrtException {
-        this(0);
+  /**
+   * Constructs TensorRT execution provider options for device 0.
+   *
+   * @throws OrtException If TensorRT is unavailable.
+   */
+  public OrtTensorRTProviderOptions() throws OrtException {
+    this(0);
+  }
+
+  /**
+   * Constructs TensorRT execution provider options for the specified non-negative device id.
+   *
+   * @param deviceId The device id.
+   * @throws OrtException If TensorRT is unavailable.
+   */
+  public OrtTensorRTProviderOptions(int deviceId) throws OrtException {
+    super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
+    if (deviceId < 0) {
+      close();
+      throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
     }
 
-    /**
-     * Constructs TensorRT execution provider options for the specified non-negative device id.
-     * @param deviceId The device id.
-     * @throws OrtException If TensorRT is unavailable.
-     */
-    public OrtTensorRTProviderOptions(int deviceId) throws OrtException {
-        super(loadLibraryAndCreate(PROVIDER, () -> create(getApiHandle())));
-        if (deviceId < 0) {
-            close();
-            throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
-        }
+    String id = "" + deviceId;
+    this.options.put("device_id", id);
+    add(getApiHandle(), this.nativeHandle, "device_id", id);
+  }
 
-        String id = "" + deviceId;
-        this.options.put("device_id",id);
-        add(getApiHandle(),this.nativeHandle,"device_id", id);
-    }
+  @Override
+  public OrtProvider getProvider() {
+    return PROVIDER;
+  }
 
-    @Override
-    public OrtProvider getProvider() {
-        return PROVIDER;
-    }
+  /**
+   * Creates a native OrtTensorRTProviderOptionsV2.
+   *
+   * @param apiHandle The ONNX Runtime api handle.
+   * @return A pointer to a new OrtTensorRTProviderOptionsV2.
+   * @throws OrtException If the creation failed (usually due to TensorRT being unavailable).
+   */
+  private static native long create(long apiHandle) throws OrtException;
 
-    /**
-     * Creates a native OrtTensorRTProviderOptionsV2.
-     * @param apiHandle The ONNX Runtime api handle.
-     * @return A pointer to a new OrtTensorRTProviderOptionsV2.
-     * @throws OrtException If the creation failed (usually due to TensorRT being unavailable).
-     */
-    private static native long create(long apiHandle) throws OrtException;
+  /**
+   * Adds an option to this options instance.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativeHandle The native options pointer.
+   * @param key The option key.
+   * @param value The option value.
+   * @throws OrtException If the addition failed.
+   */
+  @Override
+  protected native void add(long apiHandle, long nativeHandle, String key, String value)
+      throws OrtException;
 
-    /**
-     * Adds an option to this options instance.
-     * @param apiHandle The api pointer.
-     * @param nativeHandle The native options pointer.
-     * @param key The option key.
-     * @param value The option value.
-     * @throws OrtException If the addition failed.
-     */
-    @Override
-    protected native void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
-
-    /**
-     * Closes this options instance.
-     * @param apiHandle The api pointer.
-     * @param nativeHandle The native options pointer.
-     */
-    @Override
-    protected native void close(long apiHandle, long nativeHandle);
+  /**
+   * Closes this options instance.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativeHandle The native options pointer.
+   */
+  @Override
+  protected native void close(long apiHandle, long nativeHandle);
 }

--- a/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/OrtTensorRTProviderOptions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime.providers;
+
+import ai.onnxruntime.OrtException;
+
+/**
+ * Options for configuring the TensorRT execution provider.
+ *
+ * <p> Supported options are listed on the <a href="https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options">ORT website</a>.
+ */
+public final class OrtTensorRTProviderOptions extends StringConfigProviderOptions {
+
+    /**
+     * Constructs TensorRT execution provider options for device 0.
+     * @throws OrtException If TensorRT is unavailable.
+     */
+    public OrtTensorRTProviderOptions() throws OrtException {
+        this(0);
+    }
+
+    /**
+     * Constructs TensorRT execution provider options for the specified non-negative device id.
+     * @param deviceId The device id.
+     * @throws OrtException If TensorRT is unavailable.
+     */
+    public OrtTensorRTProviderOptions(int deviceId) throws OrtException {
+        super(create(getApiHandle()));
+        if (deviceId < 0) {
+            close();
+            throw new IllegalArgumentException("Device id must be non-negative, received " + deviceId);
+        }
+
+        String id = "" + deviceId;
+        this.options.put("device_id",id);
+        add(getApiHandle(),this.nativeHandle,"device_id", id);
+    }
+
+    /**
+     * Creates a native OrtTensorRTProviderOptionsV2.
+     * @param apiHandle The ONNX Runtime api handle.
+     * @return A pointer to a new OrtTensorRTProviderOptionsV2.
+     * @throws OrtException If the creation failed (usually due to TensorRT being unavailable).
+     */
+    private static native long create(long apiHandle) throws OrtException;
+
+    /**
+     * Adds an option to this options instance.
+     * @param apiHandle The api pointer.
+     * @param nativeHandle The native options pointer.
+     * @param key The option key.
+     * @param value The option value.
+     * @throws OrtException If the addition failed.
+     */
+    @Override
+    protected native void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
+
+    /**
+     * Closes this options instance.
+     * @param apiHandle The api pointer.
+     * @param nativeHandle The native options pointer.
+     */
+    @Override
+    protected native void close(long apiHandle, long nativeHandle);
+}

--- a/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime.providers;
+
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtProviderOptions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract base class for provider options which are configured solely by key value string pairs.
+ */
+abstract class StringConfigProviderOptions extends OrtProviderOptions {
+    protected final Map<String, String> options;
+
+    protected StringConfigProviderOptions(long nativeHandle) {
+        super(nativeHandle);
+        // LinkedHashMap to ensure iteration order matches insertion order for the native object.
+        this.options = new LinkedHashMap<>();
+    }
+
+    /**
+     * Adds a configuration option to this options.
+     *
+     * @param key   The key.
+     * @param value The value.
+     * @throws OrtException If the addition failed.
+     */
+    public void add(String key, String value) throws OrtException {
+        Objects.requireNonNull(key, "Key must not be null");
+        Objects.requireNonNull(value, "Value must not be null");
+        options.put(key, value);
+        add(getApiHandle(), nativeHandle, key, value);
+    }
+
+    /**
+     * Parses the output of {@link #getOptionsString()} and adds those options
+     * to this options instance.
+     * @param serializedForm The serialized form to parse.
+     * @throws OrtException If the option could not be added.
+     */
+    public void parseOptionsString(String serializedForm) throws OrtException {
+        String[] options = serializedForm.split(";");
+        for (String o : options) {
+            if (!o.isEmpty() && o.contains("=")) {
+                String[] curOption = o.split("=");
+                if ((curOption.length == 2) && !curOption[0].isEmpty() && !curOption[1].isEmpty()) {
+                    add(curOption[0],curOption[1]);
+                } else {
+                    throw new IllegalArgumentException("Failed to parse option from string '" + o + "'");
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "(" + getOptionsString() + ")";
+    }
+
+    /**
+     * Returns the serialized options string
+     *
+     * @return The serialized options string.
+     */
+    public String getOptionsString() {
+        return options.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(";", "", ";"));
+    }
+
+    /**
+     * Adds an option to this options instance.
+     * @param apiHandle The api pointer.
+     * @param nativeHandle The native options pointer.
+     * @param key The option key.
+     * @param value The option value.
+     * @throws OrtException If the addition failed.
+     */
+    protected abstract void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
+}

--- a/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
@@ -6,7 +6,6 @@ package ai.onnxruntime.providers;
 
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtProviderOptions;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -16,69 +15,74 @@ import java.util.stream.Collectors;
  * Abstract base class for provider options which are configured solely by key value string pairs.
  */
 abstract class StringConfigProviderOptions extends OrtProviderOptions {
-    protected final Map<String, String> options;
+  protected final Map<String, String> options;
 
-    protected StringConfigProviderOptions(long nativeHandle) {
-        super(nativeHandle);
-        // LinkedHashMap to ensure iteration order matches insertion order for the native object.
-        this.options = new LinkedHashMap<>();
-    }
+  protected StringConfigProviderOptions(long nativeHandle) {
+    super(nativeHandle);
+    // LinkedHashMap to ensure iteration order matches insertion order for the native object.
+    this.options = new LinkedHashMap<>();
+  }
 
-    /**
-     * Adds a configuration option to this options.
-     *
-     * @param key   The key.
-     * @param value The value.
-     * @throws OrtException If the addition failed.
-     */
-    public void add(String key, String value) throws OrtException {
-        Objects.requireNonNull(key, "Key must not be null");
-        Objects.requireNonNull(value, "Value must not be null");
-        options.put(key, value);
-        add(getApiHandle(), nativeHandle, key, value);
-    }
+  /**
+   * Adds a configuration option to this options.
+   *
+   * @param key The key.
+   * @param value The value.
+   * @throws OrtException If the addition failed.
+   */
+  public void add(String key, String value) throws OrtException {
+    Objects.requireNonNull(key, "Key must not be null");
+    Objects.requireNonNull(value, "Value must not be null");
+    options.put(key, value);
+    add(getApiHandle(), nativeHandle, key, value);
+  }
 
-    /**
-     * Parses the output of {@link #getOptionsString()} and adds those options
-     * to this options instance.
-     * @param serializedForm The serialized form to parse.
-     * @throws OrtException If the option could not be added.
-     */
-    public void parseOptionsString(String serializedForm) throws OrtException {
-        String[] options = serializedForm.split(";");
-        for (String o : options) {
-            if (!o.isEmpty() && o.contains("=")) {
-                String[] curOption = o.split("=");
-                if ((curOption.length == 2) && !curOption[0].isEmpty() && !curOption[1].isEmpty()) {
-                    add(curOption[0],curOption[1]);
-                } else {
-                    throw new IllegalArgumentException("Failed to parse option from string '" + o + "'");
-                }
-            }
+  /**
+   * Parses the output of {@link #getOptionsString()} and adds those options to this options
+   * instance.
+   *
+   * @param serializedForm The serialized form to parse.
+   * @throws OrtException If the option could not be added.
+   */
+  public void parseOptionsString(String serializedForm) throws OrtException {
+    String[] options = serializedForm.split(";");
+    for (String o : options) {
+      if (!o.isEmpty() && o.contains("=")) {
+        String[] curOption = o.split("=");
+        if ((curOption.length == 2) && !curOption[0].isEmpty() && !curOption[1].isEmpty()) {
+          add(curOption[0], curOption[1]);
+        } else {
+          throw new IllegalArgumentException("Failed to parse option from string '" + o + "'");
         }
+      }
     }
+  }
 
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName() + "(" + getOptionsString() + ")";
-    }
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + "(" + getOptionsString() + ")";
+  }
 
-    /**
-     * Returns the serialized options string
-     *
-     * @return The serialized options string.
-     */
-    public String getOptionsString() {
-        return options.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(";", "", ";"));
-    }
+  /**
+   * Returns the serialized options string
+   *
+   * @return The serialized options string.
+   */
+  public String getOptionsString() {
+    return options.entrySet().stream()
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining(";", "", ";"));
+  }
 
-    /**
-     * Adds an option to this options instance.
-     * @param apiHandle The api pointer.
-     * @param nativeHandle The native options pointer.
-     * @param key The option key.
-     * @param value The option value.
-     * @throws OrtException If the addition failed.
-     */
-    protected abstract void add(long apiHandle, long nativeHandle, String key, String value) throws OrtException;
+  /**
+   * Adds an option to this options instance.
+   *
+   * @param apiHandle The api pointer.
+   * @param nativeHandle The native options pointer.
+   * @param key The option key.
+   * @param value The option value.
+   * @throws OrtException If the addition failed.
+   */
+  protected abstract void add(long apiHandle, long nativeHandle, String key, String value)
+      throws OrtException;
 }

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -382,6 +382,22 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addCUD
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    addCUDAV2
+ * Signature: (JJJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addCUDAV2
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
+    (void)jobj;
+  #ifdef USE_CUDA
+    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SesssionOptionsAppendExecutionProvider_CUDA_V2((OrtSessionOptions*) handle, (const OrtCUDAProviderOptionsV2*) optsHandle));
+  #else
+    (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when CUDA is defined.
+    throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with CUDA support.");
+  #endif
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    addDnnl
  * Signature: (JJI)V
  */
@@ -426,6 +442,22 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addTen
     checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,OrtSessionOptionsAppendExecutionProvider_Tensorrt((OrtSessionOptions*) handle, deviceNum));
   #else
     (void)apiHandle;(void)handle;(void)deviceNum; // Parameters used when TensorRT is defined.
+    throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with TensorRT support.");
+  #endif
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    addTensorrtV2
+ * Signature: (JJJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addTensorrtV2
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
+    (void)jobj;
+  #ifdef USE_TENSORRT
+    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SesssionOptionsAppendExecutionProvider_TensorRT_V2((OrtSessionOptions*) handle, (const OrtTensorRTProviderOptionsV2*) optsHandle));
+  #else
+    (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when TensorRT is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with TensorRT support.");
   #endif
 }

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -389,7 +389,8 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addCUD
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
     (void)jobj;
   #ifdef USE_CUDA
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SessionOptionsAppendExecutionProvider_CUDA_V2((OrtSessionOptions*) handle, (const OrtCUDAProviderOptionsV2*) optsHandle));
+    const OrtApi* api = (OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SessionOptionsAppendExecutionProvider_CUDA_V2((OrtSessionOptions*) handle, (const OrtCUDAProviderOptionsV2*) optsHandle));
   #else
     (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when CUDA is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with CUDA support.");
@@ -455,7 +456,8 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addTen
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
     (void)jobj;
   #ifdef USE_TENSORRT
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SessionOptionsAppendExecutionProvider_TensorRT_V2((OrtSessionOptions*) handle, (const OrtTensorRTProviderOptionsV2*) optsHandle));
+    const OrtApi* api = (OrtApi*) apiHandle;
+    checkOrtStatus(jniEnv,api,api->SessionOptionsAppendExecutionProvider_TensorRT_V2((OrtSessionOptions*) handle, (const OrtTensorRTProviderOptionsV2*) optsHandle));
   #else
     (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when TensorRT is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with TensorRT support.");

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -389,7 +389,7 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addCUD
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
     (void)jobj;
   #ifdef USE_CUDA
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SesssionOptionsAppendExecutionProvider_CUDA_V2((OrtSessionOptions*) handle, (const OrtCUDAProviderOptionsV2*) optsHandle));
+    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SessionOptionsAppendExecutionProvider_CUDA_V2((OrtSessionOptions*) handle, (const OrtCUDAProviderOptionsV2*) optsHandle));
   #else
     (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when CUDA is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with CUDA support.");
@@ -455,7 +455,7 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addTen
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
     (void)jobj;
   #ifdef USE_TENSORRT
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SesssionOptionsAppendExecutionProvider_TensorRT_V2((OrtSessionOptions*) handle, (const OrtTensorRTProviderOptionsV2*) optsHandle));
+    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,SessionOptionsAppendExecutionProvider_TensorRT_V2((OrtSessionOptions*) handle, (const OrtTensorRTProviderOptionsV2*) optsHandle));
   #else
     (void)apiHandle;(void)handle;(void)optsHandle; // Parameters used when TensorRT is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with TensorRT support.");

--- a/java/src/main/native/ai_onnxruntime_providers_OrtCUDAProviderOptions.c
+++ b/java/src/main/native/ai_onnxruntime_providers_OrtCUDAProviderOptions.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include <jni.h>
+#include <string.h>
+#include "onnxruntime/core/session/onnxruntime_c_api.h"
+#include "OrtJniUtil.h"
+#include "ai_onnxruntime_providers_OrtCUDAProviderOptions.h"
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtCUDAProviderOptions
+ * Method:    create
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_providers_OrtCUDAProviderOptions_create
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    OrtCUDAProviderOptionsV2* opts;
+    checkOrtStatus(jniEnv,api,api->CreateCUDAProviderOptions(&opts));
+    return (jlong) opts;
+}
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtCUDAProviderOptions
+ * Method:    add
+ * Signature: (JJLjava/lang/String;Ljava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_providers_OrtCUDAProviderOptions_add
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring key, jstring value) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtCUDAProviderOptionsV2* opts = (OrtCUDAProviderOptionsV2*) optionsHandle;
+  const char* keyStr = (*jniEnv)->GetStringUTFChars(jniEnv, key, NULL);
+  const char* valueStr = (*jniEnv)->GetStringUTFChars(jniEnv, value, NULL);
+  checkOrtStatus(jniEnv,api,api->UpdateCUDAProviderOptions(opts, &keyStr, &valueStr, 1));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,key,keyStr);
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,value,valueStr);
+}
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtCUDAProviderOptions
+ * Method:    close
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_providers_OrtCUDAProviderOptions_close
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void)jniEnv; (void)jobj;  // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  api->ReleaseCUDAProviderOptions((OrtCUDAProviderOptionsV2*)handle);
+}

--- a/java/src/main/native/ai_onnxruntime_providers_OrtTensorRTProviderOptions.c
+++ b/java/src/main/native/ai_onnxruntime_providers_OrtTensorRTProviderOptions.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include <jni.h>
+#include "onnxruntime/core/session/onnxruntime_c_api.h"
+#include "OrtJniUtil.h"
+#include "ai_onnxruntime_providers_OrtTensorRTProviderOptions.h"
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtTensorRTProviderOptions
+ * Method:    create
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_providers_OrtTensorRTProviderOptions_create
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle) {
+    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    const OrtApi* api = (const OrtApi*) apiHandle;
+    OrtTensorRTProviderOptionsV2* opts;
+    checkOrtStatus(jniEnv,api,api->CreateTensorRTProviderOptions(&opts));
+    return (jlong) opts;
+}
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtTensorRTProviderOptions
+ * Method:    add
+ * Signature: (JJLjava/lang/String;Ljava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_providers_OrtTensorRTProviderOptions_add
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring key, jstring value) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtTensorRTProviderOptionsV2* opts = (OrtTensorRTProviderOptionsV2*) optionsHandle;
+  const char* keyStr = (*jniEnv)->GetStringUTFChars(jniEnv, key, NULL);
+  const char* valueStr = (*jniEnv)->GetStringUTFChars(jniEnv, value, NULL);
+  checkOrtStatus(jniEnv,api,api->UpdateTensorRTProviderOptions(opts, &keyStr, &valueStr, 1));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,key,keyStr);
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,value,valueStr);
+}
+
+/*
+ * Class:     ai_onnxruntime_providers_OrtTensorRTProviderOptions
+ * Method:    close
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_providers_OrtTensorRTProviderOptions_close
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void)jniEnv; (void)jobj;  // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  api->ReleaseTensorRTProviderOptions((OrtTensorRTProviderOptionsV2*)handle);
+}

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -1455,7 +1455,7 @@ public class InferenceTest {
   }
 
   /** Carrier tuple for the squeeze net model. */
-  private static class SqueezeNetTuple {
+  public static class SqueezeNetTuple {
     public final OrtSession session;
     public final float[] inputData;
     public final float[] outputData;

--- a/java/src/test/java/ai/onnxruntime/TestHelpers.java
+++ b/java/src/test/java/ai/onnxruntime/TestHelpers.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Assertions;
 
 /** Test helpers for manipulating primitive arrays. */
-class TestHelpers {
+public class TestHelpers {
 
   private static final Pattern LOAD_PATTERN = Pattern.compile("[,\\[\\] ]");
 
@@ -136,7 +136,7 @@ class TestHelpers {
     return toPrimitiveLong(output);
   }
 
-  static float[] flattenFloat(Object o) {
+  public static float[] flattenFloat(Object o) {
     List<Float> output = new ArrayList<>();
 
     flatten((Object[]) o, output, float.class);
@@ -250,15 +250,15 @@ class TestHelpers {
     output.addAll(Arrays.asList(input));
   }
 
-  static Path getResourcePath(String path) {
+  public static Path getResourcePath(String path) {
     return new File(InferenceTest.class.getResource(path).getFile()).toPath();
   }
 
-  static float[] loadTensorFromFile(Path filename) {
+  public static float[] loadTensorFromFile(Path filename) {
     return loadTensorFromFile(filename, true);
   }
 
-  static float[] loadTensorFromFile(Path filename, boolean skipHeader) {
+  public static float[] loadTensorFromFile(Path filename, boolean skipHeader) {
     // read data from file
     try (BufferedReader reader = new BufferedReader(new FileReader(filename.toFile()))) {
       if (skipHeader) {

--- a/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
+++ b/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
@@ -50,8 +50,7 @@ public class ProviderOptionsTest {
         OrtException.class, () -> invalidKeyOpts.add("not_a_real_provider_option", "not a number"));
     // Test invalid value throws
     OrtCUDAProviderOptions invalidValueOpts = new OrtCUDAProviderOptions(0);
-    assertThrows(
-        OrtException.class, () -> invalidValueOpts.add("gpu_mem_limit", "not a number"));
+    assertThrows(OrtException.class, () -> invalidValueOpts.add("gpu_mem_limit", "not a number"));
   }
 
   @Test

--- a/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
+++ b/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
@@ -4,6 +4,13 @@
  */
 package ai.onnxruntime.providers;
 
+import static ai.onnxruntime.TestHelpers.getResourcePath;
+import static ai.onnxruntime.TestHelpers.loadTensorFromFile;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import ai.onnxruntime.InferenceTest;
 import ai.onnxruntime.NodeInfo;
 import ai.onnxruntime.OnnxTensor;
@@ -15,102 +22,96 @@ import ai.onnxruntime.OrtSession;
 import ai.onnxruntime.OrtUtil;
 import ai.onnxruntime.TensorInfo;
 import ai.onnxruntime.TestHelpers;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-
-import static ai.onnxruntime.TestHelpers.getResourcePath;
-import static ai.onnxruntime.TestHelpers.loadTensorFromFile;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 public class ProviderOptionsTest {
 
-    @Test
-    @EnabledIfSystemProperty(named = "USE_CUDA", matches = "1")
-    public void testCUDAOptions() throws OrtException {
-        // Test standard options
-        OrtCUDAProviderOptions cudaOpts = new OrtCUDAProviderOptions(0);
-        cudaOpts.add("gpu_mem_limit",""+ (512*1024*1024));
-        OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
-        sessionOpts.addCUDA(cudaOpts);
-        runProvider(OrtProvider.CUDA, sessionOpts);
+  @Test
+  @EnabledIfSystemProperty(named = "USE_CUDA", matches = "1")
+  public void testCUDAOptions() throws OrtException {
+    // Test standard options
+    OrtCUDAProviderOptions cudaOpts = new OrtCUDAProviderOptions(0);
+    cudaOpts.add("gpu_mem_limit", "" + (512 * 1024 * 1024));
+    OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
+    sessionOpts.addCUDA(cudaOpts);
+    runProvider(OrtProvider.CUDA, sessionOpts);
 
-        // Test invalid device num throws
-        assertThrows(OrtException.class, () -> new OrtCUDAProviderOptions(-1));
+    // Test invalid device num throws
+    assertThrows(OrtException.class, () -> new OrtCUDAProviderOptions(-1));
 
-        // Test invalid key name throws
-        OrtCUDAProviderOptions invalidOpts = new OrtCUDAProviderOptions(0);
-        assertThrows(OrtException.class, () -> invalidOpts.add("not_a_real_provider_option","not a number"));
+    // Test invalid key name throws
+    OrtCUDAProviderOptions invalidOpts = new OrtCUDAProviderOptions(0);
+    assertThrows(
+        OrtException.class, () -> invalidOpts.add("not_a_real_provider_option", "not a number"));
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "USE_TENSORRT", matches = "1")
+  public void testTensorRT() throws OrtException {
+    // Test standard options
+    OrtTensorRTProviderOptions cudaOpts = new OrtTensorRTProviderOptions(0);
+    cudaOpts.add("trt_max_workspace_size", "" + (512 * 1024 * 1024));
+    OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
+    sessionOpts.addTensorrt(cudaOpts);
+    runProvider(OrtProvider.TENSOR_RT, sessionOpts);
+
+    // Test invalid device num throws
+    assertThrows(OrtException.class, () -> new OrtTensorRTProviderOptions(-1));
+
+    // Test invalid key name throws
+    OrtTensorRTProviderOptions invalidOpts = new OrtTensorRTProviderOptions(0);
+    assertThrows(
+        OrtException.class, () -> invalidOpts.add("not_a_real_provider_option", "not a number"));
+  }
+
+  private void runProvider(OrtProvider provider, OrtSession.SessionOptions options)
+      throws OrtException {
+    EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
+    assertTrue(providers.size() > 1);
+    assertTrue(providers.contains(OrtProvider.CPU));
+    assertTrue(providers.contains(provider));
+    InferenceTest.SqueezeNetTuple tuple = openSessionSqueezeNet(options);
+    try (OrtEnvironment env = tuple.env;
+        OrtSession session = tuple.session) {
+      float[] inputData = tuple.inputData;
+      float[] expectedOutput = tuple.outputData;
+      NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+      Map<String, OnnxTensor> container = new HashMap<>();
+      long[] inputShape = ((TensorInfo) inputMeta.getInfo()).getShape();
+      Object tensor = OrtUtil.reshape(inputData, inputShape);
+      container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
+      try (OrtSession.Result result = session.run(container)) {
+        OnnxValue resultTensor = result.get(0);
+        float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
+        assertEquals(expectedOutput.length, resultArray.length);
+        assertArrayEquals(expectedOutput, resultArray, 1e-6f);
+      } catch (OrtException e) {
+        throw new IllegalStateException("Failed to execute a scoring operation", e);
+      }
+      OnnxValue.close(container.values());
     }
+  }
 
-    @Test
-    @EnabledIfSystemProperty(named = "USE_TENSORRT", matches = "1")
-    public void testTensorRT() throws OrtException {
-        // Test standard options
-        OrtTensorRTProviderOptions cudaOpts = new OrtTensorRTProviderOptions(0);
-        cudaOpts.add("trt_max_workspace_size",""+ (512*1024*1024));
-        OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
-        sessionOpts.addTensorrt(cudaOpts);
-        runProvider(OrtProvider.TENSOR_RT, sessionOpts);
-
-        // Test invalid device num throws
-        assertThrows(OrtException.class, () -> new OrtTensorRTProviderOptions(-1));
-
-        // Test invalid key name throws
-        OrtTensorRTProviderOptions invalidOpts = new OrtTensorRTProviderOptions(0);
-        assertThrows(OrtException.class, () -> invalidOpts.add("not_a_real_provider_option","not a number"));
-    }
-
-    private void runProvider(OrtProvider provider, OrtSession.SessionOptions options) throws OrtException {
-        EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
-        assertTrue(providers.size() > 1);
-        assertTrue(providers.contains(OrtProvider.CPU));
-        assertTrue(providers.contains(provider));
-        InferenceTest.SqueezeNetTuple tuple = openSessionSqueezeNet(options);
-        try (OrtEnvironment env = tuple.env;
-             OrtSession session = tuple.session) {
-            float[] inputData = tuple.inputData;
-            float[] expectedOutput = tuple.outputData;
-            NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
-            Map<String, OnnxTensor> container = new HashMap<>();
-            long[] inputShape = ((TensorInfo) inputMeta.getInfo()).getShape();
-            Object tensor = OrtUtil.reshape(inputData, inputShape);
-            container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
-            try (OrtSession.Result result = session.run(container)) {
-                OnnxValue resultTensor = result.get(0);
-                float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
-                assertEquals(expectedOutput.length, resultArray.length);
-                assertArrayEquals(expectedOutput, resultArray, 1e-6f);
-            } catch (OrtException e) {
-                throw new IllegalStateException("Failed to execute a scoring operation", e);
-            }
-            OnnxValue.close(container.values());
-        }
-    }
-
-    /**
-     * Loads the squeezenet model into a session using the supplied session options.
-     *
-     * @param options The session options.
-     * @return The squeezenet session, input and output.
-     * @throws OrtException If the native code failed.
-     */
-    private static InferenceTest.SqueezeNetTuple openSessionSqueezeNet(OrtSession.SessionOptions options)
-            throws OrtException {
-        Path squeezeNet = getResourcePath("/squeezenet.onnx");
-        String modelPath = squeezeNet.toString();
-        OrtEnvironment env = OrtEnvironment.getEnvironment();
-        OrtSession session = env.createSession(modelPath, options);
-        float[] inputData = loadTensorFromFile(getResourcePath("/bench.in"));
-        float[] expectedOutput = loadTensorFromFile(getResourcePath("/bench.expected_out"));
-        return new InferenceTest.SqueezeNetTuple(env, session, inputData, expectedOutput);
-    }
-
+  /**
+   * Loads the squeezenet model into a session using the supplied session options.
+   *
+   * @param options The session options.
+   * @return The squeezenet session, input and output.
+   * @throws OrtException If the native code failed.
+   */
+  private static InferenceTest.SqueezeNetTuple openSessionSqueezeNet(
+      OrtSession.SessionOptions options) throws OrtException {
+    Path squeezeNet = getResourcePath("/squeezenet.onnx");
+    String modelPath = squeezeNet.toString();
+    OrtEnvironment env = OrtEnvironment.getEnvironment();
+    OrtSession session = env.createSession(modelPath, options);
+    float[] inputData = loadTensorFromFile(getResourcePath("/bench.in"));
+    float[] expectedOutput = loadTensorFromFile(getResourcePath("/bench.expected_out"));
+    return new InferenceTest.SqueezeNetTuple(env, session, inputData, expectedOutput);
+  }
 }

--- a/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
+++ b/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Licensed under the MIT License.
+ */
+package ai.onnxruntime.providers;
+
+import ai.onnxruntime.InferenceTest;
+import ai.onnxruntime.NodeInfo;
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OnnxValue;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtProvider;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtUtil;
+import ai.onnxruntime.TensorInfo;
+import ai.onnxruntime.TestHelpers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import static ai.onnxruntime.TestHelpers.getResourcePath;
+import static ai.onnxruntime.TestHelpers.loadTensorFromFile;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProviderOptionsTest {
+
+    @Test
+    @EnabledIfSystemProperty(named = "USE_CUDA", matches = "1")
+    public void testCUDAOptions() throws OrtException {
+        // Test standard options
+        OrtCUDAProviderOptions cudaOpts = new OrtCUDAProviderOptions(0);
+        cudaOpts.add("gpu_mem_limit",""+ (512*1024*1024));
+        OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
+        sessionOpts.addCUDA(cudaOpts);
+        runProvider(OrtProvider.CUDA, sessionOpts);
+
+        // Test invalid device num throws
+        assertThrows(OrtException.class, () -> new OrtCUDAProviderOptions(-1));
+
+        // Test invalid key name throws
+        OrtCUDAProviderOptions invalidOpts = new OrtCUDAProviderOptions(0);
+        assertThrows(OrtException.class, () -> invalidOpts.add("not_a_real_provider_option","not a number"));
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "USE_TENSORRT", matches = "1")
+    public void testTensorRT() throws OrtException {
+        // Test standard options
+        OrtTensorRTProviderOptions cudaOpts = new OrtTensorRTProviderOptions(0);
+        cudaOpts.add("trt_max_workspace_size",""+ (512*1024*1024));
+        OrtSession.SessionOptions sessionOpts = new OrtSession.SessionOptions();
+        sessionOpts.addTensorrt(cudaOpts);
+        runProvider(OrtProvider.TENSOR_RT, sessionOpts);
+
+        // Test invalid device num throws
+        assertThrows(OrtException.class, () -> new OrtTensorRTProviderOptions(-1));
+
+        // Test invalid key name throws
+        OrtTensorRTProviderOptions invalidOpts = new OrtTensorRTProviderOptions(0);
+        assertThrows(OrtException.class, () -> invalidOpts.add("not_a_real_provider_option","not a number"));
+    }
+
+    private void runProvider(OrtProvider provider, OrtSession.SessionOptions options) throws OrtException {
+        EnumSet<OrtProvider> providers = OrtEnvironment.getAvailableProviders();
+        assertTrue(providers.size() > 1);
+        assertTrue(providers.contains(OrtProvider.CPU));
+        assertTrue(providers.contains(provider));
+        InferenceTest.SqueezeNetTuple tuple = openSessionSqueezeNet(options);
+        try (OrtEnvironment env = tuple.env;
+             OrtSession session = tuple.session) {
+            float[] inputData = tuple.inputData;
+            float[] expectedOutput = tuple.outputData;
+            NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+            Map<String, OnnxTensor> container = new HashMap<>();
+            long[] inputShape = ((TensorInfo) inputMeta.getInfo()).getShape();
+            Object tensor = OrtUtil.reshape(inputData, inputShape);
+            container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
+            try (OrtSession.Result result = session.run(container)) {
+                OnnxValue resultTensor = result.get(0);
+                float[] resultArray = TestHelpers.flattenFloat(resultTensor.getValue());
+                assertEquals(expectedOutput.length, resultArray.length);
+                assertArrayEquals(expectedOutput, resultArray, 1e-6f);
+            } catch (OrtException e) {
+                throw new IllegalStateException("Failed to execute a scoring operation", e);
+            }
+            OnnxValue.close(container.values());
+        }
+    }
+
+    /**
+     * Loads the squeezenet model into a session using the supplied session options.
+     *
+     * @param options The session options.
+     * @return The squeezenet session, input and output.
+     * @throws OrtException If the native code failed.
+     */
+    private static InferenceTest.SqueezeNetTuple openSessionSqueezeNet(OrtSession.SessionOptions options)
+            throws OrtException {
+        Path squeezeNet = getResourcePath("/squeezenet.onnx");
+        String modelPath = squeezeNet.toString();
+        OrtEnvironment env = OrtEnvironment.getEnvironment();
+        OrtSession session = env.createSession(modelPath, options);
+        float[] inputData = loadTensorFromFile(getResourcePath("/bench.in"));
+        float[] expectedOutput = loadTensorFromFile(getResourcePath("/bench.expected_out"));
+        return new InferenceTest.SqueezeNetTuple(env, session, inputData, expectedOutput);
+    }
+
+}

--- a/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
+++ b/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
@@ -42,12 +42,16 @@ public class ProviderOptionsTest {
     runProvider(OrtProvider.CUDA, sessionOpts);
 
     // Test invalid device num throws
-    assertThrows(OrtException.class, () -> new OrtCUDAProviderOptions(-1));
+    assertThrows(IllegalArgumentException.class, () -> new OrtCUDAProviderOptions(-1));
 
     // Test invalid key name throws
-    OrtCUDAProviderOptions invalidOpts = new OrtCUDAProviderOptions(0);
+    OrtCUDAProviderOptions invalidKeyOpts = new OrtCUDAProviderOptions(0);
     assertThrows(
-        OrtException.class, () -> invalidOpts.add("not_a_real_provider_option", "not a number"));
+        OrtException.class, () -> invalidKeyOpts.add("not_a_real_provider_option", "not a number"));
+    // Test invalid value throws
+    OrtCUDAProviderOptions invalidValueOpts = new OrtCUDAProviderOptions(0);
+    assertThrows(
+        OrtException.class, () -> invalidValueOpts.add("gpu_mem_limit", "not a number"));
   }
 
   @Test
@@ -61,12 +65,16 @@ public class ProviderOptionsTest {
     runProvider(OrtProvider.TENSOR_RT, sessionOpts);
 
     // Test invalid device num throws
-    assertThrows(OrtException.class, () -> new OrtTensorRTProviderOptions(-1));
+    assertThrows(IllegalArgumentException.class, () -> new OrtTensorRTProviderOptions(-1));
 
     // Test invalid key name throws
-    OrtTensorRTProviderOptions invalidOpts = new OrtTensorRTProviderOptions(0);
+    OrtTensorRTProviderOptions invalidKeyOpts = new OrtTensorRTProviderOptions(0);
     assertThrows(
-        OrtException.class, () -> invalidOpts.add("not_a_real_provider_option", "not a number"));
+        OrtException.class, () -> invalidKeyOpts.add("not_a_real_provider_option", "not a number"));
+    // Test invalid value throws
+    OrtTensorRTProviderOptions invalidValueOpts = new OrtTensorRTProviderOptions(0);
+    assertThrows(
+        OrtException.class, () -> invalidValueOpts.add("trt_max_workspace_size", "not a number"));
   }
 
   private static void runProvider(OrtProvider provider, OrtSession.SessionOptions options)

--- a/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
+++ b/java/src/test/java/ai/onnxruntime/providers/ProviderOptionsTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.onnxruntime.InferenceTest;
 import ai.onnxruntime.NodeInfo;
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OnnxValue;
@@ -82,7 +83,7 @@ public class ProviderOptionsTest {
     assertTrue(providers.size() > 1);
     assertTrue(providers.contains(OrtProvider.CPU));
     assertTrue(providers.contains(provider));
-    SqueezeNetTuple tuple = openSessionSqueezeNet(options);
+    InferenceTest.SqueezeNetTuple tuple = openSessionSqueezeNet(options);
     try (OrtSession session = tuple.session) {
       float[] inputData = tuple.inputData;
       float[] expectedOutput = tuple.outputData;
@@ -110,26 +111,13 @@ public class ProviderOptionsTest {
    * @return The squeezenet session, input and output.
    * @throws OrtException If the native code failed.
    */
-  private static SqueezeNetTuple openSessionSqueezeNet(OrtSession.SessionOptions options)
-      throws OrtException {
+  private static InferenceTest.SqueezeNetTuple openSessionSqueezeNet(
+      OrtSession.SessionOptions options) throws OrtException {
     Path squeezeNet = getResourcePath("/squeezenet.onnx");
     String modelPath = squeezeNet.toString();
     OrtSession session = env.createSession(modelPath, options);
     float[] inputData = loadTensorFromFile(getResourcePath("/bench.in"));
     float[] expectedOutput = loadTensorFromFile(getResourcePath("/bench.expected_out"));
-    return new SqueezeNetTuple(session, inputData, expectedOutput);
-  }
-
-  /** Carrier tuple for the squeeze net model. */
-  public static class SqueezeNetTuple {
-    public final OrtSession session;
-    public final float[] inputData;
-    public final float[] outputData;
-
-    public SqueezeNetTuple(OrtSession session, float[] inputData, float[] outputData) {
-      this.session = session;
-      this.inputData = inputData;
-      this.outputData = outputData;
-    }
+    return new InferenceTest.SqueezeNetTuple(session, inputData, expectedOutput);
   }
 }


### PR DESCRIPTION
**Description**:
Adds support for configuring the CUDA and TensorRT execution providers using the new V2 options classes.

There are two abstract classes, `OrtProviderOptions` which provides the basic functionality for accessing the package private pointers used to call native methods, and `StringConfigProviderOptions` which provides specific functionality for working on the V2 style string configured options classes. `OrtProviderOptions` can be used as the basis for other non-string configured provider options classes, though I've not added implementations for any of those yet. The new provider options classes live in `ai.onnxruntime.providers` along with the previously defined `NNAPIFlags` and `CoreMLFlags`.

It may not apply cleanly over the top of some of the other PRs I have out, so I'll rebase it as those are merged if necessary.

**Motivation and Context**
- Why is this change required? What problem does it solve? Adds support for configuring Nvidia GPU based providers.
