### PR TITLE
use #include <hiprand/hiprand.h>, not deprecated #include <hiprand.h>

### DIFF
--- a/onnxruntime/core/providers/rocm/rocm_pch.h
+++ b/onnxruntime/core/providers/rocm/rocm_pch.h
@@ -11,7 +11,7 @@
 #include <hip/hip_runtime.h>
 #include <rocblas.h>
 #include <hipsparse.h>
-#include <hiprand.h>
+#include <hiprand/hiprand.h>
 #include <miopen/miopen.h>
 #include <hipfft.h>
 


### PR DESCRIPTION
In ROCm 5.2, the <hiprand.h> header is deprecated with a warning directing users to use the <hiprand/hiprand.h> header instead.  The warning will trigger a build failure due to -Werror.  This PR updates the header path to avoid future build issues.