### PR TITLE
Follow up update for python API checking if `vcruntime140_1.dll` is available (#10927)

### DIFF
--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -24,7 +24,8 @@ if platform.system() == "Windows":
         system_root = os.getenv("SystemRoot") or "C:\\Windows"
         if not os.path.isfile(os.path.join(system_root, "System32", "vcruntime140_1.dll")):
             warnings.warn("Please install the 2019 Visual C++ runtime and then try again. "
-                          "If you've installed the runtime in a non-standard location (other than %SystemRoot%\System32), "
+                          "If you've installed the runtime in a non-standard location "
+                          "(other than %SystemRoot%\System32), "
                           "make sure it can be found by setting the correct path.")
 
 @ONNXRUNTIME_SETDLOPENFLAGS_GLOBAL@

--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -17,12 +17,15 @@ if platform.system() == "Windows":
 
     # If on Windows, check if this import error is caused by the user not installing the 2019 VC Runtime
     # The VC Redist installer usually puts the VC Runtime dlls in the System32 folder, but it may also be found
-    # in some other locations or in some case Windows is not installed at C:\Windows.
+    # in some other locations.
     # TODO, we may want to try to load the VC Runtime dlls instead of checking if the hardcoded file path
     # is valid, and raise ImportError if the load fails
     if version_info.vs2019 and platform.architecture()[0] == "64bit":
-        if not os.path.isfile("C:\\Windows\\System32\\vcruntime140_1.dll"):
-            warnings.warn("Please install the 2019 Visual C++ runtime and then try again")
+        system_root = os.getenv("SystemRoot") or "C:\\Windows"
+        if not os.path.isfile(os.path.join(system_root, "System32", "vcruntime140_1.dll")):
+            warnings.warn("Please install the 2019 Visual C++ runtime and then try again. "
+                          "If you've installed the runtime in a non-standard location (other than %SystemRoot%\System32), "
+                          "make sure it can be found by setting the correct path.")
 
 @ONNXRUNTIME_SETDLOPENFLAGS_GLOBAL@
 from .onnxruntime_pybind11_state import *  # noqa


### PR DESCRIPTION
**Description**: Follow up update for python API checking if `vcruntime140_1.dll` is available (#10927)

**Motivation and Context**
- This is a follow up update after #10927
- Make the checking more robust to use %SystemRoot% instead of hardcoded `C:\Windows`
- Update the warning message


