### PR TITLE
Exclude unavailable EPs from C# mobile build

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -821,7 +821,9 @@ namespace Microsoft.ML.OnnxRuntime
         // CoreML is available on iOS and macOS so we can't exclude based on __MOBILE__ && __IOS__
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_CoreML(IntPtr /*(OrtSessionOptions*)*/ options, uint coreml_flags);
+#endif
 
+#if !__MOBILE__
         // on non-mobile platforms any of these EPs are possible
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_Dnnl(IntPtr /*(OrtSessionOptions*) */ options, int use_arena);


### PR DESCRIPTION
**Description**: 
Exclude EPs that aren't available on mobile to try and fix Xamarin build error on M1.

#10675 incorrectly allowed the stubs to be included.

**Motivation and Context**
#11204 