### PR TITLE
Add int32_t as supported input to Clip opset 12

### DIFF
--- a/onnxruntime/core/providers/cpu/math/clip.cc
+++ b/onnxruntime/core/providers/cpu/math/clip.cc
@@ -23,7 +23,7 @@ ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES(
     float);
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES(
     kCpuExecutionProvider, kOnnxDomain, Clip, 12, Input, 0,
-    float, double, int8_t, uint8_t, int64_t, uint64_t);
+    float, double, int8_t, uint8_t, int32_t, int64_t, uint64_t);
 }  // namespace op_kernel_type_control
 
 using Clip11Types = ORT_OP_KERNEL_ARG_DEFAULT_TYPE_LIST(

--- a/onnxruntime/core/providers/cuda/math/clip.cc
+++ b/onnxruntime/core/providers/cuda/math/clip.cc
@@ -33,7 +33,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     12, 12,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", BuildKernelDefConstraints<float, double, MLFloat16, int8_t, uint8_t, int64_t, uint64_t>()),
+        .TypeConstraint("T", BuildKernelDefConstraints<float, double, MLFloat16, int8_t, uint8_t, int32_t, int64_t, uint64_t>()),
     Clip);
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -125,4 +125,3 @@ Status Clip::ComputeInternal(OpKernelContext* ctx) const {
 
 }  // namespace cuda
 }  // namespace onnxruntime
-


### PR DESCRIPTION
Needed by https://github.com/pytorch/pytorch/pull/72401
Descried as supported by ONNX spec https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Clip-12
