### PR TITLE
[cmake] Add MLAS_TARGET_* macro to target onnxruntime_mlas

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -169,6 +169,8 @@ function(setup_mlas_source_for_windows)
       ${MLAS_SRC_DIR}/i386/SgemmKernelAvx.asm
     )
   endif()
+  
+  target_compile_definitions(onnxruntime_mlas PRIVATE MLAS_TARGET_AMD64)
 endfunction()
 
 if (onnxruntime_BUILD_WEBASSEMBLY)
@@ -490,6 +492,8 @@ else()
         else()
           set(MLAS_SOURCE_IS_NOT_SET 0)
         endif()
+        
+        target_compile_definitions(onnxruntime_mlas PRIVATE MLAS_TARGET_AMD64_IX86)
     endif()
     if(NOT ONNXRUNTIME_MLAS_MULTI_ARCH AND MLAS_SOURCE_IS_NOT_SET)
         file(GLOB_RECURSE mlas_platform_srcs


### PR DESCRIPTION
**Description**: Describe your changes.
In https://github.com/microsoft/onnxruntime/blob/47c09e670126b33a57491627006d7d447754373e/onnxruntime/core/mlas/lib/mlasi.h#L859-L865

class variable `GemvU8S8Kernel` will only be declared when `MLAS_TARGET_AMD64` was defined, but in 
https://github.com/microsoft/onnxruntime/blob/47c09e670126b33a57491627006d7d447754373e/onnxruntime/core/mlas/lib/qgemm_kernel_avx2.cpp#L110

There is no condition to controls this code.
And this file is added to build in 
https://github.com/microsoft/onnxruntime/blob/47c09e670126b33a57491627006d7d447754373e/cmake/onnxruntime_mlas.cmake#L125
And 
https://github.com/microsoft/onnxruntime/blob/47c09e670126b33a57491627006d7d447754373e/cmake/onnxruntime_mlas.cmake#L477
where also not define macro `MLAS_TARGET_AMD64` or `MLAS_TARGET_AMD64_IX86`.

Fix it.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
