### PR TITLE
Auto mixed precision conversion of GPT-2 onnx model

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -160,6 +160,7 @@ def parse_arguments(argv=None):
         "float to float16 conversion parameters that works when \"--precision fp16\" is specified")
 
     fp16_option_group.add_argument(
+        '-a',
         '--auto_mixed_precision',
         required=False,
         action='store_true',

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -159,6 +159,12 @@ def parse_arguments(argv=None):
     fp16_option_group = parser.add_argument_group(
         "float to float16 conversion parameters that works when \"--precision fp16\" is specified")
 
+    fp16_option_group.add_argument('--auto_mixed_precision',
+                                   required=False,
+                                   action='store_true',
+                                   help='Convert to mixed precision automatically. Other float16 conversion parameters will be ignored.')
+    fp16_option_group.set_defaults(auto_mixed_precision=False)
+    
     fp16_option_group.add_argument('--keep_io_types',
                                    required=False,
                                    action='store_true',
@@ -324,7 +330,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         logger.info(f"Optimizing model to {output_path}")
         gpt2helper.optimize_onnx(raw_onnx_model, output_path, args.precision == Precision.FLOAT16,
                                  model.config.num_attention_heads, model.config.hidden_size,
-                                 args.use_external_data_format, **fp16_params)
+                                 args.use_external_data_format, auto_mixed_precision=args.auto_mixed_precision, **fp16_params)
     else:
         output_path = raw_onnx_model
 
@@ -390,7 +396,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         with open(csv_filename, mode="a", newline='') as csv_file:
             column_names = [
                 "experiment", "run_id", "model_name", "model_class", "gpu", "precision", "optimizer", "test_cases",
-                "runs", "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers",
+                "runs", "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers", "auto_mixed_precision",
                 "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime", latency_name, "top1_match_rate",
                 "onnx_size_in_MB", "diff_50_percentile", "diff_90_percentile", "diff_95_percentile",
                 "diff_99_percentile", "diff_pass_rate", "nan_rate", "top1_match_rate_per_run"
@@ -413,6 +419,7 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
                 "op_block_list": args.op_block_list,
                 "node_block_list": args.node_block_list,
                 "force_fp16_initializers": args.force_fp16_initializers,
+                "auto_mixed_precision": args.auto_mixed_precision,
                 "ORT_TRANSFORMER_OPTIONS": os.getenv('ORT_TRANSFORMER_OPTIONS'),
                 "ORT_CUDA_GEMM_OPTIONS": os.getenv('ORT_CUDA_GEMM_OPTIONS'),
                 "onnxruntime": ort_version,

--- a/onnxruntime/python/tools/transformers/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/convert_to_onnx.py
@@ -159,12 +159,13 @@ def parse_arguments(argv=None):
     fp16_option_group = parser.add_argument_group(
         "float to float16 conversion parameters that works when \"--precision fp16\" is specified")
 
-    fp16_option_group.add_argument('--auto_mixed_precision',
-                                   required=False,
-                                   action='store_true',
-                                   help='Convert to mixed precision automatically. Other float16 conversion parameters will be ignored.')
+    fp16_option_group.add_argument(
+        '--auto_mixed_precision',
+        required=False,
+        action='store_true',
+        help='Convert to mixed precision automatically. Other float16 conversion parameters will be ignored.')
     fp16_option_group.set_defaults(auto_mixed_precision=False)
-    
+
     fp16_option_group.add_argument('--keep_io_types',
                                    required=False,
                                    action='store_true',
@@ -328,9 +329,14 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         output_path = onnx_model_paths[str(args.precision) if args.precision != Precision.INT8 else 'fp32']
 
         logger.info(f"Optimizing model to {output_path}")
-        gpt2helper.optimize_onnx(raw_onnx_model, output_path, args.precision == Precision.FLOAT16,
-                                 model.config.num_attention_heads, model.config.hidden_size,
-                                 args.use_external_data_format, auto_mixed_precision=args.auto_mixed_precision, **fp16_params)
+        gpt2helper.optimize_onnx(raw_onnx_model,
+                                 output_path,
+                                 args.precision == Precision.FLOAT16,
+                                 model.config.num_attention_heads,
+                                 model.config.hidden_size,
+                                 args.use_external_data_format,
+                                 auto_mixed_precision=args.auto_mixed_precision,
+                                 **fp16_params)
     else:
         output_path = raw_onnx_model
 
@@ -396,9 +402,9 @@ def main(argv=None, experiment_name="", run_id=0, csv_filename="gpt2_parity_resu
         with open(csv_filename, mode="a", newline='') as csv_file:
             column_names = [
                 "experiment", "run_id", "model_name", "model_class", "gpu", "precision", "optimizer", "test_cases",
-                "runs", "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers", "auto_mixed_precision",
-                "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime", latency_name, "top1_match_rate",
-                "onnx_size_in_MB", "diff_50_percentile", "diff_90_percentile", "diff_95_percentile",
+                "runs", "keep_io_types", "io_block_list", "op_block_list", "node_block_list", "force_fp16_initializers",
+                "auto_mixed_precision", "ORT_TRANSFORMER_OPTIONS", "ORT_CUDA_GEMM_OPTIONS", "onnxruntime", latency_name,
+                "top1_match_rate", "onnx_size_in_MB", "diff_50_percentile", "diff_90_percentile", "diff_95_percentile",
                 "diff_99_percentile", "diff_pass_rate", "nan_rate", "top1_match_rate_per_run"
             ]
             csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)

--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -17,7 +17,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
 def _npfloat16_to_int(np_list):
     '''
     Convert numpy float16 to python int.
@@ -28,13 +27,14 @@ def _npfloat16_to_int(np_list):
     return [int(bin(_.view('H'))[2:].zfill(16), 2) for _ in np_list]
 
 
-def convert_np_to_float16(np_array, min_positive_val=1e-7, max_finite_val=1e4):
+def convert_np_to_float16(np_array, min_positive_val=5.96e-08, max_finite_val=65504.0):
     '''
     Convert float32 numpy array to float16 without changing sign or finiteness.
     Positive values less than min_positive_val are mapped to min_positive_val.
     Positive finite values greater than max_finite_val are mapped to max_finite_val.
     Similar for negative values. NaN, 0, inf, and -inf are unchanged.
     '''
+
     def between(a, b, c):
         return np.logical_and(a < b, b < c)
 
@@ -45,7 +45,7 @@ def convert_np_to_float16(np_array, min_positive_val=1e-7, max_finite_val=1e4):
     return np.float16(np_array)
 
 
-def convert_tensor_float_to_float16(tensor, min_positive_val=1e-7, max_finite_val=1e4):
+def convert_tensor_float_to_float16(tensor, min_positive_val=5.96e-08, max_finite_val=65504.0):
     """Convert tensor float to float16.
 
     Args:
@@ -97,6 +97,7 @@ DEFAULT_OP_BLOCK_LIST = [
 
 class InitializerTracker:
     """Class for keeping track of initializer."""
+
     def __init__(self, initializer: onnx_proto.TensorProto):
         self.initializer = initializer
         self.fp32_nodes = []
@@ -110,8 +111,8 @@ class InitializerTracker:
 
 
 def convert_float_to_float16(model,
-                             min_positive_val=1e-7,
-                             max_finite_val=1e4,
+                             min_positive_val=5.96e-08,
+                             max_finite_val=65504.0,
                              keep_io_types=False,
                              disable_shape_infer=False,
                              op_block_list=None,
@@ -121,8 +122,8 @@ def convert_float_to_float16(model,
 
     Args:
         model (ModelProto): The ONNX model to convert.
-        min_positive_val (float, optional): minimal positive value. Defaults to 1e-7.
-        max_finite_val (float, optional): maximal finite value. Defaults to 1e4.
+        min_positive_val (float, optional): minimal positive value. Defaults to 5.96e-08.
+        max_finite_val (float, optional): maximal finite value of float16. Defaults to 65504.
         keep_io_types (Union[bool, List[str]], optional): It could be boolean or a list of float32 input/output names.
                                                           If True, model inputs/outputs should be left as float32. Defaults to False.
         disable_shape_infer (bool, optional): Skips running onnx shape/type inference. Useful if shape inference has been done. Defaults to False.
@@ -158,6 +159,8 @@ def convert_float_to_float16(model,
         node_block_list = []
     op_block_list = set(op_block_list)
     node_block_list = set(node_block_list)
+
+    logger.debug(f"fp16 parameters: min_positive_val={min_positive_val} max_finite_val={max_finite_val} keep_io_types={keep_io_types} disable_shape_infer={disable_shape_infer} op_block_list={op_block_list} node_block_list={node_block_list} force_fp16_initializers={force_fp16_initializers}")
 
     # create a queue for BFS
     queue = []
@@ -328,3 +331,18 @@ def convert_float_to_float16(model,
                     node.output[i] = input_name
                     break
     return model
+
+def float_to_float16_max_diff(tensor, min_positive_val=5.96e-08, max_finite_val=65504.0):
+    """Measure the maximum absolute difference after converting a float tensor to float16."""
+    if not isinstance(tensor, onnx_proto.TensorProto):
+        raise ValueError('Expected input type is an ONNX TensorProto but got %s' % type(tensor))
+    if tensor.data_type == onnx_proto.TensorProto.FLOAT:
+        raise ValueError('Expected tensor data type is float.')
+
+    if tensor.float_data:
+        float32_data = np.array(tensor.float_data)
+    if tensor.raw_data:
+        float32_data = np.fromstring(tensor.raw_data, dtype='float32')
+
+    float16_data = convert_np_to_float16(float32_data, min_positive_val, max_finite_val)
+    return np.amax(np.abs(float32_data - np.float32(float16_data)))

--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -17,6 +17,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def _npfloat16_to_int(np_list):
     '''
     Convert numpy float16 to python int.
@@ -160,7 +161,9 @@ def convert_float_to_float16(model,
     op_block_list = set(op_block_list)
     node_block_list = set(node_block_list)
 
-    logger.debug(f"fp16 parameters: min_positive_val={min_positive_val} max_finite_val={max_finite_val} keep_io_types={keep_io_types} disable_shape_infer={disable_shape_infer} op_block_list={op_block_list} node_block_list={node_block_list} force_fp16_initializers={force_fp16_initializers}")
+    logger.debug(
+        f"fp16 parameters: min_positive_val={min_positive_val} max_finite_val={max_finite_val} keep_io_types={keep_io_types} disable_shape_infer={disable_shape_infer} op_block_list={op_block_list} node_block_list={node_block_list} force_fp16_initializers={force_fp16_initializers}"
+    )
 
     # create a queue for BFS
     queue = []
@@ -332,6 +335,7 @@ def convert_float_to_float16(model,
                     break
     return model
 
+
 def float_to_float16_max_diff(tensor, min_positive_val=5.96e-08, max_finite_val=65504.0):
     """Measure the maximum absolute difference after converting a float tensor to float16."""
     if not isinstance(tensor, onnx_proto.TensorProto):
@@ -341,7 +345,7 @@ def float_to_float16_max_diff(tensor, min_positive_val=5.96e-08, max_finite_val=
 
     if tensor.float_data:
         float32_data = np.array(tensor.float_data)
-        
+
     if tensor.raw_data:
         float32_data = np.fromstring(tensor.raw_data, dtype='float32')
 

--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -336,11 +336,12 @@ def float_to_float16_max_diff(tensor, min_positive_val=5.96e-08, max_finite_val=
     """Measure the maximum absolute difference after converting a float tensor to float16."""
     if not isinstance(tensor, onnx_proto.TensorProto):
         raise ValueError('Expected input type is an ONNX TensorProto but got %s' % type(tensor))
-    if tensor.data_type == onnx_proto.TensorProto.FLOAT:
+    if tensor.data_type != onnx_proto.TensorProto.FLOAT:
         raise ValueError('Expected tensor data type is float.')
 
     if tensor.float_data:
         float32_data = np.array(tensor.float_data)
+        
     if tensor.raw_data:
         float32_data = np.fromstring(tensor.raw_data, dtype='float32')
 

--- a/onnxruntime/python/tools/transformers/fusion_utils.py
+++ b/onnxruntime/python/tools/transformers/fusion_utils.py
@@ -12,6 +12,7 @@ logger = getLogger(__name__)
 
 
 class FusionUtils:
+
     def __init__(self, model: OnnxModel):
         self.model: OnnxModel = model
 
@@ -124,10 +125,11 @@ class FusionUtils:
         return None
 
     def remove_cascaded_cast_nodes(self):
-        # Remove Cast node that are overrided by another Cast node like  --> Cast --> Cast -->
-        # Note that this shall be used carefully since it might introduce semantic change.
-        # For example, float -> int -> float could get different value than the original float value.
-        # So, it is recommended to used only in post-processing of mixed precision conversion.
+        """Remove Cast node that are overrided by another Cast node like  --> Cast --> Cast -->
+           Note that this shall be used carefully since it might introduce semantic change.
+           For example, float -> int -> float could get different value than the original float value.
+           So, it is recommended to used only in post-processing of mixed precision conversion.
+        """
         removed_count = 0
         for node in self.model.nodes():
             if node.op_type == "Cast":
@@ -139,7 +141,7 @@ class FusionUtils:
         if removed_count > 0:
             logger.info(f"Removed {removed_count} cascaded Cast nodes")
             self.model.prune_graph()
-    
+
     def remove_useless_cast_nodes(self):
         """Remove cast nodes that are not needed: input and output has same data type.
         """
@@ -201,6 +203,7 @@ class FusionUtils:
 
 
 class NumpyHelper:
+
     @staticmethod
     def to_array(tensor: TensorProto, fill_zeros: bool = False) -> ndarray:
         # When weights are in external data format but not presented, we can still test the optimizer with two changes:

--- a/onnxruntime/python/tools/transformers/gpt2_helper.py
+++ b/onnxruntime/python/tools/transformers/gpt2_helper.py
@@ -477,7 +477,7 @@ class Gpt2Helper:
             # when the max difference of value after converting float to float16 is lower than a threshold (1e-6), 
             # we can deduce that the weights are stored in float16 precision.
             max_diff = float_to_float16_max_diff(initializer)
-            logger.info(f"max diff of converting weights in last MatMul node {node.name}: {max_diff}")
+            logger.debug(f"max diff of converting weights in last MatMul node {node.name}: {max_diff}")
             is_weight_fp16_precision = (max_diff < 1E-6)
         else:
             logger.warning(f"Failed to find MatMul node for logits. Found {node.op_type} of node {node.name}")
@@ -488,11 +488,11 @@ class Gpt2Helper:
         else:
             # When original weight is float32 precision, keep logits and last MatMul in float32 could get better precision.
             keep_io_types = [logits_output_name]
-            node_block_list = [last_matmul_node]
+            node_block_list = [last_matmul_node.name]
 
         parameters = { "keep_io_types": keep_io_types, "op_block_list": op_block_list, "node_block_list": node_block_list, "force_fp16_initializers": is_weight_fp16_precision}
 
-        logger.debug(f"auto_mixed_precision parameters: {parameters}")
+        logger.info(f"auto_mixed_precision parameters: {parameters}")
         onnx_model.convert_float_to_float16(use_symbolic_shape_infer=True, **parameters)
 
         fusion_utils = FusionUtils(onnx_model)


### PR DESCRIPTION
**Description**:

Add an option "--auto_mixed_precision" to convert GPT-2 model from float32 to mixed precision. It will detect whether the weights are float16. If so, the output model will have all weights converted to float16, and logits output is also float16. Otherwise, weights for nodes computed in float32 will still remain float32, and logits will be float32.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Automatic converting fp32 model to mixed precision, with good tradeoff between precision and performance.