### PR TITLE
Fix fp16 converter bugs[1/n]

### DIFF
--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -280,6 +280,12 @@ def convert_float_to_float16(model,
                         if n.name not in graph_io_to_skip:
                             n.type.tensor_type.elem_type = onnx_proto.TensorProto.FLOAT16
                             value_info_list.append(n)
+                    if n.type.HasField('sequence_type'):
+                        if n.type.sequence_type.elem_type.tensor_type.elem_type == onnx_proto.TensorProto.FLOAT:
+                            if n.name not in graph_io_to_skip:
+                                n.type.sequence_type.elem_type.tensor_type.elem_type = onnx_proto.TensorProto.FLOAT16
+                                value_info_list.append(n)
+                            
         queue = next_level
 
     for key, value in fp32_initializers.items():


### PR DESCRIPTION
handle sequence type when converting I/O and value_info
TODO: handle SequenceEmpty since it's default dtype is 1
TODO: do not append new tensor. insert under topological order
TODO: value_info_list needs to include outer graph's IO

**Description**: Describe your changes.

Resolve issues during converting an internal model to fp16 format

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
