### PR TITLE
Fix bug for ConcatFromSequence Op [CUDA]

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/sequence_op.h
+++ b/onnxruntime/core/providers/cuda/tensor/sequence_op.h
@@ -149,7 +149,7 @@ class ConcatFromSequence final : public CudaKernel, public ConcatBase {
         CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
             output + (initial_output_offset + cur_out_offset) * element_bytes,
             input + cur_in_offset * element_bytes, input_axis_pitch * element_bytes,
-            cudaMemcpyHostToDevice, Stream()));
+            cudaMemcpyDeviceToDevice, Stream()));
         cur_out_offset += p.output_axis_pitch;
         cur_in_offset += input_axis_pitch;
       }


### PR DESCRIPTION
Fix incorrect cudaMemcpyAsync kind in ConcatFromSequence Op.

**Description**: Use cudaMemcpyDeviceToDevice instead of cudaMemcpyHostToDevice in cudaMemcpyAsync for ConcatFromSequence Op (CUDA) because src and dst are device pointers already. Tensors are copied before. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
#11360 
