### PR TITLE
Add python static type checking in CI checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,14 @@ jobs:
           level: warning
           filter_mode: file
           lib: true
+      - name: pylint
+        uses: justinchuby/action-pylint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: warning
+          filter_mode: file
+          pylint_args: "$(git ls-files '*.py')"
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           filter_mode: file
           lib: true
       - name: pylint
-        uses: dciborow/action-pylint@master
+        uses: dciborow/action-pylint@main
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,21 @@ jobs:
           level: info
           filter_mode: file
           markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
+      - name: pylint
+        uses: dciborow/action-pylint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: warning
+          filter_mode: file
+      - name: pyright
+        uses: jordemort/action-pyright@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: warning
+          filter_mode: file
+          lib: true
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           filter_mode: file
           lib: true
       - name: pylint
-        uses: justinchuby/action-pylint@master
+        uses: dciborow/action-pylint@master
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,61 +13,61 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-#       - name: black
-#         uses: reviewdog/action-black@v3
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
-#           reporter: github-pr-check
-#           # Change reporter level if you need.
-#           # GitHub Status Check won't become failure with a warning.
-#           level: error
-#           filter_mode: file
-#       - name: flake8
-#         uses: reviewdog/action-flake8@v3
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           reporter: github-pr-check
-#           level: error
-#           filter_mode: file
-#       - name: pyflakes
-#         uses: reviewdog/action-pyflakes@v1
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           reporter: github-pr-check
-#           level: warning
-#           filter_mode: file
-#       - name: misspell # Check spellings as well
-#         uses: reviewdog/action-misspell@v1
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           locale: "US"
-#           reporter: github-pr-check
-#           level: info
-#           filter_mode: diff_context
-#       - name: shellcheck # Static check shell scripts
-#         uses: reviewdog/action-shellcheck@v1
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           reporter: github-pr-check
-#           level: info
-#           filter_mode: file
-#       - name: markdownlint
-#         uses: reviewdog/action-markdownlint@v0.7
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           reporter: github-pr-check
-#           level: info
-#           filter_mode: file
-#           markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
-#       - name: pyright
-#         uses: jordemort/action-pyright@v1
-#         with:
-#           github_token: ${{ secrets.github_token }}
-#           reporter: github-pr-check
-#           level: warning
-#           filter_mode: file
-#           lib: true
+      - name: black
+        uses: reviewdog/action-black@v3
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
+          reporter: github-pr-check
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with a warning.
+          level: error
+          filter_mode: file
+      - name: flake8
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: error
+          filter_mode: file
+      - name: pyflakes
+        uses: reviewdog/action-pyflakes@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: warning
+          filter_mode: file
+      - name: misspell # Check spellings as well
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          locale: "US"
+          reporter: github-pr-check
+          level: info
+          filter_mode: diff_context
+      - name: shellcheck # Static check shell scripts
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: info
+          filter_mode: file
+      - name: markdownlint
+        uses: reviewdog/action-markdownlint@v0.7
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: info
+          filter_mode: file
+          markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
+      - name: pyright
+        uses: jordemort/action-pyright@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: warning
+          filter_mode: file
+          lib: true
       - name: pylint
         uses: justinchuby/action-pylint@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,61 +13,61 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: black
-        uses: reviewdog/action-black@v3
-        with:
-          github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
-          reporter: github-pr-check
-          # Change reporter level if you need.
-          # GitHub Status Check won't become failure with a warning.
-          level: error
-          filter_mode: file
-      - name: flake8
-        uses: reviewdog/action-flake8@v3
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: error
-          filter_mode: file
-      - name: pyflakes
-        uses: reviewdog/action-pyflakes@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: warning
-          filter_mode: file
-      - name: misspell # Check spellings as well
-        uses: reviewdog/action-misspell@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          locale: "US"
-          reporter: github-pr-check
-          level: info
-          filter_mode: diff_context
-      - name: shellcheck # Static check shell scripts
-        uses: reviewdog/action-shellcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: info
-          filter_mode: file
-      - name: markdownlint
-        uses: reviewdog/action-markdownlint@v0.7
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: info
-          filter_mode: file
-          markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
-      - name: pyright
-        uses: jordemort/action-pyright@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: warning
-          filter_mode: file
-          lib: true
+#       - name: black
+#         uses: reviewdog/action-black@v3
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
+#           reporter: github-pr-check
+#           # Change reporter level if you need.
+#           # GitHub Status Check won't become failure with a warning.
+#           level: error
+#           filter_mode: file
+#       - name: flake8
+#         uses: reviewdog/action-flake8@v3
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           reporter: github-pr-check
+#           level: error
+#           filter_mode: file
+#       - name: pyflakes
+#         uses: reviewdog/action-pyflakes@v1
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           reporter: github-pr-check
+#           level: warning
+#           filter_mode: file
+#       - name: misspell # Check spellings as well
+#         uses: reviewdog/action-misspell@v1
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           locale: "US"
+#           reporter: github-pr-check
+#           level: info
+#           filter_mode: diff_context
+#       - name: shellcheck # Static check shell scripts
+#         uses: reviewdog/action-shellcheck@v1
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           reporter: github-pr-check
+#           level: info
+#           filter_mode: file
+#       - name: markdownlint
+#         uses: reviewdog/action-markdownlint@v0.7
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           reporter: github-pr-check
+#           level: info
+#           filter_mode: file
+#           markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
+#       - name: pyright
+#         uses: jordemort/action-pyright@v1
+#         with:
+#           github_token: ${{ secrets.github_token }}
+#           reporter: github-pr-check
+#           level: warning
+#           filter_mode: file
+#           lib: true
       - name: pylint
         uses: justinchuby/action-pylint@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           filter_mode: file
