### PR TITLE
Refactor Node::AddAttribute()

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -342,20 +342,19 @@ class Node {
   /** Gets the number of output edges from this Node */
   size_t GetOutputEdgesCount() const noexcept { return relationships_.output_edges.size(); }
 
-  /** Adds an AttributeProto to this Node. The attribute name is used as the key in the attribute map.
-  @return True if a new attribute was added, false if an existing attribute was overwritten. */
-  bool AddAttributeProto(ONNX_NAMESPACE::AttributeProto value);
+  /** Adds an AttributeProto to this Node.
+  @remarks The attribute name is used as the key in the attribute map. */
+  void AddAttributeProto(ONNX_NAMESPACE::AttributeProto value);
 
-  /** Add an attribute to this Node with specified attribute name and value.
-  @return True if a new attribute was added, false if an existing attribute was overwritten. */
-  bool AddAttribute(std::string attr_name, int64_t value);
-  bool AddAttribute(std::string attr_name, gsl::span<const int64_t> value);
+  /** Adds an attribute to this Node with the specified attribute name and value(s). */
+  void AddAttribute(std::string attr_name, int64_t value);
+  void AddAttribute(std::string attr_name, gsl::span<const int64_t> values);
 
 #define ADD_ATTR_SINGLE_INTERFACE(Type) \
-  bool AddAttribute(std::string attr_name, Type value)
+  void AddAttribute(std::string attr_name, Type value)
 
 #define ADD_ATTR_LIST_INTERFACE(Type) \
-  bool AddAttribute(std::string attr_name, gsl::span<const Type> values)
+  void AddAttribute(std::string attr_name, gsl::span<const Type> values)
 
 #define ADD_ATTR_INTERFACES(Type)  \
   ADD_ATTR_SINGLE_INTERFACE(Type); \
@@ -376,10 +375,10 @@ class Node {
 #undef ADD_ATTR_INTERFACES
 
   // The below overload is made so the compiler does not attempt to resolve
-  // C-strings with the gsl::span overload
+  // string literals with the gsl::span overload
   template <size_t N>
-  bool AddAttribute(std::string attr_name, const char (&value)[N]) {
-    return this->AddAttribute(std::move(attr_name), std::string(value, N - 1));
+  void AddAttribute(std::string attr_name, const char (&value)[N]) {
+    this->AddAttribute(std::move(attr_name), std::string(value, N - 1));
   }
 
   /** Gets the Node's attributes. */

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -346,10 +346,6 @@ class Node {
   @return True if a new attribute was added, false if an existing attribute was overwritten. */
   bool AddAttributeProto(ONNX_NAMESPACE::AttributeProto value);
 
-  // TODO can this function be removed?
-  /** Add an attribute to this Node with specified attribute name and value. */
-  bool AddAttribute(std::string_view attr_name, ONNX_NAMESPACE::AttributeProto value);
-
   /** Add an attribute to this Node with specified attribute name and value.
   @return True if a new attribute was added, false if an existing attribute was overwritten. */
   bool AddAttribute(std::string attr_name, int64_t value);

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -342,50 +342,48 @@ class Node {
   /** Gets the number of output edges from this Node */
   size_t GetOutputEdgesCount() const noexcept { return relationships_.output_edges.size(); }
 
+  /** Adds an AttributeProto to this Node. The attribute name is used as the key in the attribute map.
+  @return True if a new attribute was added, false if an existing attribute was overwritten. */
+  bool AddAttributeProto(ONNX_NAMESPACE::AttributeProto value);
+
+  // TODO can this function be removed?
   /** Add an attribute to this Node with specified attribute name and value. */
-  void AddAttribute(std::string attr_name, const ONNX_NAMESPACE::AttributeProto& value);
-  void AddAttribute(std::string attr_name, ONNX_NAMESPACE::AttributeProto&& value);
+  bool AddAttribute(std::string_view attr_name, ONNX_NAMESPACE::AttributeProto value);
 
-#define ADD_ATTR_INTERFACES(TypeName)                              \
-  void AddAttribute(std::string attr_name, const TypeName& value); \
-  void AddAttribute(std::string attr_name,                         \
-                    gsl::span<TypeName const> values);
+  /** Add an attribute to this Node with specified attribute name and value.
+  @return True if a new attribute was added, false if an existing attribute was overwritten. */
+  bool AddAttribute(std::string attr_name, int64_t value);
+  bool AddAttribute(std::string attr_name, gsl::span<const int64_t> value);
 
-#define ADD_ATTR_MOVE_INTERFACE(TypeName) \
-  void AddAttribute(std::string attr_name, TypeName&& value);
+#define ADD_ATTR_SINGLE_INTERFACE(Type) \
+  bool AddAttribute(std::string attr_name, Type value)
 
-  void AddAttribute(std::string attr_name, std::string value);
-  void AddAttribute(std::string attr_name, gsl::span<std::string const> values);
+#define ADD_ATTR_LIST_INTERFACE(Type) \
+  bool AddAttribute(std::string attr_name, gsl::span<const Type> values)
 
-  ADD_ATTR_INTERFACES(int64_t)
-  ADD_ATTR_INTERFACES(float)
-  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::TensorProto)
-  ADD_ATTR_MOVE_INTERFACE(ONNX_NAMESPACE::TensorProto)
+#define ADD_ATTR_INTERFACES(Type)  \
+  ADD_ATTR_SINGLE_INTERFACE(Type); \
+  ADD_ATTR_LIST_INTERFACE(Type)
+
+  ADD_ATTR_INTERFACES(float);
+  ADD_ATTR_INTERFACES(std::string);
+  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::TensorProto);
 #if !defined(DISABLE_SPARSE_TENSORS)
-  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::SparseTensorProto)
-  ADD_ATTR_MOVE_INTERFACE(ONNX_NAMESPACE::SparseTensorProto)
+  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::SparseTensorProto);
 #endif
-  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::TypeProto)
-  ADD_ATTR_MOVE_INTERFACE(ONNX_NAMESPACE::TypeProto)
+  ADD_ATTR_INTERFACES(ONNX_NAMESPACE::TypeProto);
 
-  void AddAttribute(std::string attr_name, const ONNX_NAMESPACE::GraphProto& value);
-  void AddAttribute(std::string attr_name, ONNX_NAMESPACE::GraphProto&& value);
+  ADD_ATTR_SINGLE_INTERFACE(ONNX_NAMESPACE::GraphProto);
 
-  // The below overloads are made so the compiler does not attempt to resolve
-  // C-strings with a gsl::span overloads
+#undef ADD_ATTR_SINGLE_INTERFACE
+#undef ADD_ATTR_LIST_INTERFACE
+#undef ADD_ATTR_INTERFACES
+
+  // The below overload is made so the compiler does not attempt to resolve
+  // C-strings with the gsl::span overload
   template <size_t N>
