### PR TITLE
Add Initialize() to shared providers to allow for reload

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -30,7 +30,8 @@ cuda::INcclService& GetINcclService();
 }
 #endif
 
-void Shutdown_DeleteRegistry();
+void InitializeRegistry();
+void DeleteRegistry();
 
 struct CUDAProviderFactory : IExecutionProviderFactory {
   CUDAProviderFactory(const CUDAExecutionProviderInfo& info)
@@ -248,8 +249,12 @@ struct CUDA_Provider : Provider {
     return onnxruntime::CUDAExecutionProviderInfo::ToProviderOptions(options);
   }
 
+  void Initialize() override {
+    InitializeRegistry();
+  }
+
   void Shutdown() override {
-    Shutdown_DeleteRegistry();
+    DeleteRegistry();
   }
 
 } g_provider;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -87,19 +87,20 @@ static Status RegisterMIGraphXKernels(KernelRegistry& kernel_registry) {
 }
 
 static std::shared_ptr<KernelRegistry> s_kernel_registry;
-void Shutdown_DeleteRegistry() {
+
+void InitializeRegistry() {
+  s_kernel_registry = KernelRegistry::Create();
+  auto status = RegisterMIGraphXKernels(*s_kernel_registry);
+  if (!status.IsOK())
+    s_kernel_registry.reset();
+  ORT_THROW_IF_ERROR(status);
+}
+
+void DeleteRegistry() {
   s_kernel_registry.reset();
 }
 
 std::shared_ptr<KernelRegistry> MIGraphXExecutionProvider::GetKernelRegistry() const {
-  if (!s_kernel_registry) {
-    s_kernel_registry = KernelRegistry::Create();
-    auto status = RegisterMIGraphXKernels(*s_kernel_registry);
-    if (!status.IsOK())
-      s_kernel_registry.reset();
-    ORT_THROW_IF_ERROR(status);
-  }
-
   return s_kernel_registry;
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -16,7 +16,8 @@ using namespace onnxruntime;
 
 namespace onnxruntime {
 
-void Shutdown_DeleteRegistry();
+void InitializeRegistry();
+void DeleteRegistry();
 
 struct MIGraphXProviderFactory : IExecutionProviderFactory {
   MIGraphXProviderFactory(const MIGraphXExecutionProviderInfo& info) : info_{info} {}
@@ -67,8 +68,12 @@ struct MIGraphX_Provider : Provider {
     return onnxruntime::MIGraphXExecutionProviderInfo::ToProviderOptions(options);
   }
 
+  void Initialize() override {
+    InitializeRegistry();
+  }
+
   void Shutdown() override {
-    Shutdown_DeleteRegistry();
+    DeleteRegistry();
   }
 
 } g_provider;

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
@@ -28,7 +28,8 @@ rocm::INcclService& GetINcclService();
 }
 #endif
 
-void Shutdown_DeleteRegistry();
+void InitializeRegistry();
+void DeleteRegistry();
 
 struct ROCMProviderFactory : IExecutionProviderFactory {
   ROCMProviderFactory(const ROCMExecutionProviderInfo& info)
@@ -179,8 +180,12 @@ struct ROCM_Provider : Provider {
     return std::make_shared<ROCMProviderFactory>(info);
   }
 
+  void Initialize() override {
+    InitializeRegistry();
+  }
+
   void Shutdown() override {
-    Shutdown_DeleteRegistry();
+    DeleteRegistry();
   }
 
 } g_provider;

--- a/onnxruntime/core/providers/shared_library/provider_host_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_host_api.h
@@ -26,6 +26,7 @@ struct Provider {
   // Update provider options from key-value string configuration
   virtual void UpdateProviderOptions(void* /*provider options to be configured*/, const ProviderOptions& /*key-value string provider options*/){};
 
+  virtual void Initialize() = 0;
   virtual void Shutdown() = 0;
 };
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_provider_factory.cc
@@ -13,7 +13,8 @@ using namespace onnxruntime;
 
 namespace onnxruntime {
 
-void Shutdown_DeleteRegistry();
+void InitializeRegistry();
+void DeleteRegistry();
 
 struct TensorrtProviderFactory : IExecutionProviderFactory {
   TensorrtProviderFactory(const TensorrtExecutionProviderInfo& info) : info_{info} {}
@@ -142,8 +143,12 @@ struct Tensorrt_Provider : Provider {
     return onnxruntime::TensorrtExecutionProviderInfo::ToProviderOptions(options);
   }
 
+  void Initialize() override {
+    InitializeRegistry();
+  }
+
   void Shutdown() override {
-    Shutdown_DeleteRegistry();
+    DeleteRegistry();
   }
 
 } g_provider;

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1031,6 +1031,7 @@ struct ProviderLibrary {
     }
 
     provider_ = PGetProvider();
+    provider_->Initialize();
     return provider_;
   }
 

--- a/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
+++ b/onnxruntime/test/testdata/custom_execution_provider_library/my_ep_factory.cc
@@ -11,10 +11,6 @@ using namespace onnxruntime;
 
 namespace onnxruntime {
 
-void Shutdown_DeleteRegistry() {
-
-}
-
 struct MyProviderFactory : IExecutionProviderFactory {
   MyProviderFactory(const MyProviderInfo& info) : info_{info} {}
   ~MyProviderFactory() override {}
@@ -57,8 +53,10 @@ struct MyEP_Provider : Provider {
     return std::make_shared<MyProviderFactory>(info);
   }
 
+  void Initialize() override {
+  }
+
   void Shutdown() override {
-    Shutdown_DeleteRegistry();
   }
 
 } g_provider;


### PR DESCRIPTION
**Description**: Currently, when a shared provider library is unloaded by the onnxruntime code, it calls the Shutdown() method on it, then unloads the library. On Linux dlclose will many times do nothing and not unload the library. So when Onnxruntime then loads the library a second time, all static variables cleaned up in Shutdown() are stuck in their 'cleaned up state' and we will fail the second time.

This adds an 'Initialize()' method and avoids the magic static initializer problem.

**Motivation and Context**
- Why is this change required? What problem does it solve?
   We have users that create/destroy/create an OrtEnv which would unload/reload the shared providers. Currently on Linux this will crash. On windows it will work as 'FreeLibrary' will unload the library and hence refresh the global variables on the next reload.
