### PR TITLE
add build flag for emscripten settings

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -179,9 +179,15 @@ else()
                         -s LLD_REPORT_UNDEFINED                                     \
                         -s VERBOSE=0                                                \
                         -s NO_FILESYSTEM=1                                          \
-                        -s MALLOC=${onnxruntime_WEBASSEMBLY_MALLOC}                 \
                         --closure 1                                                 \
                         --no-entry")
+
+  if (onnxruntime_EMSCRIPTEN_SETTINGS)
+    foreach(setting IN LISTS onnxruntime_EMSCRIPTEN_SETTINGS)
+    set_property(TARGET onnxruntime_webassembly APPEND_STRING PROPERTY LINK_FLAGS
+      " -s ${setting}")
+    endforeach()
+  endif()
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set_property(TARGET onnxruntime_webassembly APPEND_STRING PROPERTY LINK_FLAGS " -s ASSERTIONS=2 -s SAFE_HEAP=1 -s STACK_OVERFLOW_CHECK=1 -s DEMANGLE_SUPPORT=1")

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -852,7 +852,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
     if is_windows():
         if args.enable_msvc_static_runtime:
             add_default_definition(cmake_extra_defines, "CMAKE_MSVC_RUNTIME_LIBRARY",
-                                              "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+                                   "MultiThreaded$<$<CONFIG:Debug>:Debug>")
             add_default_definition(cmake_extra_defines, "ONNX_USE_MSVC_STATIC_RUNTIME", "ON")
             add_default_definition(cmake_extra_defines, "protobuf_MSVC_STATIC_RUNTIME", "ON")
             add_default_definition(cmake_extra_defines, "gtest_force_shared_crt", "OFF")

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -731,9 +731,11 @@ def add_default_definition(definition_list, key, default_value):
             return definition_list
     definition_list.append(key + "=" + default_value)
 
+
 def normalize_arg_list(nested_list):
     return ([i for j in nested_list for i in j]
             if nested_list else [])
+
 
 def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, rocm_home,
                         mpi_home, nccl_home, tensorrt_home, migraphx_home, acl_home, acl_libs, armnn_home, armnn_libs,
@@ -1040,7 +1042,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             cmake_args += [
                 "-Donnxruntime_BUILD_UNIT_TESTS=OFF",
             ]
-        
+
         # add default emscripten settings
         emscripten_settings = normalize_arg_list(args.emscripten_settings)
 
@@ -2115,7 +2117,7 @@ def main():
             # Node.js when trying to load the .wasm file.
             # To debug ONNX Runtime WebAssembly, use ONNX Runtime Web to debug ort-wasm.wasm in browsers.
             raise BuildError("WebAssembly tests cannot be enabled with flag --enable_wasm_debug_info")
-        
+
         if args.wasm_malloc is not None:
             # mark --wasm_malloc as deprecated
             log.warning(

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -356,7 +356,14 @@ def parse_arguments():
     # WebAssembly build
     parser.add_argument("--build_wasm", action='store_true', help="Build for WebAssembly")
     parser.add_argument("--build_wasm_static_lib", action='store_true', help="Build for WebAssembly static library")
+    parser.add_argument(
+        "--emsdk_version", default="3.1.3", help="Specify version of emsdk")
+
     parser.add_argument("--enable_wasm_simd", action='store_true', help="Enable WebAssembly SIMD")
+    parser.add_argument(
+        "--enable_wasm_threads", action='store_true',
+        help="Enable WebAssembly multi-threads support")
+
     parser.add_argument(
         "--disable_wasm_exception_catching", action='store_true',
         help="Disable exception catching in WebAssembly.")
@@ -364,19 +371,19 @@ def parse_arguments():
         "--enable_wasm_exception_throwing_override", action='store_true',
         help="Enable exception throwing in WebAssembly, this will override default disabling exception throwing "
         "behavior when disable exceptions.")
-    parser.add_argument(
-        "--enable_wasm_threads", action='store_true',
-        help="Enable WebAssembly multi-threads support")
+
     parser.add_argument(
         "--enable_wasm_profiling", action='store_true',
         help="Enable WebAsselby profiling and preserve function names")
     parser.add_argument(
         "--enable_wasm_debug_info", action='store_true',
         help="Build WebAssembly with DWARF format debug info")
+
+    parser.add_argument("--wasm_malloc", help="Specify memory allocator for WebAssembly")
+
     parser.add_argument(
-        "--wasm_malloc", default="dlmalloc", help="Specify memory allocator for WebAssembly")
-    parser.add_argument(
-        "--emsdk_version", default="3.1.3", help="Specify version of emsdk")
+        "--emscripten_settings", nargs="+", action='append',
+        help="Extra emscripten settings to pass to emcc using '-s <key>=<value>' during build.")
 
     # Enable onnxruntime-extensions
     parser.add_argument(
@@ -724,10 +731,13 @@ def add_default_definition(definition_list, key, default_value):
             return definition_list
     definition_list.append(key + "=" + default_value)
 
+def normalize_arg_list(nested_list):
+    return ([i for j in nested_list for i in j]
+            if nested_list else [])
 
 def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, rocm_home,
                         mpi_home, nccl_home, tensorrt_home, migraphx_home, acl_home, acl_libs, armnn_home, armnn_libs,
-                        path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args):
+                        path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args, emscripten_settings):
     log.info("Generating CMake build tree")
     cmake_dir = os.path.join(source_dir, "cmake")
     cmake_args = [
@@ -830,7 +840,6 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         "-Donnxruntime_ENABLE_WEBASSEMBLY_THREADS=" + ("ON" if args.enable_wasm_threads else "OFF"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO=" + ("ON" if args.enable_wasm_debug_info else "OFF"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_PROFILING=" + ("ON" if args.enable_wasm_profiling else "OFF"),
-        "-Donnxruntime_WEBASSEMBLY_MALLOC=" + args.wasm_malloc,
         "-Donnxruntime_ENABLE_EAGER_MODE=" + ("ON" if args.build_eager_mode else "OFF"),
         "-Donnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS=" + ("ON" if args.enable_external_custom_op_schemas
                                                               else "OFF"),
@@ -1031,6 +1040,12 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             cmake_args += [
                 "-Donnxruntime_BUILD_UNIT_TESTS=OFF",
             ]
+        
+        # add default emscripten settings
+        add_default_definition(emscripten_settings, 'MALLOC', 'dlmalloc')
+
+        if (emscripten_settings):
+            cmake_args += [f"-Donnxruntime_EMSCRIPTEN_SETTINGS={';'.join(emscripten_settings)}"]
 
     # Append onnxruntime-extensions cmake options
     if args.use_extensions:
@@ -2037,8 +2052,7 @@ def main():
     log.debug("Command line arguments:\n  {}".format(" ".join(shlex.quote(arg) for arg in sys.argv[1:])))
 
     args = parse_arguments()
-    cmake_extra_defines = ([i for j in args.cmake_extra_defines for i in j]
-                           if args.cmake_extra_defines else [])
+    cmake_extra_defines = normalize_arg_list(args.cmake_extra_defines)
     cross_compiling = args.arm or args.arm64 or args.arm64ec or args.android
 
     # If there was no explicit argument saying what to do, default
@@ -2096,6 +2110,17 @@ def main():
             # Node.js when trying to load the .wasm file.
             # To debug ONNX Runtime WebAssembly, use ONNX Runtime Web to debug ort-wasm.wasm in browsers.
             raise BuildError("WebAssembly tests cannot be enabled with flag --enable_wasm_debug_info")
+        
+        emscripten_settings = normalize_arg_list(args.emscripten_settings)
+        if args.wasm_malloc is not None:
+            # mark --wasm_malloc as deprecated
+            log.warning(
+                "Flag '--wasm_malloc=<Value>' is deprecated. "
+                "Please use '--emscripten_settings MALLOC=<Value>'.")
+
+            # if both '--wasm_malloc=<Value>' and '--emscripten_settings MALLOC=<Value>' are specified,
+            # we use the value from --emscripten_settings
+            add_default_definition(emscripten_settings, 'MALLOC', args.wasm_malloc)        
 
     if args.code_coverage and not args.android:
         raise BuildError("Using --code_coverage requires --android")
@@ -2320,7 +2345,7 @@ def main():
         generate_build_tree(
             cmake_path, source_dir, build_dir, cuda_home, cudnn_home, rocm_home, mpi_home, nccl_home,
             tensorrt_home, migraphx_home, acl_home, acl_libs, armnn_home, armnn_libs,
-            path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args)
+            path_to_protoc_exe, configs, cmake_extra_defines, args, cmake_extra_args, emscripten_settings)
 
     if args.clean:
         clean_targets(cmake_path, build_dir, configs)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -276,7 +276,7 @@ def parse_arguments():
 
     # Build options
     parser.add_argument(
-        "--cmake_extra_defines", nargs="+",
+        "--cmake_extra_defines", nargs="+", action='append',
         help="Extra definitions to pass to CMake during build system "
         "generation. These are just CMake -D options without the leading -D.")
     parser.add_argument(
@@ -718,11 +718,11 @@ def use_dev_mode(args):
     return 'ON'
 
 
-def add_cmake_define_without_override(cmake_extra_defines, key, value):
-    for x in cmake_extra_defines:
+def add_default_definition(definition_list, key, default_value):
+    for x in definition_list:
         if x.startswith(key + "="):
-            return cmake_extra_defines
-    cmake_extra_defines.append(key + "=" + value)
+            return definition_list
+    definition_list.append(key + "=" + default_value)
 
 
 def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home, rocm_home,
@@ -841,26 +841,26 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         cmake_args.append("-Donnxruntime_EXTERNAL_TRANSFORMER_SRC_PATH=" + args.external_graph_transformer_path)
     # It should be default ON in CI build pipelines, and OFF in packaging pipelines.
     # And OFF for the people who are not actively developing onnx runtime.
-    add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_DEV_MODE", use_dev_mode(args))
+    add_default_definition(cmake_extra_defines, "onnxruntime_DEV_MODE", use_dev_mode(args))
     if args.use_cuda:
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_USE_CUDA", "ON")
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDA_VERSION", args.cuda_version)
+        add_default_definition(cmake_extra_defines, "onnxruntime_USE_CUDA", "ON")
+        add_default_definition(cmake_extra_defines, "onnxruntime_CUDA_VERSION", args.cuda_version)
         # TODO: this variable is not really needed
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDA_HOME", cuda_home)
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_CUDNN_HOME", cudnn_home)
+        add_default_definition(cmake_extra_defines, "onnxruntime_CUDA_HOME", cuda_home)
+        add_default_definition(cmake_extra_defines, "onnxruntime_CUDNN_HOME", cudnn_home)
 
     if is_windows():
         if args.enable_msvc_static_runtime:
-            add_cmake_define_without_override(cmake_extra_defines, "CMAKE_MSVC_RUNTIME_LIBRARY",
+            add_default_definition(cmake_extra_defines, "CMAKE_MSVC_RUNTIME_LIBRARY",
                                               "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-            add_cmake_define_without_override(cmake_extra_defines, "ONNX_USE_MSVC_STATIC_RUNTIME", "ON")
-            add_cmake_define_without_override(cmake_extra_defines, "protobuf_MSVC_STATIC_RUNTIME", "ON")
-            add_cmake_define_without_override(cmake_extra_defines, "gtest_force_shared_crt", "OFF")
+            add_default_definition(cmake_extra_defines, "ONNX_USE_MSVC_STATIC_RUNTIME", "ON")
+            add_default_definition(cmake_extra_defines, "protobuf_MSVC_STATIC_RUNTIME", "ON")
+            add_default_definition(cmake_extra_defines, "gtest_force_shared_crt", "OFF")
         else:
             # CMAKE_MSVC_RUNTIME_LIBRARY is default to MultiThreaded$<$<CONFIG:Debug>:Debug>DLL
-            add_cmake_define_without_override(cmake_extra_defines, "ONNX_USE_MSVC_STATIC_RUNTIME", "OFF")
-            add_cmake_define_without_override(cmake_extra_defines, "protobuf_MSVC_STATIC_RUNTIME", "OFF")
-            add_cmake_define_without_override(cmake_extra_defines, "gtest_force_shared_crt", "ON")
+            add_default_definition(cmake_extra_defines, "ONNX_USE_MSVC_STATIC_RUNTIME", "OFF")
+            add_default_definition(cmake_extra_defines, "protobuf_MSVC_STATIC_RUNTIME", "OFF")
+            add_default_definition(cmake_extra_defines, "gtest_force_shared_crt", "ON")
 
     if acl_home and os.path.exists(acl_home):
         cmake_args += ["-Donnxruntime_ACL_HOME=" + acl_home]
@@ -1071,9 +1071,9 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
             "-Donnxruntime_USE_FULL_PROTOBUF=ON"]
 
     if args.gen_doc:
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_PYBIND_EXPORT_OPSCHEMA", "ON")
+        add_default_definition(cmake_extra_defines, "onnxruntime_PYBIND_EXPORT_OPSCHEMA", "ON")
     else:
-        add_cmake_define_without_override(cmake_extra_defines, "onnxruntime_PYBIND_EXPORT_OPSCHEMA", "OFF")
+        add_default_definition(cmake_extra_defines, "onnxruntime_PYBIND_EXPORT_OPSCHEMA", "OFF")
 
     if args.build_eager_mode:
         import torch
@@ -2037,7 +2037,7 @@ def main():
     log.debug("Command line arguments:\n  {}".format(" ".join(shlex.quote(arg) for arg in sys.argv[1:])))
 
     args = parse_arguments()
-    cmake_extra_defines = (args.cmake_extra_defines
+    cmake_extra_defines = ([i for j in args.cmake_extra_defines for i in j]
                            if args.cmake_extra_defines else [])
     cross_compiling = args.arm or args.arm64 or args.arm64ec or args.android
 


### PR DESCRIPTION
**Description**: This change depends on #10953.

This change adds a build flag `--emscripten_settings` in build.py. This is a general solution for passing settings to emscripten. By doing this, we avoid too many build flags for emscripten in future, like requirement from this PR: #10912

example:
```
build --build_wasm --emscripten_settings TOTAL_STACK=4194304 INITIAL_MEMORY=4194304
# or
build --emscripten_settings TOTAL_STACK=4194304 --build_wasm --emscripten_settings INITIAL_MEMORY=4194304

```