### PR TITLE
Add clearer error message about misuse of OrtEnv.

### DIFF
--- a/onnxruntime/core/session/ort_env.h
+++ b/onnxruntime/core/session/ort_env.h
@@ -81,6 +81,8 @@ struct OrtEnv {
   static onnxruntime::OrtMutex m_;
   static int ref_count_;
 
+  static std::atomic_bool dtor_has_run_once_;
+
   std::unique_ptr<onnxruntime::Environment> value_;
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(OrtEnv);


### PR DESCRIPTION
**Description**
The goal is to provide a clearer error message when OrtEnv is misused.
My understanding (possibly incomplete) is that OrtEnv should not be created again after it is destroyed. Opening this PR to prompt discussion on how to provide better feedback to users.

**Motivation and Context**
For example, creation of another OrtEnv after one was destroyed was the cause of this issue, but it was not initially obvious: https://github.com/microsoft/onnxruntime/issues/10955