### PR TITLE
Add link to release plan

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,70 +12,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="import" href="docs/redirect.json">
     <link rel="stylesheet" href="css/custom.css">
     <link rel="stylesheet" href="css/responsive.css">
     <link rel="icon" href="./images/ONNXRuntime-Favicon.png" type="image/gif" sizes="16x16">
 
-    <!--Redirect for moved links-->
-
-    <!--[if lt IE 9]><script type="text/javascript">var IE_fix=true;</script><![endif]-->
-    <script type="text/javascript">
-        
-        window.onload = function ()
-        {
-            var delay = "0";
-            setTimeout(GoToURL, delay);
-        }
-        function GoToURL()
-        {
-            if(typeof IE_fix != "undefined") // IE8 and lower fix to pass the http referer
-            {
-                var url = "/docs";
-                var referLink = document.createElement("a");
-                referLink.href = url;
-                document.body.appendChild(referLink);
-                referLink.click();
-            }
-            else { 
-
-                var redirectRulesUrl = window.location.origin;
-                var isTest =  window.location.origin.includes("github.io");
-
-                if(isTest){
-                    redirectRulesUrl = redirectRulesUrl + "/onnxruntime/docs/redirect.json";
-                }
-                else{
-                    redirectRulesUrl = redirectRulesUrl + "/docs/redirect.json"
-                }
-                
-
-                $.getJSON(redirectRulesUrl, (json) => {
-
-                    var redirectRules = json.redirectRules;
-                    var pathname = window.location.pathname;
-                    
-                    for(let i = 0; i < redirectRules.length; i++){
-
-                        if(pathname.includes(redirectRules[i].pathname)){
-                            if(!isTest){
-                                window.location.replace(redirectRules[i].redirect);
-                                break;
-                             }
-                             else{
-                                 window.location.replace(redirectRules[i].testRedirect);
-                                 break;
-                             }
-                        }
-                    }
-                });
-
-             }
-        }
-    </script>
-
-
-    <title>ONNX Runtime | Oops</title>
+    <title>ONNX Runtime | 404 - Page Not Found</title>
     <link rel="icon" href="/images/ONNXRuntime-Favicon.png" type="image/gif" sizes="16x16">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i&display=swap">

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,10 @@
 ---
 title: API Docs
 nav_order: 5
+redirect_from: /docs/reference/api
 ---
-# ORT API docs
+
+# ONNX Runtime API docs
 {: .no_toc }
 
 |:----------------------------------------------------------------------------------|

--- a/docs/execution-providers/index.md
+++ b/docs/execution-providers/index.md
@@ -2,6 +2,7 @@
 title: Execution Providers
 has_children: true
 nav_order: 10
+redirect_from: /docs/reference/execution-provider
 ---
 
 # ONNX Runtime Execution Providers

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,11 @@
 ---
-title: ONNX Runtime (ORT)
+title: ONNX Runtime
+description: ONNX Runtime is a cross-platform machine-learning model accelerator
 has_children: false
 nav_order: 0
+redirect_from: /how-to
 ---
+
 # Welcome to ONNX Runtime
 {: .no_toc }
 

--- a/docs/reference/build-web-app.md
+++ b/docs/reference/build-web-app.md
@@ -3,7 +3,7 @@ title: Build a web app with ONNX Runtime
 description: Considerations and options for building a web application with ONNX Runtime
 parent: Reference
 has_children: false
-nav_order: 5
+nav_order: 6
 ---
 
 # Build a web application with ONNX Runtime

--- a/docs/reference/citing.md
+++ b/docs/reference/citing.md
@@ -1,7 +1,7 @@
 ---
 title: Citing ONNX Runtime
 parent: Reference
-nav_order: 8
+nav_exclude: true
 ---
 
 # Citing ONNX Runtime

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -2,7 +2,7 @@
 title: Compatibility
 parent: Reference
 toc: true
-nav_order: 1
+nav_order: 2
 ---
 
 # ONNX Runtime compatibility

--- a/docs/reference/high-level-design.md
+++ b/docs/reference/high-level-design.md
@@ -1,10 +1,10 @@
 ---
-title: Technical design
+title: Architecture
 parent: Reference
-nav_order: 6
+nav_order: 5
 ---
 
-# ONNX Runtime High Level Design
+# ONNX Runtime Architecture
 {: .no_toc }
 
 This document outlines the high level design of ONNX Runtime.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,7 @@
 title: Reference
 has_children: true
 nav_order: 7
+redirect_from: /docs/resources
 ---
 
 # ONNX Runtime Reference

--- a/docs/reference/mobile/index.md
+++ b/docs/reference/mobile/index.md
@@ -2,6 +2,7 @@
 title: Mobile
 parent: Reference
 has_children: true
+nav_order: 5
 # manual TOC as we don't want some low level things to appear in it, but they need to be children of this page
 # for the navigation to work as desired. e.g. doco on scripts mentioned in Model Export Helpers
 has_toc: false  

--- a/docs/reference/operators/index.md
+++ b/docs/reference/operators/index.md
@@ -2,7 +2,7 @@
 title: Operators
 parent: Reference
 has_children: true
-nav_order: 2
+nav_order: 3
 ---
 # ONNX Runtime Operators
 

