### PR TITLE
Make Graph::InlineFunction be able to process initializers

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3409,9 +3409,11 @@ void Graph::ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto) const 
   graph_proto_->clear_value_info();
   graph_proto.set_name(Name());
   graph_proto.set_doc_string(Description());
+
   for (const auto* input_arg : GetInputsIncludingInitializers()) {
     *(graph_proto.mutable_input()->Add()) = input_arg->ToProto();
   }
+
   for (const auto* output_arg : GetOutputs()) {
     *(graph_proto.mutable_output()->Add()) = output_arg->ToProto();
   }
@@ -3419,6 +3421,7 @@ void Graph::ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto) const 
   for (const auto* value_info : value_info_) {
     *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
   }
+
   // add the NodeArg info for outer scope NodeArgs so we capture the type information
   for (const auto& name : outer_scope_node_arg_names_) {
     auto* node_arg = GetNodeArg(name);

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4014,6 +4014,11 @@ Status Graph::InlineFunction(Node& node) {
   auto uniq_identifier = ss.str();
 
   const auto& model_path = ModelPath();
+  for (auto& init : subgraph.name_to_initial_tensor_) {
+    const gsl::not_null<TensorProto*> tensor{graph_proto_->add_initializer()};
+    *tensor = *init.second;
+    name_to_initial_tensor_[tensor->name() + uniq_identifier] = tensor;
+  }
   for (const auto& subgraph_node : subgraph.Nodes()) {
     if (subgraph_node.OpType() == kConstant) {
       // Copy constant nodes _value to name_to_initial_tensor_

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3409,11 +3409,9 @@ void Graph::ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto) const 
   graph_proto_->clear_value_info();
   graph_proto.set_name(Name());
   graph_proto.set_doc_string(Description());
-
   for (const auto* input_arg : GetInputsIncludingInitializers()) {
     *(graph_proto.mutable_input()->Add()) = input_arg->ToProto();
   }
-
   for (const auto* output_arg : GetOutputs()) {
     *(graph_proto.mutable_output()->Add()) = output_arg->ToProto();
   }
@@ -3421,7 +3419,6 @@ void Graph::ToGraphProtoInternal(ONNX_NAMESPACE::GraphProto& graph_proto) const 
   for (const auto* value_info : value_info_) {
     *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
   }
-
   // add the NodeArg info for outer scope NodeArgs so we capture the type information
   for (const auto& name : outer_scope_node_arg_names_) {
     auto* node_arg = GetNodeArg(name);
@@ -4017,7 +4014,8 @@ Status Graph::InlineFunction(Node& node) {
   for (auto& init : subgraph.name_to_initial_tensor_) {
     const gsl::not_null<TensorProto*> tensor{graph_proto_->add_initializer()};
     *tensor = *init.second;
-    name_to_initial_tensor_[tensor->name() + uniq_identifier] = tensor;
+    tensor->set_name(tensor->name() + uniq_identifier);
+    name_to_initial_tensor_[tensor->name()] = tensor;
   }
   for (const auto& subgraph_node : subgraph.Nodes()) {
     if (subgraph_node.OpType() == kConstant) {


### PR DESCRIPTION
**Description**: 

Make Graph::InlineFunction be able to process initializers. Currently they are silently ignored. 


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
