### PR TITLE
support gpt2 past/present(fp16) 

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/qorder_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/qorder_attention.cc
@@ -4,7 +4,7 @@
 #include "qorder_common.h"
 #include "qorder_common_impl.h"
 #include "qorder_attention.h"
-#include "contrib_ops/cuda/bert/attention_impl.h"
+#include "qorder_attention_impl.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include <iostream>
@@ -17,23 +17,26 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_TYPED_KERNEL_EX(
     QOrderedAttention,
     kMSDomain,
     1,
+    MLFloat16,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .TypeConstraint("Q", DataTypeImpl::GetTensorType<int8_t>())
         .TypeConstraint("S", BuildKernelDefConstraints<float>())
         .TypeConstraint("G", DataTypeImpl::GetTensorType<int32_t>())
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>())
         .InputMemoryType(OrtMemTypeCPUInput, 1)
         .InputMemoryType(OrtMemTypeCPUInput, 3)
         .InputMemoryType(OrtMemTypeCPUInput, 5)
         .InputMemoryType(OrtMemTypeCPUInput, 6)
         .InputMemoryType(OrtMemTypeCPUInput, 8),
-    QOrderedAttention);
+    QOrderedAttention<MLFloat16>);
 
-QOrderedAttention::QOrderedAttention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info) {
+template <typename T>
+QOrderedAttention<T>::QOrderedAttention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info) {
   order_input_ = GetCublasLtOrderAttr(info, "order_input");
   order_weight_ = GetCublasLtOrderAttr(info, "order_weight");
   order_bias_ = GetCublasLtOrderAttr(info, "order_bias");
@@ -45,11 +48,12 @@ QOrderedAttention::QOrderedAttention(const OpKernelInfo& info) : CudaKernel(info
   // ORT_ENFORCE(order_input_ == CUBLASLT_ORDER_COL32, "Only CUBLASLT_ORDER_COL32 is supported for order_input");
 }
 
-Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
+template <typename T>
+Status QOrderedAttention<T>::ComputeInternal(OpKernelContext* context) const {
   // inputs are column based
   const Tensor* input = context->Input<Tensor>(0);
   const Tensor* weights = context->Input<Tensor>(2);
-  const Tensor* bias = context->Input<Tensor>(4);
+  const Tensor* bias = context->Input<Tensor>(4); // Support MLFloat16 in the future
   const Tensor* mask_index = context->Input<Tensor>(7);
 
   auto& device_prop = GetDeviceProp();
@@ -61,6 +65,7 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
   // const Tensor* scale_bias = context->Input<Tensor>(5);
   const Tensor* scale_gemm = context->Input<Tensor>(6);
   const Tensor* scale_output = context->Input<Tensor>(8);
+  const Tensor* past = context->Input<Tensor>(9);
 
   const float* scale_input_data = scale_input->template Data<float>();
   const float* scale_weights_data = scale_weights->template Data<float>();
@@ -86,6 +91,10 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
   output_shape[2] = static_cast<int64_t>(hidden_size);
   Tensor* output = context->Output(0, output_shape);
 
+  // Past and Present will be row32 and fp16
+  int past_sequence_length = 0;
+  Tensor* present = GetPresent(context, past, batch_size, head_size, sequence_length, past_sequence_length);
+
   cublasLtHandle_t cublasLt = CublasLtHandle();
   // Use GEMM for fully connection.
   int m = batch_size * sequence_length;
@@ -104,12 +113,12 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
                       bias->Data<float>(), gemm_buffer_quantized.get(),
                       (cublasLtOrder_t)order_weight_));
 
-  using CudaT = ToCudaType<MLFloat16>::MappedType;
-  constexpr size_t element_size = sizeof(MLFloat16);
+  typedef typename ToCudaType<T>::MappedType CudaT;
+  constexpr size_t element_size = sizeof(T);
 
   auto gemm_buffer = GetScratchBuffer<int8_t>(m * n * element_size);  // row, fp16
   QOrderDequantizeCol32ToRow(stream, GetDeviceProp(), gemm_buffer_quantized.get(), (CudaT*)gemm_buffer.get(),
-                             *(const float*)scale_gemm_data, batch_size, sequence_length, n);
+                             *(const float*)scale_gemm_data, batch_size, sequence_length, n); // Maybe support float in the future
   // // reorder to row major
   // ORT_RETURN_IF_ERROR(
   //   Reorder(cublasLt, stream, device_prop, gsl::narrow_cast<int>(1), m, n, CUDA_R_8I,
