### PR TITLE
Add additional NNAPI QDQ test cases for expected failure path

### DIFF
--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -100,7 +100,7 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
 
 GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupportedInputScaleZp() {
   return [](ModelTestBuilder& builder) {
-    const std::vector<std::vector<int64_t>>& input_shapes = {
+    const std::vector<std::vector<int64_t>> input_shapes = {
         {1, 6, 36},
         {1, 6, 8},
         {1, 6, 2},

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -98,5 +98,39 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
   };
 }
 
+/*
+#ifdef USE_NNAPI
+GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
+  return [](ModelTestBuilder& builder) {
+    const std::vector<std::vector<int64_t>>& input_shapes = {
+        {1, 6, 36},
+        {1, 6, 8},
+        {1, 6, 2},
+    };
+    int64_t axis = 2;
+
+    std::vector<NodeArg*> input_args;
+    std::vector<NodeArg*> q_input_args;
+    
+    // set unmatched input scales/zp for test purpose
+    input_args.push_back(builder.MakeInput<float>(input_shapes[0], -1.f, 1.f));
+    q_input_args.push_back(AddQDQNodePair<uint8_t>(builder, input_args.back(), 0.05f, 128));
+    input_args.push_back(builder.MakeInput<float>(input_shapes[1], -1.f, 1.f));
+    q_input_args.push_back(AddQDQNodePair<uint8_t>(builder, input_args.back(), 0.04f, 127));
+    input_args.push_back(builder.MakeInput<float>(input_shapes[2], -1.f, 1.f));
+    q_input_args.push_back(AddQDQNodePair<uint8_t>(builder, input_args.back(), 0.03f, 126));
+
+    auto* concat_output = builder.MakeIntermediate();
+    Node& concat_node = builder.AddNode("Concat", q_input_args, {concat_output});
+    concat_node.AddAttribute("axis", axis);
+
+    auto* q_concat_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(concat_output, 0.05f, 128, q_concat_output);
+    auto* output_arg = builder.MakeOutput();
+    builder.AddDequantizeLinearNode<uint8_t>(q_concat_output, 0.05f, 128, output_arg);
+  };
+}
+#endif
+*/
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -98,7 +98,6 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
   };
 }
 
-/*
 #ifdef USE_NNAPI
 GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
   return [](ModelTestBuilder& builder) {
@@ -111,7 +110,7 @@ GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
 
     std::vector<NodeArg*> input_args;
     std::vector<NodeArg*> q_input_args;
-    
+
     // set unmatched input scales/zp for test purpose
     input_args.push_back(builder.MakeInput<float>(input_shapes[0], -1.f, 1.f));
     q_input_args.push_back(AddQDQNodePair<uint8_t>(builder, input_args.back(), 0.05f, 128));
@@ -131,6 +130,6 @@ GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
   };
 }
 #endif
-*/
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.cc
+++ b/onnxruntime/test/optimizer/qdq_test_utils.cc
@@ -98,8 +98,7 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
   };
 }
 
-#ifdef USE_NNAPI
-GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
+GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupportedInputScaleZp() {
   return [](ModelTestBuilder& builder) {
     const std::vector<std::vector<int64_t>>& input_shapes = {
         {1, 6, 36},
@@ -129,7 +128,6 @@ GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported() {
     builder.AddDequantizeLinearNode<uint8_t>(q_concat_output, 0.05f, 128, output_arg);
   };
 }
-#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -256,8 +256,9 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
 }
 
 template <typename InputType, typename OutputType>
-GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape, const int64_t& axis = -1) {
-  return [input_shape, axis](ModelTestBuilder& builder) {
+GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape, const int64_t& axis = -1,
+                                         float output_scales = 0.0f, OutputType output_zero_point = 0) {
+  return [input_shape, axis, output_scales, output_zero_point](ModelTestBuilder& builder) {
     auto* input_arg = builder.MakeInput<InputType>(input_shape,
                                                    std::numeric_limits<InputType>::min(),
                                                    std::numeric_limits<InputType>::max());
@@ -275,7 +276,7 @@ GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape
     softmax_node.AddAttribute("axis", axis);
 
     // add Q
-    builder.AddQuantizeLinearNode<OutputType>(softmax_output, 1.f / 256, 0, output_arg);
+    builder.AddQuantizeLinearNode<OutputType>(softmax_output, output_scales, output_zero_point, output_arg);
   };
 }
 

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -289,9 +289,7 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
                                         bool has_input_int8 = false,
                                         bool has_output_int8 = false);
 
