### PR TITLE
Add type and shape information to profiled numbers

### DIFF
--- a/onnxruntime/core/common/profiler.cc
+++ b/onnxruntime/core/common/profiler.cc
@@ -135,7 +135,7 @@ std::string Profiler::EndProfiling() {
     bool is_first_arg = true;
     for (std::pair<std::string, std::string> event_arg : rec.args) {
       if (!is_first_arg) profile_stream_ << ",";
-      if (!event_arg.second.empty() && event_arg.second[0] == '{') {
+      if (!event_arg.second.empty() && (event_arg.second[0] == '{' || event_arg.second[0] == '[')) {
         profile_stream_ << "\"" << event_arg.first << "\" : " << event_arg.second << "";
       } else {
         profile_stream_ << "\"" << event_arg.first << "\" : \"" << event_arg.second << "\"";

--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -77,8 +77,9 @@ static void CalculateTotalOutputSizes(OpKernelContextInternal* op_kernel_context
                          << "\n";
 #endif
       total_output_sizes += tensor_size;
-      ss << "{\"" << DataTypeImpl::ToString(tensor.DataType()) << "\":"
-         << tensor.Shape().ToString() << (i == output_count - 1 ? "}" : "},");
+      auto shape_str = tensor.Shape().ToString();
+      ss << "{\"" << DataTypeImpl::ToString(tensor.DataType()) << "\":["
+         << shape_str.substr(1, shape_str.size() - 2) << "]" << (i == output_count - 1 ? "}" : "},");
     }
   }
   ss << "]";
@@ -122,8 +123,9 @@ static void CalculateTotalInputSizes(const OpKernelContextInternal* op_kernel_co
       } else {
         input_activation_sizes += tensor_size;
       }
-      ss << "{\"" << DataTypeImpl::ToString(p_tensor->DataType()) << "\":"
-         << p_tensor->Shape().ToString() << (i == input_count - 1 ? "}" : "},");
+      auto shape_str = p_tensor->Shape().ToString();
+      ss << "{\"" << DataTypeImpl::ToString(p_tensor->DataType()) << "\":["
+         << shape_str.substr(1, shape_str.size() - 2) << "]" << (i == input_count - 1 ? "}" : "},");
     }
   }
   ss << "]";

--- a/onnxruntime/core/framework/tensor_shape.cc
+++ b/onnxruntime/core/framework/tensor_shape.cc
@@ -91,7 +91,7 @@ TensorShape TensorShape::Slice(size_t dimstart, size_t dimend) const {
 std::string TensorShape::ToString() const {
   std::string result;
 
-  result.append("{");
+  result.append("[");
   bool first = true;
   for (auto dim : GetDims()) {
     if (!first) {
@@ -101,7 +101,7 @@ std::string TensorShape::ToString() const {
     result.append(std::to_string(dim));
     first = false;
   }
-  result.append("}");
+  result.append("]");
 
   return result;
 }

--- a/onnxruntime/core/framework/tensor_shape.cc
+++ b/onnxruntime/core/framework/tensor_shape.cc
@@ -91,7 +91,7 @@ TensorShape TensorShape::Slice(size_t dimstart, size_t dimend) const {
 std::string TensorShape::ToString() const {
   std::string result;
 
-  result.append("[");
+  result.append("{");
   bool first = true;
   for (auto dim : GetDims()) {
     if (!first) {
@@ -101,7 +101,7 @@ std::string TensorShape::ToString() const {
     result.append(std::to_string(dim));
     first = false;
   }
-  result.append("]");
+  result.append("}");
 
   return result;
 }

--- a/tools/perf_view/ort_perf_view.html
+++ b/tools/perf_view/ort_perf_view.html
@@ -75,7 +75,15 @@
                   summarized_cpu[node.args.op_name] = {all:0,children:[]};
                 }
                 summarized_cpu[node.args.op_name].all += node.dur;
-                summarized_cpu[node.args.op_name].children.push({name: node.name, value:node.dur})
+                // summarized_cpu[node.args.op_name].children.push({name: node.name, value:node.dur, input: node.input_type_shape})
+                //var node_statistics = JSON.stringify(node.args).replaceAll('","','",\n"').replaceAll('],"','],\n"');
+                var metadata = JSON.parse('{}');
+                metadata.name = node.name
+                metadata.input = node.args.input_type_shape
+                metadata.output = node.args.output_type_shape
+                metadata.duration_in_microseconds = node.dur
+                var metadata_str = JSON.stringify(metadata).replaceAll('","','",\n"').replaceAll('},{','},\n{').replaceAll('],"','],\n"')
+                summarized_cpu[node.args.op_name].children.push({name: metadata_str, value: node.dur})
             } else if (category == "Kernel") {
                 var op_name = node.args.op_name == "" ? "Session" : node.args.op_name;
                 if (summarized_gpu[op_name] == null) {

--- a/tools/perf_view/ort_perf_view.html
+++ b/tools/perf_view/ort_perf_view.html
@@ -75,8 +75,6 @@
                   summarized_cpu[node.args.op_name] = {all:0,children:[]};
                 }
                 summarized_cpu[node.args.op_name].all += node.dur;
-                // summarized_cpu[node.args.op_name].children.push({name: node.name, value:node.dur, input: node.input_type_shape})
-                //var node_statistics = JSON.stringify(node.args).replaceAll('","','",\n"').replaceAll('],"','],\n"');
                 var metadata = JSON.parse('{}');
                 metadata.name = node.name
                 metadata.input = node.args.input_type_shape


### PR DESCRIPTION
E.g.

[
...
{"cat" : "Node","pid" :30704,"tid" :26028,"dur" :246,"ts" :1326720,"ph" : "X","name" :"Add_0_kernel_time","args" : ... ,**"input_type_shape" : [{"int32":[4096]},{"int32":[4096]}],"output_type_shape" : [{"int32":[4096]}]**, ... }
...
]

perf view also enhanced to demonstrate the input and output type and shapes:

![image](https://user-images.githubusercontent.com/48490400/156836070-c9c203b2-e2ff-4e3e-9c7a-99ec4ccb4f71.png)
