### PR TITLE
Update QDQFinalCleanup transformer to also handle removing DQ/Q node pairs.

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
@@ -10,6 +10,123 @@
 #include "core/optimizer/utils.h"
 
 namespace onnxruntime {
+namespace {
+// type of node sequence to clean up
+enum class NodeSequence {
+  Q_DQ,
+  DQ_Q,
+};
+
+bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeIndex first_node_idx,
+                         const logging::Logger& logger) {
+  Node* first_node_ptr = graph.GetNode(first_node_idx);
+  if (!first_node_ptr) {
+    return false;
+  }
+  Node& first_node = *first_node_ptr;
+
+  const auto match_first = node_sequence_type == NodeSequence::Q_DQ ? &QDQ::MatchQNode : &QDQ::MatchDQNode;
+  const auto match_second = node_sequence_type == NodeSequence::Q_DQ ? &QDQ::MatchDQNode : &QDQ::MatchQNode;
+
+  if (!match_first(first_node) ||
+      // not filtering on provider currently
+      // !graph_utils::IsSupportedProvider(first_node, compatible_execution_providers) ||
+      !optimizer_utils::CheckOutputEdges(graph, first_node, 1)) {
+    return false;
+  }
+
+  Node& second_node = *graph.GetNode(first_node.OutputNodesBegin()->Index());
+  if (!match_second(second_node)
+      // not filtering on provider currently
+      // || !graph_utils::IsSupportedProvider(second_node, compatible_execution_providers)
+  ) {
+    return false;
+  }
+
+  if (node_sequence_type == NodeSequence::DQ_Q) {
+    // for DQ -> Q, check for constant, matching scale/ZP values
+    const auto get_constant_initializer = [&graph](const std::string& initializer_name) {
+      return graph.GetConstantInitializer(initializer_name, true);
+    };
+
+    if (!QDQ::IsQDQPairSupported(second_node, first_node, get_constant_initializer, graph.ModelPath())) {
+      return false;
+    }
+  }
+
+  // we have a node sequence to clean up
+  LOGS(logger, VERBOSE) << "Cleaning up back-to-back nodes: "
+                        << first_node.OpType() << " with name \"" << first_node.Name() << "\" and "
+                        << second_node.OpType() << " with name \"" << second_node.Name() << "\"";
+
+  // we support a second_node that produces a graph output if it has no output edges, or a second_node with one output edge.
+  bool is_graph_output = graph.NodeProducesGraphOutput(second_node);
+  auto edges_count = second_node.GetOutputEdgesCount();
+
+  if ((is_graph_output && edges_count != 0) ||
+      (!is_graph_output && edges_count != 1)) {
+    return false;
+  }
+
+  // src node or graph input/initializer -> first_node -> second_node -> downstream node or graph output
+  NodeIndex src_node_idx = 0;
+  int src_arg_idx = -1;
+  NodeIndex downstream_node_idx = 0;
+  int downstream_arg_idx = -1;
+
+  // input could be node or initializer/graph input so need to handle both.
+  // if it's a node we need to replace the edge, so need info on which output idx it was attached to on the src node.
+  const Node::EdgeEnd* input_edge = nullptr;
+  if (first_node.GetInputEdgesCount() == 1) {
+    input_edge = &*first_node.InputEdgesBegin();
+    src_node_idx = input_edge->GetNode().Index();
+    src_arg_idx = input_edge->GetSrcArgIndex();
+    // remove edge from src to first_node. dest arg idx is 0 as first_node (Q or DQ) only has one input
+    graph.RemoveEdge(src_node_idx, first_node.Index(), src_arg_idx, 0);
+  }
+
+  // remove edge between pair we're removing
+  // both DQ and Q are single input single output so src idx and dest idx must be 0
+  graph.RemoveEdge(first_node.Index(), second_node.Index(), 0, 0);
+
+  if (!is_graph_output) {
+    // remove edge to downstream node
+    const Node::EdgeEnd& output_edge = *second_node.OutputEdgesBegin();
+    downstream_node_idx = output_edge.GetNode().Index();
+    downstream_arg_idx = output_edge.GetDstArgIndex();
+
+    // source arg idx is 0 as Q/DQ only has one output
+    graph.RemoveEdge(second_node.Index(), downstream_node_idx, 0, downstream_arg_idx);
+
+    // replace input on downstream node
+    Node& downstream_node = *graph.GetNode(downstream_node_idx);
+    downstream_node.MutableInputDefs()[downstream_arg_idx] = first_node.MutableInputDefs()[0];
+
+    // create edge between src_node (if available) and downstream node
+    if (input_edge) {
+      graph.AddEdge(src_node_idx, downstream_node_idx, src_arg_idx, downstream_arg_idx);
+    }
+  } else {
+    NodeArg* graph_output_nodearg = second_node.MutableOutputDefs()[0];
+    if (src_arg_idx >= 0) {
+      // update the src node to produce the graph output that was being provided by second_node
+      Node& src_node = *graph.GetNode(src_node_idx);
+      src_node.MutableOutputDefs()[src_arg_idx] = graph_output_nodearg;
+    } else {
+      // add Identity node to connect the graph input or initializer to the graph output.
+      Node& id_node = graph.AddNode(graph.GenerateNodeName("QDQFinalCleanupTransformer"),
+                                    "Identity", "", {first_node.MutableInputDefs()[0]}, {graph_output_nodearg});
+      id_node.SetExecutionProviderType(second_node.GetExecutionProviderType());
+    }
+  }
+
+  graph.RemoveNode(first_node.Index());
+  graph.RemoveNode(second_node.Index());
+
+  return true;
+}
+}  // namespace
+
 Status QDQFinalCleanupTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
                                              const logging::Logger& logger) const {
   GraphViewer graph_viewer(graph);
@@ -20,91 +137,18 @@ Status QDQFinalCleanupTransformer::ApplyImpl(Graph& graph, bool& modified, int g
     if (node_ptr == nullptr)
       continue;  // node was removed as part of an earlier optimization
 
-    Node& q_node = *node_ptr;
-    ORT_RETURN_IF_ERROR(Recurse(q_node, modified, graph_level, logger));
+    Node& node = *node_ptr;
+    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
 
-    if (!QDQ::MatchQNode(q_node) ||
-        // not filtering on provider currently
-        // !graph_utils::IsSupportedProvider(q_node, GetCompatibleExecutionProviders()) ||
-        !optimizer_utils::CheckOutputEdges(graph, q_node, 1)) {
-      continue;
+    if (CleanUpNodeSequence(NodeSequence::DQ_Q, graph, node_index, logger)) {
+      modified = true;
     }
 
-    Node& dq_node = *graph.GetNode(q_node.OutputNodesBegin()->Index());
-    if (!QDQ::MatchDQNode(dq_node) 
-        // not filtering on provider currently
-        // || !graph_utils::IsSupportedProvider(dq_node, GetCompatibleExecutionProviders())
-        ) {
-      continue;
-    }
-
-    // we have Q -> DQ pair
-
-    // we support a DQ that produces a graph output if it has no output edges, or a DQ node with one output edge.
-    bool is_graph_output = graph.NodeProducesGraphOutput(dq_node);
-    auto edges_count = dq_node.GetOutputEdgesCount();
-
-    if ((is_graph_output && edges_count != 0) ||
-        (!is_graph_output && edges_count != 1)) {
-      continue;
-    }
-
-    // src node -> Q -> DQ -> downstream node or graph output
-    NodeIndex src_node_idx = 0;
-    int src_arg_idx = -1;
-    NodeIndex downstream_node_idx = 0;
-    int downstream_arg_idx = -1;
-
-    // input could be node or initializer/graph input so need to handle both.
-    // if it's a node we need to replace the edge, so need info on which output idx it was attached to on the src node.
-    const Node::EdgeEnd* input_edge = nullptr;
-    if (q_node.GetInputEdgesCount() == 1) {
-      input_edge = &*q_node.InputEdgesBegin();
-      src_node_idx = input_edge->GetNode().Index();
-      src_arg_idx = input_edge->GetSrcArgIndex();
-      // remove edge from src to Q. dest arg idx is 0 as Q only has one input
-      graph.RemoveEdge(src_node_idx, q_node.Index(), src_arg_idx, 0);
-    }
-
-    // remove edge between pair we're removing
-    // both DQ and Q are single input single output so src idx and dest idx must be 0
-    graph.RemoveEdge(q_node.Index(), dq_node.Index(), 0, 0);
-
-    if (!is_graph_output) {
-      // remove edge to downstream node
-      const Node::EdgeEnd& output_edge = *dq_node.OutputEdgesBegin();
-      downstream_node_idx = output_edge.GetNode().Index();
-      downstream_arg_idx = output_edge.GetDstArgIndex();
-
-      // source arg idx is 0 as Q/DQ only has one output
-      graph.RemoveEdge(dq_node.Index(), downstream_node_idx, 0, downstream_arg_idx);
-
-      // replace input on downstream node
-      Node& downstream_node = *graph.GetNode(downstream_node_idx);
-      downstream_node.MutableInputDefs()[downstream_arg_idx] = q_node.MutableInputDefs()[0];
-
-      // create edge between src_node (if available) and downstream node
-      if (input_edge) {
-        graph.AddEdge(src_node_idx, downstream_node_idx, src_arg_idx, downstream_arg_idx);
-      }
-    } else {
-      NodeArg* graph_output_nodearg = dq_node.MutableOutputDefs()[0];
-      if (src_arg_idx >= 0) {
-        // update the src node to produce the graph output that was being provided by the DQ node
-        Node& src_node = *graph.GetNode(src_node_idx);
-        src_node.MutableOutputDefs()[src_arg_idx] = graph_output_nodearg;
-      } else {
-        // add Identity node to connect the graph input or initializer to the graph output.
-        Node& id_node = graph.AddNode(graph.GenerateNodeName("QDQFinalCleanupTransformer"),
-                                      "Identity", "", {q_node.MutableInputDefs()[0]}, {graph_output_nodearg});
-        id_node.SetExecutionProviderType(dq_node.GetExecutionProviderType());
+    if (enable_q_dq_cleanup_) {
+      if (CleanUpNodeSequence(NodeSequence::Q_DQ, graph, node_index, logger)) {
+        modified = true;
       }
     }
-
-    graph.RemoveNode(q_node.Index());
-    graph.RemoveNode(dq_node.Index());
-
-    modified = true;
   }
 
   return Status::OK();

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.cc
@@ -54,30 +54,32 @@ bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeInde
     }
   }
 
-  // src node or graph input/initializer -> first_node -> second_node -> downstream node(s) or graph output
+  // we have a node sequence to clean up
 
-  // we support these cases
-  // - second_node produces a graph output and has no output edges
-  // - second_node does not produce a graph output
+  // we support a second_node that produces a graph output if it has no output edges, or a second_node with one output edge.
   const bool produces_graph_output = graph.NodeProducesGraphOutput(second_node);
-  const bool has_output_edges = second_node.GetOutputEdgesCount() > 0;
-  if (produces_graph_output && has_output_edges) {
+  const auto output_edges_count = second_node.GetOutputEdgesCount();
+
+  if ((produces_graph_output && output_edges_count != 0) ||
+      (!produces_graph_output && output_edges_count != 1)) {
     return false;
   }
 
-  // we have a node sequence to clean up
   LOGS(logger, VERBOSE) << "Cleaning up back-to-back nodes: "
                         << first_node.OpType() << " with name \"" << first_node.Name() << "\" and "
                         << second_node.OpType() << " with name \"" << second_node.Name() << "\"";
 
-  const bool has_src_node = first_node.GetInputEdgesCount() == 1;
+  // src node or graph input/initializer -> first_node -> second_node -> downstream node or graph output
   NodeIndex src_node_idx = 0;
   int src_arg_idx = -1;
+  NodeIndex downstream_node_idx = 0;
+  int downstream_arg_idx = -1;
 
   // input could be node or initializer/graph input so need to handle both.
   // if it's a node we need to replace the edge, so need info on which output idx it was attached to on the src node.
-  if (has_src_node) {
-    const Node::EdgeEnd* input_edge = &*first_node.InputEdgesBegin();
+  const Node::EdgeEnd* input_edge = nullptr;
+  if (first_node.GetInputEdgesCount() == 1) {
+    input_edge = &*first_node.InputEdgesBegin();
     src_node_idx = input_edge->GetNode().Index();
     src_arg_idx = input_edge->GetSrcArgIndex();
     // remove edge from src to first_node. dest arg idx is 0 as first_node (Q or DQ) only has one input
@@ -89,31 +91,25 @@ bool CleanUpNodeSequence(NodeSequence node_sequence_type, Graph& graph, NodeInde
   graph.RemoveEdge(first_node.Index(), second_node.Index(), 0, 0);
 
   if (!produces_graph_output) {
-    if (has_output_edges) {
-      // make a copy of second_node's output EdgeEnds since we will remove them from second_node as we go
-      const auto copied_output_edges = InlinedVector<Node::EdgeEnd>(second_node.OutputEdgesBegin(),
-                                                                    second_node.OutputEdgesEnd());
-      for (const auto& output_edge : copied_output_edges) {
-        // remove edge to downstream node
-        const auto downstream_node_idx = output_edge.GetNode().Index();
-        const auto downstream_arg_idx = output_edge.GetDstArgIndex();
+    // remove edge to downstream node
+    const Node::EdgeEnd& output_edge = *second_node.OutputEdgesBegin();
+    downstream_node_idx = output_edge.GetNode().Index();
+    downstream_arg_idx = output_edge.GetDstArgIndex();
 
-        // source arg idx is 0 as Q/DQ only has one output
-        graph.RemoveEdge(second_node.Index(), downstream_node_idx, 0, downstream_arg_idx);
+    // source arg idx is 0 as Q/DQ only has one output
+    graph.RemoveEdge(second_node.Index(), downstream_node_idx, 0, downstream_arg_idx);
 
-        // replace input on downstream node
-        Node& downstream_node = *graph.GetNode(downstream_node_idx);
-        downstream_node.MutableInputDefs()[downstream_arg_idx] = first_node.MutableInputDefs()[0];
+    // replace input on downstream node
+    Node& downstream_node = *graph.GetNode(downstream_node_idx);
+    downstream_node.MutableInputDefs()[downstream_arg_idx] = first_node.MutableInputDefs()[0];
 
-        // create edge between src_node (if available) and downstream node
-        if (has_src_node) {
-          graph.AddEdge(src_node_idx, downstream_node_idx, src_arg_idx, downstream_arg_idx);
-        }
-      }
+    // create edge between src_node (if available) and downstream node
+    if (input_edge) {
+      graph.AddEdge(src_node_idx, downstream_node_idx, src_arg_idx, downstream_arg_idx);
     }
   } else {
     NodeArg* graph_output_nodearg = second_node.MutableOutputDefs()[0];
-    if (has_src_node) {
+    if (src_arg_idx >= 0) {
       // update the src node to produce the graph output that was being provided by second_node
       Node& src_node = *graph.GetNode(src_node_idx);
       src_node.MutableOutputDefs()[src_arg_idx] = graph_output_nodearg;

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_final_cleanup.h
@@ -11,10 +11,15 @@ namespace onnxruntime {
 /**
     @Class QDQFinalCleanupTransformer
 
-    Remove any remaining back-to-back QuantizeLinear and DequantizeLinear pairs.
+    Remove any remaining back-to-back QuantizeLinear (Q) and DequantizeLinear (DQ) pairs.
+    This is the final Q/DQ cleanup. It should run AFTER other optimizers which rely on Q/DQ nodes, e.g., for fusion.
+    There are two cases:
 
-    This is the final cleanup where no quantized operator was available and we're going to run the operators
-    using fp32.
+    1. DQ -> Q
+    When the DQ and Q have the same scale and zero-point, they are always unnecessary and can be removed.
+
+    2. Q -> DQ
+    In this case, no quantized operator was available and we're going to run the operators using fp32.
 
     e.g. if we have Op -> Q -> DQ -> Op2 and no more QDQ processing to run, the Q -> DQ can potentially be removed.
 
@@ -26,16 +31,20 @@ namespace onnxruntime {
     If the model was quantized with Post Training Quantization (PTQ) it is most likely better to remove the pair as the
     loss of precision from the round trip of float -> 8-bit -> float was not present when the model was trained.
 
-    As we have no knowledge of how the model was quantized we require the user to specify an option to enable this
-    transformer.
+    As we have no knowledge of how the model was quantized we require the user to specify an option to enable cleanup
+    of this case.
     */
 class QDQFinalCleanupTransformer : public GraphTransformer {
  public:
-  QDQFinalCleanupTransformer(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
-      : GraphTransformer("QDQFinalCleanupTransformer", compatible_execution_providers) {}
+  QDQFinalCleanupTransformer(bool enable_q_dq_cleanup) noexcept
+      : GraphTransformer("QDQFinalCleanupTransformer", {}),
+        enable_q_dq_cleanup_{enable_q_dq_cleanup} {
+  }
 
  private:
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+
+  const bool enable_q_dq_cleanup_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.cc
@@ -25,7 +25,7 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
                        double per_sample_tolerance,
                        double relative_per_sample_tolerance,
                        std::unique_ptr<GraphTransformer> transformer,
-                       const std::function<void(SessionOptions&)>* add_session_options) {
+                       const std::function<void(SessionOptions&)>& add_session_options) {
   // Build the model for this test.
   std::unordered_map<std::string, int> domain_to_version;
   domain_to_version[kOnnxDomain] = opset_version;
@@ -34,6 +34,7 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
               domain_to_version, {}, DefaultLoggingManager().DefaultLogger());
   Graph& graph = model.MainGraph();
   ModelTestBuilder helper(graph);
+  ASSERT_TRUE(build_test_case);
   build_test_case(helper);
   helper.SetGraphOutputs();
   ASSERT_STATUS_OK(model.MainGraph().Resolve());
@@ -51,7 +52,7 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
         ToPathString("model" + std::to_string(static_cast<int>(level)) + ".onnx");
 #endif
     if (add_session_options) {
-      (*add_session_options)(session_options);
+      add_session_options(session_options);
     }
     InferenceSessionWrapper session{session_options, GetEnvironment()};
     ASSERT_STATUS_OK(session.Load(model_data.data(), static_cast<int>(model_data.size())));
@@ -68,6 +69,7 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
                                  &fetches));
 
     if (level == target_level) {
+      ASSERT_TRUE(check_transformed_graph);
       check_transformed_graph(session);
     }
   };

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.h
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.h
@@ -282,7 +282,7 @@ void TransformerTester(const std::function<void(ModelTestBuilder& helper)>& buil
                        double per_sample_tolerance = 0.0,
                        double relative_per_sample_tolerance = 0.0,
                        std::unique_ptr<GraphTransformer> transformer = nullptr,
-                       const std::function<void(SessionOptions&)>* add_session_options = nullptr);
+                       const std::function<void(SessionOptions&)>& add_session_options = {});
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -2270,25 +2270,30 @@ TEST(QDQTransformerTests, QDQ_Selector_Test) {
 TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicQDQCleanup) {
   auto test_case = [&](const std::vector<std::vector<int64_t>>& input_shapes,
                        bool block_removal_of_last_dq = false,
-                       bool block_removal_of_first_dq = false) {
+                       bool block_removal_of_first_q = false) {
     // create model with float input to multiple -> Q -> DQ -> Concat -> Q -> DQ -> output
     // If we enable cleanup and don't run the QDQ transformer we should drop all the Q->DQ pairs
     auto build_test_case = [&](ModelTestBuilder& builder) {
       auto input_count = input_shapes.size();
       std::vector<NodeArg*> input_args;
-      std::vector<NodeArg*> q_input_args;
+      std::vector<NodeArg*> concat_input_args;
       for (size_t i = 0; i < input_count; i++) {
         input_args.push_back(builder.MakeInput<float>(input_shapes[i], -1.f, 1.f));
-        q_input_args.push_back(AddQDQNodePair<uint8_t>(builder, input_args.back(), 0.05f, 128));
 
-        if (i == 0 && block_removal_of_first_dq) {
-          // add another edge to the DQ node
+        auto* q_output = builder.MakeIntermediate();
+        builder.AddQuantizeLinearNode<uint8_t>(input_args.back(), 0.05f, 128, q_output);
+        auto* dq_output = builder.MakeIntermediate();
+        builder.AddDequantizeLinearNode<uint8_t>(q_output, 0.05f, 128, dq_output);
+        concat_input_args.push_back(dq_output);
+
+        if (i == 0 && block_removal_of_first_q) {
+          // add another edge to the Q node
           auto* output = builder.MakeOutput();
-          builder.AddNode("Identity", {q_input_args.back()}, {output});
+          builder.AddNode("Identity", {q_output}, {output});
         }
       }
       auto* concat_output = builder.MakeIntermediate();
-      Node& concat_node = builder.AddNode("Concat", q_input_args, {concat_output});
+      Node& concat_node = builder.AddNode("Concat", concat_input_args, {concat_output});
       concat_node.AddAttribute("axis", int64_t(1));
 
       auto* q_concat_output = builder.MakeIntermediate();
@@ -2304,8 +2309,8 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicQDQCleanup) {
       }
     };
 
-    // if we block removal of the DQ node the Q node in the pair will not be removed either
-    int expected_qdq_count = 0 + (block_removal_of_first_dq ? 1 : 0) + (block_removal_of_last_dq ? 1 : 0);
+    // if we block removal of the Q or DQ node the other node in the pair will not be removed either
+    int expected_qdq_count = 0 + (block_removal_of_first_q ? 1 : 0) + (block_removal_of_last_dq ? 1 : 0);
 
     auto check_graph = [expected_qdq_count](InferenceSessionWrapper& session) {
       auto op_to_count = CountOpsInGraph(session.GetGraph());
@@ -2332,9 +2337,9 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicQDQCleanup) {
   };
 
   test_case({{1, 2, 4}, {1, 3, 4}});
-  test_case({{1, 2, 4}, {1, 3, 4}}, true);         // block removal of first dq
+  test_case({{1, 2, 4}, {1, 3, 4}}, true);         // block removal of first q
   test_case({{1, 2, 4}, {1, 3, 4}}, false, true);  // block removal of last dq
-  test_case({{1, 2, 4}, {1, 3, 4}}, true, true);   // block removal of first and last dq
+  test_case({{1, 2, 4}, {1, 3, 4}}, true, true);   // block removal of first q and last dq
 }
 
 TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicDQQCleanUp) {
@@ -2438,6 +2443,44 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_GraphInputToOutput) {
 
   test_case(true);
   test_case(false);
+}
+
+TEST(QDQTransformerTests, QDQFinalCleanupTransformer_MultipleOutputEdges) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    const float scale = 0.05f;
+    const int8_t zp = 1;
+
+    auto* input = builder.MakeInput<int8_t>({1, 2, 4},
+                                            std::numeric_limits<int8_t>::min(),
+                                            std::numeric_limits<int8_t>::max());
+
+    auto* dq_out = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<int8_t>(input, scale, zp, dq_out);
+
+    auto* q_out = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<int8_t>(dq_out, scale, zp, q_out);
+
+    auto* neg_output = builder.MakeOutput();
+    builder.AddNode("Neg", {q_out}, {neg_output});
+
+    auto* abs_out = builder.MakeOutput();
+    builder.AddNode("Abs", {q_out}, {abs_out});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    const auto expected_op_to_count = OpCountMap{{"Abs", 1}, {"Neg", 1}};
+    EXPECT_EQ(op_to_count, expected_op_to_count);
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    12 /*opset_version*/,
+                    0.0f /*per_sample_tolerance*/,
+                    0.0f /*relative_per_sample_tolerance*/,
+                    std::make_unique<QDQFinalCleanupTransformer>(false /*enable_q_dq_cleanup*/));
 }
 
 }  // namespace test


### PR DESCRIPTION
**Description**
Update QDQFinalCleanup transformer to also handle removing DQ/Q node pairs.
` -> DQ -> Q -> ` where DQ and Q have the same scale and zero point is not necessary.

**Motivation and Context**
Clean up DQ/Q pairs that may arise from other graph transformations such as Transpose propagation.