### PR TITLE
Disable DML_GRAPH_DESC fusion when SessionOptions::SetOptimizedModelFilePath is set

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
@@ -28,7 +28,9 @@ namespace Dml
     std::unique_ptr<onnxruntime::IExecutionProvider> CreateExecutionProvider(
         IDMLDevice* dmlDevice,
         ID3D12CommandQueue* commandQueue,
-        bool enableMetacommands = true);
+        bool enableMetacommands = true,
+        bool graphFusionEnabled = true
+    );
 
     ID3D12Resource* GetD3D12ResourceFromAllocation(onnxruntime::IAllocator* allocator, void* ptr);
     void FlushContext(onnxruntime::IExecutionProvider* provider);    

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -775,6 +775,11 @@ namespace Dml
         return m_areMetacommandsEnabled;
     }
 
+    bool __stdcall ExecutionProviderImpl::IsGraphFusionEnabled() const noexcept
+    {
+        return m_isGraphFusionEnabled;
+    }
+
     std::shared_ptr<const Windows::AI::MachineLearning::Adapter::InternalRegistrationInfoMap> 
     ExecutionProviderImpl::GetInternalRegistrationInfoMap() const
     {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -34,7 +34,9 @@ namespace Dml
             IDMLDevice* dmlDevice,
             ID3D12Device* d3d12Device,
             ID3D12CommandQueue* queue,
-            bool enableMetacommands = true);
+            bool enableMetacommands = true,
+            bool enableGraphFusion = true
+        );
 
         void ReleaseCompletedReferences();
 
@@ -167,6 +169,7 @@ namespace Dml
         ComPtr<IDMLDevice> m_dmlDevice;
         bool m_isMcdmDevice = false;
         bool m_areMetacommandsEnabled = true;
+        bool m_isGraphFusionEnabled = true;
         std::shared_ptr<ExecutionContext> m_context;
         std::unique_ptr<PooledUploadHeap> m_uploadHeap;
         std::unique_ptr<ReadbackHeap> m_readbackHeap;
@@ -224,7 +227,8 @@ namespace Dml
         explicit ExecutionProvider(
             IDMLDevice* dmlDevice,
             ID3D12CommandQueue* commandQueue,
-            bool enableMetacommands = true
+            bool enableMetacommands = true,
+            bool graphFusionEnabled = true
         );
         
         std::unique_ptr<onnxruntime::IDataTransfer> GetDataTransfer() const final override

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -153,6 +153,7 @@ namespace Dml
         STDMETHOD_(bool, IsMcdmDevice)() const noexcept final;
 
         STDMETHOD_(bool, MetacommandsEnabled)() const noexcept final;
+        STDMETHOD_(bool, IsGraphFusionEnabled)() const noexcept final;
         std::shared_ptr<onnxruntime::IAllocator> GetGpuAllocator();
         std::shared_ptr<onnxruntime::IAllocator> GetCpuInputAllocator();
         std::shared_ptr<onnxruntime::IAllocator> GetCpuOutputAllocator();
@@ -252,6 +253,13 @@ namespace Dml
 
         onnxruntime::common::Status OnSessionInitializationEnd() override
         { 
+            if (!m_impl->IsGraphFusionEnabled())
+            {
+                const onnxruntime::logging::Logger* logger = this->GetLogger();
+                LOGS(*logger, WARNING) << "\n"
+                                          "DirectML EP graph fusion is disabled! Execution will run noticeably slower.\n"
+                                          "Run without SessionOptions::SetOptimizedModelFilePath for better performance.\n";
+            }
             return m_impl->OnSessionInitializationEnd();
         }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
@@ -612,7 +612,9 @@ namespace Dml
         uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         std::unordered_map<const onnxruntime::Node*, GraphNodeProperties>& graphNodePropertyMap,
         std::unordered_set<std::string>& requiredInitializerMap,
-        std::function<void(const onnxruntime::Node&)> onNodeUnsupportedInGraph)
+        std::function<void(const onnxruntime::Node&)> onNodeUnsupportedInGraph,
+        bool isGraphFusionEnabled
+    )
     {
         // Nodes are uniquely identified by the name of their first output argument
         std::vector<std::unique_ptr<GraphPartition>> partitions;
@@ -674,6 +676,8 @@ namespace Dml
                 /*out*/ &isDmlNode,
                 /*out*/ &isDmlGraphNode
             );
+
+            isDmlGraphNode &= isGraphFusionEnabled; // Even if the node otherwise supports it, disable if the user wants it disabled.
 
             // Add a unique partition if graph node usage is not supported.
             //
@@ -788,7 +792,8 @@ namespace Dml
         const std::vector<const onnxruntime::KernelRegistry*>& registries,
         uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         onnxruntime::KernelRegistry* registryForPartitionKernels,
-        const std::string& partitionKernelPrefix
+        const std::string& partitionKernelPrefix,
+        bool isGraphFusionEnabled
         )
     {
         std::vector<std::unique_ptr<onnxruntime::ComputeCapability>> result;
@@ -803,7 +808,10 @@ namespace Dml
             registries,
             supportedDeviceDataTypeMask,
             graphNodePropertyMap, 
-            requiredInitializerMap);
+            requiredInitializerMap,
+            nullptr, // onNodeUnsupportedInGraph
+            isGraphFusionEnabled
+        );
 
         // Create a map between each initialized tensor and the partition(s) it is part of.
         auto initializerPartitionMap = GetInitializerToPartitionMap(graph, partitions);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.h
