### PR TITLE
Update install-entrypoint.sh: add version lock for NCCL

### DIFF
--- a/tools/ci_build/github/linux/docker/build_scripts/install-entrypoint.sh
+++ b/tools/ci_build/github/linux/docker/build_scripts/install-entrypoint.sh
@@ -27,4 +27,4 @@ if [ "${AUDITWHEEL_POLICY}" = "musllinux_1_1" ]; then
 	apk add --no-cache bash
 fi
 yum install -y yum-plugin-versionlock
-yum versionlock cuda* libcudnn*
+yum versionlock cuda* libcudnn* libnccl*


### PR DESCRIPTION
**Description**:

Update install-entrypoint.sh: add version lock for NCCL


**Motivation and Context**
- Why is this change required? What problem does it solve?

Without this, in our training 10.2 pipelines we saw:

```
Resolving Dependencies
--> Running transaction check
---> Package kernel-headers.x86_64 0:3.10.0-1160.59.1.el7 will be updated
---> Package kernel-headers.x86_64 0:3.10.0-1160.62.1.el7 will be an update
---> Package libnccl.x86_64 0:2.11.4-1+cuda10.2 will be updated
---> Package libnccl.x86_64 0:2.12.10-1+cuda11.6 will be an update
---> Package libnccl-devel.x86_64 0:2.11.4-1+cuda10.2 will be updated
---> Package libnccl-devel.x86_64 0:2.12.10-1+cuda11.6 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package             Arch        Version                     Repository    Size
================================================================================
Updating:
 kernel-headers      x86_64      3.10.0-1160.62.1.el7        updates      9.1 M
 libnccl             x86_64      2.12.10-1+cuda11.6          cuda          86 M
 libnccl-devel       x86_64      2.12.10-1+cuda11.6          cuda          10 k

Transaction Summary
================================================================================
Upgrade  3 Packages
```


- If it fixes an open issue, please link to the issue here.
