### PR TITLE
rocm pipeline fix for rel-1.11.1

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
@@ -10,7 +10,7 @@ stages:
         clean: all
       pool: AMD-GPU
       steps:
-      - template: templates/ get-docker-image-steps.yml
+      - template: templates/get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm4_2
           Context: tools/ci_build/github/linux/docker
@@ -23,7 +23,7 @@ stages:
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-10/root/usr/bin:
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
           Repository: onnxruntimetrainingrocmbuild-torch1.10.0-rocm4.2
-      - template: templates/ get-docker-image-steps.yml
+      - template: templates/get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm4_3_1
           Context: tools/ci_build/github/linux/docker
@@ -36,7 +36,7 @@ stages:
             --build-arg PREPEND_PATH=/opt/rh/devtoolset-10/root/usr/bin:
             --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
           Repository: onnxruntimetrainingrocmbuild-torch1.10.0-rocm4.3.1
-      - template: templates/ get-docker-image-steps.yml
+      - template: templates/get-docker-image-steps.yml
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5_0_1
           Context: tools/ci_build/github/linux/docker
@@ -102,7 +102,7 @@ stages:
         clean: true
         submodules: recursive
 
-      - template: templates/ set-python-manylinux-variables-step.yml
+      - template: templates/set-python-manylinux-variables-step.yml
 
       - task: CmdLine@2
         inputs:
@@ -322,8 +322,8 @@ stages:
         condition: and(succeeded(), eq(variables['DRY_RUN'], '0'))
         displayName: 'Upload Rocm wheel to release repository'
 
-      - template: templates/ component-governance-component-detection-steps.yml
+      - template: templates/component-governance-component-detection-steps.yml
         parameters:
           condition: 'succeeded'
 
-      - template: templates/ clean-agent-build-directory-step.yml
+      - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
@@ -12,10 +12,23 @@ stages:
       steps:
       - template: templates/ get-docker-image-steps.yml
         parameters:
+          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm4_2
+          Context: tools/ci_build/github/linux/docker
+          DockerBuildArgs: >-
+            --build-arg TORCH_VERSION=1.10.0
+            --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
+            --build-arg BUILD_UID=$(id -u)
+            --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
+            --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-10/root
+            --build-arg PREPEND_PATH=/opt/rh/devtoolset-10/root/usr/bin:
+            --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
+          Repository: onnxruntimetrainingrocmbuild-torch1.10.0-rocm4.2
+      - template: templates/ get-docker-image-steps.yml
+        parameters:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm4_3_1
           Context: tools/ci_build/github/linux/docker
           DockerBuildArgs: >-
-            --build-arg TORCH_VERSION=1.11.0
+            --build-arg TORCH_VERSION=1.10.0
             --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
             --build-arg BUILD_UID=$(id -u)
             --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
@@ -28,7 +41,7 @@ stages:
           Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5_0_1
           Context: tools/ci_build/github/linux/docker
           DockerBuildArgs: >-
-            --build-arg TORCH_VERSION=1.11.0
+            --build-arg TORCH_VERSION=1.10.0
             --build-arg INSTALL_DEPS_EXTRA_ARGS=-tmur
             --build-arg BUILD_UID=$(id -u)
             --network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64
@@ -47,6 +60,18 @@ stages:
       - ROCm_build_environment
       strategy:
         matrix:
+          Python37 Torch1100 Rocm42:
+            PythonVersion: '3.7'
+            TorchVersion: '1.10.0'
+            RocmVersion: '4.2'
+          Python38 Torch1100 Rocm42:
+            PythonVersion: '3.8'
+            TorchVersion: '1.10.0'
+            RocmVersion: '4.2'
+          Python39 Torch1100 Rocm42:
+            PythonVersion: '3.9'
+            TorchVersion: '1.10.0'
+            RocmVersion: '4.2'
           Python37 Torch1100 Rocm431:
             PythonVersion: '3.7'
             TorchVersion: '1.10.0'


### PR DESCRIPTION
**Description**: This PR fixes the rocm pipeline failures for rel 1.11.1

**Motivation and Context**
- Why is this change required? What problem does it solve?
After rel 1.11 we updated the training pipelines. Therefore a few changes are required in order to successfully build packages in 1.11.1 branch.
- If it fixes an open issue, please link to the issue here.
