### PR TITLE
One dnn v2.6 update

### DIFF
--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn.git)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.4.4)
+set(DNNL_TAG v2.6)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -489,10 +489,7 @@ bool DnnlSumNodeCapability::IsDimensionSupported(const Node* node) const {
 bool DnnlBinaryNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
-  //gpu broadcast for source 0 not supported
-  if (dnnl_engine_get_count(dnnl_engine_kind_t::dnnl_gpu)) {
-    return false;
-  }
+
   return true;
 }
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_binary.cc
@@ -24,8 +24,10 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   }
 
   // GetMemory in OrtFormat. Broadcasting and mix format binary ops can result in computation failure
-  auto src_0_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_A), eng).get_desc();
-  auto src_1_ori_md = sp.GetMemoryInOrtFormat(node.Input(IN_B), eng).get_desc();
+  auto binary_src0_mem = sp.GetMemoryInOrtFormat(node.Input(IN_A), eng);
+  auto binary_src1_mem = sp.GetMemoryInOrtFormat(node.Input(IN_B), eng);
+  auto src_0_ori_md = binary_src0_mem.get_desc();
+  auto src_1_ori_md = binary_src1_mem.get_desc();
 
   auto src_0_dims = src_0_ori_md.dims();
   auto src_1_dims = src_1_ori_md.dims();
@@ -52,11 +54,6 @@ void DnnlBinary::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
 
   auto binary_d = dnnl::binary::desc(algo, src_0_md, src_1_md, dst_md);
   auto binary_pd = dnnl::binary::primitive_desc(binary_d, eng);
-
-  auto binary_src0_mem = sp.GetMemoryAndReshape(node.Input(IN_A), binary_pd.src0_desc(), eng);
-  auto binary_src1_mem = sp.GetMemoryAndReshape(node.Input(IN_B), binary_pd.src1_desc(), eng);
-
-
 
   auto binary_dst_mem = dnnl::memory(binary_pd.dst_desc(), eng);
   auto binary_prim = dnnl::binary(binary_pd);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_layernorm.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_layernorm.cc
@@ -108,7 +108,7 @@ void DnnlLayerNorm::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   // X = LayerNornm(X)
   // Check if we are training and need the extra outputs for backprop
   dnnl::prop_kind prop_kind;
-#if defined(ENABLE_TRAINING)
+#if 0 //defined(ENABLE_TRAINING)
   prop_kind = dnnl::prop_kind::forward_training;
 #else
   prop_kind = dnnl::prop_kind::forward_inference;
@@ -146,18 +146,20 @@ void DnnlLayerNorm::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   }
 
 // Check outputs used for training
-#if defined(ENABLE_TRAINING)
+#if 0 //defined(ENABLE_TRAINING)
   // If Mean exists
-  if (node.Output(OUT_MEAN).Exists()) {
-    auto mean_mem = dnnl::memory(lnorm_pd.mean_desc(), dnnl_engine);
-    lnorm_args.insert({DNNL_ARG_MEAN, mean_mem});
-    sp.SetMemory(node.Output(OUT_MEAN), mean_mem);
-  }
-  // If Variance exists
-  if (node.Output(OUT_INV_STD_VAR).Exists()) {
-    auto variance_mem = dnnl::memory(lnorm_pd.variance_desc(), dnnl_engine);
-    lnorm_args.insert({DNNL_ARG_VARIANCE, variance_mem});
-    sp.SetMemory(node.Output(OUT_INV_STD_VAR), variance_mem);
+  if (node.OutputCount() > 1) {
+    if (node.Output(OUT_MEAN).Exists()) {
+      auto mean_mem = dnnl::memory(lnorm_pd.mean_desc(), dnnl_engine);
+      lnorm_args.insert({DNNL_ARG_MEAN, mean_mem});
+      sp.SetMemory(node.Output(OUT_MEAN), mean_mem);
+    }
+    // If Variance exists
+    if (node.Output(OUT_INV_STD_VAR).Exists()) {
+      auto variance_mem = dnnl::memory(lnorm_pd.variance_desc(), dnnl_engine);
+      lnorm_args.insert({DNNL_ARG_VARIANCE, variance_mem});
+      sp.SetMemory(node.Output(OUT_INV_STD_VAR), variance_mem);
+    }
   }
 #endif  // ENABLE_TRAINING
 

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -2749,7 +2749,7 @@ TEST(ReductionOpTest, ReduceInfLogSum) {
                         {FLOAT_INF, FLOAT_INF,
                          -std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
                          std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()});
-  test.Run();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDnnlExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceInfLogSumExp) {


### PR DESCRIPTION
**Description**:
This updates the OneDNN library used by the DNNL ep from OneDNN v2.4.4 to OneDNN v2.6
This version of the library has several performance improvements to the existing operators.

In addition this commit updates MaxPool and MaxPoolGrad due to an issue that was discovered when updating the library version.

This commit has a fix for FusedMatMul op. This was another issue that was discovered when updating the library.

This commit disables the training specific code found in SkipLayerNormalization and LayerNormalization code. We don't currently support those ops for the backward pass and the training code would cause the operations to crash if it was built with training enabled.

Binary ops Add, Mul, Sub, and Div are now enabled for intel gpu. This is possible due to a fix in OneDNN v2.5 that fixed broadcasting for those operators on gpu.

Clean up made to the print memory debug code used by the dnnl execution provider

**Motivation and Context**
- Why is this change required? What problem does it solve?
- This change does 3 things
- 1. Improves performance
- 2. expands op support
- 3. fixes bugs in the dnnl ep's implementation of FuseMatMul, SkiplayerNorm, LayerNorm, and MaxPoolGrad

- If it fixes an open issue, please link to the issue here.
