### PR TITLE
[js/rn] set minSdkVersion to 21 for ORT-RN Android

### DIFF
--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -24,7 +24,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/js/react_native/android/gradle.properties
+++ b/js/react_native/android/gradle.properties
@@ -15,4 +15,5 @@ android.enableJetifier=true
 android.useAndroidX=true
 OnnxruntimeModule_buildToolsVersion=29.0.2
 OnnxruntimeModule_compileSdkVersion=29
+OnnxruntimeModule_minSdkVersion=21
 OnnxruntimeModule_targetSdkVersion=29

--- a/js/react_native/e2e/android/build.gradle
+++ b/js/react_native/e2e/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 24
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }


### PR DESCRIPTION
**Description**: set minSdkVersion to 21 for onnxruntime-react-native Android package, align with onnxruntime mobile.