### PR TITLE
Uninstall onnxruntime-training before running local tests

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -80,18 +80,18 @@ jobs:
     inputs:
        scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
        workingDirectory: $(Build.BinariesDirectory)/Release
-       arguments: |
-          --build_dir $(Build.BinariesDirectory) \
-          --cmake_generator Ninja \
-          --config Release \
-          --test \
-          --skip_submodule_sync \
-          --build_shared_lib \
-          --parallel \
-          --build_wheel \
-          --enable_onnx_tests \
-          --enable_transformers_tool_test \
-          --build_nodejs \
+       arguments: >-
+          --build_dir $(Build.BinariesDirectory)
+          --cmake_generator Ninja
+          --config Release
+          --test
+          --skip_submodule_sync
+          --build_shared_lib
+          --parallel
+          --build_wheel
+          --enable_onnx_tests
+          --enable_transformers_tool_test
+          --build_nodejs
           --ctest_path ""
 
   - task: CmdLine@2
@@ -108,18 +108,18 @@ jobs:
     inputs:
       scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
       workingDirectory: $(Build.BinariesDirectory)/Debug
-      arguments: |
-          --build_dir $(Build.BinariesDirectory) \
-          --cmake_generator Ninja \
-          --config Debug \
-          --test \
-          --skip_submodule_sync \
-          --build_shared_lib \
-          --parallel \
-          --build_wheel \
-          --enable_onnx_tests \
-          --enable_transformers_tool_test \
-          --build_nodejs \
+      arguments: >-
+          --build_dir $(Build.BinariesDirectory)
+          --cmake_generator Ninja
+          --config Debug
+          --test
+          --skip_submodule_sync
+          --build_shared_lib
+          --parallel
+          --build_wheel
+          --enable_onnx_tests
+          --enable_transformers_tool_test
+          --build_nodejs
           --ctest_path ""
 
   - task: PythonScript@0

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -13,6 +13,11 @@ jobs:
     inputs:
       versionSpec: '12.16.3'
 
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+
   - template: templates/get-docker-image-steps.yml
     parameters:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -70,11 +70,12 @@ jobs:
          rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
          python3 -m pip install $(Build.BinariesDirectory)/Release/dist/*.whl
 
-  - task: CmdLine@2
+  - task: PythonScript@0
     displayName: 'Run Release unit tests'
     inputs:
-      script: |
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
+       scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
+       workingDirectory: $(Build.BinariesDirectory)/Release
+       arguments: |
           --build_dir $(Build.BinariesDirectory) \
           --cmake_generator Ninja \
           --config Release \
@@ -92,15 +93,17 @@ jobs:
     displayName: 'Install Debug python package'
     inputs:
       script: |
+         set -e -x
          rm -rf $(Build.BinariesDirectory)/Debug/onnxruntime $(Build.BinariesDirectory)/Debug/pybind11
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          python3 -m pip install $(Build.BinariesDirectory)/Debug/dist/*.whl
 
-  - task: CmdLine@2
+  - task: PythonScript@0
     displayName: 'Run Debug unit tests'
     inputs:
-      script: |
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
+      scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
+      workingDirectory: $(Build.BinariesDirectory)/Debug
+      arguments: |
           --build_dir $(Build.BinariesDirectory) \
           --cmake_generator Ninja \
           --config Debug \
@@ -114,12 +117,11 @@ jobs:
           --build_nodejs \
           --ctest_path ""
 
-  - task: CmdLine@2
+  - task: PythonScript@0
     displayName: 'Symbolic shape infer'
     inputs:
-      script: |
-        cd $(Build.BinariesDirectory)/Release
-        python3 $(Build.BinariesDirectory)/Release/onnxruntime_test_python_symbolic_shape_infer.py
+      scriptPath: $(Build.BinariesDirectory)/Release/onnxruntime_test_python_symbolic_shape_infer.py
+      workingDirectory: $(Build.BinariesDirectory)/Release
 
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -51,7 +51,7 @@ jobs:
     inputs:
       script: |
          set -e -x
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
          # Test ORT with the latest ONNX release.
          export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)
@@ -93,7 +93,7 @@ jobs:
     inputs:
       script: |
          rm -rf $(Build.BinariesDirectory)/Debug/onnxruntime $(Build.BinariesDirectory)/Debug/pybind11
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          python3 -m pip install $(Build.BinariesDirectory)/Debug/dist/*.whl
 
   - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
          # We assume the machine doesn't have gcc and python development header files
          sudo rm -f /build /onnxruntime_src
          sudo ln -s $(Build.SourcesDirectory) /onnxruntime_src
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
          # Test ORT with the latest ONNX release.
          export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -13,6 +13,11 @@ jobs:
     inputs:
       versionSpec: '12.16.3'
 
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+
   - template: templates/get-docker-image-steps.yml
     parameters:
       Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -71,34 +71,35 @@ jobs:
          rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
          python3 -m pip install $(Build.BinariesDirectory)/Release/dist/*.whl
 
-  - task: CmdLine@2
+
+  - task: PythonScript@0
     displayName: 'Run Release unit tests'
     inputs:
-      script: |
-        cd /tmp
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --build_dir $(Build.BinariesDirectory) --cmake_generator Ninja --config Release --test --skip_submodule_sync --build_shared_lib --parallel --build_wheel --enable_training --enable_onnx_tests --build_nodejs --ctest_path ""
+       scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
+       workingDirectory: $(Build.BinariesDirectory)/Release
+       arguments: --build_dir $(Build.BinariesDirectory) --cmake_generator Ninja --config Release --test --skip_submodule_sync --build_shared_lib --parallel --build_wheel --enable_training --enable_onnx_tests --build_nodejs --ctest_path ""
 
   - task: CmdLine@2
     displayName: 'Install Debug python package'
     inputs:
       script: |
+         set -e -x
          rm -rf $(Build.BinariesDirectory)/Debug/onnxruntime $(Build.BinariesDirectory)/Debug/pybind11
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          python3 -m pip install $(Build.BinariesDirectory)/Debug/dist/*.whl
 
-  - task: CmdLine@2
+  - task: PythonScript@0
     displayName: 'Run Debug unit tests'
     inputs:
       scriptPath: $(Build.SourcesDirectory)/tools/ci_build/build.py
       arguments: --build_dir $(Build.BinariesDirectory) --cmake_generator Ninja --config Debug --test --skip_submodule_sync --build_shared_lib --parallel --build_wheel --enable_training --enable_onnx_tests --build_nodejs --ctest_path ""
-      workingDirectory: /tmp
+      workingDirectory: $(Build.BinariesDirectory)/Debug
 
-  - task: CmdLine@2
+  - task: PythonScript@0
     displayName: 'Symbolic shape infer'
     inputs:
-      script: |
-        cd $(Build.BinariesDirectory)/Release
-        python3 $(Build.BinariesDirectory)/Release/onnxruntime_test_python_symbolic_shape_infer.py
+      scriptPath: $(Build.BinariesDirectory)/Release/onnxruntime_test_python_symbolic_shape_infer.py
+      workingDirectory: $(Build.BinariesDirectory)/Release
 
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -50,7 +50,7 @@ jobs:
     inputs:
       script: |
          set -e -x
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
          # Test ORT with the latest ONNX release.
          export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)
@@ -83,7 +83,7 @@ jobs:
     inputs:
       script: |
          rm -rf $(Build.BinariesDirectory)/Debug/onnxruntime $(Build.BinariesDirectory)/Debug/pybind11
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          python3 -m pip install $(Build.BinariesDirectory)/Debug/dist/*.whl
 
   - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
@@ -341,7 +341,7 @@ stages:
             rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
             sudo rm -f /build /onnxruntime_src
             sudo ln -s $(Build.SourcesDirectory) /onnxruntime_src
-            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
             cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
             # Test ORT with the latest ONNX release.
             export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -116,7 +116,7 @@ stages:
             rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
             sudo rm -f /build /onnxruntime_src
             sudo ln -s $(Build.SourcesDirectory) /onnxruntime_src
-            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
             cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
             # Test ORT with the latest ONNX release.
             export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)
@@ -245,7 +245,7 @@ stages:
             rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11
             sudo rm -f /build /onnxruntime_src
             sudo ln -s $(Build.SourcesDirectory) /onnxruntime_src
-            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+            python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
             cp $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt $(Build.BinariesDirectory)/requirements.txt
             # Test ORT with the latest ONNX release.
             export ONNX_VERSION=$(cat $(Build.SourcesDirectory)/cmake/external/onnx/VERSION_NUMBER)

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -173,7 +173,7 @@ jobs:
 
   - ${{ if eq(parameters.EnablePython, true) }}:
       - powershell: |
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
        
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -193,7 +193,7 @@ jobs:
 
   - ${{ if eq(parameters.EnablePython, true) }}:
       - powershell: |
-         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu -qq
+         python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
        
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'


### PR DESCRIPTION
**Description**: 

Uninstall onnxruntime-training before running local tests. Otherwise orttraining-linux-ci-pipeline may incorrectly think the package is already installed(from another run), and tests an outdated version.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
