### PR TITLE
Improve onnx shape inference in quant tool

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -17,7 +17,7 @@ from onnxruntime import SessionOptions, InferenceSession, GraphOptimizationLevel
 from .quant_utils import QuantizationMode, QuantizedValueType, QuantizedInitializer, QuantizedValue
 from .quant_utils import find_by_name, get_elem_index, get_mul_node, generate_identified_filename, attribute_to_kwarg, type_to_name
 from .quant_utils import quantize_nparray, quantize_data, compute_scale_zp, get_qrange_for_qType, get_qmin_qmax_for_qType
-from .quant_utils import save_and_reload_model, model_has_infer_metadata
+from .quant_utils import save_and_reload_model, model_has_infer_metadata, add_infer_metadata
 from .quant_utils import QuantType, onnx_domain, __producer__, __version__
 
 from .registry import CreateOpQuantizer, CreateDefaultOpQuantizer
@@ -108,6 +108,7 @@ class ONNXQuantizer:
         '''
         warped_model = onnx.helper.make_model(subgraph, producer_name='onnx-quantizer',
                                               opset_imports=self.model.model.opset_import)
+        add_infer_metadata(warped_model)
         sub_quanitzer = ONNXQuantizer(warped_model,
                                       self.per_channel,
                                       self.reduce_range,

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -27,10 +27,6 @@ class ONNXQuantizer:
     def __init__(self, model, per_channel, reduce_range, mode, static, weight_qType, input_qType, tensors_range,
                  nodes_to_quantize, nodes_to_exclude, op_types_to_quantize, extra_options={}):
 
-        # run shape inference on the model (enabled by default)
-        self.extra_options = extra_options if extra_options is not None else {}
-        if not ('DisableShapeInference' in self.extra_options and self.extra_options['DisableShapeInference']):
-            model = onnx.shape_inference.infer_shapes(model)
         self.value_infos = {vi.name: vi for vi in model.graph.value_info}
         self.value_infos.update({ot.name: ot for ot in model.graph.output})
         self.value_infos.update({it.name: it for it in model.graph.input})
@@ -41,6 +37,8 @@ class ONNXQuantizer:
         self.mode = mode  # QuantizationMode.Value
         self.static = static  # use static quantization for inputs.
         self.fuse_dynamic_quant = False
+
+        self.extra_options = extra_options if extra_options is not None else {}
         self.enable_subgraph_quantization = 'EnableSubgraph' in self.extra_options and self.extra_options['EnableSubgraph']
         self.force_quantize_no_input_check = 'ForceQuantizeNoInputCheck' in self.extra_options and self.extra_options['ForceQuantizeNoInputCheck']
         self.q_matmul_const_b_only = 'MatMulConstBOnly' in self.extra_options and self.extra_options['MatMulConstBOnly']

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -17,6 +17,7 @@ from onnxruntime import SessionOptions, InferenceSession, GraphOptimizationLevel
 from .quant_utils import QuantizationMode, QuantizedValueType, QuantizedInitializer, QuantizedValue
 from .quant_utils import find_by_name, get_elem_index, get_mul_node, generate_identified_filename, attribute_to_kwarg, type_to_name
 from .quant_utils import quantize_nparray, quantize_data, compute_scale_zp, get_qrange_for_qType, get_qmin_qmax_for_qType
+from .quant_utils import save_and_reload_model, model_has_infer_metadata
 from .quant_utils import QuantType, onnx_domain, __producer__, __version__
 
 from .registry import CreateOpQuantizer, CreateDefaultOpQuantizer
@@ -27,11 +28,15 @@ class ONNXQuantizer:
     def __init__(self, model, per_channel, reduce_range, mode, static, weight_qType, input_qType, tensors_range,
                  nodes_to_quantize, nodes_to_exclude, op_types_to_quantize, extra_options={}):
 
+        if not model_has_infer_metadata(model):
+            model = save_and_reload_model(model)
         self.value_infos = {vi.name: vi for vi in model.graph.value_info}
         self.value_infos.update({ot.name: ot for ot in model.graph.output})
         self.value_infos.update({it.name: it for it in model.graph.input})
 
         self.model = ONNXModel(model)
+        if not static: self.model.replace_gemm_with_matmul()
+
         self.per_channel = per_channel  # weight-pack per channel
         self.reduce_range = reduce_range
         self.mode = mode  # QuantizationMode.Value

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -4,6 +4,7 @@ import onnx
 
 from enum import Enum
 from onnx import onnx_pb as onnx_proto
+from onnx import external_data_helper
 from pathlib import Path
 
 __producer__ = "onnx.quantize"
@@ -447,3 +448,10 @@ def smooth_distribution(p, eps=0.0001):
     assert (hist <= 0).sum() == 0
 
     return hist
+
+def model_has_external_data(model_path : Path):
+    model = onnx.load(model_path.as_posix(), load_external_data=False)
+    for intializer in model.graph.initializer:
+        if external_data_helper.uses_external_data(intializer):
+            return True
+    return False

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -508,9 +508,8 @@ def save_and_reload_model(model):
     with tempfile.TemporaryDirectory(prefix='ort.quant.') as quant_tmp_dir:
         model_path = Path(quant_tmp_dir).joinpath("model.onnx")
         onnx.external_data_helper.convert_model_to_external_data(model,
-                                                                 all_tensors_to_one_file=True,
-                                                                 location=Path(quant_tmp_dir).joinpath("model.data").as_posix())
-        onnx.save_model(model, model_path)
+                                                                 all_tensors_to_one_file=True)
+        onnx.save_model(model, model_path.as_posix())
         return load_model(model_path, False)
 
 def clone_model_with_shape_infer(model):

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -212,8 +212,6 @@ def quantize_static(model_input,
             WeightSymmetric = True/False: symmetrize calibration data for weights (default is True).
             EnableSubgraph = True/False : Default is False. If enabled, subgraph will be quantized.
                                           Dyanmic mode currently is supported. Will support more in future.
-            DisableShapeInference = True/False : in dynamic quantize mode, shape inference is not must have
-                                                 and if it cause some issue, you could disable it.
             ForceQuantizeNoInputCheck = True/False : By default, some latent operators like maxpool, transpose, do not quantize
                                                      if their input is not quantized already. Setting to True to force such operator
                                                      always quantize input and so generate quantized output. Also the True behavior
@@ -335,8 +333,6 @@ def quantize_dynamic(model_input: Path,
             WeightSymmetric = True/False: symmetrize calibration data for weights (default is True).
             EnableSubgraph = True/False : Default is False. If enabled, subgraph will be quantized.
                                           Dyanmic mode currently is supported. Will support more in future.
-            DisableShapeInference = True/False : in dynamic quantize mode, shape inference is not must have
-                                                 and if it cause some issue, you could disable it.
             ForceQuantizeNoInputCheck = True/False : By default, some latent operators like maxpool, transpose, do not quantize
                                                      if their input is not quantized already. Setting to True to force such operator
                                                      always quantize input and so generate quantized output. Also the True behavior

--- a/onnxruntime/python/tools/transformers/quantize_helper.py
+++ b/onnxruntime/python/tools/transformers/quantize_helper.py
@@ -58,22 +58,13 @@ class QuantizeHelper:
 
     @staticmethod
     def quantize_onnx_model(onnx_model_path, quantized_model_path, use_external_data_format=False):
-        from onnxruntime.quantization import quantize, QuantizationMode
+        from onnxruntime.quantization import quantize_dynamic
+        from pathlib import Path
+        Path(quantized_model_path).parent.mkdir(parents=True, exist_ok=True)
         logger.info(f'Size of full precision ONNX model(MB):{os.path.getsize(onnx_model_path)/(1024*1024)}')
-        onnx_opt_model = onnx.load_model(onnx_model_path)
-        quantized_onnx_model = quantize(onnx_opt_model,
-                                        quantization_mode=QuantizationMode.IntegerOps,
-                                        symmetric_weight=True,
-                                        force_fusions=True)
-
-        if use_external_data_format:
-            from pathlib import Path
-            Path(quantized_model_path).parent.mkdir(parents=True, exist_ok=True)
-            onnx.external_data_helper.convert_model_to_external_data(quantized_onnx_model,
-                                                                     all_tensors_to_one_file=True,
-                                                                     location=Path(quantized_model_path).name + ".data")
-        onnx.save_model(quantized_onnx_model, quantized_model_path)
-
+        quantize_dynamic(onnx_model_path,
+                         quantized_model_path,
+                         use_external_data_format = use_external_data_format)
         logger.info(f"quantized model saved to:{quantized_model_path}")
         #TODO: inlcude external data in total model size.
         logger.info(f'Size of quantized ONNX model(MB):{os.path.getsize(quantized_model_path)/(1024*1024)}')


### PR DESCRIPTION
Fix issue #11072.

onnx.shape_inference.infer_shapes only works for model size < 2GB, while onnx.shape_inference.infer_shapes_path works for all models. This PR replaces infer_shapes with infer_shapes_path.
