### PR TITLE
Support to create a session from model buffer and external data buffers directly.

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -653,6 +653,9 @@ class Graph {
   /** Gets the path of the owning model, if any. */
   const Path& ModelPath() const;
 
+  /** Gets the external data mapping table, if any. */
+  const std::unordered_map<std::string, const void*>* ExternalDataMap() const;
+
   /** Returns true if this is a subgraph or false if it is a high-level graph. */
   bool IsSubgraph() const { return parent_graph_ != nullptr; }
 

--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -51,6 +51,11 @@ class GraphViewer {
   /** Gets the path of the owning model if any **/
   const Path& ModelPath() const noexcept { return graph_->ModelPath(); }
 
+  /** Gets the external data mapping table, if any. */
+  const std::unordered_map<std::string, const void*>* ExternalDataMap() const noexcept {
+    return graph_->ExternalDataMap();
+  }
+
   /**
   Gets a tensor created from an initializer.
   @param tensor_name The tensor name

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3303,6 +3303,11 @@ struct OrtApi {
   */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_MIGraphX,
                   _In_ OrtSessionOptions* options, _In_ const OrtMIGraphXProviderOptions* migraphx_options);
+
+  ORT_API2_STATUS(CreateSessionWithExternalDataFromArray, _In_ const OrtEnv* env, _In_ const void* model_data, size_t model_data_length,
+                  _In_reads_(external_data_len) const char* const* external_data_names,
+                  _In_reads_(external_data_len) const void* const* external_data_buffers,
+                  size_t external_data_len, _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -400,7 +400,7 @@ struct Session : Base<OrtSession> {
   Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options, OrtPrepackedWeightsContainer* prepacked_weights_container);  ///< Wraps OrtApi::CreateSessionWithPrepackedWeightsContainer
   Session(Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options);                                        ///< Wraps OrtApi::CreateSessionFromArray
   Session(Env& env, const void* model_data, size_t model_data_length,                                                                        ///< Wraps OrtApi::CreateSessionWithExternalDataFromArray
-          const std::vector<std::string>& external_data_names, const std::vector<void*>& external_data_buffers, size_t external_data_len,
+          const std::string* external_data_names, const void* const* external_data_buffers, size_t external_data_len,
           const Ort::SessionOptions& options);
 
   /** \brief Run the model returning results in an Ort allocated vector.

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include <utility>
 #include <type_traits>
+#include <algorithm>
+#include <iterator>
 
 #ifdef ORT_NO_EXCEPTIONS
 #include <iostream>
@@ -397,6 +399,9 @@ struct Session : Base<OrtSession> {
   Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options);                                                             ///< Wraps OrtApi::CreateSession
   Session(Env& env, const ORTCHAR_T* model_path, const SessionOptions& options, OrtPrepackedWeightsContainer* prepacked_weights_container);  ///< Wraps OrtApi::CreateSessionWithPrepackedWeightsContainer
   Session(Env& env, const void* model_data, size_t model_data_length, const SessionOptions& options);                                        ///< Wraps OrtApi::CreateSessionFromArray
+  Session(Env& env, const void* model_data, size_t model_data_length,                                                                        ///< Wraps OrtApi::CreateSessionWithExternalDataFromArray
+          const std::vector<std::string>& external_data_names, const std::vector<void*>& external_data_buffers, size_t external_data_len,
+          const Ort::SessionOptions& options);
 
   /** \brief Run the model returning results in an Ort allocated vector.
   * 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -562,16 +562,16 @@ inline Session::Session(Env& env, const void* model_data, size_t model_data_leng
 }
 
 inline Session::Session(Env& env, const void* model_data, size_t model_data_length,
-                        const std::vector<std::string>& external_data_names, const std::vector<void*>& external_data_buffers, size_t external_data_len,
+                        const std::string* external_data_names, const void* const* external_data_buffers, size_t external_data_len,
                         const Ort::SessionOptions& options) {
   std::vector<const char*> external_data_names_;
   std::transform(
-      external_data_names.cbegin(),
-      external_data_names.cend(),
+      external_data_names,
+      external_data_names + external_data_len,
       std::back_inserter(external_data_names_),
       [](const std::string& str) { return str.c_str(); }
   );
-  ThrowOnError(GetApi().CreateSessionWithExternalDataFromArray(env, model_data, model_data_length, external_data_names_.data(), external_data_buffers.data(), external_data_len, options, &p_));
+  ThrowOnError(GetApi().CreateSessionWithExternalDataFromArray(env, model_data, model_data_length, external_data_names_.data(), external_data_buffers, external_data_len, options, &p_));
 }
 
 inline std::vector<Value> Session::Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -561,6 +561,19 @@ inline Session::Session(Env& env, const void* model_data, size_t model_data_leng
   ThrowOnError(GetApi().CreateSessionFromArray(env, model_data, model_data_length, options, &p_));
 }
 
+inline Session::Session(Env& env, const void* model_data, size_t model_data_length,
+                        const std::vector<std::string>& external_data_names, const std::vector<void*>& external_data_buffers, size_t external_data_len,
+                        const Ort::SessionOptions& options) {
+  std::vector<const char*> external_data_names_;
+  std::transform(
+      external_data_names.cbegin(),
+      external_data_names.cend(),
+      std::back_inserter(external_data_names_),
+      [](const std::string& str) { return str.c_str(); }
+  );
+  ThrowOnError(GetApi().CreateSessionWithExternalDataFromArray(env, model_data, model_data_length, external_data_names_.data(), external_data_buffers.data(), external_data_len, options, &p_));
+}
+
 inline std::vector<Value> Session::Run(const RunOptions& run_options, const char* const* input_names, const Value* input_values, size_t input_count,
                                        const char* const* output_names, size_t output_names_count) {
   std::vector<Ort::Value> output_values;

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -307,7 +307,8 @@ class SessionState {
                               const SessionOptions& session_options = {},
                               const onnxruntime::fbs::SessionState* serialized_session_state = nullptr,
                               bool remove_initializers = true,
-                              bool saving_ort_format = false);
+                              bool saving_ort_format = false,
+                              const std::unordered_map<std::string, const void*>* external_data_map = nullptr);
 
   SessionState* Parent() {
     return parent_;
@@ -379,7 +380,8 @@ class SessionState {
                                   bool remove_initializers,
                                   std::unordered_map<std::string, size_t>& constant_initializers_use_count,
                                   const std::unordered_map<OrtValueName, OrtMemoryInfo>& outer_scope_node_arg_to_location_map = {},
-                                  bool graph_info_already_created = false);
+                                  bool graph_info_already_created = false,
+                                  const std::unordered_map<std::string, const void*>* external_data_map = nullptr);
 
 #ifdef ENABLE_TRAINING
   Status GeneratePatternGroupCache(

--- a/onnxruntime/core/framework/session_state_utils.h
+++ b/onnxruntime/core/framework/session_state_utils.h
@@ -41,7 +41,8 @@ common::Status SaveInitializedTensors(
     const logging::Logger& logger,
     const DataTransferManager& data_transfer_mgr,
     const ExecutionPlanBase& exec_plan,
-    const SessionOptions& session_options);
+    const SessionOptions& session_options,
+    const std::unordered_map<std::string, const void*>* external_data_map = nullptr);
 common::Status SaveInputOutputNamesToNodeMapping(const GraphViewer& graph,
                                                  SessionState& session_state,
                                                  const std::vector<const NodeArg*>& implicit_inputs);

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -604,7 +604,7 @@ static Status GetDataContentFromExternalBuffer(
     size_t length,
     void*& raw_buffer) {
   auto it = external_data_map.find(external_data_key);
-  ORT_RETURN_IF(it == external_data_map.end());
+  ORT_RETURN_IF(it == external_data_map.end(), "Cannot find the key (" + external_data_key + ") in the external_data_map");
 
   // copy
   auto buffer = std::make_unique<char[]>(length);

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -752,17 +752,9 @@ Status TensorProtoToTensor(const Env& /*env*/, const std::unordered_map<std::str
         tensor_proto,
         nullptr,
         external_data_name, file_offset, raw_data_len));
