### PR TITLE
Fix Build Error for BFloat16 Comparison on Device

### DIFF
--- a/include/onnxruntime/core/framework/float16.h
+++ b/include/onnxruntime/core/framework/float16.h
@@ -113,9 +113,9 @@ struct BFloat16 {
 #endif
 };
 
-inline bool operator==(const BFloat16& left, const BFloat16& right) { return left.val == right.val; }
-inline bool operator!=(const BFloat16& left, const BFloat16& right) { return left.val != right.val; }
-inline bool operator<(const BFloat16& left, const BFloat16& right) { return left.val < right.val; }
+inline ORT_HOST_DEVICE bool operator==(const BFloat16& left, const BFloat16& right) { return left.val == right.val; }
+inline ORT_HOST_DEVICE bool operator!=(const BFloat16& left, const BFloat16& right) { return left.val != right.val; }
+inline ORT_HOST_DEVICE bool operator<(const BFloat16& left, const BFloat16& right) { return left.val < right.val; }
 
 
 // User defined suffixes to make it easier to declare


### PR DESCRIPTION
Fix below DEBUG build error.  Previously we didn't have operator==, the comparison is on float. Now we added the operator overloads, but only for host. We need to add device support for BFloat16, as we use BFloat16 type for calculation on device, unlike MLFloat16 which is for host only and use half on device.

```
/onnxruntime/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu(158): error: calling a __host__ function("onnxruntime::operator ==(const ::onnxruntime::BFloat16 &, const ::onnxruntime::BFloat16 &)") from a __global__ function("onnxruntime::cuda::_WeightedReductionNoneSoftmaxCrossEntropyLossGrad< ::onnxruntime::BFloat16, float, long> ") is not allowed

/onnxruntime/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cu(158): error: identifier "onnxruntime::operator ==" is undefined in device code
```