### PR TITLE
chore: remove six reference

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -6,13 +6,11 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import os
 import numpy as np
 import onnx
 import onnxruntime
 from onnx import helper, TensorProto, ModelProto
 from onnx import onnx_pb as onnx_proto
-from six import string_types
 from enum import Enum
 
 from .quant_utils import QuantType, smooth_distribution, apply_plot


### PR DESCRIPTION
**Description**: Removes an (unused) reference to six

**Motivation and Context**
- ONNX no longer supports Python 2, so the six compatibility code is not necessary.