### PR TITLE
Parallel inference

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -188,7 +188,9 @@ Status PerformanceRunner::RunParallelDuration() {
       count++;
       counter++;
       tpool->Schedule([this, &counter, &m, &cv]() {
-        session_->ThreadSafeRun();
+        auto status = RunOneIteration<false>();
+        if (!status.IsOK())
+          std::cerr << status.ErrorMessage();
         // Simplified version of Eigen::Barrier
         std::lock_guard<OrtMutex> lg(m);
         counter--;


### PR DESCRIPTION
Description: Adding parallel inference support for timed duration test

Motivation and Context
The perf_test didn't have support for running multiple inferences in parallel when using the timed duration option
Adding this support helps in better scalability, especially for higher thread count CPUs