-  void AddAttribute(std::string attr_name, const char (&value)[N]) {
-    this->AddAttribute(std::move(attr_name), std::string(value, N - 1));
-  }
-
-  template <size_t M, size_t N>
-  void AddAttribute(const char (&attr_name)[M], const char (&value)[N]) {
-    this->AddAttribute(std::string(attr_name, M - 1), std::string(value, N - 1));
-  }
-
-  template <size_t M, typename T>
-  void AddAttribute(const char (&attr_name)[M], T&& value) {
-    this->AddAttribute(std::string(attr_name, M - 1), std::forward<T>(value));
+  bool AddAttribute(std::string attr_name, const char (&value)[N]) {
+    return this->AddAttribute(std::move(attr_name), std::string(value, N - 1));
   }
 
   /** Gets the Node's attributes. */

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -346,8 +346,12 @@ class Node {
   @remarks The attribute name is used as the key in the attribute map. */
   void AddAttributeProto(ONNX_NAMESPACE::AttributeProto value);
 
-  /** Adds an attribute to this Node with the specified attribute name and value(s). */
+  // keep this signature in sync with ADD_ATTR_SINGLE_INTERFACE below
+  /** Adds an attribute to this Node with the specified attribute name and value. */
   void AddAttribute(std::string attr_name, int64_t value);
+
+  // keep this signature in sync with ADD_ATTR_LIST_INTERFACE below
+  /** Adds an attribute to this Node with the specified attribute name and values. */
   void AddAttribute(std::string attr_name, gsl::span<const int64_t> values);
 
 #define ADD_ATTR_SINGLE_INTERFACE(Type) \

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -882,12 +882,6 @@ bool Node::AddAttributeProto(AttributeProto value) {
   return inserted;
 }
 
-bool Node::AddAttribute(std::string_view attr_name, AttributeProto value) {
-  ORT_ENFORCE(attr_name == value.name(),
-              "AttributeProto name mismatch. attr_name: ", attr_name, ", value.name(): ", value.name());
-  return AddAttributeProto(std::move(value));
-}
-
 #define ADD_ATTR_SINGLE_IMPL(Type)                                                   \
   bool Node::AddAttribute(std::string attr_name, Type value) {                       \
     AttributeProto a = utils::MakeAttribute(std::move(attr_name), std::move(value)); \

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -22,6 +22,7 @@
 #include "core/graph/indexed_sub_graph.h"
 #include "core/graph/model.h"
 #include "core/graph/model_load_utils.h"
+#include "core/graph/node_attr_utils.h"
 #include "core/graph/op.h"
 #include "core/graph/runtime_optimization_record_container.h"
 
@@ -762,7 +763,7 @@ Status Node::LoadFromOrtFormat(const onnxruntime::fbs::Node& fbs_node, const log
         subgraphs_.push_back(std::move(subgraph));
       }
 
-      AddAttribute(attr_proto.name(), std::move(attr_proto));
+      AddAttributeProto(std::move(attr_proto));
     }
   }
 
@@ -872,106 +873,62 @@ void Node::CreateSubgraph(const std::string& attr_name) {
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
-void Node::AddAttribute(std::string attr_name, const ONNX_NAMESPACE::AttributeProto& value) {
+bool Node::AddAttributeProto(AttributeProto value) {
+  const bool inserted = utils::SetNodeAttribute(std::move(value), attributes_);
+
   graph_->SetGraphResolveNeeded();
   graph_->SetGraphProtoSyncNeeded();
-  attributes_[std::move(attr_name)] = value;
+
+  return inserted;
 }
 
-void Node::AddAttribute(std::string attr_name, ONNX_NAMESPACE::AttributeProto&& value) {
-  graph_->SetGraphResolveNeeded();
-  graph_->SetGraphProtoSyncNeeded();
-  attributes_[std::move(attr_name)] = std::move(value);
+bool Node::AddAttribute(std::string_view attr_name, AttributeProto value) {
+  ORT_ENFORCE(attr_name == value.name(),
+              "AttributeProto name mismatch. attr_name: ", attr_name, ", value.name(): ", value.name());
+  return AddAttributeProto(std::move(value));
 }
 
-static void AddAttributeHelper(Node& node, std::string attr_name,
-                               AttributeProto_AttributeType attr_type, AttributeProto&& a) {
-  a.set_name(attr_name);
-  a.set_type(attr_type);
-  node.AddAttribute(std::move(attr_name), std::move(a));
-}
-
-void Node::AddAttribute(std::string attr_name, std::string value) {
-  AttributeProto a;
-  *(a.mutable_s()) = std::move(value);
-  AddAttributeHelper(*this, std::move(attr_name),
-                     AttributeProto_AttributeType::AttributeProto_AttributeType_STRING,
-                     std::move(a));
-};
-
-#define ADD_BASIC_ATTR_IMPL(type, enumType, field)                           \
-  void Node::AddAttribute(std::string attr_name, const type& value) {        \
-    AttributeProto a;                                                        \
-    a.set_##field(value);                                                    \
-    AddAttributeHelper(*this, std::move(attr_name), enumType, std::move(a)); \
-  };
-
-#define ADD_ATTR_IMPL(type, enumType, field)                                 \
-  void Node::AddAttribute(std::string attr_name, const type& value) {        \
-    AttributeProto a;                                                        \
-    *(a.mutable_##field()) = value;                                          \
-    AddAttributeHelper(*this, std::move(attr_name), enumType, std::move(a)); \
+#define ADD_ATTR_SINGLE_IMPL(Type)                                                   \
+  bool Node::AddAttribute(std::string attr_name, Type value) {                       \
+    AttributeProto a = utils::MakeAttribute(std::move(attr_name), std::move(value)); \
+    return AddAttributeProto(std::move(a));                                          \
   }
 
-#define ADD_ATTR_MOVE_IMPL(type, enumType, field)                            \
-  void Node::AddAttribute(std::string attr_name, type&& value) {             \
-    AttributeProto a;                                                        \
-    *(a.mutable_##field()) = std::move(value);                               \
-    AddAttributeHelper(*this, std::move(attr_name), enumType, std::move(a)); \
+#define ADD_ATTR_LIST_IMPL(Type)                                                 \
+  bool Node::AddAttribute(std::string attr_name, gsl::span<const Type> values) { \
+    AttributeProto a = utils::MakeAttribute(std::move(attr_name), values);       \
+    return AddAttributeProto(std::move(a));                                      \
   }
 
-#define ADD_LIST_ATTR_IMPL(type, enumType, field)                            \
-  void Node::AddAttribute(std::string attr_name,                             \
-                          gsl::span<type const> values) {                    \
-    AttributeProto a;                                                        \
-    auto* mutable_field = a.mutable_##field();                               \
-    for (const auto& val : values) {                                         \
-      *(mutable_field->Add()) = val;                                         \
-    }                                                                        \
-    AddAttributeHelper(*this, std::move(attr_name), enumType, std::move(a)); \
-  }
+#define ADD_ATTR_IMPLS(Type) \
+  ADD_ATTR_SINGLE_IMPL(Type) \
+  ADD_ATTR_LIST_IMPL(Type)
 
-void Node::AddAttribute(std::string attr_name, const GraphProto& value) {
-  AttributeProto a;
-  *a.mutable_g() = value;
-  // Do not move attr_name as it is needed below
-  AddAttributeHelper(*this, attr_name, AttributeProto_AttributeType::AttributeProto_AttributeType_GRAPH, std::move(a));
-
-#if !defined(ORT_MINIMAL_BUILD)
-  // subgraph is created via deserialization and not here in a minimal build
-  CreateSubgraph(attr_name);
-#endif
-};
-
-void Node::AddAttribute(std::string attr_name, GraphProto&& value) {
-  AttributeProto a;
-  *a.mutable_g() = std::move(value);
-  // Do not move attr_name as it is needed below
-  AddAttributeHelper(*this, attr_name, AttributeProto_AttributeType::AttributeProto_AttributeType_GRAPH, std::move(a));
-
-#if !defined(ORT_MINIMAL_BUILD)
-  // subgraph is created via deserialization and not here in a minimal build
-  CreateSubgraph(attr_name);
-#endif
-};
-
-ADD_BASIC_ATTR_IMPL(float, AttributeProto_AttributeType::AttributeProto_AttributeType_FLOAT, f)
-ADD_BASIC_ATTR_IMPL(int64_t, AttributeProto_AttributeType::AttributeProto_AttributeType_INT, i)
-ADD_ATTR_IMPL(TensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TENSOR, t)
-ADD_ATTR_MOVE_IMPL(TensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TENSOR, t)
-ADD_ATTR_IMPL(TypeProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TYPE_PROTO, tp)
-ADD_ATTR_MOVE_IMPL(TypeProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TYPE_PROTO, tp)
-
-ADD_LIST_ATTR_IMPL(float, AttributeProto_AttributeType::AttributeProto_AttributeType_FLOATS, floats)
-ADD_LIST_ATTR_IMPL(int64_t, AttributeProto_AttributeType::AttributeProto_AttributeType_INTS, ints)
-ADD_LIST_ATTR_IMPL(std::string, AttributeProto_AttributeType::AttributeProto_AttributeType_STRINGS, strings)
-ADD_LIST_ATTR_IMPL(TensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TENSORS, tensors)
-ADD_LIST_ATTR_IMPL(TypeProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TYPE_PROTOS, type_protos)
+ADD_ATTR_IMPLS(int64_t)
+ADD_ATTR_IMPLS(float)
+ADD_ATTR_IMPLS(std::string)
+ADD_ATTR_IMPLS(TensorProto)
 #if !defined(DISABLE_SPARSE_TENSORS)
-ADD_ATTR_IMPL(SparseTensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_SPARSE_TENSOR, sparse_tensor)
-ADD_ATTR_MOVE_IMPL(SparseTensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_SPARSE_TENSOR, sparse_tensor)
-ADD_LIST_ATTR_IMPL(SparseTensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_SPARSE_TENSORS, sparse_tensors)
+ADD_ATTR_IMPLS(SparseTensorProto)
 #endif
+ADD_ATTR_IMPLS(TypeProto)
+
+#undef ADD_ATTR_SINGLE_IMPL
+#undef ADD_ATTR_LIST_IMPL
+#undef ADD_ATTR_IMPLS
+
+bool Node::AddAttribute(std::string attr_name, GraphProto value) {
+  // Do not move attr_name as it is needed below
+  AttributeProto a = utils::MakeAttribute(attr_name, std::move(value));
+  const bool inserted = AddAttributeProto(std::move(a));
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // subgraph is created via deserialization and not here in a minimal build
+  CreateSubgraph(attr_name);
+#endif
+
+  return inserted;
+};
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 bool Node::ClearAttribute(const std::string& attr_name) {
@@ -2588,8 +2545,9 @@ Status Graph::VerifyNodeAndOpMatch(const ResolveOptions& options) {
         // The attribute was not specified in the node.
         if (!attr_def.second.required) {
           if (utils::HasName(attr_def.second.default_value)) {
+            assert(attr_def.first == attr_def.second.default_value.name());
             // Set default value to the node attributes.
-            node.AddAttribute(attr_def.first, attr_def.second.default_value);
+            node.AddAttributeProto(attr_def.second.default_value);
           }
           // TODO: Handle optional attribute but no default value specified in op definition.
         } else {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -873,25 +873,23 @@ void Node::CreateSubgraph(const std::string& attr_name) {
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
-bool Node::AddAttributeProto(AttributeProto value) {
-  const bool inserted = utils::SetNodeAttribute(std::move(value), attributes_);
+void Node::AddAttributeProto(AttributeProto value) {
+  utils::SetNodeAttribute(std::move(value), attributes_);
 
   graph_->SetGraphResolveNeeded();
   graph_->SetGraphProtoSyncNeeded();
-
-  return inserted;
 }
 
 #define ADD_ATTR_SINGLE_IMPL(Type)                                                   \
-  bool Node::AddAttribute(std::string attr_name, Type value) {                       \
+  void Node::AddAttribute(std::string attr_name, Type value) {                       \
     AttributeProto a = utils::MakeAttribute(std::move(attr_name), std::move(value)); \
-    return AddAttributeProto(std::move(a));                                          \
+    AddAttributeProto(std::move(a));                                                 \
   }
 
 #define ADD_ATTR_LIST_IMPL(Type)                                                 \
-  bool Node::AddAttribute(std::string attr_name, gsl::span<const Type> values) { \
+  void Node::AddAttribute(std::string attr_name, gsl::span<const Type> values) { \
     AttributeProto a = utils::MakeAttribute(std::move(attr_name), values);       \
-    return AddAttributeProto(std::move(a));                                      \
+    AddAttributeProto(std::move(a));                                             \
   }
 
 #define ADD_ATTR_IMPLS(Type) \
@@ -911,17 +909,15 @@ ADD_ATTR_IMPLS(TypeProto)
 #undef ADD_ATTR_LIST_IMPL
 #undef ADD_ATTR_IMPLS
 
-bool Node::AddAttribute(std::string attr_name, GraphProto value) {
+void Node::AddAttribute(std::string attr_name, GraphProto value) {
   // Do not move attr_name as it is needed below
   AttributeProto a = utils::MakeAttribute(attr_name, std::move(value));
-  const bool inserted = AddAttributeProto(std::move(a));
+  AddAttributeProto(std::move(a));
 
 #if !defined(ORT_MINIMAL_BUILD)
   // subgraph is created via deserialization and not here in a minimal build
   CreateSubgraph(attr_name);
 #endif
-
-  return inserted;
 };
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/onnxruntime/core/graph/node_attr_utils.cc
+++ b/onnxruntime/core/graph/node_attr_utils.cc
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/graph/node_attr_utils.h"
+
+#include "core/common/common.h"
+#include "core/framework/tensorprotoutils.h"
+
+using namespace ONNX_NAMESPACE;
+
+namespace onnxruntime::utils {
+
+static void SetNameAndType(std::string attr_name, AttributeProto_AttributeType attr_type, AttributeProto& a) {
+  a.set_name(std::move(attr_name));
+  a.set_type(attr_type);
+}
+
+#define MAKE_BASIC_ATTR_IMPL(type, enumType, field)                 \
+  AttributeProto MakeAttribute(std::string attr_name, type value) { \
+    AttributeProto a;                                               \
+    a.set_##field(std::move(value));                                \
+    SetNameAndType(std::move(attr_name), enumType, a);              \
+    return a;                                                       \
+  }
+
+#define MAKE_ATTR_IMPL(type, enumType, field)                       \
+  AttributeProto MakeAttribute(std::string attr_name, type value) { \
+    AttributeProto a;                                               \
+    *(a.mutable_##field()) = std::move(value);                      \
+    SetNameAndType(std::move(attr_name), enumType, a);              \
+    return a;                                                       \
+  }
+
+#define MAKE_LIST_ATTR_IMPL(type, enumType, field)                                    \
+  AttributeProto MakeAttribute(std::string attr_name, gsl::span<const type> values) { \
+    AttributeProto a;                                                                 \
+    auto* mutable_field = a.mutable_##field();                                        \
+    for (const auto& val : values) {                                                  \
+      *(mutable_field->Add()) = val;                                                  \
+    }                                                                                 \
+    SetNameAndType(std::move(attr_name), enumType, a);                                \
+    return a;                                                                         \
+  }
+
+MAKE_BASIC_ATTR_IMPL(int64_t, AttributeProto_AttributeType::AttributeProto_AttributeType_INT, i)
+MAKE_LIST_ATTR_IMPL(int64_t, AttributeProto_AttributeType::AttributeProto_AttributeType_INTS, ints)
+
+MAKE_BASIC_ATTR_IMPL(float, AttributeProto_AttributeType::AttributeProto_AttributeType_FLOAT, f)
+MAKE_LIST_ATTR_IMPL(float, AttributeProto_AttributeType::AttributeProto_AttributeType_FLOATS, floats)
+
+MAKE_ATTR_IMPL(std::string, AttributeProto_AttributeType::AttributeProto_AttributeType_STRING, s)
+MAKE_LIST_ATTR_IMPL(std::string, AttributeProto_AttributeType::AttributeProto_AttributeType_STRINGS, strings)
+
+MAKE_ATTR_IMPL(TensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TENSOR, t)
+MAKE_LIST_ATTR_IMPL(TensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TENSORS, tensors)
+
+#if !defined(DISABLE_SPARSE_TENSORS)
+MAKE_ATTR_IMPL(SparseTensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_SPARSE_TENSOR,
+               sparse_tensor)
+MAKE_LIST_ATTR_IMPL(SparseTensorProto, AttributeProto_AttributeType::AttributeProto_AttributeType_SPARSE_TENSORS,
+                    sparse_tensors)
+#endif
+
+MAKE_ATTR_IMPL(TypeProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TYPE_PROTO, tp)
+MAKE_LIST_ATTR_IMPL(TypeProto, AttributeProto_AttributeType::AttributeProto_AttributeType_TYPE_PROTOS, type_protos)
+
+MAKE_ATTR_IMPL(GraphProto, AttributeProto_AttributeType::AttributeProto_AttributeType_GRAPH, g)
+MAKE_LIST_ATTR_IMPL(GraphProto, AttributeProto_AttributeType::AttributeProto_AttributeType_GRAPHS, graphs)
+
+#undef MAKE_BASIC_ATTR_IMPL
+#undef MAKE_ATTR_IMPL
+#undef MAKE_LIST_ATTR_IMPL
+
+bool SetNodeAttribute(AttributeProto attribute, NodeAttributes& node_attributes) {
+  ORT_ENFORCE(utils::HasName(attribute), "AttributeProto must have a name.");
+  std::string name = attribute.name();
+  return node_attributes.insert_or_assign(std::move(name), std::move(attribute)).second;
+}
+
+}  // namespace onnxruntime::utils

--- a/onnxruntime/core/graph/node_attr_utils.cc
+++ b/onnxruntime/core/graph/node_attr_utils.cc
@@ -71,10 +71,11 @@ MAKE_LIST_ATTR_IMPL(GraphProto, AttributeProto_AttributeType::AttributeProto_Att
 #undef MAKE_ATTR_IMPL
 #undef MAKE_LIST_ATTR_IMPL
 
-bool SetNodeAttribute(AttributeProto attribute, NodeAttributes& node_attributes) {
+std::pair<NodeAttributes::iterator, bool> SetNodeAttribute(AttributeProto attribute,
+                                                           NodeAttributes& node_attributes) {
   ORT_ENFORCE(utils::HasName(attribute), "AttributeProto must have a name.");
   std::string name = attribute.name();
-  return node_attributes.insert_or_assign(std::move(name), std::move(attribute)).second;
+  return node_attributes.insert_or_assign(std::move(name), std::move(attribute));
 }
 
 }  // namespace onnxruntime::utils

--- a/onnxruntime/core/graph/node_attr_utils.h
+++ b/onnxruntime/core/graph/node_attr_utils.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+
+#include <gsl/gsl>
+
+#include "onnx/onnx_pb.h"
+
+#include "core/graph/basic_types.h"
+
+namespace onnxruntime::utils {
+
+/**
+ * Creates an AttributeProto with the specified name and value(s).
+ */
+ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, int64_t value);
+ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, gsl::span<const int64_t> values);
+
+#define DECLARE_MAKE_ATTRIBUTE_FNS(type)                                           \
+  ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, type value); \
+  ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, gsl::span<const type> values)
+
+DECLARE_MAKE_ATTRIBUTE_FNS(float);
+DECLARE_MAKE_ATTRIBUTE_FNS(std::string);
+DECLARE_MAKE_ATTRIBUTE_FNS(ONNX_NAMESPACE::TensorProto);
+#if !defined(DISABLE_SPARSE_TENSORS)
+DECLARE_MAKE_ATTRIBUTE_FNS(ONNX_NAMESPACE::SparseTensorProto);
+#endif
+DECLARE_MAKE_ATTRIBUTE_FNS(ONNX_NAMESPACE::TypeProto);
+DECLARE_MAKE_ATTRIBUTE_FNS(ONNX_NAMESPACE::GraphProto);
+
+#undef DECLARE_MAKE_ATTRIBUTE_FNS
+
+// preferred overload for string literals
+inline ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, const char* value) {
+  return MakeAttribute(std::move(attr_name), std::string{value});
+}
+
+/**
+ * Sets an attribute in `node_attributes` with key `attribute.name()` and value `attribute`.
+ * @return True if a new attribute was added, false if an existing attribute was overwritten.
+ */
+bool SetNodeAttribute(ONNX_NAMESPACE::AttributeProto attribute, NodeAttributes& node_attributes);
+
+}  // namespace onnxruntime::utils

--- a/onnxruntime/core/graph/node_attr_utils.h
+++ b/onnxruntime/core/graph/node_attr_utils.h
@@ -13,10 +13,10 @@
 
 namespace onnxruntime::utils {
 
-/**
- * Creates an AttributeProto with the specified name and value(s).
- */
+// keep these signatures in sync with DECLARE_MAKE_ATTRIBUTE_FNS below
+/** Creates an AttributeProto with the specified name and value. */
 ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, int64_t value);
+/** Creates an AttributeProto with the specified name and values. */
 ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, gsl::span<const int64_t> values);
 
 #define DECLARE_MAKE_ATTRIBUTE_FNS(type)                                           \

--- a/onnxruntime/core/graph/node_attr_utils.h
+++ b/onnxruntime/core/graph/node_attr_utils.h
@@ -34,15 +34,18 @@ DECLARE_MAKE_ATTRIBUTE_FNS(ONNX_NAMESPACE::GraphProto);
 
 #undef DECLARE_MAKE_ATTRIBUTE_FNS
 
-// preferred overload for string literals
+// The below overload is made so the compiler does not attempt to resolve
+// string literals with the gsl::span overload
 inline ONNX_NAMESPACE::AttributeProto MakeAttribute(std::string attr_name, const char* value) {
   return MakeAttribute(std::move(attr_name), std::string{value});
 }
 
 /**
  * Sets an attribute in `node_attributes` with key `attribute.name()` and value `attribute`.
- * @return True if a new attribute was added, false if an existing attribute was overwritten.
+ * If an attribute with the same name exists, it will be overwritten.
+ * @return Pair of (iterator to attribute, whether attribute was added (true) or updated (false)).
  */
-bool SetNodeAttribute(ONNX_NAMESPACE::AttributeProto attribute, NodeAttributes& node_attributes);
+std::pair<NodeAttributes::iterator, bool> SetNodeAttribute(ONNX_NAMESPACE::AttributeProto attribute,
+                                                           NodeAttributes& node_attributes);
 
 }  // namespace onnxruntime::utils

--- a/onnxruntime/core/optimizer/bias_dropout_fusion.cc
+++ b/onnxruntime/core/optimizer/bias_dropout_fusion.cc
@@ -188,10 +188,10 @@ Status BiasDropoutFusion::ApplyImpl(Graph& graph, bool& modified, int graph_leve
                                                   kMSDomain);
 
     // Get attribute "seed" from "Dropout" node if available.
-    NodeAttributes dropout_attrs = dropout_node.GetAttributes();
+    const NodeAttributes& dropout_attrs = dropout_node.GetAttributes();
     NodeAttributes::const_iterator seed = dropout_attrs.find("seed");
     if (seed != dropout_attrs.end()) {
-      dropout_add_fusion_node.AddAttribute("seed", seed->second);
+      dropout_add_fusion_node.AddAttributeProto(seed->second);
     }
 
     // Assign provider to this new node. Provider should be same as the provider for old node.

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -8,6 +8,7 @@
 #include "core/common/inlined_containers.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/graph_utils.h"
+#include "core/graph/node_attr_utils.h"
 #include "core/optimizer/utils.h"
 #include "core/optimizer/selectors_actions/actions.h"
 
@@ -137,23 +138,6 @@ class ConvAddRelu : public NodeSelector {
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 namespace actions {
-// TODO refactor to lift common logic from Node::AddAttribute()
-void SetStringAttribute(std::string name, std::string value, NodeAttributes& attributes) {
-  ONNX_NAMESPACE::AttributeProto a{};
-  a.set_name(name);
-  a.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRING);
-  a.set_s(std::move(value));
-  attributes.insert_or_assign(std::move(name), std::move(a));
-};
-
-void SetFloatsAttribute(std::string name, gsl::span<float> value, NodeAttributes& attributes) {
-  ONNX_NAMESPACE::AttributeProto a{};
-  a.set_name(name);
-  a.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOATS);
-  a.mutable_floats()->Assign(value.begin(), value.end());
-  attributes.insert_or_assign(std::move(name), std::move(a));
-};
-
 using NTO = NodesToOptimize;
 
 class FuseConvActivation : public ReplaceWithNew {
@@ -169,7 +153,7 @@ class FuseConvActivation : public ReplaceWithNew {
     ORT_ENFORCE(activation != nullptr, "Expected activation node.");
 
     const auto& activation_op_type = activation->OpType();
-    SetStringAttribute("activation", activation_op_type, extra_fused_conv_attributes);
+    utils::SetNodeAttribute(utils::MakeAttribute("activation", activation_op_type), extra_fused_conv_attributes);
 
     InlinedVector<float> activation_params;
     if (activation_op_type == "LeakyRelu") {
@@ -190,7 +174,8 @@ class FuseConvActivation : public ReplaceWithNew {
     }
 
     if (!activation_params.empty()) {
-      SetFloatsAttribute("activation_params", activation_params, extra_fused_conv_attributes);
+      utils::SetNodeAttribute(utils::MakeAttribute("activation_params", activation_params),
+                              extra_fused_conv_attributes);
     }
 
     return extra_fused_conv_attributes;
@@ -215,7 +200,7 @@ class FuseConvAddRelu : public ReplaceWithNew {
 
   NodeAttributes ExtraAttributes(const RuntimeState&) const override {
     NodeAttributes extra_fused_conv_attributes;
-    SetStringAttribute("activation", "Relu", extra_fused_conv_attributes);
+    utils::SetNodeAttribute(utils::MakeAttribute("activation", "Relu"), extra_fused_conv_attributes);
     return extra_fused_conv_attributes;
   }
 

--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -42,7 +42,7 @@ static NodeArg* CastToInt32(Graph& graph, NodeArg* input, ProviderType provider_
   to.set_name("to");
   to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
   to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_INT32));
-  node.AddAttribute("to", std::move(to));
+  node.AddAttributeProto(std::move(to));
 
   node.SetExecutionProviderType(provider_type);
   return &cast32;
@@ -525,7 +525,7 @@ static void CreateEmbedLayernormNode(Graph& graph,
   NodeAttributes ln_attrs = layer_norm_node.GetAttributes();
   NodeAttributes::const_iterator epsilon = ln_attrs.find("epsilon");
   if (epsilon != ln_attrs.end()) {
-    embed_layer_norm_node.AddAttribute("epsilon", epsilon->second);
+    embed_layer_norm_node.AddAttributeProto(epsilon->second);
   } else {
     embed_layer_norm_node.AddAttribute("epsilon", contrib::kDefaultEmbedLayerNormEpsilon);
   }

--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -38,11 +38,7 @@ static NodeArg* CastToInt32(Graph& graph, NodeArg* input, ProviderType provider_
                              kOnnxDomain);
 
   // Add attribute: "to" = 6
-  ONNX_NAMESPACE::AttributeProto to;
-  to.set_name("to");
-  to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-  to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_INT32));
-  node.AddAttributeProto(std::move(to));
+  node.AddAttribute("to", int64_t{ONNX_NAMESPACE::TensorProto_DataType_INT32});
 
   node.SetExecutionProviderType(provider_type);
   return &cast32;

--- a/onnxruntime/core/optimizer/gemm_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_activation_fusion.cc
@@ -83,7 +83,7 @@ Status GemmActivationFusion::ApplyImpl(Graph& graph, bool& modified, int graph_l
     for (const auto& attr : attrs) {
       AttributeProto fused_gemm_attr(attr.second);
       fused_gemm_attr.set_name("activation_" + attr.first);
-      fused_gemm.AddAttribute("activation_" + attr.first, std::move(fused_gemm_attr));
+      fused_gemm.AddAttributeProto(std::move(fused_gemm_attr));
     }
 
     // move output definitions and edges from act_node to fused_gemm. delete gemm_node and act_node.

--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -447,7 +447,7 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
       continue;
     }
     bool cast_1_present = false;
-    int64_t cast_1_to_attr;
+    int64_t cast_1_to_attr{};
     // check if there are Casts as input to the Pow and Div
     if (p_div_input == p_pow_input) {
       const Node* p_pow_input_node = graph_utils::GetInputNode(pow_node, 0);
@@ -574,7 +574,7 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
     // Assign provider to this new node. Provider should be same as the provider for old node.
     layer_norm_node.SetExecutionProviderType(reduce_mean_node.GetExecutionProviderType());
 
-    if (allow_precision_change_ && p_cast_2 != nullptr) {
+    if (allow_precision_change_ && cast_1_present && p_cast_2 != nullptr) {
       ONNX_NAMESPACE::TensorProto_DataType cast_1_type = gsl::narrow_cast<ONNX_NAMESPACE::TensorProto_DataType>(cast_1_to_attr);
       const ONNX_NAMESPACE::TypeProto* casted_type = DataTypeImpl::TensorTypeFromONNXEnum(cast_1_type)->GetTypeProto();
       NodeArg* LN_output = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("layer_norm_out"), casted_type);

--- a/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
@@ -248,7 +248,7 @@ Status SkipLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_le
     NodeAttributes ln_attrs = ln_node.GetAttributes();
     NodeAttributes::const_iterator epsilon = ln_attrs.find("epsilon");
     if (epsilon != ln_attrs.end()) {
-      skip_layer_norm_node.AddAttribute("epsilon", epsilon->second);
+      skip_layer_norm_node.AddAttributeProto(epsilon->second);
     } else {
       skip_layer_norm_node.AddAttribute("epsilon", contrib::kDefaultSkipLayerNormEpsilon);
     }

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -326,7 +326,7 @@ void ApiNode::CopyAttributes(const api::NodeRef& node) {
   const ApiNode& ort_node = static_cast<const ApiNode&>(node);
   const NodeAttributes& attributes = ort_node.node_.GetAttributes();
   for (const auto& pair : attributes) {
-    node_.AddAttribute(pair.first, pair.second);
+    node_.AddAttributeProto(pair.second);
   }
 }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphTransformer.cpp
@@ -214,7 +214,7 @@ namespace Dml
                 // Change the name of the attribute to its fused node version
                 std::string fusedAttributeName = Dml::FusionHelpers::GetFusedAttributeName(attribute.first);
                 attribute.second.set_name(fusedAttributeName);
-                node.AddAttribute(fusedAttributeName, attribute.second);
+                node.AddAttributeProto(attribute.second);
             }
         }
     }

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1416,7 +1416,7 @@ TEST(InferenceSessionTests, Test3LayerNestedSubgraph) {
         to.set_name("to");
         to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
         to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-        cast_node.AddAttribute("to", to);
+        cast_node.AddAttributeProto(std::move(to));
       }
       {
         std::vector<onnxruntime::NodeArg*> inputs = {&node_2, &data_0};
@@ -1466,7 +1466,7 @@ TEST(InferenceSessionTests, Test3LayerNestedSubgraph) {
     to.set_name("to");
     to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
     to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-    cast_node.AddAttribute("to", to);
+    cast_node.AddAttributeProto(std::move(to));
   }
 
   std::vector<onnxruntime::NodeArg*> inputs = {&if_cond_input};
@@ -1604,7 +1604,7 @@ TEST(InferenceSessionTests, Test2LayerNestedSubgraph) {
     to.set_name("to");
     to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
     to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-    cast_node.AddAttribute("to", to);
+    cast_node.AddAttributeProto(std::move(to));
   }
   {
     std::vector<onnxruntime::NodeArg*> inputs = {&graph_0__value_2, &input_0};

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1412,11 +1412,7 @@ TEST(InferenceSessionTests, Test3LayerNestedSubgraph) {
         std::vector<onnxruntime::NodeArg*> inputs = {&node_1};
         std::vector<onnxruntime::NodeArg*> outputs = {&node_2};
         auto& cast_node = graph.AddNode("cast_1", "Cast", "node 2", inputs, outputs);
-        ONNX_NAMESPACE::AttributeProto to;
-        to.set_name("to");
-        to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-        to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-        cast_node.AddAttributeProto(std::move(to));
+        cast_node.AddAttribute("to", int64_t{ONNX_NAMESPACE::TensorProto_DataType_FLOAT});
       }
       {
         std::vector<onnxruntime::NodeArg*> inputs = {&node_2, &data_0};
@@ -1462,11 +1458,7 @@ TEST(InferenceSessionTests, Test3LayerNestedSubgraph) {
     std::vector<onnxruntime::NodeArg*> inputs = {&if_cond_input};
     std::vector<onnxruntime::NodeArg*> outputs = {&graph_if_input};
     auto& cast_node = graph.AddNode("cast_9", "Cast", "node 2", inputs, outputs);
-    ONNX_NAMESPACE::AttributeProto to;
-    to.set_name("to");
-    to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-    to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-    cast_node.AddAttributeProto(std::move(to));
+    cast_node.AddAttribute("to", int64_t{ONNX_NAMESPACE::TensorProto_DataType_FLOAT});
   }
 
   std::vector<onnxruntime::NodeArg*> inputs = {&if_cond_input};
@@ -1600,11 +1592,7 @@ TEST(InferenceSessionTests, Test2LayerNestedSubgraph) {
     std::vector<onnxruntime::NodeArg*> inputs = {&graph_0__value_1};
     std::vector<onnxruntime::NodeArg*> outputs = {&graph_0__value_2};
     auto& cast_node = graph.AddNode("graph_0__cast_0", "Cast", "cast node in main graph", inputs, outputs);
-    ONNX_NAMESPACE::AttributeProto to;
-    to.set_name("to");
-    to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-    to.set_i(static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-    cast_node.AddAttributeProto(std::move(to));
+    cast_node.AddAttribute("to", int64_t{ONNX_NAMESPACE::TensorProto_DataType_FLOAT});
   }
   {
     std::vector<onnxruntime::NodeArg*> inputs = {&graph_0__value_2, &input_0};

--- a/onnxruntime/test/framework/shape_inference_test.cc
+++ b/onnxruntime/test/framework/shape_inference_test.cc
@@ -95,7 +95,7 @@ TEST_F(ShapeInferenceTest, BasicTest) {
   cast_to.set_i(ONNX_NAMESPACE::TensorProto_DataType_INT32);
   //cast_to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRING);
   //cast_to.set_s("INT16");
-  node.AddAttribute("to", cast_to);
+  node.AddAttributeProto(std::move(cast_to));
 
   DoShapeInference();
   // check inferred shapes

--- a/onnxruntime/test/framework/shape_inference_test.cc
+++ b/onnxruntime/test/framework/shape_inference_test.cc
@@ -84,18 +84,7 @@ TEST_F(ShapeInferenceTest, BasicTest) {
   Input("X1", type1);
 
   auto& node = Node("Cast", "X1", "Y1");
-  //AttributeProto squeezed_axes;
-  //squeezed_axes.set_name("axes");
-  //squeezed_axes.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
-  //squeezed_axes.add_ints(0);
-  //p_node->AddAttribute("axes", squeezed_axes);
-  AttributeProto cast_to;
-  cast_to.set_name("to");
-  cast_to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
-  cast_to.set_i(ONNX_NAMESPACE::TensorProto_DataType_INT32);
-  //cast_to.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRING);
-  //cast_to.set_s("INT16");
-  node.AddAttributeProto(std::move(cast_to));
+  node.AddAttribute("to", int64_t{ONNX_NAMESPACE::TensorProto_DataType_INT32});
 
   DoShapeInference();
   // check inferred shapes

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -1541,7 +1541,7 @@ void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, int64
   attr.set_name(attr_name);
   attr.set_type(AttributeProto_AttributeType_INT);
   attr.set_i(attr_value);
-  p_node.AddAttribute(attr_name, attr);
+  p_node.AddAttributeProto(std::move(attr));
 }
 
 void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, std::initializer_list<int64_t> attr_value) {
@@ -1551,7 +1551,7 @@ void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, std::
   for (auto v : attr_value) {
     attr.add_ints(v);
   }
-  p_node.AddAttribute(attr_name, attr);
+  p_node.AddAttributeProto(std::move(attr));
 }
 
 // Test that output type can be inferred for ops with a type-attribute

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -1537,21 +1537,11 @@ TEST_F(GraphTest, AddTensorAttribute) {
 }
 
 void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, int64_t attr_value) {
-  AttributeProto attr;
-  attr.set_name(attr_name);
-  attr.set_type(AttributeProto_AttributeType_INT);
-  attr.set_i(attr_value);
-  p_node.AddAttributeProto(std::move(attr));
+  p_node.AddAttribute(attr_name, attr_value);
 }
 
 void AddAttribute(onnxruntime::Node& p_node, const std::string& attr_name, std::initializer_list<int64_t> attr_value) {
-  AttributeProto attr;
-  attr.set_name(attr_name);
-  attr.set_type(AttributeProto_AttributeType_INTS);
-  for (auto v : attr_value) {
-    attr.add_ints(v);
-  }
-  p_node.AddAttributeProto(std::move(attr));
+  p_node.AddAttribute(attr_name, attr_value);
 }
 
 // Test that output type can be inferred for ops with a type-attribute

--- a/onnxruntime/test/providers/cpu/controlflow/if_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/if_test.cc
@@ -84,7 +84,7 @@ class IfOpTester : public OpTester {
         *split_attribute->Add() = 1;  // split "unevenly" to create different shapes across the "then" and "else" branches
         *split_attribute->Add() = 2;
 
-        split_node.AddAttribute("split", attr_proto);
+        split_node.AddAttributeProto(std::move(attr_proto));
       }
     }
 
@@ -382,7 +382,7 @@ class IfOpTesterOnlyConstantNodesInConditionalBranches : public OpTester {
         then_constant_attr_tensor_proto->add_dims(1);
         then_constant_attr_tensor_proto->add_float_data(value);  // Constant value of 10.f
 
-        then_constant_node.AddAttribute("value", then_constant_attr_proto);
+        then_constant_node.AddAttributeProto(std::move(then_constant_attr_proto));
 
         auto status_then = graph_then.Resolve();
         EXPECT_EQ(status_then, Status::OK());

--- a/onnxruntime/test/providers/cpu/controlflow/loop_test.cc
+++ b/onnxruntime/test/providers/cpu/controlflow/loop_test.cc
@@ -802,7 +802,7 @@ TEST(Loop, Opset11WithNoVariadicInputsAndOutputs) {
       constant_attribute_tensor_proto->set_data_type(TensorProto_DataType_FLOAT);  // float scalar
       *constant_attribute_tensor_proto->mutable_float_data()->Add() = 1.0f;        // float scalar with value 1.0f
 
-      constant_node.AddAttribute("value", attr_proto);
+      constant_node.AddAttributeProto(std::move(attr_proto));
     }
 
     graph.SetInputs({&iter_num_in, &cond_in});

--- a/onnxruntime/test/providers/provider_test_utils.h
+++ b/onnxruntime/test/providers/provider_test_utils.h
@@ -317,7 +317,6 @@ class OpTester {
     AddData(input_data_, name, dims_var, p_values, size, is_initializer, false, dim_params);
   }
 
-
   template <typename T>
   void AddInput(const char* name, std::initializer_list<int64_t> dims, const TensorShapeVector& values,
                 bool is_initializer = false, const std::vector<std::string>* dim_params = nullptr) {
@@ -500,7 +499,6 @@ class OpTester {
             values ? values->size() : 0, is_initializer, false, dim_params, 0.0f, 0.0f, true);
   }
 
-
   template <typename T>
   void AddOptionalTypeTensorOutput(const char* name, const DimsVariant& dims,
                                    const std::initializer_list<T>* expected_values = nullptr,
@@ -519,7 +517,6 @@ class OpTester {
             expected_values ? expected_values->size() : 0, false,
             sort_output, nullptr /* dim_params */, rel_error, abs_error, true);
   }
-
 
   template <typename T>
   void AddOptionalTypeSeqInput(const char* name,
@@ -546,12 +543,12 @@ class OpTester {
   }
 
   /*
-  * Use this API to add an input *edge* to the node/op being tested that won't 
-  * have any data passed into.
-  * Such an edge will have the qualifier OpSchema::Optional in the schema.
-  * This is exposed to ensure the op kernel implementations can be tested to handle 
-  * presence/absence of such optional input edges.
-  */
+   * Use this API to add an input *edge* to the node/op being tested that won't
+   * have any data passed into.
+   * Such an edge will have the qualifier OpSchema::Optional in the schema.
+   * This is exposed to ensure the op kernel implementations can be tested to handle
+   * presence/absence of such optional input edges.
+   */
   template <typename T>
   void AddOptionalInputEdge() {
     std::string name;  // empty == input doesn't exist
@@ -575,14 +572,13 @@ class OpTester {
             sort_output, nullptr /* dim_params */, rel_error, abs_error);
   }
 
-    template <typename T>
+  template <typename T>
   void AddOutput(const char* name, std::initializer_list<int64_t> dims, const T* p_values, const size_t size,
                  bool sort_output = false, float rel_error = 0.0f, float abs_error = 0.0f) {
     const DimsVariant dims_var = std::vector<int64_t>(dims);
     AddData(output_data_, name, dims, p_values, size, false,
             sort_output, nullptr /* dim_params */, rel_error, abs_error);
   }
-
 
   template <typename T>
   void AddOutput(const char* name, const DimsVariant& dims, std::initializer_list<T> expected_values,
@@ -712,12 +708,12 @@ class OpTester {
 #endif
 
   /*
-  * Use this API to add an output *edge* to the node/op being tested that shouldn't have any 
-  * data produced into.
-  * Such an edge will have the qualifier OpSchema::Optional in the schema.
-  * This is exposed to ensure the op kernel implementations can be tested to handle 
-  * presence/absence of such optional output edges.
-  */
+   * Use this API to add an output *edge* to the node/op being tested that shouldn't have any
+   * data produced into.
+   * Such an edge will have the qualifier OpSchema::Optional in the schema.
+   * This is exposed to ensure the op kernel implementations can be tested to handle
+   * presence/absence of such optional output edges.
+   */
   template <typename T>
   void AddOptionalOutputEdge() {
     std::string name;  // empty == output doesn't exist
@@ -784,6 +780,12 @@ class OpTester {
 
   void SetCustomOutputVerifier(CustomOutputVerifierFn custom_output_verifier) {
     custom_output_verifier_ = custom_output_verifier;
+  }
+
+  void AddAttributeProto(ONNX_NAMESPACE::AttributeProto attr) {
+    add_attribute_funcs_.emplace_back([attr = std::move(attr)](onnxruntime::Node& node) {
+      node.AddAttributeProto(attr);
+    });
   }
 
   template <typename T>

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -35,7 +35,7 @@ void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64
  * Create a simple model with dynamic or non-dynamic input shape.
  * \param model_name - model name
  * \param graph_name - graph name
- * \params dims - input dimensions 
+ * \params dims - input dimensions
  *
  * input: "X", "Y" and "Z"
  *        you can specify input dimensions, for example (1, 3, 2), (1, 2) or (1, -1, -1)). Note: -1 means the dimension is dynamic.
@@ -45,9 +45,9 @@ void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64
  *      "X"  "Y"
  *        \  /
  *    "Z"  Add
- *      \  / 
+ *      \  /
  *       Add
- *       / 
+ *       /
  *     "M"
  *
  */
@@ -204,7 +204,7 @@ TEST_P(TensorrtExecutionProviderCacheTest, Run) {
 
       // check min/max shape ranges of dynamic shape dimensions
       for(auto it = shape_ranges.cbegin(); it != shape_ranges.cend(); ++it) {
-        auto ranges = it->second;  
+        auto ranges = it->second;
         for (auto it2 = ranges.cbegin(); it2 != ranges.cend(); ++it2) {
           if (it2->first == 1) {
             ASSERT_EQ(it2->second.first, 3);
@@ -254,7 +254,7 @@ TEST_P(TensorrtExecutionProviderCacheTest, Run) {
 
       // check min/max shape ranges of dynamic shape dimensions
       for(auto it = shape_ranges2.cbegin(); it != shape_ranges2.cend(); ++it) {
-        auto ranges = it->second;  
+        auto ranges = it->second;
         for (auto it2 = ranges.cbegin(); it2 != ranges.cend(); ++it2) {
           if (it2->first == 1) {
             ASSERT_EQ(it2->second.first, 1);
@@ -285,7 +285,7 @@ TEST_P(TensorrtExecutionProviderCacheTest, Run) {
  * We have following test parameters:
  * - engine_static: engine cache enabled with non-dynamic input shape
  * - engine_dynamic: engine cache enabled with dynamic input shape
- * - timing_static: will be added 
+ * - timing_static: will be added
  * - timing_dynamic: will be added
  */
 INSTANTIATE_TEST_SUITE_P(TensorrtExecutionProviderCacheTests, TensorrtExecutionProviderCacheTest, testing::Values("engine_static",
@@ -406,11 +406,7 @@ TEST(TensorrtExecutionProviderTest, NodeIndexMappingTest) {
   auto& output_arg_1 = graph.GetOrCreateNodeArg("node_1_out", &uint8_tensor);
   outputs.push_back(&output_arg_1);
   auto& cast_node = graph.AddNode("cast1", "Cast", "node 1.", inputs, outputs);
-  AttributeProto attr_proto;
-  attr_proto.set_name("to");
-  attr_proto.set_type(AttributeProto_AttributeType_INT);
-  attr_proto.set_i(2);
-  cast_node.AddAttribute("to", attr_proto);
+  cast_node.AddAttribute("to", int64_t{2});
 
   inputs.clear();
   inputs.push_back(&output_arg_1);
@@ -418,11 +414,7 @@ TEST(TensorrtExecutionProviderTest, NodeIndexMappingTest) {
   outputs.clear();
   outputs.push_back(&output_arg_2);
   auto& cast_node_2 = graph.AddNode("cast2", "Cast", "node 2.", inputs, outputs);
-  AttributeProto attr_proto_2;
-  attr_proto_2.set_name("to");
-  attr_proto_2.set_type(AttributeProto_AttributeType_INT);
-  attr_proto_2.set_i(9);
-  cast_node_2.AddAttribute("to", attr_proto_2);
+  cast_node_2.AddAttribute("to", int64_t{9});
 
   auto& input_arg_2 = graph.GetOrCreateNodeArg("Y", &float_tensor);
   auto& input_arg_3 = graph.GetOrCreateNodeArg("Z", &float_tensor);

--- a/orttraining/orttraining/test/gradient/allreduce_op_test.cc
+++ b/orttraining/orttraining/test/gradient/allreduce_op_test.cc
@@ -43,7 +43,7 @@ TEST(AllreduceTest, CPUAdasumAllreduceTestReduceTwoTensors) {
 
   allreduce_test.AddOutput<float>("G_new1", {3}, output_grad);
   allreduce_test.AddOutput<float>("G_new2", {3}, output_grad);
-  allreduce_test.AddAttribute("reduce_algo", static_cast<int64_t>(0));
+  allreduce_test.AddAttribute("reduce_algo", int64_t{0});
 
   std::vector<std::unique_ptr<IExecutionProvider>> providers;
   providers.push_back(DefaultCpuExecutionProvider());
@@ -86,7 +86,7 @@ TEST(AllreduceTest, CPUAdasumAllreduceTestReduceTwoTensorsFP16) {
   allreduce_test.AddOutput<MLFloat16>("G_new1", {3}, output_grad_half);
   allreduce_test.AddOutput<MLFloat16>("G_new2", {3}, output_grad_half);
 
-  allreduce_test.AddAttribute("reduce_algo", static_cast<int64_t>(0));
+  allreduce_test.AddAttribute("reduce_algo", int64_t{0});
 
   std::vector<std::unique_ptr<IExecutionProvider>> providers;
   providers.push_back(DefaultCpuExecutionProvider());
@@ -112,7 +112,7 @@ TEST(AllreduceTest, CPUAdasumAllreduceTestFailTensorCountMismatch) {
 
   allreduce_test.AddOutput<float>("G_new1", {3}, {5.6301f, 6.5235f, 7.4169f});
   allreduce_test.AddOutput<float>("G_new2", {3}, {5.6301f, 6.5235f, 7.4169f});
-  allreduce_test.AddAttribute("reduce_algo", static_cast<int64_t>(0));
+  allreduce_test.AddAttribute("reduce_algo", int64_t{0});
 
   std::vector<std::unique_ptr<IExecutionProvider>> providers;
   providers.push_back(DefaultCpuExecutionProvider());
@@ -224,18 +224,8 @@ void build_optimizer_node(Graph& graph,
   auto& optimizer_node = graph.AddNode(input_gradient->Name() + "_adam_optimizer", "AdamOptimizer", "Adam optimizer.", optimizer_inputs, optimizer_outputs,
                                        nullptr /*attributes*/, kMSDomain);
 
-  ONNX_NAMESPACE::AttributeProto bias_correction_attribute, weight_decay_mode_attribute;
-
-  bias_correction_attribute.set_name("do_bias_correction");
-  bias_correction_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-  bias_correction_attribute.set_i(0);
-
-  weight_decay_mode_attribute.set_name("weight_decay_mode");
-  weight_decay_mode_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-  weight_decay_mode_attribute.set_i(0);
-
-  optimizer_node.AddAttribute("do_bias_correction", bias_correction_attribute);
-  optimizer_node.AddAttribute("weight_decay_mode", weight_decay_mode_attribute);
+  optimizer_node.AddAttribute("do_bias_correction", int64_t{0});
+  optimizer_node.AddAttribute("weight_decay_mode", int64_t{0});
 }
 
 using AllreduceGraphConfigVector = std::vector<std::tuple<std::string /*input name*/,
@@ -288,12 +278,7 @@ void build_allreduce_graph(Graph& graph, AllreduceGraphConfigVector& config,
     auto& level_1_allreduce_node = graph.AddNode("node_level_1", level_1_allreduce,
                                                  "level 1 allreduce.", level_1_inputs, level_1_outputs,
                                                  nullptr /*attributes*/, kMSDomain);
-    ONNX_NAMESPACE::AttributeProto level_1_group_type_attribute;
-
-    level_1_group_type_attribute.set_name("group_type");
-    level_1_group_type_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-    level_1_group_type_attribute.set_i(2 /*node local data parallel*/);
-    level_1_allreduce_node.AddAttribute("group_type", level_1_group_type_attribute);
+    level_1_allreduce_node.AddAttribute("group_type", int64_t{2} /*node local data parallel*/);
     // Set inputs of next node to be outputs of level 1 reduction node.
     inputs.clear();
     inputs = std::move(level_1_outputs);
@@ -317,11 +302,7 @@ void build_allreduce_graph(Graph& graph, AllreduceGraphConfigVector& config,
         auto& scaled_grad_node = graph.AddNode(std::get<0>(config[i]) + "_scaled_grad", "MixedPrecisionScale",
                                                "scale grad", scale_grad_inputs, {&scale_grad_output_arg},
                                                nullptr /*attributes*/, kMSDomain);
-        ONNX_NAMESPACE::AttributeProto scale_attribute;
-        scale_attribute.set_name("to");
-        scale_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-        scale_attribute.set_i(static_cast<int64_t>(element_type));
-        scaled_grad_node.AddAttribute("to", scale_attribute);
+        scaled_grad_node.AddAttribute("to", int64_t{element_type});
       }
       // Set inputs of next node to be outputs of scale node.
       inputs.clear();
@@ -359,19 +340,9 @@ void build_allreduce_graph(Graph& graph, AllreduceGraphConfigVector& config,
   auto& allreduce_node = graph.AddNode("node_allreduce", allreduce_op_name, "node allreduce.", inputs, allreduce_outputs,
                                        nullptr /*attributes*/, kMSDomain);
   if (adasum_reduce_type != training::AdasumReductionType::None) {
-    // Attribute
-    ONNX_NAMESPACE::AttributeProto adasum_reduction_type_attribute;
-    adasum_reduction_type_attribute.set_name("reduce_algo");
-    adasum_reduction_type_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-    adasum_reduction_type_attribute.set_i(static_cast<int64_t>(adasum_reduce_type));
-    allreduce_node.AddAttribute("reduce_algo", adasum_reduction_type_attribute);
+    allreduce_node.AddAttribute("reduce_algo", int64_t{adasum_reduce_type});
   } else {
-    // Attribute
-    ONNX_NAMESPACE::AttributeProto group_type_attribute;
-    group_type_attribute.set_name("group_type");
-    group_type_attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT);
-    group_type_attribute.set_i(0 /*data parallel*/);
-    allreduce_node.AddAttribute("group_type", group_type_attribute);
+    allreduce_node.AddAttribute("group_type", int64_t{0} /*data parallel*/);
   }
 
   if (build_optimizer) {

--- a/orttraining/orttraining/test/gradient/allreduce_op_test.cc
+++ b/orttraining/orttraining/test/gradient/allreduce_op_test.cc
@@ -340,7 +340,7 @@ void build_allreduce_graph(Graph& graph, AllreduceGraphConfigVector& config,
   auto& allreduce_node = graph.AddNode("node_allreduce", allreduce_op_name, "node allreduce.", inputs, allreduce_outputs,
                                        nullptr /*attributes*/, kMSDomain);
   if (adasum_reduce_type != training::AdasumReductionType::None) {
-    allreduce_node.AddAttribute("reduce_algo", int64_t{adasum_reduce_type});
+    allreduce_node.AddAttribute("reduce_algo", static_cast<int64_t>(adasum_reduce_type));
   } else {
     allreduce_node.AddAttribute("group_type", int64_t{0} /*data parallel*/);
   }

--- a/orttraining/orttraining/test/gradient/gradient_checker.cc
+++ b/orttraining/orttraining/test/gradient/gradient_checker.cc
@@ -263,7 +263,7 @@ inline Status GradientChecker<X_T, Y_T, JAC_T>::InitOpTesterWithGraph(
   }
   // Currently only allows setting int attributes to zero. TODO: Expand this
   for (auto attr : attributes) {
-    op_session.AddAttribute<AttributeProto>(attr.name(), attr);
+    op_session.AddAttributeProto(attr);
   }
 
   // build graph

--- a/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
+++ b/orttraining/orttraining/test/training_ops/function_op_test_utils.cc
@@ -86,7 +86,7 @@ std::unique_ptr<T> CreateOpTester(const onnxruntime::training::OpDef& op_def,
                                   int opset_version) {
   auto test = std::make_unique<T>(op_def.type.c_str(), opset_version, op_def.domain.c_str());
   for (auto attr : attributes)
-    test->AddAttribute(attr.name(), attr);
+    test->AddAttributeProto(attr);
 
   auto input_index = 0;
   for (auto& data : input_data) {


### PR DESCRIPTION
**Description**
Refactor Node::AddAttribute() to pull out AttributeProto creation logic.
Reuse in ConvActivationFusion.
Replace Node::AddAttribute(string, AttributeProto) with Node::AddAttributeProto(AttributeProto) since the name should be the same as the AttributeProto::name() value.

**Motivation and Context**
Clean up.