### PR TITLE
Support ORT WASM compilation with the training flag

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -110,6 +110,10 @@ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
       re2::re2
     )
 
+    if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
+      bundle_static_library(onnxruntime_webassembly tensorboard)
+    endif()
+
     if (onnxruntime_BUILD_UNIT_TESTS)
       file(GLOB_RECURSE onnxruntime_webassembly_test_src CONFIGURE_DEPENDS
         "${ONNXRUNTIME_ROOT}/test/wasm/test_main.cc"
@@ -168,6 +172,10 @@ else()
     onnxruntime_util
     re2::re2
   )
+
+  if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
+    target_link_libraries(onnxruntime_webassembly PRIVATE tensorboard)
+  endif()
 
   set(EXPORTED_RUNTIME_METHODS "['stackAlloc','stackRestore','stackSave','UTF8ToString','stringToUTF8','lengthBytesUTF8']")
 

--- a/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
@@ -12,7 +12,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 #endif
-#include "unsupported/Eigen/SpecialFunctions"
+#include "core/common/eigen_common_wrapper.h"
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #else


### PR DESCRIPTION
Building ort wasm with the training flag errors out because of two problems:
1. Eigen includes were not wrapped around https://github.com/microsoft/onnxruntime/issues/10852
2. `tensorboard` linker errors.

This pull request solves the above two problems.