### PR TITLE
Fix gradient builder for Cast

### DIFF
--- a/orttraining/orttraining/core/framework/gradient_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.cc
@@ -169,6 +169,20 @@ NodeSet GradientGraphBuilder::ReverseBFSWithStopGradient(const NodeSet& nodes) c
                             << " of node: " << n->Name();
         continue;
       }
+      const NodeArg* node_arg = n->InputDefs()[edge_it->GetDstArgIndex()];
+      const auto* type_proto = node_arg->TypeAsProto();
+      if (nullptr != type_proto && type_proto->value_case() == ONNX_NAMESPACE::TypeProto::kTensorType) {
+        const int32_t type = type_proto->tensor_type().elem_type();
+        if (CAST_GRAD_ALLOWED_TYPES.find(type) == CAST_GRAD_ALLOWED_TYPES.end()) {
+          LOGS(logger_, INFO) << "Skip building gradient for input_" << edge_it->GetDstArgIndex()
+                              << " of node: " << n->Name() << "because element type is: "<< type;
+          continue;
+        }
+      } else {
+        LOGS(logger_, INFO) << "Skip building gradient for input_" << edge_it->GetDstArgIndex()
+                              << " of node: " << n->Name() << "because it is not a Tensor type";
+          continue;
+      }
 
       const Node& node = edge_it->GetNode();
       if (visited.find(&node) == visited.end()) {
@@ -206,6 +220,21 @@ const std::unordered_set<size_t>* GradientGraphBuilder::GetStopGradientEdges(con
   if (op_type == "ATen") {
     std::string key = GetGradientDefinitionKeyByNode(node);
     return GradientDefinitionRegistry::Instance().GetStopGradientEdgesForNode(key);
+  } else if (op_type == "Cast") {
+    // Stop gradient edge for Cast if the cast is to non-differentiable type
+    const auto& attrs = node.GetAttributes();
+    const auto iter = attrs.find("to");
+    const auto* attr_proto = iter == attrs.end() ? nullptr : &iter->second;
+    if ((nullptr != attr_proto) && attr_proto->has_i()) {
+      const int64_t to_val = attr_proto->i();
+      if (CAST_GRAD_ALLOWED_TYPES.find(to_val) == CAST_GRAD_ALLOWED_TYPES.end()) {
+        return &CAST_STOP_EDGE;
+      } else {
+        return nullptr;
+      }
+    } else {
+      return nullptr;
+    }
   } else {
     auto it = STOP_GRADIENT_EDGES.find(op_type);
     if (it == STOP_GRADIENT_EDGES.end()) {

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -77,6 +77,13 @@ static std::unordered_map<std::string, std::unordered_set<size_t>>
 
 static std::unordered_set<std::string> INVERTIBLE_OPS{"LayerNormalization",
                                                       "Relu"};
+static std::unordered_set<int64_t> CAST_GRAD_ALLOWED_TYPES{
+    ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+    ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+    ONNX_NAMESPACE::TensorProto_DataType_DOUBLE,
+    ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16,
+};
+static const std::unordered_set<size_t> CAST_STOP_EDGE{0};
 
 class GradientGraphBuilder {
  public:
@@ -165,7 +172,7 @@ class GradientGraphBuilder {
   */
   Status CheckNodeArgsReachable() const;
 
-  /** 
+  /**
   Check if node is reachable from the 'y_node_args_'
    **/
   bool IsReachable(const Node* node) const {

--- a/orttraining/orttraining/core/framework/gradient_graph_builder.h
+++ b/orttraining/orttraining/core/framework/gradient_graph_builder.h
@@ -77,12 +77,7 @@ static std::unordered_map<std::string, std::unordered_set<size_t>>
 
 static std::unordered_set<std::string> INVERTIBLE_OPS{"LayerNormalization",
                                                       "Relu"};
-static std::unordered_set<int64_t> CAST_GRAD_ALLOWED_TYPES{
-    ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-    ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
-    ONNX_NAMESPACE::TensorProto_DataType_DOUBLE,
-    ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16,
-};
+
 static const std::unordered_set<size_t> CAST_STOP_EDGE{0};
 
 class GradientGraphBuilder {
@@ -145,6 +140,12 @@ class GradientGraphBuilder {
   // Tracks tensors that are stashed in the forward pass for later use in backward pass.
   std::unordered_set<std::string> stashed_tensors_;
 
+  const std::unordered_set<int64_t> GRAD_ALLOWED_TYPES{
+      ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+      ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE,
+      ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16,
+  };
   const std::unordered_set<size_t>* GetStopGradientEdges(const Node& node) const;
 
   /**


### PR DESCRIPTION
Currently gradient builder built a gradient for cast nodes even if they were casting to non-differentiable types. 
Eg: 
(float) -> Cast(to bool) -> Cast (to float) -> (float)

The gradient should not be propogated across cast that either have non-differentiable input or result in a non-differentiable output.

This fixes an issue reported for an MoE model.