### PR TITLE
Update py-packaging-training-cuda-stage.yml to upgrade azure blob storage package version

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -77,26 +77,15 @@ stages:
         inputs:
           ArtifactName: onnxruntime_training_cpu
 
-      - script: |
-          python3 -m pip install azure-storage-blob==2.1.0
-        displayName: 'python3 -m pip install azure-storage-blob==2.1.0'
-        timeoutInMinutes: 20
-
-      - task: AzureCLI@2
+      - task: CmdLine@2
+        condition: and (succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        displayName: 'Upload wheel'
         inputs:
-          azureSubscription: 'AIInfraBuildOnnxRuntimeOSS'
-          scriptType: 'bash'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
+          script: |
             files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
             echo ${files[0]} && \
             tools/ci_build/upload_python_package_to_azure_storage.py \
-                --python_wheel_path ${files[0]} \
-                --account_name onnxruntimepackages \
-                --account_key $(orttrainingpackagestorageaccountkey) \
-                --container_name '$web'
-          condition: succeededOrFailed()
-          displayName: 
+                --python_wheel_path ${files[0]}
 
       - template: templates/component-governance-component-detection-steps.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -597,14 +597,10 @@ stages:
           ArtifactName: onnxruntime_rocm
 
       - script: |
-          python3 -m pip install azure-storage-blob==2.1.0
           files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
           echo ${files[0]} && \
           python3 tools/ci_build/upload_python_package_to_azure_storage.py \
-              --python_wheel_path ${files[0]} \
-              --account_name onnxruntimepackages \
-              --account_key $(orttrainingpackagestorageaccountkey) \
-              --container_name '$web'
+              --python_wheel_path ${files[0]} 
         condition: and(succeeded(), eq(variables['DRY_RUN'], '0'))
         displayName: 'Upload Rocm wheel to release repository'
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
@@ -206,22 +206,16 @@ stages:
         inputs:
           ArtifactName: onnxruntime_gpu
 
-      - task: AzureCLI@2
+      - task: CmdLine@2
+        displayName: 'Upload wheel'
         condition: and(succeeded(), eq(variables['UploadWheel'], 'yes'))
         inputs:
-          azureSubscription: 'AIInfraBuildOnnxRuntimeOSS'
-          scriptType: 'bash'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            python3 -m pip install azure-storage-blob==2.1.0
+          script: |
+            set -e -x
             files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
             echo ${files[0]} && \
             python3 tools/ci_build/upload_python_package_to_azure_storage.py \
-                --python_wheel_path ${files[0]} \
-                --account_name onnxruntimepackages \
-                --account_key $(orttrainingpackagestorageaccountkey) \
-                --container_name '$web'
-          displayName:
+                --python_wheel_path ${files[0]}
 
       - template: component-governance-component-detection-steps.yml
         parameters:


### PR DESCRIPTION
**Description**: 

Update tools/ci_build/upload_python_package_to_azure_storage.py to not use the azure blob storage python package. Because there are two very similar but also conflict packages: azure-blob-storage python package and Azure SDK for python. They can't be both installed. The API of azure-blob-storage also get updated a lot recently. So, to avoid jumping into the trouble, I switch it to use azcopy which is a golang based single binary.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
