### PR TITLE
Patch absl so that it doesn't disable important VC++ warnings

### DIFF
--- a/cmake/patches/abseil/Fix_Nvidia_Build_Break.patch
+++ b/cmake/patches/abseil/Fix_Nvidia_Build_Break.patch
@@ -20,3 +20,18 @@ index 1d7d6cd..f6a7a78 100644
          {allocated_storage_view.data, allocated_storage_view.capacity});
    }
  
+diff --git a/absl/copts/copts.py b/absl/copts/copts.py
+index 0d6c1ec..75fd935 100644
+--- a/absl/copts/copts.py
++++ b/absl/copts/copts.py
+@@ -132,10 +132,6 @@ COPT_VARS = {
+             "/wd4068",  # unknown pragma
+             # qualifier applied to function type has no meaning; ignored
+             "/wd4180",
+-            # conversion from 'type1' to 'type2', possible loss of data
+-            "/wd4244",
+-            # conversion from 'size_t' to 'type', possible loss of data
+-            "/wd4267",
+             # The decorated name was longer than the compiler limit
+             "/wd4503",
+             # forcing value to bool 'true' or 'false' (performance warning)

--- a/cmake/patches/abseil/Fix_Nvidia_Build_Break.patch
+++ b/cmake/patches/abseil/Fix_Nvidia_Build_Break.patch
@@ -20,6 +20,32 @@ index 1d7d6cd..f6a7a78 100644
          {allocated_storage_view.data, allocated_storage_view.capacity});
    }
  
+diff --git a/absl/copts/GENERATED_AbseilCopts.cmake b/absl/copts/GENERATED_AbseilCopts.cmake
+index a4ab1aa..dfd13fd 100644
+--- a/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -129,8 +129,6 @@ list(APPEND ABSL_MSVC_FLAGS
+     "/wd4005"
+     "/wd4068"
+     "/wd4180"
+-    "/wd4244"
+-    "/wd4267"
+     "/wd4503"
+     "/wd4800"
+ )
+diff --git a/absl/copts/GENERATED_copts.bzl b/absl/copts/GENERATED_copts.bzl
+index a6efc98..8c4de8e 100644
+--- a/absl/copts/GENERATED_copts.bzl
++++ b/absl/copts/GENERATED_copts.bzl
+@@ -130,8 +130,6 @@ ABSL_MSVC_FLAGS = [
+     "/wd4005",
+     "/wd4068",
+     "/wd4180",
+-    "/wd4244",
+-    "/wd4267",
+     "/wd4503",
+     "/wd4800",
+ ]
 diff --git a/absl/copts/copts.py b/absl/copts/copts.py
 index 0d6c1ec..75fd935 100644
 --- a/absl/copts/copts.py


### PR DESCRIPTION
**Description**:

This is just for passing Binskim rules. 

This is how I made it:

1. git clone absl repo, checkout the version we are using
2. Then apply our patch file
3. Make modifications
4. Regenerate the patch file by "git diff > C:\src\onnxruntime\cmake\patch\xxx.patch"
5. Then submit the change to our repo

You will need to repeat the steps when you need to advance the absl commit or add more changes to it. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
