### PR TITLE
[cmake] Add keyword STATIC to add_library in function onnxruntime_add_static_library

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1219,7 +1219,7 @@ function(onnxruntime_add_shared_library target_name)
 endfunction()
 
 function(onnxruntime_add_static_library target_name)
-  add_library(${target_name} ${ARGN})
+  add_library(${target_name} STATIC ${ARGN})
   onnxruntime_configure_target(${target_name})
 endfunction()
 


### PR DESCRIPTION
**Description**: Describe your changes.
Add `STATIC` to avoid making shared library when `BUILD_SHARED_LIBS` is `ON`.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
