### PR TITLE
Change MinGrad/MaxGrad to Use Distributed Logic

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2,44 +2,41 @@
 # Licensed under the MIT License.
 # orttraining_test_ortmodule_api.py
 
+import copy
 import itertools
 import math
-import random
-import copy
-import torch
-from transformers import AutoConfig, BertForSequenceClassification, Trainer
-from transformers.modeling_outputs import SequenceClassifierOutput
-import pytest
-from time import sleep
-import warnings
-from unittest.mock import patch
-from collections import OrderedDict
-from collections import namedtuple
-from inspect import signature
-import tempfile
 import os
 import pickle
+import random
+import tempfile
+import warnings
+from collections import OrderedDict, namedtuple
 from distutils.version import LooseVersion
-from onnxruntime.training.ortmodule._custom_gradient_registry import register_gradient
-from onnxruntime.training.ortmodule import (
-    ORTModule,
-    _utils,
-    _io,
-    DebugOptions,
-    LogLevel,
-    _fallback,
-    _graph_execution_manager,
-)
-import onnxruntime.training.ortmodule as ortmodule_module
-
-from onnxruntime.training.optim import FusedAdam, AdamWMode
-from transformers import AdamW
+from inspect import signature
+from time import sleep
+from unittest.mock import patch
 
 import _test_helpers
+import pytest
+import torch
 
 # Import autocasting libs
 from torch.cuda import amp
+from transformers import AdamW, AutoConfig, BertForSequenceClassification, Trainer
+from transformers.modeling_outputs import SequenceClassifierOutput
 
+import onnxruntime.training.ortmodule as ortmodule_module
+from onnxruntime.training.optim import AdamWMode, FusedAdam
+from onnxruntime.training.ortmodule import (
+    DebugOptions,
+    LogLevel,
+    ORTModule,
+    _fallback,
+    _graph_execution_manager,
+    _io,
+    _utils,
+)
+from onnxruntime.training.ortmodule._custom_gradient_registry import register_gradient
 
 DEFAULT_OPSET = 14
 
@@ -1123,9 +1120,12 @@ def test_gradient_correctness_max(operator, dim, keepdim):
         _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
 
 
-@pytest.mark.skip("temporarily disabled due to PyTorch's change of max implementation")
+# Before 1.10 (excluded), Torch's min/max(x,y) will asign dY to y's dX if value from x and y are equal.
+# From 1.10, both x and y's dX will be dY/2. ORT follows this distribution logic, so skip below test if Torch version
+# is lower than 1.10.
+@pytest.mark.skipif(LooseVersion(torch.__version__) < LooseVersion("1.10.0"), reason="PyTorch 1.9 incompatible")
 @pytest.mark.parametrize("operator", ["min", "max"])
-def test_gradient_correctness_max_two_tensors(operator):
+def test_gradient_correctness_minmax_two_tensors(operator):
     func = getattr(torch, operator)
 
     class NeuralNetMaxTwoTensors(torch.nn.Module):
@@ -1153,6 +1153,17 @@ def test_gradient_correctness_max_two_tensors(operator):
 
         _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
         _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
+
+    # Simple test for case that has equal value.
+    pt_input = torch.tensor([0.0, 0.0, 1.0, 1.0], device=device, requires_grad=True)
+    pt_other = torch.tensor([1.0, 0.0, 1.0, 0.0], device=device, requires_grad=True)
+    ort_input = copy.deepcopy(pt_input)
+    ort_other = copy.deepcopy(pt_other)
+    pt_prediction = run_step(pt_model, pt_input, pt_other)
+    ort_prediction = run_step(ort_model, ort_input, ort_other)
+
+    _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
+    _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
 
 
 def test_gradient_correctness_argmax_unfold():
@@ -2711,7 +2722,7 @@ def test_forward_data_and_model_on_different_devices(data_device, model_device):
 
     # Now that the model has been exported, feed in data from device other than the model device
     x = torch.randn(N, D_in, device=data_device)
-    from onnxruntime.training.ortmodule._fallback import _FallbackPolicy, ORTModuleDeviceException
+    from onnxruntime.training.ortmodule._fallback import ORTModuleDeviceException, _FallbackPolicy
 
     if _test_helpers.is_all_or_nothing_fallback_enabled(None, _FallbackPolicy.FALLBACK_UNSUPPORTED_DEVICE):
         # Fallback

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1120,7 +1120,7 @@ def test_gradient_correctness_max(operator, dim, keepdim):
         _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
 
 
-# Before 1.10 (excluded), Torch's min/max(x,y) will asign dY to y's dX if value from x and y are equal.
+# Before 1.10 (excluded), Torch's min/max(x,y) will assign dY to y's dX if value from x and y are equal.
 # From 1.10, both x and y's dX will be dY/2. ORT follows this distribution logic, so skip below test if Torch version
 # is lower than 1.10.
 @pytest.mark.skipif(LooseVersion(torch.__version__) < LooseVersion("1.10.0"), reason="PyTorch 1.9 incompatible")
@@ -1153,6 +1153,7 @@ def test_gradient_correctness_minmax_two_tensors(operator):
 
         _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
         _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
+        _test_helpers.assert_values_are_close(ort_other.grad, pt_other.grad)
 
     # Simple test for case that has equal value.
     pt_input = torch.tensor([0.0, 0.0, 1.0, 1.0], device=device, requires_grad=True)
@@ -1164,6 +1165,7 @@ def test_gradient_correctness_minmax_two_tensors(operator):
 
     _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
     _test_helpers.assert_values_are_close(ort_input.grad, pt_input.grad)
+    _test_helpers.assert_values_are_close(ort_other.grad, pt_other.grad)
 
 
 def test_gradient_correctness_argmax_unfold():


### PR DESCRIPTION
Previous MinGrad/MaxGrad uses value selecting logic, when there are equal values in different inputs, only one input can get the dY value. PyTorch used this logic before 1.10, and from 1.10, it changed to distributed logic. Change ORT to distributed logic, which is more reasonable. Previous MinGrad/MaxGrad can only support 2 inputs, this PR changes it to support arbitrary inputs.