### PR TITLE
Test ONNX PR with ORT.

### DIFF
--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -103,8 +103,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomai
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, AveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, GlobalAveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSNchwcDomain, 1, float, Upsample);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, LayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, 15, float, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, 15, double, LayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, SimplifiedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, SimplifiedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
@@ -241,8 +241,8 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, ScaledTanh)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, 9, ThresholdedRelu)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, Scale)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, LayerNormalization)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, 15, float, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, 15, double, LayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, float, SimplifiedLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 1, double, SimplifiedLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,

--- a/onnxruntime/contrib_ops/cpu/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/layer_norm.cc
@@ -12,18 +12,18 @@
 namespace onnxruntime {
 namespace contrib {
 
-#define REGISTER_KERNEL_TYPED(T)                                                                        \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(LayerNormalization, kOnnxDomain, 1, T, kCpuExecutionProvider,           \
-                                KernelDefBuilder()                                                      \
-                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())              \
-                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<T>())              \
-                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<T>()),             \
-                                LayerNorm<T, false>);                                                   \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(SimplifiedLayerNormalization, kOnnxDomain, 1, T, kCpuExecutionProvider, \
-                                KernelDefBuilder()                                                      \
-                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())              \
-                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<T>())              \
-                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<T>()),             \
+#define REGISTER_KERNEL_TYPED(T)                                                                           \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(LayerNormalization, kOnnxDomain, 1, 15, T, kCpuExecutionProvider,\
+                                KernelDefBuilder()                                                         \
+                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                 \
+                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<T>())                 \
+                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<T>()),                \
+                                LayerNorm<T, false>);                                                      \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(SimplifiedLayerNormalization, kOnnxDomain, 1, T, kCpuExecutionProvider,    \
+                                KernelDefBuilder()                                                         \
+                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                 \
+                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<T>())                 \
+                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<T>()),                \
                                 LayerNorm<T, true>);
 
 REGISTER_KERNEL_TYPED(float)

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -73,10 +73,11 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_float, LayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double_double_double, LayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16_float_MLFloat16, LayerNormalization);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_MLFloat16, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, float_float_float, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, double_double_double, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, MLFloat16_float_MLFloat16, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, BFloat16_float_BFloat16, LayerNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, float_float_MLFloat16, LayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_float, SimplifiedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double_double_double, SimplifiedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16_float_MLFloat16, SimplifiedLayerNormalization);
@@ -93,7 +94,6 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, FastGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, TransposeMatMul);  // backward compatibility
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, FusedMatMul);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, BFloat16_float_BFloat16, LayerNormalization);
 
 template <>
 KernelCreateInfo BuildKernelCreateInfo<void>() {
@@ -166,10 +166,11 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_float, LayerNormalization)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double_double_double, LayerNormalization)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16_float_MLFloat16, LayerNormalization)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_MLFloat16, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, float_float_float, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, double_double_double, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, MLFloat16_float_MLFloat16, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, float_float_MLFloat16, LayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, 15, BFloat16_float_BFloat16, LayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, float_float_float, SimplifiedLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, double_double_double, SimplifiedLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, MLFloat16_float_MLFloat16, SimplifiedLayerNormalization)>,
@@ -189,7 +190,6 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
     // TransposedMatMul is still here for backward compatibility
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, TransposeMatMul)>,  // backward compatibility
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, FusedMatMul)>,
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 1, BFloat16_float_BFloat16, LayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, FusedConv)>,
   };
 