-#ifdef USE_NNAPI
-GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported();
-#endif
+GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupportedInputScaleZp();
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -288,11 +288,10 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
                                         bool has_input_float = false,
                                         bool has_input_int8 = false,
                                         bool has_output_int8 = false);
-/*
+
 #ifdef USE_NNAPI
 GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported();
 #endif
-*/
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -256,8 +256,8 @@ GetQDQTestCaseFn BuildQDQTransposeTestCase(
 }
 
 template <typename InputType, typename OutputType>
-GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape, const int64_t& axis = -1,
-                                         float output_scales = 0.0f, OutputType output_zero_point = 0) {
+GetQDQTestCaseFn BuildQDQSoftMaxTestCase(const std::vector<int64_t>& input_shape, const int64_t& axis,
+                                         float output_scales, OutputType output_zero_point) {
   return [input_shape, axis, output_scales, output_zero_point](ModelTestBuilder& builder) {
     auto* input_arg = builder.MakeInput<InputType>(input_shape,
                                                    std::numeric_limits<InputType>::min(),

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -288,10 +288,11 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
                                         bool has_input_float = false,
                                         bool has_input_int8 = false,
                                         bool has_output_int8 = false);
-
+/*
 #ifdef USE_NNAPI
 GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported();
 #endif
+*/
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_test_utils.h
+++ b/onnxruntime/test/optimizer/qdq_test_utils.h
@@ -289,5 +289,9 @@ GetQDQTestCaseFn BuildQDQConcatTestCase(const std::vector<std::vector<int64_t>>&
                                         bool has_input_int8 = false,
                                         bool has_output_int8 = false);
 
+#ifdef USE_NNAPI
+GetQDQTestCaseFn BuildQDQConcatTestCaseUnsupported();
+#endif
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -346,7 +346,7 @@ TEST(NnapiExecutionProviderTest, TestQDQConv) {
                       {1, 1, 5, 5} /* input_shape */,
                       {1, 1, 3, 3} /* weights_shape */),
                   "nnapi_qdq_test_graph_conv",
-                  {true /* verify_entire_graph_use_ep */});
+                  {ExpectedEPNodeAssignment::All});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQResize) {
@@ -362,7 +362,7 @@ TEST(NnapiExecutionProviderTest, TestQDQResize) {
                                          "linear" /* mode */,
                                          "asymmetric" /* coordinate_transformation_mode */),
                   "nnapi_qdq_test_graph_resize",
-                  {false /* verify_entire_graph_use_ep */});
+                  {ExpectedEPNodeAssignment::Some});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQResize_UnsupportedDefaultSetting) {
@@ -370,9 +370,8 @@ TEST(NnapiExecutionProviderTest, TestQDQResize_UnsupportedDefaultSetting) {
                                          {1, 3, 32, 32} /* sizes_data */),
                   "nnapi_qdq_test_graph_resize",
                   {
-                      false /* verify_entire_graph_use_ep */,
+                      ExpectedEPNodeAssignment::None,
                       1e-5f,
-                      true /* verify_expected_failure_graph */,
                   },
                   false /* nnapi_qdq_model_supported */);
 }
@@ -384,7 +383,7 @@ TEST(NnapiExecutionProviderTest, TestQDQAveragePool) {
                       {1, 3, 32, 32} /* input_shape */),
                   "nnapi_qdq_test_graph_averagepool",
                   {
-                      true /* verify_entire_graph_use_ep */,
+                      ExpectedEPNodeAssignment::All,
                       1e-2f /* fp32_abs_err */,
                   });
 }
@@ -396,7 +395,7 @@ TEST(NnapiExecutionProviderTest, TestQDQAdd) {
                       {1, 23, 13, 13} /* input_shape */,
                       "Add" /* op_type */),
                   "nnapi_qdq_test_graph_add",
-                  {true /* verify_entire_graph_use_ep */});
+                  {ExpectedEPNodeAssignment::All});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQMul) {
@@ -408,8 +407,8 @@ TEST(NnapiExecutionProviderTest, TestQDQMul) {
                       "Mul" /* op_type */),
                   "nnapi_qdq_test_graph_mul",
                   {
-                      true /* verify_entire_graph_use_ep */,
-                      1e-2f /* fp32_abs_err */,
+                      ExpectedEPNodeAssignment::All,
+                      1e-2f /* fp32_abs_err */
                   });
 }
 
@@ -419,18 +418,14 @@ TEST(NnapiExecutionProviderTest, TestQDQTranspose) {
                       {1, 3, 32, 32} /* input_shape */,
                       {0, 3, 1, 2} /* perms */),
                   "nnapi_qdq_test_graph_transpose",