--- a/docs/reference/ort-format-models.md
+++ b/docs/reference/ort-format-models.md
@@ -1,13 +1,13 @@
 ---
-title: ORT format models
+title: ORT model format
 description: Define the ORT format and show how to convert an ONNX model to ORT format to run on mobile or web
 parent: Reference
 has_children: false
-nav_order: 4
+nav_order: 8
 redirect_from: /docs/tutorials/mobile/model-conversion, /docs/tutorials/mobile/model-execution
 ---
 
-# ORT format models
+# ORT model format
 {: .no_toc}
 
 ## Contents
@@ -16,7 +16,7 @@ redirect_from: /docs/tutorials/mobile/model-conversion, /docs/tutorials/mobile/m
 * TOC
 {:toc}
 
-## What is the ORT format?
+## What is the ORT model format?
 
 The ORT format is the format supported by reduced size ONNX Runtime builds. Reduced size builds may be more appropriate for use in size-constrained environments such as mobile and web applications.
 

--- a/docs/reference/reduced-operator-config-file.md
+++ b/docs/reference/reduced-operator-config-file.md
@@ -2,7 +2,7 @@
 title: Reduced operator config file
 description: Specification of the reduced operator config file, used to reduce the size of the ONNX Runtime
 parent: Reference
-nav_order: 3
+nav_order: 7
 ---
 
 

--- a/docs/reference/releases-servicing.md
+++ b/docs/reference/releases-servicing.md
@@ -1,15 +1,20 @@
 ---
 title: Releases and servicing
+description: ONNX Runtime roadmap and release plans
 parent: Reference
 nav_order: 7
 ---
-# Releases and servicing
+
+# ONNX Runtime releases
+
+The current ONNX Runtime release is [1.11](https://github.com/microsoft/onnxruntime/releases/tag/v1.11.1).
+
+The next release is ONNX Runtime release [1.12](https://github.com/microsoft/onnxruntime/projects/9).
+
 Official releases of ONNX Runtime are managed by the core ONNX Runtime team and packages are published roughly quarterly. 
 
-[https://github.com/microsoft/onnxruntime/releases](https://github.com/microsoft/onnxruntime/releases)
+Releases are versioned according to [Versioning](https://github.com/microsoft/onnxruntime/blob/faxu-doc-updates/docs/Versioning.md) and release branches are prefixed with "rel-". Patch releases may be published periodically between full releases and have their own release branch.
 
-Releases are versioned according to [Versioning](https://github.com/microsoft/onnxruntime/blob/faxu-doc-updates/docs/Versioning.md) and release branches are prefixed with "rel-". Patch releases may be published periodically between full releases and will have their own  release branch. 
-
-ONNX Runtime releases commit to backwards compatibilty. To report a regression, please [file a Github issue](https://github.com/microsoft/onnxruntime/issues/new/choose).
+ONNX Runtime releases commit to backwards compatibility. To report a regression, please [file a Github issue](https://github.com/microsoft/onnxruntime/issues/new/choose).
 
 For questions on release process or timing, please use [Github Discussions](https://github.com/microsoft/onnxruntime/discussions).

--- a/docs/reference/releases-servicing.md
+++ b/docs/reference/releases-servicing.md
@@ -2,7 +2,7 @@
 title: Releases
 description: ONNX Runtime roadmap and release plans
 parent: Reference
-nav_order: 7
+nav_order: 1
 ---
 
 # ONNX Runtime releases

--- a/docs/reference/releases-servicing.md
+++ b/docs/reference/releases-servicing.md
@@ -1,5 +1,5 @@
 ---
-title: Releases and servicing
+title: Releases
 description: ONNX Runtime roadmap and release plans
 parent: Reference
 nav_order: 7
@@ -11,9 +11,9 @@ The current ONNX Runtime release is [1.11](https://github.com/microsoft/onnxrunt
 
 The next release is ONNX Runtime release [1.12](https://github.com/microsoft/onnxruntime/projects/9).
 
-Official releases of ONNX Runtime are managed by the core ONNX Runtime team and packages are published roughly quarterly. 
+Official releases of ONNX Runtime are managed by the core ONNX Runtime team. A new release is published approximately every quarter.
 
-Releases are versioned according to [Versioning](https://github.com/microsoft/onnxruntime/blob/faxu-doc-updates/docs/Versioning.md) and release branches are prefixed with "rel-". Patch releases may be published periodically between full releases and have their own release branch.
+Releases are versioned according to [Versioning](https://github.com/microsoft/onnxruntime/blob/master/docs/Versioning.md) and release branches are prefixed with "rel-". Patch releases may be published periodically between full releases and have their own release branch.
 
 ONNX Runtime releases commit to backwards compatibility. To report a regression, please [file a Github issue](https://github.com/microsoft/onnxruntime/issues/new/choose).
 


### PR DESCRIPTION
Notably the releases page gets approximately zero views. I think this will help a little bit, as people might search for ONNX Runtime current release. 

I'd like to improve this page even more though, perhaps with a little history and an outline of the ONNX Runtime roadmap.

This PR also removes the in-browser 404 redirection and replaces it with the static version. We do want to track and fix genuine 404s from external websites.

Staged: https://natke.github.io/onnxruntime/docs/reference/releases-servicing.html