### PR TITLE
[ep-perf] Fix the order of onnx and onnxruntime imports.

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -16,7 +16,6 @@ import numpy
 import numpy as np
 import pandas as pd
 from float16 import *
-
 from perf_utils import *
 
 import onnxruntime  # isort:skip

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -16,10 +16,11 @@ import numpy
 import numpy as np
 import pandas as pd
 from float16 import *
-from onnx import numpy_helper
+
 from perf_utils import *
 
-import onnxruntime
+import onnxruntime  # isort:skip
+from onnx import numpy_helper # isort:skip
 
 debug = False
 sys.path.append(".")

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -20,7 +20,7 @@ from float16 import *
 from perf_utils import *
 
 import onnxruntime  # isort:skip
-from onnx import numpy_helper # isort:skip
+from onnx import numpy_helper  # isort:skip
 
 debug = False
 sys.path.append(".")
@@ -347,9 +347,9 @@ def inference_ort(
                     args.io_binding,
                     io_binding,
                 )
-            if args.input_data == "fix": 
-                runtime = runtime[1:] # remove warmup
-            runtimes += runtime  
+            if args.input_data == "fix":
+                runtime = runtime[1:]  # remove warmup
+            runtimes += runtime
 
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
**Description**: Fixes the import order of the `onnxruntime` and `onnx` packages in the EP Perf script.

**Motivation and Context**
A recent [PR](https://github.com/microsoft/onnxruntime/pull/11324) introduced automatic python code formatting and import sorting. Once this PR was merged, runs of the Linux-GPU-EP-Perf pipeline began failing. The EP Perf docker containers failed to import onnxruntime and threw the following error.

```shell
from onnxruntime.capi._pybind_state import (
  File "/opt/miniconda/lib/python3.7/site-packages/onnxruntime/capi/_pybind_state.py", line 32, in <module>
    from .onnxruntime_pybind11_state import *  # noqa
ImportError: /opt/miniconda/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /opt/miniconda/lib/python3.7/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.so)
Traceback (most recent call last):
  File "benchmark_wrapper.py", line 11, in <module>
    from benchmark import *
  File "/perf/benchmark.py", line 22, in <module>
    import onnxruntime
  File "/opt/miniconda/lib/python3.7/site-packages/onnxruntime/__init__.py", line 55, in <module>
    raise import_capi_exception
  File "/opt/miniconda/lib/python3.7/site-packages/onnxruntime/__init__.py", line 23, in <module>
    from onnxruntime.capi._pybind_state import (
  File "/opt/miniconda/lib/python3.7/site-packages/onnxruntime/capi/_pybind_state.py", line 32, in <module>
    from .onnxruntime_pybind11_state import *  # noqa
ImportError: /opt/miniconda/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /opt/miniconda/lib/python3.7/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.so)
```
The error indicates that onnxruntime_pybind11_state.so is unable to find a suitable version of the c++ stdlib. 

It turns out that changing the import order of the onnx and onnxruntime packages triggered this error. Importing onnxruntime before onnx works, but the reverse does not.

This PR is temporary workaround to unblock EP Perf pipeline workflows. An internal task has been created to track the investigation of this issue.