### PR TITLE
Github action: lint python with black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,7 @@
 name: Lint Python with black
 
-on: [push, pull_request]
+on:
+  - pull_request
 
 jobs:
   lint:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint Python with black
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,3 +9,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
+        with:
+          options: "--check --diff --color"


### PR DESCRIPTION
**Description**: Create a github action to lint python with black, using the official psf/black github action. https://black.readthedocs.io/en/stable/integrations/github_actions.html

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

#11315 
