### PR TITLE
Adds missing numpy type when looking for the ort correspondance

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_iobinding.cc
+++ b/onnxruntime/python/onnxruntime_pybind_iobinding.cc
@@ -71,7 +71,7 @@ void addIoBindingMethods(pybind11::module& m) {
         Py_DECREF(dtype);
 
         OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
-        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
+        auto ml_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
         OrtValue ml_value;
         Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
 
@@ -124,7 +124,7 @@ void addIoBindingMethods(pybind11::module& m) {
         Py_DECREF(dtype);
 
         OrtMemoryInfo info(GetDeviceName(device), OrtDeviceAllocator, device, device.Id());
-        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
+        auto ml_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
         OrtValue ml_value;
         Tensor::InitOrtValue(ml_type, gsl::make_span(shape), reinterpret_cast<void*>(data_ptr), info, ml_value);
 

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -236,30 +236,7 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
   }
 }
 
-MLDataType NumpyTypeToOnnxRuntimeType(int numpy_type) {
-  static std::map<int, MLDataType> type_map{
-      {NPY_BOOL, DataTypeImpl::GetType<bool>()},
-      {NPY_FLOAT32, DataTypeImpl::GetType<float>()},
-      {NPY_FLOAT16, DataTypeImpl::GetType<MLFloat16>()},
-      {NPY_FLOAT64, DataTypeImpl::GetType<double>()},
-      {NPY_INT8, DataTypeImpl::GetType<int8_t>()},
-      {NPY_UINT8, DataTypeImpl::GetType<uint8_t>()},
-      {NPY_INT16, DataTypeImpl::GetType<int16_t>()},
-      {NPY_UINT16, DataTypeImpl::GetType<uint16_t>()},
-      {NPY_INT32, DataTypeImpl::GetType<int32_t>()},
-      {NPY_UINT32, DataTypeImpl::GetType<uint32_t>()},
-      {NPY_INT64, DataTypeImpl::GetType<int64_t>()},
-      {NPY_UINT64, DataTypeImpl::GetType<uint64_t>()},
-      {NPY_OBJECT, DataTypeImpl::GetType<std::string>()}};
-  const auto it = type_map.find(numpy_type);
-  if (it == type_map.end()) {
-    throw std::runtime_error("No corresponding Numpy type for Tensor Type.");
-  } else {
-    return it->second;
-  }
-}
-
-MLDataType NumpyToOnnxRuntimeTensorType(int numpy_type) {
+MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type) {
   static std::map<int, MLDataType> type_map{
       {NPY_BOOL, DataTypeImpl::GetType<bool>()},
       {NPY_FLOAT, DataTypeImpl::GetType<float>()},
@@ -452,7 +429,7 @@ static std::unique_ptr<Tensor> CreateTensor(const AllocatorPtr& alloc, const std
 
   const int npy_type = PyArray_TYPE(darray);
   TensorShape shape = GetArrayShape(darray);
-  auto element_type = NumpyToOnnxRuntimeTensorType(npy_type);
+  auto element_type = NumpyTypeToOnnxRuntimeTensorType(npy_type);
   if (IsNumericNumpyType(npy_type) && use_numpy_data_memory) {
     if (pyObject == darray) {
       // Use the memory of numpy array directly. The ownership belongs to the calling
@@ -544,7 +521,7 @@ static void CreateTensorMLValue(const AllocatorPtr& alloc, const std::string& na
 static void CreateTensorMLValueOwned(const OrtPybindSingleUseAllocatorPtr& pybind_alloc, const AllocatorPtr& alloc, OrtValue* p_mlvalue) {
   auto npy_type = PyArray_TYPE(pybind_alloc->GetContiguous());
   TensorShape shape = GetArrayShape(pybind_alloc->GetContiguous());
-  auto element_type = NumpyToOnnxRuntimeTensorType(npy_type);
+  auto element_type = NumpyTypeToOnnxRuntimeTensorType(npy_type);
 
   std::unique_ptr<Tensor> p_tensor;
 

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -239,17 +239,17 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
 MLDataType NumpyTypeToOnnxRuntimeType(int numpy_type) {
   static std::map<int, MLDataType> type_map{
       {NPY_BOOL, DataTypeImpl::GetType<bool>()},
-      {NPY_FLOAT, DataTypeImpl::GetType<float>()},
+      {NPY_FLOAT32, DataTypeImpl::GetType<float>()},
       {NPY_FLOAT16, DataTypeImpl::GetType<MLFloat16>()},
-      {NPY_DOUBLE, DataTypeImpl::GetType<double>()},
+      {NPY_FLOAT64, DataTypeImpl::GetType<double>()},
       {NPY_INT8, DataTypeImpl::GetType<int8_t>()},
       {NPY_UINT8, DataTypeImpl::GetType<uint8_t>()},
       {NPY_INT16, DataTypeImpl::GetType<int16_t>()},
       {NPY_UINT16, DataTypeImpl::GetType<uint16_t>()},
-      {NPY_INT, DataTypeImpl::GetType<int32_t>()},
-      {NPY_UINT, DataTypeImpl::GetType<uint32_t>()},
-      {NPY_LONGLONG, DataTypeImpl::GetType<int64_t>()},
-      {NPY_ULONGLONG, DataTypeImpl::GetType<uint64_t>()},
+      {NPY_INT32, DataTypeImpl::GetType<int32_t>()},
+      {NPY_UINT32, DataTypeImpl::GetType<uint32_t>()},
+      {NPY_INT64, DataTypeImpl::GetType<int64_t>()},
+      {NPY_UINT64, DataTypeImpl::GetType<uint64_t>()},
       {NPY_OBJECT, DataTypeImpl::GetType<std::string>()}};
   const auto it = type_map.find(numpy_type);
   if (it == type_map.end()) {

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -35,9 +35,9 @@ TensorShape GetShape(const pybind11::array& arr);
 
 int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type);
 
-MLDataType NumpyTypeToOnnxRuntimeType(int numpy_type);
+MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type);
 
-MLDataType NumpyToOnnxRuntimeTensorType(int numpy_type);
+MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type);
 
 using MemCpyFunc = void (*)(void*, const void*, size_t);
 

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -37,8 +37,6 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type);
 
 MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type);
 
-MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type);
-
 using MemCpyFunc = void (*)(void*, const void*, size_t);
 
 void CpuToCpuMemCpy(void*, const void*, size_t);

--- a/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_ortvalue.cc
@@ -152,7 +152,7 @@ void addOrtValueMethods(pybind11::module& m) {
         }
 
         auto ml_value = std::make_unique<OrtValue>();
-        auto ml_type = NumpyTypeToOnnxRuntimeType(type_num);
+        auto ml_type = NumpyTypeToOnnxRuntimeTensorType(type_num);
         Tensor::InitOrtValue(ml_type, gsl::make_span(shape), std::move(allocator), *ml_value);
         return ml_value;
       })

--- a/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
+++ b/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
@@ -199,7 +199,7 @@ void addSparseTensorMethods(pybind11::module& m) {
 
             TensorShape dense_shape(py_dense_shape);
             auto values_type = GetNumpyArrayType(py_values);
-            auto ml_type = NumpyToOnnxRuntimeTensorType(values_type);
+            auto ml_type = NumpyTypeToOnnxRuntimeTensorType(values_type);
 
             std::unique_ptr<PySparseTensor> result;
             if (IsNumericNumpyType(values_type)) {
@@ -262,7 +262,7 @@ void addSparseTensorMethods(pybind11::module& m) {
             TensorShape values_shape = GetShape(py_values);
             TensorShape index_shape = GetShape(py_indices);
             auto values_type = GetNumpyArrayType(py_values);
-            auto ml_type = NumpyToOnnxRuntimeTensorType(values_type);
+            auto ml_type = NumpyTypeToOnnxRuntimeTensorType(values_type);
 
             std::unique_ptr<PySparseTensor> result;
             if (IsNumericNumpyType(values_type)) {

--- a/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
+++ b/onnxruntime/python/onnxruntime_pybind_sparse_tensor.cc
@@ -140,7 +140,7 @@ void addSparseTensorMethods(pybind11::module& m) {
 
                     TensorShape dense_shape(py_dense_shape);
                     auto values_type = GetNumpyArrayType(py_values);
-                    auto ml_type = NumpyToOnnxRuntimeTensorType(values_type);
+                    auto ml_type = NumpyTypeToOnnxRuntimeTensorType(values_type);
 
                     std::unique_ptr<PySparseTensor> result;
                     if (IsNumericNumpyType(values_type)) {

--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -57,39 +57,50 @@ class TestIOBinding(unittest.TestCase):
     def test_bind_input_types(self):
 
         opset = onnx_opset_version()
-        device = C_OrtDevice(C_OrtDevice.cpu(), C_OrtDevice.default_memory(), 0)
+        devices = [(C_OrtDevice(C_OrtDevice.cpu(), C_OrtDevice.default_memory(), 0), ['CPUExecutionProvider'])]
+        if "CUDAExecutionProvider" in onnxrt.get_all_providers():
+            devices.append((C_OrtDevice(C_OrtDevice.cuda(), C_OrtDevice.default_memory(), 0), ['CUDAExecutionProvider']))
+            
+        for device, provider in devices:
+            for dtype in [np.float32, np.float64, np.int32, np.uint32,
+                          np.int64, np.uint64, np.int16, np.uint16,
+                          np.int8, np.uint8, np.float16, np.bool_]:
+                with self.subTest(dtype=dtype, device=str(device)):
 
-        for dtype in [np.float32, np.float64, np.int32, np.uint32,
-                      np.int64, np.uint64, np.int16, np.uint16,
-                      np.int8, np.uint8, np.float16, np.bool_]:
-            with self.subTest(dtype=dtype):
+                    x = np.arange(8).reshape((-1, 2)).astype(dtype)
+                    proto_dtype = NP_TYPE_TO_TENSOR_TYPE[x.dtype]
 
-                x = np.arange(8).reshape((-1, 2)).astype(dtype)
-                proto_dtype = NP_TYPE_TO_TENSOR_TYPE[x.dtype]
+                    X = helper.make_tensor_value_info('X', proto_dtype, [None, x.shape[1]])
+                    Y = helper.make_tensor_value_info('Y', proto_dtype, [None, x.shape[1]])
 
-                X = helper.make_tensor_value_info('X', proto_dtype, [None, x.shape[1]])
-                Y = helper.make_tensor_value_info('Y', proto_dtype, [None, x.shape[1]])
+                    # inference
+                    node_add = helper.make_node('Identity', ['X'], ['Y'])
 
-                # inference
-                node_add = helper.make_node('Identity', ['X'], ['Y'])
+                    # graph
+                    graph_def = helper.make_graph([node_add], 'lr', [X], [Y], [])
+                    model_def = helper.make_model(
+                        graph_def, producer_name='dummy', ir_version=7,
+                        producer_version="0",
+                        opset_imports=[helper.make_operatorsetid('', opset)])
 
-                # graph
-                graph_def = helper.make_graph([node_add], 'lr', [X], [Y], [])
-                model_def = helper.make_model(
-                    graph_def, producer_name='dummy', ir_version=7,
-                    producer_version="0",
-                    opset_imports=[helper.make_operatorsetid('', opset)])
+                    sess = onnxrt.InferenceSession(model_def.SerializeToString(), providers=provider)
 
-                sess = onnxrt.InferenceSession(model_def.SerializeToString(), providers=onnxrt.get_available_providers())
+                    bind = SessionIOBinding(sess._sess)
+                    ort_value = C_OrtValue.ortvalue_from_numpy(x, device)
+                    bind.bind_ortvalue_input('X', ort_value)
+                    bind.bind_output('Y', device)
+                    sess._sess.run_with_iobinding(bind, None)
+                    ortvalue = bind.get_outputs()[0]
+                    y = ortvalue.numpy()
+                    assert_almost_equal(x, y)
 
-                bind = SessionIOBinding(sess._sess)
-                ort_value = C_OrtValue.ortvalue_from_numpy(x, device)
-                bind.bind_ortvalue_input('X', ort_value)
-                bind.bind_output('Y', device)
-                sess._sess.run_with_iobinding(bind, None)
-                ortvalue = bind.get_outputs()[0]
-                y = ortvalue.numpy()
-                assert_almost_equal(x, y)
+                    bind = SessionIOBinding(sess._sess)
+                    bind.bind_input('X', device, dtype, x.shape, ort_value.data_ptr())
+                    bind.bind_output('Y', device)
+                    sess._sess.run_with_iobinding(bind, None)
+                    ortvalue = bind.get_outputs()[0]
+                    y = ortvalue.numpy()
+                    assert_almost_equal(x, y)
 
     def test_bind_input_only(self):
         input = self.create_ortvalue_input_on_gpu()


### PR DESCRIPTION
**Description**:
Use of NPY_LONG is ambiguous, it does not have the same meaning on all platforms (see https://numpy.org/doc/stable/reference/c-api/dtype.html). There were two functions implementing the mapping numpy type --> tensor type. This PR removes the wrong one.

**Motivation and Context**
Fixes issue #10853.