### PR TITLE
Add multithreading test and put a lock on nvinfer1::createInferRuntime() for TRT EP

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -200,6 +200,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   */
   std::unique_lock<OrtMutex> GetEngineBuildLock() const;
 
+  /**Get a unique_lock object to control the concurrency behavior of calling nvinfer1::createInferRuntime()*/
   std::unique_lock<OrtMutex> GetCreateInferRuntimeLock() const;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -199,5 +199,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   Otherwise, the constructed unique_lock is not associated with any mutex therefore no locking/unlocking will happen.
   */
   std::unique_lock<OrtMutex> GetEngineBuildLock() const;
+
+  std::unique_lock<OrtMutex> GetCreateInferRuntimeLock() const;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -89,7 +89,6 @@ void CreateBaseModel(std::string model_name, std::string graph_name, std::vector
 }
 
 void RunInference(std::string model_name, std::string sess_log_id) {
-  //std::cout << i << std::endl;
   SessionOptions so;
   so.session_logid = sess_log_id;
   RunOptions run_options;

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -10,6 +10,7 @@
 #include "core/providers/tensorrt/tensorrt_provider_options.h"
 #include "core/providers/tensorrt/tensorrt_execution_provider_utils.h"
 #include <string>
+#include <thread>
 
 using namespace std;
 using namespace ONNX_NAMESPACE;
@@ -85,6 +86,97 @@ void CreateBaseModel(std::string model_name, std::string graph_name, std::vector
   auto status = graph.Resolve();
   ASSERT_TRUE(status.IsOK());
   status = onnxruntime::Model::Save(model, model_name);
+}
+
+void RunInference(std::string model_name, int i) {
+  std::cout << i << std::endl;
+  SessionOptions so;
+  so.session_logid = "TensorrtExecutionProviderMultiThreadingTest";
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  InferenceSession session_object{so, GetEnvironment()};
+  auto allocator_manager = session_object.GetAllocatorManager();
+  auto cuda_provider = DefaultCudaExecutionProvider();
+  cuda_provider->RegisterAllocator(allocator_manager);
+  auto cpu_allocator = cuda_provider->GetAllocator(0, OrtMemTypeCPU);
+  std::vector<int64_t> dims_mul_x = {1, 3, 2};
+  std::vector<float> values_mul_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value_x;
+  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_x);
+  OrtValue ml_value_y;
+  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_y);
+  OrtValue ml_value_z;
+  CreateMLValue<float>(cpu_allocator, dims_mul_x, values_mul_x, &ml_value_z);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value_x));
+  feeds.insert(std::make_pair("Y", ml_value_y));
+  feeds.insert(std::make_pair("Z", ml_value_z));
+
+  // prepare outputs
+  std::vector<std::string> output_names;
+  output_names.push_back("M");
+  std::vector<OrtValue> fetches;
+
+  // prepare expected inputs and outputs
+  std::vector<int64_t> expected_dims_mul_m = {1, 3, 2};
+  std::vector<float> expected_values_mul_m = {3.0f, 6.0f, 9.0f, 12.0f, 15.0f, 18.0f};
+
+  OrtTensorRTProviderOptionsV2 params{
+      0,
+      0,
+      nullptr,
+      1000,
+      1,
+      1 << 30,
+      0,
+      0,
+      nullptr,
+      0,
+      0,
+      0,
+      0,
+      0,
+      nullptr,
+      0,
+      nullptr,
+      0};
+
+    params.trt_engine_cache_enable = 1;
+    std::unique_ptr<IExecutionProvider> execution_provider = TensorrtExecutionProviderWithOptions(&params);
+    EXPECT_TRUE(session_object.RegisterExecutionProvider(std::move(execution_provider)).IsOK());
+    auto status = session_object.Load(model_name);
+    ASSERT_TRUE(status.IsOK());
+    status = session_object.Initialize();
+    ASSERT_TRUE(status.IsOK());
+
+    // run inference
+    // TRT engine will be created and cached
+    // TRT profile will be created and cached only for dynamic input shape
+    // Data in profile,
+    // X: 1, 3, 3, 2, 2, 2
+    // Y: 1, 3, 3, 2, 2, 2
+    // Z: 1, 3, 3, 2, 2, 2
+    status = session_object.Run(run_options, feeds, output_names, &fetches);
+    ASSERT_TRUE(status.IsOK());
+    VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+
+
+}
+
+TEST(TensorrtExecutionProviderTest, MultiThreadsTest) {
+  std::vector<std::thread> threads;
+  std::string model_name = "trt_execution_provider_multithreading_test.onnx";
+  std::string graph_name = "multithreading_test";
+  std::vector<int> dims = {1, 3, 2};
+  int num_thread = 3;
+
+  CreateBaseModel(model_name, graph_name, dims);
+
+  for (int i = 0; i < num_thread; ++i)
+    threads.push_back(std::thread(RunInference, model_name, i));
+
+  for (auto& th : threads)
+    th.join();
 }
 
 TEST_P(TensorrtExecutionProviderCacheTest, Run) {

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -88,10 +88,10 @@ void CreateBaseModel(std::string model_name, std::string graph_name, std::vector
   status = onnxruntime::Model::Save(model, model_name);
 }
 
-void RunInference(std::string model_name, int i) {
-  std::cout << i << std::endl;
+void RunInference(std::string model_name, std::string sess_log_id) {
+  //std::cout << i << std::endl;
   SessionOptions so;
-  so.session_logid = "TensorrtExecutionProviderMultiThreadingTest";
+  so.session_logid = sess_log_id;
   RunOptions run_options;
   run_options.run_tag = so.session_logid;
   InferenceSession session_object{so, GetEnvironment()};
@@ -167,13 +167,14 @@ TEST(TensorrtExecutionProviderTest, MultiThreadsTest) {
   std::vector<std::thread> threads;
   std::string model_name = "trt_execution_provider_multithreading_test.onnx";
   std::string graph_name = "multithreading_test";
+  std::string sess_log_id = "TensorrtExecutionProviderMultiThreadingTest";
   std::vector<int> dims = {1, 3, 2};
-  int num_thread = 3;
+  int num_thread = 5;
 
   CreateBaseModel(model_name, graph_name, dims);
 
   for (int i = 0; i < num_thread; ++i)
-    threads.push_back(std::thread(RunInference, model_name, i));
+    threads.push_back(std::thread(RunInference, model_name, sess_log_id));
 
   for (auto& th : threads)
     th.join();


### PR DESCRIPTION
Added multithreading test as well as put a lock around nvinfer1::createInferRuntime() call.
Without the lock, the test has the change to encounter segfault or fail due to race conditions.