### PR TITLE
Move #ifndef ORT_CXX_API_THROW to the no exceptions case.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -48,6 +48,9 @@ struct Exception : std::exception {
 };
 
 #ifdef ORT_NO_EXCEPTIONS
+// The #ifndef is for the very special case where the user of this library wants to define their own way of handling errors.
+// NOTE: This header expects control flow to not continue after calling ORT_CXX_API_THROW
+#ifndef ORT_CXX_API_THROW
 #define ORT_CXX_API_THROW(string, code)       \
   do {                                        \
     std::cerr << Ort::Exception(string, code) \
@@ -55,13 +58,10 @@ struct Exception : std::exception {
               << std::endl;                   \
     abort();                                  \
   } while (false)
+#endif
 #else
-// The #ifndef is for the very special case where the user of this library wants to define their own way of handling errors.
-// NOTE: This header expects control flow to not continue after calling ORT_CXX_API_THROW
-#ifndef ORT_CXX_API_THROW
 #define ORT_CXX_API_THROW(string, code) \
   throw Ort::Exception(string, code)
-#endif
 #endif
 
 // This is used internally by the C++ API. This class holds the global variable that points to the OrtApi, it's in a template so that we can define a global variable in a header and make


### PR DESCRIPTION
This is related to https://github.com/microsoft/onnxruntime/issues/10564, which introduced a correct fix but in the wrong case where exceptions are enabled.

@RyanUnderhill since you created the original pull request, could you please take a look to this one?

I'm also fine with having the #ifndef in both cases if you find it more appropriate, although I only need it in the no exceptions case. In the exceptions one it's probably more natural to simply catch the exception and act as needed.