### PR TITLE
Remove python frontend codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,3 @@
-# Python frontend owners
-orttraining/*.py @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-orttraining/orttraining/python/** @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-orttraining/orttraining/test/python/** @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-orttraining/pytorch_frontend_examples/** @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-onnxruntime/python/training/** @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-onnxruntime/test/python/onnxruntime_test_ort_trainer.py @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-onnxruntime/test/python/onnxruntime_test_ort_trainer_with_mixed_precision.py @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-onnxruntime/test/python/onnxruntime_test_training_unit_tests.py @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-onnxruntime/test/python/onnxruntime_test_training_unittest_utils.py @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-samples/python/training/** @thiagocrepaldi @tlh20 @baijumeswani @xadupre
-
 # Mobile
 /onnxruntime/test/testdata/kernel_def_hashes/ @skottmckay @YUNQIUGUO @edgchen1
 /onnxruntime/core/framework/kernel_def_hash_helpers.* @skottmckay @YUNQIUGUO @edgchen1


### PR DESCRIPTION
Removing the codeowners for python frontend training so we no longer have targeted python frontend code maintainers (specially considering that the entire training team (frontend and backend) is in the same group).