### PR TITLE
ci(cpplint): Ignore runtime/references warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           flags: --linelength=120
+          filter: "-runtime/references"
 
   lint-js:
     name: Lint JavaScript


### PR DESCRIPTION
**Description**: ci(cpplint): Ignore runtime/references warnings

**Motivation and Context**

Allow non-const references https://github.com/microsoft/onnxruntime/blob/6f85d3e5c81c919022ac4a77e5a051da8518b15d/docs/Coding_Conventions_and_Standards.md?plain=1#L11-L12