### PR TITLE
On device training offline tooling

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -320,6 +320,17 @@ if (onnxruntime_ENABLE_TRAINING)
   file(GLOB onnxruntime_python_utils_data_srcs CONFIGURE_DEPENDS
   "${ORTTRAINING_SOURCE_DIR}/python/training/utils/data/*"
   )
+  if (onnxruntime_ENABLE_TRAINING_ON_DEVICE)
+    file(GLOB onnxruntime_python_onnxblock_srcs CONFIGURE_DEPENDS
+    "${ORTTRAINING_SOURCE_DIR}/python/training/onnxblock/*"
+    )
+    file(GLOB onnxruntime_python_onnxblock_loss_srcs CONFIGURE_DEPENDS
+    "${ORTTRAINING_SOURCE_DIR}/python/training/onnxblock/loss/*"
+    )
+    file(GLOB onnxruntime_python_onnxblock_optim_srcs CONFIGURE_DEPENDS
+    "${ORTTRAINING_SOURCE_DIR}/python/training/onnxblock/optim/*"
+    )
+  endif()
 else()
   file(GLOB onnxruntime_python_capi_training_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/python/training/*.py"
@@ -644,6 +655,23 @@ if (onnxruntime_ENABLE_TRAINING)
         ${onnxruntime_python_utils_data_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/
   )
+  if (onnxruntime_ENABLE_TRAINING_ON_DEVICE)
+    add_custom_command(
+      TARGET onnxruntime_pybind11_state POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock
+      COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock/loss
+      COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock/optim
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_onnxblock_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock/
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_onnxblock_loss_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock/loss/
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_onnxblock_optim_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/onnxblock/optim/
+    )
+  endif()
 endif()
 
 if (onnxruntime_USE_DNNL)

--- a/orttraining/orttraining/python/training/onnxblock/__init__.py
+++ b/orttraining/orttraining/python/training/onnxblock/__init__.py
@@ -2,8 +2,12 @@
 # Licensed under the MIT License.
 # __init__.py
 
-from .graph import Graph, TrainingGraph
+from .model import Model, TrainingModel
 from .checkpoint_utils import save_checkpoint
 from . import loss, optim
+from .model_accessor import onnx_model
 
-_producer_name = "onnxblock"
+import onnx
+
+_producer_name = "onnxblock offline tooling"
+_opset_import = onnx.helper.make_opsetid("com.microsoft", 1)

--- a/orttraining/orttraining/python/training/onnxblock/__init__.py
+++ b/orttraining/orttraining/python/training/onnxblock/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py
+
+from .graph import Graph, TrainingGraph
+from .checkpoint_utils import save_checkpoint
+from . import loss, optim
+
+_producer_name = "onnxblock"

--- a/orttraining/orttraining/python/training/onnxblock/_building_blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/_building_blocks.py
@@ -1,0 +1,146 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# _building_blocks.py
+
+import copy
+import onnx
+
+import onnxruntime.training.onnxblock as onnxblock
+import onnxruntime.training.onnxblock.model_accessor as accessor
+import onnxruntime.training.onnxblock._graph_utils as graph_utils
+
+
+class Sub(onnxblock.Model):
+    """Adds Sub node to an onnx model."""
+
+    def __init__(self):
+        super(Sub, self).__init__()
+
+    def build(self, sub_input_name1, sub_input_name2):
+        # get the model to manipulate
+        onnx_model = accessor.global_accessor.model
+
+        # create the graph node for sub
+        sub_node_input_names = [sub_input_name1, sub_input_name2]
+        sub_node_output_name = graph_utils.generate_random_graph_name("sub_output")
+        sub_node_output_names = [sub_node_output_name]
+        sub_node = onnx.helper.make_node(
+            "Sub",
+            sub_node_input_names,
+            sub_node_output_names,
+            name=graph_utils.generate_random_graph_name("Sub"),
+        )
+        onnx_model.graph.node.append(sub_node)
+
+        # create the graph output for sub
+        graph_output = copy.deepcopy(
+            graph_utils.get_output_from_output_name(onnx_model, sub_input_name1)
+        )
+        graph_output.name = sub_node_output_name
+        del onnx_model.graph.output[:]
+        onnx_model.graph.output.append(graph_output)
+
+        return sub_node_output_name
+
+
+class Pow(onnxblock.Model):
+    """Adds Pow node to the onnx model."""
+
+    def __init__(self, exponent):
+        super(Pow, self).__init__()
+
+        self._exponent = exponent
+
+    def build(self, pow_input_name):
+        # get the model to manipulate
+        onnx_model = accessor.global_accessor.model
+
+        # create the graph initializer for the exponent
+        pow_node_exponent_name = graph_utils.generate_random_graph_name("pow_exponent")
+        onnx_model.graph.initializer.append(
+            onnx.helper.make_tensor(
+                pow_node_exponent_name, onnx.TensorProto.FLOAT, [1], [self._exponent]
+            )
+        )
+
+        # create the graph node for pow
+        pow_node_input_names = [pow_input_name, pow_node_exponent_name]
+        pow_node_output_name = graph_utils.generate_random_graph_name("pow_output")
+        pow_node_output_names = [pow_node_output_name]
+        pow_node = onnx.helper.make_node(
+            "Pow",
+            pow_node_input_names,
+            pow_node_output_names,
+            name=graph_utils.generate_random_graph_name("Pow"),
+        )
+        onnx_model.graph.node.append(pow_node)
+
+        # create the graph output for pow
+        graph_output = copy.deepcopy(
+            graph_utils.get_output_from_output_name(onnx_model, pow_input_name)
+        )
+        graph_output.name = pow_node_output_name
+        del onnx_model.graph.output[:]
+        onnx_model.graph.output.append(graph_output)
+
+        return pow_node_output_name
+
+
+class _Reduce(onnxblock.Model):
+    """Base class for the reduce blocks."""
+
+    def __init__(self):
+        super(_Reduce, self).__init__()
+
+    def _reduce(self, reduce_input_name, reduction_op):
+        # get the model to manipulate
+        onnx_model = accessor.global_accessor.model
+
+        # create the graph node for reduce
+        reduce_node_input_names = [reduce_input_name]
+        reduce_node_output_name = graph_utils.generate_random_graph_name(
+            "reduce_output"
+        )
+        reduce_node_output_names = [reduce_node_output_name]
+        reduce_node = onnx.helper.make_node(
+            reduction_op,
+            reduce_node_input_names,
+            reduce_node_output_names,
+            name=graph_utils.generate_random_graph_name(reduction_op),
+        )
+        onnx_model.graph.node.append(reduce_node)
+
+        # create the graph output for reduce
+        reduce_input = copy.deepcopy(
+            graph_utils.get_output_from_output_name(onnx_model, reduce_input_name)
+        )
+        output_rank = len(reduce_input.type.tensor_type.shape.dim)
+        graph_outputs = [
+            onnx.helper.make_tensor_value_info(
+                reduce_node_output_name, onnx.TensorProto.FLOAT, [1] * output_rank
+            )
+        ]
+        del onnx_model.graph.output[:]
+        onnx_model.graph.output.extend(graph_outputs)
+
+        return reduce_node_output_name
+
+
+class ReduceMean(_Reduce):
+    """Adds ReduceMean node to the onnx model."""
+
+    def __init__(self):
+        super(ReduceMean, self).__init__()
+
+    def build(self, reduce_input_name):
+        return super()._reduce(reduce_input_name, "ReduceMean")
+
+
+class ReduceSum(_Reduce):
+    """Adds ReduceSum node to the onnx model."""
+
+    def __init__(self):
+        super(ReduceSum, self).__init__()
+
+    def build(self, reduce_input_name):
+        return super(ReduceSum, self)._reduce(reduce_input_name, "ReduceSum")

--- a/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
@@ -1,0 +1,144 @@
+import copy
+from onnxruntime.capi._pybind_state import GradientGraphBuilder
+import onnx
+
+from onnxruntime.training import onnxblock
+
+
+def build_gradient_model(model, user_args_requiring_grad, user_args_not_requiring_grad):
+    """Builds the gradient graph on top of the given input forward only graph."""
+
+    # Collect names of parameters that need gradients computed
+    all_args_requiring_gradient = set()
+    # Move all trainable and non trainable initializers to graph inputs.
+    # This allows training to pass in the parameters from outside the graph
+    # so as to share the parameters across multiple sessions.
+    graph_inputs = model.graph.input
+    initializers = []
+    for initializer in model.graph.initializer:
+        if not initializer.name[0].isdigit():
+            # Move only those initializers as inputs that are not local
+            # to the onnx model. i.e. initializers that are model parameters.
+            # These are tpically those initializers without any number prefixed
+            # to their names.
+            graph_inputs.append(
+                onnx.helper.make_tensor_value_info(
+                    initializer.name, initializer.data_type, initializer.dims
+                )
+            )
+            if initializer.name not in user_args_not_requiring_grad:
+                all_args_requiring_gradient.add(initializer.name)
+        else:
+            # All other initializers stay where they were.
+            initializers.append(initializer)
+
+    # Graph and model with initializers as inputs.
+    graph_with_initializers_as_inputs = onnx.helper.make_graph(
+        model.graph.node,
+        "Forward Graph with Initilializers as Inputs",
+        graph_inputs,
+        model.graph.output,
+        initializer=initializers,
+    )
+    grad_model = onnx.helper.make_model(
+        graph_with_initializers_as_inputs,
+        producer_name=onnxblock._producer_name,
+        opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)]
+        + list(model.opset_import),
+    )
+
+    # Any graph input that requires gradient, should have been already added to
+    # args_requiring_grad.
+    for argument_name in user_args_requiring_grad:
+        all_args_requiring_gradient.add(argument_name)
+
+    # Assumption is that the graph has an output called `loss`.
+    builder = GradientGraphBuilder(
+        grad_model.SerializeToString(), {"loss"}, all_args_requiring_gradient, "loss"
+    )
+    builder.build()
+    return onnx.load_from_string(builder.get_model())
+
+
+def build_gradient_accumulation_model(grad_model):
+    """Builds gradient accumulation nodes on top of a training model."""
+
+    graph_inputs = grad_model.graph.input
+    graph_nodes = grad_model.graph.node
+    graph_outputs = []
+
+    lazy_reset_grad_input_name = "lazy_reset_grad"
+    gradient_output_suffix = "_grad"
+    gradient_accumulation_name = "accumulation"
+    gradient_buffer_name_suffix = "buffer"
+    gradient_output_name_suffix = "out"
+
+    for idx, graph_output in enumerate(grad_model.graph.output):
+        # if the graph output ends with _grad,
+        # assume that that output is a gradient output
+        if not graph_output.name.endswith(gradient_output_suffix):
+            graph_outputs.append(graph_output)
+            continue
+
+        # gradient accumulation node inputs and output names
+        grad_name = graph_output.name
+        grad_accumulation_buffer_name = (
+            f"{grad_name}.{gradient_accumulation_name}.{gradient_buffer_name_suffix}"
+        )
+        grad_accumulation_output_name = (
+            f"{grad_name}.{gradient_accumulation_name}.{gradient_output_name_suffix}"
+        )
+
+        # Gradient accumulation node
+        acc_node = onnx.helper.make_node(
+            "InPlaceAccumulator",
+            [grad_accumulation_buffer_name, grad_name, lazy_reset_grad_input_name],
+            [grad_accumulation_output_name],
+            name=f"GradientAccumulator{idx}",
+            domain="com.microsoft",
+        )
+
+        graph_nodes.append(acc_node)
+
+        # grad buffer is also a graph input
+        grad_accumulation_buffer_input = copy.deepcopy(graph_output)
+        grad_accumulation_buffer_input.name = grad_accumulation_buffer_name
+        graph_inputs.append(grad_accumulation_buffer_input)
+
+        # accumulated gradient is also a graph output
+        grad_accumulation_output = copy.deepcopy(graph_output)
+        grad_accumulation_output.name = grad_accumulation_output_name
+        graph_outputs.append(grad_accumulation_output)
+
+    lazy_reset_grad_input = onnx.helper.make_tensor_value_info(
+        lazy_reset_grad_input_name, onnx.TensorProto.BOOL, [1]
+    )
+    graph_inputs.append(lazy_reset_grad_input)
+
+    graph = onnx.helper.make_graph(
+        graph_nodes,
+        "Training Graph with Gradient Accumulation Nodes",
+        graph_inputs,
+        graph_outputs,
+        grad_model.graph.initializer,
+    )
+    return onnx.helper.make_model(
+        graph,
+        producer_name=onnxblock._producer_name,
+        opset_imports=list(grad_model.opset_import),
+    )
+
+
+def get_model_parameters(model, args_not_requiring_gradient):
+    """Returns trainable and non trainable onnx model parameters."""
+
+    trainable_params = []
+    non_trainable_params = []
+    for initializer in model.graph.initializer:
+        if not initializer.name[0].isdigit():
+            if initializer.name in args_not_requiring_gradient:
+                non_trainable_params.append(initializer)
+            else:
+                trainable_params.append(initializer)
+
+    return trainable_params, non_trainable_params

--- a/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_graph_utils.py
@@ -109,7 +109,7 @@ def build_gradient_accumulation_graph(grad_model, all_args_requiring_gradient_na
 
     gradient.accumulation.buffer        gradient
         |         |                         |
-        |         v                         v
+        Ʌ         v                         v
         |         |_________________________|
         |                      |
         |               InPlaceAccumulator
@@ -128,7 +128,6 @@ def build_gradient_accumulation_graph(grad_model, all_args_requiring_gradient_na
     graph_outputs = []
 
     lazy_reset_grad_input_name = "lazy_reset_grad"
-    gradient_output_suffix = "_grad"
     gradient_accumulation_name = "accumulation"
     gradient_buffer_name_suffix = "buffer"
     gradient_output_name_suffix = "out"

--- a/orttraining/orttraining/python/training/onnxblock/checkpoint_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/checkpoint_utils.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# checkpoint_utils.py
+
+from onnxruntime.capi._pybind_state import save_checkpoint as _internal_save_checkpoint
+
+
+def save_checkpoint(parameters, path_to_checkpoint):
+    if parameters is None:
+        raise RuntimeError("No parameters provided.")
+
+    # TODO: use Parameter class to pass information to backend
+    trainable_params, non_trainable_params = parameters
+    trainable_params = [param.SerializeToString() for param in trainable_params]
+    non_trainable_params = [param.SerializeToString() for param in non_trainable_params]
+    _internal_save_checkpoint(
+        trainable_params, non_trainable_params, path_to_checkpoint
+    )

--- a/orttraining/orttraining/python/training/onnxblock/checkpoint_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/checkpoint_utils.py
@@ -6,10 +6,13 @@ from onnxruntime.capi._pybind_state import save_checkpoint as _internal_save_che
 
 
 def save_checkpoint(parameters, path_to_checkpoint):
+    """Saves the parameters to the checkpoint directory path_to_checkpoint."""
+
     if parameters is None:
-        raise RuntimeError("No parameters provided.")
+        raise RuntimeError("No checkpoint parameters provided.")
 
     # TODO: use Parameter class to pass information to backend
+    # Serialize the parameters and save the checkpoint
     trainable_params, non_trainable_params = parameters
     trainable_params = [param.SerializeToString() for param in trainable_params]
     non_trainable_params = [param.SerializeToString() for param in non_trainable_params]

--- a/orttraining/orttraining/python/training/onnxblock/graph.py
+++ b/orttraining/orttraining/python/training/onnxblock/graph.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# graph.py
+
+from abc import ABC, abstractmethod
+import onnx
+from ._graph_utils import (
+    build_gradient_model,
+    build_gradient_accumulation_model,
+    get_model_parameters,
+)
+
+
+class Graph(ABC):
+    """Builds the forward model based on user's build method."""
+
+    def __init__(self):
+        ...
+
+    @abstractmethod
+    def build(self, *args, **kwargs):
+        """Customize and build the forward graph for this model.
+
+        This method is to be overriden by the user's implementation.
+        """
+        ...
+
+    def __call__(self, *args, **kwargs):
+        """Calls the user's build method and runs validation on top.
+
+        The output onnx model is got by invoking the user's build method.
+        """
+        # build the user model
+        user_model = self.build(*args, **kwargs)
+
+        # validate and check the model
+        onnx.checker.check_model(user_model, True)
+
+        return user_model
+
+
+class TrainingGraph(Graph):
+    """Builds the training model based on user's build method."""
+
+    def __init__(self):
+        super(TrainingGraph, self).__init__()
+        self._arg_requiring_grad = set()
+        self._arg_not_requiring_grad = set()
+        self._parameters = None
+
+    @abstractmethod
+    def build(self, *args, **kwargs):
+        """Customize and build the forward graph for this training model.
+
+        This method is to be overriden by the user's implementation.
+        """
+        ...
+
+    def requires_grad(self, argument_name, value=True):
+        """Control whether the given graph input/parameter requires gradient."""
+        if value is True:
+            if argument_name in self._arg_not_requiring_grad:
+                self._arg_not_requiring_grad.remove(argument_name)
+            self._arg_requiring_grad.add(argument_name)
+        else:
+            if argument_name in self._arg_requiring_grad:
+                self._arg_requiring_grad.remove(argument_name)
+            self._arg_not_requiring_grad.add(argument_name)
+
+    def parameters(self):
+        """Returns trainable and non trainable parameters.
+
+        Model parameters that are extracted while building the training model
+        are returned by this method.
+
+        Note that the parameters are not known before the training model is
+        built. As a result, if this method is invoked before the training model
+        is built, an exception will be raised.
+        """
+        if self._parameters is None:
+            raise RuntimeError(
+                "Please build the training graph first before trying to "
+                "retrieve the parameters."
+            )
+
+        return self._parameters
+
+    def __call__(self, *args, **kwargs):
+        """Calls the user's build method and builds the gradient graph on top.
+
+        The output onnx model contains the user's training model such that:
+        1. It contains the gradient graph.
+        2. It contains inputs in the order: user inputs, weight parameters,
+           gradient inputs.
+        3. It contains the outputs in the order: user outputs, gradient outputs.
+
+        Note that the model parameters are moved to be graph inputs.
+        """
+        # build the user model
+        user_model = self.build(*args, **kwargs)
+
+        # get all the model parameters for the user_model
+        # and store them in self._parameters
+        self._parameters = get_model_parameters(
+            user_model, self._arg_not_requiring_grad
+        )
+
+        # build the gradient graph
+        grad_model = build_gradient_model(
+            user_model, self._arg_requiring_grad, self._arg_not_requiring_grad
+        )
+
+        # add gradient accumulation nodes
+        grad_model = build_gradient_accumulation_model(grad_model)
+
+        # validate and check the model
+        onnx.checker.check_model(grad_model, True)
+
+        return grad_model

--- a/orttraining/orttraining/python/training/onnxblock/loss/__init__.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py
+
+from .loss import MSELoss, CrossEntropyLoss

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -1,0 +1,203 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# loss.py
+
+import copy
+import onnx
+
+from ..graph import Graph
+from onnxruntime.training import onnxblock
+
+
+def _get_output_from_output_name(onnx_model, output_name):
+    """Returns the graph output given the output name"""
+
+    # Iterate over the graph outputs looking for output_name
+    for output in onnx_model.graph.output:
+        if output.name == output_name:
+            return output
+
+    raise LookupError("The provided output name {output_name} is not a graph output.")
+
+
+class MSELoss(Graph):
+    """MSELoss onnxblock for adding MSE loss to an onnx model."""
+
+    def __init__(self, reduction="mean"):
+        super(MSELoss, self).__init__()
+
+        self._reduction = reduction
+
+    def build(self, base_model, output_name, target_name="target"):
+        """Adds an MSELoss subgraph on top of the base_model."""
+
+        # deepcopy the base model so we don't inadvertently change the original
+        # model
+        onnx_model = copy.deepcopy(base_model)
+
+        # determine the reduction type
+        if self._reduction != "mean" and self._reduction != "sum":
+            raise RuntimeError(f"Reduction {self.reduction} not supported.")
+
+        graph_nodes = onnx_model.graph.node
+        graph_inputs = onnx_model.graph.input
+
+        # create a new graph input. this is the target input needed to compare
+        # the graph output against to calculate loss.
+        target_input = copy.deepcopy(
+            _get_output_from_output_name(onnx_model, output_name)
+        )
+        target_input.name = target_name
+        graph_inputs.append(target_input)
+
+        # create a new graph output for loss
+        graph_outputs = [
+            onnx.helper.make_tensor_value_info("loss", onnx.TensorProto.FLOAT, [1, 1])
+        ]
+
+        graph_initializers = onnx_model.graph.initializer
+
+        # loss equation
+        # loss = reduce((output-target)^2)
+
+        # create the sub node
+        sub_node_input_names = [output_name, target_name]
+        sub_node_output_names = ["loss_sub_output"]
+        sub_node = onnx.helper.make_node(
+            "Sub", sub_node_input_names, sub_node_output_names, name=f"MSELossSub"
+        )
+        graph_nodes.append(sub_node)
+
+        # create the square node
+        pow_node_input_names = sub_node_output_names
+        pow_node_input_names.append("0_pow_exponent")
+        pow_node_output_names = ["loss_pow_output"]
+        pow_node = onnx.helper.make_node(
+            "Pow", pow_node_input_names, pow_node_output_names, name=f"MSELossPow"
+        )
+        graph_nodes.append(pow_node)
+        graph_initializers.append(
+            onnx.helper.make_tensor(
+                "0_pow_exponent", onnx.TensorProto.FLOAT, [1], [2.0]
+            )
+        )
+
+        # create the reduce node
+        reduce_node_input_names = pow_node_output_names
+        reduce_node_output_names = ["loss"]
+        reduce_node = onnx.helper.make_node(
+            "ReduceMean" if self._reduction == "mean" else "ReduceSum",
+            reduce_node_input_names,
+            reduce_node_output_names,
+            name=f"MSELossReduce",
+        )
+        graph_nodes.append(reduce_node)
+
+        # generate the graph and model with above inputs, outputs, initializers
+        # and nodes
+        graph = onnx.helper.make_graph(
+            graph_nodes,
+            "GraphWithLoss",
+            graph_inputs,
+            graph_outputs,
+            graph_initializers,
+        )
+        model = onnx.helper.make_model(
+            graph,
+            producer_name=onnxblock._producer_name,
+            opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)]
+            + list(base_model.opset_import),
+        )
+
+        return model
+
+
+class CrossEntropyLoss(Graph):
+    """CrossEntropyLoss onnxblock for adding Cross Entropy loss to an onnx model."""
+
+    def __init__(self, weight=False, reduction="mean", ignore_index=None):
+        super(CrossEntropyLoss, self).__init__()
+
+        self._weight = weight
+        self._reduction = reduction
+        self._ignore_index = ignore_index
+
+    def build(
+        self, base_model, output_name, target_name="target", weight_name="loss_weight"
+    ):
+        """Adds a CrossEntropyLoss subgraph on top of the base_model."""
+
+        # deepcopy the base model so we don't inadvertently change the
+        # original model
+        onnx_model = copy.deepcopy(base_model)
+
+        # determine the reduction type
+        if self._reduction != "mean" and self._reduction != "sum":
+            raise RuntimeError(f"Reduction {self._reduction} not supported.")
+
+        graph_nodes = onnx_model.graph.node
+        graph_inputs = onnx_model.graph.input
+
+        # create a new graph input. this is the target input needed to compare
+        # the graph output against to calculate loss.
+        target_input = copy.deepcopy(
+            _get_output_from_output_name(onnx_model, output_name)
+        )
+        target_input.name = target_name
+        target_input.type.tensor_type.elem_type = onnx.TensorProto.INT32
+        # if the predictions are (num_examples x num_classes)
+        # labels should be (num_examples x 1)
+        del target_input.type.tensor_type.shape.dim[1]
+        graph_inputs.append(target_input)
+
+        if self._weight:
+            weight_input = copy.deepcopy(
+                _get_output_from_output_name(onnx_model, output_name)
+            )
+            weight_input.name = weight_name
+            dim_to_keep = weight_input.type.tensor_type.shape.dim[1]
+            del weight_input.type.tensor_type.shape.dim[:]
+            weight_input.type.tensor_type.shape.dim.append(dim_to_keep)
+            graph_inputs.append(weight_input)
+
+        # create a new graph output for loss
+        graph_outputs = [
+            onnx.helper.make_tensor_value_info("loss", onnx.TensorProto.FLOAT, [])
+        ]
+        graph_initializers = onnx_model.graph.initializer
+
+        # create the loss node
+        loss_node_input_name = [output_name, target_name]
+        if self._weight:
+            loss_node_input_name.append(weight_name)
+        loss_node_output_name = ["loss", "log_prob"]
+        loss_node = onnx.helper.make_node(
+            "SoftmaxCrossEntropyLoss",
+            loss_node_input_name,
+            loss_node_output_name,
+            reduction=self._reduction,
+            ignore_index=self._ignore_index,
+            name=f"SoftmaxCrossEntropyLoss",
+        )
+        graph_nodes.append(loss_node)
+
+        # generate the graph and model with above inputs, outputs,
+        # initializers and nodes
+        graph = onnx.helper.make_graph(
+            graph_nodes,
+            "GraphWithLoss",
+            graph_inputs,
+            graph_outputs,
+            graph_initializers,
+        )
+        model = onnx.helper.make_model(
+            graph,
+            producer_name=onnxblock._producer_name,
+            opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)]
+            + list(base_model.opset_import),
+        )
+
+        return model
+
+
+# TODO: BCEWithLogitsLoss

--- a/orttraining/orttraining/python/training/onnxblock/loss/loss.py
+++ b/orttraining/orttraining/python/training/onnxblock/loss/loss.py
@@ -5,199 +5,153 @@
 import copy
 import onnx
 
-from ..graph import Graph
-from onnxruntime.training import onnxblock
+import onnxruntime.training.onnxblock as onnxblock
+import onnxruntime.training.onnxblock.model_accessor as accessor
+import onnxruntime.training.onnxblock._graph_utils as graph_utils
+import onnxruntime.training.onnxblock._building_blocks as building_blocks
 
 
-def _get_output_from_output_name(onnx_model, output_name):
-    """Returns the graph output given the output name"""
+class MSELoss(onnxblock.Model):
+    """MSELoss onnxblock for adding MSE loss to an onnx model.
 
-    # Iterate over the graph outputs looking for output_name
-    for output in onnx_model.graph.output:
-        if output.name == output_name:
-            return output
-
-    raise LookupError("The provided output name {output_name} is not a graph output.")
-
-
-class MSELoss(Graph):
-    """MSELoss onnxblock for adding MSE loss to an onnx model."""
+    Parameters:
+        reduction: string representing the reduction method on the loss output.
+                   can be one of "mean" or "sum"
+    """
 
     def __init__(self, reduction="mean"):
         super(MSELoss, self).__init__()
 
-        self._reduction = reduction
-
-    def build(self, base_model, output_name, target_name="target"):
-        """Adds an MSELoss subgraph on top of the base_model."""
-
-        # deepcopy the base model so we don't inadvertently change the original
-        # model
-        onnx_model = copy.deepcopy(base_model)
-
         # determine the reduction type
-        if self._reduction != "mean" and self._reduction != "sum":
-            raise RuntimeError(f"Reduction {self.reduction} not supported.")
+        if reduction != "mean" and reduction != "sum":
+            raise RuntimeError(f"Reduction {reduction} not supported.")
 
-        graph_nodes = onnx_model.graph.node
-        graph_inputs = onnx_model.graph.input
+        self._reduce = (
+            building_blocks.ReduceMean()
+            if reduction == "mean"
+            else building_blocks.ReduceSum()
+        )
+        self._sub = building_blocks.Sub()
+        self._square = building_blocks.Pow(2.0)
+
+    def build(self, loss_input_name, target_name="target"):
+        """Adds an MSELoss subgraph on top of the base_model.
+
+        Creates a block that measures the mean squared error between
+        loss_input_name and the target_name.
+
+        Args:
+            loss_input_name: string input representing the loss input
+            target_name: string input representing the target
+
+        Returns:
+            Returns a string of the output name from the loss
+        """
+
+        # get the model to manipulate
+        onnx_model = accessor.global_accessor.model
 
         # create a new graph input. this is the target input needed to compare
         # the graph output against to calculate loss.
         target_input = copy.deepcopy(
-            _get_output_from_output_name(onnx_model, output_name)
+            graph_utils.get_output_from_output_name(onnx_model, loss_input_name)
         )
         target_input.name = target_name
-        graph_inputs.append(target_input)
+        onnx_model.graph.input.append(target_input)
 
-        # create a new graph output for loss
-        graph_outputs = [
-            onnx.helper.make_tensor_value_info("loss", onnx.TensorProto.FLOAT, [1, 1])
-        ]
-
-        graph_initializers = onnx_model.graph.initializer
-
-        # loss equation
-        # loss = reduce((output-target)^2)
-
-        # create the sub node
-        sub_node_input_names = [output_name, target_name]
-        sub_node_output_names = ["loss_sub_output"]
-        sub_node = onnx.helper.make_node(
-            "Sub", sub_node_input_names, sub_node_output_names, name=f"MSELossSub"
-        )
-        graph_nodes.append(sub_node)
-
-        # create the square node
-        pow_node_input_names = sub_node_output_names
-        pow_node_input_names.append("0_pow_exponent")
-        pow_node_output_names = ["loss_pow_output"]
-        pow_node = onnx.helper.make_node(
-            "Pow", pow_node_input_names, pow_node_output_names, name=f"MSELossPow"
-        )
-        graph_nodes.append(pow_node)
-        graph_initializers.append(
-            onnx.helper.make_tensor(
-                "0_pow_exponent", onnx.TensorProto.FLOAT, [1], [2.0]
-            )
-        )
-
-        # create the reduce node
-        reduce_node_input_names = pow_node_output_names
-        reduce_node_output_names = ["loss"]
-        reduce_node = onnx.helper.make_node(
-            "ReduceMean" if self._reduction == "mean" else "ReduceSum",
-            reduce_node_input_names,
-            reduce_node_output_names,
-            name=f"MSELossReduce",
-        )
-        graph_nodes.append(reduce_node)
-
-        # generate the graph and model with above inputs, outputs, initializers
-        # and nodes
-        graph = onnx.helper.make_graph(
-            graph_nodes,
-            "GraphWithLoss",
-            graph_inputs,
-            graph_outputs,
-            graph_initializers,
-        )
-        model = onnx.helper.make_model(
-            graph,
-            producer_name=onnxblock._producer_name,
-            opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)]
-            + list(base_model.opset_import),
-        )
-
-        return model
+        # create the mse loss
+        # loss = reduce(square(sub(output, target)))
+        return self._reduce(self._square(self._sub(loss_input_name, target_name)))
 
 
-class CrossEntropyLoss(Graph):
-    """CrossEntropyLoss onnxblock for adding Cross Entropy loss to an onnx model."""
+class CrossEntropyLoss(onnxblock.Model):
+    """CrossEntropyLoss onnxblock for adding Cross Entropy loss to an onnx model.
+
+    Parameters:
+        weight: boolean representing whether a manual rescaling weight given to
+                each class should be added to the inputs.
+        reduction: string representing the reduction method on the loss output.
+                   can be one of "mean" or "sum"
+        ignore_index: specifies a target value that is ignored and does not
+                      contribute to the input gradient.
+    """
 
     def __init__(self, weight=False, reduction="mean", ignore_index=None):
         super(CrossEntropyLoss, self).__init__()
+
+        # determine the reduction type
+        if reduction != "mean" and reduction != "sum":
+            raise RuntimeError(f"Reduction {reduction} not supported.")
 
         self._weight = weight
         self._reduction = reduction
         self._ignore_index = ignore_index
 
-    def build(
-        self, base_model, output_name, target_name="target", weight_name="loss_weight"
-    ):
-        """Adds a CrossEntropyLoss subgraph on top of the base_model."""
+    def build(self, scores_input_name, labels_name="labels", weight_name="loss_weight"):
+        """Adds a CrossEntropyLoss subgraph on top of an onnx model.
 
-        # deepcopy the base model so we don't inadvertently change the
-        # original model
-        onnx_model = copy.deepcopy(base_model)
+        Creates a block that measures the softmax cross entropy between
+        scores_input_name and the labels_name.
 
-        # determine the reduction type
-        if self._reduction != "mean" and self._reduction != "sum":
-            raise RuntimeError(f"Reduction {self._reduction} not supported.")
+        Args:
+            loss_input_name: string input representing the loss input
+            labels_name: string input representing the labels
 
-        graph_nodes = onnx_model.graph.node
-        graph_inputs = onnx_model.graph.input
+        Returns:
+            Returns a string of the output name from the loss
+        """
 
-        # create a new graph input. this is the target input needed to compare
+        # get the model to manipulate
+        onnx_model = accessor.global_accessor.model
+
+        # create a new graph input. this is the labels input needed to compare
         # the graph output against to calculate loss.
-        target_input = copy.deepcopy(
-            _get_output_from_output_name(onnx_model, output_name)
+        labels_input = copy.deepcopy(
+            graph_utils.get_output_from_output_name(onnx_model, scores_input_name)
         )
-        target_input.name = target_name
-        target_input.type.tensor_type.elem_type = onnx.TensorProto.INT32
+        labels_input.name = labels_name
+        labels_input.type.tensor_type.elem_type = onnx.TensorProto.INT32
         # if the predictions are (num_examples x num_classes)
         # labels should be (num_examples x 1)
-        del target_input.type.tensor_type.shape.dim[1]
-        graph_inputs.append(target_input)
+        del labels_input.type.tensor_type.shape.dim[1]
+        onnx_model.graph.input.append(labels_input)
 
         if self._weight:
             weight_input = copy.deepcopy(
-                _get_output_from_output_name(onnx_model, output_name)
+                graph_utils.get_output_from_output_name(onnx_model, scores_input_name)
             )
             weight_input.name = weight_name
             dim_to_keep = weight_input.type.tensor_type.shape.dim[1]
             del weight_input.type.tensor_type.shape.dim[:]
             weight_input.type.tensor_type.shape.dim.append(dim_to_keep)
-            graph_inputs.append(weight_input)
+            onnx_model.graph.input.append(weight_input)
 
-        # create a new graph output for loss
-        graph_outputs = [
-            onnx.helper.make_tensor_value_info("loss", onnx.TensorProto.FLOAT, [])
-        ]
-        graph_initializers = onnx_model.graph.initializer
-
-        # create the loss node
-        loss_node_input_name = [output_name, target_name]
+        # create a new graph node for the loss
+        loss_node_input_names = [scores_input_name, labels_name]
         if self._weight:
-            loss_node_input_name.append(weight_name)
-        loss_node_output_name = ["loss", "log_prob"]
+            loss_node_input_names.append(weight_name)
+        loss_node_output_name = graph_utils.generate_random_graph_name("loss")
+        loss_node_output_names = [
+            loss_node_output_name,
+            graph_utils.generate_random_graph_name("log_prob"),
+        ]
         loss_node = onnx.helper.make_node(
             "SoftmaxCrossEntropyLoss",
-            loss_node_input_name,
-            loss_node_output_name,
+            loss_node_input_names,
+            loss_node_output_names,
             reduction=self._reduction,
             ignore_index=self._ignore_index,
-            name=f"SoftmaxCrossEntropyLoss",
+            name=graph_utils.generate_random_graph_name("SoftmaxCrossEntropyLoss"),
         )
-        graph_nodes.append(loss_node)
+        onnx_model.graph.node.append(loss_node)
 
-        # generate the graph and model with above inputs, outputs,
-        # initializers and nodes
-        graph = onnx.helper.make_graph(
-            graph_nodes,
-            "GraphWithLoss",
-            graph_inputs,
-            graph_outputs,
-            graph_initializers,
-        )
-        model = onnx.helper.make_model(
-            graph,
-            producer_name=onnxblock._producer_name,
-            opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)]
-            + list(base_model.opset_import),
-        )
+        # create a new graph output for the loss
+        graph_outputs = [
+            onnx.helper.make_tensor_value_info(
+                loss_node_output_name, onnx.TensorProto.FLOAT, []
+            )
+        ]
+        del onnx_model.graph.output[:]
+        onnx_model.graph.output.extend(graph_outputs)
 
-        return model
-
-
-# TODO: BCEWithLogitsLoss
+        return loss_node_output_name

--- a/orttraining/orttraining/python/training/onnxblock/model_accessor.py
+++ b/orttraining/orttraining/python/training/onnxblock/model_accessor.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# global_model.py
+
+from contextlib import contextmanager
+
+
+class ModelAccessor:
+    """This class stores the onnx model that is manipulated by the onnx blocks."""
+
+    def __init__(self, model):
+        self.model = model
+        self.eval_model = None
+
+
+# This variable resides in the global namespace.
+# Different methods can access this global model and manipulate it.
+# Its construction and destruction is managed by the onnx_model contextmanager
+global_accessor = None
+
+
+@contextmanager
+def onnx_model(model):
+    """Context manager that is the entry point to graph manipulations on model.
+
+    Manages the construction and destruction of the global model.
+    """
+    global global_accessor
+    global_accessor = ModelAccessor(model)
+    try:
+        yield global_accessor
+    finally:
+        global_accessor = None

--- a/orttraining/orttraining/python/training/onnxblock/model_accessor.py
+++ b/orttraining/orttraining/python/training/onnxblock/model_accessor.py
@@ -20,7 +20,7 @@ global_accessor = None
 
 
 @contextmanager
-def onnx_model(model):
+def onnx_model(model=None):
     """Context manager that is the entry point to graph manipulations on model.
 
     Manages the construction and destruction of the global model.

--- a/orttraining/orttraining/python/training/onnxblock/optim/__init__.py
+++ b/orttraining/orttraining/python/training/onnxblock/optim/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py
+
+from .optim import AdamW

--- a/orttraining/orttraining/python/training/onnxblock/optim/optim.py
+++ b/orttraining/orttraining/python/training/onnxblock/optim/optim.py
@@ -1,0 +1,148 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# optim.py
+
+import copy
+import onnx
+
+from ..graph import Graph
+from onnxruntime.training import onnxblock
+
+
+class AdamW(Graph):
+    """Builds AdamW optimizer onnxblock for the given training model."""
+
+    def __init__(
+        self, bias_correction=True, betas=(0.9, 0.999), eps=1e-6, weight_decay=0.0
+    ):
+        super(AdamW, self).__init__()
+        self.bias_correction = bias_correction
+        self.betas = betas
+        self.eps = eps
+        self.weight_decay = weight_decay
+        self.max_norm_clip = 1.0
+
+    def build(self, base_model):
+        """Returns an AdamW optimizer model based on the input training model."""
+
+        learning_rate_name = "learning_rate"
+        step_name = "step"
+        gradient_output_suffix = "_grad.accumulation.out"
+        first_order_moment_suffix = "exp_avg"
+        second_order_moment_fuffix = "exp_avg_sq"
+        output_name_suffix = "out"
+
+        graph_nodes = []
+        graph_inputs = [
+            onnx.helper.make_tensor_value_info(
+                learning_rate_name, onnx.TensorProto.FLOAT, [1]
+            ),
+            onnx.helper.make_tensor_value_info(step_name, onnx.TensorProto.INT64, [1]),
+        ]
+        graph_outputs = []
+
+        # Iterate over all training graph outputs that are gradient outputs
+        for idx, graph_output in enumerate(base_model.graph.output):
+            if not graph_output.name.endswith(gradient_output_suffix):
+                continue
+
+            weight_name = graph_output.name[: -len(gradient_output_suffix)]
+            grad_name = graph_output.name
+            first_order_moment_name = f"{weight_name}.{first_order_moment_suffix}"
+            second_order_moment_name = f"{weight_name}.{second_order_moment_fuffix}"
+            # prepare node (and graph) inputs and outputs
+            node_input_names = [
+                learning_rate_name,  # learning rate
+                step_name,  # training step (used for beta correction)
+                weight_name,  # weight to be updated
+                grad_name,  # gradient of the weight to be used for update
+                first_order_moment_name,  # first order moment for this weight
+                second_order_moment_name,  # second order moment for this weight
+            ]
+
+            weight_tensor_value_info = copy.deepcopy(graph_output)
+            weight_tensor_value_info.name = weight_name
+            first_order_moment_tensor_value_info = copy.deepcopy(graph_output)
+            first_order_moment_tensor_value_info.name = first_order_moment_name
+            second_order_moment_tensor_value_info = copy.deepcopy(graph_output)
+            second_order_moment_tensor_value_info.name = second_order_moment_name
+            node_inputs = [
+                weight_tensor_value_info,
+                copy.deepcopy(graph_output),
+                first_order_moment_tensor_value_info,
+                second_order_moment_tensor_value_info,
+            ]
+            graph_inputs.extend(node_inputs)
+
+            step_output_name = f"{weight_name}.{step_name}.{output_name_suffix}"
+            first_order_moment_output_name = (
+                f"{first_order_moment_name}.{output_name_suffix}"
+            )
+            second_order_moment_output_name = (
+                f"{second_order_moment_name}.{output_name_suffix}"
+            )
+            weight_output_name = f"{weight_name}.{output_name_suffix}"
+
+            first_order_moment_output_tensor_value_info = copy.deepcopy(graph_output)
+            first_order_moment_output_tensor_value_info.name = (
+                first_order_moment_output_name
+            )
+            second_order_moment_output_tensor_value_info = copy.deepcopy(graph_output)
+            second_order_moment_output_tensor_value_info.name = (
+                second_order_moment_output_name
+            )
+            weight_output_tensor_value_info = copy.deepcopy(graph_output)
+            weight_output_tensor_value_info.name = weight_output_name
+
+            node_output_names = [
+                step_output_name,  # step out
+                first_order_moment_output_name,  # first order moment output
+                second_order_moment_output_name,  # second order moment output
+                weight_output_name,  # updated weights
+            ]
+
+            node_outputs = [
+                onnx.helper.make_tensor_value_info(
+                    step_output_name, onnx.TensorProto.INT64, [1]
+                ),
+                first_order_moment_output_tensor_value_info,
+                second_order_moment_output_tensor_value_info,
+                weight_output_tensor_value_info,
+            ]
+            graph_outputs.extend(node_outputs)
+
+            # AdamOptimizer node attributes
+            node_attributes = {
+                "alpha": self.betas[0],  # beta1
+                "beta": self.betas[1],  # beta2
+                "lambda": self.weight_decay,  # weight decay
+                "epsilon": self.eps,  # epsilon
+                "do_bias_correction": 1
+                if self.bias_correction
+                else 0,  # bias_correction
+                "weight_decay_mode": 1,  # weight decay mode
+                "max_norm_clip": self.max_norm_clip,  # used for gradient scaling
+            }
+
+            # make the node
+            optimizer_node = onnx.helper.make_node(
+                "AdamOptimizer",
+                node_input_names,
+                node_output_names,
+                name=f"AdamOptimizer{idx}",
+                domain="com.microsoft",
+                **node_attributes,
+            )
+
+            graph_nodes.append(optimizer_node)
+
+        # make the graph and the model
+        graph = onnx.helper.make_graph(
+            graph_nodes, "Optimizer Graph", graph_inputs, graph_outputs
+        )
+        model = onnx.helper.make_model(
+            graph,
+            producer_name=onnxblock._producer_name,
+            opset_imports=[onnx.helper.make_opsetid("com.microsoft", 1)],
+        )
+        return model

--- a/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
+++ b/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
@@ -355,7 +355,7 @@ def test_adamw_optimizer_composition(graph):
         _ = simple_model(onnx_model.graph.output[0].name)
 
     optimizer = onnxblock.optim.AdamW()
-    with onnxblock.onnx_model(None) as accessor:
+    with onnxblock.onnx_model() as accessor:
         _ = optimizer(simple_model.parameters())
         optimizer_model = accessor.model
         assert optimizer_model
@@ -375,7 +375,7 @@ def test_adamw_optimizer_execution():
         _ = simple_model(onnx_model.graph.output[0].name)
 
     optimizer = onnxblock.optim.AdamW()
-    with onnxblock.onnx_model(None) as accessor:
+    with onnxblock.onnx_model() as accessor:
         _ = optimizer(simple_model.parameters())
         optimizer_model = accessor.model
 

--- a/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
+++ b/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
@@ -1,0 +1,517 @@
+import torch
+import io
+import onnx
+import onnxruntime.training.onnxblock as onnxblock
+import onnxruntime
+from onnxruntime.capi import _pybind_state as C
+import pytest
+import tempfile
+import os
+import copy
+import numpy as np
+
+
+# PyTorch Module definitions
+
+
+class SimpleNet(torch.nn.Module):
+    def __init__(self, input_size, hidden_size, num_classes):
+        super(SimpleNet, self).__init__()
+
+        self.fc1 = torch.nn.Linear(input_size, hidden_size)
+        self.relu = torch.nn.ReLU()
+        self.fc2 = torch.nn.Linear(hidden_size, num_classes)
+
+    def forward(self, model_input):
+        out = self.fc1(model_input)
+        out = self.relu(out)
+        out = self.fc2(out)
+        return out
+
+
+# onnxblock Graph definitions
+
+
+class SimpleGraphWithMSELoss(onnxblock.Graph):
+    def __init__(self, base_model):
+        super(SimpleGraphWithMSELoss, self).__init__()
+        self.loss = onnxblock.loss.MSELoss()
+        self.base_model = base_model
+
+    def build(self):
+        outputs = self.base_model.graph.output
+        lossful_graph = self.loss(self.base_model, outputs[0].name)
+        return lossful_graph
+
+
+class SimpleGraphWithCrossEntropyLoss(onnxblock.Graph):
+    def __init__(self, base_model):
+        super(SimpleGraphWithCrossEntropyLoss, self).__init__()
+        self.loss = onnxblock.loss.CrossEntropyLoss()
+        self.base_model = base_model
+
+    def build(self):
+        outputs = self.base_model.graph.output
+        lossful_graph = self.loss(self.base_model, outputs[0].name)
+        return lossful_graph
+
+
+class SimpleTrainingGraphWithMSELoss(onnxblock.TrainingGraph):
+    def __init__(self, base_model):
+        super(SimpleTrainingGraphWithMSELoss, self).__init__()
+        self.loss = onnxblock.loss.MSELoss()
+        self.base_model = base_model
+
+    def build(self):
+        outputs = self.base_model.graph.output
+        lossful_graph = self.loss(self.base_model, outputs[0].name)
+        return lossful_graph
+
+
+class SimpleTrainingGraphWithCrossEntropyLoss(onnxblock.TrainingGraph):
+    def __init__(self, base_model):
+        super(SimpleTrainingGraphWithCrossEntropyLoss, self).__init__()
+        self.loss = onnxblock.loss.CrossEntropyLoss()
+        self.base_model = base_model
+
+    def build(self):
+        outputs = self.base_model.graph.output
+        lossful_graph = self.loss(self.base_model, outputs[0].name)
+        return lossful_graph
+
+
+# Test utility methods
+
+
+def _get_onnx_model(torch_model, model_inputs):
+    model_outputs = torch_model(*model_inputs)
+    if isinstance(model_outputs, torch.Tensor):
+        model_outputs = [model_outputs]
+    dynamic_axes = {}
+    input_names = []
+    output_names = []
+    for i, model_input in enumerate(model_inputs):
+        input_name = f"input-{i}"
+        input_names.append(input_name)
+        dynamic_axes[input_name] = {}
+        for dim_idx in range(len(model_input.shape)):
+            dynamic_axes[input_name].update({dim_idx: f"{input_name}_dim{dim_idx}"})
+
+    for i, model_output in enumerate(model_outputs):
+        output_name = f"output-{i}"
+        output_names.append(output_name)
+        dynamic_axes[output_name] = {}
+        for dim_idx in range(len(model_output.shape)):
+            dynamic_axes[output_name].update({dim_idx: f"{output_name}_dim{dim_idx}"})
+
+    f = io.BytesIO()
+    torch.onnx.export(
+        torch_model,
+        model_inputs,
+        f,
+        input_names=input_names,
+        output_names=output_names,
+        opset_version=14,
+        do_constant_folding=False,
+        training=torch.onnx.TrainingMode.TRAINING,
+        dynamic_axes=dynamic_axes,
+        export_params=True,
+        keep_initializers_as_inputs=False,
+    )
+    return onnx.load_model_from_string(f.getvalue())
+
+
+def _to_numpy(tensor):
+    return (
+        tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+    )
+
+
+# All unit tests
+
+
+@pytest.mark.parametrize(
+    "graph",
+    [
+        SimpleGraphWithMSELoss,
+        SimpleGraphWithCrossEntropyLoss,
+        SimpleTrainingGraphWithMSELoss,
+        SimpleTrainingGraphWithCrossEntropyLoss,
+    ],
+)
+def test_loss_composition(graph):
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    # When / Then no error occurs
+    simple_graph = graph(onnx_model)
+    lossful_graph = simple_graph()
+
+
+def test_mse_loss_execution():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    target = torch.randn(N, D_out, device=device)
+    onnx_model = _get_onnx_model(model, (copy.deepcopy(x),))
+    simple_graph = SimpleGraphWithMSELoss(onnx_model)
+    lossful_model = simple_graph()
+    model_name = "model_with_mse_loss.onnx"
+    ort_output_names = [lossful_model.graph.output[0].name]
+    ort_inputs = {
+        lossful_model.graph.input[0].name: _to_numpy(copy.deepcopy(x)),
+        lossful_model.graph.input[1].name: _to_numpy(copy.deepcopy(target)),
+    }
+
+    def mse_loss(prediction, target):
+        loss = torch.nn.MSELoss()
+        return loss(prediction, target)
+
+    # When
+    with tempfile.TemporaryDirectory() as onnx_dir_name:
+        onnx_file_path = os.path.join(onnx_dir_name, model_name)
+        onnx.save(lossful_model, onnx_file_path)
+        ort_session = onnxruntime.InferenceSession(
+            onnx_file_path, providers=C.get_available_providers()
+        )
+
+        ort_outs = ort_session.run(ort_output_names, ort_inputs)
+        torch_outs = mse_loss(model(copy.deepcopy(x)), copy.deepcopy(target))
+
+        # Then
+        assert np.allclose(ort_outs[0], _to_numpy(torch_outs))
+
+
+def test_crossentropy_loss_execution():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    target = torch.randint(high=D_out, size=(N,), dtype=torch.int64, device=device)
+    onnx_model = _get_onnx_model(model, (copy.deepcopy(x),))
+    simple_graph = SimpleGraphWithCrossEntropyLoss(onnx_model)
+    lossful_model = simple_graph()
+    model_name = "model_with_crossentropy_loss.onnx"
+    ort_output_names = [lossful_model.graph.output[0].name]
+    ort_inputs = {
+        lossful_model.graph.input[0].name: _to_numpy(copy.deepcopy(x)),
+        lossful_model.graph.input[1].name: _to_numpy(
+            copy.deepcopy(target).type(torch.int32)
+        ),
+    }
+
+    def crossentropy_loss(prediction, target):
+        loss = torch.nn.CrossEntropyLoss()
+        return loss(prediction, target)
+
+    # When
+    with tempfile.TemporaryDirectory() as onnx_dir_name:
+        onnx_file_path = os.path.join(onnx_dir_name, model_name)
+        onnx.save(lossful_model, onnx_file_path)
+        ort_session = onnxruntime.InferenceSession(
+            onnx_file_path, providers=C.get_available_providers()
+        )
+
+        ort_outs = ort_session.run(ort_output_names, ort_inputs)
+        torch_outs = crossentropy_loss(model(copy.deepcopy(x)), copy.deepcopy(target))
+
+        # Then
+        assert np.allclose(ort_outs[0], _to_numpy(torch_outs))
+
+
+def test_mse_loss_training_graph_execution():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    target = torch.randn(N, D_out, device=device)
+    onnx_model = _get_onnx_model(model, (copy.deepcopy(x),))
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+    lossful_model = simple_graph()
+    model_name = "model_with_mse_loss.onnx"
+    ort_output_names = [lossful_model.graph.output[0].name]
+    for name, _ in model.named_parameters():
+        ort_output_names.append(f"{name}_grad.accumulation.out")
+    ort_inputs = {
+        lossful_model.graph.input[0].name: _to_numpy(copy.deepcopy(x)),
+        lossful_model.graph.input[1].name: _to_numpy(copy.deepcopy(target)),
+    }
+    for name, param in model.named_parameters():
+        ort_inputs[name] = _to_numpy(copy.deepcopy(param))
+        ort_inputs[f"{name}_grad.accumulation.buffer"] = _to_numpy(
+            torch.zeros_like(param)
+        )
+    ort_inputs["lazy_reset_grad"] = np.full(1, True)
+
+    def mse_loss(prediction, target):
+        loss = torch.nn.MSELoss()
+        return loss(prediction, target)
+
+    # When
+    with tempfile.TemporaryDirectory() as onnx_dir_name:
+        onnx_file_path = os.path.join(onnx_dir_name, model_name)
+        onnx.save(lossful_model, onnx_file_path)
+        ort_session = onnxruntime.InferenceSession(
+            onnx_file_path, providers=C.get_available_providers()
+        )
+
+        ort_outs = ort_session.run(ort_output_names, ort_inputs)
+        torch_outs = mse_loss(model(copy.deepcopy(x)), copy.deepcopy(target))
+        torch_outs.backward()
+
+        # Then
+        # assert loss is close
+        assert np.allclose(ort_outs[0], _to_numpy(torch_outs))
+
+        # assert all the gradients are close
+        for ort_grad, pt_param in zip(ort_outs[1:], model.parameters()):
+            assert np.allclose(ort_grad, _to_numpy(pt_param.grad))
+
+
+def test_crossentropy_loss_training_graph_execution():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    target = torch.randint(high=D_out, size=(N,), dtype=torch.int64, device=device)
+    onnx_model = _get_onnx_model(model, (copy.deepcopy(x),))
+    simple_graph = SimpleTrainingGraphWithCrossEntropyLoss(onnx_model)
+    lossful_model = simple_graph()
+    model_name = "model_with_crossentropy_loss.onnx"
+    ort_output_names = [lossful_model.graph.output[0].name]
+    for name, _ in model.named_parameters():
+        ort_output_names.append(f"{name}_grad.accumulation.out")
+    ort_inputs = {
+        lossful_model.graph.input[0].name: _to_numpy(copy.deepcopy(x)),
+        lossful_model.graph.input[1].name: _to_numpy(
+            copy.deepcopy(target).type(torch.int32)
+        ),
+    }
+    for name, param in model.named_parameters():
+        ort_inputs[name] = _to_numpy(copy.deepcopy(param))
+        ort_inputs[f"{name}_grad.accumulation.buffer"] = _to_numpy(
+            torch.zeros_like(param)
+        )
+    ort_inputs["lazy_reset_grad"] = np.full(1, True)
+
+    def crossentropy_loss(prediction, target):
+        loss = torch.nn.CrossEntropyLoss()
+        return loss(prediction, target)
+
+    # When
+    with tempfile.TemporaryDirectory() as onnx_dir_name:
+        onnx_file_path = os.path.join(onnx_dir_name, model_name)
+        onnx.save(lossful_model, onnx_file_path)
+        ort_session = onnxruntime.InferenceSession(
+            onnx_file_path, providers=C.get_available_providers()
+        )
+
+        ort_outs = ort_session.run(ort_output_names, ort_inputs)
+        torch_outs = crossentropy_loss(model(copy.deepcopy(x)), copy.deepcopy(target))
+        torch_outs.backward()
+
+        # Then
+        # assert loss is close
+        assert np.allclose(ort_outs[0], _to_numpy(torch_outs))
+
+        # assert all the gradients are close
+        for ort_grad, pt_param in zip(ort_outs[1:], model.parameters()):
+            assert np.allclose(ort_grad, _to_numpy(pt_param.grad))
+
+
+@pytest.mark.parametrize(
+    "graph", [SimpleTrainingGraphWithMSELoss, SimpleTrainingGraphWithCrossEntropyLoss]
+)
+def test_adamw_optimizer_composition(graph):
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    # When / Then no error occurs
+    simple_graph = graph(onnx_model)
+    lossful_graph = simple_graph()
+    optimizer = onnxblock.optim.AdamW()
+    optimizer_model = optimizer(lossful_graph)
+
+
+def test_adamw_optimizer_execution():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    target = torch.randn(N, D_out, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+    lossful_graph = simple_graph()
+    optimizer = onnxblock.optim.AdamW()
+    optimizer_model = optimizer(lossful_graph)
+    model_name = "optimizer_model.onnx"
+    learning_rate = 0.001
+    step = 1
+    ort_output_names = []
+    for name, _ in model.named_parameters():
+        ort_output_names.append(f"{name}.out")
+
+    def mse_loss(prediction, target):
+        loss = torch.nn.MSELoss()
+        return loss(prediction, target)
+
+    # When
+    with tempfile.TemporaryDirectory() as onnx_dir_name:
+        onnx_file_path = os.path.join(onnx_dir_name, model_name)
+        onnx.save(optimizer_model, onnx_file_path)
+
+        loss = mse_loss(model(copy.deepcopy(x)), copy.deepcopy(target))
+        loss.backward()
+
+        ort_inputs = {
+            "learning_rate": np.full(1, learning_rate, dtype=np.float32),
+            "step": np.full(1, step, dtype=np.int64),
+        }
+        for name, param in model.named_parameters():
+            ort_inputs[name] = _to_numpy(copy.deepcopy(param))
+            ort_inputs[f"{name}_grad.accumulation.out"] = _to_numpy(
+                copy.deepcopy(param.grad)
+            )
+            ort_inputs[f"{name}.exp_avg"] = _to_numpy(torch.zeros_like(param))
+            ort_inputs[f"{name}.exp_avg_sq"] = _to_numpy(torch.zeros_like(param))
+
+        # Then no error occurs when executing the model
+        ort_session = onnxruntime.InferenceSession(
+            onnx_file_path, providers=C.get_available_providers()
+        )
+        ort_outs = ort_session.run(ort_output_names, ort_inputs)
+
+
+def test_retrieve_parameters():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+    training_model = simple_graph()
+
+    # When
+    trainable_params, non_trainable_params = simple_graph.parameters()
+
+    # Then
+    assert not non_trainable_params
+    for ort_param, (pt_param_name, pt_param) in zip(
+        trainable_params, model.named_parameters()
+    ):
+        assert ort_param.name == pt_param_name
+        assert np.allclose(
+            np.frombuffer(ort_param.raw_data, dtype=np.float32).reshape(pt_param.shape),
+            _to_numpy(pt_param),
+        )
+
+
+def test_retrieve_parameters_before_building_gradient_graph():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+
+    # When / Then
+    with pytest.raises(Exception) as ex_info:
+        trainable_params, non_trainable_params = simple_graph.parameters()
+    assert (
+        "Please build the training graph first before trying to retrieve the parameters."
+        in str(ex_info.value)
+    )
+
+
+def test_save_checkpoint():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+    training_model = simple_graph()
+    trainable_params, non_trainable_params = simple_graph.parameters()
+
+    # When
+    with tempfile.TemporaryDirectory() as checkpoint_dir_name:
+        checkpoint_file_path = os.path.join(checkpoint_dir_name, "checkpoint")
+        onnxblock.save_checkpoint(
+            (trainable_params, non_trainable_params), checkpoint_file_path
+        )
+
+        # Then
+        assert os.path.exists(checkpoint_file_path)
+
+
+def test_set_requires_grad_on_parameters():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+
+    # When
+    simple_graph.requires_grad("fc2.weight", False)
+    simple_graph.requires_grad("fc1.bias", False)
+    training_model = simple_graph()
+    trainable_params, non_trainable_params = simple_graph.parameters()
+
+    # Then
+    expected_trainable_parameters = {"fc1.weight", "fc2.bias"}
+    expected_non_trainable_parameters = {"fc2.weight", "fc1.bias"}
+    for param in trainable_params:
+        assert param.name in expected_trainable_parameters
+    for param in non_trainable_params:
+        assert param.name in expected_non_trainable_parameters
+
+
+def test_set_requires_grad_on_inputs():
+    # Given
+    device = "cuda"
+    N, D_in, H, D_out = 64, 784, 500, 10
+    model = SimpleNet(D_in, H, D_out).to(device)
+    x = torch.randn(N, D_in, device=device)
+    onnx_model = _get_onnx_model(model, (x,))
+
+    simple_graph = SimpleTrainingGraphWithMSELoss(onnx_model)
+
+    # When
+    simple_graph.requires_grad("input-0")
+    training_model = simple_graph()
+    trainable_params, non_trainable_params = simple_graph.parameters()
+
+    # Then
+    expected_input_gradient_buffer_name = "input-0_grad.accumulation.buffer"
+    expected_input_gradient_output_name = "input-0_grad.accumulation.out"
+    graph_input_names = {graph_input.name for graph_input in training_model.graph.input}
+    graph_output_names = {
+        graph_output.name for graph_output in training_model.graph.output
+    }
+
+    assert expected_input_gradient_buffer_name in graph_input_names
+    assert expected_input_gradient_output_name in graph_output_names

--- a/setup.py
+++ b/setup.py
@@ -329,6 +329,7 @@ requirements_file = "requirements.txt"
 
 local_version = None
 enable_training = parse_arg_remove_boolean(sys.argv, '--enable_training')
+enable_training_on_device = parse_arg_remove_boolean(sys.argv, '--enable_training_on_device')
 disable_auditwheel_repair = parse_arg_remove_boolean(sys.argv, '--disable_auditwheel_repair')
 default_training_package_device = parse_arg_remove_boolean(sys.argv, '--default_training_package_device')
 
@@ -374,6 +375,8 @@ if enable_training:
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.torch_gpu_allocator',
                      'onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.fused_ops',
                      'onnxruntime.training.utils.data'])
+    if enable_training_on_device:
+        packages.append('onnxruntime.training.onnxblock')
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.aten_op_executor'] = ['*.cc']
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.torch_interop_utils'] = ['*.cc']
     package_data['onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.torch_gpu_allocator'] = ['*.cc']

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -177,6 +177,8 @@ def parse_arguments():
     parser.add_argument(
         "--enable_training_torch_interop", action='store_true', help="Enable training kernels interop with torch.")
     parser.add_argument(
+        "--enable_training_on_device", action='store_true', help="Enable on device training in ORT.")
+    parser.add_argument(
         "--disable_nccl", action='store_true', help="Disable Nccl.")
     parser.add_argument(
         "--mpi_home", help="Path to MPI installation dir")
@@ -836,6 +838,7 @@ def generate_build_tree(cmake_path, source_dir, build_dir, cuda_home, cudnn_home
         "-Donnxruntime_ENABLE_TRAINING=" + ("ON" if args.enable_training else "OFF"),
         "-Donnxruntime_ENABLE_TRAINING_OPS=" + ("ON" if args.enable_training_ops else "OFF"),
         "-Donnxruntime_ENABLE_TRAINING_TORCH_INTEROP=" + ("ON" if args.enable_training_torch_interop else "OFF"),
+        "-Donnxruntime_ENABLE_TRAINING_ON_DEVICE=" + ("ON" if args.enable_training_on_device else "OFF"),
         # Enable advanced computations such as AVX for some traininig related ops.
         "-Donnxruntime_ENABLE_CPU_FP16_OPS=" + ("ON" if args.enable_training else "OFF"),
         "-Donnxruntime_USE_NCCL=" + ("OFF" if args.disable_nccl else "ON"),
@@ -1801,7 +1804,7 @@ def build_python_wheel(
         source_dir, build_dir, configs, use_cuda, cuda_version, use_rocm, rocm_version, use_dnnl,
         use_tensorrt, use_openvino, use_nuphar, use_tvm, use_vitisai, use_acl, use_armnn, use_dml,
         wheel_name_suffix, enable_training, nightly_build=False, default_training_package_device=False,
-        use_ninja=False, build_eager_mode=False):
+        use_ninja=False, build_eager_mode=False, enable_training_on_device=False):
     for config in configs:
         cwd = get_config_build_dir(build_dir, config)
         if is_windows() and not use_ninja:
@@ -1819,6 +1822,8 @@ def build_python_wheel(
             args.append('--wheel_name_suffix={}'.format(wheel_name_suffix))
         if enable_training:
             args.append("--enable_training")
+        if enable_training_on_device:
+            args.append("--enable_training_on_device")
         if build_eager_mode:
             args.append("--disable_auditwheel_repair")
 
@@ -2451,7 +2456,8 @@ def main():
                 nightly_build=nightly_build,
                 default_training_package_device=default_training_package_device,
                 use_ninja=(args.cmake_generator == 'Ninja'),
-                build_eager_mode=args.build_eager_mode
+                build_eager_mode=args.build_eager_mode,
+                enable_training_on_device=args.enable_training_on_device
             )
         if args.build_nuget:
             build_nuget_package(


### PR DESCRIPTION
This pull request introduces the offline tooling capabilities for on device training for `onnxruntime-training` . With these set of tools, users can stack onnx layers (called `onnxblock`'s in this PR) on top of each other with relative ease. The purpose for this kind of tooling is to allow users to prepare a training onnx model given an inference only model with ease.

For example, user's can start with an inference only model, add a loss on top of it, and build the gradient graph on top of that with a few lines of code. Given this training model, users can also build an optimizer graph for training.

Here is an example usage for the above description:
```py
# Imports
import onnxruntime.training.onnxblock as onnxblock

# Define how to stack onnxblocks together
class SimpleGraph(onnxblock.TrainingGraph):
    def __init__(self):
        super(SimpleGraph, self).__init__()
        self.loss = onnxblock.loss.MSELoss()

    def build(self):
        base_graph_output_name = self.base_model.graph.output[0].name
        return self.loss(base_graph_output_name)

# Build the training model
graph_builder = SimpleGraph()
with onnxblock.onnx_model(inference_onnx_model) as accessor:
    model_outputs = graph_builder()

    # inference_onnx_model has not been manipulated inplace to be a training model
    eval_model = accessor.eval_model


# Build optimizer model
optimizer_builder = onnxblock.optim.AdamW()
with onnxblock.onnx_model() as accessor:
    optimizer_outputs = optimizer_builder()
    optimizer_model = accessor.model
```

The onnx building blocks provided in this pull request:
- Loss
  - MSELoss
  - CrossEntropyLoss
- Optimizer
  - AdamW


The pull request also adds unit tests that test the usability of this offline tooling.