### PR TITLE
[Fix #11447] Use correct type for tensor shape vectors

### DIFF
--- a/onnxruntime/core/providers/acl/nn/pool.cc
+++ b/onnxruntime/core/providers/acl/nn/pool.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "core/common/common.h"
+#include "core/common/inlined_containers.h"
 #include "core/framework/op_kernel.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
@@ -67,7 +68,7 @@ ACLNEPool PoolOperation(onnxruntime::OpKernelContext* context,
       aclStrides[0] = (strides.size() == 2) ? strides[1] : 1;
       aclStrides[1] = strides[0];
 
-      absl::InlinedVector<int64_t, 4> aclPads;
+      InlinedVector<int64_t, 4> aclPads(4);
     // The pad order in acl is: pad_left, pad_right, pad_top, pad_bottom
       if (pads.size() == 2) {
         if (strides.size() == 1) {
@@ -146,7 +147,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
 
   TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
-  absl::InlinedVector<int64_t, 2> aclDilations;
+  InlinedVector<int64_t, 2> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
 
@@ -192,7 +193,7 @@ Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
 
   TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
-  absl::InlinedVector<int64_t, 2> aclDilations;
+  InlinedVector<int64_t, 2> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
 

--- a/onnxruntime/core/providers/acl/nn/pool.cc
+++ b/onnxruntime/core/providers/acl/nn/pool.cc
@@ -68,7 +68,7 @@ ACLNEPool PoolOperation(onnxruntime::OpKernelContext* context,
       aclStrides[0] = (strides.size() == 2) ? strides[1] : 1;
       aclStrides[1] = strides[0];
 
-      InlinedVector<int64_t, 4> aclPads(4);
+      InlinedVector<int64_t> aclPads(4);
     // The pad order in acl is: pad_left, pad_right, pad_top, pad_bottom
       if (pads.size() == 2) {
         if (strides.size() == 1) {
@@ -147,7 +147,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
 
   TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
-  InlinedVector<int64_t, 2> aclDilations(2);
+  InlinedVector<int64_t> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
 
@@ -193,7 +193,7 @@ Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
 
   TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
-  InlinedVector<int64_t, 2> aclDilations(2);
+  InlinedVector<int64_t> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
 

--- a/onnxruntime/core/providers/acl/nn/pool.cc
+++ b/onnxruntime/core/providers/acl/nn/pool.cc
@@ -37,9 +37,9 @@ ACLNEPool PoolOperation(onnxruntime::OpKernelContext* context,
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& x_shape = X->Shape();
 
-  std::vector<int64_t> pads = pool_attrs.pads;
-  std::vector<int64_t> strides = pool_attrs.strides;
-  std::vector<int64_t> kernel_shape = pool_attrs.kernel_shape;
+  auto pads = pool_attrs.pads;
+  auto strides = pool_attrs.strides;
+  auto kernel_shape = pool_attrs.kernel_shape;
 
   if (pool_attrs.global_pooling) {
     const auto& input_dims = x_shape.GetDims();
@@ -47,7 +47,7 @@ ACLNEPool PoolOperation(onnxruntime::OpKernelContext* context,
     pads.assign(kernel_shape.size(), 0);
   }
 
-  std::vector<int64_t> output_dims = pool_attrs.SetOutputSize(x_shape, x_shape[1], &pads);
+  auto output_dims = pool_attrs.SetOutputSize(x_shape, x_shape[1], &pads);
   Tensor* Y = context->Output(0, TensorShape(output_dims));
 
   ACLNEPool tpool;
@@ -145,7 +145,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
 
   const Tensor* X = context->Input<Tensor>(0);
 
-  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
   std::vector<int64_t> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
@@ -191,7 +191,7 @@ template <typename T>
 Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
 
-  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  TensorShapeVector dilations(PoolBase::pool_attrs_.dilations);
   std::vector<int64_t> aclDilations(2);
   aclDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   aclDilations[1] = (!dilations.empty()) ? dilations[0] : 1;


### PR DESCRIPTION
**Description**: 

Fixes #11447 by using `auto` or explicitly `TensorShapeVector` where appropriate.

There are other points in the code where `std::vector`s are used in what looks like should be either a `TensorShape` or a `TensorShapeVector`, but as I don't have sufficient familiarty with the code, I did not add any fix beyond the necessary ones to make the code compile without errors.
