### PR TITLE
[js/web] Change a pipeline vmImage from windows-latest to windows-2019

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-web-multi-browsers.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-multi-browsers.yml
@@ -6,7 +6,7 @@ parameters:
 jobs:
 - job: build_onnxruntime_web_windows
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
   timeoutInMinutes: 30
   workspace:
     clean: all


### PR DESCRIPTION
Use windows-2019 explicitly to avoid any unexpected issues when windows-latest uses windows-2022.
