### PR TITLE
Onecore build

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -178,6 +178,10 @@ option(onnxruntime_EXTERNAL_TRANSFORMER_SRC_PATH "Path to external transformer s
 
 option(onnxruntime_ENABLE_CUDA_PROFILING "Enable CUDA kernel profiling" OFF)
 
+if (WIN32 AND NOT CMAKE_CXX_STANDARD_LIBRARIES MATCHES kernel32.lib)
+  set(onnxruntime_IS_WCOS_BUILD TRUE)
+endif()
+
 if (onnxruntime_USE_CUDA)
   set(onnxruntime_DISABLE_RTTI OFF)
 endif()
@@ -1215,7 +1219,10 @@ endfunction()
 
 function(onnxruntime_add_shared_library target_name)
   add_library(${target_name} SHARED ${ARGN})
-  onnxruntime_configure_target(${target_name})
+  onnxruntime_configure_target(${target_name})  
+  if(onnxruntime_IS_WCOS_BUILD)
+    target_link_options(${target_name} PRIVATE "/NODEFAULTLIB:kernel32.lib" "/NODEFAULTLIB:onecore.lib")
+  endif()
 endfunction()
 
 function(onnxruntime_add_static_library target_name)
@@ -1236,6 +1243,9 @@ function(onnxruntime_add_shared_library_module target_name)
   if (MSVC AND onnxruntime_target_platform STREQUAL "x86" AND NOT onnxruntime_BUILD_WEBASSEMBLY)
     target_link_options(${target_name} PRIVATE /SAFESEH)
   endif()
+  if(onnxruntime_IS_WCOS_BUILD)
+    target_link_options(${target_name} PRIVATE "/NODEFAULTLIB:kernel32.lib" "/NODEFAULTLIB:onecore.lib")
+  endif()
 endfunction()
 
 function(onnxruntime_add_executable target_name)
@@ -1243,6 +1253,9 @@ function(onnxruntime_add_executable target_name)
   onnxruntime_configure_target(${target_name})
   if (MSVC AND onnxruntime_target_platform STREQUAL "x86" AND NOT onnxruntime_BUILD_WEBASSEMBLY)
     target_link_options(${target_name} PRIVATE /SAFESEH)
+  endif()
+  if(onnxruntime_IS_WCOS_BUILD)
+    target_link_options(${target_name} PRIVATE "/NODEFAULTLIB:kernel32.lib" "/NODEFAULTLIB:onecore.lib")
   endif()
 endfunction()
 


### PR DESCRIPTION
**Description**: 

onnxruntime has a build option: "--enable_wcos". WCOS stands for Windows Core OS.  onecore is the common component of all Windows 10/11 editions.  So if onnxruntime only uses functions provided by onecore, then it can support all Windows 10 variants, including Windows 10 IoTs. 

When we build a Windows binary, at link step there are two cases:
1. Build the binary for onecore by linking to onecore_apiset.lib or onecoreuap_apiset.lib. They are called [Windows umbrella libraries](https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-umbrella-libraries) and this tech uses [API set direct forwarding](https://docs.microsoft.com/en-us/windows/win32/apiindex/api-set-loader-operation#direct-forwarding). It is clean and simple: if the target OS has the api set, then it can run this binary. Otherwise it doesn't.  It is more efficient than reverse forwarding which we will discuss below. This approach has two drawbacks:
   a. The target OS must understand what is api set.  So it doesn't support Windows 7.  Windows 8.1 is ok as long as it has the api set we need. 
   b.  Not all Windows APIs are in api sets. For example, LocalFree is available on Windows 8.1 but it should be provided by "api-ms-win-core-heap-l2" api set and Windows 8.1 doesn't have the api set.  So if we used the function, VC++ will generate a binary that works fine on Windows 10 but not Windows 8.1. 

2. Build the binary for Desktop by linking to kernel32.lib and the others, as what we were doing in the past before onecore came out. In this case, the generated binary will depends on kernel32.dll. So it had two drawbacks:
    a. If the target OS doesn't have kernel32.dll, then it can't run.
    b. It doesn't support Windows Store.
Now, for Windows 10 the two drawbacks are gone. Windows 10 introduced a new tech called "reverse forwarder", basically you can installed a fake kernel32.dll on the OS that doesn't have a kernel32.dll.  We call it api set "reverse forwarder". The fake DLL forwards Windows API names to api set names, then if the api set is available, the implementation dll will be loaded and run. 

This is why I say we need two kinds of onnxruntime binaries. If one fits all,  Windows SDK doesn't need to provide two kinds of  umbrella libraries: onecore.lib and onecore_apiset.lib. 

Based on these two, we have the third option: link to onecore.lib(or onecoreuap.lib).  But I don't know it much. 

**What get changed**

Without this change, onnxruntime.dll uses direct forward api sets and kernel32.dll. So it supports Windows 8.1/10/11 desktop builds, and the onecore builds that have a reverse forwarder. But I doubt its value. This change removes the dependency on kernel32.dll. It is verified by using VC++'s dumpbin tool.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
