### PR TITLE
[js/node] Use LF as eol for node package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -584,6 +584,16 @@ jobs:
   steps:
   - checkout: self
     submodules: true
+
+  - script: |
+     echo.>>.gitattributes
+     echo /js/** text=auto eol=lf>>.gitattributes
+     rd /s /q js
+     git checkout -- js/**
+     git checkout -- .gitattributes
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Testing: force EOL to lf on windows for /js/**' 
+
   - task: DownloadPipelineArtifact@0
     displayName: 'Download Pipeline Artifact - NuGet (Win x64)'
     inputs:


### PR DESCRIPTION
This PR builds a node npm package with LF as eol, which is the same packaging policy with onnxruntime-web and onnxruntime-react-native and generates the same onnxruntime-common npm package.