### PR TITLE
Update dnnl Add, Mul, Sub, Div ops to handle scalar values

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -461,13 +461,6 @@ bool DnnlElementwiseCapability::IsDimensionSupported(const Node* node) const {
     } 
   }
 
-  // OneDNN will silently convert scaler values to a {1} tensor which causes issues for
-  // for Onnruntime when it expects an empty tensor i.e. {}
-  // TODO convert {1} outputs back to scaler {} once that is done DnnlElementwiseCapability
-  // can be removed and just us the DnnlDefaultNodeCapability.
-  if (node_inputs[0]->Shape() != nullptr && node_inputs[0]->Shape()->dim_size() == 0) {
-    return false;
-  }
   return true;
 }
 

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -432,30 +432,8 @@ bool DnnlSumNodeCapability::IsDimensionSupported(const Node* node) const {
 bool DnnlBinaryNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
-  if (!IsDimensionSupported(node)) return false;
   //gpu broadcast for source 0 not supported
   if (dnnl_engine_get_count(dnnl_engine_kind_t::dnnl_gpu)) {
-    return false;
-  }
-  return true;
-}
-
-bool DnnlBinaryNodeCapability::IsDimensionSupported(const Node* node) const {
-  auto node_inputs = node->InputDefs();
-  if (node_inputs[0]->Shape() == nullptr || node_inputs[1]->Shape() == nullptr) {
-    return true;
-  }
-
-  // DNNL binary ops Add and Mul do not work if both inputs are scalar values
-  bool src0_is_scalar = false;
-  bool src1_is_scalar = false;
-  if (node_inputs[0]->Shape() != nullptr && node_inputs[0]->Shape()->dim_size() == 0) {
-    src0_is_scalar = true;
-  }
-  if (node_inputs[1]->Shape() != nullptr && node_inputs[1]->Shape()->dim_size() == 0) {
-    src1_is_scalar = true;
-  }
-  if (src0_is_scalar && src1_is_scalar) {
     return false;
   }
   return true;

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -213,9 +213,6 @@ class DnnlBinaryNodeCapability : public DnnlDefaultNodeCapability {
   DnnlBinaryNodeCapability() : DnnlDefaultNodeCapability({type_int8, type_uint8, type_float32}) {}
 
   bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
-
- private:
-  bool IsDimensionSupported(const Node* node) const;
 };
 
 /**

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
@@ -65,7 +65,11 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
                                 {DNNL_ARG_SRC_1, binary_src1_mem},
                                 {DNNL_ARG_DST, binary_dst_mem}});
 
-  sp.SetMemory(node.Output(OUT_Y), binary_dst_mem);
+  if (sp.IsScalar(node.Input(IN_A)) && sp.IsScalar(node.Input(IN_B))) {
+    sp.SetMemory(node.Output(OUT_Y), binary_dst_mem, false, true);
+  } else {
+    sp.SetMemory(node.Output(OUT_Y), binary_dst_mem);
+  }
 }
 
 }  // namespace ort_dnnl

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_elementwise.cc
@@ -65,8 +65,11 @@ void DnnlElementwise::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node)
   auto elemenwise_primitive = dnnl::eltwise_forward(elementwise_pd);
   sp.AddPrimitive(elemenwise_primitive, {{DNNL_ARG_SRC, elementwise_src_mem},
                                          {DNNL_ARG_DST, elementwise_dst_mem}});
-
-  sp.SetMemory(node.Output(OUT_Y), elementwise_dst_mem);
+  if (sp.IsScalar(node.Input(IN_X))) {
+    sp.SetMemory(node.Output(OUT_Y), elementwise_dst_mem, false, true);
+  } else {
+    sp.SetMemory(node.Output(OUT_Y), elementwise_dst_mem);
+  }
 }
 
 float DnnlElementwise::GetAlpha(DnnlNode& node, float default_alpha) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_gelu.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_gelu.cc
@@ -89,7 +89,11 @@ void DnnlGelu::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   sp.AddPrimitive(gelu_op, {{DNNL_ARG_SRC, gelu_src_mem},
                             {DNNL_ARG_DST, dst_mem}});
 
-  sp.SetMemory(node.Output(OUT_Y), dst_mem);
+  if (sp.IsScalar(node.Input(IN_X))) {
+    sp.SetMemory(node.Output(OUT_Y), dst_mem, false, true);
+  } else {
+    sp.SetMemory(node.Output(OUT_Y), dst_mem);
+  }
 }
 
 }  // namespace ort_dnnl

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmax.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_softmax.cc
@@ -36,8 +36,11 @@ void DnnlSoftmax::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto softmax_op = dnnl::softmax_forward(softmax_pd);
   sp.AddPrimitive(softmax_op, {{DNNL_ARG_SRC, softmax_src_mem},
                            {DNNL_ARG_DST, softmax_dst_mem}});
-
-  sp.SetMemory(node.Output(OUT_Y), softmax_dst_mem);
+  if (sp.IsScalar(node.Input(IN_X))) {
+    sp.SetMemory(node.Output(OUT_Y), softmax_dst_mem, false, true);
+  } else {
+    sp.SetMemory(node.Output(OUT_Y), softmax_dst_mem);
+  }
 }
 
 int64_t DnnlSoftmax::ReadAxis(DnnlNode& node) {

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -405,6 +405,8 @@ void DnnlSubgraphPrimitive::SetMemory(DnnlTensor tensor, dnnl::memory mem, bool 
     outputs_are_always_copied_.insert(tensor.Name());
   }
   if (is_scalar) {
+    // output may be input for another subgraph node
+    input_is_scalar_.insert(tensor.Name());
     scalar_outputs_.insert(tensor.Name());
   }
   SetMemory(tensor.Name(), mem);


### PR DESCRIPTION
Signed-off-by: George Nash <george.nash@intel.com>

**Description**: Describe your changes.
This updates the dnnl execution provider to handle scaler inputs and outputs properly.


**Motivation and Context**
- Why is this change required? What problem does it solve?
The dnnl execution provider was not running any Add, Mul, Sub, or Div operations that resulted in a scalar output. This resulted in over 800 nodes in MobileBert model. As well as many other models.

- If it fixes an open issue, please link to the issue here.
