### PR TITLE
Fix CUDA 10.2 compile error due to inlined_containers.h inclusion

### DIFF
--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -10,8 +10,8 @@
 #include <gsl/gsl>
 #include "onnxruntime_config.h"
 
-// I have to bring it here because including inline_containers.h
-// causes CUDA 10.2 compilers to fail
+// Need to include abseil inlined_vector.h header directly here
+// as hash tables cause CUDA 10.2 compilers to fail. inlined_vector.h is fine.
 #ifdef _MSC_VER
 #pragma warning(push)
 // C4127: conditional expression is constant

--- a/include/onnxruntime/core/graph/graph_nodes.h
+++ b/include/onnxruntime/core/graph/graph_nodes.h
@@ -77,8 +77,6 @@ class ValidNodes {
 
   bool empty() const noexcept { return nodes_->empty(); }
 
-  size_t size() const noexcept { return nodes_->size(); }
-
   /**
   @class NodeIterator
   Iterator to provide const and non-const access to valid Node instances in a Graph.

--- a/onnxruntime/contrib_ops/cpu/unique.cc
+++ b/onnxruntime/contrib_ops/cpu/unique.cc
@@ -46,7 +46,8 @@ Status Unique<float>::Compute(OpKernelContext* ctx) const {
   // XXX: Refactoring for less memory allocations. unordered_map
   // used originally for float uniqueness, is this correct?
   using IndexingMap = InlinedHashMap<float, ElementData>;
-  IndexingMap mapped_indices(num_elements);
+  IndexingMap mapped_indices;
+  mapped_indices.reserve(num_elements);
 
   // processing
   for (int64_t i = 0; i < num_elements; ++i) {

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -500,7 +500,8 @@ class PlannerImpl {
     // Note: for every ml-value, its definition must appear before all its uses in a topological sort of a valid model
     using GraphInputsSet = InlinedHashSet<std::string_view>;
     const auto& graph_inputs_nodes = graph_viewer_.GetInputsIncludingInitializers();
-    GraphInputsSet graph_inputs(graph_inputs_nodes.size());
+    GraphInputsSet graph_inputs;
+    graph_inputs.reserve(graph_inputs_nodes.size());
     for (auto& graph_input : graph_inputs_nodes) {
       graph_inputs.insert(graph_input->Name());
     }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -859,7 +859,7 @@ void SessionState::UpdateToBeExecutedNodes(gsl::span<int const> fetch_mlvalue_id
   InlinedVector<const Node*> nodes;
   nodes.reserve(fetch_mlvalue_idxs.size());
   InlinedHashSet<NodeIndex> reachable_nodes;
-  reachable_nodes.reserve(graph_.Nodes().size());
+  reachable_nodes.reserve(graph_.NumberOfNodes());
 
   for (auto idx : fetch_mlvalue_idxs) {
     std::string node_arg_name;

--- a/onnxruntime/core/providers/cpu/tensor/slice_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_helper.h
@@ -33,7 +33,8 @@ inline Status PrepareForComputeHelper(const gsl::span<const int64_t>& raw_starts
   // Iterate through the provided axes and override the start/end ranges
   using AxesSet = InlinedHashSet<int64_t>;
   const auto axes_count = axes.size();
-  AxesSet unique_axes(axes_count);
+  AxesSet unique_axes;
+  unique_axes.reserve(axes_count);
 
   const auto dimension_count = compute_metadata.input_dimensions_.size();
   for (size_t axis_index = 0; axis_index < axes_count; ++axis_index) {
@@ -91,7 +92,8 @@ inline Status PrepareForComputeHelper(const gsl::span<const int64_t>& raw_starts
   // Iterate through the provided axes and override the start/end/steps ranges
   using AxesSet = InlinedHashSet<int64_t>;
   const auto axes_count = axes.size();
-  AxesSet unique_axes(axes_count);
+  AxesSet unique_axes;
+  unique_axes.reserve(axes_count);
 
   const auto dimension_count = compute_metadata.input_dimensions_.size();
   for (size_t axis_index = 0; axis_index < axes_count; ++axis_index) {

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -5,7 +5,6 @@
 
 #include <unordered_set>
 #include "core/framework/allocator.h"
-#include "core/common/inlined_containers.h"
 #include "core/platform/ort_mutex.h"
 
 namespace onnxruntime {
@@ -48,7 +47,7 @@ class CUDAExternalAllocator : public CUDAAllocator {
   ExternalAlloc alloc_;
   ExternalFree free_;
   ExternalEmptyCache empty_cache_;
-  InlinedHashSet<void*> reserved_;
+  std::unordered_set<void*> reserved_;
 };
 
 //TODO: add a default constructor


### PR DESCRIPTION
**Description**: 
Fix CUDA 10.2 compile error due to inlined_containers.h inclusion into a common CUDA header.
 Use NumberOfNodes() to reserve space in a hash table
 Prefer separate call to reserve() rather than passing in the
 hash table constructor. They have somewhat different meaning.

**Motivation and Context**
Python packaging pipeline builds on CUDA 10.2 and orttraining files include common cuda headers.