### PR TITLE
Revert "[TensorRT EP] reduce CI pipelines test execution time (#11440)"

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -37,19 +37,9 @@
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error executing ", #expr))
 
-namespace onnxruntime {
-TensorrtLogger& GetTensorrtLogger();
-}
-
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::logging;
 namespace {
-#ifdef ORT_RUN_EXTERNAL_ONNX_TESTS
-// instantiate global unused builder object which keeps the TRT kernel library in memory
-// so that subsequent builders avoid the expensive load / unload process.
-auto const trt_builder_placeholder =
-    tensorrt_ptr::unique_pointer<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(GetTensorrtLogger()));
-#endif
 // Check if cycle exists in the graph after partitioning
 bool FindCycleHelper(size_t i, const std::list<size_t>* adjacency_map, bool visited[], bool* st, std::vector<size_t>& cycles) {
   if (!visited[i]) {


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/pull/11440 seems to cause a timeout in the capi test of the combined gpu package pipeline (only for Windows)
e.g. https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=206395&view=logs&j=7ac7b520-9dc4-5344-f469-01b07bb067d1
Revert the commit while the investigation is pending. 
