### PR TITLE
[rel-1.11.0] Remove unused six dependency

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -12,7 +12,6 @@ import onnx
 import onnxruntime
 from onnx import helper, TensorProto, ModelProto
 from onnx import onnx_pb as onnx_proto
-from six import string_types
 from enum import Enum
 
 from .quant_utils import QuantType, smooth_distribution, apply_plot


### PR DESCRIPTION
**Description**:
Remove the unused "six" library.

**Motivation and Context**
Continue the work of https://github.com/microsoft/onnxruntime/pull/9941. Both ONNX and ONNXRuntime does not support Python 2. ONNX has removed six dependency since ONNX 1.11. ONNXRuntime also removed six dependency recently. However, one more six has not been removed: a unused six is breaking CIs.