### PR TITLE
Add min max moving average calibration method

### DIFF
--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -226,6 +226,11 @@ def quantize_static(model_input,
                                                             If specific op type supports per channel quantization but not explicitly specified with channel axis,
                                                             default channel axis will be used.
             CalibTensorRangeSymmetric = True/False : Default is False. If enabled, the final range of tensor during calibration will be explicitly set to symmetric to central point "0".
+            CalibMovingAverage = True/False : Default is False. If enabled, the moving average of the minimum and maximum values
+                                              will be computed when the calibration method selected is MinMax.
+            CalibMovingAverageConstant = float : Default is 0.01. Constant smoothing factor to use when computing the moving average of
+                                                 the minimum and maximum values. Effective only when the calibration method selected is
+                                                 MinMax and when CalibMovingAverage is set to True.
     '''
 
     mode = QuantizationMode.QLinearOps
@@ -235,7 +240,13 @@ def quantize_static(model_input,
 
     model = load_model(Path(model_input), optimize_model, False)
 
-    calib_extra_options = {} if 'CalibTensorRangeSymmetric' not in extra_options else {'symmetric': extra_options['CalibTensorRangeSymmetric']} 
+    calib_extra_options = {}
+    if 'CalibTensorRangeSymmetric' in extra_options:
+        calib_extra_options.update({'symmetric': extra_options['CalibTensorRangeSymmetric']})
+    if 'CalibMovingAverage' in extra_options:
+        calib_extra_options.update({"moving_average": extra_options['CalibMovingAverage']})
+    if 'CalibMovingAverageConstant' in extra_options:
+        calib_extra_options.update({"averaging_constant": extra_options['CalibMovingAverageConstant']})
     calibrator = create_calibrator(
         model,
         op_types_to_quantize,

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -240,13 +240,12 @@ def quantize_static(model_input,
 
     model = load_model(Path(model_input), optimize_model, False)
 
-    calib_extra_options = {}
-    if 'CalibTensorRangeSymmetric' in extra_options:
-        calib_extra_options.update({'symmetric': extra_options['CalibTensorRangeSymmetric']})
-    if 'CalibMovingAverage' in extra_options:
-        calib_extra_options.update({"moving_average": extra_options['CalibMovingAverage']})
-    if 'CalibMovingAverageConstant' in extra_options:
-        calib_extra_options.update({"averaging_constant": extra_options['CalibMovingAverageConstant']})
+    calib_extra_options_keys = [
+        ('CalibTensorRangeSymmetric', 'symmetric'),
+        ('CalibMovingAverage', 'moving_average'),
+        ('CalibMovingAverageConstant', 'averaging_constant')
+    ]
+    calib_extra_options = {key: extra_options.get(name) for (name, key) in calib_extra_options_keys if name in extra_options}
     calibrator = create_calibrator(
         model,
         op_types_to_quantize,


### PR DESCRIPTION
This PR provides a variant of the min max calibration method, which computes the exponential moving average of the minimum and maximum values instead of the global minimum and maximum. This can be useful when the calibration datasets is composed of a large number of examples, in which case the activations quantization ranges will increase with the number of examples, resulting in a drop in precision which could lead to an important accuracy drop.

It introduces two additionnal attributes to `MinMaxCalibrater` :

- `moving_average`: which indicates whether or not to compute the moving average of the minimum and maximum values (instead of computing the global minimum and maximum).
- `averaging_constant`: which is the constant smoothing factor to use when computing the exponential moving average of the minimum and maximum values.