### PR TITLE
[js/web] allow multiple inference session creating concurrently

### DIFF
--- a/js/web/test/e2e/browser-test-wasm-multi-session-create.js
+++ b/js/web/test/e2e/browser-test-wasm-multi-session-create.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+it('Browser E2E testing - WebAssembly backend (multiple inference session create calls)', async function () {
+  const sessionPromiseA = createSession(ort);
+  const sessionPromiseB = createSession(ort);
+  await Promise.all(sessionPromiseA, sessionPromiseB);
+});

--- a/js/web/test/e2e/browser-test-wasm-multi-session-create.js
+++ b/js/web/test/e2e/browser-test-wasm-multi-session-create.js
@@ -6,5 +6,5 @@
 it('Browser E2E testing - WebAssembly backend (multiple inference session create calls)', async function () {
   const sessionPromiseA = createSession(ort);
   const sessionPromiseB = createSession(ort);
-  await Promise.all(sessionPromiseA, sessionPromiseB);
+  await Promise.all([sessionPromiseA, sessionPromiseB]);
 });

--- a/js/web/test/e2e/common.js
+++ b/js/web/test/e2e/common.js
@@ -7,8 +7,12 @@ function assert(cond) {
   if (!cond) throw new Error();
 }
 
+var createSession = function(ort) {
+  return ort.InferenceSession.create('./model.onnx', options || {});
+}
+
 var testFunction = async function (ort, options) {
-  const session = await ort.InferenceSession.create('./model.onnx', options || {});
+  const session = await createSession(ort);
 
   const dataA = Float32Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
   const dataB = Float32Array.from([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);

--- a/js/web/test/e2e/common.js
+++ b/js/web/test/e2e/common.js
@@ -7,12 +7,12 @@ function assert(cond) {
   if (!cond) throw new Error();
 }
 
-var createSession = function(ort) {
+var createSession = function(ort, options) {
   return ort.InferenceSession.create('./model.onnx', options || {});
 }
 
 var testFunction = async function (ort, options) {
-  const session = await createSession(ort);
+  const session = await createSession(ort, options);
 
   const dataA = Float32Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
   const dataB = Float32Array.from([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);

--- a/js/web/test/e2e/run.js
+++ b/js/web/test/e2e/run.js
@@ -100,6 +100,7 @@ async function testAllBrowserCases({ hostInKarma }) {
   await runKarma({ hostInKarma, main: './browser-test-webgl.js', ortMain: 'ort.webgl.min.js'});
   await runKarma({ hostInKarma, main: './browser-test-wasm.js'});
   await runKarma({ hostInKarma, main: './browser-test-wasm.js', ortMain: 'ort.wasm.min.js'});
+  await runKarma({ hostInKarma, main: './browser-test-wasm-multi-session-create.js'});
   await runKarma({ hostInKarma, main: './browser-test-wasm-no-threads.js'});
   await runKarma({ hostInKarma, main: './browser-test-wasm-no-threads.js', ortMain: 'ort.wasm-core.min.js'});
   await runKarma({ hostInKarma, main: './browser-test-wasm-proxy.js'});


### PR DESCRIPTION
**Description**: When the second call comes to `resolveBackends()`, we should not fail the call. Instead, we can return the uncompleted promise that created at the first call. Both calls can continue when the promise resolved or rejected.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  WebAssembly instance should be initialized only once. However, this restriction should not block users from creating multiple inference sessions concurrently. See the added test case and #10774 for more details.
