### PR TITLE
avoid using LocalFree on FormatMessageW buffer

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -545,7 +545,7 @@ class WindowsEnv : public Env {
     if (!*handle) {
       const auto error_code = GetLastError();
       static const DWORD bufferLength = 64 * 1024;
-      std::string s(bufferLength, '\0');
+      std::wstring s(bufferLength, '\0');
       FormatMessageW(
           FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
@@ -556,7 +556,7 @@ class WindowsEnv : public Env {
           (LPWSTR)s.data(),
           0, NULL);
       std::wostringstream oss;
-      oss << L"LoadLibrary failed with error " << error_code << L" \"" << (LPWSTR)s.c_str() << L"\" when trying to load \"" << wlibrary_filename << L"\"";
+      oss << L"LoadLibrary failed with error " << error_code << L" \"" << s.c_str() << L"\" when trying to load \"" << wlibrary_filename << L"\"";
       std::wstring errmsg = oss.str();
       // TODO: trim the ending '\r' and/or '\n'
       common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));
@@ -578,7 +578,7 @@ class WindowsEnv : public Env {
     if (!*symbol) {
       const auto error_code = GetLastError();
       static const DWORD bufferLength = 64 * 1024;
-      std::string s(bufferLength, '\0');
+      std::wstring s(bufferLength, '\0');
       FormatMessageW(
           FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
@@ -589,7 +589,7 @@ class WindowsEnv : public Env {
           (LPWSTR)s.data(),
           0, NULL);
       std::wostringstream oss;
-      oss << L"Failed to find symbol " << ToWideString(symbol_name) << L" in library, error code: " << error_code << L" \"" << (LPWSTR)s.c_str() << L"\"";
+      oss << L"Failed to find symbol " << ToWideString(symbol_name) << L" in library, error code: " << error_code << L" \"" << s.c_str() << L"\"";
       std::wstring errmsg = oss.str();
       // TODO: trim the ending '\r' and/or '\n'
       common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -547,7 +547,6 @@ class WindowsEnv : public Env {
       static const DWORD bufferLength = 64 * 1024;
       std::wstring s(bufferLength, '\0');
       FormatMessageW(
-          FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
               FORMAT_MESSAGE_IGNORE_INSERTS,
           NULL,
@@ -580,7 +579,6 @@ class WindowsEnv : public Env {
       static const DWORD bufferLength = 64 * 1024;
       std::wstring s(bufferLength, '\0');
       FormatMessageW(
-          FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
               FORMAT_MESSAGE_IGNORE_INSERTS,
           NULL,

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -544,7 +544,7 @@ class WindowsEnv : public Env {
 #endif
     if (!*handle) {
       const auto error_code = GetLastError();
-      static const DWORD bufferLength = 64 * 1024;
+      static constexpr DWORD bufferLength = 64 * 1024;
       std::wstring s(bufferLength, '\0');
       FormatMessageW(
               FORMAT_MESSAGE_FROM_SYSTEM |
@@ -576,7 +576,7 @@ class WindowsEnv : public Env {
     *symbol = ::GetProcAddress(reinterpret_cast<HMODULE>(handle), symbol_name.c_str());
     if (!*symbol) {
       const auto error_code = GetLastError();
-      static const DWORD bufferLength = 64 * 1024;
+      static constexpr DWORD bufferLength = 64 * 1024;
       std::wstring s(bufferLength, '\0');
       FormatMessageW(
               FORMAT_MESSAGE_FROM_SYSTEM |

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -544,7 +544,8 @@ class WindowsEnv : public Env {
 #endif
     if (!*handle) {
       const auto error_code = GetLastError();
-      LPVOID lpMsgBuf;
+      static const DWORD bufferLength = 64 * 1024;
+      std::string s(bufferLength, '\0');
       FormatMessageW(
           FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
@@ -552,14 +553,13 @@ class WindowsEnv : public Env {
           NULL,
           error_code,
           MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-          (LPWSTR)&lpMsgBuf,
+          (LPWSTR)s.data(),
           0, NULL);
       std::wostringstream oss;
-      oss << L"LoadLibrary failed with error " << error_code << L" \"" << (LPWSTR)lpMsgBuf << L"\" when trying to load \"" << wlibrary_filename << L"\"";
+      oss << L"LoadLibrary failed with error " << error_code << L" \"" << (LPWSTR)s.c_str() << L"\" when trying to load \"" << wlibrary_filename << L"\"";
       std::wstring errmsg = oss.str();
       // TODO: trim the ending '\r' and/or '\n'
       common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));
-      LocalFree(lpMsgBuf);
       return status;
     }
     return Status::OK();
@@ -577,7 +577,8 @@ class WindowsEnv : public Env {
     *symbol = ::GetProcAddress(reinterpret_cast<HMODULE>(handle), symbol_name.c_str());
     if (!*symbol) {
       const auto error_code = GetLastError();
-      LPVOID lpMsgBuf;
+      static const DWORD bufferLength = 64 * 1024;
+      std::string s(bufferLength, '\0');
       FormatMessageW(
           FORMAT_MESSAGE_ALLOCATE_BUFFER |
               FORMAT_MESSAGE_FROM_SYSTEM |
@@ -585,14 +586,13 @@ class WindowsEnv : public Env {
           NULL,
           error_code,
           MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-          (LPWSTR)&lpMsgBuf,
+          (LPWSTR)s.data(),
           0, NULL);
       std::wostringstream oss;
-      oss << L"Failed to find symbol " << ToWideString(symbol_name) << L" in library, error code: " << error_code << L" \"" << (LPWSTR)lpMsgBuf << L"\"";
+      oss << L"Failed to find symbol " << ToWideString(symbol_name) << L" in library, error code: " << error_code << L" \"" << (LPWSTR)s.c_str() << L"\"";
       std::wstring errmsg = oss.str();
       // TODO: trim the ending '\r' and/or '\n'
       common::Status status(common::ONNXRUNTIME, common::FAIL, ToUTF8String(errmsg));
-      LocalFree(lpMsgBuf);
       return status;
     }
     return Status::OK();


### PR DESCRIPTION
LocalFree doesn't work downlevel on windows 8.1. 

Onecoreuap.lib should be used so that specific apisets don't need to be required to run on downlevel OS's like 8.1 and can fall back to using kernel32.dll using reverseforwarders.

The builds need to be changed in a separate change, from using Onecoreuap_apiset.lib to using onecoreuap.lib. With this change, a check must be added in the CI pipelines by using the APIValidator tool to check for regressions


