### PR TITLE
Detect runtime CUDA JIT and warn the user

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -195,10 +195,16 @@ struct CUDA_Provider : Provider {
     // See the linked issue in the warning message for more info
     {
       auto start_time = std::chrono::steady_clock::now();
-      ::cudaDeviceSynchronize();
+      // Do a trivial cuda operation that will cause JIT to occur
+      {
+        void** cuda_memory {};
+        ::cudaMalloc(&cuda_memory, 1);
+        ::cudaFree(cuda_memory);
+      }
       auto end_time = std::chrono::steady_clock::now();
-      if (std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time) > std::chrono::seconds{30}) {
-        LOGS_DEFAULT(WARNING) << "CUDA took more than 30 seconds to start, please see this issue for how to fix it: https://github.com/microsoft/onnxruntime/issues/10746";
+      auto duration = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
+      if (duration > std::chrono::seconds{30}) {
+        LOGS_DEFAULT(WARNING) << "CUDA took " << duration.count() << " seconds to start, please see this issue for how to fix it: https://github.com/microsoft/onnxruntime/issues/10746";
       }
     }
 


### PR DESCRIPTION
**Description**: With the CUDA provider enabled there can be a huge delay doing the first cuda* function, due to the CUDA runtime JIT'ing the CUDA PTX virtual assembly into binary code for the user's current GPU architecture. This happens if we didn't include the binaries for that architecture at Onnxruntime build time.

Since we can't fix that issue (all binaries would be too large, and new GPUs come out that didn't exist when our binary was created), we can at least warn the user and explain the workarounds.

**Motivation and Context**
Users keep reporting this as a perf issue.