### PR TITLE
[trt-perf-test] Fix bug that suppresses latency gain reporting

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -1231,18 +1231,18 @@ def calculate_gain(value, ep1, ep2):
 
 def add_improvement_information(model_to_latency):
     for key, value in model_to_latency.items():
-        if "ORT-TRT" in value and "ORT-CUDA" in value:
+        if trt in value and cuda in value:
             gain = calculate_gain(value, trt, cuda)
             value[trt_cuda_gain] = "{:.2f} %".format(gain)
-            if trt_fp16 in value and cuda_fp16 in value:
-                gain = calculate_gain(value, trt_fp16, cuda_fp16)
-                value[trt_cuda_fp16_gain] = "{:.2f} %".format(gain)
-        if "ORT-TRT" in value and is_standalone(value):
+        if trt_fp16 in value and cuda_fp16 in value:
+            gain = calculate_gain(value, trt_fp16, cuda_fp16)
+            value[trt_cuda_fp16_gain] = "{:.2f} %".format(gain)
+        if trt in value and standalone_trt in value:
             gain = calculate_gain(value, trt, standalone_trt)
             value[trt_native_gain] = "{:.2f} %".format(gain)
-            if trt_fp16 in value and standalone_trt_fp16 in value:
-                gain = calculate_gain(value, trt_fp16, standalone_trt_fp16)
-                value[trt_native_fp16_gain] = "{:.2f} %".format(gain)
+        if trt_fp16 in value and standalone_trt_fp16 in value:
+            gain = calculate_gain(value, trt_fp16, standalone_trt_fp16)
+            value[trt_native_fp16_gain] = "{:.2f} %".format(gain)
 
 def output_details(results, csv_filename):
     need_write_header = True 


### PR DESCRIPTION
**Description**: This fixes a bug that prevents the benchmark script from reporting the latency gain for various EPs.

**Motivation and Context**
The README provides the following example output, which compares the latency gain for the pairs (ORT-TRT vs ORT-CUDA) and (ORT-TRT vs TRT) for both fp32 and fp16.

```python
{ 
    'ResNet101-DUC-7' : {
        ...
        'TRT_CUDA_fp16_gain(%)': '51.54 %',
        'TRT_CUDA_gain(%)': '14.07 %',
        'TRT_Standalone_fp16_gain(%)': '40.44 %',
        'TRT_Standalone_gain(%)': '4.35 %',
        ...
    }
}
```
Code that incorrectly checked for the existence of keys in a dictionary prevented the above information from being computed and reported.

