### PR TITLE
Change how we apply patches to absl

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -510,6 +510,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS")
 endif()
 
 find_package(Threads)
+find_package(Patch)
+if(Patch_FOUND)
+  message("Patch found: ${Patch_EXECUTABLE}")
+endif()
 
 macro(check_nvcc_compiler_flag _FLAG _RESULT)
     execute_process(COMMAND ${onnxruntime_CUDA_HOME}/bin/nvcc "${_FLAG}" RESULT_VARIABLE NVCC_OUT ERROR_VARIABLE NVCC_ERROR)

--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -8,7 +8,7 @@ set(ABSL_PROPAGATE_CXX_STD 1)
 set(BUILD_TESTING 0)
 
 if(Patch_FOUND)
-  set(ABSL_PATCH_COMMAND patch --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch)
+  set(ABSL_PATCH_COMMAND ${Patch_EXECUTABLE} --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch)
 else()
   set(ABSL_PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch)
 endif()

--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -7,12 +7,18 @@ include(FetchContent)
 set(ABSL_PROPAGATE_CXX_STD 1)
 set(BUILD_TESTING 0)
 
+if(Patch_FOUND)
+  set(ABSL_PATCH_COMMAND patch --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch)
+else()
+  set(ABSL_PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch)
+endif()
+
 FetchContent_Declare(
     abseil_cpp
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/abseil-cpp"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/abseil-cpp"
     URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip
-    PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/abseil/Fix_Nvidia_Build_Break.patch
+    PATCH_COMMAND ${ABSL_PATCH_COMMAND}
 )
 
 FetchContent_MakeAvailable(abseil_cpp)


### PR DESCRIPTION
**Description**:

"git apply" doesn't work when a parent dir of the build dir contains a ".git" folder.  We should use the "patch" command when possible.  Though this fix isn't an ultimate solution, it should solve the needs of all Linux developers. 


**Motivation and Context**
- Why is this change required? What problem does it solve?

The patch is ignored when the build was run from "build.sh" instead of "build.py"

- If it fixes an open issue, please link to the issue here.
