### PR TITLE
Fixed creation of ORT_Value to pass offset of 0

### DIFF
--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -133,7 +133,7 @@ OrtValue create_ort_value(
 
   OrtValue ort_tensor;
   onnxruntime::Tensor::InitOrtValue(element_type, onnxruntime::TensorShape(tensor.sizes().vec()), tensor.data_ptr(),
-                                    *mem_info, ort_tensor, 0L /* offset */,
+                                    *mem_info, ort_tensor, 0L /* offset = 0 - because tensor.data_ptr() includes the underyling offset */,
                                     tensor.strides().vec());
   return ort_tensor;
 }

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -133,7 +133,7 @@ OrtValue create_ort_value(
 
   OrtValue ort_tensor;
   onnxruntime::Tensor::InitOrtValue(element_type, onnxruntime::TensorShape(tensor.sizes().vec()), tensor.data_ptr(),
-                                    *mem_info, ort_tensor, tensor.storage_offset() * element_type->Size(),
+                                    *mem_info, ort_tensor, 0L /* offset */,
                                     tensor.strides().vec());
   return ort_tensor;
 }

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -114,5 +114,11 @@ class OrtOpTests(unittest.TestCase):
     x = cpu_tensor.min()
     assert torch.allclose(x, y.cpu())
 
+  def test_narrow(self):
+    cpu_tensor = torch.rand(10, 10)
+    cpu_narrow = cpu_tensor.narrow(0, 5, 5)
+    ort_narrow = cpu_narrow.to('ort')
+    assert torch.allclose(cpu_narrow, ort_narrow.cpu())
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
PR #10578 changed how we create an OrtValue to call InitOrtValue - however it passes in the underlying storage offset from the PyTorch Tensor. However tensor.data_ptr() already accounts for the storage offset, so in cases where storage offset is not 0 - we end up going out of bounds for the underlying Tensor. This is evident from the test case I added.

This fixes that by passing an offset of 0.