### PR TITLE
Github action: lint python with isort

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -11,5 +11,3 @@ jobs:
         with:
           python-version: "3.10"
       - uses: isort/isort-action@master
-        with:
-            requirementsFiles: "requirements-dev.txt"

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: isort/isort-action@master
         with:
             requirementsFiles: "requirements-dev.txt"

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,0 +1,15 @@
+name: Lint Python with isort
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - uses: isort/isort-action@master
+        with:
+            requirementsFiles: "requirements-dev.txt"

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,6 +1,5 @@
 name: Lint Python with isort
 on:
-  - push
   - pull_request
 
 jobs:

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,6 +1,7 @@
 name: Lint Python with isort
 on:
   - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
**Description**: Create a github action to lint python with isort, using the official isort action. https://github.com/marketplace/actions/python-isort

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

#11315