### PR TITLE
Fix reduced pipeline by excluding test case standalone op

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -405,7 +405,7 @@ TEST(CApiTest, custom_op_handler) {
 #endif
 }
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) && !defined(REDUCED_OPS_BUILD)
 TEST(CApiTest, instant_op_handler) {
   std::vector<Input> inputs(1);
   Input& input = inputs[0];

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -406,6 +406,7 @@ TEST(CApiTest, custom_op_handler) {
 }
 
 #if !defined(ORT_MINIMAL_BUILD) && !defined(REDUCED_OPS_BUILD)
+//disable test in reduced-op-build since TOPK and GRU are excluded there
 TEST(CApiTest, instant_op_handler) {
   std::vector<Input> inputs(1);
   Input& input = inputs[0];


### PR DESCRIPTION
Fix pipeline failure. 
Disable the test case for standalone op from reduced-op-build since TOPK and GRU ops are absent there.
