### PR TITLE
Add support for opset 16 to transpose optimizer.

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api.h
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api.h
@@ -428,7 +428,7 @@ class GraphRef {
 }  // namespace api
 
 constexpr int64_t kMinSupportedOpset = 7;
-constexpr int64_t kMaxSupportedOpset = 15;
+constexpr int64_t kMaxSupportedOpset = 16;
 
 enum class OptimizerMode {
   OPTIMIZE_TRANSPOSE,        // simple transpose optimization
@@ -440,6 +440,11 @@ enum class OptimizerMode {
 /// </summary>
 /// <returns>const reference to an unordered set of op_types which are layout sensitive</returns>
 const std::unordered_set<std::string_view>& GetLayoutSensitiveOps();
+
+struct OptimizeResult {
+  std::optional<std::string> error_msg;  // set if there was an error
+  bool graph_modified{false};
+};
 
 /// <summary>
 /// Performs transpose optimization on a graph. Returns true if the graph was modified.
@@ -453,15 +458,17 @@ const std::unordered_set<std::string_view>& GetLayoutSensitiveOps();
 /// <param name="graph">The graph to optimize (or a portion of a graph, see api::GraphRef docs)</param>
 /// <param name="allow_extended_ops">Whether com.microsoft ops can be used for optimization</param>
 /// <param name="provider_type">Execution provider if applicable.</param>
-/// <param name="mode">Current mode. Optimizer can be called in the context of transpose optimizations or during layout transformations.</param>
-/// <param name="layout_sensitive_ops">List of ops which are treated as layout sensitive by the ONNX standard as well as any runtime specific ops.
-/// These ops should be provided when mode is set to OPTIMIZE_LAYOUT_TRANSFORM. If these ops are not provided, transpose optimizer may convert the
-/// layout for these ops </param>
-/// <returns>true if the graph was modified</returns>
-bool Optimize(api::GraphRef& graph, bool allow_extended_ops,
-              const std::string& provider_type = "",
-              OptimizerMode mode = OptimizerMode::OPTIMIZE_TRANSPOSE,
-              const std::unordered_set<std::string_view>& layout_sensitive_ops = {});
+/// <param name="mode">Current mode. Optimizer can be called in the context of transpose optimizations or during
+/// layout transformations.</param>
+/// <param name="layout_sensitive_ops">List of ops which are treated as layout sensitive by the ONNX standard
+/// as well as any runtime specific ops. These ops should be provided when mode is set to OPTIMIZE_LAYOUT_TRANSFORM.
+/// If these ops are not provided, transpose optimizer may convert the layout for these ops </param>
+/// <returns>OptimizeResult. If error_msg is set the Optimize failed. If not set, graph_modified indicates whether
+/// any changes were required during optimization.</returns>
+OptimizeResult Optimize(api::GraphRef& graph, bool allow_extended_ops,
+                        const std::string& provider_type = "",
+                        OptimizerMode mode = OptimizerMode::OPTIMIZE_TRANSPOSE,
+                        const std::unordered_set<std::string_view>& layout_sensitive_ops = {});
 
 /* Layout Transformation Tools
  * These methods help change the channel ordering of layout sensitive ops (like Conv). ONNX currently only supports

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -876,9 +876,14 @@ Status TransformLayoutForCompilingEP(Graph& graph, bool& modified, const IExecut
   }
 
   if (modified) {
-    onnx_layout_transformation::Optimize(*api_graph, /*allow_extended_ops*/ true, execution_provider.Type(),
-                                         onnx_layout_transformation::OptimizerMode::OPTIMIZE_LAYOUT_TRANSFORM,
-                                         layout_sensitive_ops);
+    OptimizeResult result =
+        onnx_layout_transformation::Optimize(*api_graph, /*allow_extended_ops*/ true, execution_provider.Type(),
+                                             onnx_layout_transformation::OptimizerMode::OPTIMIZE_LAYOUT_TRANSFORM,
+                                             layout_sensitive_ops);
+    if (result.error_msg) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Optimization after layout transformation failed: ",
+                             result.error_msg.value());
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/core/optimizer/transpose_optimizer/ort_transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/ort_transpose_optimizer.cc
@@ -24,7 +24,9 @@ Status TransposeOptimizer::ApplyImpl(Graph& graph, bool& modified, int graph_lev
     LOGS(logger, WARNING) << "Transpose optimizer failed: " << result.error_msg.value();
   }
 
-  modified = result.graph_modified;
+  if (result.graph_modified) {
+    modified = true;
+  }
 
   GraphViewer graph_viewer(graph);
   auto nodes = std::vector<std::unique_ptr<api::NodeRef>>();

