### PR TITLE
Add LegalizeSessionOptions interface. Move EP specific logic to EP impl.

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -298,6 +298,16 @@ class IExecutionProvider {
     return static_cast<DataLayout>(0);
   }
 
+  /** Some session option values (default or user provided) may not work with some EPs.
+   * The EP should alter the SessionOptions object fit its implementation to avoid potential crash.
+   * Rather than put the onus on the user to know these, make the appropriate change while logging the change.
+   *
+   * @param so The SessionOptions object to be altered
+   */
+  virtual void LegalizeSessionOptions(SessionOptions& so) {
+    ORT_UNUSED_PARAMETER(so);
+  }
+
  private:
   const std::string type_;
   AllocatorMap allocators_;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -471,38 +471,10 @@ common::Status InferenceSession::RegisterExecutionProvider(const std::shared_ptr
 
   const std::string& provider_type = p_exec_provider->Type();
 
+  p_exec_provider->LegalizeSessionOptions(session_options_);
   p_exec_provider->RegisterAllocator(allocator_manager_);
 
-  // Some session option values (default or user provided) may not work with some EPs.
-  // Rather than put the onus on the user to know these, make the appropriate change while logging the change.
-  if (provider_type == onnxruntime::kDmlExecutionProvider) {
-    // DML's memory is not byte addressable and hence mem pattern doesn't work.
-    if (session_options_.enable_mem_pattern) {
-      LOGS(*session_logger_, WARNING)
-          << "Having memory pattern enabled is not supported while using the DML Execution Provider. "
-          << "So disabling it for this session since it uses the DML Execution Provider.";
-      session_options_.enable_mem_pattern = false;
-    }
-
-    // Parallel execution mode does not support DML EP
-    if (session_options_.execution_mode != ExecutionMode::ORT_SEQUENTIAL) {
-      LOGS(*session_logger_, WARNING)
-          << "Parallel execution mode does not support the DML Execution Provider. "
-          << "So making the execution mode sequential for this session since it uses the DML Execution Provider.";
-
-      session_options_.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
-    }
-  }
-
   if (provider_type == onnxruntime::kCudaExecutionProvider) {
-    // Parallel execution mode does not support the CUDA EP
-    if (session_options_.execution_mode != ExecutionMode::ORT_SEQUENTIAL) {
-      LOGS(*session_logger_, WARNING)
-          << "Parallel execution mode does not support the CUDA Execution Provider. "
-          << "So making the execution mode sequential for this session since it uses the CUDA Execution Provider.";
-      session_options_.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
-    }
-
     auto trt_ep = execution_providers_.Get(kTensorrtExecutionProvider);
     if (trt_ep) {
       ORT_RETURN_IF_ERROR(p_exec_provider->SetComputeStream(trt_ep->GetComputeStream()));


### PR DESCRIPTION
**Description**:

Small refactor. Avoid leaking the SessionOptions legalization impl to inference session. Move them to EP.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  Some other EPs might also need it to avoid session option problem, currently the only way to achieve it is add another `if` branch in `inference_session.cc`, which is ugly.

