### PR TITLE
Update benchmark_longformer.py to output accurate GPU memory needed

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
@@ -33,7 +33,7 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 
 template <typename T>
 LongformerAttention<T>::LongformerAttention(const OpKernelInfo& info) : CudaKernel(info), LongformerAttentionBase(info) {
-  use_compact_memory_ = ParseEnvironmentVariableWithDefault<bool>(longformer::kUseCompactMemory, true);
+  use_compact_memory_ = ParseEnvironmentVariableWithDefault<bool>(longformer::kUseCompactMemory, false);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
@@ -159,7 +159,7 @@ Status LongformerAttention<T>::ComputeInternal(OpKernelContext* context) const {
         &one, reinterpret_cast<CudaT*>(global_gemm_buffer.get()), n, device_prop));
   }
 
-  size_t workSpaceSize = GetLongformerAttentionWorkspaceSize(element_size, batch_size, num_heads_, head_size, sequence_length, max_num_global, window_, use_fast_kernel);
+  size_t workSpaceSize = GetLongformerAttentionWorkspaceSize(element_size, batch_size, num_heads_, head_size, sequence_length, max_num_global, window_, disable_compact_memory);
   auto workspace_buffer = GetScratchBuffer<void>(workSpaceSize);
   if (!LaunchLongformerAttentionKernel(
           device_prop,

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
@@ -8,7 +8,7 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
- size_t GetPinnedBufferSize(
+size_t GetPinnedBufferSize(
     int batch_size);
 
 size_t GetLongformerAttentionWorkspaceSize(
@@ -19,7 +19,7 @@ size_t GetLongformerAttentionWorkspaceSize(
     int sequence_length,
     int max_num_global,
     int window,
-    bool use_fast_kernel);
+    bool disable_compact_memory);
 
 bool LaunchLongformerAttentionKernel(
     const cudaDeviceProp& device_prop,  // Device Properties
@@ -41,7 +41,7 @@ bool LaunchLongformerAttentionKernel(
     int window,                         // One sided attention window (W)
     int max_num_global,                 // Maximum number of global tokens (G)
     const size_t element_size,          // Element size of input tensor,
-    bool use_fast_kernel                // Use compact memory
+    bool disable_compact_memory         // Disable compact memory kernel
 );
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
@@ -14,15 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This is fast cuda kernels for longformer attention softmax.
-// It uses two temporary matrix of BxNxSxS, and consumes more memory when sequence length is large.
-
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-// Launch the softmax kernel for non compact memory.
-bool launchSoftmaxFastKernel(
+// Launch the softmax kernels that does not use compact memory.
+bool LaunchLongformerSoftmaxSimpleKernel(
     cudaStream_t stream,
     cublasHandle_t cublas,
     void* workspace,              // softmax space

--- a/onnxruntime/python/tools/transformers/models/longformer/benchmark_longformer.py
+++ b/onnxruntime/python/tools/transformers/models/longformer/benchmark_longformer.py
@@ -7,24 +7,28 @@
 # This script run benchmark of latency or peak memory usage of Longformer model inference.
 # Please run convert_to_onnx.py to get onnx model before running benchmark.
 #
-# It is tested with python 3.8, onnxruntime-gpu 1.11.0, PyTorch 1.11.0, transformers 4.18.0, CUDA 11.3 like the following
+# It is tested with python 3.8, onnxruntime-gpu 1.11.0, PyTorch 1.11.0, transformers 4.18.0, CUDA 11.3 like:
 #   conda create -n gpu_env python=3.8
 #   conda activate gpu_env
 #   pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
 #   pip3 install onnx transformers onnxruntime-gpu numpy sympy coloredlogs psutil py3nvml
 #   python benchmark_longformer.py
 #
-# When there is no parameter, all avaiable tests (memory & latency) will run on the longformer-base-4096 pretrained model.
+# When there is no parameter, all avaiable tests will run on the longformer-base-4096 pretrained model.
 
 # Benchmark the latency (Exported onnx model is in the current directory):
-#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 512 1024 2048 4096 --global_lengths 8 --onnx ./longformer-base-4096_fp16.onnx --validate_onnx -t 100
+#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 512 1024 2048 4096 \
+#          --global_lengths 8 --onnx ./longformer-base-4096_fp16.onnx --validate_onnx -t 100
 #
 # Benchmark GPU peak memory:
 #   export ORT_LONGFORMER_COMPACT_MEMORY=0
-#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 4096 --global_lengths 8 --onnx_dir . --memory -t 10
+#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 4096 \
+#          --global_lengths 8 --onnx ./longformer-base-4096_fp32.onnx --memory -t 10 --engine onnxruntime
 #   export ORT_LONGFORMER_COMPACT_MEMORY=1
-#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 4096 --global_lengths 8 --onnx_dir . --memory -t 10
-# By default, compact memory kernel is enabled. You need set an environment variable ORT_LONGFORMER_COMPACT_MEMORY=0 to disable it.
+#   python benchmark_longformer.py --model longformer-base-4096 --batch_sizes 1 --sequence_lengths 4096 \
+#          --global_lengths 8 --onnx ./longformer-base-4096_fp32.onnx --memory -t 10 --engine onnxruntime
+#
+# By default, compact memory kernel is disabled. To enable it, set environment variable ORT_LONGFORMER_COMPACT_MEMORY=1.
 
 import argparse
 import csv
@@ -85,7 +89,8 @@ def test_torch_latency(
                     "sequence_length": sequence_length,
                     "global_length": global_length,
                     "datetime": str(datetime.now()),
-                    "memory": "?",
+                    "memory": "",
+                    "max_diff": 0,
                 }
                 result.update(benchmark_helper.get_latency_result(runtimes, batch_size))
 
@@ -95,9 +100,8 @@ def test_torch_latency(
 
 
 def test_parity(device, model, ort_session, batch_size, sequence_length, global_length, verbose=True):
-    print(
-        f"Comparing Torch and ORT outputs for batch_size={batch_size} sequence_length={sequence_length} global_length={global_length}..."
-    )
+    parameters = f"batch_size={batch_size} sequence_length={sequence_length} global_length={global_length}"
+    print(f"Comparing Torch and ORT outputs for {parameters}...")
     dummy_inputs: LongformerInputs = LongformerHelper.get_dummy_inputs(
         batch_size, sequence_length, global_length, device
     )
@@ -110,7 +114,7 @@ def test_parity(device, model, ort_session, batch_size, sequence_length, global_
     if verbose and (math.isnan(max_diff) or max_diff > 0.001):
         print("torch last_state:", torch_outputs[0])
         print("ort last_state:", ort_outputs[0])
-    return max_diff
+    return float(max_diff)
 
 
 def test_ort_latency(
@@ -137,8 +141,10 @@ def test_ort_latency(
                 assert (
                     global_length <= model.config.attention_window[0]
                 ), "Limitation of current implementation: number of global token <= attention_window"
+
                 print(
-                    f"Testing batch_size={batch_size} sequence_length={sequence_length} global_length={global_length} optimizer={optimizer}, precision={precision} io_binding={not disable_io_binding}..."
+                    f"Testing batch_size={batch_size} sequence_length={sequence_length} global_length={global_length} "
+                    f"optimizer={optimizer}, precision={precision} io_binding={not disable_io_binding}..."
                 )
                 dummy_inputs: LongformerInputs = LongformerHelper.get_dummy_inputs(
                     batch_size, sequence_length, global_length, device
@@ -158,17 +164,18 @@ def test_ort_latency(
                     "description": description,
                     "inputs": 3,
                     "engine": "OnnxRuntime",
-                    "version": onnxruntime.__version__,
+                    "version": str(onnxruntime.__version__),
                     "device": "cuda",
-                    "precision": precision,
-                    "optimizer": optimizer,
-                    "threads": num_threads,
-                    "batch_size": batch_size,
-                    "sequence_length": sequence_length,
-                    "global_length": global_length,
-                    "test_times": test_times,
+                    "precision": str(precision),
+                    "optimizer": int(optimizer),
+                    "threads": int(num_threads),
+                    "batch_size": int(batch_size),
+                    "sequence_length": int(sequence_length),
+                    "global_length": int(global_length),
+                    "test_times": int(test_times),
                     "datetime": str(datetime.now()),
                     "memory": "",
+                    "max_diff": None,
                 }
 
                 if not disable_io_binding:
@@ -197,7 +204,7 @@ def test_ort_latency(
                     )
 
                 if validate_onnx:
-                    max_diff = test_parity(
+                    result["max_diff"] = test_parity(
                         device,
                         model,
                         ort_session,
@@ -206,7 +213,6 @@ def test_ort_latency(
                         global_length,
                         verbose,
                     )
-                    result["description"] += f"(max_diff={max_diff})"
 
                 results.append(result)
     return results
@@ -222,15 +228,20 @@ def test_ort_memory(
     num_threads,
 ):
     print(
-        f"Testing memory for model={onnx_model_path}, batch_size={batch_size}, sequence_length={sequence_length}, global_length={global_length}, test_times={test_times}, num_threads={num_threads}"
+        f"Testing memory for model={onnx_model_path}, batch_size={batch_size}, sequence_length={sequence_length}, "
+        f"global_length={global_length}, test_times={test_times}, num_threads={num_threads}"
     )
 
     def inference():
+        # Update Arena strategy so that we can measure the mininum memory required
+        cuda_provider_options = {"arena_extend_strategy": "kSameAsRequested"}
+        provider_options = {"CUDAExecutionProvider": cuda_provider_options}
         session = benchmark_helper.create_onnxruntime_session(
             onnx_model_path,
             use_gpu=True,
             enable_all_optimization=True,
             num_threads=num_threads,
+            provider_options=provider_options,
         )
 
         dummy_inputs: LongformerInputs = LongformerHelper.get_dummy_inputs(
@@ -405,15 +416,17 @@ def parse_arguments(argv=None):
 
     parser.add_argument("-b", "--batch_sizes", nargs="+", type=int, default=[1])
 
-    # If --export_padding is not used in exporting onnx model, there is no padding in ONNX model so you will need padding inputs by yourself before running onnx model.
-    # In that case, you can only test sequence length that is multiple of attention window size.
+    # If --export_padding is not used in exporting onnx model, there is no padding in ONNX model,
+    # and you will need padding inputs by yourself before running onnx model.
+    # Here, we only test sequence length that is multiple of attention window size.
     parser.add_argument(
         "-s",
         "--sequence_lengths",
         nargs="+",
         type=int,
         default=[512, 1024, 2048, 4096],
-        help="Sequence lengths. It could have multiple values in latency test. If --export_padding is not used in exporting onnx model, sequence length shall be multiple of window size.",
+        help="Sequence lengths. It could have multiple values in latency test."
+        "If --export_padding is not used, sequence length shall be multiple of window size.",
     )
 
     parser.add_argument("--onnx", required=False, type=str, default=None, help="Onnx model path")
@@ -488,6 +501,7 @@ def output_details(results, csv_filename):
             "batch_size",
             "sequence_length",
             "global_length",
+            "max_diff",
             "memory",
             "QPS",
             "average_latency_ms",
@@ -500,9 +514,7 @@ def output_details(results, csv_filename):
         csv_writer = csv.DictWriter(csv_file, fieldnames=column_names)
         csv_writer.writeheader()
         for result in latency_results:
-            print(
-                f"b={result['batch_size']}, s={result['sequence_length']}, g={result['global_length']}, latency={result['average_latency_ms']}ms, memory={result['memory']}MB {result['description']}"
-            )
+            print(result)
             csv_writer.writerow(result)
     print(f"Detail results are saved to csv file: {csv_filename}")
 
@@ -525,7 +537,17 @@ def run(args):
         return test_latency(args, device)
 
 
+def launch_test(arguments):
+    from concurrent.futures import ProcessPoolExecutor
+
+    with ProcessPoolExecutor() as executor:
+        results = list(executor.map(run, [arguments]))
+        assert len(results) == 1
+        return results[0]
+
+
 def test_all():
+    torch.multiprocessing.set_start_method("spawn")
     results = []
     test_times = 100
     sequence_lengths = [512, 1024, 2048, 4096]
@@ -535,9 +557,8 @@ def test_all():
                 for global_length in [8]:
                     engine_name = "torch"
                     args = parse_arguments(
-                        f"-e {engine_name} -t {test_times} -b {batch_size} -s {sequence_length} -g {global_length} -t {test_times} -m {model_name}".split(
-                            " "
-                        )
+                        f"-e {engine_name} -t {test_times} -b {batch_size} -s {sequence_length} -g {global_length} "
+                        f"-t {test_times} -m {model_name}".split(" ")
                     )
                     results += run(args)
 
@@ -548,18 +569,27 @@ def test_all():
                     ]  # optimized models
                     for onnx_path in onnx_paths:
                         if os.path.exists(onnx_path):
-                            for compact_memory in ["0", "1"]:
+                            for compact_memory in [
+                                "1",
+                                "0",
+                            ]:  # run test with less memory first due to ORT arena memory.
                                 os.environ["ORT_LONGFORMER_COMPACT_MEMORY"] = compact_memory
                                 print("ORT_LONGFORMER_COMPACT_MEMORY=", compact_memory)
-                                arguments = f"--disable_io_binding -e {engine_name} --onnx {onnx_path} -t {test_times} -b {batch_size} -s {sequence_length} -g {global_length} -m {model_name}"
+                                arguments = (
+                                    f"--disable_io_binding -e {engine_name} --onnx {onnx_path} "
+                                    f"-b {batch_size} -s {sequence_length} -g {global_length} -m {model_name}"
+                                )
+
                                 args = parse_arguments(f"{arguments} -t 10 --memory".split(" "))
-                                memory_results = run(args)
+                                memory_results = launch_test(args)
                                 print(memory_results)
 
                                 args = parse_arguments(f"{arguments} -t {test_times} --validate_onnx".split(" "))
-                                latency_results = run(args)
+                                latency_results = launch_test(args)
                                 if len(latency_results) == 1:
                                     latency_results[0]["memory"] = memory_results["memory"]
+                                else:
+                                    raise RuntimeError("len(latency_results) is not 1")
 
                                 print(latency_results)
 
@@ -570,7 +600,7 @@ def test_all():
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         args = parse_arguments()
-        results = run(args)
+        results = launch_test(args)
     else:
         results = test_all()
 


### PR DESCRIPTION
**Description**: 
(1) Update longformer benchmark tool to output more accurate GPU memory used. It is because default Arena memory strategy could allocate more memory than needed, so we change the arena strategy during testing memory.
(2) Output the percentile of result difference between PyTorch and OnnxRuntime
(3) Test both enable/disable io binding
(4) Rename fast kernel to simple kernel to avoid confusion since there is no significant difference in speed.
(5) Remove a cuda stream synchronize that is not needed.

Example output of benchmark_longformer.py in T4 GPU:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/tlwu/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/tlwu/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{mso-number-format:"mm\:ss\.0";}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



optimizer | io_binding | model_name | inputs | threads | datetime | test_times | description | batch_size | sequence_length | global_length | use_compact_memory | diff_max | diff_90_percentile | diff_95_percentile | diff_99_percentile | memory | QPS | average_latency_ms | latency_variance | latency_90_percentile | latency_95_percentile | latency_99_percentile
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | longformer-base-4096 | 3 | 0 | 08:18.2 | 100 | longformer-base-4096 [torch] | 1 | 512 | 8 | NA | 0 | 0 | 0 | 0 | NA | 18.47 | 54.15 | 0.01 | 54.39 | 54.93 | 58.31
1 | TRUE | longformer-base-4096 | 3 | 0 | 08:29.8 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 512 | 8 | TRUE | 0.115309 | 0.010818 | 0.020054 | 0.044395 | 2383 | 32.74 | 30.54 | 0.01 | 30.95 | 31.4 | 42.03
1 | FALSE | longformer-base-4096 | 3 | 0 | 08:53.4 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 512 | 8 | TRUE | 0.172204 | 0.022171 | 0.032953 | 0.05601 | 2383 | 32.34 | 30.92 | 0.01 | 31.2 | 31.4 | 47.65
1 | TRUE | longformer-base-4096 | 3 | 0 | 09:17.7 | 100 | longformer-base-4096_fp32.onnx | 1 | 512 | 8 | FALSE | 0.186228 | 0.014232 | 0.018855 | 0.085474 | 2383 | 32.4 | 30.86 | 0 | 31.47 | 35.99 | 36.3
1 | FALSE | longformer-base-4096 | 3 | 0 | 09:41.2 | 100 | longformer-base-4096_fp32.onnx | 1 | 512 | 8 | FALSE | 0.041253 | 0.009395 | 0.017446 | 0.021826 | 2383 | 32.05 | 31.2 | 0.01 | 31.27 | 31.6 | 53
1 | TRUE | longformer-base-4096 | 3 | 0 | 10:04.1 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 512 | 8 | TRUE | 1.947114 | 0.29116 | 0.405888 | 0.796125 | 2019 | 99.38 | 10.06 | 0.01 | 16.5 | 16.96 | 17.56
1 | FALSE | longformer-base-4096 | 3 | 0 | 10:22.9 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 512 | 8 | TRUE | 0.981294 | 0.289454 | 0.418736 | 0.712943 | 2019 | 95.36 | 10.49 | 0 | 10.22 | 17.85 | 17.93
1 | TRUE | longformer-base-4096 | 3 | 0 | 10:41.7 | 100 | longformer-base-4096_fp16.onnx | 1 | 512 | 8 | FALSE | 2.381754 | 0.340966 | 0.382374 | 1.048071 | 2019 | 99.51 | 10.05 | 0 | 11.86 | 12.08 | 17.56
1 | FALSE | longformer-base-4096 | 3 | 0 | 11:00.4 | 100 | longformer-base-4096_fp16.onnx | 1 | 512 | 8 | FALSE | 1.231057 | 0.295839 | 0.33891 | 0.819433 | 2019 | 92.95 | 10.76 | 0 | 14.19 | 14.2 | 17.98
  |   | longformer-base-4096 | 3 | 0 | 11:20.5 | 100 | longformer-base-4096 [torch] | 1 | 1024 | 8 | NA | 0 | 0 | 0 | 0 | NA | 9.9 | 100.97 | 0 | 101.96 | 102.27 | 102.58
1 | TRUE | longformer-base-4096 | 3 | 0 | 11:32.4 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 1024 | 8 | TRUE | 0.364257 | 0.018973 | 0.046317 | 0.132145 | 2499 | 15.21 | 65.76 | 0.01 | 68.39 | 69.09 | 82.45
1 | FALSE | longformer-base-4096 | 3 | 0 | 12:08.2 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 1024 | 8 | TRUE | 0.095862 | 0.017984 | 0.023471 | 0.037441 | 2499 | 14.97 | 66.78 | 0 | 68.36 | 68.54 | 69.35
1 | TRUE | longformer-base-4096 | 3 | 0 | 12:44.2 | 100 | longformer-base-4096_fp32.onnx | 1 | 1024 | 8 | FALSE | 0.755554 | 0.051617 | 0.111101 | 0.504256 | 2587 | 14.34 | 69.72 | 0 | 70.34 | 70.68 | 72.17
1 | FALSE | longformer-base-4096 | 3 | 0 | 13:20.6 | 100 | longformer-base-4096_fp32.onnx | 1 | 1024 | 8 | FALSE | 0.043007 | 0.016951 | 0.026051 | 0.041458 | 2587 | 14.98 | 66.73 | 0 | 67.73 | 68.19 | 68.74
1 | TRUE | longformer-base-4096 | 3 | 0 | 13:55.6 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 1024 | 8 | TRUE | 1.818193 | 0.359966 | 0.672181 | 1.73606 | 2069 | 44.13 | 22.66 | 0.01 | 22.71 | 31.82 | 33.44
1 | FALSE | longformer-base-4096 | 3 | 0 | 14:21.9 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 1024 | 8 | TRUE | 3.778682 | 0.338999 | 0.416265 | 1.887169 | 2069 | 43.85 | 22.81 | 0.01 | 22.59 | 32.36 | 33.16
1 | TRUE | longformer-base-4096 | 3 | 0 | 14:48.1 | 100 | longformer-base-4096_fp16.onnx | 1 | 1024 | 8 | FALSE | 1.543581 | 0.478249 | 0.658389 | 1.183217 | 2113 | 40.36 | 24.78 | 0.01 | 25.39 | 26.55 | 40.94
1 | FALSE | longformer-base-4096 | 3 | 0 | 15:14.5 | 100 | longformer-base-4096_fp16.onnx | 1 | 1024 | 8 | FALSE | 1.765 | 0.415368 | 0.781657 | 1.36115 | 2113 | 44.28 | 22.58 | 0.01 | 22.14 | 35.46 | 35.54
  |   | longformer-base-4096 | 3 | 0 | 15:50.6 | 100 | longformer-base-4096 [torch] | 1 | 2048 | 8 | NA | 0 | 0 | 0 | 0 | NA | 5.29 | 188.98 | 0 | 190.18 | 190.83 | 192.71
1 | TRUE | longformer-base-4096 | 3 | 0 | 16:03.1 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 2048 | 8 | TRUE | 0.839089 | 0.055509 | 0.088526 | 0.432448 | 2735 | 7.63 | 131.04 | 0 | 132.27 | 132.48 | 133
1 | FALSE | longformer-base-4096 | 3 | 0 | 17:01.1 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 2048 | 8 | TRUE | 0.369992 | 0.070198 | 0.131104 | 0.283282 | 2735 | 7.91 | 126.43 | 0 | 127.55 | 127.86 | 128.7
1 | TRUE | longformer-base-4096 | 3 | 0 | 17:58.8 | 100 | longformer-base-4096_fp32.onnx | 1 | 2048 | 8 | FALSE | 0.665912 | 0.040486 | 0.078072 | 0.225002 | 3279 | 7.48 | 133.64 | 0 | 134.82 | 135.2 | 136.71
1 | FALSE | longformer-base-4096 | 3 | 0 | 18:57.1 | 100 | longformer-base-4096_fp32.onnx | 1 | 2048 | 8 | FALSE | 0.230745 | 0.056941 | 0.112875 | 0.194818 | 3279 | 7.9 | 126.51 | 0.01 | 127.91 | 128.69 | 129.74
1 | TRUE | longformer-base-4096 | 3 | 0 | 19:53.4 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 2048 | 8 | TRUE | 2.981424 | 0.512912 | 0.822318 | 2.09327 | 2167 | 23.59 | 42.4 | 0.03 | 43.16 | 43.32 | 66.94
1 | FALSE | longformer-base-4096 | 3 | 0 | 20:32.5 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 2048 | 8 | TRUE | 1.110744 | 0.55197 | 0.680658 | 0.752213 | 2167 | 24.51 | 40.79 | 0.01 | 41.44 | 41.63 | 42.55
1 | TRUE | longformer-base-4096 | 3 | 0 | 21:11.6 | 100 | longformer-base-4096_fp16.onnx | 1 | 2048 | 8 | FALSE | 1.879188 | 0.605905 | 0.677307 | 0.95168 | 2439 | 23.83 | 41.97 | 0.01 | 42.06 | 42.3 | 56.19
1 | FALSE | longformer-base-4096 | 3 | 0 | 21:50.6 | 100 | longformer-base-4096_fp16.onnx | 1 | 2048 | 8 | FALSE | 3.282095 | 0.490413 | 0.904003 | 1.643991 | 2439 | 24.87 | 40.21 | 0.01 | 40.91 | 41.42 | 57.47
  |   | longformer-base-4096 | 3 | 0 | 22:57.4 | 100 | longformer-base-4096 [torch] | 1 | 4096 | 8 | NA | 0 | 0 | 0 | 0 | NA | 2.7 | 370.31 | 0 | 371.91 | 372.32 | 372.75
1 | TRUE | longformer-base-4096 | 3 | 0 | 23:11.3 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 4096 | 8 | TRUE | 0.440111 | 0.088898 | 0.152991 | 0.419793 | 3215 | 3.81 | 262.79 | 0.01 | 264.47 | 264.6 | 265.17
1 | FALSE | longformer-base-4096 | 3 | 0 | 24:54.8 | 100 | longformer-base-4096_fp32.onnx [compact_memory]| 1 | 4096 | 8 | TRUE | 0.678493 | 0.116736 | 0.168539 | 0.447598 | 3215 | 3.98 | 251.24 | 0 | 253.57 | 254.06 | 255.02
1 | TRUE | longformer-base-4096 | 3 | 0 | 26:37.3 | 100 | longformer-base-4096_fp32.onnx | 1 | 4096 | 8 | FALSE | 1.09698 | 0.073133 | 0.132248 | 0.3797 | 5823 | 3.66 | 272.92 | 0.01 | 274.47 | 274.71 | 275.17
1 | FALSE | longformer-base-4096 | 3 | 0 | 28:21.9 | 100 | longformer-base-4096_fp32.onnx | 1 | 4096 | 8 | FALSE | 0.473748 | 0.078869 | 0.131047 | 0.346251 | 5823 | 3.98 | 251.27 | 0 | 253.43 | 254.3 | 255.08
1 | TRUE | longformer-base-4096 | 3 | 0 | 30:02.0 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 4096 | 8 | TRUE | 4.452011 | 0.930048 | 1.458097 | 3.248316 | 2365 | 12.01 | 83.26 | 0.03 | 89.34 | 89.68 | 90.35
1 | FALSE | longformer-base-4096 | 3 | 0 | 31:07.7 | 100 | longformer-base-4096_fp16.onnx [compact_memory]| 1 | 4096 | 8 | TRUE | 3.017366 | 1.043737 | 1.998309 | 2.83413 | 2365 | 12.79 | 78.21 | 0.02 | 79.12 | 79.39 | 81.01
1 | TRUE | longformer-base-4096 | 3 | 0 | 32:12.9 | 100 | longformer-base-4096_fp16.onnx | 1 | 4096 | 8 | FALSE | 2.340105 | 1.202832 | 1.445294 | 1.744889 | 3669 | 10.38 | 96.34 | 0.01 | 97.69 | 97.88 | 99.08
1 | FALSE | longformer-base-4096 | 3 | 0 | 33:19.6 | 100 | longformer-base-4096_fp16.onnx | 1 | 4096 | 8 | FALSE | 3.800427 | 0.675454 | 1.000179 | 1.812835 | 3669 | 13.01 | 76.84 | 0.01 | 77.58 | 77.85 | 91.53



</body>

</html>

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
