### PR TITLE
Print tensor snippet in dumping node Inputs/Outputs to StdOut

### DIFF
--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -53,6 +53,13 @@ constexpr const char* kSqliteDbPrefix = "ORT_DEBUG_NODE_IO_SQLITE_DB_PREFIX";
 // set to non-zero to confirm that dumping data files for all nodes is acceptable
 constexpr const char* kDumpingDataToFilesForAllNodesIsOk =
     "ORT_DEBUG_NODE_IO_DUMPING_DATA_TO_FILES_FOR_ALL_NODES_IS_OK";
+
+// Total number of elements which trigger snippet rather than full dump (default 200). Value 0 disables snippet.
+constexpr const char* kSnippetThreshold = "ORT_DEBUG_NODE_IO_SNIPPET_THRESHOLD";
+// Number of array items in snippet at beginning and end of each dimension (default 3)
+constexpr const char* kSnippetEdgeItems = "ORT_DEBUG_NODE_IO_SNIPPET_EDGE_ITEMS";
+
+
 }  // namespace debug_node_inputs_outputs_env_vars
 
 constexpr char kFilterPatternDelimiter = ';';
@@ -102,6 +109,12 @@ struct NodeDumpOptions {
   Path output_dir;
   // the sqlite3 db to append dumped data
   Path sqlite_db_prefix;
+
+  // Total number of elements which trigger snippet rather than full array for Stdout. Value 0 disables snippet.
+  int snippet_threshold;
+
+  // Number of array items in snippet at beginning and end of each dimension for Stdout.
+  int snippet_edge_items;
 };
 
 struct NodeDumpContext {

--- a/onnxruntime/core/framework/print_tensor_utils.h
+++ b/onnxruntime/core/framework/print_tensor_utils.h
@@ -30,7 +30,7 @@ constexpr int64_t kDefaultSnippetThreshold = 200;
   }
 
 template <typename T>
