### PR TITLE
Update to use teams instead of individual GH handles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Mobile
-/onnxruntime/test/testdata/kernel_def_hashes/ @onnxruntime-mobile
+/onnxruntime/test/testdata/kernel_def_hashes/ @microsoft/onnxruntime-mobile
 /onnxruntime/core/framework/kernel_def_hash_helpers.* @microsoft/onnxruntime-mobile
 
 # Contrib Ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Mobile
-/onnxruntime/test/testdata/kernel_def_hashes/ @skottmckay @YUNQIUGUO @edgchen1
-/onnxruntime/core/framework/kernel_def_hash_helpers.* @skottmckay @YUNQIUGUO @edgchen1
+/onnxruntime/test/testdata/kernel_def_hashes/ @onnxruntime-mobile
+/onnxruntime/core/framework/kernel_def_hash_helpers.* @microsoft/onnxruntime-mobile
 
 # Contrib Ops
-onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @zhanghuanrong @chenfucn @yufenglee @yihonglyu @snnn
-onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @zhanghuanrong @chenfucn @yufenglee @yihonglyu @snnn
-onnxruntime/core/graph/contrib_ops/quantization_defs.* @zhanghuanrong @chenfucn @yufenglee @yihonglyu @snnn
-onnxruntime/core/mlas/** @zhanghuanrong @chenfucn @yufenglee @yihonglyu @snnn
+onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
+onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
+onnxruntime/core/graph/contrib_ops/quantization_defs.* microsoft/@onnxruntime-contrib-ops
+onnxruntime/core/mlas/** @microsoft/onnxruntime-contrib-ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # Contrib Ops
 onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
 onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
-onnxruntime/core/graph/contrib_ops/quantization_defs.* microsoft/@onnxruntime-contrib-ops
+onnxruntime/core/graph/contrib_ops/quantization_defs.* @microsoft/@onnxruntime-contrib-ops
 onnxruntime/core/mlas/** @microsoft/onnxruntime-contrib-ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # Contrib Ops
 onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
 onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
-onnxruntime/core/graph/contrib_ops/quantization_defs.* @microsoft/@onnxruntime-contrib-ops
+onnxruntime/core/graph/contrib_ops/quantization_defs.* @microsoft/onnxruntime-contrib-ops
 onnxruntime/core/mlas/** @microsoft/onnxruntime-contrib-ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 /onnxruntime/core/framework/kernel_def_hash_helpers.* @microsoft/onnxruntime-mobile
 
 # Contrib Ops
-onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
-onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @microsoft/onnxruntime-contrib-ops
-onnxruntime/core/graph/contrib_ops/quantization_defs.* @microsoft/onnxruntime-contrib-ops
-onnxruntime/core/mlas/** @microsoft/onnxruntime-contrib-ops
+onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc @microsoft/onnxruntime-mlas
+onnxruntime/core/graph/contrib_ops/nchwc_schema_defs.cc @microsoft/onnxruntime-mlas
+onnxruntime/core/graph/contrib_ops/quantization_defs.* @microsoft/onnxruntime-mlas
+onnxruntime/core/mlas/** @microsoft/onnxruntime-mlas


### PR DESCRIPTION
Updating codeowner file owners to use sub-teams under onnxruntime, rather than individual names