-                  {
-                      true /* verify_entire_graph_use_ep */
-                  });
+                  {ExpectedEPNodeAssignment::All});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQReshape) {
   RunQDQModelTest(BuildQDQReshapeTestCase({1, 3, 64, 64} /* input_shape */,
                                           {1, 64, 64, 3} /* reshape_shape */),
                   "nnapi_qdq_test_graph_reshape",
-                  {
-                      true /* verify_entire_graph_use_ep */
-                  });
+                  {ExpectedEPNodeAssignment::All});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQSoftMax) {
@@ -440,9 +435,7 @@ TEST(NnapiExecutionProviderTest, TestQDQSoftMax) {
                       1.f / 256 /* output_scales */,
                       0 /* output_zp */),
                   "nnapi_qdq_test_graph_softmax",
-                  {
-                      true /* verify_entire_graph_use_ep */
-                  });
+                  {ExpectedEPNodeAssignment::All});
 }
 
 // This is to verify when Nnapi required scale and zero point are not satisfied
@@ -454,11 +447,8 @@ TEST(NnapiExecutionProviderTest, TestQDQSoftMax_UnsupportedOutputScaleAndZp) {
                       0.002f /* output_scales */,
                       1 /* output_zp */),
                   "nnapi_qdq_test_graph_softmax",
-                  {
-                      false /* verify_entire_graph_use_ep */,
-                      1e-5,
-                      true /* verify_expected_failure_graph */,
-                  },
+                  {ExpectedEPNodeAssignment::None,
+                   1e-5},
                   false /* nnapi_qdq_model_supported */);
 }
 
@@ -518,9 +508,7 @@ TEST(NnapiExecutionProviderTest, TestQDQConcat) {
                       } /* input_shapes */,
                       2 /* axis */),
                   "nnapi_qdq_test_graph_concat",
-                  {
-                      true /* verify_entire_graph_use_ep */
-                  },
+                  {ExpectedEPNodeAssignment::All},
                   true, /* nnapi_qdq_model_supported */
                   check_graph);
 }
@@ -532,11 +520,8 @@ TEST(NnapiExecutionProviderTest, TestQDQConcat_UnsupportedInputScalesAndZp) {
   if (nnapi->nnapi_runtime_feature_level < ANEURALNETWORKS_FEATURE_LEVEL_3) {
     RunQDQModelTest(BuildQDQConcatTestCaseUnsupported(),
                     "nnapi_qdq_test_graph_concat",
-                    {
-                        false /* verify_entire_graph_use_ep */,
-                        1e-5,
-                        true /* verify_expected_failure_graph */
-                    },
+                    {ExpectedEPNodeAssignment::None,
+                     1e-5},
                     false /* nnapi_qdq_model_supported */);
   }
 }

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -341,10 +341,7 @@ TEST(NnapiExecutionProviderTest, TestQDQResize_UnsupportedDefaultSetting) {
   RunQDQModelTest(BuildQDQResizeTestCase({1, 3, 64, 64} /* input_shape */,
                                          {1, 3, 32, 32} /* sizes_data */),
                   "nnapi_qdq_test_graph_resize_unsupported",
-                  {
-                      ExpectedEPNodeAssignment::None,
-                      1e-5f,
-                  });
+                  {ExpectedEPNodeAssignment::None});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQAveragePool) {

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -303,6 +303,9 @@ static void RunQDQModelTest(
   if (params.ep_node_assignment == ExpectedEPNodeAssignment::None) {
     ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 0)
         << "No node should have been taken by the NNAPI EP";
+  } else if (params.ep_node_assignment == ExpectedEPNodeAssignment::All) {
+    ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), session_object.GetGraph().NumberOfNodes())
+        << "All nodes should have been taken by the NNAPI EP";
   } else {
     ASSERT_GT(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 0)
         << "Some nodes should have been taken by the NNAPI EP";
@@ -415,8 +418,7 @@ TEST(NnapiExecutionProviderTest, TestQDQSoftMax_UnsupportedOutputScaleAndZp) {
                       0.002f /* output_scales */,
                       1 /* output_zp */),
                   "nnapi_qdq_test_graph_softmax_unsupported",
-                  {ExpectedEPNodeAssignment::None,
-                   1e-5});
+                  {ExpectedEPNodeAssignment::None});
 }
 
 TEST(NnapiExecutionProviderTest, TestQDQConcat) {
@@ -442,8 +444,7 @@ TEST(NnapiExecutionProviderTest, TestQDQConcat_UnsupportedInputScalesAndZp) {
   if (nnapi->nnapi_runtime_feature_level < ANEURALNETWORKS_FEATURE_LEVEL_3) {
     RunQDQModelTest(BuildQDQConcatTestCaseUnsupportedInputScaleZp(),
                     "nnapi_qdq_test_graph_concat_unsupported",
-                    {ExpectedEPNodeAssignment::None,
-                     1e-5});
+                    {ExpectedEPNodeAssignment::None});
   }
 }
 #endif

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -294,7 +294,6 @@ static void RunQDQModelTest(
                             std::make_unique<NnapiExecutionProvider>(0),
                             helper.feeds_, params);
 #else