-          pylint_args: "$(git ls-files '*.py')"
+          pylint_args: "$(/usr/bin/git ls-files '*.py')"
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           filter_mode: file
-          pylint_args: "$(git ls-files '*.py')"
+          glob_pattern: "**/*.py"
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           filter_mode: file
           lib: true
       - name: pylint
-        uses: dciborow/action-pylint@main
+        uses: dciborow/action-pylint@0.0.6
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           filter_mode: diff_context
           lib: true
       - name: pylint
-        uses: dciborow/action-pylint@0.0.6
+        uses: dciborow/action-pylint@0.0.7
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          filter_mode: file
+          filter_mode: diff_context
           lib: true
       - name: pylint
         uses: dciborow/action-pylint@0.0.6
@@ -74,7 +74,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          filter_mode: file
+          filter_mode: diff_context
           glob_pattern: "**/*.py"
 
   lint-python-format:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: reviewdog/action-black@v3
+      - name: black
+        uses: reviewdog/action-black@v3
         with:
           github_token: ${{ secrets.github_token }}
           # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
@@ -22,7 +23,8 @@ jobs:
           # GitHub Status Check won't become failure with a warning.
           level: error
           filter_mode: file
-      - uses: reviewdog/action-flake8@v3
+      - name: flake8
+        uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
@@ -58,13 +60,6 @@ jobs:
           level: info
           filter_mode: file
           markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
-      - name: pylint
-        uses: dciborow/action-pylint@master
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: warning
-          filter_mode: file
       - name: pyright
         uses: jordemort/action-pyright@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
           filter_mode: file
           markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
       - name: pylint
-        uses: dciborow/action-pylint@v1
+        uses: dciborow/action-pylint@master
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           filter_mode: file
-          pylint_args: "$(/usr/bin/git ls-files '*.py')"
+          pylint_args: "**/*.py"
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           filter_mode: file
-          pylint_args: "**/*.py"
+          pylint_args: "$(git ls-files '*.py')"
 
   lint-python-format:
     # Separated black/isort from other Python linters because we want this job to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,14 +52,6 @@ jobs:
           reporter: github-pr-check
           level: info
           filter_mode: file
-      - name: markdownlint
-        uses: reviewdog/action-markdownlint@v0.7
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: info
-          filter_mode: file
-          markdownlint_flags: ". --disable MD013 MD041 MD033 MD034"
       - name: pyright
         uses: jordemort/action-pyright@v1
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,8 +29,10 @@
     ],
     "python.linting.enabled": true,
     "python.linting.flake8Enabled": true,
+    "python.linting.pylintEnabled": true,
     "python.linting.pydocstyleEnabled": true,
     "python.linting.pydocstyleArgs": [
         "--convention=google"
-    ]
+    ],
+    "python.linting.banditEnabled": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ extend_skip_glob = [
 
 [tool.pydocstyle]
 convention = "google"
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = ["format", "line-too-long"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ extend_skip_glob = [
 convention = "google"
 
 [tool.pylint.'MESSAGES CONTROL']
-disable = ["format", "line-too-long"]
+disable = ["format", "line-too-long", "import-error", "no-name-in-module"]
 
 [tool.pyright]
 exclude = ["onnxruntime/core/flatbuffers/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ convention = "google"
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = ["format", "line-too-long"]
+
+[tool.pyright]
+exclude = ["onnxruntime/core/flatbuffers/*"]
+reportMissingImports = false


### PR DESCRIPTION
**Description**: Add python static type checking in CI checks

**Motivation and Context**

- Enable pyright and pylint (https://github.com/microsoft/pyright) in CI
- Enable pyright, pylint and bandit by default in VS code

Pylint has some good style checks. pyright is Microsoft's static type checker.

e,g,

![image](https://user-images.githubusercontent.com/11205048/168653355-87d1b941-2d48-4872-b61e-1f408b8de163.png)
