### PR TITLE
orttraining cuda 10.2 to not build for compute_80

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda102.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda102.yml
@@ -8,7 +8,7 @@ stages:
     opset_version: '14'
     cuda_version: '10.2'
     gcc_version: 8
-    cmake_cuda_architectures: 37;50;52;60;61;70;80
+    cmake_cuda_architectures: 37;50;52;60;61;70
     docker_file: Dockerfile.manylinux2014_training_cuda10_2
     agent_pool: Onnxruntime-Linux-GPU-NV6
     upload_wheel: 'yes'


### PR DESCRIPTION
release pipeline build failed due to compute_80. Removing it from cuda 10.2 pipeline.