### PR TITLE
[MinBuild] 132KB minimal build binary size reduction via dummy __cxa_demangle

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -135,6 +135,16 @@ if (NOT WIN32)
 endif()
 
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Android" AND onnxruntime_MINIMAL_BUILD)
+  # target onnxruntime is a shared library, the dummy __cxa_demangle is only attach to it to avoid
+  # affecting downstream ort library users with the behaviour of dummy __cxa_demangle. So the dummy
+  # __cxa_demangle must not expose to libonnxruntime_common.a. It works as when the linker is
+  # creating the DSO, our dummy __cxa_demangle always comes before libc++abi.a so the
+  # __cxa_demangle in libc++abi.a is discarded, thus, huge binary size reduction.
+  target_sources(onnxruntime PRIVATE "${ONNXRUNTIME_ROOT}/core/platform/android/cxa_demangle.cc")
+  target_compile_definitions(onnxruntime PRIVATE USE_DUMMY_EXA_DEMANGLE=1)
+endif()
+
 # strip binary on Android, or for a minimal build on Unix
 if(CMAKE_SYSTEM_NAME STREQUAL "Android" OR (onnxruntime_MINIMAL_BUILD AND UNIX))
   if (onnxruntime_MINIMAL_BUILD AND ADD_DEBUG_INFO_TO_MINIMAL_BUILD)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1075,6 +1075,13 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
             LIBS ${onnxruntime_shared_lib_test_LIBS}
             DEPENDS ${all_dependencies}
     )
