### PR TITLE
Remove the unused six library in code and CIs

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -12,7 +12,6 @@ import onnx
 import onnxruntime
 from onnx import helper, TensorProto, ModelProto
 from onnx import onnx_pb as onnx_proto
-from six import string_types
 from enum import Enum
 
 from .quant_utils import QuantType, smooth_distribution, apply_plot

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -85,7 +85,7 @@ jobs:
     displayName: 'API Documentation Check and generate'
 
   - script: |
-     python -m pip install -q setuptools wheel numpy six
+     python -m pip install -q setuptools wheel numpy
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -98,7 +98,7 @@ jobs:
     displayName: 'API Documentation Check and generate'
 
   - script: |
-     python -m pip install -q setuptools wheel numpy six
+     python -m pip install -q setuptools wheel numpy
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'
 

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -7,4 +7,3 @@ git+http://github.com/onnx/onnx.git@be76ca7148396176784ba8733133b9fb1186ea0d#egg
 protobuf
 sympy==1.1.1
 flatbuffers
-six


### PR DESCRIPTION
**Description**:
- Remove the unused "six" library in certain Python code
- Remove installing six in CIs since it should not be needed

**Motivation and Context**
Same as https://github.com/microsoft/onnxruntime/pull/10822 which targeted release branch. This PR is targeting the main branch. Furthermore, try to remove installing six in CIs.