### PR TITLE
Making the Java tests faster by optionally disabling ones which require running multiple JVMs

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -167,12 +167,16 @@ test {
 	java {
 		dependsOn spotlessJava
 	}
-	forkEvery 1 // Forces each test class to be run in a separate JVM, which is necessary for testing the environment thread pool
+	if (System.getProperty("JAVA_FULL_TEST") != null) {
+		// Forces each test class to be run in a separate JVM,
+		// which is necessary for testing the environment thread pool which is ignored if full test is not set.
+		forkEvery 1
+	}
 	useJUnitPlatform()
 	if (cmakeBuildDir != null) {
 		workingDir cmakeBuildDir
 	}
-	systemProperties System.getProperties().subMap(['USE_CUDA', 'USE_ROCM', 'USE_TENSORRT', 'USE_DNNL', 'USE_OPENVINO'])
+	systemProperties System.getProperties().subMap(['USE_CUDA', 'USE_ROCM', 'USE_TENSORRT', 'USE_DNNL', 'USE_OPENVINO', 'JAVA_FULL_TEST'])
 	testLogging {
 		events "passed", "skipped", "failed"
 		showStandardStreams = true

--- a/java/src/test/java/ai/onnxruntime/EnvironmentThreadPoolTest.java
+++ b/java/src/test/java/ai/onnxruntime/EnvironmentThreadPoolTest.java
@@ -14,10 +14,12 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /** This test is in a separate class to ensure it is run in a clean JVM. */
 public class EnvironmentThreadPoolTest {
 
+  @EnabledIfSystemProperty(named = "JAVA_FULL_TEST", matches = "1")
   @Test
   public void environmentThreadPoolTest() throws OrtException {
     Path squeezeNet = getResourcePath("/squeezenet.onnx");


### PR DESCRIPTION
**Description**: 

Makes the environment thread pool test optional, controlled by a system property `JAVA_FULL_TEST` which is not currently plumbed through the full build pipeline. That test needs to be run in a fresh JVM as it has to have the `OrtEnvironment` constructed fresh in the process to specify the thread pools, and I'd previously ensured that by forcing Gradle to fork a fresh JVM for each test (which is much slower).

**Motivation and Context**
- Why is this change required? What problem does it solve? Allows the Java tests to all run in the same JVM, to make them run faster. See #10808
