### PR TITLE
Fixed macros for graph transformer registration.

### DIFF
--- a/orttraining/orttraining/core/optimizer/graph_transformer_registry.h
+++ b/orttraining/orttraining/core/optimizer/graph_transformer_registry.h
@@ -68,7 +68,7 @@ class GraphTransformerRegisterOnce final {
 #define ONNX_REGISTER_EXTERNAL_GRAPH_TRANSFORMER_UNIQ(Counter, name, level, flag) \
   static ONNX_UNUSED onnxruntime::training::GraphTransformerRegisterOnce \
       graph_transformer_register_once##name##Counter(       \
-      #name, [](const std::unordered_set<std::string>& eps) { \
+      #name, [](const InlinedHashSet<std::string_view>& eps) { \
         return std::make_unique<name>(eps);   \
       }, TransformerLevel::level, flag); 
 
@@ -77,7 +77,7 @@ class GraphTransformerRegisterOnce final {
 #define ONNX_REGISTER_EXTERNAL_REWRITE_RULE_UNIQ(Counter, name, level, flag) \
   static ONNX_UNUSED onnxruntime::training::GraphTransformerRegisterOnce \
       graph_transformer_register_once##name##Counter(       \
-      #name, [](const std::unordered_set<std::string>& eps) { \
+      #name, [](const InlinedHashSet<std::string_view>& eps) { \
         auto rule_base_transformer = std::make_unique<RuleBasedGraphTransformer>(#name, eps); \
         ORT_THROW_IF_ERROR(rule_base_transformer->Register(std::make_unique<name>())); \
         return rule_base_transformer;   \


### PR DESCRIPTION
PR #10523 changed the signature of GraphTransformerCreator to use a InlinedHashSet<std::string_view>& from std::unordered_set<std::string>&, but the MACROS were not updated. This causes a build break if you use the macros.