### PR TITLE
fix post coverage bug

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -325,6 +325,5 @@ jobs:
       azureSubscription: AIInfraBuild
       scriptType: bash
       scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
-      arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" \
-        "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
+      arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
       workingDirectory: '$(Build.BinariesDirectory)'


### PR DESCRIPTION
**Description**: 
There's error in Post Android Code Coverage To DashBoard.

**Motivation and Context**
It looks the line break isn't correct, rever it.
It is the [error link](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=611616&view=logs&j=6a44f4f7-5fa1-5ade-cbc3-089c0a8f1f03&t=8a4a9de5-eb13-59c3-5618-91cb2a17923f).

[Old semantics](https://github.com/microsoft/onnxruntime/blob/aa76520e60b0be9b2ff81de8db3861b2a1d7cc31/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml#L104) worked
