### PR TITLE
Fix how the output tensor is created in CUDA SpaceDepth ops

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -86,13 +86,14 @@ Status Transpose::DoTranspose(const cudaDeviceProp& prop,
                               cudaStream_t stream,
                               const cublasHandle_t cublas_handle,
                               const gsl::span<const size_t>& permutations, const Tensor& input, Tensor& output,
-                              const TensorShape* input_shape_override) {
+                              const TensorShape* input_shape_override,
+                              const TensorShape* output_shape_override) {
   // special case when there is a dim value of 0 in the shape.
   if (output.Shape().Size() == 0)
     return Status::OK();
 
   const auto input_dims = input_shape_override ? input_shape_override->GetDims() : input.Shape().GetDims();
-  const auto output_dims = output.Shape().GetDims();
+  const auto output_dims = output_shape_override ? output_shape_override->GetDims() : output.Shape().GetDims();
   auto rank = static_cast<int32_t>(input_dims.size());
 
   // flatten the adjacent dimensions which are contiguous

--- a/onnxruntime/core/providers/cuda/tensor/transpose.h
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.h
@@ -22,11 +22,14 @@ class Transpose final : public CudaKernel, public TransposeBase {
                             const gsl::span<const size_t>& permutations, const Tensor& input, Tensor& output);
 
   //  `input_shape_override` (if provided) overrides the shape of `input` for compute purposes
+  //  `output_shape_override` (if provided) overrides the shape of `output` for compute purposes
   static Status DoTranspose(const cudaDeviceProp& prop,
                             cudaStream_t stream,
                             const cublasHandle_t cublas_handle,
                             const gsl::span<const size_t>& permutations,
-                            const Tensor& input, Tensor& output, const TensorShape* input_shape_override = nullptr);
+                            const Tensor& input, Tensor& output,
+                            const TensorShape* input_shape_override = nullptr,
+                            const TensorShape* output_shape_override = nullptr);
 };
 
 }  // namespace cuda


### PR DESCRIPTION
**Description**: 

The SpaceDepth ops are just thin wrappers over Transpose in that they do some re-ordering of the input based on a "virtual input shape" of the regular NCHW image input. The output tensor in these ops were being created based on the "virtual otuput shape" of this Transpose operation and then finally reshaped into the NCHW shape before the operation exits. The execution frame has a check to ensure that the requested output shape of the output buffer of the op be the same as the "expected" shape if the op output is also a graph output and if it isn't it produces a warning - https://github.com/microsoft/onnxruntime/blob/4d0214f8510c740682082a00b00a5f2422142165/onnxruntime/core/framework/execution_frame.cc#L806. This change adjusts the op's output tensor creation logic so that such warnings don't kick in should the SpaceDepth ops be producing graph outputs. 

The existing op unit tests should keep this change covered.

**Motivation and Context**
Fix jarring warning seen by user in https://github.com/microsoft/onnxruntime/issues/11274