--- a/onnxruntime/contrib_ops/cuda/layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/layer_norm.cc
@@ -10,18 +10,18 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-#define REGISTER_KERNEL_TYPED(T, U, V)                                                                               \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(LayerNormalization, kOnnxDomain, 1, T##_##U##_##V, kCudaExecutionProvider,           \
-                                (*KernelDefBuilder::Create())                                                        \
-                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                           \
-                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<U>())                           \
-                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<V>()),                          \
-                                LayerNorm<T, U, V, false>);                                                          \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(SimplifiedLayerNormalization, kOnnxDomain, 1, T##_##U##_##V, kCudaExecutionProvider, \
-                                (*KernelDefBuilder::Create())                                                        \
-                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                           \
-                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<U>())                           \
-                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<V>()),                          \
+#define REGISTER_KERNEL_TYPED(T, U, V)                                                                                   \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(LayerNormalization, kOnnxDomain, 1, 15, T##_##U##_##V, kCudaExecutionProvider, \
+                                (*KernelDefBuilder::Create())                                                            \
+                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                               \
+                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<U>())                               \
+                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<V>()),                              \
+                                LayerNorm<T, U, V, false>);                                                              \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(SimplifiedLayerNormalization, kOnnxDomain, 1, T##_##U##_##V, kCudaExecutionProvider,     \
+                                (*KernelDefBuilder::Create())                                                            \
+                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                               \
+                                    .TypeConstraint("U", DataTypeImpl::GetTensorType<U>())                               \
+                                    .TypeConstraint("V", DataTypeImpl::GetTensorType<V>()),                              \
                                 LayerNorm<T, U, V, true>);
 
 REGISTER_KERNEL_TYPED(float, float, float)

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -18,8 +18,16 @@ using namespace std;
 namespace onnxruntime {
 namespace test {
 
-TEST(LayerNormTest, BERTLayerNorm) {
-  OpTester tester("LayerNormalization", 1 /*opset_version*/);
+void BERTLayerNormCore(const int opset_version) {
+  // LayerNormalization was wrongly registered 
+  // in ai.onnx domain since version 1. To maintain BC,
+  // we keep the wrong operator as is and officially
+  // propose a new one in opset 16 to hide the old one
+  // for future opset.  This function should test
+  // the old (since opset 1) LayerNormalization
+  // and the new (since opset 16) LayerNormalization
+  // because they have the same definition.
+  OpTester tester("LayerNormalization", opset_version);
   tester.AddAttribute<int64_t>("axis", -1);
   tester.AddAttribute<float>("epsilon", 1e-12f);
 
@@ -43,8 +51,13 @@ TEST(LayerNormTest, BERTLayerNorm) {
   tester.Run();
 }
 
-TEST(LayerNormTest, BERTLayerNorm_NoBias) {
-  OpTester tester("LayerNormalization", 1 /*opset_version*/);
+TEST(LayerNormTest, BERTLayerNorm) {
+  BERTLayerNormCore(1);
+  BERTLayerNormCore(16);
+}
+
+void BERTLayerNormNoBiasCoreCore(const int opset_version) {
+  OpTester tester("LayerNormalization", opset_version);
   tester.AddAttribute<int64_t>("axis", -1);
   tester.AddAttribute<float>("epsilon", 1e-12f);
 
@@ -66,8 +79,13 @@ TEST(LayerNormTest, BERTLayerNorm_NoBias) {
   tester.Run();
 }
 
-TEST(LayerNormTest, LayerNorm) {
-  OpTester test("LayerNormalization");
+TEST(LayerNormTest, BERTLayerNorm_NoBias) {
+  BERTLayerNormNoBiasCoreCore(1);
+  BERTLayerNormNoBiasCoreCore(16);
+}
+
+void LayerNormCore(const int opset_version) {
+  OpTester test("LayerNormalization", opset_version);
   test.AddAttribute<float>("epsilon", 1e-05f);
 
   std::vector<int64_t> dims{1, 2, 3};
@@ -77,8 +95,13 @@ TEST(LayerNormTest, LayerNorm) {
   test.Run();
 }
 
-TEST(LayerNormTest, LayerNorm_Scale) {
-  OpTester test("LayerNormalization");
+TEST(LayerNormTest, LayerNorm) {
+  LayerNormCore(1);
+  LayerNormCore(16);
+}
+
+void LayerNormScaleCore(const int opset_version) {
+  OpTester test("LayerNormalization", opset_version);
   test.AddAttribute<float>("epsilon", 1e-05f);
 
   std::vector<int64_t> dims{2, 2, 2};
@@ -88,8 +111,13 @@ TEST(LayerNormTest, LayerNorm_Scale) {
   test.Run();
 }
 
-TEST(LayerNormTest, LayerNorm_Scale_Bias) {
-  OpTester test("LayerNormalization");
+TEST(LayerNormTest, LayerNorm_Scale) {
+  LayerNormScaleCore(1);
+  LayerNormScaleCore(16);
+}
+
+void LayerNormScaleBiasCore(const int opset_version) {
+  OpTester test("LayerNormalization", opset_version);
   test.AddAttribute<float>("epsilon", 1e-05f);
 
   std::vector<int64_t> dims{1, 3, 2};
@@ -98,6 +126,11 @@ TEST(LayerNormTest, LayerNorm_Scale_Bias) {
   test.AddInput<float>("bias", {2}, {0.6435f, -0.3964f});
   test.AddOutput<float>("output", dims, {-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f});
   test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Bias) {
+  LayerNormScaleBiasCore(1);
+  LayerNormScaleBiasCore(16);
 }
 
 }  // namespace test


### PR DESCRIPTION
After https://github.com/onnx/onnx/pull/4076 is done, we can merge this PR to test the new proposed op.

Back to years ago, layer normalization is wrongly defined in `ai.onnx` domain since version 1 in ORT's codebase. However, such an operator doesn't exist in official ONNX and just recently a [PR ](https://github.com/onnx/onnx/pull/4076/)made a formal proposal for adding it. This PR is used to test that new ONNX PR.