-void PrintValue(const T& value) {
+inline void PrintValue(const T& value) {
   if (std::is_floating_point<T>::value)
     std::cout << std::setprecision(8) << value;
   else
@@ -38,23 +38,23 @@ void PrintValue(const T& value) {
 }
 
 // Explicit specialization
-template <> void PrintValue(const MLFloat16& value) {
-     std::cout << std::setprecision(8) << value.ToFloat();
+template <> inline void PrintValue(const MLFloat16& value) {
+  std::cout << std::setprecision(8) << value.ToFloat();
 }
 
-template <> void PrintValue(const BFloat16& value) {
-     std::cout << std::setprecision(8) << value.ToFloat();
+template <> inline void PrintValue(const BFloat16& value) {
+  std::cout << std::setprecision(8) << value.ToFloat();
 }
 
-template <> void PrintValue(const uint8_t value) {
+template <> inline void PrintValue(const uint8_t& value) {
   std::cout << static_cast<uint32_t>(value);
 }
 
-template <> void PrintValue(const int8_t value) {
+template <> inline void PrintValue(const int8_t& value) {
   std::cout << static_cast<int32_t>(value);
 }
 
-// Print 2D tensor snippet
+// Print snippet of 2D tensor with shape (dim0, dim1)
 template <typename T>
 void PrintCpuTensorSnippet(const T* tensor, int64_t dim0, int64_t dim1, int64_t edge_items) {
   for (int64_t i = 0; i < dim0; i++) {
@@ -70,7 +70,7 @@ void PrintCpuTensorSnippet(const T* tensor, int64_t dim0, int64_t dim1, int64_t 
   std::cout << std::endl;
 }
 
-// Print 3D tensor
+// Print snippet of 3D tensor with shape (dim0, dim1, dim2)
 template <typename T>
 void PrintCpuTensorSnippet(const T* tensor, int64_t dim0, int64_t dim1, int64_t dim2, int64_t edge_items) {
   for (int64_t i = 0; i < dim0; i++) {
@@ -78,7 +78,7 @@ void PrintCpuTensorSnippet(const T* tensor, int64_t dim0, int64_t dim1, int64_t 
     for (int64_t j = 0; j < dim1; j++) {
       SKIP_NON_EDGE_ITEMS(dim1, j, edge_items);
       PrintValue(tensor[i * dim1 * dim2 + j * dim2]);
-      for (int64_t k = 0; k < dim2; k++) {
+      for (int64_t k = 1; k < dim2; k++) {
         SKIP_NON_EDGE_ITEMS_LAST_DIM(dim2, k, edge_items);
         std::cout << ", ";
         PrintValue(tensor[i * dim1 * dim2 + j * dim2 + k]);
@@ -110,7 +110,7 @@ void PrintCpuTensorFull(const T* tensor, int64_t dim0, int64_t dim1, int64_t dim
   for (int64_t i = 0; i < dim0; i++) {
     for (int64_t j = 0; j < dim1; j++) {
       PrintValue(tensor[i * dim1 * dim2 + j * dim2]);
-      for (int64_t k = 0; k < dim2; k++) {
+      for (int64_t k = 1; k < dim2; k++) {
         std::cout << ", ";
         PrintValue(tensor[i * dim1 * dim2 + j * dim2 + k]);
       }

--- a/onnxruntime/core/framework/print_tensor_utils.h
+++ b/onnxruntime/core/framework/print_tensor_utils.h
@@ -37,9 +37,21 @@ void PrintValue(const T& value) {
     std::cout << value;
 }
 
-// Explicit specialization for half
+// Explicit specialization
 template <> void PrintValue(const MLFloat16& value) {
-     std::cout << std::setprecision(8) << (float)value;
+     std::cout << std::setprecision(8) << value.ToFloat();
+}
+
+template <> void PrintValue(const BFloat16& value) {
+     std::cout << std::setprecision(8) << value.ToFloat();
+}
+
+template <> void PrintValue(const uint8_t value) {
+  std::cout << static_cast<uint32_t>(value);
+}
+
+template <> void PrintValue(const int8_t value) {
+  std::cout << static_cast<int32_t>(value);
 }
 
 // Print 2D tensor snippet


### PR DESCRIPTION
**Description**: 

Enable print tensor snippet during dumping node input or output tensors. When a tensor with number of elements no larger than a threshold (default 200), we will print the whole tensor. Otherwise, we only print a few (default 3) edge items per dimension as snippet.

There are two environment variables for controlling the threshold and edge items:
- ORT_DEBUG_NODE_IO_SNIPPET_THRESHOLD
- ORT_DEBUG_NODE_IO_SNIPPET_EDGE_ITEMS

To disable snippet, set ORT_DEBUG_NODE_IO_SNIPPET_THRESHOLD=0, and the whole tensor will be printed.

Also update the layout so that 3D tensor could be printed nicely.  For tensor with >3 dimension, it will be printed with 3D tensor layout. For example,  a tensor with shape (2,12,2,9,64) will be printed like a tensor with shape (48, 9, 64). Previously, it was printed with 2D layout (2, 13824), which is hard to read by human.

Examples:
----
1D Tensor
```
 Shape: {768}
-0.038146973, 0.025604248, -0.2010498, ... , -0.17407227, -0.053100586, -0.30200195
```

2D Tensor
```
 Shape: {3072,768}
0.052642822, 0.20373535, -0.22802734, ... , 0.028518677, 0.062103271, 0.085388184
0.16540527, -0.20373535, 0.016159058, ... , -0.090209961, -0.027709961, -0.16320801
0.13525391, 0.112854, -0.035430908, ... , 0.06463623, 0.064880371, -0.15466309
...
0.40429688, 0.21777344, -0.13928223, ... , 0.17248535, 0.0065040588, 0.10302734
0.053283691, 0.096252441, -0.48144531, ... , -0.0038356781, -0.10522461, 0.11853027
0.17956543, -0.12902832, 0.13916016, ... , 0.044036865, 0.24621582, -0.16870117
```

3D Tensor (Note that there is a blank line after snippet of each 6x768):
```
 Shape: {12,6,768}
0.84521484, -0.16259766, 0.41430664, ... , 0.00045776367, 0.15258789, 0.27905273
1.0732422, -0.19897461, 0.31323242, ... , -9.1552734e-05, 0.15063477, 0.29199219
0.12023926, -0.4309082, 0.80615234, ... , 0.040344238, 0.006942749, 0.040039062
0.51220703, -0.12585449, 0.32324219, ... , 0.20556641, -0.017211914, 0.22216797
-0.3972168, -0.001953125, 0.45581055, ... , 0.13574219, -0.0048522949, -0.017837524
-1.484375, 0.50390625, 0.24597168, ... , 0.15490723, -0.072998047, 0.25878906

0.84521484, -0.16259766, 0.41430664, ... , 0.00045776367, 0.15258789, 0.27905273
1.0732422, -0.19897461, 0.31323242, ... , -9.1552734e-05, 0.15063477, 0.29199219
0.12023926, -0.4309082, 0.80615234, ... , 0.040344238, 0.006942749, 0.040039062
0.51220703, -0.12585449, 0.32324219, ... , 0.20556641, -0.017211914, 0.22216797
-0.3972168, -0.001953125, 0.45581055, ... , 0.13574219, -0.0048522949, -0.017837524
-1.484375, 0.50390625, 0.24597168, ... , 0.15490723, -0.072998047, 0.25878906

0.84521484, -0.16259766, 0.41430664, ... , 0.00045776367, 0.15258789, 0.27905273
1.0732422, -0.19897461, 0.31323242, ... , -9.1552734e-05, 0.15063477, 0.29199219
0.12023926, -0.4309082, 0.80615234, ... , 0.040344238, 0.006942749, 0.040039062
0.51220703, -0.12585449, 0.32324219, ... , 0.20556641, -0.017211914, 0.22216797
-0.3972168, -0.001953125, 0.45581055, ... , 0.13574219, -0.0048522949, -0.017837524
-1.484375, 0.50390625, 0.24597168, ... , 0.15490723, -0.072998047, 0.25878906

...
0.83251953, -0.56640625, 0.63671875, ... , -0.03616333, 0.17211914, 0.30078125
1.2763672, 0.48852539, 0.37158203, ... , -0.23046875, 0.086181641, 0.060913086
0.83105469, 0.15625, -0.18017578, ... , -0.15209961, -0.14855957, 0.04107666
-0.52392578, -0.18786621, -0.39233398, ... , -0.21264648, -0.040161133, 0.031860352
0.38671875, -0.14794922, 0.2244873, ... , -0.087158203, 0.10644531, 0.10119629
1.0556641, -0.37036133, 0.31396484, ... , -0.011322021, 0.12017822, 0.18017578

0.83251953, -0.56640625, 0.63671875, ... , -0.03616333, 0.17211914, 0.30078125
1.2763672, 0.48852539, 0.37158203, ... , -0.23046875, 0.086181641, 0.060913086
0.83105469, 0.15625, -0.18017578, ... , -0.15209961, -0.14855957, 0.04107666
-0.52392578, -0.18786621, -0.39233398, ... , -0.21264648, -0.040161133, 0.031860352
0.38671875, -0.14794922, 0.2244873, ... , -0.087158203, 0.10644531, 0.10119629
1.0556641, -0.37036133, 0.31396484, ... , -0.011322021, 0.12017822, 0.18017578

0.83251953, -0.56640625, 0.63671875, ... , -0.03616333, 0.17211914, 0.30078125
1.2763672, 0.48852539, 0.37158203, ... , -0.23046875, 0.086181641, 0.060913086
0.83105469, 0.15625, -0.18017578, ... , -0.15209961, -0.14855957, 0.04107666
-0.52392578, -0.18786621, -0.39233398, ... , -0.21264648, -0.040161133, 0.031860352
0.38671875, -0.14794922, 0.2244873, ... , -0.087158203, 0.10644531, 0.10119629
1.0556641, -0.37036133, 0.31396484, ... , -0.011322021, 0.12017822, 0.18017578
```

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

It tackles two problems:
(1) It is time consuming to dump the whole tensor when there are too many elements.
(2) Print tensor in 2D layout is hard to read when input tensor has 3 or more dimensions.
