### PR TITLE
Performance: add io_binding support for bert benchmark util

### DIFF
--- a/onnxruntime/python/tools/transformers/bert_perf_test.py
+++ b/onnxruntime/python/tools/transformers/bert_perf_test.py
@@ -21,6 +21,7 @@ import statistics
 import psutil
 import csv
 import numpy as np
+import torch
 import random
 from datetime import datetime
 import multiprocessing
@@ -36,6 +37,7 @@ class TestSetting:
     test_cases: int
     test_times: int
     use_gpu: bool
+    use_io_binding: bool
     provider: str
     intra_op_num_threads: int
     seed: int
@@ -119,6 +121,57 @@ def create_session(model_path, use_gpu, provider, intra_op_num_threads, graph_op
 
     return session
 
+def numpy_type(torch_type):
+    type_map = {torch.float32: np.float32,
+                torch.float16: np.float16,
+                torch.int32: np.int32,
+                torch.int64: np.longlong}
+    return type_map[torch_type]
+
+def create_input_output_tensors(inputs, outputs, device):
+    input_tensors = {name: torch.from_numpy(array).to(device)
+                        for name, array in inputs.items()}
+    output_tensors = {name: torch.from_numpy(array).to(device)
+                        for name, array in outputs.items()}
+    return input_tensors, output_tensors
+
+def create_io_binding(sess, input_tensors, output_tensors):
+    io_binding = sess.io_binding()
+    for name, tensor in input_tensors.items():
+        io_binding.bind_input(name, tensor.device.type, 0,
+                                numpy_type(tensor.dtype), tensor.shape,
+                                tensor.data_ptr())
+    for name, tensor in output_tensors.items():
+        io_binding.bind_output(name, tensor.device.type, 0,
+                                numpy_type(tensor.dtype), tensor.shape,
+                                tensor.data_ptr())
+    return io_binding
+
+def onnxruntime_inference_with_io_binding(session, all_inputs, output_names, test_setting):
+
+    inputs = random.choice(all_inputs)
+    result = session.run(output_names, inputs)
+    outputs = {}
+    for i in range(len(output_names)):
+        outputs[output_names[i]] = result[i]
+
+    device = 'cuda' if test_setting.use_gpu else 'cpu'
+    input_tensors, output_tensors = create_input_output_tensors(inputs, outputs, device)
+    io_binding = create_io_binding(session, input_tensors, output_tensors)
+
+    # warm up
+    for iter in range(1):
+        session.run_with_iobinding(io_binding)
+
+    results = []
+    latency_list = []
+    max_iters = 10
+    for iter in range(max_iters):
+        start_time = timeit.default_timer()
+        session.run_with_iobinding(io_binding)
+        latency = timeit.default_timer() - start_time
+        latency_list.append(latency)
+    return results, latency_list
 
 def onnxruntime_inference(session, all_inputs, output_names):
     if len(all_inputs) > 0:
@@ -134,7 +187,6 @@ def onnxruntime_inference(session, all_inputs, output_names):
         results.append(result)
         latency_list.append(latency)
     return results, latency_list
-
 
 def to_string(model_path, session, test_setting):
     sess_options = session.get_session_options()
@@ -159,9 +211,14 @@ def run_one_test(model_setting, test_setting, perf_results, all_inputs, intra_op
     print("Running test:", key)
 
     all_latency_list = []
-    for i in range(test_setting.test_times):
-        results, latency_list = onnxruntime_inference(session, all_inputs, output_names)
-        all_latency_list.extend(latency_list)
+    if test_setting.use_io_binding:
+        for i in range(test_setting.test_times):
+            results, latency_list = onnxruntime_inference_with_io_binding(session, all_inputs, output_names, test_setting)
+            all_latency_list.extend(latency_list)
+    else:
+        for i in range(test_setting.test_times):
+            results, latency_list = onnxruntime_inference(session, all_inputs, output_names)
+            all_latency_list.extend(latency_list)
 
     # latency in miliseconds
     latency_ms = np.array(all_latency_list) * 1000
@@ -269,6 +326,9 @@ def parse_arguments():
     parser.add_argument('--use_gpu', required=False, action='store_true', help="use GPU")
     parser.set_defaults(use_gpu=False)
 
+    parser.add_argument('--use_io_binding', required=False, action='store_true', help="use io_binding")
+    parser.set_defaults(use_io_binding=False)
+
     parser.add_argument("--provider",
                         required=False,
                         type=str,
@@ -311,7 +371,7 @@ def main():
                                  args.opt_level)
 
     for batch_size in batch_size_set:
-        test_setting = TestSetting(batch_size, args.sequence_length, args.samples, args.test_times, args.use_gpu,
+        test_setting = TestSetting(batch_size, args.sequence_length, args.samples, args.test_times, args.use_gpu, args.use_io_binding,
                                    args.provider, args.intra_op_num_threads, args.seed, args.verbose)
 
         print("test setting", test_setting)


### PR DESCRIPTION
**Description**: Add io_binding support for bert_perf_test.py

**Motivation and Context**
In the recent benchmark for 1p model, we found there's perf gap between python util (bert_bert_test.py) and c++ based util (onnxruntime_perf_test). ~ (10 ms vs. 5.5 ms)

Sample cmd:
ORT_TENSORRT_INT8_ENABLE=0 ORT_TENSORRT_ENGINE_CACHE_ENABLE=1 ORT_TENSORRT_MAX_WORKSPACE_SIZE=4294967296 ORT_TENSORRT_FP16_ENABLE=1 python bert_perf_test.py --model xyz.onnx --batch_size 32 --sequence_length 128 --intra_op_num_threads 24 --use_gpu --provider tensorrt --opt_level=0 --input_ids_name input_ids --input_mask_name attention_mask

./onnxruntime_perf_test -i "trt_engine_cache_enable|true trt_fp16_enable|true" -t 50 -e tensorrt xyz.onnx -s ./res.txt

After experimenting io_binding for the python util, we are able to bring the number down to 
4.02 ms (not output copy to cpu)
7.22 ms (plus output copy to cpu)

Thus we 'd like to add the --use_io_binding support to bring the perf number comparable to c++ based benchmark util.