### PR TITLE
Move Contains() helper function to a higher common.h.

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -286,4 +286,12 @@ inline std::string ToWideString(const std::string& s) { return s; }
 
 constexpr size_t kMaxStrLen = 2048;
 
+// Returns whether `key` is in `container`.
+// Like C++20's map/set contains() member function.
+template <typename Key, typename... OtherContainerArgs,
+          template <typename...> typename AssociativeContainer>
+inline bool Contains(const AssociativeContainer<Key, OtherContainerArgs...>& container, const Key& key) {
+  return container.find(key) != container.end();
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/common.h
+++ b/onnxruntime/core/providers/common.h
@@ -137,11 +137,6 @@ inline Status ComputePadAndOutputShape(const int64_t in_dim,
   return Status::OK();
 }
 
-template <class AssociativeContainer, class Key>
-inline bool Contains(const AssociativeContainer& container, const Key& key) {
-  return container.find(key) != container.end();
-}
-
 // Note: This helper function will not have overflow protection
 template <template <typename...> class Container, typename T>
 T Product(const Container<T>& c) {


### PR DESCRIPTION
**Description**
Move Contains() helper function to a higher common.h.

**Motivation and Context**
It's generally useful.