### PR TITLE
Increase the timeout so the packaging pipeline stops failing.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -47,7 +47,7 @@ jobs:
 - job: Linux_C_API_Packaging_CPU_x64
   workspace:
     clean: all
-  timeoutInMinutes:  180
+  timeoutInMinutes:  210
   strategy:
     matrix:
       ARCH_x86_64:


### PR DESCRIPTION
**Description**: 
Increase timeout so Linux_C_API_Packaging_CPU_x64 ARCH_AARCH64 completes.

TODO: Someone should investigate why the AARCH64 build takes 3+ hours and reduce it if possible. Assuming it's using an emulator given the x64 build with the same arguments takes 13 minutes.

**Motivation and Context**
Fix packaging pipeline.