### PR TITLE
Cherry pick from rel-1.11.0: skip optional related models from opset16 (#10840)

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -275,6 +275,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 { "test_optional_get_element_sequence", "not implemented yet"},
                 { "test_optional_has_element", "not implemented yet"},
                 { "test_optional_has_element_empty", "not implemented yet"},
+                { "test_identity_opt", "opset16 version not implemented yet"},
+                { "test_if_opt", "opset16 version not implemented yet"},
+                { "test_loop16_seq_none", "opset16 version not implemented yet"},
             };
 
             // The following models fails on nocontribops win CI


### PR DESCRIPTION
**Description**: Describe your changes.
Cherry pick from rel-1.11.0: skip optional related models from opset16 (#10840)

**Motivation and Context**
Same as #10840. Fix NuGet pipelines failure due to ONNX 1.11.
