### PR TITLE
allow trailing slash in directory

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -592,8 +592,10 @@ def parse_arguments():
         cupti library must be added to PATH beforehand.")
 
     args = parser.parse_args()
-    if args.android_sdk_path: args.android_sdk_path = os.path.normpath(args.android_sdk_path)
-    if args.android_ndk_path: args.android_ndk_path = os.path.normpath(args.android_ndk_path)
+    if args.android_sdk_path:
+        args.android_sdk_path = os.path.normpath(args.android_sdk_path)
+    if args.android_ndk_path:
+        args.android_ndk_path = os.path.normpath(args.android_ndk_path)
 
     return args
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -591,7 +591,11 @@ def parse_arguments():
         "--enable_cuda_profiling", action='store_true', help="enable cuda kernel profiling, \
         cupti library must be added to PATH beforehand.")
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.android_sdk_path: args.android_sdk_path = os.path.normpath(args.android_sdk_path)
+    if args.android_ndk_path: args.android_ndk_path = os.path.normpath(args.android_ndk_path)
+
+    return args
 
 
 def is_reduced_ops_build(args):


### PR DESCRIPTION
**Description**: 


**Motivation and Context**
As the below example, the build.bat would failed if the directory has the trailing slash.
`build.bat --android --android_sdk_path "%appdata%\Local\Android\Sdk\" --android_ndk_path "%appdata%\Local\Android\Sdk\ndk\21.3.6528147\" ...`
