### PR TITLE
Remove python 3.6 from training pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -15,8 +15,6 @@ stages:
 
       strategy:
         matrix:
-          Python36:
-            PythonVersion: '3.6'
           Python37:
             PythonVersion: '3.7'
           Python38:

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
@@ -57,14 +57,6 @@ stages:
       pool: ${{ parameters.agent_pool }}
       strategy:
         matrix:
-          Python36:
-            PythonVersion: '3.6'
-            TorchVersion: ${{ parameters.torch_version }}
-            OpsetVersion: ${{ parameters.opset_version }}
-            CudaVersion: ${{ parameters.cuda_version }}
-            DockerFile: ${{ parameters.docker_file }}
-            GccVersion: ${{ parameters.gcc_version }}
-            UploadWheel: ${{ parameters.upload_wheel }}
           Python37:
             PythonVersion: '3.7'
             TorchVersion: ${{ parameters.torch_version }}

--- a/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-python-manylinux-variables-step.yml
@@ -9,11 +9,8 @@ steps:
     script: |
       version = "$(PythonVersion)"
 
-      if version == "3.6":
-        variables = {
-          "PythonManylinuxDir": "/opt/python/cp36-cp36m"
-        }
-      elif version == "3.7":
+
+      if version == "3.7":
         variables = {
           "PythonManylinuxDir": "/opt/python/cp37-cp37m"
         }


### PR DESCRIPTION
**Description**: 

Because the numpy we use doesn't support python 3.6.  And inference pipelines already removed python 3.6.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
