### PR TITLE
Increase the timeout value of the Linux C-API ARM64 build job

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -47,7 +47,7 @@ jobs:
 - job: Linux_C_API_Packaging_CPU_x64
   workspace:
     clean: all
-  timeoutInMinutes:  180
+  timeoutInMinutes:  300
   strategy:
     matrix:
       ARCH_x86_64:


### PR DESCRIPTION
**Description**: 

Increase the timeout value of the Linux C-API ARM64 build job
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
