### PR TITLE
Allow custom ops to set input memory type

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3634,7 +3634,6 @@ struct OrtCustomOp {
   ONNXTensorElementDataType(ORT_API_CALL* GetInputType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   size_t(ORT_API_CALL* GetInputTypeCount)(_In_ const struct OrtCustomOp* op);
   ONNXTensorElementDataType(ORT_API_CALL* GetOutputType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
-  OrtMemType(ORT_API_CALL* GetInputMemoryType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   size_t(ORT_API_CALL* GetOutputTypeCount)(_In_ const struct OrtCustomOp* op);
 
   // Op kernel callbacks
@@ -3644,6 +3643,9 @@ struct OrtCustomOp {
   // Returns the characteristics of the input & output tensors
   OrtCustomOpInputOutputCharacteristic(ORT_API_CALL* GetInputCharacteristic)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   OrtCustomOpInputOutputCharacteristic(ORT_API_CALL* GetOutputCharacteristic)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
+
+  // Returns the memory type of the input tensors
+  OrtMemType(ORT_API_CALL* GetInputMemoryType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3644,7 +3644,11 @@ struct OrtCustomOp {
   OrtCustomOpInputOutputCharacteristic(ORT_API_CALL* GetInputCharacteristic)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   OrtCustomOpInputOutputCharacteristic(ORT_API_CALL* GetOutputCharacteristic)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
 
-  // Returns the memory type of the input tensors
+  // Returns the memory type of the input tensors. This API allows the custom op
+  // to place the inputs on specific devices. By default, it returns
+  // OrtMemTypeDefault, which means the input is placed on the default device for
+  // the execution provider. If the inputs need to be with different memory tyeps,
+  // this function can be overriden to return the specific memory types.
   OrtMemType(ORT_API_CALL* GetInputMemoryType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
 };
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3634,6 +3634,7 @@ struct OrtCustomOp {
   ONNXTensorElementDataType(ORT_API_CALL* GetInputType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   size_t(ORT_API_CALL* GetInputTypeCount)(_In_ const struct OrtCustomOp* op);
   ONNXTensorElementDataType(ORT_API_CALL* GetOutputType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
+  OrtMemType(ORT_API_CALL* GetInputMemoryType)(_In_ const struct OrtCustomOp* op, _In_ size_t index);
   size_t(ORT_API_CALL* GetOutputTypeCount)(_In_ const struct OrtCustomOp* op);
 
   // Op kernel callbacks

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1649,6 +1649,7 @@ struct CustomOpBase : OrtCustomOp {
 
     OrtCustomOp::GetInputTypeCount = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetInputTypeCount(); };
     OrtCustomOp::GetInputType = [](const OrtCustomOp* this_, size_t index) { return static_cast<const TOp*>(this_)->GetInputType(index); };
+    OrtCustomOp::GetInputMemoryType= [](const OrtCustomOp* this_, size_t index) { return static_cast<const TOp*>(this_)->GetInputMemoryType(index); };
 
     OrtCustomOp::GetOutputTypeCount = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetOutputTypeCount(); };
     OrtCustomOp::GetOutputType = [](const OrtCustomOp* this_, size_t index) { return static_cast<const TOp*>(this_)->GetOutputType(index); };
@@ -1677,6 +1678,11 @@ struct CustomOpBase : OrtCustomOp {
 
   OrtCustomOpInputOutputCharacteristic GetOutputCharacteristic(size_t /*index*/) const {
     return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_REQUIRED;
+  }
+
+  // Default implemention of GetInputMemoryType() that returns OrtMemTypeDefault
+  OrtMemType GetInputMemoryType(size_t /*index*/) const {
+    return OrtMemTypeDefault;
   }
 };
 

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -248,6 +248,11 @@ common::Status CreateCustomRegistry(gsl::span<OrtCustomOpDomain* const> op_domai
           .SetDomain(domain->domain_)
           .SinceVersion(1);
 
+      auto input_count = op->GetInputTypeCount(op);
+      for (size_t i = 0; i < input_count; i++) {
+        def_builder.InputMemoryType(op->GetInputMemoryType(op, i), i);
+      }
+
       for (auto& id : type_constraint_ids[op]) {
         def_builder.TypeConstraint(id, DataTypeImpl::AllTensorTypes());
       }

--- a/onnxruntime/test/shared_lib/custom_op_utils.cc
+++ b/onnxruntime/test/shared_lib/custom_op_utils.cc
@@ -23,9 +23,6 @@ void MyCustomKernel::Compute(OrtKernelContext* context) {
   const float* X = input_X.GetTensorData<float>();
   const float* Y = input_Y.GetTensorData<float>();
 
-  auto x_mem_type = input_X.GetTensorMemoryInfo().GetMemoryType();
-  auto y_mem_type = input_Y.GetTensorMemoryInfo().GetMemoryType();
-
   // Setup output
   auto dimensions = input_X.GetTensorTypeAndShapeInfo().GetShape();
   auto output = ctx.GetOutput(0, dimensions);
@@ -36,9 +33,6 @@ void MyCustomKernel::Compute(OrtKernelContext* context) {
 
   // Do computation
 #ifdef USE_CUDA
-  ASSERT_EQ(x_mem_type, OrtMemType::OrtMemTypeDefault);
-  ASSERT_EQ(y_mem_type, OrtMemType::OrtMemTypeDefault);
-
   // Launch on stream 0 or user provided stream
   cuda_add(size, out, X, Y, compute_stream_ == nullptr ? 0 : reinterpret_cast<cudaStream_t>(compute_stream_));
   // cudaStreamSynchronize(nullptr);
@@ -50,14 +44,60 @@ void MyCustomKernel::Compute(OrtKernelContext* context) {
   //     and use the same compute stream to launch the custom op.
   // Here, an example for (1) is shown (See test_inference.cc to see how this custom op is used.)
 #else
-  ASSERT_EQ(x_mem_type, OrtMemType::OrtMemTypeDefault);
-  ASSERT_EQ(y_mem_type, OrtMemType::OrtMemTypeDefault);
   ORT_UNUSED_PARAMETER(compute_stream_);
   for (int64_t i = 0; i < size; i++) {
     out[i] = X[i] + Y[i];
   }
 #endif
 }
+
+#ifdef USE_CUDA
+void MyCustomKernelSecondInputOnCpu::Compute(OrtKernelContext* context) {
+  // Setup inputs
+  Ort::KernelContext ctx(context);
+  auto input_X = ctx.GetInput(0);
+  auto input_Y = ctx.GetInput(1);
+  const float* X = input_X.GetTensorData<float>();
+  const float* Y = input_Y.GetTensorData<float>();
+
+  // check if the second input is on CPU
+  cudaPointerAttributes attributes;
+  cudaPointerGetAttributes(&attributes, Y);
+  auto y_mem_type = attributes.device;
+  // TODO: check why the below ORT API does not work as expected:
+  // `auto y_mem_type = input_Y.GetTensorMemoryInfo().GetMemoryType();`
+  ASSERT_EQ(y_mem_type, OrtMemType::OrtMemTypeCPUInput);
+
+  // copy the second input to GPU
+  const int64_t y_size =  input_Y.GetTensorTypeAndShapeInfo().GetElementCount();
+  float* Y_cuda {};
+  cudaMalloc(&Y_cuda, y_size * sizeof(float));
+  cudaMemcpy(Y_cuda, Y, y_size * sizeof(float), cudaMemcpyHostToDevice);
+
+
+  // Setup output
+  auto dimensions = input_X.GetTensorTypeAndShapeInfo().GetShape();
+  auto output = ctx.GetOutput(0, dimensions);
+  float* out = output.GetTensorMutableData<float>();
+
+  auto output_info = output.GetTensorTypeAndShapeInfo();
+  int64_t size = output_info.GetElementCount();
+
+  // Do computation
+
+  // Launch on stream 0 or user provided stream
+  cuda_add(size, out, X, Y_cuda, compute_stream_ == nullptr ? 0 : reinterpret_cast<cudaStream_t>(compute_stream_));
+  // cudaStreamSynchronize(nullptr);
+  // If everything is setup correctly, custom op implementations need not have such explicit synchronization logic as above.
+  // To make sure custom kernels and ORT CUDA kernels are implicitly synchronized:
+  // (1) Create your session with a compute stream passed in via SessionOptions and use the same compute
+  //     stream to launch the custom op (OR)
+  // (2) Use the API KernelContext_GetGPUComputeStream() to query the CUDA compute stream being used by ORT kernels in this session
+  //     and use the same compute stream to launch the custom op.
+  // Here, an example for (1) is shown (See test_inference.cc to see how this custom op is used.)
+  cudaFree(Y_cuda);
+}
+#endif
 
 void MyCustomKernelMultipleDynamicInputs::Compute(OrtKernelContext* context) {
   // Setup inputs

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -392,14 +392,19 @@ TEST(CApiTest, custom_op_handler) {
   Ort::CustomOpDomain custom_op_domain("");
   custom_op_domain.Add(&custom_op);
 
+  auto mem_type = custom_op.GetInputMemoryType(0);
+
 #ifdef USE_CUDA
   TestInference<float>(*ort_env, CUSTOM_OP_MODEL_URI, inputs, "Y", expected_dims_y, expected_values_y, 1,
                        custom_op_domain, nullptr, nullptr, false, compute_stream);
   cudaStreamDestroy(compute_stream);
+  ASSERT_EQ(mem_type, OrtMemType::OrtMemTypeDefault);
 #else
   TestInference<float>(*ort_env, CUSTOM_OP_MODEL_URI, inputs, "Y", expected_dims_y, expected_values_y, 0,
                        custom_op_domain, nullptr);
+  ASSERT_EQ(mem_type, OrtMemType::OrtMemTypeDefault);
 #endif
+
 }
 
 #if !defined(ORT_MINIMAL_BUILD) && !defined(REDUCED_OPS_BUILD)


### PR DESCRIPTION
**Description**: 

This PR wants to provide the custom  ops with the flexibility to set the memory type for each input. 

**Motivation and Context**
- Why is this change required? What problem does it solve?

Right now, custom ops API could not set input memory types. However, for some custom ops, the inputs may be in different memory types, such as CUDA `TopK` has the input `X` on GPU and the input `K` on CPU. With this change, the input memory types can be set based on the preferred location so that the kernel implementation can avoid the overhead of data transferring across devices.


- If it fixes an open issue, please link to the issue here.

N/A
