### PR TITLE
Add location planning logic for implicit inputs which are graph inputs 

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -651,7 +651,7 @@ class PlannerImpl {
 
               // The "ideal" solution is to set the location of its first "explicit" usage which may occur
               // in any nested subgraph of the node, but that is potentially too costly to
-              // get at this stage (TODO: Investigate feasibility of this)
+              // get at this stage (TODO: Investigate feasibility of this, see TODO in FinalizeSessionStateImpl() arouxcnds this)
 
               // Instead, we take a "less than ideal" route which is to set the location to be the device
               // corresponding to the EP that the node is partitioned to. The hypothesis is that it is "most likely"

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -651,7 +651,7 @@ class PlannerImpl {
 
               // The "ideal" solution is to set the location of its first "explicit" usage which may occur
               // in any nested subgraph of the node, but that is potentially too costly to
-              // get at this stage (TODO: Investigate feasibility of this, see TODO in FinalizeSessionStateImpl() arouxcnds this)
+              // get at this stage (TODO: Investigate feasibility of this, see TODO in FinalizeSessionStateImpl() around this)
 
               // Instead, we take a "less than ideal" route which is to set the location to be the device
               // corresponding to the EP that the node is partitioned to. The hypothesis is that it is "most likely"

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -564,6 +564,9 @@ class PlannerImpl {
 
     InlinedHashSet<OrtValueIndex> set_node_arg_has_explicit_consumer;
 
+    InlinedHashMap<OrtValueIndex, const IExecutionProvider*> map_implicitly_consumed_node_arg_to_ep;
+    InlinedHashSet<OrtValueIndex> set_implicitly_consumed_node_arg_has_heterogenous_ep_consumers;
+
     for (SequentialExecutionPlan::NodeExecutionPlan& step : plan_.execution_plan) {
       auto pnode = graph_viewer_.GetNode(step.node_index);
       if (pnode == nullptr) {
@@ -589,6 +592,8 @@ class PlannerImpl {
       // increment UseCount and add location information if applicable for the provided input def
       auto process_input = [&graph_inputs, &exec_provider, &p_kernel_def, &is_implicit_input,
                             &set_node_arg_has_explicit_consumer,
+                            &map_implicitly_consumed_node_arg_to_ep,
+                            &set_implicitly_consumed_node_arg_has_heterogenous_ep_consumers,
                             this](const NodeArg& input, size_t arg_idx) {
         const auto& name = input.Name();
         UseCount(name)++;
@@ -612,15 +617,17 @@ class PlannerImpl {
             plan_.SetLocation(static_cast<size_t>(index), exec_provider->GetAllocator(0, mem_type)->Info());
             set_node_arg_has_explicit_consumer.insert(index);
           } else {  // implicit input
-            // Only process an implicit input:
-            // 1) Within a subgraph
-            // 2) If there is no explicit consumer at this graph level
+            // Only process an implicit input if there are explicit consumers at this graph level
             // If there is an explicit consumer, the location MUST be where it is consumed
             // and not where it is located in the outer scope.
             // It is okay if we process a node consuming this arg as an implicit input
             // ahead of a node that is an explicit consumer, because we will just reset
             // this location in the 'if' branch above.
 
+            // CASE 1: We see an implicit input without explicit consumers in a subgraph (pass-through subgraph inputs),
+            // then set its location to be its corresponding location in the outer scope.
+            // This is so that the subgraph copying mechanism doesn't trigger an unnecessary copy and any copying
+            // decisions are deferred till there is an explicit consumer of the subgraph input in nested subgraphs.
             if (is_subgraph && set_node_arg_has_explicit_consumer.count(index) == 0) {
               auto iter = outer_scope_node_arg_to_location_map_.find(name);
               bool found_in_outer_scope_location_map = (iter != outer_scope_node_arg_to_location_map_.end());
@@ -636,6 +643,56 @@ class PlannerImpl {
 
               if (found_in_outer_scope_location_map) {
                 plan_.SetLocation(static_cast<size_t>(index), iter->second);
+              }
+            } else if (set_node_arg_has_explicit_consumer.count(index) == 0) {
+              // CASE 2: We see an implicit input without explicit consumers in the main graph,
+              // then set its location to be the device corresponding to the EP that the subgraph
+              // holding node has been partitioned to.
+
+              // The "ideal" solution is to set the location of its first "explicit" usage which may occur
+              // in any nested subgraph of the node, but that is potentially too costly to
+              // get at this stage (TODO: Investigate feasibility of this)
+
+              // Instead, we take a "less than ideal" route which is to set the location to be the device
+              // corresponding to the EP that the node is partitioned to. The hypothesis is that it is "most likely"
+              // that the implicit input will eventually be consumed on that device in a nested subgraph.
+
+              // The previous behavior was to default to CPU which will cause unnecessary copies when
+              // (1) The user invokes Run() with an OrtValue backed by non-CPU memory (eg CUDA) and
+              // the explicit consumer of the implicit input is on the non-CPU device in the subgraph
+              // (2) The user tries to IOBind implicitly consumed graph inputs (GH Issue 11254) and
+              // the explicit consumer of the implicit input is on the non-CPU device in the subgraph
+
+              // Even if the user provides an input on CPU and the explicit consumer of the implicit input
+              // is on the non-CPU device, instead of the subgraph copying mechanism taking it to the device,
+              // all we will do is "front-load" this copy in utils::CopyInputsAcrossDevices() with this approach.
+
+              // NOTE 1: The only case this will be sub-optimal is when a node containing a subgraph is partitioned to a
+              // non-CPU EP and the user provides an input (or tries to IOBind the input) AND it will eventually be
+              // explicitly consumed on CPU - this scenario should be very rare and we forgo performance in this case
+              // (the subgraph copying mechanism will make the copy to CPU eventually) in favor of optimizing for the
+              // common case (which is that we expect the implicit input to be consumed on the non-CPU device corresponding
+              // to the non-CPU EP).
+
+              // NOTE 2: If the implicit input is consumed by multiple nodes (as implicit inputs in all of them) and
+              // all of them are partitioned to the same EP, then we go ahead with the above stated logic.
+              // If there are multiple EPs involved, we default the location to just CPU as there is ambiguity involved
+              // as to which non-CPU device is "most optimal" for the implicit input.
+
+              if (set_implicitly_consumed_node_arg_has_heterogenous_ep_consumers.count(index) == 0) {
+                // First time we are encountering this implicitly consumed input at this graph level (or)
+                // the EP that we previously seen for this implicit input is the same one as the current EP
+                // we have seen
+                if (!map_implicitly_consumed_node_arg_to_ep.contains(index)) {
+                  plan_.SetLocation(static_cast<size_t>(index), exec_provider->GetAllocator(0, OrtMemType::OrtMemTypeDefault)->Info());
+                  map_implicitly_consumed_node_arg_to_ep.insert({index, exec_provider});
+                } else if (map_implicitly_consumed_node_arg_to_ep.find(index)->second == exec_provider) {
+                  plan_.SetLocation(static_cast<size_t>(index), exec_provider->GetAllocator(0, OrtMemType::OrtMemTypeDefault)->Info());
+                } else {  // Default the location to CPU
+                  plan_.SetLocation(static_cast<size_t>(index),
+                                    execution_providers_.Get(CPU)->GetAllocator(0, OrtMemType::OrtMemTypeDefault)->Info());
+                  set_implicitly_consumed_node_arg_has_heterogenous_ep_consumers.insert(index);
+                }
               }
             }
           }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1501,6 +1501,10 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
       auto& control_flow_kernel = static_cast<controlflow::IControlFlowKernel&>(*p_op_kernel);
       ORT_RETURN_IF_ERROR(control_flow_kernel.SetupSubgraphExecutionInfo(*this, attr_name, subgraph_session_state));
     }
+
+    // TODO: Once the subgraph session states have been finalized, can we go back and plan the location of implicit
+    // inputs that are fed through as graph inputs in the graph level holding the subgraphs ? Ideally the planned
+    // locations for these would be the locations they are explicitly consumed on in nested subgraphs.
   }
 
   return Status::OK();

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -59,7 +59,10 @@ static common::Status AllocateBufferUsingDeviceAllocatorFromShapeAndType(const T
 // released with the deleter of the ORT value which holds the ext data tensor
 struct ExtDataNullAllocator : public IAllocator {
   ExtDataNullAllocator() : IAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
-  void* Alloc(size_t size) override { ORT_UNUSED_PARAMETER(size); return nullptr; }
+  void* Alloc(size_t size) override {
+    ORT_UNUSED_PARAMETER(size);
+    return nullptr;
+  }
   void Free(void* p) override { ORT_UNUSED_PARAMETER(p); }
 };
 
@@ -79,10 +82,9 @@ struct ExtDataValueDeleter {
 // by the OrtValue's deleter
 static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                                         const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                                        OrtValue& ort_value)
-{
+                                                        OrtValue& ort_value) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  ORT_ENFORCE(! proto_path.empty());
+  ORT_ENFORCE(!proto_path.empty());
 
   void* ext_data_buf = nullptr;
   size_t ext_data_len = 0;
@@ -96,12 +98,12 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const st
   AllocatorPtr ext_data_alloc = std::make_shared<ExtDataNullAllocator>();
   const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
   std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
-  TensorShape tensor_shape {tensor_shape_vec};
+  TensorShape tensor_shape{tensor_shape_vec};
   MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
 
   auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, ext_data_alloc);
 
-  ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get() };
+  ExtDataValueDeleter deleter{ext_data_deleter, p_tensor.get()};
 
   ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);
   return common::Status::OK();
@@ -297,7 +299,7 @@ common::Status SaveInitializedTensors(
     } else if (utils::HasExternalData(*entry.second)) {
       const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
       Status st = ExtDataTensorProtoToTensor(env, graph_loc, tensor_proto, ort_value);
-      if (! st.IsOK()) {
+      if (!st.IsOK()) {
         std::ostringstream oss;
         oss << "Load of external data tensor " << name << " failed." << st.ErrorMessage();
         return Status(st.Category(), st.Code(), oss.str());
@@ -396,6 +398,16 @@ common::Status SaveInputOutputNamesToNodeMapping(const onnxruntime::GraphViewer&
       // is consumed in the subgraph if there is an explicit consumer.
       // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes, its
       // location is the location of the value in the enclosing outer scope.
+
+      // In the main graph, the location of the implicit input(s) is the location it
+      // is consumed in the main graph if there is an explicit consumer.
+      // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes and
+      // all of them have been partitioned to the same EP, its location is the
+      // location of the non-CPU device corresponding to the EP.
+      // If multiple EPs are involved, then the planned location for such implicit inputs
+      // just default to CPU (as there is ambiguity involved as to which non-CPU device is
+      // most optimal)
+
       // All this is setup in the planner, we just use the location from the plan here.
       for (const auto& input_def : node_implicit_inputs) {
         int arg_index;

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -394,11 +394,6 @@ common::Status SaveInputOutputNamesToNodeMapping(const onnxruntime::GraphViewer&
     // implicit inputs to a node could come directly from a feed, so we need to make sure they have an entry too
     const auto& node_implicit_inputs = node.ImplicitInputDefs();
     if (!node_implicit_inputs.empty()) {
-      // In nested subgraphs, the location of the implicit input(s) is the location it
-      // is consumed in the subgraph if there is an explicit consumer.
-      // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes, its
-      // location is the location of the value in the enclosing outer scope.
-
       // In the main graph, the location of the implicit input(s) is the location it
       // is consumed in the main graph if there is an explicit consumer.
       // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes and
@@ -407,6 +402,11 @@ common::Status SaveInputOutputNamesToNodeMapping(const onnxruntime::GraphViewer&
       // If multiple EPs are involved, then the planned location for such implicit inputs
       // just default to CPU (as there is ambiguity involved as to which non-CPU device is
       // most optimal)
+
+      // In nested subgraphs, the location of the implicit input(s) is the location it
+      // is consumed in the subgraph if there is an explicit consumer.
+      // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes, its
+      // location is the location of the value in the enclosing outer scope.
 
       // All this is setup in the planner, we just use the location from the plan here.
       for (const auto& input_def : node_implicit_inputs) {

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -1139,7 +1139,7 @@ TEST_F(PlannerTest, LocationPlanningForImplicitInputsWithoutExplicitConsumersInM
   EXPECT_EQ(main_graph_plan->allocation_plan[input_data_index].location.device.Type(), OrtDevice::GPU);
 }
 
-#endif
+#endif  // USE_CUDA
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -1133,10 +1133,10 @@ TEST_F(PlannerTest, LocationPlanningForImplicitInputsWithoutExplicitConsumersInM
   const auto& main_graph_ort_value_index_map = main_graph_session_state.GetOrtValueNameIdxMap();
   const auto* main_graph_plan = main_graph_session_state.GetExecutionPlan();
 
-  OrtValueIndex init_data_index;
-  ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("image_data_in", init_data_index));
+  OrtValueIndex input_data_index;
+  ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("image_data_in", input_data_index));
 
-  EXPECT_EQ(main_graph_plan->allocation_plan[init_data_index].location.device.Type(), OrtDevice::GPU);
+  EXPECT_EQ(main_graph_plan->allocation_plan[input_data_index].location.device.Type(), OrtDevice::GPU);
 }
 
 #endif

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -167,8 +167,8 @@ class PlannerTest : public ::testing::Test {
   std::unique_ptr<::onnxruntime::KernelDef> in_place_kernel_;          // a unary kernel with in-place
   std::unique_ptr<::onnxruntime::KernelDef> external_outputs_kernel_;  // an unary kernel with external outputs
 #ifdef ENABLE_TRAINING
-  std::unique_ptr<::onnxruntime::KernelDef> may_strided_input_kernel_;  // an uinary kernel with may_strided_input
-  std::unique_ptr<::onnxruntime::KernelDef> may_strided_output_kernel_; // an unary kernel with may_strided_output
+  std::unique_ptr<::onnxruntime::KernelDef> may_strided_input_kernel_;   // an uinary kernel with may_strided_input
+  std::unique_ptr<::onnxruntime::KernelDef> may_strided_output_kernel_;  // an unary kernel with may_strided_output
 #endif
 
   std::unordered_map<std::string, onnxruntime::NodeArg*> name_to_arg_;
@@ -944,7 +944,7 @@ TEST_F(PlannerTest, LocationPlanningForInitializersOnlyUsedInANestedSubgraph) {
   EXPECT_EQ(main_graph_plan->allocation_plan[init_data_index].location.device.Type(), OrtDevice::GPU);
 }
 
-TEST_F(PlannerTest, LocationPlanningForInitializersUsedInMainGraphAndSubgraph) {
+TEST_F(PlannerTest, LocationPlanningForInitializersUsedOnDifferentDevicesInMainGraphAndSubgraph) {
   // This a simple model that has one outer scope initializer, an `If` node followed
   // by a `TopK` node. The initializer is used in both nested subgraphs(`Add` consumes it
   // and requires it on GPU) and main graph(the second input of `TopK` is required on CPU).
@@ -1049,6 +1049,94 @@ TEST_F(PlannerTest, LocationPlanningForInitializersUsedInMainGraphAndSubgraph) {
   ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("init_data", init_data_index));
 
   EXPECT_EQ(main_graph_plan->allocation_plan[init_data_index].location.device.Type(), OrtDevice::CPU);
+}
+
+TEST_F(PlannerTest, LocationPlanningForImplicitInputsWithoutExplicitConsumersInMainGraph) {
+  // This a simple model that has two inputs and an `If` node.
+  // The first input is the condition for the `If` node and the second input
+  // is an input consumed implicitly by the `If` node to be used in its subgraphs.
+  // Note that there are no other explicit consumers of this input in the main graph.
+
+  // We want to test that the location planned for this implicit input is the default device
+  // of the EP that the `If` node is partitioned to (which will be CUDA)
+  // and that it doesn't default to CPU.
+
+  // Types
+  TypeProto float_tensor;
+  float_tensor.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_param("dim_param");
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  auto create_model = [&float_tensor, &bool_scalar]() -> Model {
+    auto create_if_subgraph = [&float_tensor](bool is_then) -> GraphProto {
+      Model model("if_branch_subgraph", true, DefaultLoggingManager().DefaultLogger());
+      auto& graph = model.MainGraph();
+
+      auto& outer_scope_0 = graph.GetOrCreateNodeArg("image_data_in", &float_tensor);
+      graph.AddOuterScopeNodeArg("image_data_in");
+
+      auto& if_out = graph.GetOrCreateNodeArg(is_then ? "if_then_out" : "if_else_out", &float_tensor);
+      graph.AddNode("if_out", "Relu", "relu", {&outer_scope_0}, {&if_out});
+
+      auto status = graph.Resolve();
+      EXPECT_EQ(status, Status::OK());
+
+      return graph.ToGraphProto();
+    };
+
+    onnxruntime::Model model("main_graph", false, ModelMetaData(),
+                             PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+                             {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
+    auto& main_graph = model.MainGraph();
+    auto& image_data_in = main_graph.GetOrCreateNodeArg("image_data_in", &float_tensor);
+
+    // If
+    auto& if_in = main_graph.GetOrCreateNodeArg("if_in", &bool_scalar);
+    auto& if_out = main_graph.GetOrCreateNodeArg("if_out", &float_tensor);
+    auto& node = main_graph.AddNode("if_out", "If", "If", {&if_in}, {&if_out});
+    node.AddAttribute("then_branch", create_if_subgraph(true));
+    node.AddAttribute("else_branch", create_if_subgraph(false));
+
+    // Main graph's inputs/outputs
+    main_graph.SetInputs({&image_data_in, &if_in});
+    main_graph.SetOutputs({&if_out});
+
+    auto status = main_graph.Resolve();
+    EXPECT_EQ(status, Status::OK());
+
+    return model;
+  };
+
+  // Create and load session
+  SessionOptions so;
+  InferenceSession sess{so, GetEnvironment()};
+
+  auto status = sess.RegisterExecutionProvider(DefaultCudaExecutionProvider());
+  ASSERT_TRUE(status.IsOK());
+
+  std::string s1;
+  const bool rc = create_model().ToProto().SerializeToString(&s1);
+  EXPECT_EQ(rc, true);
+  std::stringstream sstr(s1);
+
+  status = sess.Load(sstr);
+  ASSERT_TRUE(status.IsOK());
+
+  status = sess.Initialize();
+  ASSERT_TRUE(status.IsOK());
+
+  // Check planned locations for the implicit input
+  const auto& main_graph_session_state = sess.GetSessionState();
+  const auto& main_graph_ort_value_index_map = main_graph_session_state.GetOrtValueNameIdxMap();
+  const auto* main_graph_plan = main_graph_session_state.GetExecutionPlan();
+
+  OrtValueIndex init_data_index;
+  ASSERT_STATUS_OK(main_graph_ort_value_index_map.GetIdx("image_data_in", init_data_index));
+
+  EXPECT_EQ(main_graph_plan->allocation_plan[init_data_index].location.device.Type(), OrtDevice::GPU);
 }
 
 #endif


### PR DESCRIPTION
**Description**: 
Currently, there is no location planning for implicit inputs except in subgraphs where we set the location to be the location where they are produced on in the outer scope to avoid "round-trip" copying when the subgraph executes. This we do only when there are no explicit consumers of an implicit input in the subgraph (https://github.com/microsoft/onnxruntime/pull/8702).

Enhancing this further, we support location planning for implicit inputs flowing through as  **graph inputs** without explicit consumers in that graph level (eg: When the entire model is an `If` node and the "business logic" is within `If` subgraphs and these subgraphs impliclty consume top level graph inputs - for instance, images.). Currently, we do not plan locations for such implicit inputs are they default to "CPU" even if the implicitly consuming `If` were partitioned to CUDA. This is counter-productive  in **most** cases (and counter-intuitive as well - why default to CPU for a CUDA partitioned node ?). In most cases, these inputs will be consumed on the device and if the "required location" is marked to be CPU in the main graph and if the users were to provide an `OrtValue` with CUDA backed data or if they tried to `IOBind` such graph inputs, the data will be on CPU in the top graph (making a copy if the users were to provide/IOBind CUDA data). Then the subgraph copying mechanism will take it to the device where it is consumed on (**most likely** CUDA) thus incurring a round-trip CUDA->CPU->CUDA copy.

The "ideal fix" is to finalize the locations for OrtValues in all the nested subgraphs and then come back to the main graph and plan the location of such implicit inputs to be the first location of explicit usage in the nested subgraphs. This will require decent amount of code change and is marked as a TODO. The "less than" ideal but "on average" better than the current state is to default the planned locations as the device corresponding to the EP that the subgraph holding node is partitioned to (than default it to CPU which is a counter-intuitive default as already stated). The only case where this could lead to a regression is when a user supplies inputs on CPU && the implicit consumer (`If`) is on CUDA && the final explicit consumer is on CPU in the nested subgraph (this will incur a CPU->CUDA->CPU round-trip), but this change keeps the "average case" optimal (when the final consumer is bound to be on CUDA when the subgraph holding node is partitioned to CUDA)

NOTE: When we see graph inputs (without explicit consumers) implicitly consumed by multiple nodes (and the associated EPs are heterogeneous), then we default to CPU as before. This is because there is ambiguity involved as to which device is the most optimal location (such cases should be very rare and it will be okay to default to CPU and let the subgraph copying mechanism trigger necessary copies)  

**Motivation and Context**
Fixes https://github.com/microsoft/onnxruntime/issues/11254
