### PR TITLE
[js/wasm] Add WebAssembly static library build into web CI pipeline

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -110,35 +110,37 @@ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
       re2::re2
     )
 
-    file(GLOB_RECURSE onnxruntime_webassembly_test_src CONFIGURE_DEPENDS
-      "${ONNXRUNTIME_ROOT}/test/wasm/test_main.cc"
-      "${ONNXRUNTIME_ROOT}/test/wasm/test_inference.cc"
-    )
+    if (onnxruntime_BUILD_UNIT_TESTS)
+      file(GLOB_RECURSE onnxruntime_webassembly_test_src CONFIGURE_DEPENDS
+        "${ONNXRUNTIME_ROOT}/test/wasm/test_main.cc"
+        "${ONNXRUNTIME_ROOT}/test/wasm/test_inference.cc"
+      )
 
-    source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_webassembly_test_src})
+      source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_webassembly_test_src})
 
-    add_executable(onnxruntime_webassembly_test
-      ${onnxruntime_webassembly_test_src}
-    )
+      add_executable(onnxruntime_webassembly_test
+        ${onnxruntime_webassembly_test_src}
+      )
 
-    set_target_properties(onnxruntime_webassembly_test PROPERTIES LINK_FLAGS
-      "-s ALLOW_MEMORY_GROWTH=1 -s \"EXPORTED_RUNTIME_METHODS=['FS']\" --preload-file ${CMAKE_CURRENT_BINARY_DIR}/testdata@/testdata -s EXIT_RUNTIME=1"
-    )
+      set_target_properties(onnxruntime_webassembly_test PROPERTIES LINK_FLAGS
+        "-s ALLOW_MEMORY_GROWTH=1 -s \"EXPORTED_RUNTIME_METHODS=['FS']\" --preload-file ${CMAKE_CURRENT_BINARY_DIR}/testdata@/testdata -s EXIT_RUNTIME=1"
+      )
 
-    target_link_libraries(onnxruntime_webassembly_test PUBLIC
-      onnxruntime_webassembly
-      GTest::gtest
-    )
+      target_link_libraries(onnxruntime_webassembly_test PUBLIC
+        onnxruntime_webassembly
+        GTest::gtest
+      )
 
-    find_program(NODE_EXECUTABLE node required)
-    if (NOT NODE_EXECUTABLE)
-      message(FATAL_ERROR "Node is required for a test")
+      find_program(NODE_EXECUTABLE node required)
+      if (NOT NODE_EXECUTABLE)
+        message(FATAL_ERROR "Node is required for a test")
+      endif()
+
+      add_test(NAME onnxruntime_webassembly_test
+        COMMAND ${NODE_EXECUTABLE} onnxruntime_webassembly_test.js
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:onnxruntime_webassembly_test>
+      )
     endif()
-
-    add_test(NAME onnxruntime_webassembly_test
-      COMMAND ${NODE_EXECUTABLE} onnxruntime_webassembly_test.js
-      WORKING_DIRECTORY $<TARGET_FILE_DIR:onnxruntime_webassembly_test>
-    )
 else()
   file(GLOB_RECURSE onnxruntime_webassembly_src CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/wasm/api.cc"

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -74,7 +74,7 @@ stages:
       ExtraBuildArgs: '--skip_tests --disable_wasm_exception_catching --disable_rtti $(ExtraBuildArgs)'
       PoolName: ${{ parameters.PoolName }}
 
-- ${{ if ne(parameters.BuildStaticLib, 'true') }}:
+- ${{ if eq(parameters.BuildStaticLib, 'true') }}:
   - stage: Build_wasm_Release_static_library
     dependsOn: Extract_commit
     jobs:

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -15,6 +15,10 @@ parameters:
   displayName: 'Package name'
   type: string
   default: 'NPM_packages'
+- name: BuildStaticLib
+  displayName: 'Build static library'
+  type: boolean
+  default: false
 
 stages:
 - stage: Extract_commit
@@ -69,6 +73,17 @@ stages:
       BuildConfig: 'Release'
       ExtraBuildArgs: '--skip_tests --disable_wasm_exception_catching --disable_rtti $(ExtraBuildArgs)'
       PoolName: ${{ parameters.PoolName }}
+
+- ${{ if ne(parameters.BuildStaticLib, 'true') }}:
+  - stage: Build_wasm_Release_static_library
+    dependsOn: Extract_commit
+    jobs:
+    - template: win-wasm-ci.yml
+      parameters:
+        CommitOverride: true
+        BuildConfig: 'Release'
+        ExtraBuildArgs: '$(ExtraBuildArgs)'
+        PoolName: ${{ parameters.PoolName }}
 
 - stage: Build_web_Release
   dependsOn: Build_wasm_Release

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -97,7 +97,7 @@ stages:
       PoolName: ${{ parameters.PoolName }}
       PackageName: ${{ parameters.PackageName }}
 
-- ${{ if ne(parameters.IsReleasePipeline, 'true') }}:
+- ${{ if ne(parameters.IsReleasePipeline, true) }}:
   - stage: Test_web_BrowserStack
     dependsOn: Build_wasm_Release
     jobs:
@@ -105,7 +105,7 @@ stages:
       parameters:
         CommitOverride: true
 
-- ${{ if ne(parameters.IsReleasePipeline, 'true') }}:
+- ${{ if ne(parameters.IsReleasePipeline, true) }}:
   - stage: Test_web_MultiBrowsers
     dependsOn: Build_wasm_Release
     jobs:

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -84,6 +84,7 @@ stages:
         BuildConfig: 'Release'
         ExtraBuildArgs: '$(ExtraBuildArgs)'
         PoolName: ${{ parameters.PoolName }}
+        SkipPublish: true
 
 - stage: Build_web_Release
   dependsOn: Build_wasm_Release

--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -93,14 +93,14 @@ jobs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
       arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)\wasm_simd --path_to_protoc_exe $(Build.BinariesDirectory)\wasm\host_protoc\Release\protoc.exe --enable_wasm_simd'
       workingDirectory: '$(Build.BinariesDirectory)'
