### PR TITLE
use int storage for python package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -1,5 +1,12 @@
 trigger: none
 
+variables:
+  - name: finalStorage
+    $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]:
+      value: '--final_storage'
+    $[nq(variables['Build.SourceBranch'], 'refs/heads/main')]:
+      value: ~
+
 stages:
 - stage: Python_Packaging
 
@@ -85,7 +92,7 @@ stages:
             files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
             echo ${files[0]} && \
             tools/ci_build/upload_python_package_to_azure_storage.py \
-                --python_wheel_path ${files[0]}
+                --python_wheel_path ${files[0]}  $[variables['finalStorage']]
 
       - template: templates/component-governance-component-detection-steps.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -45,6 +45,13 @@ parameters:
   type: boolean
   default: true
 
+variables:
+  - name: finalStorage
+    $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]:
+      value: '--final_storage'
+    $[nq(variables['Build.SourceBranch'], 'refs/heads/main')]:
+      value: ~
+
 stages:
 - stage: Python_Packaging
 
@@ -746,6 +753,14 @@ stages:
         displayName: 'Publish Artifact: ONNXRuntime python wheel'
         inputs:
           ArtifactName: onnxruntime
+
+      - script: |
+          files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
+          echo ${files[0]} && \
+          python3 tools/ci_build/upload_python_package_to_azure_storage.py \
+              --python_wheel_path ${files[0]} $[variables['finalStorage']]
+        condition: and(succeeded(), eq(variables['DRY_RUN'], '0'))
+        displayName: 'Upload Mac wheel to release repository'
 
       - template: component-governance-component-detection-steps.yml
         parameters:

--- a/tools/ci_build/upload_python_package_to_azure_storage.py
+++ b/tools/ci_build/upload_python_package_to_azure_storage.py
@@ -29,9 +29,10 @@ def run_subprocess(args, cwd=None):
     return subprocess.run(args, cwd=cwd, check=True)
 
 
-def upload_whl(python_wheel_path):
+def upload_whl(python_wheel_path, final_storage=False):
+    storage_account_name = "onnxruntimepackages" if final_storage else "onnxruntimepackagesint" 
     blob_name = os.path.basename(python_wheel_path)
-    run_subprocess(['azcopy', 'cp', python_wheel_path, 'https://onnxruntimepackages.blob.core.windows.net/$web/'])
+    run_subprocess(['azcopy', 'cp', python_wheel_path, f'https://{storage_account_name}.blob.core.windows.net/$web/'])
 
     nightly_build, local_version = parse_nightly_and_local_version_from_whl_name(blob_name)
     if local_version:
@@ -41,7 +42,7 @@ def upload_whl(python_wheel_path):
 
     download_path_to_html = "./onnxruntime_{}.html".format(nightly_build)
 
-    run_subprocess(['azcopy', 'cp', 'https://onnxruntimepackages.blob.core.windows.net/$web/'+html_blob_name,
+    run_subprocess(['azcopy', 'cp', f'https://{storage_account_name}.blob.core.windows.net/$web/'+html_blob_name,
                     download_path_to_html])
 
     blob_name_plus_replaced = blob_name.replace('+', '%2B')
@@ -59,7 +60,7 @@ def upload_whl(python_wheel_path):
     else:
         warnings.warn("'{}' exists in {}. The html file is not updated.".format(new_line, download_path_to_html))
     run_subprocess(['azcopy', 'cp', download_path_to_html,
-                    'https://onnxruntimepackages.blob.core.windows.net/$web/'+html_blob_name,
+                    f'https://{storage_account_name}.blob.core.windows.net/$web/'+html_blob_name,
                     '--content-type', 'text/html', '--overwrite', 'true'])
 
 
@@ -67,7 +68,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Upload python whl to azure storage.")
 
     parser.add_argument("--python_wheel_path", type=str, help="path to python wheel")
+    parser.add_argument("--final_storage", type=bool, action='store_true', help="upload to final storage")
 
     args = parser.parse_args()
 
-    upload_whl(args.python_wheel_path)
+    upload_whl(args.python_wheel_path, args.final_storage)

--- a/tools/ci_build/upload_python_package_to_azure_storage.py
+++ b/tools/ci_build/upload_python_package_to_azure_storage.py
@@ -30,7 +30,7 @@ def run_subprocess(args, cwd=None):
 
 
 def upload_whl(python_wheel_path, final_storage=False):
-    storage_account_name = "onnxruntimepackages" if final_storage else "onnxruntimepackagesint" 
+    storage_account_name = "onnxruntimepackages" if final_storage else "onnxruntimepackagesint"
     blob_name = os.path.basename(python_wheel_path)
     run_subprocess(['azcopy', 'cp', python_wheel_path, f'https://{storage_account_name}.blob.core.windows.net/$web/'])
 


### PR DESCRIPTION
**Description**: 
For PR build, the package will be uploaded into Int storage
For master build, the package will be uploaded in to final storage

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