--- a/onnxruntime/core/optimizer/transpose_optimizer/ort_transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/ort_transpose_optimizer.cc
@@ -17,9 +17,14 @@ namespace onnxruntime {
 
 Status TransposeOptimizer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   auto api_graph = MakeApiGraph(graph, cpu_allocator_, /*new_node_ep*/ nullptr);
-  if (onnx_layout_transformation::Optimize(*api_graph, /*allow_extended_ops*/ false)) {
-    modified = true;
+  OptimizeResult result = onnx_layout_transformation::Optimize(*api_graph, /*allow_extended_ops*/ false);
+  if (result.error_msg) {
+    // currently onnx_layout_transformation::Optimize only fails if we hit an unsupported opset.
+    // we don't want to fail loading the model just because we can't optimize Transpose ops, so just log a warning
+    LOGS(logger, WARNING) << "Transpose optimizer failed: " << result.error_msg.value();
   }
+
+  modified = result.graph_modified;
 
   GraphViewer graph_viewer(graph);
   auto nodes = std::vector<std::unique_ptr<api::NodeRef>>();

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -1412,7 +1412,7 @@ static bool HandleTile(HandlerArgs& args) {
 
 constexpr HandlerInfo tile_handler = {&FirstInput, &HandleTile};
 
-// Helper to remove cancelling Transpose -> Transpose or 
+// Helper to remove cancelling Transpose -> Transpose or
 // Transpose -> Reshape nodes.
 static void RemoveCancelingTransposeNodes(HandlerArgs& args) {
   // Input to 1st transpose
@@ -1491,7 +1491,7 @@ static bool HandleTranspose(HandlerArgs& args) {
 constexpr HandlerInfo transpose_handler = {&FirstInput, &HandleTranspose, /*transposes_outputs*/ false};
 
 static bool HandleReshape(HandlerArgs& args) {
-  // We check for a very specific case where Transpose is replaced by Reshape 
+  // We check for a very specific case where Transpose is replaced by Reshape
   // for performance. For example Transpose(input {1, 1, 1, X}, perm{0, 3, 2, 1}) can be replaced by Reshape
   // Reshape(input{1, 1, 1, X}, shape{1, X, 1, 1})
   // During transpose optimization we need to detect such reshape nodes so that we can remove them if possible.
@@ -1502,7 +1502,7 @@ static bool HandleReshape(HandlerArgs& args) {
     return false;
   }
 
-  // Check only 1 dim is not equal to 1. This is to validate that tranpose and reshape are truly canceling nodes 
+  // Check only 1 dim is not equal to 1. This is to validate that tranpose and reshape are truly canceling nodes
   // and can be therefore removed.
   int num_dims_not_equal_to_1 = 0;
   for (int i = 0; i < 4; i++) {
@@ -1521,7 +1521,7 @@ static bool HandleReshape(HandlerArgs& args) {
   }
 
   // Check whether transpose cancels with reshape node
-  // We check if shape of transpose node's input matches the shape data 
+  // We check if shape of transpose node's input matches the shape data
   // provided for reshape node.
   auto reshape_output_shape = DataInt64(*shape_data);
   if (reshape_output_shape != transpose_input_shape) {
@@ -1812,14 +1812,22 @@ bool ProcessTranspose(OptimizerCtx& ctx, api::NodeRef& transpose, api::NodeRef& 
 // Returns nullopt if graph opset is unsupported.
 std::optional<OptimizerCtx> MakeOptimizerContext(api::GraphRef& graph, bool allow_extended_ops,
                                                  const std::string& provider_type, OptimizerMode mode,
-                                                 const std::unordered_set<std::string_view>& layout_sensitive_ops) {
+                                                 const std::unordered_set<std::string_view>& layout_sensitive_ops,
+                                                 std::string& error_msg) {
   auto opset = graph.Opset("");
   if (opset == std::nullopt) {
     opset = graph.Opset("ai.onnx");
   }
+
   if (opset == std::nullopt || *opset > kMaxSupportedOpset || *opset < kMinSupportedOpset) {
+    // if the model doesn't have an ONNX opset that's fine as there are no ops we'd move around
+    if (opset.has_value()) {
+      error_msg = "Unsupported ONNX opset";
+    }
+	
     return std::nullopt;
   }
+
   if (allow_extended_ops) {
     auto ms_opset = graph.Opset("com.microsoft");
     if (ms_opset == std::nullopt || *ms_opset != 1) {
@@ -1836,7 +1844,8 @@ std::optional<OptimizerCtx> MakeOptimizerContext(api::GraphRef& graph, bool allo
 
 // Performs optimization. General algorithm: iterate over nodes in topological order. If a node has a transpose
 // as input, push it through if the transpose cost does not increase and is likely to decrease.
-bool OptimizeImpl(OptimizerCtx& ctx) {
+OptimizeResult OptimizeImpl(OptimizerCtx& ctx) {
+  OptimizeResult result;
   const std::vector<std::unique_ptr<api::NodeRef>> nodes = ctx.graph.Nodes();
 
   std::unordered_set<std::string> outputs_leading_to_transpose;
@@ -1901,7 +1910,8 @@ bool OptimizeImpl(OptimizerCtx& ctx) {
   // Currently limiting the second optimization pass to layout transform mode
   // TODO: Enable this for both the modes.
   if (ctx.mode == OptimizerMode::OPTIMIZE_TRANSPOSE) {
-    return changed;
+    result.graph_modified = changed;
+    return result;
   }
 
   // Run second optimization pass.
@@ -1944,24 +1954,33 @@ bool OptimizeImpl(OptimizerCtx& ctx) {
       changed = true;
     }
   }
-  return changed;
+
+  result.graph_modified = changed;
+  return result;
 }
 
 const std::unordered_set<std::string_view>& GetLayoutSensitiveOps() {
   // List of all layout sensitive ops defined in ONNX standard.
   static std::unordered_set<std::string_view> layout_sensitive_ops = {"Conv", "QLinearConv", "BatchNormalization",
                                                                       "AveragePool", "GlobalAveragePool", "MaxPool",
-                                                                      "GlobalMaxPool", "LRN"};
+                                                                      "GlobalMaxPool", "LRN", "GridSample"};
 
   return layout_sensitive_ops;
 }
 
-bool Optimize(api::GraphRef& graph, bool allow_extended_ops,
-              const std::string& provider_type, OptimizerMode mode,
-              const std::unordered_set<std::string_view>& layout_sensitive_ops) {
-  auto ctx = MakeOptimizerContext(graph, allow_extended_ops, provider_type, mode, layout_sensitive_ops);
+OptimizeResult Optimize(api::GraphRef& graph, bool allow_extended_ops,
+                        const std::string& provider_type, OptimizerMode mode,
+                        const std::unordered_set<std::string_view>& layout_sensitive_ops) {
+  OptimizeResult result;
+
+  std::string error_msg;
+  auto ctx = MakeOptimizerContext(graph, allow_extended_ops, provider_type, mode, layout_sensitive_ops, error_msg);
   if (ctx == std::nullopt) {
-    return false;
+    if (!error_msg.empty()) {
+      result.error_msg = std::move(error_msg);
+    }
+	
+    return result;
   }
   return OptimizeImpl(*ctx);
 }

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -1824,7 +1824,7 @@ std::optional<OptimizerCtx> MakeOptimizerContext(api::GraphRef& graph, bool allo
     if (opset.has_value()) {
       error_msg = "Unsupported ONNX opset";
     }
-	
+
     return std::nullopt;
   }
 
@@ -1845,7 +1845,7 @@ std::optional<OptimizerCtx> MakeOptimizerContext(api::GraphRef& graph, bool allo
 // Performs optimization. General algorithm: iterate over nodes in topological order. If a node has a transpose
 // as input, push it through if the transpose cost does not increase and is likely to decrease.
 OptimizeResult OptimizeImpl(OptimizerCtx& ctx) {
-  OptimizeResult result;
+  OptimizeResult result{};
   const std::vector<std::unique_ptr<api::NodeRef>> nodes = ctx.graph.Nodes();
 
   std::unordered_set<std::string> outputs_leading_to_transpose;
@@ -1971,17 +1971,18 @@ const std::unordered_set<std::string_view>& GetLayoutSensitiveOps() {
 OptimizeResult Optimize(api::GraphRef& graph, bool allow_extended_ops,
                         const std::string& provider_type, OptimizerMode mode,
                         const std::unordered_set<std::string_view>& layout_sensitive_ops) {
-  OptimizeResult result;
+  OptimizeResult result{};
 
   std::string error_msg;
   auto ctx = MakeOptimizerContext(graph, allow_extended_ops, provider_type, mode, layout_sensitive_ops, error_msg);
   if (ctx == std::nullopt) {
     if (!error_msg.empty()) {
-      result.error_msg = std::move(error_msg);
+      result.error_msg = error_msg;
     }
-	
+
     return result;
   }
+
   return OptimizeImpl(*ctx);
 }
 


### PR DESCRIPTION
**Description**: 
The transpose optimizer has a maximum opset. Update that to opset 16.

For opset 16, the only change required is for GridSample to be added to the layout sensitive ops. 
The existing handling for layout transpose works with that as the first input and first output are layout sensitive.

Update the optimize to be able to return an error message if it fails.

**Motivation and Context**
Fix failing test.
Support transpose optimization in an opset 16 model.