### PR TITLE
Consolidate TensorRT subgraphs to reduce inference overhead

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -845,7 +845,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
 }
 
 // Detect and remove cycles from supported node list
-bool TensorrtExecutionProvider::DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const {
+bool TensorrtExecutionProvider::DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool detect_only) const {
   const std::vector<NodeIndex>& node_index = graph.GetNodesInTopologicalOrder();
   bool trt_cycle = true, cycle_detected = false;
   while (trt_cycle) {
@@ -937,7 +937,7 @@ bool TensorrtExecutionProvider::DetectRemoveTensorRTGraphCycles(SubGraphCollecti
     }
 
     // Remove TensorRT subgraph from the supported node list if it's part of the cycle
-    if (has_cycle) {
+    if (has_cycle && !detect_only) {
       for (size_t i = 0; i < cycles.size(); ++i) {
         auto loc = index_to_node_map.find(cycles[i]);
         if (loc != index_to_node_map.end() && loc->second.find("TRTKernel") != std::string::npos) {
@@ -996,7 +996,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
     }
   }  
   SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
-  if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph)) {
+  if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph, true)) {
     LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are not consolidated because graph will have cycles after consolidation";
   } else {
     LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are consolidated into one subgraph";

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -845,7 +845,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
 }
 
 // Detect and remove cycles from supported node list
-bool TensorrtExecutionProvider::DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool detect_only) const {
+bool TensorrtExecutionProvider::DetectTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool remove_cycles) const {
   const std::vector<NodeIndex>& node_index = graph.GetNodesInTopologicalOrder();
   bool trt_cycle = true, cycle_detected = false;
   while (trt_cycle) {
@@ -937,7 +937,7 @@ bool TensorrtExecutionProvider::DetectRemoveTensorRTGraphCycles(SubGraphCollecti
     }
 
     // Remove TensorRT subgraph from the supported node list if it's part of the cycle
-    if (has_cycle && !detect_only) {
+    if (has_cycle && remove_cycles) {
       for (size_t i = 0; i < cycles.size(); ++i) {
         auto loc = index_to_node_map.find(cycles[i]);
         if (loc != index_to_node_map.end() && loc->second.find("TRTKernel") != std::string::npos) {
@@ -986,7 +986,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   }
 
   // Detect and remove cycles from supported node list
-  DetectRemoveTensorRTGraphCycles(supported_nodes_vector, graph);
+  DetectTensorRTGraphCycles(supported_nodes_vector, graph);
 
   // Consolidate supported node list
   if (supported_nodes_vector.size() > 1) {
@@ -997,7 +997,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
         }
       } 
       SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
-      if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph, true)) {
+      if (DetectTensorRTGraphCycles(consolidated_supported_nodes_vector, graph, false)) {
         LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are not consolidated because graph will have cycles after consolidation";
       } else {
         LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are consolidated into one subgraph";

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -989,18 +989,20 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   DetectRemoveTensorRTGraphCycles(supported_nodes_vector, graph);
 
   // Consolidate supported node list
-  nodes_vector.clear();
-  for (const auto& group : supported_nodes_vector) {
-    if (!group.first.empty()) {
-      nodes_vector.insert(nodes_vector.end(), group.first.begin(), group.first.end());
-    }
-  }  
-  SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
-  if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph, true)) {
-    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are not consolidated because graph will have cycles after consolidation";
-  } else {
-    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are consolidated into one subgraph";
-    supported_nodes_vector = consolidated_supported_nodes_vector;
+  if (supported_nodes_vector.size() > 1) {
+      nodes_vector.clear();
+      for (const auto& group : supported_nodes_vector) {
+        if (!group.first.empty()) {
+          nodes_vector.insert(nodes_vector.end(), group.first.begin(), group.first.end());
+        }
+      } 
+      SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
+      if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph, true)) {
+        LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are not consolidated because graph will have cycles after consolidation";
+      } else {
+        LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are consolidated into one subgraph";
+        supported_nodes_vector = consolidated_supported_nodes_vector;
+      }
   }
 
   // Construct subgraph capability from node list

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -988,7 +988,7 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   // Detect and remove cycles from supported node list
   DetectRemoveTensorRTGraphCycles(supported_nodes_vector, graph);
 
-  // Try to consolidate the supported node list
+  // Consolidate supported node list
   nodes_vector.clear();
   for (const auto& group : supported_nodes_vector) {
     if (!group.first.empty()) {
@@ -997,8 +997,9 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   }  
   SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
   if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph)) {
-    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT node list is not consolidated because the graph will have cycles after consolidation";
+    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes is not consolidated because graph will have cycles after consolidation";
   } else {
+    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes is consolidated into one subgraph";
     supported_nodes_vector = consolidated_supported_nodes_vector;
   }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -997,9 +997,9 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
   }  
   SubGraphCollection_t consolidated_supported_nodes_vector = {{nodes_vector, true}};
   if (DetectRemoveTensorRTGraphCycles(consolidated_supported_nodes_vector, graph)) {
-    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes is not consolidated because graph will have cycles after consolidation";
+    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are not consolidated because graph will have cycles after consolidation";
   } else {
-    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes is consolidated into one subgraph";
+    LOGS_DEFAULT(INFO) << "[TensorRT EP] TensorRT nodes are consolidated into one subgraph";
     supported_nodes_vector = consolidated_supported_nodes_vector;
   }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -191,7 +191,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   SubGraphCollection_t GetSupportedList(SubGraphCollection_t supported_nodes_list, int iterations, const int max_iterations,
                                         const GraphViewer& graph, bool* early_termination) const;
 
-  bool DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool detect_only = false) const;
+  bool DetectTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool remove_cycles = true) const;
 
   /** 
   Get a unique_lock object to control the concurrency behavior. 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -191,7 +191,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   SubGraphCollection_t GetSupportedList(SubGraphCollection_t supported_nodes_list, int iterations, const int max_iterations,
                                         const GraphViewer& graph, bool* early_termination) const;
 
-  void RemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const;
+  bool DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const;
 
   /** 
   Get a unique_lock object to control the concurrency behavior. 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -191,7 +191,7 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   SubGraphCollection_t GetSupportedList(SubGraphCollection_t supported_nodes_list, int iterations, const int max_iterations,
                                         const GraphViewer& graph, bool* early_termination) const;
 
-  bool DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph) const;
+  bool DetectRemoveTensorRTGraphCycles(SubGraphCollection_t& supported_nodes_vector, const GraphViewer& graph, bool detect_only = false) const;
 
   /** 
   Get a unique_lock object to control the concurrency behavior. 


### PR DESCRIPTION
Consolidate TensorRT subgraphs to reduce inference overhead. Consolidation will be done only when there is no cycles in the new graph.
