### PR TITLE
Update to Slice

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/slice_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_helper.h
@@ -136,20 +136,12 @@ inline Status PrepareForComputeHelper(const gsl::span<const int64_t>& raw_starts
 
     // process end
     auto end = raw_ends[axis_index];
-    // INT_MAX has a special meaning for end according to spec
-    // equivalent to 'None' in numpy
-    // it represent slicing to the end of the dimension
-    if (end == std::numeric_limits<int32_t>::max() ||
-        end == std::numeric_limits<int64_t>::max()) {
-      end = step < 0 ? -1 : dim_value;
-    } else {
-      if (end < 0)
-        end += dim_value;
-      if (step < 0)
-        end = std::clamp(end, int64_t{-1}, dim_value);
-      else
-        end = std::clamp(end, int64_t{0}, dim_value);
-    }
+    if (end < 0)
+      end += dim_value;
+    if (step < 0)
+      end = std::clamp(end, int64_t{-1}, dim_value);
+    else
+      end = std::clamp(end, int64_t{0}, dim_value);
 
     compute_metadata.ends_[axis] = end;
 

--- a/onnxruntime/core/providers/cpu/tensor/slice_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_helper.h
@@ -139,7 +139,7 @@ inline Status PrepareForComputeHelper(const gsl::span<const int64_t>& raw_starts
     if (end < 0)
       end += dim_value;
     if (step < 0)
-      end = std::clamp(end, int64_t{-1}, dim_value);
+      end = std::clamp(end, int64_t{-1}, dim_value - 1);
     else
       end = std::clamp(end, int64_t{0}, dim_value);
 

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -514,7 +514,7 @@ TEST(SliceTest, Slice2D_ReverseAllAxes) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1, -1},
-                      {std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min()},  // Slice till the beginning
                       {0, 1},
                       {-1, -1},
                       {2, 2},
@@ -526,7 +526,7 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfAxes_1) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the beginning
                       {1},                                    // axis = 1 only
                       {-1},
                       {2, 2},
@@ -538,7 +538,7 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfAxes_2) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the beginning
                       {0},                                    // axis = 0 only
                       {-1},
                       {2, 2},
@@ -582,7 +582,7 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfNegAxes_1) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the beginning
                       {-1},                                   // axis = -1 only
                       {-1},
                       {2, 2},

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -472,17 +472,15 @@ TEST(SliceTest, Slice3D_WithPositiveAndNegativeSteps_SubsetOfAxes_2) {
 }
 
 // Slice for Reversing
-// With numeric_limit_max, it means slice to the end of a dimension
-// (whichever direction we are stepping)
-TEST(SliceTest, Slice1D_ReverseAllAxes_1) {
+TEST(SliceTest, Slice1D_ReverseAllAxes_EmptyResult) {
   RunSliceTest<float>({4},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
                       {std::numeric_limits<int32_t>::max()},
                       {0},
                       {-1},
-                      {4},
-                      {4.0f, 3.0f, 2.0f, 1.0f},
+                      {0},
+                      {},
                       true);
 }
 
@@ -516,7 +514,7 @@ TEST(SliceTest, Slice2D_ReverseAllAxes) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1, -1},
-                      {std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()},
+                      {std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min()},  // Slice till the end
                       {0, 1},
                       {-1, -1},
                       {2, 2},
@@ -528,8 +526,8 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfAxes_1) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::max()},
-                      {1},  // axis = 1 only
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {1},                                    // axis = 1 only
                       {-1},
                       {2, 2},
                       {2.0f, 1.0f, 4.0f, 3.0f},
@@ -540,7 +538,7 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfAxes_2) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::max()},  // end of dimension
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
                       {0},                                    // axis = 0 only
                       {-1},
                       {2, 2},
@@ -584,8 +582,8 @@ TEST(SliceTest, Slice2D_ReverseSubsetOfNegAxes_1) {
   RunSliceTest<float>({2, 2},
                       {1.0f, 2.0f, 3.0f, 4.0f},
                       {-1},
-                      {std::numeric_limits<int64_t>::max()},
-                      {-1},  // axis = -1 only
+                      {std::numeric_limits<int64_t>::min()},  // Slice till the end
+                      {-1},                                   // axis = -1 only
                       {-1},
                       {2, 2},
                       {2.0f, 1.0f, 4.0f, 3.0f},


### PR DESCRIPTION
**Description**: 
While implementing Slice-10, `INT_MAX` was treated as a special value to denote "end of a dimension" while slicing in any direction due to spec ambiguity. This has been clarified that this is indeed not the case (https://github.com/microsoft/onnxruntime/issues/11107#issuecomment-1090656720). So, adjusting the implementation and the tests to reflect this clarification. This shouldn't affect any real world model (as the only way this can break a model is if they had used INT_MAX while slicing in reverse which is totally unintuitive) and is more of a spec alignment update.

**Motivation and Context**
Resolve https://github.com/microsoft/onnxruntime/issues/11107