-
-    std::string external_data_key = ONNXStringToString(external_data_name);
-
-    // load the file
-    if (external_data_map.count(external_data_key)) {
-      auto it = external_data_map.find(external_data_key);
-    }
-
     // load the file
     ORT_RETURN_IF_ERROR(GetDataContentFromExternalBuffer(
-        external_data_map, external_data_key, file_offset, raw_data_len, raw_data));
+        external_data_map, ONNXStringToString(external_data_name), file_offset, raw_data_len, raw_data));
   } else if (utils::HasRawData(tensor_proto)) {
     raw_data = const_cast<char*>(tensor_proto.raw_data().data());
     // TODO The line above has const-correctness issues. Below is a possible fix which copies the tensor_proto data

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -57,6 +57,10 @@ common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
                                    const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                    Tensor& tensor);
 
+common::Status TensorProtoToTensor(const Env& env, const std::unordered_map<std::string, const void*>& external_data_map,
+                                   const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                   Tensor& tensor);
+
 /** Creates a TensorProto from a Tensor.
     @param[in] tensor the Tensor whose data and shape will be used to create the TensorProto.
     @param[in] tensor_proto_name the name of the TensorProto.

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2831,6 +2831,10 @@ const Path& Graph::ModelPath() const {
   return owning_model_.ModelPath();
 }
 
+const std::unordered_map<std::string, const void*>* Graph::ExternalDataMap() const {
+  return owning_model_.ExternalDataMap();
+}
+
 template <typename T, typename TIter>
 static void RemoveRepeatedFieldEntry(T& repeated_field, const TIter& entry_to_remove) {
   auto num_entries = repeated_field.size();

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -57,29 +57,33 @@ class Model {
   // hold a copy of <model_proto>.
   explicit Model(const ONNX_NAMESPACE::ModelProto& model_proto,
                  const IOnnxRuntimeOpSchemaRegistryList* local_registries,
-                 const logging::Logger& logger, bool allow_released_opsets_only = true)
-      : Model(model_proto, PathString(), local_registries, logger, allow_released_opsets_only) {}
+                 const logging::Logger& logger, bool allow_released_opsets_only = true,
+                 const std::unordered_map<std::string, const void*>* external_data_map = nullptr)
+      : Model(model_proto, PathString(), local_registries, logger, allow_released_opsets_only, external_data_map) {}
 
   // NOTE: after calling this constructor, <*this> model will
   // hold a copy of <model_proto>.
   explicit Model(const ONNX_NAMESPACE::ModelProto& model_proto,
                  const PathString& model_path,
                  const IOnnxRuntimeOpSchemaRegistryList* local_registries,
-                 const logging::Logger& logger, bool allow_released_opsets_only = true);
+                 const logging::Logger& logger, bool allow_released_opsets_only = true,
+                 const std::unordered_map<std::string, const void*>* external_data_map = nullptr);
 
   // NOTE: after calling this constructor, <*this> model will
   // own the <model_proto>.
   explicit Model(ONNX_NAMESPACE::ModelProto&& model_proto,
                  const IOnnxRuntimeOpSchemaRegistryList* local_registries,
-                 const logging::Logger& logger, bool allow_released_opsets_only = true)
-      : Model(std::move(model_proto), PathString(), local_registries, logger, allow_released_opsets_only) {}
+                 const logging::Logger& logger, bool allow_released_opsets_only = true,
+                 const std::unordered_map<std::string, const void*>* external_data_map = nullptr)
+      : Model(std::move(model_proto), PathString(), local_registries, logger, allow_released_opsets_only, external_data_map) {}
 
   // NOTE: after calling this constructor, <*this> model will
   // own the <model_proto>.
   explicit Model(ONNX_NAMESPACE::ModelProto&& model_proto,
                  const PathString& model_path,
                  const IOnnxRuntimeOpSchemaRegistryList* local_registries,
-                 const logging::Logger& logger, bool allow_released_opsets_only = true);
+                 const logging::Logger& logger, bool allow_released_opsets_only = true,
+                 const std::unordered_map<std::string, const void*>* external_data_map = nullptr);
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
@@ -156,6 +160,9 @@ class Model {
 
   // Gets the path from which the model was loaded, if any.
   const Path& ModelPath() const noexcept { return model_path_; }
+
+  // Gets the external data mapping table, if any.
+  const std::unordered_map<std::string, const void*>* ExternalDataMap() const noexcept { return external_data_map_; }
 
   // Get model's main graph.
   Graph& MainGraph() noexcept;
@@ -247,6 +254,12 @@ class Model {
                              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
                              const logging::Logger& logger);
 
+  static common::Status Load(const ONNX_NAMESPACE::ModelProto& model_proto,
+                             const std::unordered_map<std::string, const void*>* external_data_map,
+                             /*out*/ std::shared_ptr<Model>& p_model,
+                             const IOnnxRuntimeOpSchemaRegistryList* local_registries,
+                             const logging::Logger& logger);
+
   static common::Status Load(ONNX_NAMESPACE::ModelProto&& model_proto,
                              /*out*/ std::shared_ptr<Model>& p_model,
                              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
@@ -255,6 +268,13 @@ class Model {
 
   static common::Status Load(ONNX_NAMESPACE::ModelProto&& model_proto,
                              const PathString& model_path,
+                             /*out*/ std::shared_ptr<Model>& p_model,
+                             const IOnnxRuntimeOpSchemaRegistryList* local_registries,
+                             const logging::Logger& logger,
+                             bool allow_released_opsets_only = true);
+
+  static common::Status Load(ONNX_NAMESPACE::ModelProto&& model_proto,
+                             const std::unordered_map<std::string, const void*>* external_data_map,
                              /*out*/ std::shared_ptr<Model>& p_model,
                              const IOnnxRuntimeOpSchemaRegistryList* local_registries,
                              const logging::Logger& logger,
@@ -295,6 +315,9 @@ class Model {
 
   // Path to model file. May be empty.
   const Path model_path_;
+
+  // Pointer to external data mapping table. May be nullptr.
+  const std::unordered_map<std::string, const void*>* external_data_map_;
 
   // Main graph of the model.
   std::unique_ptr<Graph> graph_;

--- a/onnxruntime/core/optimizer/attention_fusion.cc
+++ b/onnxruntime/core/optimizer/attention_fusion.cc
@@ -99,9 +99,10 @@ static NodeArg& MergeQkvWeights(Graph& graph, int64_t hidden_size,
   assert(nullptr != q_tensor);
   assert(nullptr != k_tensor);
   assert(nullptr != v_tensor);
-  Initializer q_initializer(*q_tensor, graph.ModelPath());
-  Initializer k_initializer(*k_tensor, graph.ModelPath());
-  Initializer v_initializer(*v_tensor, graph.ModelPath());
+  InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+  Initializer q_initializer(*q_tensor, opt);
+  Initializer k_initializer(*k_tensor, opt);
+  Initializer v_initializer(*v_tensor, opt);
   auto data_type = q_tensor->data_type();
 
   ONNX_NAMESPACE::TensorProto initializer;

--- a/onnxruntime/core/optimizer/concat_slice_elimination.cc
+++ b/onnxruntime/core/optimizer/concat_slice_elimination.cc
@@ -83,7 +83,7 @@ static bool GetSliceInfo(const Graph& graph,
 
     auto get_initializer_data =
         [&graph](const ONNX_NAMESPACE::TensorProto* initializer) -> InlinedVector<int64_t> {
-      Initializer init(*initializer, graph.ModelPath());
+      Initializer init(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
       if (initializer->data_type() == ONNX_NAMESPACE::TensorProto::INT32) {
         int32_t* init_data = init.data<int32_t>();
         return InlinedVector<int64_t>(init_data, init_data + init.size());

--- a/onnxruntime/core/optimizer/conv_add_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_add_fusion.cc
@@ -62,8 +62,9 @@ Status ConvAddFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& modifie
       return Status::OK();
     }
 
-    Initializer conv_B{*conv_B_tensor_proto, graph.ModelPath()};
-    Initializer add_B{*add_B_tensor_proto, graph.ModelPath()};
+    InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+    Initializer conv_B{*conv_B_tensor_proto, opt};
+    Initializer add_B{*add_B_tensor_proto, opt};
 
     if (conv_B.size() != add_B.size()) {
       return Status::OK();

--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -61,11 +61,12 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
     return Status::OK();
   }
 
-  Initializer bn_scale{*bn_scale_tensor_proto, graph.ModelPath()};
-  Initializer bn_B{*bn_B_tensor_proto, graph.ModelPath()};
-  Initializer bn_mean{*bn_mean_tensor_proto, graph.ModelPath()};
-  Initializer bn_var{*bn_var_tensor_proto, graph.ModelPath()};
-  Initializer conv_W{*conv_W_tensor_proto, graph.ModelPath()};
+  InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+  Initializer bn_scale{*bn_scale_tensor_proto, opt};
+  Initializer bn_B{*bn_B_tensor_proto, opt};
+  Initializer bn_mean{*bn_mean_tensor_proto, opt};
+  Initializer bn_var{*bn_var_tensor_proto, opt};
+  Initializer conv_W{*conv_W_tensor_proto, opt};
 
   std::unique_ptr<Initializer> conv_B = nullptr;
   const ONNX_NAMESPACE::TensorProto* conv_B_tensor_proto = nullptr;
@@ -79,7 +80,7 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
         conv_B_tensor_proto->data_type() != bn_B_tensor_proto->data_type()) {
       return Status::OK();
     }
-    conv_B = std::make_unique<Initializer>(*conv_B_tensor_proto, graph.ModelPath());
+    conv_B = std::make_unique<Initializer>(*conv_B_tensor_proto, opt);
   }
 
   // Calculate new value of initializers of conv node

--- a/onnxruntime/core/optimizer/conv_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_mul_fusion.cc
@@ -52,8 +52,9 @@ Status ConvMulFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_ef
     }
   }
 
-  Initializer conv_W{*conv_W_tensor_proto, graph.ModelPath()};
-  Initializer mul_B{*mul_B_tensor_proto, graph.ModelPath()};
+  InitializerOption initOpt{graph.ModelPath(), graph.ExternalDataMap()};
+  Initializer conv_W{*conv_W_tensor_proto, initOpt};
+  Initializer mul_B{*mul_B_tensor_proto, initOpt};
 
   const ONNX_NAMESPACE::TensorProto* conv_B_tensor_proto = nullptr;
   std::unique_ptr<Initializer> conv_B = nullptr;
@@ -68,7 +69,7 @@ Status ConvMulFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_ef
       return Status::OK();
     }
 
-    conv_B = std::make_unique<Initializer>(*conv_B_tensor_proto, graph.ModelPath());
+    conv_B = std::make_unique<Initializer>(*conv_B_tensor_proto, initOpt);
   }
 
   // Calculate new value of initializers of conv node

--- a/onnxruntime/core/optimizer/div_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/div_mul_fusion.cc
@@ -40,7 +40,7 @@ bool DivMulFusion::SatisfyCondition(const Graph& graph, const Node& node, const 
   }
 
   int32_t data_type = initializer->data_type();
-  Initializer div_A(*initializer, graph.ModelPath());
+  Initializer div_A(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
   if (div_A.size() > 1) {
     return false;
   }

--- a/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/embed_layer_norm_fusion.cc
@@ -448,7 +448,7 @@ static NodeArg* ExtractEmbedding(Graph& graph,
   assert(sequence_length > 0);
   assert(hidden_size > 0);
 
-  Initializer old_initializer{*tensor, graph.ModelPath()};
+  Initializer old_initializer{*tensor, {graph.ModelPath(), graph.ExternalDataMap()}};
   auto data_type = tensor->data_type();
 
   ONNX_NAMESPACE::TensorProto initializer;

--- a/onnxruntime/core/optimizer/expand_elimination.cc
+++ b/onnxruntime/core/optimizer/expand_elimination.cc
@@ -36,7 +36,7 @@ bool ExpandElimination::SatisfyCondition(const Graph& graph, const Node& node, c
     return false;
   }
 
-  auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+  auto initializer = std::make_unique<Initializer>(*tensor_proto, InitializerOption{graph.ModelPath(), graph.ExternalDataMap()});
   if (initializer->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
     return false;
   }

--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -98,7 +98,7 @@ Status Initializer::ReadExternalRawData(
   auto external_data_name = external_data->GetRelPath();
   auto external_data_key = ONNXStringToString(external_data_name);
   auto it = external_data_map.find(external_data_key);
-  ORT_RETURN_IF(it == external_data_map.end());
+  ORT_RETURN_IF(it == external_data_map.end(), "Cannot find the key (" + external_data_key + ") in the external_data_map");
 
   std::vector<char> buffer(actual_tensor_data_length);
   std::copy((const char*)it->second + buffer_offset,

--- a/onnxruntime/core/optimizer/initializer.h
+++ b/onnxruntime/core/optimizer/initializer.h
@@ -14,6 +14,12 @@
 
 namespace onnxruntime {
 
+struct InitializerOption {
+ public:
+  Path model_path = Path();
+  const std::unordered_map<std::string, const void*>* external_data_map = nullptr;
+};
+
 class Initializer final {
  public:
   // Construct an initializer with the provided name and data type, with all values initialized to 0
@@ -64,7 +70,8 @@ class Initializer final {
     }
   }
 
-  Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto, const Path& model_path) {
+  Initializer(const ONNX_NAMESPACE::TensorProto& tensor_proto,
+              const Path& model_path) {
     data_type_ = tensor_proto.data_type();
     if (utils::HasName(tensor_proto)) {
       name_ = tensor_proto.name();

--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -313,7 +313,7 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, add2_node.MutableInputDefs()[1]->Name());
     if (tensor_proto != nullptr &&
         tensor_proto->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-      Initializer initializer{*tensor_proto, graph.ModelPath()};
+      Initializer initializer{*tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()}};
       layer_norm_node.AddAttribute("epsilon", initializer.data<float>()[0]);
     } else {
       layer_norm_node.AddAttribute("epsilon", DEFAULT_LAYERNORM_EPSILON);
@@ -565,7 +565,7 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
     const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, add_node.MutableInputDefs()[1]->Name());
     if (tensor_proto != nullptr &&
         tensor_proto->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
-      Initializer initializer{*tensor_proto, graph.ModelPath()};
+      Initializer initializer{*tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()}};
       layer_norm_node.AddAttribute("epsilon", initializer.data<float>()[0]);
     } else {
       layer_norm_node.AddAttribute("epsilon", DEFAULT_LAYERNORM_EPSILON);

--- a/onnxruntime/core/optimizer/noop_elimination.cc
+++ b/onnxruntime/core/optimizer/noop_elimination.cc
@@ -51,7 +51,7 @@ bool NoopElimination::SatisfyCondition(const Graph& graph, const Node& node, con
   }
 
   int32_t data_type = initializer->data_type();
-  Initializer add_init(*initializer, graph.ModelPath());
+  Initializer add_init(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
   if (add_init.size() > 1) {
     return false;
   }

--- a/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/clip_quantizelinear.cc
@@ -26,7 +26,8 @@ static bool GetQConstantLowerUpper(const Graph& graph, const Node& node, float& 
     return false;
   }
 
-  Initializer s_initializer(*s_tensor_proto, graph.ModelPath());
+  InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+  Initializer s_initializer(*s_tensor_proto, opt);
   if (s_initializer.dims().size() != 0 ||
       s_initializer.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
     return false;
@@ -41,7 +42,7 @@ static bool GetQConstantLowerUpper(const Graph& graph, const Node& node, float& 
     return false;
   }
 
-  Initializer zp_initializer(*zp_tensor_proto, graph.ModelPath());
+  Initializer zp_initializer(*zp_tensor_proto, opt);
   if (zp_initializer.dims().size() != 0) {
     return false;
   }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -57,8 +57,9 @@ Status QDQS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_l
     }
 
     using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
-    Initializer q_zero_point(*q_zp_tensor_proto, graph.ModelPath());
-    Initializer dq_zero_point(*dq_zp_tensor_proto, graph.ModelPath());
+    InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+    Initializer q_zero_point(*q_zp_tensor_proto, opt);
+    Initializer dq_zero_point(*dq_zp_tensor_proto, opt);
     if (q_zero_point.size() != 1 ||
         dq_zero_point.size() != 1 ||
         q_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 ||

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_util.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_util.cc
@@ -16,7 +16,8 @@ namespace onnxruntime::QDQ {
 bool IsQDQPairSupported(
     const Node& q_node, const Node& dq_node,
     const GetConstantInitializerFn& get_const_initializer,
-    const Path& model_path) {
+    const Path& model_path,
+    const std::unordered_map<std::string, const void*>* external_data_map) {
   ConstPointerContainer<std::vector<NodeArg*>> dq_input_defs = dq_node.InputDefs();
   ConstPointerContainer<std::vector<NodeArg*>> q_input_defs = q_node.InputDefs();
 
@@ -48,10 +49,11 @@ bool IsQDQPairSupported(
   }
 
   // check Q/DQ have same scale and zero point
-  Initializer q_zp(*q_zp_tensor_proto, model_path);
-  Initializer q_scale(*q_scale_tensor_proto, model_path);
-  Initializer dq_zp(*dq_zp_tensor_proto, model_path);
-  Initializer dq_scale(*dq_scale_tensor_proto, model_path);
+  InitializerOption opt{model_path, external_data_map};
+  Initializer q_zp(*q_zp_tensor_proto, opt);
+  Initializer q_scale(*q_scale_tensor_proto, opt);
+  Initializer dq_zp(*dq_zp_tensor_proto, opt);
+  Initializer dq_scale(*dq_scale_tensor_proto, opt);
 
   return q_zp.data_type() == dq_zp.data_type() &&
          *q_zp.data<int8_t>() == *dq_zp.data<int8_t>() &&

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_util.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_util.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <functional>
 #include <string>
 
@@ -36,7 +37,8 @@ using GetConstantInitializerFn = std::function<const ONNX_NAMESPACE::TensorProto
 bool IsQDQPairSupported(
     const Node& q_node, const Node& dq_node,
     const GetConstantInitializerFn& get_const_initializer,
-    const Path& model_path);
+    const Path& model_path,
+    const std::unordered_map<std::string, const void*>* external_data_map);
 
 // Check if DQ is supported in extended level QDQ transformers. It requires:
 // 1. DQ doesn't have optional input.

--- a/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/relu_quantizelinear.cc
@@ -43,7 +43,7 @@ Status ReluQuantFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_
   }
 
   using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
-  Initializer zero_point(*zp_tensor_proto, graph.ModelPath());
+  Initializer zero_point(*zp_tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()});
   if (zero_point.size() != 1 ||
       (zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 && zero_point.data<int8_t>()[0] != -128) ||
       (zero_point.data_type() == ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_UINT8 && zero_point.data<uint8_t>()[0] != 0)) {

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -108,7 +108,7 @@ bool DropQDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
     return graph_viewer.GetConstantInitializer(initializer_name, true);
   };
 
-  return IsQDQPairSupported(q_node, dq_node, get_const_initializer, graph_viewer.ModelPath());
+  return IsQDQPairSupported(q_node, dq_node, get_const_initializer, graph_viewer.ModelPath(), graph_viewer.ExternalDataMap());
 }
 
 bool DropDQNodeGroupSelector::CheckDQNodes(const Node& node, const std::vector<const Node*>& dq_nodes) const {

--- a/onnxruntime/core/optimizer/relu_clip_fusion.cc
+++ b/onnxruntime/core/optimizer/relu_clip_fusion.cc
@@ -56,7 +56,7 @@ Status FuseReluClip::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
 
       data_type = initializer->data_type();
       // construct an initializer to gracefully handle typed or raw data in the TensorProto
-      Initializer i(*initializer, graph.ModelPath());
+      Initializer i(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
       switch (data_type) {
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
           if (*i.data<float>() < 0.f) {

--- a/onnxruntime/core/optimizer/slice_elimination.cc
+++ b/onnxruntime/core/optimizer/slice_elimination.cc
@@ -61,7 +61,7 @@ bool EliminateSlice::SatisfyCondition(const Graph& graph, const Node& node, cons
 
     auto get_initializer_data =
         [&graph](const ONNX_NAMESPACE::TensorProto* initializer) -> InlinedVector<int64_t> {
-      Initializer init(*initializer, graph.ModelPath());
+      Initializer init(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
       if (initializer->data_type() == ONNX_NAMESPACE::TensorProto::INT32) {
         int32_t* init_data = init.data<int32_t>();
         return InlinedVector<int64_t>(init_data, init_data + init.size());

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -56,7 +56,7 @@ bool IsInitializerWithExpectedValue(const Graph& graph, const NodeArg& input_arg
     return false;
   }
 
-  Initializer init_const{*tensor_proto, graph.ModelPath()};
+  Initializer init_const{*tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()}};
   const auto data_type = tensor_proto->data_type();
   if (data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
     const float* val = init_const.data<float>();
@@ -110,7 +110,7 @@ bool IsInitializerWithExpectedValue(const Graph& graph, const NodeArg& input_arg
     return false;
   }
 
-  Initializer init_const{*tensor_proto, graph.ModelPath()};
+  Initializer init_const{*tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()}};
   const auto data_type = tensor_proto->data_type();
   if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
     const int64_t* val = init_const.data<int64_t>();
@@ -171,7 +171,7 @@ bool AppendTensorFromInitializer(const Graph& graph, const NodeArg& input_arg, I
     return false;
   }
 
-  Initializer init_const{*tensor_proto, graph.ModelPath()};
+  Initializer init_const{*tensor_proto, {graph.ModelPath(), graph.ExternalDataMap()}};
   const auto data_type = tensor_proto->data_type();
   if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
     const int64_t* val = init_const.data<int64_t>();
@@ -313,7 +313,7 @@ bool GetClipConstantMinMax(const Graph& graph, const Node& node, float& min, flo
           bool is_constant = true;
           const ONNX_NAMESPACE::TensorProto* initializer = graph.GetConstantInitializer(input->Name(), true);
           if (initializer) {
-            Initializer i(*initializer, graph.ModelPath());
+            Initializer i(*initializer, {graph.ModelPath(), graph.ExternalDataMap()});
             switch (initializer->data_type()) {
               case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
                 value = *i.data<float>();

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -814,7 +814,7 @@ common::Status InferenceSession::Load(const void* model_data, int model_data_len
 
   external_data_map_ = external_data_map;
 
-  auto loader = [this, model_data, model_data_len](std::shared_ptr<onnxruntime::Model>& model) {
+  auto loader = [this, model_data, model_data_len, external_data_map](std::shared_ptr<onnxruntime::Model>& model) {
     ModelProto model_proto;
 
     const bool result = model_proto.ParseFromArray(model_data, model_data_len);
@@ -829,8 +829,12 @@ common::Status InferenceSession::Load(const void* model_data, int model_data_len
     }
 #endif
 
-    return onnxruntime::Model::Load(std::move(model_proto), PathString(), model,
-                                    HasLocalSchema() ? &custom_schema_registries_ : nullptr, *session_logger_);
+    return onnxruntime::Model::Load(std::move(model_proto),
+                                    external_data_map,
+                                    model,
+                                    HasLocalSchema() ? &custom_schema_registries_ : nullptr,
+                                    *session_logger_,
+                                    true);
   };
 
   return Load(loader, "model_loading_array");

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -172,7 +172,8 @@ class InferenceSession {
   InferenceSession(const SessionOptions& session_options,
                    const Environment& session_env,
                    const void* model_data,
-                   int model_data_len);
+                   int model_data_len,
+                   const std::unordered_map<std::string, const void*>* external_data_map);
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
@@ -250,18 +251,18 @@ class InferenceSession {
   common::Status Load(const std::wstring& model_uri) ORT_MUST_USE_RESULT;
 #endif
   /**
-   * Load an ONNX or ORT format model.
-   *
-   * Set SessionOptions session config value ORT_SESSION_OPTIONS_CONFIG_LOAD_MODEL_FORMAT to 'ORT' or 'ONNX' to
-   * explicitly choose model format.
-   *
-   * If format is not explicitly specified the model format will be inferred from the bytes, defaulting to ONNX.
-   *
-   * @param model_data Model data buffer
-   * @param model_data_len Model data buffer size
-   * @return OK if success.
-   */
-  common::Status Load(const void* model_data, int model_data_len) ORT_MUST_USE_RESULT;
+    * Load an ONNX or ORT format model.
+    *
+    * Set SessionOptions session config value ORT_SESSION_OPTIONS_CONFIG_LOAD_MODEL_FORMAT to 'ORT' or 'ONNX' to
+    * explicitly choose model format.
+    *
+    * If format is not explicitly specified the model format will be inferred from the bytes, defaulting to ONNX.
+    *
+    * @param model_data Model data buffer
+    * @param model_data_len Model data buffer size
+    * @return OK if success.
+    */
+  common::Status Load(const void* model_data, int model_data_len, const std::unordered_map<std::string, const void*>* external_data_map = nullptr) ORT_MUST_USE_RESULT;
 
 #if !defined(ORT_MINIMAL_BUILD)
   /**
@@ -792,6 +793,8 @@ class InferenceSession {
   };
 
   CachedExecutionProviderForGraphReplay cached_execution_provider_for_graph_replay_;
+
+  const std::unordered_map<std::string, const void*>* external_data_map_ = nullptr;
 };
 
 struct SessionIOBinding {

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -251,17 +251,18 @@ class InferenceSession {
   common::Status Load(const std::wstring& model_uri) ORT_MUST_USE_RESULT;
 #endif
   /**
-    * Load an ONNX or ORT format model.
-    *
-    * Set SessionOptions session config value ORT_SESSION_OPTIONS_CONFIG_LOAD_MODEL_FORMAT to 'ORT' or 'ONNX' to
-    * explicitly choose model format.
-    *
-    * If format is not explicitly specified the model format will be inferred from the bytes, defaulting to ONNX.
-    *
-    * @param model_data Model data buffer
-    * @param model_data_len Model data buffer size
-    * @return OK if success.
-    */
+   * Load an ONNX or ORT format model.
+   *
+   * Set SessionOptions session config value ORT_SESSION_OPTIONS_CONFIG_LOAD_MODEL_FORMAT to 'ORT' or 'ONNX' to
+   * explicitly choose model format.
+   *
+   * If format is not explicitly specified the model format will be inferred from the bytes, defaulting to ONNX.
+   *
+   * @param model_data Model data buffer
+   * @param model_data_len Model data buffer size
+   * @param external_data_map External data mapping table (name and buffer)
+   * @return OK if success.
+   */
   common::Status Load(const void* model_data, int model_data_len, const std::unordered_map<std::string, const void*>* external_data_map = nullptr) ORT_MUST_USE_RESULT;
 
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -45,6 +45,11 @@ ORT_API_STATUS_IMPL(CreateSession, _In_ const OrtEnv* env, _In_ const ORTCHAR_T*
 ORT_API_STATUS_IMPL(CreateSessionFromArray, _In_ const OrtEnv* env, _In_ const void* model_data, size_t model_data_length,
                     _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
 
+ORT_API_STATUS_IMPL(CreateSessionWithExternalDataFromArray, _In_ const OrtEnv* env, _In_ const void* model_data, size_t model_data_length,
+                    _In_reads_(external_data_len) const char* const* external_data_names,
+                    _In_reads_(external_data_len) const void* const* external_data_buffers,
+                    size_t external_data_len, _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
+
 ORT_API_STATUS_IMPL(Run, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options,
                     _In_reads_(input_len) const char* const* input_names,
                     _In_reads_(input_len) const OrtValue* const* input, size_t input_len,

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -2072,20 +2072,21 @@ TEST_F(GraphTransformationTests, ReluClip11Fusion) {
 
         auto type = min_input->data_type();
 
+        InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
         if (&node == &clip1) {
           // fusion with float16 data and min set to 0
           EXPECT_EQ(type, ONNX_NAMESPACE::TensorProto::DataType::TensorProto_DataType_FLOAT16);
-          MLFloat16 value = *Initializer(*min_input, graph.ModelPath()).data<MLFloat16>();
+          MLFloat16 value = *Initializer(*min_input, opt).data<MLFloat16>();
           EXPECT_EQ(math::halfToFloat(value.val), 0.f) << "Min was not 0.f. Got:" << math::halfToFloat(value.val);
         } else if (&node == &clip2) {
           // fusion with float data and min untouched
           EXPECT_EQ(type, ONNX_NAMESPACE::TensorProto::DataType::TensorProto_DataType_FLOAT);
-          float value = *Initializer(*min_input, graph.ModelPath()).data<float>();
+          float value = *Initializer(*min_input, opt).data<float>();
           EXPECT_EQ(value, 1.0) << "Min should have remained unchanged but is now " << value;
         } else if (&node == &clip3) {
           // fusion with no min so type comes from input
           EXPECT_EQ(type, ONNX_NAMESPACE::TensorProto::DataType::TensorProto_DataType_FLOAT);
-          float value = *Initializer(*min_input, graph.ModelPath()).data<float>();
+          float value = *Initializer(*min_input, opt).data<float>();
           EXPECT_EQ(value, 0.f) << "Min was not 0.f. Got:" << value;
 
         } else {
@@ -2143,7 +2144,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionTest) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 4);
 
@@ -2179,7 +2181,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionOneConstTest) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2214,7 +2217,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionInternalNodeIsOutput) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2250,7 +2254,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionInternalReuseTest) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 5);
 
@@ -2309,7 +2314,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerSubgrap
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2342,7 +2348,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerApplies
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2412,7 +2419,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphMultipleOutputs) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2446,7 +2454,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraph) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2480,7 +2489,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionWithSlice1) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2550,7 +2560,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithDiv) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2586,7 +2597,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithMul) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 3);
 
@@ -2620,7 +2632,8 @@ TEST_F(GraphTransformationTests, ReshapeFusionDistilBertTest) {
       const ONNX_NAMESPACE::TensorProto* tensor_proto = graph_utils::GetConstantInitializer(graph, node.InputDefs()[1]->Name());
       ASSERT_TRUE(tensor_proto != nullptr);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
       EXPECT_EQ(initializer->size(), 4);
 
@@ -2698,7 +2711,8 @@ static void ValidateAttention(Graph& graph) {
       ASSERT_TRUE(tensor_proto != nullptr);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(initializer->size(), 192);
 
       // Validate two rows (2x24 items) for sanity check.
@@ -2762,7 +2776,7 @@ static void ValidateAttention(Graph& graph) {
       ASSERT_TRUE(tensor_proto != nullptr);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
-      auto initializer2 = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      auto initializer2 = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(initializer2->size(), 24);
 
       std::vector<double> expected_value2 = {
@@ -4009,7 +4023,8 @@ static void EmbedLayerNormFusionFormat5(const std::basic_string<ORTCHAR_T>& file
       ASSERT_TRUE(tensor_proto != nullptr);
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
-      auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
+      InitializerOption opt{graph.ModelPath(), graph.ExternalDataMap()};
+      auto initializer = std::make_unique<Initializer>(*tensor_proto, opt);
       EXPECT_EQ(initializer->size(), 12);
 
       std::vector<double> expected_value = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 8.0, 7.0, 6.0};

--- a/onnxruntime/test/optimizer/initializer_test.cc
+++ b/onnxruntime/test/optimizer/initializer_test.cc
@@ -79,10 +79,10 @@ TEST(OptimizerInitializerTest, LoadExternalData) {
         SetTensorProtoExternalData("length", std::to_string(length * sizeof(int32_t)), tensor_proto);
 
         if (offset + length <= tensor_data_span.size()) {
-          Initializer i(tensor_proto, tensor_data_dir_path);
+          Initializer i(tensor_proto, {tensor_data_dir_path});
           EXPECT_EQ(gsl::make_span(i.data<int32_t>(), i.size()), tensor_data_span.subspan(offset, length));
         } else {
-          EXPECT_THROW(Initializer i(tensor_proto, tensor_data_dir_path), OnnxRuntimeException);
+          EXPECT_THROW(Initializer i(tensor_proto, {tensor_data_dir_path}), OnnxRuntimeException);
         }
       };
 
@@ -94,8 +94,8 @@ TEST(OptimizerInitializerTest, LoadExternalData) {
   check_initializer_load(0, tensor_data.size() + 1);
 
   // bad model paths
-  EXPECT_THROW(Initializer i(tensor_proto_base, Path{}), OnnxRuntimeException);
-  EXPECT_THROW(Initializer i(tensor_proto_base, Path::Parse(ToPathString("invalid/directory"))), OnnxRuntimeException);
+  EXPECT_THROW(Initializer i(tensor_proto_base, {Path{}}), OnnxRuntimeException);
+  EXPECT_THROW(Initializer i(tensor_proto_base, {Path::Parse(ToPathString("invalid/directory"))}), OnnxRuntimeException);
 
   // bad length
   {
@@ -103,7 +103,7 @@ TEST(OptimizerInitializerTest, LoadExternalData) {
     tensor_proto.clear_dims();
     SetTensorProtoExternalData("length", std::to_string(tensor_data.size() * sizeof(int32_t) + 1), tensor_proto);
 
-    EXPECT_THROW(Initializer i(tensor_proto, tensor_data_dir_path), OnnxRuntimeException);
+    EXPECT_THROW(Initializer i(tensor_proto, {tensor_data_dir_path}), OnnxRuntimeException);
   }
 }
 
@@ -138,7 +138,7 @@ void TestInitializerRawData() {
   tensor_proto.add_dims(4);
   tensor_proto.set_raw_data(data.data(), data.size() * sizeof(T));
 
-  Initializer init(tensor_proto, Path());
+  Initializer init(tensor_proto, {Path()});
 
   for (size_t idx = 0; idx < data.size(); idx++) {
     EXPECT_EQ(data[idx], init.data<T>()[idx]);
@@ -179,7 +179,7 @@ void TestInitializerDataField() {
     }
   }
 
-  Initializer init(tensor_proto, Path());
+  Initializer init(tensor_proto, {Path()});
 
   for (size_t idx = 0; idx < data.size(); idx++) {
     EXPECT_EQ(data[idx], init.data<T>()[idx]);
@@ -203,7 +203,7 @@ void TestInitializerDataField() {
       tensor_proto.add_##type##_data(data[idx]);                 \
     }                                                            \
                                                                  \
-    Initializer init(tensor_proto, Path());                      \
+    Initializer init(tensor_proto, {Path()});                      \
                                                                  \
     for (size_t idx = 0; idx < data.size(); idx++) {             \
       EXPECT_EQ(data[idx], init.data<type>()[idx]);              \


### PR DESCRIPTION
**Description**: A new C API for creating session pointer and C++ API session constructor which is a wrap of the C API.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Hi ONNX Team,
  - Problem:
There are many model are larger than 2GB, and would be stored in graph onnx file and some of external weight files in physical disk.
In our product code, we have to decrypt the encrypt files in memory and follow the session buffer type constructor.
But there isn't a constructor for construct the session with providing everything in memory. 
  - Solution:
I open a new API then user can feeding the `external_data_names` and `external_data_buffers` directly.
The runtime will use these buffers with high priority instead of open the files from disk.
```c++ 
Session(Env& env, const void* model_data, size_t model_data_length,    ///< Wraps OrtApi::CreateSessionWithExternalDataFromArray
        const std::string* external_data_names, const void* const* external_data_buffers, size_t external_data_len,
        const Ort::SessionOptions& options)
```
- If it fixes an open issue, please link to the issue here.
NaN

Regards,
Yi-Ren Liu