@@ -48,7 +48,9 @@ namespace Dml
         uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         std::unordered_map<const onnxruntime::Node*, GraphNodeProperties>& graphNodePropertyMap,
         std::unordered_set<std::string>& requiredInitializerMap,
-        std::function<void(const onnxruntime::Node&)> onNodeUnsupportedInGraph = nullptr);
+        std::function<void(const onnxruntime::Node&)> onNodeUnsupportedInGraph = nullptr,
+        bool isGraphFusionEnabled = true
+    );
 
     std::vector<std::unique_ptr<onnxruntime::ComputeCapability>>
     PartitionGraph(
@@ -57,7 +59,8 @@ namespace Dml
         const std::vector<const onnxruntime::KernelRegistry*>& registries,
         uint32_t supportedDeviceDataTypeMask, // Each bit corresponds to each DML_TENSOR_DATA_TYPE.
         onnxruntime::KernelRegistry* registryForPartitionKernels,
-        const std::string& partitionKernelPrefix
+        const std::string& partitionKernelPrefix,
+        bool isGraphFusionEnabled
     );
 
     bool IsNodeSupportedByDml(

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -65,6 +65,7 @@ void DMLProviderFactory::SetMetacommandsEnabled(bool metacommands_enabled) {
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(IDMLDevice* dml_device,
                                                                               ID3D12CommandQueue* cmd_queue,
                                                                               _In_ OrtSessionOptions* options) {
+#ifndef _GAMING_XBOX
   // Validate that the D3D12 devices match between DML and the command queue. This specifically asks for IUnknown in
   // order to be able to compare the pointers for COM object identity.
   ComPtr<IUnknown> d3d12_device_0;

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -77,12 +77,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(ID
   }
 #endif
 
-  bool graph_fusion_enabled = true;
-  std::string graph_fusion_value;
-  if (options->value.config_options.TryGetConfigEntry(kOrtSessionOptionsConfigDmlEpDisableGraphFusion, graph_fusion_value))
-  {
-      graph_fusion_enabled = (graph_fusion_value == "0");
-  }
+  bool graph_fusion_enabled = options->value.graph_optimization_level > TransformerLevel::Level1;
 
   ComPtr<ID3D12Device> d3d12_device;
   ORT_THROW_IF_FAILED(dml_device->GetParentDevice(IID_GRAPHICS_PPV_ARGS(d3d12_device.ReleaseAndGetAddressOf())));

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -77,7 +77,10 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(ID
   }
 #endif
 
-  bool graph_fusion_enabled = options->value.graph_optimization_level > TransformerLevel::Level1;
+  // Disable DML_GRAPH_DESC fusion if the user wants to export the model because otherwise the graph cannot be
+  // reloaded again since all nodes were fused into a single large IDMLOperator (which isn't any kind of
+  // registered ONNX operator).
+  bool graph_fusion_enabled = options->value.optimized_model_filepath.empty();
 
   ComPtr<ID3D12Device> d3d12_device;
   ORT_THROW_IF_FAILED(dml_device->GetParentDevice(IID_GRAPHICS_PPV_ARGS(d3d12_device.ReleaseAndGetAddressOf())));


### PR DESCRIPTION
**Description**: Customers cannot export to .ort files and reload them via the DML EP because during the `IExecutionProvider::Partition` call, the DirectML EP fuses all nodes assigned to a DML partition into a single ORT graph node (a single DML_GRAPH_DESC). ORT actually *exports* the .ort file fine, but because the entire DML partition has become one ubernode with a name like "DmlFusedNodeXXXX", upon reloading, kernel creation finds no matching operator.

Because `InferenceSessionInitialize()` calls `SaveToOrtFormat` *after* the `Partition` and `Compile` calls, it's already too late by then (already ubernodified), and there's nothing we can do about it at that point. Ideally `SaveToOrtFormat` would be called before any *final* graph fusion (e.g. a hypothetical post-Compile function for the EP), but alternately we can just disable whole graph fusion when they're exporting an optimized model via the `SessionOptions::SetOptimizedModelFilePath`. Then when the customer reloads the model for *actual* inference, full graph fusion would happen like normal (as `SetOptimizedModelFilePath` is not called).

This does yield a perf hit and should not be used for normal inference/profiling, which is why it's important to emit a performance warning.

Note *whole graph fusion* and *operator fusion* are distinct. Operator fusion (like `FusedGemm`) still happens either way.

Beware in the *general* case, it's unreliable to store an .ort file and reload it using the DML EP because saving it with one GPU and replaying it with a different GPU will cause issues, due to GPU's supporting different data types and incurring EP node fallback. However, in the specific scenario of known hardware being targeted, it works.

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Blocks customer scenario.
- *If it fixes an open issue, please link to the issue here.* https://github.com/microsoft/onnxruntime/issues/8440

+Jeff because he knows the graph best.
+Justin because it affects certain hardware he's interested in.
+Scott because he has some thoughts on the matter.
+Sumit because pertinent to another issue he's wrangling with.