### PR TITLE
DirectML EP docs - warn user that GPU 0 is not necessarily performant

### DIFF
--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -59,7 +59,7 @@ When using the [C API](../get-started/with-c.md) with a DML-enabled build of onn
 ### `OrtSessionOptionsAppendExecutionProvider_DML` function
 {: .no_toc }
 
- Creates a DirectML Execution Provider which executes on the hardware adapter with the given `device_id`, also known as the adapter index. The device ID corresponds to the enumeration order of hardware adapters as given by [IDXGIFactory::EnumAdapters](https://docs.microsoft.com/windows/win32/api/dxgi/nf-dxgi-idxgifactory-enumadapters). A `device_id` of 0 always corresponds to the default adapter, which is typically the primary display GPU installed on the system. A negative `device_id` is invalid.
+ Creates a DirectML Execution Provider which executes on the hardware adapter with the given `device_id`, also known as the adapter index. The device ID corresponds to the enumeration order of hardware adapters as given by [IDXGIFactory::EnumAdapters](https://docs.microsoft.com/windows/win32/api/dxgi/nf-dxgi-idxgifactory-enumadapters). A `device_id` of 0 always corresponds to the default adapter, which is typically the primary display GPU installed on the system. Beware that in systems with multiple GPU's, the primary display (GPU 0) is often not the most performant one, particularly on laptops with dual adapters where battery lifetime is preferred over performance. So you can double check in Task Manager's performance tab to see which GPU is which. A negative `device_id` is invalid.
 
 ```c
 OrtStatus* OrtSessionOptionsAppendExecutionProvider_DML(


### PR DESCRIPTION
**Description**: Some users just select GPU 0 and then get poor performance (because based on the power plan settings, the primary GPU is the integrated GPU rather than discrete higher power GPU).

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Users are confused about performance.
- *If it fixes an open issue, please link to the issue here.* NA
