### PR TITLE
Fix compile error of calling a __host__ func of std::numeric_limits<T>::lowest in cuda kernel

### DIFF
--- a/onnxruntime/contrib_ops/cuda/transformers/beam_search_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/beam_search_impl.cu
@@ -4,6 +4,7 @@
 #include "beam_search_impl.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/cu_inc/common.cuh"
+#include "cub/util_type.cuh"
 
 namespace onnxruntime {
 namespace contrib {
@@ -109,27 +110,27 @@ __global__ void LogitsProcessKernel(
       }
 
       if (found) {
-        next_token_scores[index] = std::numeric_limits<T>::lowest();
+        next_token_scores[index] = cub::FpLimits<T>::Lowest();
         return;
       }
     }
 
     // VocabMaskLogitsProcessor
     if (vocab_mask != nullptr && vocab_mask[word_id] == 0) {
-      next_token_scores[index] = std::numeric_limits<T>::lowest();
+      next_token_scores[index] = cub::FpLimits<T>::Lowest();
       return;
     }
 
     // PrefixVocabMaskLogitsProcessor
     int batch_id = batch_beam_index / num_beams;
     if (prefix_vocab_mask != nullptr && prefix_vocab_mask[batch_id * vocab_size + word_id] == 0) {
-      next_token_scores[index] = std::numeric_limits<T>::lowest();
+      next_token_scores[index] = cub::FpLimits<T>::Lowest();
       return;
     }
 
     // MinLengthLogitsProcessor
     if (word_id == demote_token_id) {
-      next_token_scores[index] = std::numeric_limits<T>::lowest();
+      next_token_scores[index] = cub::FpLimits<T>::Lowest();
     }
   }
 }


### PR DESCRIPTION
**Description**: 

Fix build error in Windows GPU(cuda10.2) Validation Pipeline: `calling a __host__ function("std::numeric_limits<    ::__half> ::lowest") from a __global__ function`.

Here we replace std::numeric_limits<T> with cub::FpLimits<T> to avoid the error.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
