### PR TITLE
[trt-perf-test] Pass TensorRT/CUDA EP options via dictionary argument

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/README.md
+++ b/onnxruntime/python/tools/tensorrt/perf/README.md
@@ -58,6 +58,8 @@ However, benchmark.py creates only one process to run all the model inferences o
 - **--track_memory**: Track memory usage of CUDA and TensorRT execution providers.
 - **--ep_list**: Optional argument. List of eps to run against, surround with quotes and separate with spaces.
 - **--trt_ep_options**: Optional argument. Comma-separated key/value pairs denoting TensorRT EP options. Ex: `--trt_ep_options trt_engine_cache_enable=True,trt_max_workspace_size=4294967296`. Refer to [TensorRT Execution Provider Options](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for a complete list of options.
+- **--cuda_ep_options**: Optional argument. Comma-separated key/value pairs denoting CUDA EP options. Ex: `--cuda_ep_options device_id=0,arena_extend_strategy=kNextPowerOfTwo`. Refer to [CUDA Execution Provider Options](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#configuration-options) for a complete list of options.
+
 
 ### Validation Configuration 
 - **--percent_mismatch**: The allowed percentage of values to be incorrect when comparing given outputs to ORT outputs. 

--- a/onnxruntime/python/tools/tensorrt/perf/README.md
+++ b/onnxruntime/python/tools/tensorrt/perf/README.md
@@ -56,7 +56,8 @@ However, benchmark.py creates only one process to run all the model inferences o
 - **--fp16**: (*default: True*) Enable TensorRT/CUDA FP16 and include the performance of this floating point optimization.
 - **--trtexec**: Path of standalone TensorRT executable, for example: trtexec.
 - **--track_memory**: Track memory usage of CUDA and TensorRT execution providers.
-- **--ep_list**: Optional argument. List of eps to run against, surround with quotes and separate with spaces. 
+- **--ep_list**: Optional argument. List of eps to run against, surround with quotes and separate with spaces.
+- **--trt_ep_options**: Optional argument. Comma-separated key/value pairs denoting TensorRT EP options. Ex: `--trt_ep_options trt_engine_cache_enable=True,trt_max_workspace_size=4294967296`. Refer to [TensorRT Execution Provider Options](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for a complete list of options.
 
 ### Validation Configuration 
 - **--percent_mismatch**: The allowed percentage of values to be incorrect when comparing given outputs to ORT outputs. 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -748,15 +748,16 @@ def get_cudnn_version(workspace):
     cudnn_version = major + '.' + minor + '.' + patch 
     return cudnn_version
 
-def get_system_info(workspace):
+def get_system_info(args):
     info = {}
     info["cuda"] = get_cuda_version()
-    info["trt"] = get_trt_version(workspace)
-    info["cudnn"] = get_cudnn_version(workspace)
+    info["trt"] = get_trt_version(args.workspace)
+    info["cudnn"] = get_cudnn_version(args.workspace)
     info["linux_distro"] = get_linux_distro()
     info["cpu_info"] = get_cpu_info()
     info["gpu_info"] = get_gpu_info()
     info["memory"] = get_memory_info()
+    info["ep_option_overrides"] = {trt_ep: args.trt_ep_options, cuda_ep: args.cuda_ep_options}
 
     return info
 
@@ -1389,11 +1390,13 @@ def output_specs(info, csv_filename):
     tensorrt_version = info['trt'] + ' , *All ORT-TRT and TRT are run in Mixed Precision mode (Fp16 and Fp32).'
     cuda_version = info['cuda']
     cudnn_version = info['cudnn']
+    ep_option_overrides = json.dumps(info['ep_option_overrides'])
 
-    table = pd.DataFrame({'.': [1, 2, 3, 4, 5],
-                        'Spec': ['CPU', 'GPU', 'TensorRT', 'CUDA', 'CuDNN'], 
-                        'Version': [cpu_version, gpu_version, tensorrt_version, cuda_version, cudnn_version]})
-    table.to_csv(csv_filename, index=False)   
+    table = pd.DataFrame({'.': [1, 2, 3, 4, 5, 6],
+                        'Spec': ['CPU', 'GPU', 'TensorRT', 'CUDA', 'CuDNN', 'EPOptionOverrides'],
+                        'Version': [cpu_version, gpu_version, tensorrt_version, cuda_version, cudnn_version,
+                                    ep_option_overrides]})
+    table.to_csv(csv_filename, index=False)
 
 def output_session_creation(results, csv_filename):
     need_write_header = True 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -1104,7 +1104,7 @@ def run_onnxruntime(args, models):
                         "fp16": fp16,
                         "io_binding": args.io_binding,
                         "graph_optimizations": args.graph_enablement,
-                        "enable_cache": eval_bool_str(args.trt_ep_options.get(enable_cache_key)),
+                        "enable_cache": args.trt_ep_options.get("trt_engine_cache_enable", "False"),
                         "model_name": name,
                         "inputs": len(sess.get_inputs()),
                         "batch_size": batch_size,
@@ -1714,8 +1714,8 @@ def parse_arguments():
     
     parser.add_argument("-e", "--ep_list", nargs="+", required=False, default=None, help="Specify ORT Execution Providers list.")
 
-    parser.add_argument("--trt_ep_options", required=False, default=default_trt_ep_options, action=ParseDictArgAction, metavar="Opt1=Val1,Opt2=Val2...",
-                        help="Specify options for the ORT TensorRT Execution Provider")
+    parser.add_argument("--trt_ep_options", required=False, default={"trt_engine_cache_enable": "True", "trt_max_workspace_size": "4294967296"},
+                        action=ParseDictArgAction, metavar="Opt1=Val1,Opt2=Val2...", help="Specify options for the ORT TensorRT Execution Provider")
     
     parser.add_argument("-z", "--track_memory", required=False, default=True, help="Track CUDA and TRT Memory Usage")
 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -1393,9 +1393,9 @@ def output_specs(info, csv_filename):
     ep_option_overrides = json.dumps(info['ep_option_overrides'])
 
     table = pd.DataFrame({'.': [1, 2, 3, 4, 5, 6],
-                        'Spec': ['CPU', 'GPU', 'TensorRT', 'CUDA', 'CuDNN', 'EPOptionOverrides'],
-                        'Version': [cpu_version, gpu_version, tensorrt_version, cuda_version, cudnn_version,
-                                    ep_option_overrides]})
+                          'Spec': ['CPU', 'GPU', 'TensorRT', 'CUDA', 'CuDNN', 'EPOptionOverrides'],
+                          'Version': [cpu_version, gpu_version, tensorrt_version, cuda_version, cudnn_version,
+                                      ep_option_overrides]})
     table.to_csv(csv_filename, index=False)
 
 def output_session_creation(results, csv_filename):

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -1688,8 +1688,10 @@ class ParseDictArgAction(argparse.Action):
             try:
                 k, v = kv.split("=")
             except ValueError:
-                # Terminates the program.
                 parser.error("argument {opt_str}: Expected '=' between key and value".format(opt_str=option_string))
+
+            if k in dict_arg:
+                parser.error("argument {opt_str}: Specified duplicate key '{dup_key}'".format(opt_str=option_string, dup_key=k))
 
             dict_arg[k] = v
 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -1104,7 +1104,7 @@ def run_onnxruntime(args, models):
                         "fp16": fp16,
                         "io_binding": args.io_binding,
                         "graph_optimizations": args.graph_enablement,
-                        "enable_cache": args.enable_cache,
+                        "enable_cache": eval_bool_str(args.trt_ep_options.get(enable_cache_key)),
                         "model_name": name,
                         "inputs": len(sess.get_inputs()),
                         "batch_size": batch_size,
@@ -1720,9 +1720,6 @@ def parse_arguments():
     parser.add_argument("-b", "--io_binding", required=False, default=False, help="Bind Inputs")
     
     parser.add_argument("-g", "--graph_enablement", required=False, default=enable_all, choices=[disable, basic, extended, enable_all], help="Choose graph optimization enablement.")
-
-    # TODO: Remove this argument (set with --trt_ep_options)
-    parser.add_argument("-n", "--enable_cache", required=False, default=True, help="Enable ORT-TRT Caching")
 
     parser.add_argument("--ep", required=False, default=None, help="Specify ORT Execution Provider.") 
 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark_wrapper.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark_wrapper.py
@@ -28,6 +28,9 @@ def resolve_trtexec_path(workspace):
     logger.info("using trtexec {}".format(trtexec_path))
     return trtexec_path
 
+def dict_to_args(dct):
+    return ','.join(["{}={}".format(k, v) for k, v in dct.items()])
+
 def main():
     args = parse_arguments()
     setup_logger(False)
@@ -80,6 +83,12 @@ def main():
                     continue 
                 else:
                     command.extend(["--trtexec", trtexec])
+
+            if len(args.cuda_ep_options):
+                command.extend(["--cuda_ep_options", dict_to_args(args.cuda_ep_options)])
+
+            if len(args.trt_ep_options):
+                command.extend(["--trt_ep_options", dict_to_args(args.trt_ep_options)])
 
             if args.running_mode == "validate":
                 command.extend(["--benchmark_metrics_csv", benchmark_metrics_csv])
@@ -176,7 +185,7 @@ def main():
     logger.info("\n===========================================")
     logger.info("=========== System information  ===========")
     logger.info("===========================================")
-    info = get_system_info(args.workspace)
+    info = get_system_info(args)
     pretty_print(pp, info)
     logger.info("\n")
     output_specs(info, os.path.join(path, specs_csv))

--- a/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
+++ b/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
@@ -59,7 +59,17 @@ extended = 'extended'
 enable_all = 'all'
 
 # default TRT EP options
-default_trt_ep_options = {"trt_max_workspace_size": "4294967296", "trt_engine_cache_enable": "True"}
+enable_cache_key = "trt_engine_cache_enable"
+max_workspace_key = "trt_max_workspace_size"
+default_trt_ep_options = {max_workspace_key: "4294967296", enable_cache_key: "True"}
+
+def eval_bool_str(val):
+    if val in ('True', 'true', '1'):
+        return True
+    elif val in ('False', 'false', '0', None):
+        return False
+    else:
+        raise ValueError("Invalid bool value {}".format(repr(val)))
 
 def is_standalone(ep):
     return ep == standalone_trt or ep == standalone_trt_fp16

--- a/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
+++ b/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
@@ -58,6 +58,9 @@ basic = 'basic'
 extended = 'extended'
 enable_all = 'all'
 
+# default TRT EP options
+default_trt_ep_options = {"trt_max_workspace_size": "4294967296", "trt_engine_cache_enable": "True"}
+
 def is_standalone(ep):
     return ep == standalone_trt or ep == standalone_trt_fp16
 

--- a/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
+++ b/onnxruntime/python/tools/tensorrt/perf/perf_utils.py
@@ -58,19 +58,6 @@ basic = 'basic'
 extended = 'extended'
 enable_all = 'all'
 
-# default TRT EP options
-enable_cache_key = "trt_engine_cache_enable"
-max_workspace_key = "trt_max_workspace_size"
-default_trt_ep_options = {max_workspace_key: "4294967296", enable_cache_key: "True"}
-
-def eval_bool_str(val):
-    if val in ('True', 'true', '1'):
-        return True
-    elif val in ('False', 'false', '0', None):
-        return False
-    else:
-        raise ValueError("Invalid bool value {}".format(repr(val)))
-
 def is_standalone(ep):
     return ep == standalone_trt or ep == standalone_trt_fp16
 

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -45,7 +45,7 @@ parameters:
   type: object
   default:
     - trt_max_workspace_size=4294967296
-    - trt_engine_cache_enable=$(enableCache)
+    - trt_engine_cache_enable=True
 
 jobs:
 - job: 'Onnxruntime_Linux_GPU_TensorRT_Perf'

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -40,6 +40,13 @@ parameters:
   type: boolean
   default: false
 
+- name: TrtEPOptions
+  displayName: TensorRT EP options
+  type: object
+  default:
+    - trt_max_workspace_size=4294967296
+    - trt_engine_cache_enable=$(enableCache)
+
 jobs:
 - job: 'Onnxruntime_Linux_GPU_TensorRT_Perf'
   workspace:
@@ -74,8 +81,14 @@ jobs:
       ${{ if eq(parameters.BuildORT, false) }}:
         value: $(dockerfile)
 
+    - name: trtEpOptionsKVPairs
+      value: ${{ join(',',parameters.TrtEPOptions) }}
+
     - name: optional_arguments
-      value: -a "-a -g $(optimizeGraph) -b $(bindInputs) -n $(enableCache)"
+      ${{ if not(eq(length(parameters.TrtEPOptions), 0)) }}:
+        value: -a "-a -g $(optimizeGraph) -b $(bindInputs) --trt_ep_options $(trtEpOptionsKVPairs)"
+      ${{ if eq(length(parameters.TrtEPOptions), 0) }}:
+        value: -a "-a -g $(optimizeGraph) -b $(bindInputs)"
 
   steps:
     - ${{ if eq(parameters.BuildORT, false) }}:

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -47,6 +47,11 @@ parameters:
     - trt_max_workspace_size=4294967296
     - trt_engine_cache_enable=True
 
+- name: CUDAEPOptions
+  displayName: CUDA EP options
+  type: object
+  default: []
+
 jobs:
 - job: 'Onnxruntime_Linux_GPU_TensorRT_Perf'
   workspace:
@@ -59,36 +64,38 @@ jobs:
       ${{ if eq(parameters.RunNvidiaContainer, true)}}:
         ${{ if eq(parameters.TrtVersion, '8.2.1.8') }}:
           value: 21.12
-        ${{ if eq(parameters.TrtVersion, '8.0.1.6') }}:
+        ${{ elseif eq(parameters.TrtVersion, '8.0.1.6') }}:
           value: 21.07
-        ${{ if eq(parameters.TrtVersion, '7.2.3.4') }}:
+        ${{ elseif eq(parameters.TrtVersion, '7.2.3.4') }}:
           value: 20.12
 
     - name: dockerfile
-      ${{ if eq(parameters.RunNvidiaContainer, true)}}:
+      ${{ if eq(parameters.RunNvidiaContainer, true) }}:
         value: nvcr.io/nvidia/tensorrt:$(trtContainerVersion)-py3
-      ${{ if eq(parameters.RunNvidiaContainer, false)}}:
+      ${{ else }}:
         ${{ if eq(parameters.TrtVersion, '8.2.1.8') }}:
           value: Dockerfile.ubuntu_cuda11_4_tensorrt8_2
-        ${{ if eq(parameters.TrtVersion, '8.0.1.6') }}:
+        ${{ elseif eq(parameters.TrtVersion, '8.0.1.6') }}:
           value: Dockerfile.ubuntu_cuda11_4_tensorrt8_0
-        ${{ if eq(parameters.TrtVersion, '7.2.3.4') }}:
+        ${{ elseif eq(parameters.TrtVersion, '7.2.3.4') }}:
           value: Dockerfile.ubuntu_cuda11_4_tensorrt7_2
 
     - name: image
       ${{ if eq(parameters.BuildORT, true) }}:
         value: ort-$(branch)
-      ${{ if eq(parameters.BuildORT, false) }}:
+      ${{ else }}:
         value: $(dockerfile)
 
-    - name: trtEpOptionsKVPairs
-      value: ${{ join(',',parameters.TrtEPOptions) }}
+    - name: trtEPOptionsArg
+      ${{ if not(eq(length(parameters.TrtEPOptions), 0)) }}:
+        value: --trt_ep_options ${{ join(',',parameters.TrtEPOptions) }}
+
+    - name: cudaEPOptionsArg
+      ${{ if not(eq(length(parameters.CUDAEPOptions), 0)) }}:
+        value: --cuda_ep_options ${{ join(',',parameters.CUDAEPOptions) }}
 
     - name: optional_arguments
-      ${{ if not(eq(length(parameters.TrtEPOptions), 0)) }}:
-        value: -a "-a -g $(optimizeGraph) -b $(bindInputs) --trt_ep_options $(trtEpOptionsKVPairs)"
-      ${{ if eq(length(parameters.TrtEPOptions), 0) }}:
-        value: -a "-a -g $(optimizeGraph) -b $(bindInputs)"
+      value: -a "-a -g $(optimizeGraph) -b $(bindInputs) $(trtEPOptionsArg) $(cudaEPOptionsArg)"
 
   steps:
     - ${{ if eq(parameters.BuildORT, false) }}:
@@ -112,7 +119,7 @@ jobs:
         - script: '$(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/build/build_image.sh -o $(Build.SourcesDirectory)/dockerfiles/Dockerfile.tensorrt -b $(branch) -t $(trtContainerVersion) -i ort-$(branch) -c 75 '
           displayName: 'Build latest ORT Image in Nvidia Container'
           workingDirectory: '$(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/build'
-      - ${{ if eq(parameters.RunNvidiaContainer, false) }}: 
+      - ${{ else }}: 
         - script: '$(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/build/build_image.sh -o $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/$(dockerfile) -b $(branch) -t $(trtContainerVersion) -i ort-$(branch) -c 75 '
           displayName: 'Build latest ORT Image'
           workingDirectory: '$(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/build'


### PR DESCRIPTION
**Description**: This enables users to pass a dictionary of TensorRT and CUDA EP options to the benchmark.py script.

Ex: `python3 benchmark.py --trt_ep_options trt_engine_cache_enable=True,trt_max_workspace_size=4294967296 --cuda_ep_options arena_extend_strategy=kNextPowerOfTwo ...`

**Motivation and Context**
Currently, the perf script automatically sets the following TensorRT provider options.
- `trt_max_workspace_size`: hardcoded to 2^32
- `trt_engine_cache_enable`: set via the `-n` command-line argument (defaults to true)
- `trt_fp16_enable`: set based on the input EP name. EX: true for ORT-TRTFp16

This PR allows the script caller to override TensorRT and CUDA EP options and sets the groundwork for eventually overriding any EP option.
