### PR TITLE
Issue form for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Use this template for raising a feature request.
+title: ""
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create a feature request!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Related issue
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear and concise description of what the problem is. Ex. I'm always frustrated when ...
+    validations:
+      required: false
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      placeholder: Insert system information here
+      value: "- ONNX Runtime version (you are using):"
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Desired solution
+      description: Describe the solution you'd like
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe alternatives you've considered
+      placeholder: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
**Description**: Issue form for feature requests so we can have something like this:

![image](https://user-images.githubusercontent.com/11205048/166781783-1aa62b6a-bd6b-49f0-a296-bf9d8bf022d8.png)


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms