### PR TITLE
Fix wrong percentile values returned during calibration

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -607,11 +607,12 @@ class HistogramCollector(CalibrationDataCollector):
             total = hist.sum()
             cdf = np.cumsum(hist/total)
             if self.symmetric:
-                idx_right = np.searchsorted(cdf, percentile/100)
+                idx_right = np.searchsorted(cdf, np.percentile(cs, percentile))
                 thresholds_dict[tensor] = (-float(hist_edges[idx_right]), float(hist_edges[idx_right]))
             else:
-                idx_right = np.searchsorted(cdf, percentile/200)
-                idx_left = np.searchsorted(cdf, (1.0 - percentile/200))
+                print(f"Search percentiles ({1 - percentile}, {percentile})")
+                idx_right = np.searchsorted(cdf, np.percentile(percentile))
+                idx_left = np.searchsorted(cdf, np.percentile(1 - percentile))
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))
 
             # Plot histogram for debug only

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -599,7 +599,7 @@ class HistogramCollector(CalibrationDataCollector):
 
         print("Number of tensors : {}".format(len(histogram_dict)))
         print("Number of histogram bins : {}".format(self.num_bins))
-        print("Percentile : {}".format(percentile))
+        print("Percentile : ({},{})".format(100.0 - percentile, percentile))
 
         for tensor, histogram in histogram_dict.items():
             hist = histogram[0]
@@ -610,7 +610,6 @@ class HistogramCollector(CalibrationDataCollector):
                 idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
                 thresholds_dict[tensor] = (-float(hist_edges[idx_right]), float(hist_edges[idx_right]))
             else:
-                print(f"Search percentiles ({1 - percentile}, {percentile})")
                 idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
                 idx_left = np.searchsorted(cdf, np.percentile(cdf, 100.0 - percentile))
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -607,12 +607,12 @@ class HistogramCollector(CalibrationDataCollector):
             total = hist.sum()
             cdf = np.cumsum(hist/total)
             if self.symmetric:
-                idx_right = np.searchsorted(cdf, np.percentile(cs, percentile))
+                idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
                 thresholds_dict[tensor] = (-float(hist_edges[idx_right]), float(hist_edges[idx_right]))
             else:
                 print(f"Search percentiles ({1 - percentile}, {percentile})")
-                idx_right = np.searchsorted(cdf, np.percentile(percentile))
-                idx_left = np.searchsorted(cdf, np.percentile(1.0 - percentile))
+                idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
+                idx_left = np.searchsorted(cdf, np.percentile(cdf, 1.0 - percentile))
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))
 
             # Plot histogram for debug only

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -612,7 +612,7 @@ class HistogramCollector(CalibrationDataCollector):
             else:
                 print(f"Search percentiles ({1 - percentile}, {percentile})")
                 idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
-                idx_left = np.searchsorted(cdf, np.percentile(cdf, 1.0 - percentile))
+                idx_left = np.searchsorted(cdf, np.percentile(cdf, 100.0 - percentile))
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))
 
             # Plot histogram for debug only

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -607,11 +607,12 @@ class HistogramCollector(CalibrationDataCollector):
             total = hist.sum()
             cdf = np.cumsum(hist/total)
             if self.symmetric:
-                idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
-                thresholds_dict[tensor] = (-float(hist_edges[idx_right]), float(hist_edges[idx_right]))
+                idx_right = np.searchsorted(cdf, percentile / 100.0)
+                thresholds_dict[tensor] = (-float(hist_edges[idx_ringht]), float(hist_edges[idx_right]))
             else:
-                idx_right = np.searchsorted(cdf, np.percentile(cdf, percentile))
-                idx_left = np.searchsorted(cdf, np.percentile(cdf, 100.0 - percentile))
+                percent_to_cut_one_side = (100.0 - percentile) / 200.0
+                idx_right = np.searchsorted(cdf, 1.0 - percent_to_cut_one_side)
+                idx_left = np.searchsorted(cdf, percent_to_cut_one_side)
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))
 
             # Plot histogram for debug only

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -612,7 +612,7 @@ class HistogramCollector(CalibrationDataCollector):
             else:
                 print(f"Search percentiles ({1 - percentile}, {percentile})")
                 idx_right = np.searchsorted(cdf, np.percentile(percentile))
-                idx_left = np.searchsorted(cdf, np.percentile(1 - percentile))
+                idx_left = np.searchsorted(cdf, np.percentile(1.0 - percentile))
                 thresholds_dict[tensor] = (float(hist_edges[idx_left]), float(hist_edges[idx_right]))
 
             # Plot histogram for debug only


### PR DESCRIPTION
The current formula used to compute asymmetric calibration values using percentile method leads to invalid values being returned and thus the resulting quantization operator has zero point = 255.

This PR proposes to rely on numpy's `percentile` function to compute the percentile value.

This approach trades-off the performance (`numpy.percentile` is potentially slower than just dividing) but, supports more potential interpolation schema along with being robustly tested on numpy's side

Related Issue #10846 