### PR TITLE
fix(onnx_export): Extract arg value from torch Value

### DIFF
--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -72,6 +72,8 @@ def register():
 
     _reg(inverse)
 
+    # TODO(justinchuby): Remove reference to symbolic_helper because it is supposed to be private
+    @torch.onnx.symbolic_helper.parse_args("v", "s")
     def gelu(g, self: torch._C.Value, approximate: str = "none"):
         # Use microsoft::Gelu for performance if possible. It only supports approximate == "none"
         if approximate == "none":

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -72,7 +72,6 @@ def register():
 
     _reg(inverse)
 
-    # TODO(#11472): Remove reference to symbolic_helper because it is supposed to be private
     @torch.onnx.symbolic_helper.parse_args("v", "s")
     def gelu(g, self: torch._C.Value, approximate: str = "none"):
         # Use microsoft::Gelu for performance if possible. It only supports approximate == "none"

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -72,7 +72,7 @@ def register():
 
     _reg(inverse)
 
-    # TODO(justinchuby): Remove reference to symbolic_helper because it is supposed to be private
+    # TODO(#11472): Remove reference to symbolic_helper because it is supposed to be private
     @torch.onnx.symbolic_helper.parse_args("v", "s")
     def gelu(g, self: torch._C.Value, approximate: str = "none"):
         # Use microsoft::Gelu for performance if possible. It only supports approximate == "none"

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -141,8 +141,10 @@ class ONNXExporterTest(unittest.TestCase):
             opset_version=self.opset_version,
             custom_opsets={"com.microsoft": 1},
         )
+        f.seek(0)
         onnx_model = onnx.load(f)
-        
+        op_type = onnx_model.graph.node[1].op_type  # Node 0 is the input
+        self.assertEqual(op_type, "com.microsoft::Gelu")
 
     @parameterized.parameterized.expand([("default_approximate", "none"), ("tanh_approximate", "tanh")])
     @unittest.skipIf(_torch_version_lower_than("1.12"), "Gelu's approximate parameter unsupported in PyTorch < 1.12")

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -12,6 +12,7 @@ import numpy as np
 import parameterized
 import torch
 
+import onnx
 import onnxruntime
 from onnxruntime.tools import pytorch_export_contrib_ops
 
@@ -128,6 +129,20 @@ class ONNXExporterTest(unittest.TestCase):
         model = torch.nn.GELU()
         x = torch.randn(3, 3)
         self.run_test(model, x, custom_opsets={"com.microsoft": 1})
+
+    def test_gelu_is_fused_by_default(self):
+        model = torch.nn.GELU()
+
+        f = io.BytesIO()
+        torch.onnx.export(
+            model,
+            torch.randn(3, 3),
+            f,
+            opset_version=self.opset_version,
+            custom_opsets={"com.microsoft": 1},
+        )
+        onnx_model = onnx.load(f)
+        
 
     @parameterized.parameterized.expand([("default_approximate", "none"), ("tanh_approximate", "tanh")])
     @unittest.skipIf(_torch_version_lower_than("1.12"), "Gelu's approximate parameter unsupported in PyTorch < 1.12")

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -9,10 +9,10 @@ import io
 import unittest
 
 import numpy as np
+import onnx
 import parameterized
 import torch
 
-import onnx
 import onnxruntime
 from onnxruntime.tools import pytorch_export_contrib_ops
 
@@ -143,8 +143,9 @@ class ONNXExporterTest(unittest.TestCase):
         )
         f.seek(0)
         onnx_model = onnx.load(f)
-        op_type = onnx_model.graph.node[1].op_type  # Node 0 is the input
-        self.assertEqual(op_type, "com.microsoft::Gelu")
+        node = onnx_model.graph.node[0]
+        self.assertEqual(node.op_type, "Gelu")
+        self.assertEqual(node.domain, "com.microsoft")
 
     @parameterized.parameterized.expand([("default_approximate", "none"), ("tanh_approximate", "tanh")])
     @unittest.skipIf(_torch_version_lower_than("1.12"), "Gelu's approximate parameter unsupported in PyTorch < 1.12")


### PR DESCRIPTION
**Description**: Extract arg value from torch Value

**Motivation and Context**

Input to gelu is `torch._C.Value` type values. This caused the `if approximate == "none"` check to always fail, preventing the optimized `com.microsoft::Gelu` op from being used.

Tested:
Confirmed that the `if approximate == "none"` branch is hit when `torch.nn.GELU()` is exported.