### PR TITLE
Fixed the function calls for memory pattern

### DIFF
--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -84,9 +84,9 @@ OrtSessionOptions* OrtCreateSessionOptions(size_t graph_optimization_level,
   }
 
   if (enable_mem_pattern) {
-    RETURN_NULLPTR_IF_ERROR(EnableCpuMemArena, session_options);
+    RETURN_NULLPTR_IF_ERROR(EnableMemPattern, session_options);
   } else {
-    RETURN_NULLPTR_IF_ERROR(DisableCpuMemArena, session_options);
+    RETURN_NULLPTR_IF_ERROR(DisableMemPattern, session_options);
   }
 
   // assume that an execution mode is checked and properly set at JavaScript


### PR DESCRIPTION
**Description**: 
Updated the function calls to Disable/Enable memory pattern instead of memory arena

**Motivation and Context**
- After this fix the ORT session status will be update correctly according to the parameter "enable_mem_pattern"
- This issue was discovered during the memory optimization effort