+    if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+      target_sources(onnxruntime_shared_lib_test PRIVATE
+        "${ONNXRUNTIME_ROOT}/core/platform/android/cxa_demangle.cc"
+        "${TEST_SRC_DIR}/platform/android/cxa_demangle_test.cc"
+      )
+      target_compile_definitions(onnxruntime_shared_lib_test PRIVATE USE_DUMMY_EXA_DEMANGLE=1)
+    endif()
     if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
       add_custom_command(
         TARGET onnxruntime_shared_lib_test POST_BUILD

--- a/onnxruntime/core/platform/android/cxa_demangle.cc
+++ b/onnxruntime/core/platform/android/cxa_demangle.cc
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if USE_DUMMY_EXA_DEMANGLE
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#define DEMANGLE_INVALID_ARGUMENTS -3
+#define DEMANGLE_INVALID_MANGLED_NAME -2
+#define DEMANGLE_MEMORY_ALLOCATION_FAILURE -1
+#define DEMANGLE_SUCCESS 0
+
+// Reduced from https://github.com/llvm/llvm-project/blob/dbd80d7d27/libcxxabi/src/demangle/Utility.h
+static inline bool initialize_output_buffer(char*& buf, size_t* n, size_t& buf_size, size_t init_size) {
+  // only handle buf == null case, is buf is provided, in original impl, it realloc to expand buf space.
+  // we don't handle the expansion, instead, the name copied to buf will be truncated.
+  if (buf == nullptr) {
+    buf = static_cast<char*>(malloc(init_size));
+    if (buf == nullptr)
+      return false;
+    buf_size = init_size;
+  } else {
+    buf_size = *n;
+  }
+  return true;
+}
+
+/**
+ * An dummy implementation of __cxa_demangle https://itanium-cxx-abi.github.io/cxx-abi/abi.html#demangler
+ * It is referred in https://github.com/llvm/llvm-project/blob/d09d297c5d/libcxxabi/src/cxa_default_handlers.cpp#L53
+ * However it contribute a large percentage of binary size in minimal build. To avoid it, the LLVM user can compile
+ * libc++abi.a with LIBCXXABI_NON_DEMANGLING_TERMINATE defined, see https://reviews.llvm.org/D88189
+ * But this make the compilation process extremely complex.
+ *
+ * Here we provide a dummy __cxa_demangle. It always copy the mangled name to output buffer.
+ *
+ * Reduced from https://github.com/llvm/llvm-project/blob/dbd80d7d27/libcxxabi/src/cxa_demangle.cpp
+ */
+extern "C" {
+char* __cxa_demangle(const char* mangled_name, char* buf, size_t* n, int* status) {
+  if (mangled_name == nullptr || (buf != nullptr && n == nullptr)) {
+    if (status)
+      *status = DEMANGLE_INVALID_ARGUMENTS;
+    return nullptr;
+  }
+
+  int internal_status = DEMANGLE_SUCCESS;
+  size_t buf_size;
+
+  if (!initialize_output_buffer(buf, n, buf_size, 1024)) {
+    internal_status = DEMANGLE_MEMORY_ALLOCATION_FAILURE;
+  } else {
+    strncpy(buf, mangled_name, buf_size);
+    // Blindly guard the output buffer, this might cause a truncated mangled name being returned without error status,
+    // but this should be fine for debugging purpose. As we are returning the mangle name directly, if the caller is
+    // doing crazy stuff with the name, it should both fail with the return mangled name and a truncated mangled name.
+    buf[buf_size - 1] = '\0';
+  }
+
+  if (status)
+    *status = internal_status;
+  return internal_status == DEMANGLE_SUCCESS ? buf : nullptr;
+}
+}
+
+#undef DEMANGLE_SUCCESS
+#undef DEMANGLE_MEMORY_ALLOCATION_FAILURE
+#undef DEMANGLE_INVALID_MANGLED_NAME
+#undef DEMANGLE_INVALID_ARGUMENTS
+
+#endif

--- a/onnxruntime/test/platform/android/cxa_demangle_test.cc
+++ b/onnxruntime/test/platform/android/cxa_demangle_test.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/platform/env.h"
+
+#include <fstream>
+
+#include "gtest/gtest.h"
+
+extern "C" char* __cxa_demangle(const char* mangled_name, char* buf, size_t* n, int* status);
+
+namespace onnxruntime {
+namespace test {
+
+const char input[] = "_ZNSt6__ndk115basic_streambufIcNS_11char_traitsIcEEE5imbueERKNS_6localeE";
+
+TEST(DummyCxaDemangleTest, InvalidArgs) {
+  int status = 1000;
+  ASSERT_EQ(__cxa_demangle(nullptr, nullptr, nullptr, &status), nullptr);
+  ASSERT_EQ(status, -3);
+}
+
+TEST(DummyCxaDemangleTest, Alloc) {
+  int status = 1000;
+  char* output_buffer = __cxa_demangle(input, nullptr, nullptr, &status);
+  ASSERT_EQ(status, 0);
+  ASSERT_STREQ(output_buffer, input);
+  std::free(output_buffer);
+
+  // verify status can be omited
+  char* output_buffer2 = __cxa_demangle(input, nullptr, nullptr, nullptr);
+  ASSERT_STREQ(output_buffer2, input);
+  std::free(output_buffer2);
+}
+
+TEST(DummyCxaDemangleTest, StackAllocatedBufferIsTooSmallButNoRealloc) {
+  int status = 1000;
+  const char* input = "0123456789";
+  char buf[8];
+  size_t buf_size = 8;
+  char* output_buffer = __cxa_demangle(input, buf, &buf_size, &status);
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(output_buffer, buf);
+  ASSERT_STREQ(output_buffer, "0123456");
+  ASSERT_DEATH(std::free(output_buffer), ".*");
+}
+
+TEST(DummyCxaDemangleTest, ExistingBufferLargeEnough) {
+  int status = -1;
+  const char* input = "0123456789";
+  char buf[50];
+  size_t buf_size = 50;
+  char* output_buffer = __cxa_demangle(input, buf, &buf_size, &status);
+  ASSERT_EQ(status, 0);
+  ASSERT_EQ(buf_size, 50);
+  ASSERT_EQ(output_buffer, buf);
+  ASSERT_STREQ(output_buffer, "0123456789");
+  ASSERT_DEATH(std::free(output_buffer), ".*");
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1438,7 +1438,7 @@ def run_android_tests(args, source_dir, build_dir, config, cwd):
                 adb_push('onnxruntime_shared_lib_test', device_dir, cwd=cwd)
                 adb_shell('chmod +x {}/onnxruntime_shared_lib_test'.format(device_dir))
                 run_adb_shell(
-                    'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0} && {0}/onnxruntime_shared_lib_test'.format(
+                    'LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{0} {0}/onnxruntime_shared_lib_test'.format(
                         device_dir))
 
 

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -358,6 +358,7 @@ jobs:
         --skip_submodule_sync \
         --parallel \
         --use_nnapi \
+        --build_shared_lib \
         --cmake_generator=Ninja \
         --path_to_protoc_exe $(Build.SourcesDirectory)/protobuf_install/bin/protoc \
         --build_java \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -309,7 +309,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+  # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   steps:
     - task: UsePythonVersion@0
       displayName: Use Python $(pythonVersion)

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -309,7 +309,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  # condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
+  condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   steps:
     - task: UsePythonVersion@0
       displayName: Use Python $(pythonVersion)


### PR DESCRIPTION
**Description**:

bloaty shows following size contribution to the mininmal build binary
```
   2.2%  89.6Ki   2.1%  89.6Ki    /buildbot/src/android/ndk-release-r23/toolchain/llvm-project/libcxx/../../../toolchain/llvm-project/libcxxabi/src/cxa_demangle.cpp
```


Add the option `-Wl,--trace-symbol=__cxa_demangle`, shows `__cxa_demangle` is only referenced in
```
/home/guangyunhan/android_sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++abi.a: lazy definition of __cxa_demangle
/home/guangyunhan/android_sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++abi.a(cxa_default_handlers.o): reference to __cxa_demangle
/home/guangyunhan/android_sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++abi.a(cxa_demangle.o): definition of __cxa_demangle
```

It is possible to recompile the `libc++abi.a` with `LIBCXXABI_SILENT_TERMINATE` defined. But it might make the building too complicated at the moment.

To further reduce the binary size. We can provide a **dummy** implementation of `__cxa_demangle`

Do a minimal build without any operator included for `libonnxruntime.so`:

Before: 1109976
After:   977568

~132 KB reduction

**Motivation and Context**
- Why is this change required? What problem does it solve?
   Minimal build is currently reaching the limit. This change free us to add more useful code.

