### PR TITLE
Fix NNAPI EP error when handling external node adjacent to partition.

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -653,21 +653,21 @@ int32_t ModelBuilder::FindActivation(const NodeUnit& node_unit) {
   for (auto it = output_node.OutputEdgesBegin(), end = output_node.OutputEdgesEnd(); it != end; ++it) {
     const auto& dst_node = it->GetNode();
     const auto* dst_input = dst_node.InputDefs()[it->GetDstArgIndex()];
-    const auto* dst_node_unit = GetNodeUnit(&dst_node);
-    if (!dst_node_unit) {
-      return ANEURALNETWORKS_FUSED_NONE;
-    }
 
-    if (auto activation_it = activation_node_units_.find(dst_node_unit);
-        activation_it != activation_node_units_.end()) {
-      if (&output == dst_input) {
-        fuse_code = activation_it->second;
-      }
-    } else {
-      // if there is any other non-relu node using the output
-      // will add relu separately
-      if (&output == dst_input)
+    if (&output == dst_input) {
+      const auto* dst_node_unit = GetNodeUnit(&dst_node);
+      if (!dst_node_unit) {
         return ANEURALNETWORKS_FUSED_NONE;
+      }
+
+      if (auto activation_it = activation_node_units_.find(dst_node_unit);
+          activation_it != activation_node_units_.end()) {
+        fuse_code = activation_it->second;
+      } else {
+        // if there is any other non-relu node using the output
+        // will add relu separately
+        return ANEURALNETWORKS_FUSED_NONE;
+      }
     }
   }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -679,7 +679,7 @@ int32_t ModelBuilder::FindActivation(const NodeUnit& node_unit) {
     }
 
     if (fuse_code_assigned_from_activation) {
-      // don't overwrite an previously assigned fuse code, just don't fuse
+      // don't overwrite a previously assigned fuse code, just don't fuse
       return ANEURALNETWORKS_FUSED_NONE;
     }
 

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -109,8 +109,8 @@ class ModelBuilder {
   const GraphViewer& GetGraphViewer() const { return graph_viewer_; }
 
   // Get the NodeUnit which contains the given node
-  // Returns nullptr if `node` is not in the graph viewer
-  const NodeUnit* GetNodeUnit(const Node* node) const;
+  // the given node must be in the underlying graph_viewer
+  const NodeUnit& GetNodeUnit(const Node* node) const;
 
  private:
   const NnApi* nnapi_{nullptr};

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -109,7 +109,8 @@ class ModelBuilder {
   const GraphViewer& GetGraphViewer() const { return graph_viewer_; }
 
   // Get the NodeUnit which contains the given node
-  const NodeUnit& GetNodeUnit(const Node* node) const;
+  // Returns nullptr if `node` is not in the graph viewer
+  const NodeUnit* GetNodeUnit(const Node* node) const;
 
  private:
   const NnApi* nnapi_{nullptr};

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -810,14 +810,7 @@ bool ReshapeOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) const {
 
   // We will go through all the output edges
   for (auto it = output_node.OutputEdgesBegin(), end = output_node.OutputEdgesEnd(); it != end; ++it) {
-    const auto* dest_node_unit_ptr = model_builder.GetNodeUnit(&it->GetNode());
-    if (!dest_node_unit_ptr) {
-      LOGS_DEFAULT(VERBOSE) << "Reshape/Flatten can not be skipped when an output node is not in the partition"
-                            << ", output name, " << output_name
-                            << ", to external " << it->GetNode().OpType() << " node";
-      return false;
-    }
-    const auto& dest_node_unit = *dest_node_unit_ptr;
+    const auto& dest_node_unit = model_builder.GetNodeUnit(&it->GetNode());
     const auto& op_type = dest_node_unit.OpType();
     // TODO add quantized matmul when reshape support quantized input
     if (op_type != "Gemm" && op_type != "MatMul") {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -810,7 +810,14 @@ bool ReshapeOpBuilder::IsQuantizedOp(const NodeUnit& node_unit) const {
 
   // We will go through all the output edges
   for (auto it = output_node.OutputEdgesBegin(), end = output_node.OutputEdgesEnd(); it != end; ++it) {
-    const auto& dest_node_unit = model_builder.GetNodeUnit(&it->GetNode());
+    const auto* dest_node_unit_ptr = model_builder.GetNodeUnit(&it->GetNode());
+    if (!dest_node_unit_ptr) {
+      LOGS_DEFAULT(VERBOSE) << "Reshape/Flatten can not be skipped when an output node is not in the partition"
+                            << ", output name, " << output_name
+                            << ", to external " << it->GetNode().OpType() << " node";
+      return false;
+    }
+    const auto& dest_node_unit = *dest_node_unit_ptr;
     const auto& op_type = dest_node_unit.OpType();
     // TODO add quantized matmul when reshape support quantized input
     if (op_type != "Gemm" && op_type != "MatMul") {

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -492,6 +492,21 @@ TEST(NnapiExecutionProviderTest, TestOrtFormatModel) {
 #endif
 }
 
+// test that NNAPI EP can process an activation node that is outside of its partition
+TEST(NnapiExecutionProviderTest, ActivationOutsideOfPartition) {
+  // model starts with Conv -> Relu
+  constexpr auto* model_file_name = ORT_TSTR("testdata/mnist.level1_opt.onnx");
+  // stop NNAPI partitioning at Relu so NNAPI EP only takes first Conv
+  const auto nnapi_partitioning_stop_ops = "Relu";
+  SessionOptions so;
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+  ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(
+      std::make_unique<NnapiExecutionProvider>(0, nnapi_partitioning_stop_ops)));
+  ASSERT_STATUS_OK(session_object.Load(model_file_name));
+  ASSERT_STATUS_OK(session_object.Initialize());
+  ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 1);
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -504,6 +504,7 @@ TEST(NnapiExecutionProviderTest, ActivationOutsideOfPartition) {
       std::make_unique<NnapiExecutionProvider>(0, nnapi_partitioning_stop_ops)));
   ASSERT_STATUS_OK(session_object.Load(model_file_name));
   ASSERT_STATUS_OK(session_object.Initialize());
+  // expect one NNAPI partition
   ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 1);
 }
 


### PR DESCRIPTION
**Description**
Fix NNAPI EP error when handling external node adjacent to partition.
Move a check for a graph output (for the partition) prior to iterating the downstream nodes to avoid trying to get a NodeUnit for a node that is outside of the partition.

**Motivation and Context**
Fix error found while testing a model with an unsupported activation.
