### PR TITLE
skip python arena shrinkage test on ppc

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1069,9 +1069,9 @@ class TestInferenceSession(unittest.TestCase):
         onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so2, providers=onnxrt.get_available_providers())
 
     def testMemoryArenaShrinkage(self):
-        if platform.architecture()[0] == '32bit':
-            # on x86 builds, the CPU allocator does not use an arena
-            print("Skipping testMemoryArenaShrinkage in 32bit platform.")
+        if platform.architecture()[0] == '32bit' or 'ppc' in platform.machine() or 'powerpc' in platform.machine():
+            # on x86 or ppc builds, the CPU allocator does not use an arena
+            print("Skipping testMemoryArenaShrinkage in 32bit or powerpc platform.")
         else:
             x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
 


### PR DESCRIPTION
**Description**: Skip python memory arena shrinkage api test on powerpc.

**Motivation and Context**
- https://github.com/microsoft/onnxruntime/pull/10694#issuecomment-1069315150 changes caused powerpc builds to fail
- ppc cpu EP does not use memory arena
