### PR TITLE
Allow external allocator in C++

### DIFF
--- a/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
+++ b/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
@@ -27,4 +27,7 @@ struct OrtCUDAProviderOptionsV2 {
   int cudnn_conv_use_max_workspace;                        // flag specifying if maximum workspace can be used in cudnn conv algo search.
   int enable_cuda_graph;                                   // flag specifying if the CUDA graph is to be captured for the model.
   int cudnn_conv1d_pad_to_nc1d;                            // flag specifying if pad Conv1D's input [N,C,D] to [N,C,1,D] or [N,C,D,1].
+  void* (*alloc)(size_t);                                  // External allocation function for GPU.
+  void (*free)(void*);                                     // Release memory allocated by external function.
+  void (*empty_cache)();                                   // Clean cached GPU memory. 
 };

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3346,13 +3346,13 @@ struct OrtApi {
                   _In_reads_(input_len) const OrtValue* const* initializers, size_t initializers_num);
 
   /** \brief: Create attribute of onnxruntime operator
-  * 
+  *
   * \param[in] name of the attribute
   * \param[in] data of the attribute
   * \param[in] data length
   * \param[in] data type
   * \param[out] attribute that has been created, which must be released by OrtApi::ReleaseOpAttr
-  * 
+  *
   * \since Version 1.12.
   */
   ORT_API2_STATUS(CreateOpAttr,
@@ -3365,14 +3365,14 @@ struct OrtApi {
   /* \brief: Release op attribute
   *
   * \param[in] attribute created by OrtApi::CreateOpAttr
-  * 
+  *
   * \since Version 1.12.
   */
   ORT_CLASS_RELEASE(OpAttr);
 
   /** \brief: Create onnxruntime native operator
-  * 
-  * \param[in] kernel info 
+  *
+  * \param[in] kernel info
   * \param[in] operator name
   * \param[in] operator domain
   * \param[in] operator opset
@@ -3382,7 +3382,7 @@ struct OrtApi {
   * \param[in] attributes used to initialize the operator
   * \param[in] number of the attributes
   * \param[out] operator that has been created
-  * 
+  *
   * \since Version 1.12.
   */
   ORT_API2_STATUS(CreateOp,
@@ -3399,14 +3399,14 @@ struct OrtApi {
 
   /** \brief: Invoke the operator created by OrtApi::CreateOp
   * The inputs must follow the order as specified in onnx specification
-  * 
+  *
   * \param[in] kernel context
   * \param[in] operator that has been created
   * \param[in] inputs
   * \param[in] number of inputs
   * \param[in] outputs
   * \param[in] number of outputs
-  * 
+  *
   * \since Version 1.12.
   */
   ORT_API2_STATUS(InvokeOp,
@@ -3420,7 +3420,7 @@ struct OrtApi {
   /* \brief: Release an onnxruntime operator
   *
   * \param[in] operator created by OrtApi::CreateOp
-  * 
+  *
   * \since Version 1.12.
   */
   ORT_CLASS_RELEASE(Op);

--- a/onnxruntime/core/providers/cuda/cuda_allocator.h
+++ b/onnxruntime/core/providers/cuda/cuda_allocator.h
@@ -39,6 +39,17 @@ class CUDAExternalAllocator : public CUDAAllocator {
     empty_cache_ = reinterpret_cast<ExternalEmptyCache>(empty_cache);
   }
 
+  // This ctor is more type-safer.
+  CUDAExternalAllocator(OrtDevice::DeviceId device_id,
+                        const char* name,
+                        ExternalAlloc alloc,
+                        ExternalFree free,
+                        ExternalEmptyCache empty_cache)
+      : CUDAAllocator(device_id, name),
+        alloc_(alloc),
+        free_(free),
+        empty_cache_(empty_cache) {}
+
   void* Alloc(size_t size) override;
   void Free(void* p) override;
   void* Reserve(size_t size) override;

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -118,16 +118,29 @@ AllocatorPtr CUDAExecutionProvider::CreateCudaAllocator(OrtDevice::DeviceId devi
   if (external_allocator_info.UseExternalAllocator()) {
     AllocatorCreationInfo default_memory_info(
         [external_allocator_info](OrtDevice::DeviceId id) {
-          return std::make_unique<CUDAExternalAllocator>(id, CUDA,
-                                                         external_allocator_info.alloc,
-                                                         external_allocator_info.free,
-                                                         external_allocator_info.empty_cache);
+          return std::make_unique<CUDAExternalAllocator>(
+            id, CUDA,
+            external_allocator_info.alloc,
+            external_allocator_info.free,
+            external_allocator_info.empty_cache);
         },
         device_id,
         false);
 
     return CreateAllocator(default_memory_info);
+  } else if (external_allocator_info.UseTypeSafeExternalAllocator()) {
+    AllocatorCreationInfo default_memory_info(
+        [external_allocator_info](OrtDevice::DeviceId id) {
+          return std::make_unique<CUDAExternalAllocator>(
+            id, CUDA,
+            external_allocator_info.type_safe_alloc,
+            external_allocator_info.type_safe_free,
+            external_allocator_info.type_safe_empty_cache);
+        },
+        device_id,
+        false);
 
+    return CreateAllocator(default_memory_info);
   } else {
     AllocatorCreationInfo default_memory_info(
         [](OrtDevice::DeviceId id) {

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider_info.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider_info.h
@@ -16,21 +16,34 @@ struct CUDAExecutionProviderExternalAllocatorInfo {
   void* alloc{nullptr};
   void* free{nullptr};
   void* empty_cache{nullptr};
+  void* (*type_safe_alloc)(size_t);
+  void (*type_safe_free)(void*);
+  void (*type_safe_empty_cache)();
 
   CUDAExecutionProviderExternalAllocatorInfo() {
     alloc = nullptr;
     free = nullptr;
     empty_cache = nullptr;
+    type_safe_alloc = nullptr;
+    type_safe_free = nullptr;
+    type_safe_empty_cache = nullptr;
   }
 
   CUDAExecutionProviderExternalAllocatorInfo(void* a, void* f, void* e) {
     alloc = a;
     free = f;
     empty_cache = e;
+    type_safe_alloc = nullptr;
+    type_safe_free = nullptr;
+    type_safe_empty_cache = nullptr;
   }
 
   bool UseExternalAllocator() const {
     return (alloc != nullptr) && (free != nullptr);
+  }
+
+  bool UseTypeSafeExternalAllocator() const {
+    return type_safe_alloc && type_safe_free;
   }
 };
 

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -219,6 +219,9 @@ struct CUDA_Provider : Provider {
     info.cudnn_conv_use_max_workspace = params->cudnn_conv_use_max_workspace != 0;
     info.enable_cuda_graph = params->enable_cuda_graph != 0;
     info.cudnn_conv1d_pad_to_nc1d = params->cudnn_conv1d_pad_to_nc1d != 0;
+    info.external_allocator_info.type_safe_alloc = params->alloc;
+    info.external_allocator_info.type_safe_free = params->free;
+    info.external_allocator_info.type_safe_empty_cache = params->empty_cache;
 
     return std::make_shared<CUDAProviderFactory>(info);
   }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1126,6 +1126,9 @@ OrtCUDAProviderOptionsV2 OrtCUDAProviderOptionsToOrtCUDAProviderOptionsV2(const 
   cuda_options_converted.cudnn_conv_use_max_workspace = 0;
   cuda_options_converted.enable_cuda_graph = 0;
   cuda_options_converted.cudnn_conv1d_pad_to_nc1d = 0;
+  cuda_options_converted.alloc = 0;
+  cuda_options_converted.free = 0;
+  cuda_options_converted.empty_cache = 0;
 
   return cuda_options_converted;
 }

--- a/onnxruntime/test/framework/cuda/custom_allocator_test.cc
+++ b/onnxruntime/test/framework/cuda/custom_allocator_test.cc
@@ -1,0 +1,86 @@
+//// Copyright (c) Microsoft Corporation. All rights reserved.
+//// Licensed under the MIT License.
+#include <memory>
+#include "cuda_runtime.h"
+#include "core/framework/execution_provider.h"
+#include "core/providers/cuda/cuda_provider_options.h"
+#include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/provider_factory_creators.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+class CustomAllocator {
+public:
+  static CustomAllocator& GetInstance() {
+    static CustomAllocator instance_;
+    return instance_;
+  };
+  void* Alloc(size_t nbytes) {
+    alloc_count_ += 1;
+    void* ptr = nullptr;
+    cudaError_t err = cudaMalloc(&ptr, nbytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error("CustomAllocator::alloc failed: " + std::string(cudaGetErrorString(err)));
+    }
+    return ptr;
+  }
+  void Free(void* ptr) {
+    free_count_ += 1;
+    cudaError_t err = cudaFree(ptr);
+    if (err != cudaSuccess) {
+      throw std::runtime_error("CustomAllocator::free failed: " + std::string(cudaGetErrorString(err)));
+    }
+  }
+  size_t GetAllocCount() const {
+    return alloc_count_;
+  }
+  size_t GetFreeCount() const {
+    return free_count_;
+  }
+private:
+  CustomAllocator() = default;
+  ~CustomAllocator() = default;
+  CustomAllocator(const CustomAllocator&) = delete;
+  CustomAllocator& operator=(const CustomAllocator&) = delete;
+  size_t empty_cache_count_;
+  size_t alloc_count_;
+  size_t free_count_;
+};
+
+void* CustomAlloc(size_t nbytes) {
+  return CustomAllocator::GetInstance().Alloc(nbytes);
+}
+
+void CustomFree(void* ptr) {
+  return CustomAllocator::GetInstance().Free(ptr);
+}
+
+TEST(AllocatorTest, CUDAExternalAllocator) {
+  OrtCUDAProviderOptionsV2 provider_options{};
+  provider_options.device_id = 0;
+  provider_options.do_copy_in_default_stream = true;
+  provider_options.alloc = CustomAlloc;
+  provider_options.free = CustomFree;
+  auto factory = CudaProviderFactoryCreator::Create(&provider_options);
+  auto provider = factory->CreateProvider();
+  auto allocator = provider->GetAllocator(0, OrtMemTypeDefault);
+
+  size_t size = 8;
+  void* cuda_addr_0 = allocator->Alloc(size);
+  EXPECT_TRUE(cuda_addr_0);
+
+  // this should trigger an allocation equal to the current total, which should fail initially and gradually fall back
+  // to a smaller block.
+  size_t next_size = 1024;
+
+  void* cuda_addr_1 = allocator->Alloc(next_size);
+  EXPECT_TRUE(cuda_addr_1);
+  allocator->Free(cuda_addr_0);
+  allocator->Free(cuda_addr_1);
+
+  EXPECT_EQ(CustomAllocator::GetInstance().GetAllocCount(), 2);
+  EXPECT_EQ(CustomAllocator::GetInstance().GetFreeCount(), 2);
+}
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
Similar to the use of Pytorch allocator via ORTModule, we need to expose the same API to C++ for supporting Lazy Tensor.
