### PR TITLE
Remove example outputs for onnx

### DIFF
--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -41,7 +41,6 @@ def export_onnx(model, onnx_model_path, float16, hidden_size, device):
                       input_names=['input'],
                       output_names=["output"],
                       dynamic_axes=dynamic_axes,
-                      example_outputs=outputs,
                       opset_version=11,
                       do_constant_folding=True)
     print("exported:", onnx_model_path)

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -364,7 +364,6 @@ def convert_model_loss_fn_to_onnx(model, loss_fn, model_desc, device, inputs, op
                        output_names=output_names,
                        opset_version=opset_version,
                        dynamic_axes=dynamic_axes,
-                       example_outputs=tuple(sample_outputs),
                        do_constant_folding=False,
                        **other_export_options)
 

--- a/orttraining/orttraining/python/training/orttrainer.py
+++ b/orttraining/orttraining/python/training/orttrainer.py
@@ -545,7 +545,6 @@ class ORTTrainer(object):
                            output_names=[output.name for output in self.model_desc.outputs],
                            opset_version=self.options._internal_use.onnx_opset_version,
                            dynamic_axes=dynamic_axes,
-                           example_outputs=tuple(sample_outputs),
                            do_constant_folding=False,
                            training=torch.onnx.TrainingMode.TRAINING)
         onnx_model = onnx.load_model_from_string(f.getvalue())


### PR DESCRIPTION
**Description**: Trying to fix pipeline failures after updating to torch 1.10

**Motivation and Context**
- Why is this change required? What problem does it solve?
example_outputs for export is deprecated.
- If it fixes an open issue, please link to the issue here.
