### PR TITLE
WIP: Fix openvino global variable deletion that causes a double free when unloading the openvino provider lib in Triton.

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -4,6 +4,7 @@
 #include "core/providers/shared_library/provider_api.h"
 #include <inference_engine.hpp>
 #include <fstream>
+#include <iostream>
 
 #include "contexts.h"
 #include "backend_manager.h"
@@ -23,7 +24,13 @@ GlobalContext& BackendManager::GetGlobalContext() {
 }
 
 void BackendManager::ReleaseGlobalContext() {
-  g_global_context.reset();
+  std::cout << "Inside ReleaseGlobalContext" << std::endl;
+  if (g_global_context) {
+    // delete g_global_context;
+    // g_global_context = nullptr;
+    std::cout << "Inside ReleaseGlobalContext just before calling reset" << std::endl;
+    g_global_context.reset();
+  }
 }
 
 BackendManager::BackendManager(const Node* fused_node, const logging::Logger& logger) {
@@ -186,7 +193,7 @@ std::string MakeMapKeyString(std::vector<std::vector<int64_t>>& shapes,
                              std::string& device_type) {
   std::string key;
   key += device_type;
-  key += "|";  //separator
+  key += "|";  // separator
   for (auto shape : shapes) {
     for (auto dim : shape) {
       std::ostringstream o;

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -4,12 +4,16 @@
 #pragma once
 
 #include "ov_interface.h"
+#include <iostream>
 
 namespace onnxruntime {
 namespace openvino_ep {
 
 // Holds context applicable to the entire EP instance.
 struct GlobalContext {
+  ~GlobalContext() {
+    std::cout << "Inside globalcontext destr" << std::endl;
+  }
   OVCore ie_core;
   bool is_wholly_supported_graph = false;
   bool enable_vpu_fast_compile = false;
@@ -25,7 +29,7 @@ struct GlobalContext {
   std::string onnx_model_name;
   std::string onnx_model_path_name;
   int onnx_opset_version;
-  void *context = 0;
+  void* context = 0;
   bool use_api_2;
 };
 
@@ -35,7 +39,7 @@ struct SubGraphContext {
   bool enable_batching = false;
   bool set_vpu_config = false;
   bool is_constant = false;
-  void *context = 0;
+  void* context = 0;
   std::string subgraph_name;
   std::vector<int> input_indexes;
   std::unordered_map<std::string, int> input_names;


### PR DESCRIPTION
**Description**: Fix openvino global variable deletion that causes a double free when unloading the openvino provider lib in Triton.

**Motivation and Context**
This showed up when upgrading ORT 1.11 in Triton.
   * The onnx loader is [global](https://github.com/triton-inference-server/onnxruntime_backend/blob/708ec66e57aa7009b8df6858a98bdf6a3b10cd24/src/onnxruntime_loader.cc#L38).
   * The openvino global context is also [global](https://github.com/microsoft/onnxruntime/blob/81fa28bc56cc5630abfe72bf23e1024570d4058a/onnxruntime/core/providers/openvino/backend_manager.cc#L16) which gets destructed as part of unloading openvino ORT lib.
   * When Triton shuts down, this context ptr gets destroyed before onnx loader and the destruction doesn't set the ptr to null.
  * Now when onnx loader is destructed it calls the ov ReleaseGlobalContext function which tries to delete the already deleted ov ctx ptr causing the double free.