### PR TITLE
fix windows ci debug build break

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind.h
+++ b/onnxruntime/python/onnxruntime_pybind.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-// If performing a debug build with VS2019 (>=16.11.14) or VS2022 (_MSC_FULL_VER >= 192930145) 
+// If performing a debug build with VS2019 (>=16.11.14) or VS2022 (_MSC_FULL_VER >= 192930145)
 // we need to include corecrt.h before pybind so that the _STL_ASSERT macro is defined in a compatible way.
 //
 // pybind11/pybind11.h includes pybind11/detail/common.h, which undefines _DEBUG whilst including the Python headers

--- a/onnxruntime/python/onnxruntime_pybind.h
+++ b/onnxruntime/python/onnxruntime_pybind.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-// If performing a debug build with VS2019 (latest versions) or VS2022 (_MSC_FULL_VER >= 192930145) 
+// If performing a debug build with VS2019 (>=16.11.14) or VS2022 (_MSC_FULL_VER >= 192930145) 
 // we need to include corecrt.h before pybind // so that the _STL_ASSERT macro is defined in a compatible way.
 //
 // pybind11/pybind11.h includes pybind11/detail/common.h, which undefines _DEBUG whilst including the Python headers

--- a/onnxruntime/python/onnxruntime_pybind.h
+++ b/onnxruntime/python/onnxruntime_pybind.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-// If performing a debug build with VS2022 (_MSC_VER == 1930) we need to include corecrt.h before pybind
-// so that the _STL_ASSERT macro is defined in a compatible way.
+// If performing a debug build with VS2019 (latest versions) or VS2022 (_MSC_FULL_VER >= 192930145) 
+// we need to include corecrt.h before pybind // so that the _STL_ASSERT macro is defined in a compatible way.
 //
 // pybind11/pybind11.h includes pybind11/detail/common.h, which undefines _DEBUG whilst including the Python headers
 // (which in turn include corecrt.h). This alters how the _STL_ASSERT macro is defined and causes the build to fail.
 //
 // see https://github.com/microsoft/onnxruntime/issues/9735
 //
-#if defined(_MSC_VER) && defined(_DEBUG) && _MSC_VER >= 1930
+#if defined(_MSC_FULL_VER) && defined(_DEBUG) && _MSC_FULL_VER >= 192930145
 #include <corecrt.h>
 #endif
 

--- a/onnxruntime/python/onnxruntime_pybind.h
+++ b/onnxruntime/python/onnxruntime_pybind.h
@@ -4,7 +4,7 @@
 #pragma once
 
 // If performing a debug build with VS2019 (>=16.11.14) or VS2022 (_MSC_FULL_VER >= 192930145) 
-// we need to include corecrt.h before pybind // so that the _STL_ASSERT macro is defined in a compatible way.
+// we need to include corecrt.h before pybind so that the _STL_ASSERT macro is defined in a compatible way.
 //
 // pybind11/pybind11.h includes pybind11/detail/common.h, which undefines _DEBUG whilst including the Python headers
 // (which in turn include corecrt.h). This alters how the _STL_ASSERT macro is defined and causes the build to fail.


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/issues/9735 started impacting recent Windows CI debug builds after an auto update to VS 2019 16.11.14 
this PR updates the workaround in https://github.com/microsoft/onnxruntime/pull/9794 to check for _MSC_FULL_VER >= 192930145