### PR TITLE
Add cleanup steps

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -7,6 +7,8 @@
 jobs:
 - job: Build_CPU_EP
   pool: Linux-CPU-2019
+  workspace:
+    clean: all
   timeoutInMinutes: 30
   steps:
   # Onnx has no 3.9 python package available yet, need to use python 3.8
@@ -91,10 +93,14 @@ jobs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: CPUBuildOutput
 
+  - template: templates/clean-agent-build-directory-step.yml
+
 - job: Test_CPU_EP
   pool:
     vmImage: 'macOS-11'
   dependsOn: Build_CPU_EP
+  workspace:
+    clean: all
   condition: succeeded()
   steps:
     - task: DownloadPipelineArtifact@2
@@ -130,9 +136,13 @@ jobs:
       displayName: Stop Android emulator
       condition: always()
 
+    - template: templates/clean-agent-build-directory-step.yml
+
 - job: Build_NNAPI_EP
   pool: Linux-CPU-2019
   timeoutInMinutes: 30
+  workspace:
+    clean: all
   condition: notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   steps:
   - task: UsePythonVersion@0
@@ -212,10 +222,14 @@ jobs:
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: NNAPIBuildOutput
+      
+  - template: templates/clean-agent-build-directory-step.yml
 
 - job: Test_NNAPI_EP
   pool:
     vmImage: 'macOS-11'
+  workspace:
+    clean: all
   dependsOn: Build_NNAPI_EP
   condition: and(succeeded(), notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
   steps:
@@ -285,12 +299,16 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
+      
+    - template: templates/clean-agent-build-directory-step.yml
 
 # The below jobs only run on master build
 - job: NNAPI_EP_MASTER
   pool:
     vmImage: 'macOS-11'
   timeoutInMinutes: 120
+  workspace:
+    clean: all
   condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
   steps:
     - task: UsePythonVersion@0
@@ -374,6 +392,8 @@ jobs:
       displayName: Stop Android emulator
       condition: always()
       
+    - template: templates/clean-agent-build-directory-step.yml
+      
 - job: Update_Dashboard
   workspace:
     clean: all
@@ -386,17 +406,19 @@ jobs:
   - Test_CPU_EP
   - NNAPI_EP_MASTER
   steps:
-  - task: DownloadPipelineArtifact@0
-    displayName: 'Download code coverage report'
-    inputs:
-      artifactName: 'coverage_rpt.txt'
-      targetPath: '$(Build.BinariesDirectory)'
+    - task: DownloadPipelineArtifact@0
+      displayName: 'Download code coverage report'
+      inputs:
+        artifactName: 'coverage_rpt.txt'
+        targetPath: '$(Build.BinariesDirectory)'
 
-  - task: AzureCLI@2
-    displayName: 'Post Android Code Coverage To DashBoard'
-    inputs:
-      azureSubscription: AIInfraBuild
-      scriptType: bash
-      scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
-      arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
-      workingDirectory: '$(Build.BinariesDirectory)'
+    - task: AzureCLI@2
+      displayName: 'Post Android Code Coverage To DashBoard'
+      inputs:
+        azureSubscription: AIInfraBuild
+        scriptType: bash
+        scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
+        arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
+        workingDirectory: '$(Build.BinariesDirectory)'
+      
+    - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
@@ -109,10 +109,4 @@ jobs:
         targetPath: $(Build.BinariesDirectory)/1b/MinSizeRel/libonnxruntime.so
         artifactName: AndroidMinimalBaselineDebugBinary
 
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: succeeded()
-
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-eager-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-eager-pipeline.yml
@@ -66,3 +66,5 @@ jobs:
               --parallel \
               --build_eager_mode --enable_training --build_wheel --test"
       workingDirectory: $(Build.SourcesDirectory)
+
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -293,18 +293,4 @@ jobs:
               --skip_tests
       workingDirectory: $(Build.SourcesDirectory)
 
-  - task: PublishTestResults@2
-    displayName: 'Publish unit test results'
-    inputs:
-      testResultsFiles: '**/*.results.xml'
-      searchFolder: '$(Build.BinariesDirectory)'
-      testRunTitle: 'Unit Test Run'
-    condition: succeededOrFailed()
-
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
-
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -66,13 +66,7 @@ jobs:
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
 
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
-
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()
+  - template: templates/clean-agent-build-directory-step.yml
 
 - job: Linux_Test
   timeoutInMinutes: 60
@@ -120,6 +114,4 @@ jobs:
               --enable_onnx_tests --use_cuda --cuda_version=11.4 --cuda_home=/usr/local/cuda-11.4 --cudnn_home=/usr/local/cuda-11.4 \
               --enable_pybind --build_java --ctest_path ''
 
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/linux-tvm-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-tvm-ci-pipeline.yml
@@ -44,18 +44,4 @@ jobs:
                     --use_tvm"
           workingDirectory: $(Build.SourcesDirectory)
 
-      - task: PublishTestResults@2
-        displayName: 'Publish unit test results'
-        inputs:
-          testResultsFiles: '**/*.results.xml'
-          searchFolder: '$(Build.BinariesDirectory)'
-          testRunTitle: 'Unit Test Run'
-        condition: succeededOrFailed()
-
-      - template: templates/component-governance-component-detection-steps.yml
-        parameters:
-          condition: 'succeeded'
-
-      - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-        displayName: 'Clean Agent Directories'
-        condition: always()
+      - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -114,10 +114,4 @@ jobs:
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
 
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
-
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()
+  - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/clean-agent-build-directory-step.yml
@@ -1,10 +1,23 @@
 # cleans $(Agent.BuildDirectory) unconditionally on multiple platforms
 
 steps:
-- script: rd /S /Q $(Agent.BuildDirectory)
-  displayName: Clean build files (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT') # and always()
-- script: rm -rf $(Agent.BuildDirectory)
-  displayName: Clean build files (POSIX)
-  condition: not(eq(variables['Agent.OS'], 'Windows_NT')) # and always()
-  continueOnError: true  # continuing on error for this step, since linux build folder is somehow getting permission issue
+- task: PublishTestResults@2
+  displayName: 'Publish unit test results'
+  inputs:
+    testResultsFiles: '**/*.results.xml'
+    searchFolder: '$(Build.BinariesDirectory)'
+    testRunTitle: 'Unit Test Run'
+  condition: succeededOrFailed()
+
+- template: component-governance-component-detection-steps.yml
+  parameters :
+    condition : 'succeeded'
+
+- task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+  displayName: 'Clean Agent Directories'
+  condition: always()
+
+- script: docker image prune -f
+  displayName: Clean docker images
+  condition: eq(variables['Agent.OS'], 'Linux')
+  continueOnError: true


### PR DESCRIPTION
**Description**: 

Our Linux CPU machine pool disks often get full.  I did some investigation.  It is because:

1. Nuphar pipeline forgot to add "--rm" to its "docker run" command. It can be easily fixed by updating https://github.com/microsoft/onnxruntime/blob/master/tools/ci_build/github/linux/run_dockerbuild.sh , I will submit a PR soon.
	
2. Many jobs do not clean their workspace. It seems we need to manually add cleanup instruction to the yaml files. https://stackoverflow.com/questions/58945481/how-to-specify-clean-all-build-directories-in-yaml-in-azure-devops 
	
3. Most important, we may need to add "docker image prune" command to every Linux pipeline. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
