### PR TITLE
Infer output memory type for MemcpyFromHost

### DIFF
--- a/include/onnxruntime/core/graph/node_arg.h
+++ b/include/onnxruntime/core/graph/node_arg.h
@@ -64,6 +64,12 @@ class NodeArg {
   bool HasTensorOrScalarShape() const;
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  // FIXME: typing, doc string
+  int8_t MemoryType() const;
+
+  void SetMemoryType(int8_t);
+
+  bool HasMemoryType() const;
 
   /** Sets the shape.
   @remarks Shape can only be set if the TypeProto was provided to the ctor, or #SetType has been called,
@@ -130,5 +136,9 @@ class NodeArg {
 
   // Flag indicates whether <*this> node arg exists or not.
   bool exists_;
+
+  bool has_mem_type_;
+  // FIXME: typing
+  int8_t mem_type_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -659,8 +659,10 @@ class PlannerImpl {
         ProcessDef(index, node_output);
         // Ensures external outputs will not be reused.
         UseCount(index) += (has_external_outputs ? 2 : 1);
-        auto allocator = exec_provider->GetAllocator(0, p_kernel_def->OutputMemoryType(i));
-        ORT_ENFORCE(allocator);
+        OrtMemType mem_type = node_output->HasMemoryType()
+                                  ? static_cast<OrtMemType>(node_output->MemoryType()) // FIXME: typing
+                                  : p_kernel_def->OutputMemoryType(i);
+        auto allocator = exec_provider->GetAllocator(0, mem_type);
         plan_.SetLocation(static_cast<size_t>(index),
                           allocator->Info());
       }

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -695,7 +695,9 @@ class PlannerImpl {
     if (utils::IsInputOnCpu(node, &kernel_create_info, input_index))
       // weights are not output from any node, so it's OK to put its location on CPU provider
       return execution_providers_.GetDefaultCpuMemoryInfo();
-    return p_provider->GetAllocator(0, OrtMemTypeDefault)->Info();
+
+    auto mem_type = kernel_create_info.kernel_def->InputMemoryType(input_index);
+    return p_provider->GetAllocator(0, mem_type)->Info();
   }
 
   void GeneratePlanForWeightsHelper(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -183,7 +183,8 @@ static TypeProto TypeProtoFromTensorProto(const TensorProto& tensor) {
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-NodeArg::NodeArg(const std::string& name, const TypeProto* p_node_arg_type) {
+NodeArg::NodeArg(const std::string& name, const TypeProto* p_node_arg_type)
+    : has_mem_type_(false), mem_type_{} {
   node_arg_info_.set_name(name);
   // If the name is empty, it means the arg does not exist.
   exists_ = !(name.empty());
@@ -201,7 +202,8 @@ NodeArg::NodeArg(const std::string& name, const TypeProto* p_node_arg_type) {
 }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
-NodeArg::NodeArg(NodeArgInfo&& node_arg_info) {
+NodeArg::NodeArg(NodeArgInfo&& node_arg_info)
+    : has_mem_type_(false), mem_type_{} {
   node_arg_info_ = std::move(node_arg_info);
 
   exists_ = !node_arg_info_.name().empty();
@@ -291,6 +293,19 @@ bool NodeArg::HasTensorOrScalarShape() const {
 }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+int8_t NodeArg::MemoryType() const {
+  return mem_type_;
+}
+
+void NodeArg::SetMemoryType(int8_t memory_type) {
+  has_mem_type_ = true;
+  mem_type_ = memory_type;
+}
+
+bool NodeArg::HasMemoryType() const {
+  return has_mem_type_;
+}
+
 void NodeArg::SetShape(const TensorShapeProto& shape) {
   const auto type_case = node_arg_info_.type().value_case();
   switch (type_case) {

--- a/onnxruntime/core/optimizer/transformer_memcpy.cc
+++ b/onnxruntime/core/optimizer/transformer_memcpy.cc
@@ -13,16 +13,16 @@ namespace onnxruntime {
 // note that GraphTransformer::Apply() is supposed to be stateless, so this cannot derive from GraphTranformer
 class TransformerMemcpyImpl {
  public:
-  TransformerMemcpyImpl(onnxruntime::Graph& graph, const std::string& provider)
-      : graph_(graph), provider_(provider) {}
+  TransformerMemcpyImpl(onnxruntime::Graph& graph, const std::string& provider, const KernelRegistryManager& kernel_registries)
+      : graph_(graph), provider_(provider), kernel_registries_(std::cref(kernel_registries)) {}
 
-  bool ModifyGraph(const KernelRegistryManager& schema_registries);
+  bool ModifyGraph();
 
  private:
-  void ProcessDefs(onnxruntime::Node& node, const KernelRegistryManager& kernel_registries, InitializedTensorSet& initializers_consumed);
-  void BuildDefsMapping(const onnxruntime::NodeArg* arg, const KernelRegistryManager& kernel_registries);
+  void ProcessDefs(onnxruntime::Node& node, InitializedTensorSet& initializers_consumed);
+  void BuildDefsMapping(const onnxruntime::NodeArg* arg);
   void AddCopyNode(onnxruntime::NodeArg* arg, bool is_input);
-  bool ProcessInitializers(const KernelRegistryManager& kernel_registries, const InitializedTensorSet& initializers_consumed);
+  bool ProcessInitializers(const InitializedTensorSet& initializers_consumed);
 
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(TransformerMemcpyImpl);
@@ -44,6 +44,7 @@ class TransformerMemcpyImpl {
 
   onnxruntime::Graph& graph_;
   std::string provider_;
+  std::reference_wrapper<const KernelRegistryManager> kernel_registries_;
 };
 
 /** Helper that returns a pointer to the corresponding TensorProto for a name if it is an initializer.
@@ -64,8 +65,8 @@ static const onnx::TensorProto* GetInitializer(const Graph& graph, const std::st
 common::Status MemcpyTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   for (auto& provider : provider_types_) {
     if (!utils::ProviderIsCpuBased(provider)) {
-      TransformerMemcpyImpl copy_impl(graph, provider);
-      auto current_modified = copy_impl.ModifyGraph(registry_manager_);
+      TransformerMemcpyImpl copy_impl(graph, provider, registry_manager_);
+      auto current_modified = copy_impl.ModifyGraph();
       modified = modified || current_modified;
       break;
     }
@@ -111,27 +112,27 @@ This transformer does not currently optimize copies between, e.g., two different
 
 */
 
-bool TransformerMemcpyImpl::ModifyGraph(const KernelRegistryManager& kernel_registries) {
+bool TransformerMemcpyImpl::ModifyGraph() {
   bool modified = false;
   InitializedTensorSet initializers_consumed;
   // find defs that require copy
   for (auto& node : graph_.Nodes()) {
     //as we process the defs, collect all the initializers consumed at the current graph level
-    ProcessDefs(node, kernel_registries, initializers_consumed);
+    ProcessDefs(node, initializers_consumed);
   }
 
   // for initializers shared by different providers, create dups
-  if (ProcessInitializers(kernel_registries, initializers_consumed))
+  if (ProcessInitializers(initializers_consumed))
     modified = true;
 
   for (auto arg : graph_.GetInputs())
-    BuildDefsMapping(arg, kernel_registries);
+    BuildDefsMapping(arg);
 
   for (auto arg : non_provider_input_defs_)
-    BuildDefsMapping(arg, kernel_registries);
+    BuildDefsMapping(arg);
 
   for (auto arg : non_provider_output_defs_)
-    BuildDefsMapping(arg, kernel_registries);
+    BuildDefsMapping(arg);
 
   for (auto arg : graph_.GetInputs())
     // For inputs we need to create a copy node only when the input is connected to both provider
@@ -185,8 +186,7 @@ bool TransformerMemcpyImpl::ModifyGraph(const KernelRegistryManager& kernel_regi
   return modified;
 }
 
-void TransformerMemcpyImpl::ProcessDefs(onnxruntime::Node& node, const KernelRegistryManager& kernel_registries,
-                                        InitializedTensorSet& initializers_consumed) {
+void TransformerMemcpyImpl::ProcessDefs(onnxruntime::Node& node, InitializedTensorSet& initializers_consumed) {
   auto node_provider_type = node.GetExecutionProviderType();
   if ((node_provider_type == provider_) ||
       (node_provider_type == kCudaExecutionProvider && kTensorrtExecutionProvider == provider_) ||
@@ -194,7 +194,7 @@ void TransformerMemcpyImpl::ProcessDefs(onnxruntime::Node& node, const KernelReg
     provider_nodes_.insert(&node);
     // note KernelCreateInfo might be nullptr for custom kernel
     const KernelCreateInfo* kci = nullptr;
-    ORT_IGNORE_RETURN_VALUE(kernel_registries.SearchKernelRegistry(node, &kci));
+    ORT_IGNORE_RETURN_VALUE(kernel_registries_.get().SearchKernelRegistry(node, &kci));
 
     bool is_implicit_input = false;
     auto process_inputs =
@@ -268,7 +268,7 @@ void TransformerMemcpyImpl::ProcessDefs(onnxruntime::Node& node, const KernelReg
 }
 
 //for non_provider defs, collect the nodes that expect it is provider tensor as input/output.
-void TransformerMemcpyImpl::BuildDefsMapping(const onnxruntime::NodeArg* arg, const KernelRegistryManager& kernel_registries) {
+void TransformerMemcpyImpl::BuildDefsMapping(const onnxruntime::NodeArg* arg) {
   for (auto& it : graph_.Nodes()) {
     if (it.OpType() == "MemcpyFromHost" || it.OpType() == "MemcpyToHost") continue;
     auto input_it =
@@ -286,7 +286,7 @@ void TransformerMemcpyImpl::BuildDefsMapping(const onnxruntime::NodeArg* arg, co
         (node_provider_type == kCudaExecutionProvider && kTensorrtExecutionProvider == provider_) ||
         (node_provider_type == kRocmExecutionProvider && kMIGraphXExecutionProvider == provider_)) {
       const KernelCreateInfo* kci = nullptr;
-      ORT_IGNORE_RETURN_VALUE(kernel_registries.SearchKernelRegistry(it, &kci));
+      ORT_IGNORE_RETURN_VALUE(kernel_registries_.get().SearchKernelRegistry(it, &kci));
       if (arg_input_index != -1) {
         if (!kci || !utils::IsInputOnCpu(it, kci, arg_input_index)) provider_input_nodes_[arg].insert(&it);
       }
@@ -316,6 +316,18 @@ void TransformerMemcpyImpl::AddCopyNode(onnxruntime::NodeArg* arg, bool is_input
   std::map<const onnxruntime::NodeArg*, onnxruntime::NodeArg*> map = {{arg, new_arg}};
   auto it = provider_input_nodes_.find(arg);
   if (it != provider_input_nodes_.end()) {
+    if (is_input) {
+      for (auto* node : it->second) {
+        const KernelCreateInfo* kci = nullptr;
+        ORT_IGNORE_RETURN_VALUE(kernel_registries_.get().SearchKernelRegistry(*node, &kci));
+        if (kci != nullptr) {
+          auto arg_it = std::find_if(node->InputDefs().begin(), node->InputDefs().end(), [&](const NodeArg* o) { return o->Name() == arg->Name(); });
+          auto arg_index = std::distance(node->InputDefs().begin(), arg_it);
+
+          new_arg->SetMemoryType(kci->kernel_def->InputMemoryType(arg_index));
+        }
+      }
+    }
     for (auto* node : it->second)
       node->ReplaceDefs(map);
   }
@@ -338,7 +350,7 @@ static const onnxruntime::NodeArg* FindNodeArg(const NodeArgSetType& def_set, co
 // We duplicate any initializer that is used by both provider nodes and non-provider nodes
 // to ensure that provider nodes and non-provider nodes don't share initializers, as they
 // need to stay in different memory locations.
-bool TransformerMemcpyImpl::ProcessInitializers(const KernelRegistryManager& kernel_registries, const InitializedTensorSet& initializers_consumed) {
+bool TransformerMemcpyImpl::ProcessInitializers(const InitializedTensorSet& initializers_consumed) {
   std::map<const onnxruntime::NodeArg*, onnxruntime::NodeArg*> replacements;
   for (const auto& pair : initializers_consumed) {
     const auto& name = pair.first;
@@ -370,7 +382,7 @@ bool TransformerMemcpyImpl::ProcessInitializers(const KernelRegistryManager& ker
     auto dup_replacements = replacements;
 
     const KernelCreateInfo* kci = nullptr;
-    auto status = kernel_registries.SearchKernelRegistry(*p_node, &kci);
+    auto status = kernel_registries_.get().SearchKernelRegistry(*p_node, &kci);
     ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
     if (kci == nullptr) continue;
     if (kci->kernel_def == nullptr) continue;


### PR DESCRIPTION
**Description**:

Split from OpenCL PR. 

**Motivation and Context**

Minor extend to allocation_planner and transformer_memcpy. In OpenCL, there are
at least 2 kinds of device memory, Buffer and Image2D. The problem here is in
MemcpyFromHost OpKernel implementation (`OpKernel::Compute`), the tensor is
allocated with `out_tensor->Output(0, shape)`, there is no way to correctly
assign the desired output tensor memory type to a correct one.

For example:

```cpp
// Kernel B is registered with
KernelDefBuilder()
    .InputMemoryType(Buffer, 0)
    .OutputMemoryType(Buffer, 0);

// Kernel I is registered with
KernelDefBuilder()
    .InputMemoryType(Image2D, 0)
    .OutputMemoryType(Image2D, 0);
```

If Image2D is set as the default memory type for the OpenCL exectuion provider,
then the automatically inserted MemcpyFromHost Op will not work in

Op1 output cpu mem --> Op2 B

since it is transformed as:

Op1 output cpu mem --> Op3 MemcpyFromHost --> Op2 B

MemcpyFromHost has no designated OutputMemoryType, it always output memtype with defaut type, in this case Image2D, which is not compatible with Op2 B. If it has, then it won't be
generic enough! To circumvent it, infer the output memory type.
