### PR TITLE
Skip optional related opset16 tests in NuGet pipelines

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -337,6 +337,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { "test_optional_get_element_sequence", "not implemented yet"},
                 { "test_optional_has_element", "not implemented yet"},
                 { "test_optional_has_element_empty", "not implemented yet"},
+                { "test_identity_opt", "opset16 version not implemented yet"},
+                { "test_if_opt", "opset16 version not implemented yet"},
+                { "test_loop16_seq_none", "opset16 version not implemented yet"},
             };
 
             // The following models fails on nocontribops win CI


### PR DESCRIPTION
**Description**:
Skip optional related opset16 tests (test_identity_opt, test_if_opt, test_loop16_seq_none) in NuGet pipelines

**Motivation and Context**
NuGet pipeline failed due to these test data brought from ONNX 1.11. The failure is: `System.Exception : Opset opset14, Model test_if_opt: ModelFile = /Users/runner/work/1/b/models/opset14/test_if_opt/model.onnx error = [ErrorCode:NotImplemented] not implemented`. Since these tests are skipped [here](https://github.com/microsoft/onnxruntime/blob/e23892ddbecbc2be5a527c66c105f4949c742236/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc#L79) and [here](https://github.com/microsoft/onnxruntime/blob/7396689c2b358b4b73aa0fd4ecbd4253d4e6d770/onnxruntime/test/onnx/main.cc#L600), I assume ORT has not supported these tests yet. Therefore, this PR is for skipping these tests. Please correct me if I am wrong. Thank you!