### PR TITLE
Add new QDQ nodes after the Transpose node in Layout Transformer.

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -596,7 +596,7 @@ static Node& CreateNodeHelper(onnxruntime::Graph& graph, std::string_view op_typ
 
   output_args.reserve(num_outputs);
   for (size_t i = 0; i < num_outputs; ++i) {
-    std::string output = graph.GenerateNodeArgName(name + "_out" + std::to_string(i));
+    std::string output = graph.GenerateNodeArgName(inputs.empty() ? "" : std::string(inputs.front()) + name + "_out" + std::to_string(i));
     NodeArg* arg = &graph.GetOrCreateNodeArg(output, nullptr);
     output_args.push_back(arg);
   }
@@ -640,6 +640,8 @@ static const std::unordered_map<std::string, std::vector<int>> onnx_ops_availabl
     {"Gather", {1, 11, 13}},
     {"Transpose", {1, 13}},
     {"Identity", {1, 13, 14, 16}},
+    {"QuantizeLinear", {1, 13}},
+    {"DequantizeLinear", {1, 13}},
 };
 
 // Based on the opset version imported for this model, returns the since version for the node.
@@ -741,7 +743,7 @@ void ApiGraph::MoveOutput(api::NodeRef& src_node, size_t src_idx, api::NodeRef& 
 
   graph_utils::GraphEdge::RemoveGraphEdges(graph_, output_edges);
 
-  std::string new_name = graph_.GenerateNodeArgName(src_ort_node.Name());
+  std::string new_name = graph_.GenerateNodeArgName(node_arg->Name());
   src_output_defs[src_idx] = &graph_.GetOrCreateNodeArg(new_name, nullptr);
   graph_.UpdateProducerNode(new_name, src_node_idx);
 }

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -1954,38 +1954,39 @@ OptimizeResult OptimizeImpl(OptimizerCtx& ctx) {
         continue;
       }
       auto q_node = ctx.graph.GetNodeProducingOutput(dq_node->Inputs()[0]);
-      if (q_node || q_node->OpType() != "QuantizeLinear") {
-        auto transpose_out = transpose_node.Outputs()[0];
-        std::unique_ptr<api::NodeRef> new_q_node = ctx.graph.AddNode("QuantizeLinear",
-                                                                     {transpose_out,
-                                                                      q_node->Inputs()[1],
-                                                                      q_node->Inputs()[2]},
-                                                                     /*num_outputs = */ 1);
-
-        auto q_out = q_node->Outputs()[0];
-        auto new_q_out = new_q_node->Outputs()[0];
-        ctx.graph.CopyValueInfo(q_out, new_q_out);
-        ctx.graph.GetValueInfo(new_q_out)->PermuteDims(*perm);
-
-        std::unique_ptr<api::NodeRef> new_dq_node = ctx.graph.AddNode("DequantizeLinear",
-                                                                      {new_q_node->Outputs()[0],
-                                                                       dq_node->Inputs()[1],
-                                                                       dq_node->Inputs()[2]},
-                                                                      /*num_output = */ 1);
-        auto dq_out = dq_node->Outputs()[0];
-        auto new_dq_out = new_dq_node->Outputs()[0];
-        ctx.graph.CopyValueInfo(dq_out, new_dq_out);
-        ctx.graph.GetValueInfo(new_q_out)->PermuteDims(*perm);
-
-        ctx.graph.MoveOutput(transpose_node, 0, *new_dq_node, 0);
-        std::string_view new_transpose_out = transpose_node.Outputs()[0];
-        ctx.graph.CopyValueInfo(transpose_out, new_transpose_out);
-        ctx.graph.GetValueInfo(new_transpose_out)->PermuteDims(*perm);
-
-        new_q_node->SetInput(0, new_transpose_out);
-        ctx.graph.CopyValueInfo(new_dq_out, new_dq_node->Outputs()[0]);
-        changed = true;
+      if (!q_node) {
+        continue;
       }
+      auto transpose_out = transpose_node.Outputs()[0];
+      std::unique_ptr<api::NodeRef> new_q_node = ctx.graph.AddNode("QuantizeLinear",
+                                                                   {transpose_out,
+                                                                    q_node->Inputs()[1],
+                                                                    q_node->Inputs()[2]},
+                                                                   /*num_outputs = */ 1);
+
+      auto q_out = q_node->Outputs()[0];
+      auto new_q_out = new_q_node->Outputs()[0];
+      ctx.graph.CopyValueInfo(q_out, new_q_out);
+      ctx.graph.GetValueInfo(new_q_out)->PermuteDims(*perm);
+
+      std::unique_ptr<api::NodeRef> new_dq_node = ctx.graph.AddNode("DequantizeLinear",
+                                                                    {new_q_node->Outputs()[0],
+                                                                     dq_node->Inputs()[1],
+                                                                     dq_node->Inputs()[2]},
+                                                                    /*num_output = */ 1);
+      auto dq_out = dq_node->Outputs()[0];
+      auto new_dq_out = new_dq_node->Outputs()[0];
+      ctx.graph.CopyValueInfo(dq_out, new_dq_out);
+      ctx.graph.GetValueInfo(new_q_out)->PermuteDims(*perm);
+
+      ctx.graph.MoveOutput(transpose_node, 0, *new_dq_node, 0);
+      std::string_view new_transpose_out = transpose_node.Outputs()[0];
+      ctx.graph.CopyValueInfo(transpose_out, new_transpose_out);
+      ctx.graph.GetValueInfo(new_transpose_out)->PermuteDims(*perm);
+
+      new_q_node->SetInput(0, new_transpose_out);
+      ctx.graph.CopyValueInfo(new_dq_out, new_dq_node->Outputs()[0]);
+      changed = true;
     }
   }
 

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -1953,20 +1953,16 @@ OptimizeResult OptimizeImpl(OptimizerCtx& ctx) {
       if (!HandleQuantizeDequantizeScale(ctx.graph, *perm, *dq_node, ctx.opset)) {
         continue;
       }
-      auto q_node = ctx.graph.GetNodeProducingOutput(dq_node->Inputs()[0]);
-      if (!q_node) {
-        continue;
-      }
       auto transpose_out = transpose_node.Outputs()[0];
       std::unique_ptr<api::NodeRef> new_q_node = ctx.graph.AddNode("QuantizeLinear",
                                                                    {transpose_out,
-                                                                    q_node->Inputs()[1],
-                                                                    q_node->Inputs()[2]},
+                                                                    dq_node->Inputs()[1],
+                                                                    dq_node->Inputs()[2]},
                                                                    /*num_outputs = */ 1);
 
-      auto q_out = q_node->Outputs()[0];
+      auto dq_in = dq_node->Inputs()[0];
       auto new_q_out = new_q_node->Outputs()[0];
-      ctx.graph.CopyValueInfo(q_out, new_q_out);
+      ctx.graph.CopyValueInfo(dq_in, new_q_out);
       ctx.graph.GetValueInfo(new_q_out)->PermuteDims(*perm);
 
       std::unique_ptr<api::NodeRef> new_dq_node = ctx.graph.AddNode("DequantizeLinear",


### PR DESCRIPTION
**Description**: Modified Layout Transformer to insert QDQ nodes after a Transpose node

**Motivation and Context**
- Why is this change required? What problem does it solve?
For the QNN Execution Provider, we require layout transformer insert a new QDQ node-pair instead of inserting the Transpose node between Q and DQ nodes.
- If it fixes an open issue, please link to the issue here.
