### PR TITLE
Move orttraining-linux-external-custom-ops pipeline to a new pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-external-custom-ops.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-external-custom-ops.yml
@@ -3,7 +3,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  pool: Linux-CPU-2019
+  pool: onnxruntime-training-linux-ext-custom-ops
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
Currently the pipeline is causing problems to the other pipelines who share the same machine pool, because:
1. The  custom op pipeline doesn't always clean up docker images, which makes disk full
2. The  custom op pipeline creates dirs with root. But our build agents doesn't have root privileges, so it can't cleanup them. 