### PR TITLE
Fix profiling json format and enhance perf view

### DIFF
--- a/onnxruntime/core/framework/sequential_executor.cc
+++ b/onnxruntime/core/framework/sequential_executor.cc
@@ -59,6 +59,7 @@ static void CalculateTotalOutputSizes(OpKernelContextInternal* op_kernel_context
                                       size_t& total_output_sizes, const std::string& node_name, std::string& output_type_shape) {
   // Calculate total output sizes for this operation.
   std::stringstream ss;
+  int added_type_shapes = 0;
   ss << "[";
   total_output_sizes = 0;
   ORT_UNUSED_PARAMETER(node_name);
@@ -78,8 +79,9 @@ static void CalculateTotalOutputSizes(OpKernelContextInternal* op_kernel_context
 #endif
       total_output_sizes += tensor_size;
       auto shape_str = tensor.Shape().ToString();
-      ss << "{\"" << DataTypeImpl::ToString(tensor.DataType()) << "\":["
-         << shape_str.substr(1, shape_str.size() - 2) << "]" << (i == output_count - 1 ? "}" : "},");
+      ss << (added_type_shapes++ > 0 ? "," : "")
+         << "{\"" << DataTypeImpl::ToString(tensor.DataType()) << "\":["
+         << shape_str.substr(1, shape_str.size() - 2) << "]}";
     }
   }
   ss << "]";
@@ -93,6 +95,7 @@ static void CalculateTotalInputSizes(const OpKernelContextInternal* op_kernel_co
   // Calculate total input sizes for this operation.
   std::stringstream ss;
   ss << "[";
+  int added_type_shapes = 0;
   input_activation_sizes = 0;
   input_parameter_sizes = 0;
   ORT_UNUSED_PARAMETER(node_name);
@@ -124,8 +127,9 @@ static void CalculateTotalInputSizes(const OpKernelContextInternal* op_kernel_co
         input_activation_sizes += tensor_size;
       }
       auto shape_str = p_tensor->Shape().ToString();
-      ss << "{\"" << DataTypeImpl::ToString(p_tensor->DataType()) << "\":["
-         << shape_str.substr(1, shape_str.size() - 2) << "]" << (i == input_count - 1 ? "}" : "},");
+      ss << (added_type_shapes++ > 0 ? "," : "")
+         << "{\"" << DataTypeImpl::ToString(p_tensor->DataType()) << "\":["
+         << shape_str.substr(1, shape_str.size() - 2) << "]}";
     }
   }
   ss << "]";

--- a/tools/perf_view/ort_perf_view.html
+++ b/tools/perf_view/ort_perf_view.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>My First JavaScript Treemap Chart</title>
+    <title id="filename">Onnxruntime Perf View</title>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-core.min.js"></script>
     <script src="https://cdn.anychart.com/releases/8.11.0/js/anychart-ui.min.js"></script>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-treemap.min.js"></script>
@@ -60,6 +60,7 @@
         preloader.visible(true);
 
         const fileList = event.target.files;
+		document.getElementById('filename').text = fileList[0].name;
         console.log(fileList);
         const reader = new FileReader();
         reader.addEventListener('load', (event) => {


### PR DESCRIPTION
When the inputs of a node are composed of tensors and tensor sequence, profiling numbers in json format will have some invalid comma placed before ']', which result in parsing failure. To tackle the case, let variable "added_type_shapes" do the tracking dedicatedly.
Beyond the fix, reset perf view header whenever user opens a profiling file.