-  - ${{ if eq(parameters.SkipPublish, 'false') }}:
+  - ${{ if eq(parameters.SkipPublish, false) }}:
     - script: |
         copy $(Build.BinariesDirectory)\wasm\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
         copy $(Build.BinariesDirectory)\wasm_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
         copy $(Build.BinariesDirectory)\wasm_simd_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
         copy $(Build.BinariesDirectory)\wasm_simd\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
       displayName: 'Create Artifacts'
-  - ${{ if eq(parameters.SkipPublish, 'false') }}:
+  - ${{ if eq(parameters.SkipPublish, false) }}:
     - task: PublishPipelineArtifact@0
       displayName: 'Publish Pipeline Artifact'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -15,6 +15,10 @@ parameters:
   type: string
   default: 'Win-CPU-2019'
 
+- name: SkipPublish
+  type: boolean
+  default: false
+
 jobs:
 - job: build_WASM
   pool: ${{ parameters.PoolName }}
@@ -89,17 +93,19 @@ jobs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
       arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)\wasm_simd --path_to_protoc_exe $(Build.BinariesDirectory)\wasm\host_protoc\Release\protoc.exe --enable_wasm_simd'
       workingDirectory: '$(Build.BinariesDirectory)'
-  - script: |
-      copy $(Build.BinariesDirectory)\wasm\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
-      copy $(Build.BinariesDirectory)\wasm_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
-      copy $(Build.BinariesDirectory)\wasm_simd_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
-      copy $(Build.BinariesDirectory)\wasm_simd\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
-    displayName: 'Create Artifacts'
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Pipeline Artifact'
-    inputs:
-      artifactName: '${{ parameters.BuildConfig }}_wasm'
-      targetPath: '$(Build.ArtifactStagingDirectory)'
+  - ${{ if eq(parameters.SkipPublish, 'false') }}:
+    - script: |
+        copy $(Build.BinariesDirectory)\wasm\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)\wasm_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)\wasm_simd_threads\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)\wasm_simd\${{ parameters.BuildConfig }}\ort-wasm*.* $(Build.ArtifactStagingDirectory)
+      displayName: 'Create Artifacts'
+  - ${{ if eq(parameters.SkipPublish, 'false') }}:
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish Pipeline Artifact'
+      inputs:
+        artifactName: '${{ parameters.BuildConfig }}_wasm'
+        targetPath: '$(Build.ArtifactStagingDirectory)'
   - task: PublishTestResults@2
     displayName: 'Publish unit test results'
     inputs:

--- a/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
@@ -29,3 +29,4 @@ stages:
     NpmPackagingMode: ${{ variables.NpmPackagingMode }}
     IsReleasePipeline: false
     PoolName: 'Win-CPU-2019'
+    BuildStaticLib: true


### PR DESCRIPTION
Current ONNX Runtime Web CI pipeline doesn't have a build for WebAssembly static library and test. This PR adds it in parallel with wasm debug and release build. And if '--skip_tests" build option is given, a test for static library must be skipped accordingly, otherwise, a build fails due to missing GTest library.