### PR TITLE
Enable Pytorch exporter 's Aten fallback by default

### DIFF
--- a/orttraining/orttraining/test/python/_test_helpers.py
+++ b/orttraining/orttraining/test/python/_test_helpers.py
@@ -444,3 +444,16 @@ def run_evaluate_test_on_device_and_compare(
         val_list_a = [o.detach().cpu() for o in outputs if o is not None]
         val_list_b = [o.detach().cpu() for o in outputs_ort if o is not None]
         compare_tensor_list(val_list_a, val_list_b)
+
+
+def assert_aten_op(onnx_model, operator, overload_name=""):
+    all_aten_nodes = [p for p in onnx_model.graph.node if p.op_type == "ATen" and p.domain == "org.pytorch.aten"]
+    assert len(all_aten_nodes) > 0
+
+    for op in all_aten_nodes:
+        attrs = {attr.name: attr.s.decode() for attr in op.attribute}
+        if attrs.get("operator") == operator:
+            break
+
+    assert attrs["operator"] == operator
+    assert attrs.get("overload_name", "") == overload_name

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
@@ -580,6 +580,9 @@ def test_ortmodule_fallback_onnx_model__missing_op(is_training, fallback_enabled
     pt_model = CrossModule()
     ort_model = ORTModule(copy.deepcopy(pt_model))
     ort_model.train(is_training)
+    ort_model._torch_module._execution_manager(is_training)._export_extra_kwargs = {
+        "operator_export_type": torch.onnx.OperatorExportTypes.ONNX  # disable aten fallback
+    }
     pt_model.train(is_training)
 
     for i in range(3):


### PR DESCRIPTION
This PR enables ONNX ATen fallback feature by default

When this feature is enabled, ATen operators are used when the user model has torch operators that are currently not supported by ONNX spec or maybe because its implementation has bugs/limitations.

ATen operators will be emitted by `torch.onnx.export` when one of the following conditions are met during ONNX export::

* When an ATen operator symbolic is not registered/implemented by PyTorch ONNX exporter
* When an existing symbolic implementation raises `RuntimeError` during its execution, usually because its implementation cannot cover all input combination
* When an existing symbolic implementation explicitly creates an ATen operator through the use of `g.at()` API (usually when `operator_export_type` is either `ONNX_ATEN` or `ONNX_ATEN_FALLBACK`)

It is important to note that the `torch.onnx.export` only creates "forward" ATen operators. `ORTModule` must have the gradients operators for each ATen operator used by the model manually registered as shown at https://github.com/microsoft/onnxruntime/blob/master/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py#L85-L94. 