### PR TITLE
Remove hardcoded library name from gen_def.py

### DIFF
--- a/tools/ci_build/gen_def.py
+++ b/tools/ci_build/gen_def.py
@@ -36,7 +36,7 @@ symbols = sorted(symbols)
 symbol_index = 1
 with open(args.output, 'w') as file:
     if args.style == 'vc':
-        file.write('LIBRARY "onnxruntime.dll"\n')
+        file.write('LIBRARY\n')
         file.write('EXPORTS\n')
     elif args.style == 'xcode':
         pass    # xcode compile don't has any header.


### PR DESCRIPTION
**Description**: Describe your changes.
Remove hardcoded onnxruntime library from gen_def.py. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
Solves a linker error with arn64x. 
- If it fixes an open issue, please link to the issue here.
