### PR TITLE
Link cpuinfo only if supported

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -895,7 +895,6 @@ else()
   set(CPUINFO_SUPPORTED FALSE)
 endif()
 
-# TODO  do we have to add target_include_directories to each project that uses this?
 if (CPUINFO_SUPPORTED)
   set(PYTORCH_CPUINFO_DIR external/pytorch_cpuinfo)
   set(PYTORCH_CPUINFO_INCLUDE_DIR ${PYTORCH_CPUINFO_DIR}/include)

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -210,12 +210,14 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
     # msvc compiler report syntax error with cpuinfo arm source files
     # and cpuinfo does not have code for getting arm uarch info under windows
   else()
-    # Link cpuinfo
+    # Link cpuinfo if supported
     # Using it mainly in ARM with Android.
     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
 
-    target_include_directories(onnxruntime_common PRIVATE ${PYTORCH_CPUINFO_INCLUDE_DIR})
-    list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
+    if (CPUINFO_SUPPORTED)
+      target_link_libraries(onnxruntime_common cpuinfo)
+      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
+    endif()
   endif()
 endif()
 

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -215,7 +215,6 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
 
     target_include_directories(onnxruntime_common PRIVATE ${PYTORCH_CPUINFO_INCLUDE_DIR})
-    target_link_libraries(onnxruntime_common cpuinfo)
     list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
   endif()
 endif()


### PR DESCRIPTION
**Description**: Link to cpuinfo library only if supported.

**Motivation and Context**
Compilation fails e.g. for ARMv7 targets where `CPUINFO_SUPPORTED` is `false`. `onnxruntime_common` is linked to cpuinfo library but cpuinfo wasn't added as subdirectory: https://github.com/microsoft/onnxruntime/blob/master/cmake/CMakeLists.txt#L913.
