### PR TITLE
Fix MelSpectrogramOnThreeToneSignal Test: The default for the STFT onesided attribute should be 1

### DIFF
--- a/onnxruntime/core/graph/signal_ops/signal_defs.cc
+++ b/onnxruntime/core/graph/signal_ops/signal_defs.cc
@@ -188,10 +188,10 @@ void RegisterSignalSchemas() {
           "the real-to-complex Fourier transform satisfies the conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. "
           "Note if the input or window tensors are complex, then onesided output is not possible. "
           "Enabling onesided with real inputs performs a Real-valued fast Fourier transform (RFFT)."
-          "When invoked with real or complex valued input, the default value is 0. "
+          "When invoked with real or complex valued input, the default value is 1. "
           "Values can be 0 or 1.",
           AttributeProto::INT,
-          static_cast<int64_t>(0))
+          static_cast<int64_t>(1))
       .Input(0,
              "signal",
              "Input tensor representing a real or complex valued signal. "


### PR DESCRIPTION
Fix MelSpectrogramOnThreeToneSignal Test: The default for the STFT onesided attribute should be 1

Issue: The MelSpectrogramOnThreeToneSignal Test is failing because the test expects the STFT operator to produce onesided results by by default. This was regressed when the operator was made to honor the schema default, which was erroneously set to 1.

Fix: Set the schema default to 1.