### PR TITLE
Add LGTM config for c++ and c#

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,15 @@
+extraction:
+  cpp:
+    index:
+      build_command:
+        - ./build.sh --config RelWithDebInfo --parallel --skip_tests
+  csharp:
+    index:
+      solution: ["csharp/OnnxRuntime.DesktopOnly.CSharp.sln"]
+      msbuild:
+        configuration: release
+        platform: x64
+  java:
+    index:
+      build_command:
+      - ./build.sh --parallel --skip_tests --build_java

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,5 +1,10 @@
 extraction:
   cpp:
+    after_prepare:
+      # Install cmake
+      - mkdir custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
+      - export PATH=$(pwd)/custom_cmake/bin:${PATH}
     index:
       build_command:
         - ./build.sh --config RelWithDebInfo --parallel --skip_tests
@@ -10,6 +15,11 @@ extraction:
         configuration: release
         platform: x64
   java:
+    after_prepare:
+      # Install cmake
+      - mkdir custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
+      - export PATH=$(pwd)/custom_cmake/bin:${PATH}
     index:
       build_command:
       - ./build.sh --parallel --skip_tests --build_java

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,10 @@
+path_classifiers:
+  library:
+    - exclude: cmake
+
+queries:
+  - include: "*"
+
 extraction:
   cpp:
     after_prepare:
@@ -23,7 +30,4 @@ extraction:
       gradle:
         version: 7.4
       build_command:
-      - ./build.sh --parallel --skip_tests --build_java
-
-queries:
-  - include: "*"
+        - ./build.sh --parallel --skip_tests --build_java

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,24 +2,23 @@ extraction:
   cpp:
     after_prepare:
       # Install cmake
-      - mkdir custom_cmake
-      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
-      - export PATH=$(pwd)/custom_cmake/bin:${PATH}
+      - mkdir -p $LGTM_WORKSPACE/custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C $LGTM_WORKSPACE/custom_cmake
     index:
       build_command:
-        - ./build.sh --config RelWithDebInfo --parallel --skip_tests
+        - ./build.sh --config RelWithDebInfo --parallel --skip_tests --cmake_path $LGTM_WORKSPACE/custom_cmake/bin/cmake
   csharp:
     index:
       solution: ["csharp/OnnxRuntime.DesktopOnly.CSharp.sln"]
-      msbuild:
-        configuration: release
-        platform: x64
+
   java:
     after_prepare:
       # Install cmake
-      - mkdir custom_cmake
-      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
-      - export PATH=$(pwd)/custom_cmake/bin:${PATH}
+      - mkdir -p $LGTM_WORKSPACE/custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C $LGTM_WORKSPACE/custom_cmake
     index:
       build_command:
-      - ./build.sh --parallel --skip_tests --build_java
+      - ./build.sh --parallel --skip_tests --build_java --cmake_path $LGTM_WORKSPACE/custom_cmake/bin/cmake
+
+queries:
+  - include: "*"

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -10,8 +10,9 @@ extraction:
         - ./build.sh --config RelWithDebInfo --parallel --skip_tests
   csharp:
     index:
-      solution: ["csharp/OnnxRuntime.DesktopOnly.CSharp.sln"]
-
+      solution: ["csharp/OnnxRuntime.CSharp.sln"]
+      buildless: true
+      nuget_restore: false
   java:
     after_prepare:
       # Install cmake
@@ -19,6 +20,8 @@ extraction:
       - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
       - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
     index:
+      gradle:
+        version: 7.4
       build_command:
       - ./build.sh --parallel --skip_tests --build_java
 

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -7,6 +7,9 @@ queries:
 
 extraction:
   cpp:
+    prepare:
+      packages:
+        - ninja-build
     after_prepare:
       # Install cmake
       - mkdir custom_cmake
@@ -14,20 +17,9 @@ extraction:
       - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
     index:
       build_command:
-        - ./build.sh --config RelWithDebInfo --parallel --skip_tests
+        - ./build.sh --cmake_generator Ninja --config Debug --skip_submodule_sync --build_shared_lib --parallel --skip_tests --minimal_build --disable_exceptions --enable_training_ops
   csharp:
     index:
       solution: ["csharp/OnnxRuntime.CSharp.sln"]
       buildless: true
-      nuget_restore: false
-  java:
-    after_prepare:
-      # Install cmake
-      - mkdir custom_cmake
-      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
-      - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
-    index:
-      gradle:
-        version: 7.4
-      build_command:
-        - ./build.sh --parallel --skip_tests --build_java
+      nuget_restore: true

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,11 +2,12 @@ extraction:
   cpp:
     after_prepare:
       # Install cmake
-      - mkdir -p $LGTM_WORKSPACE/custom_cmake
-      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C $LGTM_WORKSPACE/custom_cmake
+      - mkdir custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
+      - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
     index:
       build_command:
-        - ./build.sh --config RelWithDebInfo --parallel --skip_tests --cmake_path $LGTM_WORKSPACE/custom_cmake/bin/cmake
+        - ./build.sh --config RelWithDebInfo --parallel --skip_tests
   csharp:
     index:
       solution: ["csharp/OnnxRuntime.DesktopOnly.CSharp.sln"]
@@ -14,11 +15,12 @@ extraction:
   java:
     after_prepare:
       # Install cmake
-      - mkdir -p $LGTM_WORKSPACE/custom_cmake
-      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1.tar.gz" | tar --strip-components=1 -xz -C $LGTM_WORKSPACE/custom_cmake
+      - mkdir custom_cmake
+      - wget --quiet -O - "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C custom_cmake
+      - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
     index:
       build_command:
-      - ./build.sh --parallel --skip_tests --build_java --cmake_path $LGTM_WORKSPACE/custom_cmake/bin/cmake
+      - ./build.sh --parallel --skip_tests --build_java
 
 queries:
   - include: "*"


### PR DESCRIPTION
**Description**: Add LGTM config for c++, cs and java so that it can successfully built by lgtm.

**Motivation and Context**

LGTM is able to analyze python and js automatically. It needs to be configured properly to analyze c++ and the other languages.
![186C5834-D577-4F5F-8DFF-CEE83DDD8300](https://user-images.githubusercontent.com/11205048/165579712-95c4c328-9ddc-426b-a622-01274377ebd0.jpeg)

