### PR TITLE
WIP: Skip excess copying of output OrtValue (Tensor) to numpy array in python run method 

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -211,12 +211,20 @@ class Tensor final {
     return static_cast<char*>(p_data_) + byte_offset_;
   }
 
+  void* MutableDataRawWithoutOffset() noexcept {
+    return static_cast<char*>(p_data_);
+  }
+
   const void* DataRaw() const noexcept {
     return static_cast<char*>(p_data_) + byte_offset_;
   }
 
   bool OwnsBuffer() const noexcept {
     return buffer_deleter_ != nullptr;
+  }
+
+  AllocatorPtr StealDeleter() {
+    return std::move(buffer_deleter_);
   }
 
   /**


### PR DESCRIPTION
This pull request solves [the issue](https://github.com/microsoft/onnxruntime/issues/11099). Numpy array is constructed on memory allocated for Tensor, but it lives independently on InferenceSession. The memory ownership is transferred by py::capsule mechanism.
