### PR TITLE
[js/web] disable test_tan temorarily

### DIFF
--- a/js/web/test/suite-test-list.jsonc
+++ b/js/web/test/suite-test-list.jsonc
@@ -207,7 +207,7 @@
       // "test_slice_start_out_of_bounds", // tensor shape of 0
       "test_squeeze",
       "test_tan_example",
-      "test_tan",
+      //"test_tan", // incorrect result in Chrome v100... investigating
       "test_tanh_example",
       "test_tanh",
       "test_tile",


### PR DESCRIPTION
**Description**: Chrome v99 -> v100 upgrade brakes test case "test_tan". To unblock the pipeline, I disable this case temporarily. After investigating I will start another PR to fix it.