### PR TITLE
fix: Add the extra param to match gelu in PyTorch in the contrib symbolic function

### DIFF
--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -5,6 +5,7 @@
 Support for registering ONNX Runtime's built-in contrib ops with
 PyTorch-ONNX exporter (torch.onnx.export).
 """
+from __future__ import annotations
 
 import typing
 

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -17,6 +17,9 @@ except ModuleNotFoundError:
 import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_registry as sym_registry
 
+if typing.TYPE_CHECKING:
+    import torch._C
+
 _OPSET_VERSION = 1
 _registered_ops: typing.AbstractSet[str] = set()
 
@@ -65,8 +68,10 @@ def register():
         return g.op("com.microsoft::Inverse", self).setType(self.type())
     _reg(inverse)
 
-    def gelu(g, self):
-        return g.op("com.microsoft::Gelu", self).setType(self.type())
+    def gelu(g, self: torch._C.Value, approximate: str = "none"):
+        if approximate == "none":
+            return g.op("com.microsoft::Gelu", self).setType(self.type())
+        return torch.onnx.symbolic_opset9.gelu(g, self, approximate=approximate)
     _reg(gelu)
 
     def triu(g, self, diagonal):

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:
     raise ModuleNotFoundError(
         "This module is only useful in combination with PyTorch. "
         "To install PyTorch see https://pytorch.org/.")
+import torch.onnx
 import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_registry as sym_registry
 
@@ -72,7 +73,7 @@ def register():
     def gelu(g, self: torch._C.Value, approximate: str = "none"):
         if approximate == "none":
             return g.op("com.microsoft::Gelu", self).setType(self.type())
-        return torch.onnx.symbolic_opset9.gelu(g, self, approximate=approximate)
+        return torch.onnx.symbolic_opset9.gelu(g, self, approximate)
     _reg(gelu)
 
     def triu(g, self, diagonal):
@@ -82,7 +83,6 @@ def register():
     def tril(g, self, diagonal):
         return g.op("com.microsoft::Trilu", self, diagonal, upper_i=0).setType(self.type())
     _reg(tril)
-
 
 
 def unregister():

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -109,6 +109,15 @@ class ONNXExporterTest(unittest.TestCase):
         x = torch.randn(3, 3)
         self.run_test(model, x, custom_opsets={"com.microsoft": 1})
 
+    def test_gelu_supports_approximate_param(self):
+        # TODO(justinchu): Change this to a parameterized test
+        possible_args = ("none", "tanh")
+        for approximate in possible_args:
+            with self.subTest(approximate=approximate):
+                model = torch.nn.GELU(approximate=approximate)
+                x = torch.randn(3, 3)
+                self.run_test(model, x, custom_opsets={"com.microsoft": 1})
+
     def test_triu(self):
         for i in range(-5, 5):
             class Module(torch.nn.Module):


### PR DESCRIPTION
**Description**: 

Add the extra param to match gelu in PyTorch in the contrib symbolic function

**Motivation and Context**
- Why is this change required? What problem does it solve?

The symbolic function in `/onnxruntime/python/tools/pytorch_export_contrib_ops.py` is missing a recently added parameter `approximate`. We add this parameter and use the exporter defined `gelu` if `approximate` is "tanh". 

- If it fixes an open issue, please link to the issue here.

https://github.com/microsoft/onnx-converters-private/issues/6
