### PR TITLE
For BUILD demo - extend C# APIs to invoke remote ort on AML

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -11,7 +11,6 @@ using System.Buffers;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.ML.OnnxRuntime
 {
@@ -234,7 +233,9 @@ namespace Microsoft.ML.OnnxRuntime
 
                     HttpResponseMessage response = await client.PostAsync("", multipartContent).ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
+                    {
                         result = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    }
                     else
                     {
                         string headers = response.Headers.ToString();
@@ -249,24 +250,8 @@ namespace Microsoft.ML.OnnxRuntime
             return result;
         }
 
-        private string SerializeInput(IReadOnlyCollection<NamedOnnxValue> inputs) 
-        {
-            JObject jobj = new JObject();
-            var input_array = new JArray();
-            foreach (var input in inputs) {
-                input_array.Add(input.ToString());
-            }
-            jobj["data"] = input_array;
-            return jobj.ToString();
-        }
-
-        private IDisposableReadOnlyCollection<DisposableNamedOnnxValue> DeserializeOutput(byte[] raw_output)
-        {
-            return null;
-        }
-
         /// <summary>
-        /// accept input in form of json string, and return a json string of output
+        /// forward bytes to AML endpoint
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -40,6 +40,8 @@ namespace Microsoft.ML.OnnxRuntime
         // Delay-loaded CUDA or cuDNN DLLs. Currently, delayload is disabled. See cmake/CMakeLists.txt for more information.
         private static string[] cudaDelayLoadedLibs = { };
         private static string[] trtDelayLoadedLibs = { };
+        private string azureEndPoint = string.Empty;
+        private string azureEndPointKey = string.Empty;
 
         #region Constructor and Factory methods
 
@@ -175,9 +177,9 @@ namespace Microsoft.ML.OnnxRuntime
             options.AppendExecutionProvider_ROCM(deviceId);
             return options;
         }
-#endregion
+        #endregion
 
-#region ExecutionProviderAppends
+        #region ExecutionProviderAppends
         /// <summary>
         /// Appends CPU EP to a list of available execution providers for the session.
         /// </summary>
@@ -384,9 +386,25 @@ namespace Microsoft.ML.OnnxRuntime
             }
 #endif
         }
-#endregion //ExecutionProviderAppends
+        #endregion //ExecutionProviderAppends
 
-#region Public Methods
+        public string GetAzureEndPoint() 
+        { 
+            return azureEndPoint;
+        }
+
+        public string GetAzureEndPointKey()
+        {
+            return azureEndPointKey;
+        }
+
+        public void AppendAzureEP(string endPoint, string apikey)
+        {
+            azureEndPoint = endPoint;
+            azureEndPointKey = apikey;
+        }
+
+        #region Public Methods
         /// <summary>
         /// (Deprecated) Loads a DLL named 'libraryPath' and looks for this entry point:
         /// OrtStatus* RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api);


### PR DESCRIPTION
Extend c# APIs for BUILD demo:

1.  Add "AppendAzureEP" for SessionOption;
2.  Add "Run(byte[])" for InferenceSession;

Sample client code:

```
var session_option = new SessionOptions();
session_option.AppendAzureEP(<uri string>, <key string>);
var session = new InferenceSession(<path to model>, session_option); // model will not be load locally
byte[] input_bytes = ...//convert image to byte[]
try {
  byte[] output_bytes = session.Run(input_bytes);
}...
```