### PR TITLE
[docs/web] update build instructions for web

### DIFF
--- a/docs/build/web.md
+++ b/docs/build/web.md
@@ -48,8 +48,8 @@ There are 2 steps to build ONNX Runtime Web:
 
   (If you are using Windows, you can skip this step) in `<ORT_ROOT>/cmake/external/emsdk/`, run the following commands to setup emsdk:
   ```sh
-  ./emsdk install 3.1.3
-  ./emsdk activate 3.1.3
+  ./emsdk install latest
+  ./emsdk activate latest
   source ./emsdk_env.sh
   ```
 

--- a/docs/build/web.md
+++ b/docs/build/web.md
@@ -32,12 +32,26 @@ There are 2 steps to build ONNX Runtime Web:
   ```
 - [Install](https://cmake.org/download/) cmake-3.18 or higher.
 
-- [Install](https://nodejs.org/) Node.js (14.0+)
+- [Install](https://nodejs.org/) Node.js (16.0+)
 
   - (Optional) Use nvm ([Windows](https://github.com/coreybutler/nvm-windows) / [Mac/Linux](https://github.com/creationix/nvm)) to install Node.js
 
-- Python (2.7 or 3.6+): https://www.python.org/downloads/
+- Python (3.8+): https://www.python.org/downloads/
   - python should be added to the PATH environment variable
+
+- Prepare emsdk:
+  emsdk should be automatically installed at `<ORT_ROOT>/cmake/external/emsdk/emsdk`. If the folder structure does not exist, run the following commands in `<ORT_ROOT>/` to install git submodules:
+  ```sh
+  git submodule sync --recursive
+  git submodule update --init --recursive
+  ```
+
+  (If you are using Windows, you can skip this step) in `<ORT_ROOT>/cmake/external/emsdk/`, run the following commands to setup emsdk:
+  ```sh
+  ./emsdk install 3.1.3
+  ./emsdk activate 3.1.3
+  source ./emsdk_env.sh
+  ```
 
 ### Build Instructions
 
@@ -103,7 +117,7 @@ Q: I have a C++ project for web scenario, which runs a ML model using ONNX Runti
 
 ### Prerequisites
 
-- [Install](https://nodejs.org/) Node.js (14.0+)
+- [Install](https://nodejs.org/) Node.js (16.0+)
 
   - (Optional) Use nvm ([Windows](https://github.com/coreybutler/nvm-windows)/[Mac/Linux](https://github.com/creationix/nvm)) to install Node.js
 


### PR DESCRIPTION
**Description**: Update build instructions for web.

- update nodejs and python version
- add a manual step for using emsdk when not in windows.

    reason: (from latest [emsdk document](https://emscripten.org/docs/tools_reference/emsdk.html))

   > On Linux and macOS, activate writes the required information to the configuration file, but cannot automatically set up the environment variables in the current terminal. To do this you need to call source ./emsdk_env.sh after calling activate. The use of source is a security feature of Unix shells.
   >
   > On Windows, calling activate automatically sets up the required paths and environment variables.