### PR TITLE
[TensorRT EP] reduce CI pipelines test execution time

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -37,7 +37,9 @@
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error executing ", #expr))
 
+namespace onnxruntime {
 TensorrtLogger& GetTensorrtLogger();
+}
 
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::logging;
@@ -45,7 +47,8 @@ namespace {
 #ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
 // instantiate global unused builder object which keeps the TRT kernel library in memory
 // so that subsequent builders avoid the expensive load / unload process.
-auto const trt_builder_placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
+auto const trt_builder_placeholder =
+    tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
 #endif
 // Check if cycle exists in the graph after partitioning
 bool FindCycleHelper(size_t i, const std::list<size_t>* adjacency_map, bool visited[], bool* st, std::vector<size_t>& cycles) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -37,13 +37,14 @@
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error executing ", #expr))
 
+TensorrtLogger& GetTensorrtLogger();
+
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::logging;
 namespace {
 #ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
 // instantiate global unused builder object which keeps the TRT kernel library in memory
 // so that subsequent builders avoid the expensive load / unload process.
-TensorrtLogger& GetTensorrtLogger();
 auto const trt_builder_placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
 #endif
 // Check if cycle exists in the graph after partitioning

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -32,12 +32,6 @@
 #define LIBFUNC(lib, fn) dlsym((lib), (fn))
 #endif
 
-#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
-// instantiate global unused builder object which keeps the TRT kernel library in memory
-// so that subsequent builders avoid the expensive load / unload process.
-auto const placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
-#endif
-
 #define CUDA_RETURN_IF_ERROR(expr)               \
   ORT_RETURN_IF_ERROR(CUDA_CALL(expr)            \
                           ? common::Status::OK() \
@@ -253,6 +247,12 @@ std::unique_lock<OrtMutex> TensorrtExecutionProvider::GetApiLock() const {
   static OrtMutex singleton;
   return std::unique_lock<OrtMutex>(singleton);
 }
+
+#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
+// instantiate global unused builder object which keeps the TRT kernel library in memory
+// so that subsequent builders avoid the expensive load / unload process.
+auto const placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
+#endif
 
 TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProviderInfo& info)
     : IExecutionProvider{onnxruntime::kTensorrtExecutionProvider, true}, info_(info), device_id_(info.device_id) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -40,6 +40,12 @@
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::logging;
 namespace {
+#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
+// instantiate global unused builder object which keeps the TRT kernel library in memory
+// so that subsequent builders avoid the expensive load / unload process.
+TensorrtLogger& GetTensorrtLogger();
+auto const trt_builder_placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
+#endif
 // Check if cycle exists in the graph after partitioning
 bool FindCycleHelper(size_t i, const std::list<size_t>* adjacency_map, bool visited[], bool* st, std::vector<size_t>& cycles) {
   if (!visited[i]) {
@@ -247,12 +253,6 @@ std::unique_lock<OrtMutex> TensorrtExecutionProvider::GetApiLock() const {
   static OrtMutex singleton;
   return std::unique_lock<OrtMutex>(singleton);
 }
-
-#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
-// instantiate global unused builder object which keeps the TRT kernel library in memory
-// so that subsequent builders avoid the expensive load / unload process.
-auto const placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
-#endif
 
 TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProviderInfo& info)
     : IExecutionProvider{onnxruntime::kTensorrtExecutionProvider, true}, info_(info), device_id_(info.device_id) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -32,6 +32,12 @@
 #define LIBFUNC(lib, fn) dlsym((lib), (fn))
 #endif
 
+#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
+// instantiate global unused builder object which keeps the TRT kernel library in memory
+// so that subsequent builders avoid the expensive load / unload process.
+auto const placeholder = tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
+#endif
+
 #define CUDA_RETURN_IF_ERROR(expr)               \
   ORT_RETURN_IF_ERROR(CUDA_CALL(expr)            \
                           ? common::Status::OK() \


### PR DESCRIPTION
Currently the TensorRT EP CI test pipelines (running TensorRT 8.2) take around 1 hour 40 min to run.
This can be reduced by ~1 hour on Linux (40 min on Windows) with this change. For the upcoming TensorRT 8.4, the results are even more significant. (2.5 hours reduced to ~40 min)

The long test times is caused by TensorRT builder time initialization. ORT tests are run sequentially and builder instances are created and destroyed after each test. Nvidia advised adding a global unused builder object to keep the TRT kernel library in memory to avoid builder initialization/destruction costs. 