@@ -124,7 +133,7 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
   auto temp_buffer = GetScratchBuffer<void>(workSpaceSize);
   auto output_buffer = GetScratchBuffer<int8_t>(m * n * element_size);  // row, fp16
   cublasHandle_t cublas = CublasHandle();
-  if (!LaunchAttentionKernel(
+  if (!LaunchQOrderAttentionKernel(
           device_prop,
           stream,
           reinterpret_cast<const CudaT*>(gemm_buffer.get()),
@@ -139,10 +148,10 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
           cublas,
           element_size,
           is_unidirectional_,
-          0,
+          past_sequence_length,
+          nullptr == past ? nullptr : past->template Data<T>(),
           nullptr,
-          nullptr,
-          nullptr)) {
+          nullptr == present ? nullptr : present->template MutableData<T>())) {
     // Get last error to reset it to cudaSuccess.
     CUDA_CALL(cudaGetLastError());
     return Status(common::ONNXRUNTIME, common::FAIL);

--- a/onnxruntime/contrib_ops/cuda/quantization/qorder_attention.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/qorder_attention.h
@@ -14,6 +14,7 @@ namespace cuda {
 
 using namespace onnxruntime::cuda;
 
+template <typename T>
 class QOrderedAttention final : public CudaKernel, public AttentionBase {
  public:
   QOrderedAttention(const OpKernelInfo& info);

--- a/onnxruntime/contrib_ops/cuda/quantization/qorder_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/qorder_attention_impl.cu
@@ -1,0 +1,186 @@
+/*
+ The implementation of this file is based on qkvToContext plugin in TensorRT demo:
+ https://github.com/NVIDIA/TensorRT/tree/release/5.1/demo/BERT/
+
+Copyright 2019 NVIDIA Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Modifications: scaling is moved from masked softmax to the gemm before that.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cuda_fp16.h>
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/shared_inc/fpgeneric.h"
+#include "qorder_attention_impl.h"
+#include "contrib_ops/cuda/bert/attention_softmax.h"
+#include "contrib_ops/cuda/bert/transformer_common.h"
+
+using namespace onnxruntime::cuda;
+using namespace cub;
+
+#define CHECK_CUDA(expr)  \
+  if (!CUDA_CALL(expr)) { \
+    return false;         \
+  }
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T>
+bool QOrderQkvToContext(
+    const cudaDeviceProp& prop, cublasHandle_t& cublas, cudaStream_t stream,
+    const int batch_size, const int sequence_length, const int num_heads, const int head_size, const size_t element_size,
+    const T* input, T* output, T* workspace,
+    const int* mask_index, gsl::span<const int64_t> mask_index_dims,
+    bool is_unidirectional, int past_sequence_length, const T* past, const T* extra_add_qk, T* present, bool use_persistent_softmax) {
+  const int all_sequence_length = past_sequence_length + sequence_length;
+  const size_t bytes = GetAttentionScratchSize(element_size, batch_size, num_heads, sequence_length, all_sequence_length);
+  T* scratch1 = workspace;
+  T* scratch2 = scratch1 + (bytes / element_size);
+  T* scratch3 = scratch2 + (bytes / element_size);
+
+  const int max_threads_per_block = prop.maxThreadsPerBlock;
+
+  // input should be BxSx3xNxH => scratch3: 3xBxNxSxH
+  if (!LaunchTransQkv(stream, 3, sequence_length, batch_size, head_size, num_heads, max_threads_per_block, false, input, scratch3)) {
+    return false;
+  }
+
+  // now scratch3 has Q, K, V: each has size BxNxSxH
+  const int batches = batch_size * num_heads;
+  const int size_per_batch = sequence_length * head_size;
+  const int total_size = batches * size_per_batch;
+
+  const T* q = scratch3;
+  const T* k = q + total_size;
+  const T* v = k + total_size;
+
+  cublasSetStream(cublas, stream);
+
+  // Concat past (2xBxNxS'xH) to present (2xBxNxS*xH):
+  // past_k (BxNxS'xH) + k (BxNxSxH) => present_k (BxNxS*xH)
+  // past_v (BxNxS'xH) + v (BxNxSxH) => present_v (BxNxS*xH)
+  const int present_size_per_batch = all_sequence_length * head_size;
+  if (nullptr != present) {
+    if (!LaunchConcatPastToPresent(stream, all_sequence_length, sequence_length, batch_size, head_size, num_heads, max_threads_per_block, past, k, present)) {
+      return false;
+    }
+
+    // update pointers to present_k and present_v.
+    k = present;
+    v = present + batches * present_size_per_batch;
+  }
+
+  // Raw attention mask could be 2D (BxS) or 3D (BxSxS*) or 4D(Bx1xMxM), where M is the max sequence length.
+  bool use_raw_attention_mask = (nullptr != mask_index && mask_index_dims.size() >= 2);
+
+  // compute Q*K' (as K'*Q), scaled by 1/sqrt(H) and store in scratch1: BxNxSxS*
+  // Q: BxNxSxH, K (present_k): BxNxS*xH, Q*K': BxNxSxS*
+  const float rsqrt_head_size = 1.f / sqrt(static_cast<float>(head_size));
+  const int temp_matrix_size = sequence_length * all_sequence_length;
+  float one = 1.0f;
+  float zero = 0.f;
+
+  // For raw attention mask, the scalar if 1/sqrt(H) is moved to softmax computation.
+  float alpha = use_raw_attention_mask ? one : rsqrt_head_size;
+
+  if (!CUBLAS_CALL(cublasGemmStridedBatchedHelper(
+          cublas, CUBLAS_OP_T, CUBLAS_OP_N, all_sequence_length, sequence_length, head_size, &alpha, k, head_size, present_size_per_batch,
+          q, head_size, size_per_batch, &zero, scratch1, all_sequence_length, temp_matrix_size, batches, prop))) {
+    return false;
+  }
+
+  // apply softmax and store result P to scratch2: BxNxSxS*
+  if (use_raw_attention_mask) {  // 2d, 3d or 4d attention mask
+    const int mask_dimension = static_cast<int>(mask_index_dims.size());
+    const int64_t max_sequence_length = mask_dimension == 4 ? mask_index_dims.at(3) : 0;
+
+    T* persistent_softmax_workspace = scratch1; // replace Q*K' in place with masked score if persistent softmax is selected.
+    if (!ComputeSoftmaxWithRawMask<T>(stream, all_sequence_length, sequence_length, batch_size, num_heads, mask_index, nullptr, extra_add_qk, scratch1, scratch2,
+                                      is_unidirectional, rsqrt_head_size, mask_dimension, static_cast<int>(max_sequence_length),
+                                      use_persistent_softmax, persistent_softmax_workspace)) {
+      return false;
+    }
+  } else if (nullptr != mask_index) {  // 1d mask index
+    ORT_ENFORCE(mask_index_dims.size() == 1);
+    // mask_index has 1D shape: either (batch_size) or (2*batch_size). Only the later one has start postions.
+    const int* mask_start = (mask_index_dims.at(0) > batch_size) ? mask_index + batch_size : nullptr;
+    if (!ComputeSoftmaxWithMask1D<T>(stream, all_sequence_length, sequence_length, batch_size, num_heads, mask_index, mask_start, extra_add_qk, scratch1, scratch2, is_unidirectional)) {
+      return false;
+    }
+  } else {  // no mask
+    if (!ComputeSoftmax<T>(stream, all_sequence_length, sequence_length, batch_size, num_heads, extra_add_qk, scratch1, scratch2, is_unidirectional)) {
+      return false;
+    }
+  }
+
+  // compute P*V (as V*P), and store in scratch3: BxNxSxH
+  if (!CUBLAS_CALL(cublasGemmStridedBatchedHelper(
+          cublas, CUBLAS_OP_N, CUBLAS_OP_N, head_size, sequence_length, all_sequence_length, &one, v, head_size, present_size_per_batch,
+          scratch2, all_sequence_length, temp_matrix_size, &zero, scratch3, head_size, size_per_batch, batches, prop))) {
+    return false;
+  }
+
+  // scratch3 is BxNxSxH, transpose to output BxSxNxH
+  return LaunchTransCtx(stream, sequence_length, batch_size, head_size, num_heads, max_threads_per_block, false, scratch3, output);
+}
+
+bool LaunchQOrderAttentionKernel(
+    const cudaDeviceProp& prop,
+    cudaStream_t stream,
+    const void* input,
+    const int* mask_index,
+    gsl::span<const int64_t> mask_index_dims,
+    void* output,
+    const int batch_size,
+    const int sequence_length,
+    const int num_heads,
+    const int head_size,
+    void* workspace,
+    cublasHandle_t& cublas,
+    const size_t element_size,
+    bool is_unidirectional,
+    int past_sequence_length,
+    const void* past,
+    const void* extra_add_qk,
+    void* present) {
+
+  // For testing, environment variable ORT_TRANSFORMER_OPTIONS=1 could enable persistent softmax
+  const TransformerOptions* options = TransformerOptions::GetInstance();
+  bool use_persistent_softmax = options->IsPrecisionMode() && !options->DisablePersistentSoftmax();
+
+  if (element_size == 2) {
+    return QOrderQkvToContext(prop, cublas, stream,
+                        batch_size, sequence_length, num_heads, head_size, element_size,
+                        reinterpret_cast<const half*>(input), reinterpret_cast<half*>(output), reinterpret_cast<half*>(workspace),
+                        mask_index, mask_index_dims, is_unidirectional,
+                        past_sequence_length, reinterpret_cast<const half*>(past), reinterpret_cast<const half*>(extra_add_qk),
+                        reinterpret_cast<half*>(present), use_persistent_softmax);
+  } else {
+    return QOrderQkvToContext(prop, cublas, stream,
+                        batch_size, sequence_length, num_heads, head_size, element_size,
+                        reinterpret_cast<const float*>(input), reinterpret_cast<float*>(output), reinterpret_cast<float*>(workspace),
+                        mask_index, mask_index_dims, is_unidirectional,
+                        past_sequence_length, reinterpret_cast<const float*>(past), reinterpret_cast<const float*>(extra_add_qk),
+                        reinterpret_cast<float*>(present), use_persistent_softmax);
+  }
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/qorder_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/qorder_attention_impl.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+#include "contrib_ops/cuda/bert/attention_impl.h"
+#include <cublas_v2.h>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+bool LaunchQOrderAttentionKernel(
+    const cudaDeviceProp& prop,                   // Device Properties
+    cudaStream_t stream,                          // cuda stream
+    const void* input,                            // Input tensor
+    const int* mask_index,                        // Attention mask raw data or index (end position of each sequence, or end positions and start positions). NULL means no mask.
+    gsl::span<const int64_t> mask_index_dims,     // Mask index shape
+    void* output,                                 // Output tensor
+    int batch_size,                               // Batch size (B)
+    int sequence_length,                          // Sequence length (S)
+    int num_heads,                                // Number of attention heads (N)
+    int head_size,                                // Hidden layer size per head (H)
+    void* workspace,                              // Temporary buffer
+    cublasHandle_t& cublas,                       // Cublas handle
+    const size_t element_size,                    // Element size of input tensor
+    bool is_unidirectional,                       // Whether there is unidirecitonal mask.
+    int past_sequence_length,                     // Sequence length in past state
+    const void* past,                             // Past state input
+    const void* extra_add_qk,                     // Additional Add
+    void* present                                 // Present state output
+);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
@@ -1146,7 +1146,7 @@ If mask is provided, mask index (that is position of first 0 in mask, or number 
   constexpr const char* QOrderedMatMul_ver1_doc = R"DOC(
 Quantize MatMul with order. Two type of order combination supported:
   *) When order_B is ORDER_COL, order_A must bu ORDER_ROW, MatMul will be implemented using B' * A' + bias + C' => D'.
-     bias is vector of {#cols of D}, C' should be batch 1. B' could be of batch 1. 
+     bias is vector of {#cols of D}, C' should be batch 1. B' could be of batch 1.
      Note B is reorder to ORDER_COL, or Transposed. Not Transposed first and then Reordered here.
   *) When order_B is specify ORDER_COL4_4R2_8C or ORDER_COL32_2R_4R4, orderA must be ORDER_COL32. MatMul will be implemented using alpha(A * B) + beta * C => D.
      bias is not supported here. B in fact is transposed first then reordered into ORDER_COL4_4R2_8C or ORDER_COL32_2R_4R4 here.
@@ -1247,11 +1247,14 @@ TODO: Support them if needed in the future.
              "Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), (batch_size, past_sequence_length + sequence_length)"
              "or (batch_size, sequence_length, past_sequence_length + sequence_length), or index with shape (batch_size) or (2 * batch_size).",
              "G", OpSchema::Optional)
-      .Input(8, "scale_output", "scale of the output", "S")
+      .Input(8, "scale_output", "scale of the output", "S", OpSchema::Optional)
+      .Input(9, "past", "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).", "T", OpSchema::Optional)
       .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, hidden_size)", "Q")
+      .Output(1, "present", "present state for key and value with shape (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)", "T", OpSchema::Optional)
       .TypeConstraint("Q", {"tensor(int8)"}, "Constrain input and output types to int8 tensors.")
       .TypeConstraint("S", {"tensor(float)"}, "Constrain scales to float32 tensors.")
       .TypeConstraint("G", {"tensor(int32)"}, "Constrain to integer types")
+      .TypeConstraint("T", {"tensor(float16)"}, "Constrain input and output types to float tensors.")
       .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
 
   // TODO: quantize the gamma and beta or not


### PR DESCRIPTION
**Description**: Describe your changes.

support gpt2 attention with past/present (currently only support fp16)
the interface changes (added two more optional IO) will not break current kernel inference
introduce impl files to prepare later matmul quantization

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