-  ORT_UNUSED_PARAMETER(params);
   // test load only
   SessionOptions so;
   InferenceSessionWrapper session_object{so, GetEnvironment()};
@@ -439,6 +438,8 @@ TEST(NnapiExecutionProviderTest, TestQDQConcat) {
 TEST(NnapiExecutionProviderTest, TestQDQConcat_UnsupportedInputScalesAndZp) {
   // This is to verify all the inputs have the same scale and zp as input 0 for API 28-
   // Currently, this test can only be run locally with a android emulator with API < 29
+  // See https://developer.android.com/studio/run/emulator-commandline for some info on
+  // starting a testing android emulator in command line. (Run an android build with emulator started)
   // TODO: consider to configure this and enable it to run in Android CI.
   const auto* nnapi = NnApiImplementation();
   if (nnapi->nnapi_runtime_feature_level < ANEURALNETWORKS_FEATURE_LEVEL_3) {

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -5,6 +5,7 @@
 #include "core/common/logging/logging.h"
 #include "core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.h"
 #include "core/providers/nnapi/nnapi_builtin/nnapi_lib/NeuralNetworksTypes.h"
+#include "core/providers/nnapi/nnapi_builtin/nnapi_lib/nnapi_implementation.h"
 #include "core/session/inference_session.h"
 #include "core/framework/tensorprotoutils.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -535,7 +536,7 @@ TEST(NnapiExecutionProviderTest, TestQDQConcat_UnsupportedInputScalesAndZp) {
     RunQDQModelTest(BuildQDQConcatTestCaseUnsupported(),
                     "nnapi_qdq_test_graph_concat",
                     {
-                        false /* verify_entire_graph_use_ep */
+                        false /* verify_entire_graph_use_ep */,
                         1e-5,
                         true /* verify_expected_failure_graph */
                     },

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -339,6 +339,7 @@ TEST(NnapiExecutionProviderTest, TestQDQResize) {
                   {false /* verify_entire_graph_use_ep */});
 }
 
+#if !defined(__ANDROID__)
 TEST(NnapiExecutionProviderTest, TestQDQResize_UnsupportedDefaultSetting) {
   RunQDQModelTest(BuildQDQResizeTestCase({1, 3, 64, 64} /* input_shape */,
                                          {1, 3, 32, 32} /* sizes_data */),
@@ -346,6 +347,7 @@ TEST(NnapiExecutionProviderTest, TestQDQResize_UnsupportedDefaultSetting) {
                   {false /* verify_entire_graph_use_ep */},
                   false /* nnapi_qdq_model_supported */);
 }
+#endif
 
 TEST(NnapiExecutionProviderTest, TestQDQAveragePool) {
   // NNAPI use different rounding, which may cause ~1% difference in the result
@@ -415,6 +417,7 @@ TEST(NnapiExecutionProviderTest, TestQDQSoftMax) {
                   });
 }
 
+#if !defined(__ANDROID__)
 // See https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc#L1236
 TEST(NnapiExecutionProviderTest, TestQDQSoftMax_UnsupportedOutputScaleAndZp) {
   RunQDQModelTest(BuildQDQSoftMaxTestCase<uint8_t, uint8_t>(
@@ -428,6 +431,7 @@ TEST(NnapiExecutionProviderTest, TestQDQSoftMax_UnsupportedOutputScaleAndZp) {
                   },
                   false /* nnapi_qdq_model_supported */);
 }
+#endif
 
 TEST(NnapiExecutionProviderTest, TestQDQConcat) {
   // This is to verify all the inputs have the same scale and zp as input 0

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -25,6 +25,8 @@ struct EPVerificationParams {
   // the default of 1e-5f, especially for scenarios such as [Q -> Quantized op -> DQ]
   // Set this only if this is necessary
   float fp32_abs_err = 1e-5f;
+
+  bool verify_expected_failure_graph{false};
 };
 
 // return number of nodes in the Graph and any subgraphs that are assigned to the specified execution provider

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -15,18 +15,22 @@ class Graph;
 
 namespace test {
 
+// If set to All: verify the entire graph is taken by ep
+// If set to Some: verify that at least one node is assigned to ep
+// If set to None: verify that no nodes is assigned to ep (typically for an expected failure path test case)
+enum class ExpectedEPNodeAssignment { All,
+                                      Some,
+                                      None, };
+
 // struct to hold some verification params for RunAndVerifyOutputsWithEP
 struct EPVerificationParams {
-  // Verify the entire graph is taken by the EP
-  // if this is set to false, then will verify that at least one node is assigned to 'execution_provider'
-  bool verify_entire_graph_use_ep{false};
+  
+  ExpectedEPNodeAssignment ep_node_assignment;
 
   // Some EP may use different rounding than ORT CPU EP, which may cause a bigger abs error than
   // the default of 1e-5f, especially for scenarios such as [Q -> Quantized op -> DQ]
   // Set this only if this is necessary
   float fp32_abs_err = 1e-5f;
-
-  bool verify_expected_failure_graph{false};
 };
 
 // return number of nodes in the Graph and any subgraphs that are assigned to the specified execution provider

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -18,14 +18,14 @@ namespace test {
 // If set to All: verify the entire graph is taken by ep
 // If set to Some: verify that at least one node is assigned to ep
 // If set to None: verify that no nodes is assigned to ep (typically for an expected failure path test case)
-enum class ExpectedEPNodeAssignment { All,
+enum class ExpectedEPNodeAssignment { None,
                                       Some,
-                                      None, };
+                                      All, };
 
 // struct to hold some verification params for RunAndVerifyOutputsWithEP
 struct EPVerificationParams {
   
-  ExpectedEPNodeAssignment ep_node_assignment;
+  ExpectedEPNodeAssignment ep_node_assignment = ExpectedEPNodeAssignment::Some;
 
   // Some EP may use different rounding than ORT CPU EP, which may cause a bigger abs error than
   // the default of 1e-5f, especially for scenarios such as [Q -> Quantized op -> DQ]

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -123,10 +123,10 @@ void RunAndVerifyOutputsWithEP(const std::string& model_data, const char* log_id
   // make sure that some nodes are assigned to the EP, otherwise this test is pointless...
   const auto& graph2 = session_object2.GetGraph();
   auto ep_nodes = CountAssignedNodes(graph2, provider_type);
-  if (params.verify_entire_graph_use_ep) {
+  if (params.ep_node_assignment == ExpectedEPNodeAssignment::All) {
     // Verify the entire graph is assigned to the EP
     ASSERT_EQ(ep_nodes, graph2.NumberOfNodes()) << "Not all nodes were assigned to " << provider_type;
-  } else if (params.verify_expected_failure_graph) {
+  } else if (params.ep_node_assignment == ExpectedEPNodeAssignment::None) {
     // Check if expected failure path is correctly handled by ep. (only used in NNAPI EP QDQ model test case for now)
     ASSERT_EQ(ep_nodes, 0) << "No nodes are supposed to be assigned to " << provider_type;
   } else {

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -126,6 +126,9 @@ void RunAndVerifyOutputsWithEP(const std::string& model_data, const char* log_id
   if (params.verify_entire_graph_use_ep) {
     // Verify the entire graph is assigned to the EP
     ASSERT_EQ(ep_nodes, graph2.NumberOfNodes()) << "Not all nodes were assigned to " << provider_type;
+  } else if (params.verify_expected_failure_graph) {
+    // Check if expected failure path is correctly handled by ep. (only used in NNAPI EP QDQ model test case for now)
+    ASSERT_EQ(ep_nodes, 0) << "No nodes are supposed to be assigned to " << provider_type;
   } else {
     ASSERT_GT(ep_nodes, 0) << "No nodes were assigned to " << provider_type;
   }


### PR DESCRIPTION
**Description**: Describe your changes.

As title.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

#10666 Remaining task motivated by this pr. 

Issues not sure about:
1. For QDQConcat, when we make the inputs scale/zp unmatched, supposedly it shouldn't be supported by NNAPI. But TestCase `TestQDQConcat_UnsupportedInputScalesAndZp` (commented out) is failing, showing there are nodes can handled by NNAPI. not sure which part is incorrect.
2. Supposedly ASAIK for operators `AveragePool`, `Transpose`, `Reshape`, `Binary` operator, input&output scales and zp should match for NNAPI. Haven't added the check, only added check_graph function for concat as it appears to be a bit long process to achieve the scale and zp.  open to suggestions.
