### PR TITLE
Correct symbolic name of GridSample function

### DIFF
--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -33,7 +33,7 @@ def register():
     Should be run before torch.onnx.export().
     """
 
-    def grid_sample(g, input, grid, mode, padding_mode, align_corners):
+    def grid_sampler(g, input, grid, mode, padding_mode, align_corners):
         # mode
         #   'bilinear'      : onnx::Constant[value={0}]
         #   'nearest'       : onnx::Constant[value={1}]
@@ -59,7 +59,7 @@ def register():
                     mode_s=mode_str,
                     padding_mode_s=padding_mode_str,
                     align_corners_i=align_corners)
-    _reg(grid_sample)
+    _reg(grid_sampler)
 
     def inverse(g, self):
         return g.op("com.microsoft::Inverse", self).setType(self.type())


### PR DESCRIPTION
**Description**: Correct the symbolic function name of grid_sampler

**Motivation**

I want to export a PyTorch model including `F.grid_sample` operation.

**Detailed Context**

`register` function (including the change of this PR) in `onnxruntime/python/tools/pytorch_export_contrib_ops.py` registers `grid_sample` as an ONNX Runtime's contrib ops. We are expected to export PyTorch models with `F.grid_sample` using this `register` function like below but this fails currently.

```python
import onnxruntime as ort
from onnxruntime.tools import pytorch_export_contrib_ops

pytorch_export_contrib_ops.register()

import torch
import torch.nn.functional as F

x = torch.randn(1, 4, 10, 10)
grid = 2*torch.rand(1, 8, 8, 2) - 1 # scale as (-1, 1)

class Sampler(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x, grid):
        return F.grid_sample(x, grid, align_corners=False)

torch.onnx.export(
    Sampler(),
    (x, grid),
    'sampler.onnx',
    verbose=True,
    input_names=['input', 'grid'],
    output_names=['output'],
)
```

```bash
RuntimeError: Exporting the operator grid_sampler to ONNX opset version 9 is not supported. 
Please feel free to request support or submit a pull request on PyTorch GitHub.
```

**This is because `F.grid_sample` function originally uses `aten::grid_sampler` operator in PyTorch (defined [here](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/GridSampler.cpp#L971)) and symbolic function name should also be `grid_sampler` (not `grid_sample`).** We can correctly register `"com.microsoft::GridSample"` as a counterpart of `F.grid_sample` with this modification. 

I have checked this modification works well with the below environment.

- MacBook Pro 2020 (Intel Core i5)
- python 3.9.5
- torch 1.10.2 (cpu)
- onnxruntime 1.11.0 (build&install from source with this modification)
- above snippet
