### PR TITLE
Data type and shape aware allocation

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -6,6 +6,7 @@
 #include "core/common/common.h"
 #include "core/framework/fence.h"
 #include "core/framework/allocator_stats.h"
+#include "core/framework/tensor_shape.h"
 #include "core/session/onnxruntime_c_api.h"
 #include "ortdevice.h"
 #include "ortmemoryinfo.h"
@@ -58,6 +59,7 @@ class IAllocator {
   @remarks Use SafeInt when calculating the size of memory to allocate using Alloc.
   */
   virtual void* Alloc(size_t size) = 0;
+  virtual void* Alloc(const TensorShape&) { return nullptr; }
 
   virtual void Free(void* p) = 0;
 

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -6,7 +6,7 @@
 #include "core/common/common.h"
 #include "core/framework/fence.h"
 #include "core/framework/allocator_stats.h"
-#include "core/framework/tensor_shape.h"
+#include "core/framework/tensor_desc.h"
 #include "core/session/onnxruntime_c_api.h"
 #include "ortdevice.h"
 #include "ortmemoryinfo.h"
@@ -59,7 +59,11 @@ class IAllocator {
   @remarks Use SafeInt when calculating the size of memory to allocate using Alloc.
   */
   virtual void* Alloc(size_t size) = 0;
-  virtual void* Alloc(const TensorShape&) { return nullptr; }
+
+  /**
+   * Optional shape and data type aware Alloc interface.
+   */
+  virtual void* Alloc(const TensorDesc& /*desc*/) { return nullptr; }
 
   virtual void Free(void* p) = 0;
 

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -63,7 +63,7 @@ class IAllocator {
   /**
    * Optional shape and data type aware Alloc interface.
    */
-  virtual void* Alloc(const TensorDesc& /*desc*/) { return nullptr; }
+  virtual void* AllocWithDesc(const TensorDesc& /*desc*/) { return nullptr; }
 
   virtual void Free(void* p) = 0;
 

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -70,3 +70,5 @@ inline bool operator==(const OrtDevice& left, const OrtDevice& other) {
 inline bool operator!=(const OrtDevice& left, const OrtDevice& other) {
   return !(left == other);
 }
+
+std::ostream& operator<<(std::ostream& out, const OrtDevice& dev);

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -70,5 +70,3 @@ inline bool operator==(const OrtDevice& left, const OrtDevice& other) {
 inline bool operator!=(const OrtDevice& left, const OrtDevice& other) {
   return !(left == other);
 }
-
-std::ostream& operator<<(std::ostream& out, const OrtDevice& dev);

--- a/include/onnxruntime/core/framework/tensor_desc.h
+++ b/include/onnxruntime/core/framework/tensor_desc.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include "tensor_shape.h"
-#include "data_types.h"
 
 namespace onnxruntime {
+
+// data_types.h and provider_api.h have this
+class DataTypeImpl;
+using MLDataType = const DataTypeImpl*;
 
 struct TensorDesc {
   MLDataType dtype;

--- a/include/onnxruntime/core/framework/tensor_desc.h
+++ b/include/onnxruntime/core/framework/tensor_desc.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "tensor_shape.h"
+#include "data_types.h"
+
+namespace onnxruntime {
+
+struct TensorDesc {
+  MLDataType dtype;
+  TensorShapeVector shape;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -111,6 +111,7 @@ void CPUAllocator::Free(void* p) {
 }
 }  // namespace onnxruntime
 
+std::ostream& operator<<(std::ostream& out, const OrtDevice& dev) { return (out << dev.ToString()); }
 std::ostream& operator<<(std::ostream& out, const OrtMemoryInfo& info) { return (out << info.ToString()); }
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -27,7 +27,10 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
     ORT_THROW("shape.Size() must >=0");
 
   void* p_data = nullptr;
-  if (shape_size > 0) {
+  if (shape.NumDimensions() && shape_size) {
+    p_data = allocator->Alloc(shape);
+  }
+  if (!p_data && shape_size > 0) {
     SafeInt<size_t> len = 0;
     if (!IAllocator::CalcMemSizeForArray(SafeInt<size_t>(shape_size), p_type->Size(), &len))
       ORT_THROW("tensor failed memory size calculation");

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -27,8 +27,9 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
     ORT_THROW("shape.Size() must >=0");
 
   void* p_data = nullptr;
+  // if tensor is not scalar, first try to allocate with datatype and shape aware interface.
   if (shape.NumDimensions() && shape_size) {
-    p_data = allocator->Alloc(shape);
+    p_data = allocator->Alloc({p_type, shape.AsShapeVector()});
   }
   if (!p_data && shape_size > 0) {
     SafeInt<size_t> len = 0;

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -29,7 +29,7 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
   void* p_data = nullptr;
   // if tensor is not scalar, first try to allocate with datatype and shape aware interface.
   if (shape.NumDimensions() && shape_size) {
-    p_data = allocator->Alloc({p_type, shape.AsShapeVector()});
+    p_data = allocator->AllocWithDesc({p_type, shape.AsShapeVector()});
   }
   if (!p_data && shape_size > 0) {
     SafeInt<size_t> len = 0;


### PR DESCRIPTION
**Description**:

This is splitted from dev/opencl branch. This PR adds a new optional interface to IAllocator for allocating Image/Texture like memeory.

The packing process to fit high dimensional tensor into a Texture, say, 2D texture, is left for EP impl.

The returned ptr can be taken as an opaque ptr/handle/object. It shares some similarity with pointers which are created from `cudaMalloc` in CUDA EP: The host cannot access the content directly via dereferencing. In the case of Texture memory ptr, it is more restrictive that pointer arithmetic is allowed.  So the Tensor only holds the opaque ptr for lifetime management.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  Previously, allocation can only be size based, however, in APIs that can leverage the GPU compute power, such as OpenCL, OpenGL, Vulkan, DirectX, CUDA, there exists another memory kind that is related with Texture/Surface/Image. The name may vary, but they share the common characteristic that they leverage Texture Memory Unit to accelerate accessing. They thus need the datatype and shape information to be correctly setup.

