### PR TITLE
Disable Some Einsum ORTModule Tests Due to Issue from PyTorch Exporter

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -257,22 +257,28 @@ def permute_and_reshape_tensor(g, tensor, is_lhs, rank, perm, matmul_output_axes
             remaining_axes = [axis for axis in range(rank) if axis not in axes_to_remove]
             # Calculate the new shape, use 0 or -1 if possible.
             shape_tensors = []
-            all_zeros = True
+            before_contiguous_axes = True
+            last_zero_dim = -1
+            has_neg_one_dim = False
             for axis in remaining_axes:
                 if axis == first_matmul_output_axis:
                     shape_tensors.append(matmul_output_numel_tensor)
-                    all_zeros = False
+                    before_contiguous_axes = False
                 elif axis == first_contraction_axis:
                     shape_tensors.append(contraction_numel_tensor)
-                    all_zeros = False
-                elif all_zeros:
+                    before_contiguous_axes = False
+                elif before_contiguous_axes:
                     shape_tensors.append(g.op("Constant", value_t=torch.tensor([0], dtype=torch.int64)))
+                    last_zero_dim = len(shape_tensors) - 1
                 elif axis == remaining_axes[-1]:
                     shape_tensors.append(g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
+                    has_neg_one_dim = True
                 else:
                     single_axis_shape_tensor, _, shape_tensor = get_shape_tensor_by_axes(
                         g, tensor, shape_tensor, [axis], False)
                     shape_tensors.append(single_axis_shape_tensor)
+            if not has_neg_one_dim and last_zero_dim >= 0:
+                shape_tensors[last_zero_dim] = g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
             # Adjust the perm.
             perm = [axis for axis in perm if axis not in axes_to_remove]
             new_axis = 0
@@ -458,21 +464,22 @@ def einsum(g, equation, tensor_list):
     # Need to Reshape the result for the example, the new shape is [size(s), size(m)].
     if len(lhs_matmul_output_axes) != 1 or len(rhs_matmul_output_axes) != 1:
         shape_tensors = [g.op("Constant", value_t=torch.tensor([0], dtype=torch.int64))] * len(batched_axes)
-        all_zeros = True
+        last_zero_dim = len(shape_tensors) - 1
+        has_neg_one_dim = False
         if lhs_matmul_output_axes:
             if len(lhs_matmul_output_axes) == 1:
                 shape_tensors.append(g.op("Constant", value_t=torch.tensor([0], dtype=torch.int64)))
+                last_zero_dim = len(shape_tensors) - 1
             else:
                 shape_tensors.append(lhs_matmul_output_shape_tensor)
-                all_zeros = False
         if rhs_matmul_output_axes:
             if len(rhs_matmul_output_axes) == 1:
                 shape_tensors.append(g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
+                has_neg_one_dim = True
             else:
                 shape_tensors.append(rhs_matmul_output_shape_tensor)
-            all_zeros = False
-        if all_zeros:
-            shape_tensors[-1] = g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
+        if not has_neg_one_dim and last_zero_dim >= 0:
+            shape_tensors[last_zero_dim] = g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
         result = reshape_tensor(g, result, shape_tensors)
 
     # Now output axes is ordered by [batched_axes, lhs_matmul_output_axes, rhs_matmut_output_axes],

--- a/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_op_symbolic_registry.py
@@ -458,16 +458,21 @@ def einsum(g, equation, tensor_list):
     # Need to Reshape the result for the example, the new shape is [size(s), size(m)].
     if len(lhs_matmul_output_axes) != 1 or len(rhs_matmul_output_axes) != 1:
         shape_tensors = [g.op("Constant", value_t=torch.tensor([0], dtype=torch.int64))] * len(batched_axes)
+        all_zeros = True
         if lhs_matmul_output_axes:
             if len(lhs_matmul_output_axes) == 1:
                 shape_tensors.append(g.op("Constant", value_t=torch.tensor([0], dtype=torch.int64)))
             else:
                 shape_tensors.append(lhs_matmul_output_shape_tensor)
+                all_zeros = False
         if rhs_matmul_output_axes:
             if len(rhs_matmul_output_axes) == 1:
                 shape_tensors.append(g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
             else:
                 shape_tensors.append(rhs_matmul_output_shape_tensor)
+            all_zeros = False
+        if all_zeros:
+            shape_tensors[-1] = g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
         result = reshape_tensor(g, result, shape_tensors)
 
     # Now output axes is ordered by [batched_axes, lhs_matmul_output_axes, rhs_matmut_output_axes],

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1134,8 +1134,12 @@ def test_gradient_correctness_reducesum(dim, keepdim):
         _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
         _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
 
-@pytest.mark.parametrize("equation", ["s,se->se", "se,sc->sec", "se,se->s", "sec,sm->ecm",
-                                      "sec,ecm->sm", "ks,ksm->sm", "kes,ems->mek", "kes,ksm->ms"])
+# In PyTorch 1.11.0, there is issue during reduce node shape handling for exporter, so any sub-graph that
+# contains ReduceProd will fail to run, for example, "sec,sm->ecm", "sec,ecm->sm".
+# Currently move these cases out from the tests, and disable the test_gradient_correctness_einsum2 as well.
+# Will enable these tests again once the issue in PyTorch is fixed.
+@pytest.mark.parametrize("equation", ["s,se->se", "se,sc->sec", "se,se->s",
+                                      "ks,ksm->sm", "kes,ems->mek", "kes,ksm->ms"])
 def test_gradient_correctness_einsum(equation):
     class NeuralNetEinsum(torch.nn.Module):
         def __init__(self, bias_size):
@@ -1183,89 +1187,89 @@ def test_gradient_correctness_einsum(equation):
         _test_helpers.assert_values_are_close(ort_prediction, pt_prediction, atol=1e-3, rtol=1e-3)
         _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model, atol=1e-3, rtol=1e-3)
 
-def test_gradient_correctness_einsum_2():
-    class NeuralNetEinsum(torch.nn.Module):
-        def __init__(self, bias_size):
-            super(NeuralNetEinsum, self).__init__()
-            self.register_parameter(name='bias', param=torch.nn.Parameter(torch.randn(bias_size)))
+# def test_gradient_correctness_einsum_2():
+#     class NeuralNetEinsum(torch.nn.Module):
+#         def __init__(self, bias_size):
+#             super(NeuralNetEinsum, self).__init__()
+#             self.register_parameter(name='bias', param=torch.nn.Parameter(torch.randn(bias_size)))
 
-        def forward(self, left, right):
-            left = left + self.bias
-            return torch.einsum(equation, left, right)
+#         def forward(self, left, right):
+#             left = left + self.bias
+#             return torch.einsum(equation, left, right)
 
-    device = 'cuda'
-    A, B, C, D = 16, 32, 8, 64
+#     device = 'cuda'
+#     A, B, C, D = 16, 32, 8, 64
 
-    SIZE_MAP = { 'A': A, 'B': B, 'C': C, 'D': D }
+#     SIZE_MAP = { 'A': A, 'B': B, 'C': C, 'D': D }
 
-    def to_string(perm):
-        result = ''
-        for v in perm:
-            result += chr(ord('a') + v)
-        return result
+#     def to_string(perm):
+#         result = ''
+#         for v in perm:
+#             result += chr(ord('a') + v)
+#         return result
 
-    lhs_candidates = [[0], [0,1], [0,1,2]]
-    perm = [0,1,2,3]
-    combs = list(itertools.combinations(perm, 1)) + list(itertools.combinations(perm, 2)) + list(itertools.combinations(perm, 3))
-    rhs_candidates = []
-    for comb in combs:
-        rhs_candidates += list(itertools.permutations(comb))
+#     lhs_candidates = [[0], [0,1], [0,1,2]]
+#     perm = [0,1,2,3]
+#     combs = list(itertools.combinations(perm, 1)) + list(itertools.combinations(perm, 2)) + list(itertools.combinations(perm, 3))
+#     rhs_candidates = []
+#     for comb in combs:
+#         rhs_candidates += list(itertools.permutations(comb))
 
-    all_cases = []
-    for lhs_candidate in lhs_candidates:
-        for rhs_candidate in [list(candidate) for candidate in rhs_candidates]:
-            union = list(set(lhs_candidate + rhs_candidate))
-            # Union should contains contiguous numbers from 0, otherwise it's same as another case.
-            if any(v >= len(union) for v in union):
-                continue
-            # Numbers in right but not in left should be sorted, otherwise it's same as another case.
-            only_in_right = [v for v in rhs_candidate if v not in lhs_candidate]
-            if any(only_in_right[i] > only_in_right[i + 1] for i in range(len(only_in_right) - 1)):
-                continue
-            combs = []
-            for i in range(1, len(union) + 1):
-                combs += list(itertools.combinations(union, i))
-            output_candidates = []
-            for comb in combs:
-                output_candidates += list(itertools.permutations(comb))
-            # When output_candidates is too many, it will take long time to run. Sample part of them.
-            random.shuffle(output_candidates)
-            output_candidates = output_candidates[:8]
-            for output_candidate in [list(candidate) for candidate in output_candidates]:
-                all_cases.append((lhs_candidate, rhs_candidate, output_candidate))
+#     all_cases = []
+#     for lhs_candidate in lhs_candidates:
+#         for rhs_candidate in [list(candidate) for candidate in rhs_candidates]:
+#             union = list(set(lhs_candidate + rhs_candidate))
+#             # Union should contains contiguous numbers from 0, otherwise it's same as another case.
+#             if any(v >= len(union) for v in union):
+#                 continue
+#             # Numbers in right but not in left should be sorted, otherwise it's same as another case.
+#             only_in_right = [v for v in rhs_candidate if v not in lhs_candidate]
+#             if any(only_in_right[i] > only_in_right[i + 1] for i in range(len(only_in_right) - 1)):
+#                 continue
+#             combs = []
+#             for i in range(1, len(union) + 1):
+#                 combs += list(itertools.combinations(union, i))
+#             output_candidates = []
+#             for comb in combs:
+#                 output_candidates += list(itertools.permutations(comb))
+#             # When output_candidates is too many, it will take long time to run. Sample part of them.
+#             random.shuffle(output_candidates)
+#             output_candidates = output_candidates[:8]
+#             for output_candidate in [list(candidate) for candidate in output_candidates]:
+#                 all_cases.append((lhs_candidate, rhs_candidate, output_candidate))
 
-    for case in all_cases:
-        equation = to_string(case[0]) + ',' + to_string(case[1]) + '->' + to_string(case[2])
-        pos1 = equation.find(',')
-        pos2 = equation.find('->')
-        lhs_op = equation[0:pos1]
-        rhs_op = equation[pos1 + 1:pos2]
-        lhs_shape = []
-        for c in lhs_op:
-            lhs_shape.append(SIZE_MAP[c.upper()])
-        rhs_shape = []
-        for c in rhs_op:
-            rhs_shape.append(SIZE_MAP[c.upper()])
+#     for case in all_cases:
+#         equation = to_string(case[0]) + ',' + to_string(case[1]) + '->' + to_string(case[2])
+#         pos1 = equation.find(',')
+#         pos2 = equation.find('->')
+#         lhs_op = equation[0:pos1]
+#         rhs_op = equation[pos1 + 1:pos2]
+#         lhs_shape = []
+#         for c in lhs_op:
+#             lhs_shape.append(SIZE_MAP[c.upper()])
+#         rhs_shape = []
+#         for c in rhs_op:
+#             rhs_shape.append(SIZE_MAP[c.upper()])
 
-        pt_model = NeuralNetEinsum(lhs_shape[-1]).to(device)
-        ort_model = ORTModule(copy.deepcopy(pt_model))
+#         pt_model = NeuralNetEinsum(lhs_shape[-1]).to(device)
+#         ort_model = ORTModule(copy.deepcopy(pt_model))
 
-        def run_step(model, input_left, input_right):
-            prediction = model(input_left, input_right)
-            loss = prediction.sum()
-            loss.backward()
-            return prediction
+#         def run_step(model, input_left, input_right):
+#             prediction = model(input_left, input_right)
+#             loss = prediction.sum()
+#             loss.backward()
+#             return prediction
 
-        for _ in range(5):
-            pt_input_left = torch.rand(lhs_shape, device=device)
-            pt_input_right = torch.rand(rhs_shape, device=device)
-            ort_input_left = copy.deepcopy(pt_input_left)
-            ort_input_right = copy.deepcopy(pt_input_right)
-            pt_prediction = run_step(pt_model, pt_input_left, pt_input_right)
-            ort_prediction = run_step(ort_model, ort_input_left, ort_input_right)
+#         for _ in range(5):
+#             pt_input_left = torch.rand(lhs_shape, device=device)
+#             pt_input_right = torch.rand(rhs_shape, device=device)
+#             ort_input_left = copy.deepcopy(pt_input_left)
+#             ort_input_right = copy.deepcopy(pt_input_right)
+#             pt_prediction = run_step(pt_model, pt_input_left, pt_input_right)
+#             ort_prediction = run_step(ort_model, ort_input_left, ort_input_right)
 
-            _test_helpers.assert_values_are_close(ort_prediction, pt_prediction, atol=1e-3, rtol=1e-3)
-            _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model, atol=1e-3, rtol=1e-3)
+#             _test_helpers.assert_values_are_close(ort_prediction, pt_prediction, atol=1e-3, rtol=1e-3)
+#             _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model, atol=1e-3, rtol=1e-3)
 
 # Since multinomial is a generator function, we do not have to test for gradient
 # Two consecutive calls on the torch.multinomail on a probability distribution with more


### PR DESCRIPTION
In PyTorch 1.11.0, there is issue in PyTorch exporter that fail to handle reduce node shape, so if there is ReduceProd in the sub-graph of Einsum, ORTModule will fail to run. Disable such tests for now. Will enable them once the issue in PyTorch is fixed.

This PR also contains a bug fix to Reshape node when generating Einsum sub-graph.