### PR TITLE
Model tests refactor

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -81,16 +81,19 @@ TEST_P(ModelTest, Run) {
     // Besides saving CI build time, TRT isn’t able to support full ONNX ops spec and therefore some testcases will fail.
     // That's one of reasons we skip those testcases and only test latest ONNX opsets.
     SkipTest();
+    return;
   }
   if (model_info->GetONNXOpSetVersion() == 10 && provider_name == "dnnl") {
     // DNNL can run most of the model tests, but only part of
     // them is enabled here to save CI build time.
     SkipTest();
+    return;
   }
 #ifndef ENABLE_TRAINING
   if (model_info->HasDomain(ONNX_NAMESPACE::AI_ONNX_TRAINING_DOMAIN) ||
       model_info->HasDomain(ONNX_NAMESPACE::AI_ONNX_PREVIEW_TRAINING_DOMAIN)) {
     SkipTest();
+    return;
   }
 #endif
   // TODO: filter model based on opset
@@ -555,12 +558,14 @@ TEST_P(ModelTest, Run) {
         (model_version == TestModelInfo::unknown_version || iter->broken_versions_.empty() ||
          iter->broken_versions_.find(model_version) != iter->broken_versions_.end())) {
       SkipTest();
+      return;
     }
 
     for (auto iter2 = broken_tests_keyword_set.begin(); iter2 != broken_tests_keyword_set.end(); ++iter2) {
       std::string keyword = *iter2;
       if (ToUTF8String(test_case_name).find(keyword) != std::string::npos) {
         SkipTest();
+        return;
       }
     }
   }

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -27,9 +27,6 @@ extern std::unique_ptr<Ort::Env> ort_env;
 
 using namespace onnxruntime::common;
 
-#define LATEST_ONNX_OPSET 16
-#define LATEST_ONNX_OPSET_SUPPORTED_BY_TENSORRT 13
-
 namespace onnxruntime {
 namespace test {
 // parameter is provider_name + "_" + model_path
@@ -75,7 +72,7 @@ TEST_P(ModelTest, Run) {
   }
 
   std::unique_ptr<OnnxModelInfo> model_info = std::make_unique<OnnxModelInfo>(model_path.c_str());
-  if (model_info->GetONNXOpSetVersion() != LATEST_ONNX_OPSET_SUPPORTED_BY_TENSORRT && model_info->GetONNXOpSetVersion() != (LATEST_ONNX_OPSET_SUPPORTED_BY_TENSORRT - 1) && provider_name == "tensorrt") {
+  if (model_info->GetONNXOpSetVersion() != 14 && model_info->GetONNXOpSetVersion() != 15 && provider_name == "tensorrt") {
     // TensorRT can run most of the model tests, but only part of
     // them is enabled here to save CI build time.
     // Besides saving CI build time, TRT isn’t able to support full ONNX ops spec and therefore some testcases will fail.

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -55,7 +55,9 @@ struct BrokenTest {
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ModelTest);
 #endif
 
-// 
+// Besides the disabled tests we already set,
+// there are some situations where we want to skip the test, for example,
+// we only run latest onnx opset models to save CI time or we know some specific opsets will fail for some test cases.
 bool CheckAndSkipTest(std::basic_string<PATH_CHAR_TYPE> model_path, std::basic_string<PATH_CHAR_TYPE> ep) {
   std::unique_ptr<OnnxModelInfo> model_info = std::make_unique<OnnxModelInfo>(model_path.c_str());
   std::string provider_name = ToUTF8String(ep);


### PR DESCRIPTION
Current model tests will list all the unit tests on the CI log.
In fact, some of the unit tests can be configured to be skipped and will not be run. Even though being skipped, these unit tests can still be listed on the CI log which confuses people.
This PR changes the behavior to show only tests which are actually being run.

Also, create a new macro, LATEST_ONNX_OPSET to define the latest opset.