### PR TITLE
Perf metrics

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -147,6 +147,7 @@ Status PerformanceRunner::Run() {
             << "Average inference time cost: " << performance_result_.total_time_cost / performance_result_.time_costs.size() * 1000 << " ms\n"
             // Time between start and end of run. Less than Total time cost when running requests in parallel.
             << "Total inference run time: " << inference_duration.count() << " s\n"
+            << "Number of inferences per second: " << performance_result_.time_costs.size() / inference_duration.count() << " \n"
             << "Avg CPU usage: " << performance_result_.average_CPU_usage << " %\n"
             << "Peak working set size: " << performance_result_.peak_workingset_size << " bytes"
             << std::endl;


### PR DESCRIPTION
Description: Adding Inference/second as a metric for the perf_test

Motivation and Context
When running tests for timed duration across tests, not all tests run for the exact time specified
so this measure will be useful for a fair comparison across systems