### PR TITLE
Update gather to use multiple threads

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
@@ -78,7 +78,7 @@ FORCEINLINE int64_t GetIndex(size_t i, const T* indices, int64_t axis_size) {
   if (index < 0)  // Handle negative indices
     index += axis_size;
   if (std::make_unsigned_t<T>(index) >= std::make_unsigned_t<T>(axis_size))
-    throw std::out_of_range{"Index out of range"};
+    ORT_THROW("Index out of range");
   return index;
 };
 
@@ -114,7 +114,7 @@ static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, 
 
   auto MainLoop = [&](auto* output_data, auto* input_data) {
     auto BatchWork = [&](size_t inner_dim) {
-      try {
+      ORT_TRY {
         auto output = output_data + inner_dim_size * inner_dim;
         auto input = input_data + CalculateOffset(inner_dim, input_shape_pitches, axis, indices_shape);
         auto indices = indices_data + inner_dim_size * inner_dim;
@@ -126,7 +126,8 @@ static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, 
           for (size_t i = 0; i < inner_dim_size; i++)
             output[i] = input[GetIndex(i, indices, axis_size) * axis_pitch + i];
         }
-      } catch (const std::out_of_range&) {
+      }
+      ORT_CATCH(const std::exception&) {
         index_error = true;
       }
     };

--- a/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <string>
 #include "gather_elements.h"
 #include "onnxruntime_config.h"
 
@@ -43,7 +44,8 @@ static int64_t CalculateInnerDimCount(const TensorShape& dims) {
 // The calculation is fairly straightforward, starting with the second to innermost axis we muldiv the inner_dim
 // by the indices shape size. We also skip this calculation on the skip_axis as that's handled elsewhere.
 //
-static inline size_t CalculateOffset(size_t inner_dim, const TensorPitches& input_shape_pitches, size_t skip_axis, const TensorShape& indices_shape) {
+static inline size_t CalculateOffset(size_t inner_dim, const TensorPitches& input_shape_pitches, size_t skip_axis,
+                                     const TensorShape& indices_shape) {
   // in this context, rank can never be < 1, so saving checking overhead
   size_t rank = input_shape_pitches.size();
 
@@ -88,7 +90,8 @@ FORCEINLINE int64_t GetIndex(size_t i, const T* indices, int64_t axis_size) {
 #endif
 
 template <typename Tin>
-static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, Tensor* output_tensor, int64_t axis, concurrency::ThreadPool* ttp) {
+static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, Tensor* output_tensor, int64_t axis,
+                      concurrency::ThreadPool* ttp) {
   // Get input & output pointers
   const int8_t* input_data = reinterpret_cast<const int8_t*>(input_tensor->DataRaw());
   int8_t* output_data = reinterpret_cast<int8_t*>(output_tensor->MutableDataRaw());

--- a/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_elements.cc
@@ -25,65 +25,44 @@ ONNX_CPU_OPERATOR_KERNEL(
                                                         DataTypeImpl::GetTensorType<int64_t>()}),
     GatherElements);
 
-// Some helpers needed for GatherElements op -
-
-// The following method computes the offset in the flattened array
-// using every axis except the inner dimension (as the offset is just 1)
-// and the axis that 'GatherElements' is processing for as that requires the corresponding
-// 'indices' value
-// This prevents the need to compute this offset for every element within the same 'inner_dimension' chunk
-// as this value just differs by 1 for the chunk elements and we can have this cached and re-use as needed
-static inline size_t compute_base_offset(const TensorShapeVector& shape, const TensorPitches& pitches, int64_t skip_axis) {
-  // in this context, rank can never be < 1, so saving checking overhead
-  auto loop_size = static_cast<int64_t>(shape.size()) - 1;
-
-  size_t base_offset = 0;
-
-  for (int64_t i = 0; i < loop_size; ++i) {
-    if (i != skip_axis)
-      base_offset += shape[i] * pitches[i];
-  }
-
-  return base_offset;
-}
-
-// This method computes the number of 'inner_dimension' chunks
+// Compute the number of 'inner_dimension' elements
 // Example: input = [2, 3]     output = 2
 //          input = [3, 2, 4]  output = 3 * 2 = 6
 //          input  = [2]       output = 1
-static int64_t calculate_num_inner_dim(const TensorShape& dims) {
-  // in this context, rank can never be < 1, so saving checking overhead
+static int64_t CalculateInnerDimCount(const TensorShape& dims) {
+  // Rank can never be < 1, no need to check
   return dims.SizeToDimension(dims.NumDimensions() - 1);
 }
 
-// This method computes increments over an 'inner_dimension'
-// Example 1: current_dims = [0, x] tensor_dims = [3, 1], then current_dims = [1, x]
-//            current_dims = [1, x] tensor_dims = [3, 1], then current_dims = [2, x]
-//            current_dims = [2, x] tensor_dims = [3, 1], then current_dims = [0, x]
+// Computes the offset into the input array given the inner_dim count
+//
+// If the input indices tensor matched the input tensor this would simply just be inner_dim_size * inner_dim
+// But since the indices tensor can be smaller we need to do the math based on the smaller size, as the
+// output tensor size matches the input indices tensor size.
+// 
+// The calculation is fairly straightforward, starting with the second to innermost axis we muldiv the inner_dim
+// by the indices shape size. We also skip this calculation on the skip_axis as that's handled elsewhere.
+//
+static inline size_t CalculateOffset(size_t inner_dim, const TensorPitches& input_shape_pitches, size_t skip_axis, const TensorShape& indices_shape) {
 
-// Example 2: current_dims = [0, 0, x] tensor_dims = [1, 2, 2], then current_dims = [0, 1, x]
-//            current_dims = [0, 1, x] tensor_dims = [1, 2, 2], then current_dims = [0, 0, x]
-static inline void increment_over_inner_dim(TensorShapeVector& current_dims, const TensorShape& tensor_dims) {
   // in this context, rank can never be < 1, so saving checking overhead
-  int64_t rank = static_cast<int64_t>(current_dims.size());
-
-  // 'reset' innermost dimension value
-  current_dims[rank - 1] = 0;
+  size_t rank = input_shape_pitches.size();
 
   // nothing to increment over
   if (rank == 1) {
-    return;
+    return 0;
   }
 
-  int64_t current_axis = rank - 2;
+  size_t base_offset = 0;
 
-  while (current_axis >= 0) {
-    if (++current_dims[current_axis] != tensor_dims[current_axis])
-      return;
-
-    current_dims[current_axis] = 0;
-    --current_axis;
+  for(size_t axis=rank-1;axis-->0;) {
+    auto dim = indices_shape[axis];
+    if (axis != skip_axis)
+      base_offset += (inner_dim % dim) * input_shape_pitches[axis];
+    inner_dim/=dim;
   }
+
+  return base_offset;
 }
 
 #if defined(_MSC_VER)
@@ -95,10 +74,10 @@ static inline void increment_over_inner_dim(TensorShapeVector& current_dims, con
 template <typename T>
 FORCEINLINE int64_t GetIndex(size_t i, const T* indices, int64_t axis_size) {
   int64_t index = indices[i];
-  if (index < 0)  // Handle negative indices
+  if (index < 0) // Handle negative indices
     index += axis_size;
   if (std::make_unsigned_t<T>(index) >= std::make_unsigned_t<T>(axis_size))
-    ORT_THROW("GatherElements op: Value in indices must be within bounds [-", axis_size, " , ", axis_size - 1, "]. Actual value is ", indices[i]);
+    return 0;
   return index;
 };
 
@@ -110,7 +89,7 @@ FORCEINLINE int64_t GetIndex(size_t i, const T* indices, int64_t axis_size) {
 #endif
 
 template <typename Tin>
-static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, Tensor* output_tensor, int64_t axis) {
+static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, Tensor* output_tensor, int64_t axis, concurrency::ThreadPool* ttp) {
   // Get input & output pointers
   const int8_t* input_data = reinterpret_cast<const int8_t*>(input_tensor->DataRaw());
   int8_t* output_data = reinterpret_cast<int8_t*>(output_tensor->MutableDataRaw());
@@ -120,56 +99,48 @@ static void core_impl(const Tensor* input_tensor, const Tensor* indices_tensor, 
   const int64_t input_rank = static_cast<int64_t>(input_tensor->Shape().NumDimensions());
 
   const TensorShape& indices_shape = indices_tensor->Shape();
-  size_t num_inner_dim = calculate_num_inner_dim(indices_shape);
+  size_t num_inner_dim = CalculateInnerDimCount(indices_shape);
   size_t inner_dim_size = indices_shape[input_rank - 1];
-  const Tin* indices = indices_tensor->Data<Tin>();
+  const Tin* indices_data = indices_tensor->Data<Tin>();
 
-  TensorShapeVector process_dims(input_rank, 0);
   const TensorPitches input_shape_pitches(*input_tensor);
   int64_t axis_pitch = input_shape_pitches[axis];
   int64_t axis_size = input_tensor->Shape()[axis];
 
-  auto DoAxis = [](auto* output, auto* input, auto* indices, size_t inner_dim_size, int64_t axis_size, int64_t axis_pitch) {
-    for (size_t i = 0; i < inner_dim_size; i++)
-      output[i] = input[GetIndex(i, indices, axis_size) * axis_pitch + i];
-  };
+  bool innermost_axis = axis == input_rank-1;
 
-  // Special case required for innermost axis, no axis_pitch multiply needed or adding i
-  auto DoInnermostAxis = [](auto* output, auto* input, auto* indices, size_t inner_dim_size, int64_t axis_size, int64_t /*axis_pitch*/) {
-    for (size_t i = 0; i < inner_dim_size; i++)
-      output[i] = input[GetIndex(i, indices, axis_size)];
-  };
+  auto MainLoop = [&](auto* output_data, auto* input_data) {
+    auto BatchWork = [&](size_t inner_dim) {
+      auto output = output_data + inner_dim_size * inner_dim;
+      auto input = input_data + CalculateOffset(inner_dim, input_shape_pitches, axis, indices_shape);
+      auto indices = indices_data + inner_dim_size * inner_dim;
 
-  auto MainLoop = [&](auto* output, auto* input, auto LoopFn) {
-    while (num_inner_dim-- != 0) {
-      LoopFn(output, input + compute_base_offset(process_dims, input_shape_pitches, axis), indices, inner_dim_size, axis_size, axis_pitch);
-      output += inner_dim_size;
-      indices += static_cast<Tin>(inner_dim_size);
-      increment_over_inner_dim(process_dims, indices_shape);
-    }
+      if (innermost_axis) {
+        for (size_t i = 0; i < inner_dim_size; i++)
+          output[i] = input[GetIndex(i, indices, axis_size)];
+      } else {
+        for (size_t i = 0; i < inner_dim_size; i++)
+          output[i] = input[GetIndex(i, indices, axis_size) * axis_pitch + i];
+      }
+    };
+
+    concurrency::ThreadPool::TryBatchParallelFor(ttp, num_inner_dim, BatchWork, 0);
   };
 
   // Iterate over the elements based on the element size (or if it's a string). For everything but strings
   // we do a binary copy, so handling the 1, 2, 4, and 8 byte sizes covers all cases
-  auto SwitchOnSizes = [&](auto LoopFn) {
-    if (is_string)
-      MainLoop(reinterpret_cast<std::string*>(output_data), reinterpret_cast<const std::string*>(input_data), LoopFn);
-    else if (element_size == sizeof(uint32_t))
-      MainLoop(reinterpret_cast<uint32_t*>(output_data), reinterpret_cast<const uint32_t*>(input_data), LoopFn);
-    else if (element_size == sizeof(uint16_t))
-      MainLoop(reinterpret_cast<uint16_t*>(output_data), reinterpret_cast<const uint16_t*>(input_data), LoopFn);
-    else if (element_size == sizeof(uint8_t))
-      MainLoop(reinterpret_cast<uint8_t*>(output_data), reinterpret_cast<const uint8_t*>(input_data), LoopFn);
-    else if (element_size == sizeof(uint64_t))
-      MainLoop(reinterpret_cast<uint64_t*>(output_data), reinterpret_cast<const uint64_t*>(input_data), LoopFn);
-    else
-      ORT_THROW("GatherElements op: Unsupported tensor type, size:", element_size);
-  };
-
-  if (axis == input_rank - 1)
-    SwitchOnSizes(DoInnermostAxis);
+  if (is_string)
+    MainLoop(reinterpret_cast<std::string*>(output_data), reinterpret_cast<const std::string*>(input_data));
+  else if (element_size == sizeof(uint32_t))
+    MainLoop(reinterpret_cast<uint32_t*>(output_data), reinterpret_cast<const uint32_t*>(input_data));
+  else if (element_size == sizeof(uint16_t))
+    MainLoop(reinterpret_cast<uint16_t*>(output_data), reinterpret_cast<const uint16_t*>(input_data));
+  else if (element_size == sizeof(uint8_t))
+    MainLoop(reinterpret_cast<uint8_t*>(output_data), reinterpret_cast<const uint8_t*>(input_data));
+  else if (element_size == sizeof(uint64_t))
+    MainLoop(reinterpret_cast<uint64_t*>(output_data), reinterpret_cast<const uint64_t*>(input_data));
   else
-    SwitchOnSizes(DoAxis);
+    ORT_THROW("GatherElements op: Unsupported tensor type, size:", element_size);
 }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -233,10 +204,11 @@ Status GatherElements::Compute(OpKernelContext* context) const {
   if (indices_shape.Size() == 0)
     return Status::OK();
 
+  auto* ttp = context->GetOperatorThreadPool();
   if (indices_tensor->IsDataType<int32_t>())
-    core_impl<int32_t>(input_tensor, indices_tensor, output_tensor, axis);
+    core_impl<int32_t>(input_tensor, indices_tensor, output_tensor, axis, ttp);
   else
-    core_impl<int64_t>(input_tensor, indices_tensor, output_tensor, axis);
+    core_impl<int64_t>(input_tensor, indices_tensor, output_tensor, axis, ttp);
 
   return Status::OK();
 }

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -78,7 +78,6 @@ void RunTypedTest() {
   // skip TensorRT because it doesn't support negative indices				  
   test4.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 
-#if 0
   // indices out of bounds
   OpTester test5("GatherElements", 11);
   test5.AddAttribute<int64_t>("axis", 1LL);
@@ -91,8 +90,13 @@ void RunTypedTest() {
   test5.AddOutput<T>("output", {2, 2},
                      {1, 1,
                       3, 3});
-  test5.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
-#endif
+  // skip nuphar, which will not throw error message but will ensure no out-of-bound access
+  // skip cuda as the cuda kernel won't throw the error message
+  // skip openvino which will not throw error message but will ensure no out-of-bound access
+  // skip TensorRT because it doesn't support out of bounds indices
+  test5.Run(OpTester::ExpectResult::kExpectFailure,
+            "GatherElements op: Out of range value in index tensor",
+            {kNupharExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
 
   // 3D input - axis 1
   OpTester test6("GatherElements", 11);
@@ -231,7 +235,6 @@ void RunTypedTest<std::string>() {
                                 "d", "d"});
   test3.Run();
 
-#if 0
   // indices out of bounds
   OpTester test4("GatherElements", 11);
   test4.AddAttribute<int64_t>("axis", 1LL);
@@ -244,8 +247,11 @@ void RunTypedTest<std::string>() {
   test4.AddOutput<std::string>("output", {2, 2},
                                {"a", "a",
                                 "c", "c"});
-  test4.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
-#endif
+  // skip nuphar, which will not throw error message but will ensure no out-of-bound access
+  // skip Openvino, which will not throw error message but will ensure no out-of-bound access
+  test4.Run(OpTester::ExpectResult::kExpectFailure,
+            "GatherElements op: Out of range value in index tensor",
+            {kNupharExecutionProvider, kOpenVINOExecutionProvider});
 
   // 3D input - axis 1
   OpTester test5("GatherElements", 11);

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -90,13 +90,7 @@ void RunTypedTest() {
   test5.AddOutput<T>("output", {2, 2},
                      {1, 1,
                       3, 3});
-  // skip nuphar, which will not throw error message but will ensure no out-of-bound access
-  // skip cuda as the cuda kernel won't throw the error message
-  // skip openvino which will not throw error message but will ensure no out-of-bound access
-  // skip TensorRT because it doesn't support out of bounds indices
-  test5.Run(OpTester::ExpectResult::kExpectFailure,
-            "GatherElements op: Value in indices must be within bounds [-2 , 1]. Actual value is 2",
-            {kNupharExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider, kOpenVINOExecutionProvider, kTensorrtExecutionProvider});
+  test5.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 
   // 3D input - axis 1
   OpTester test6("GatherElements", 11);
@@ -247,11 +241,7 @@ void RunTypedTest<std::string>() {
   test4.AddOutput<std::string>("output", {2, 2},
                                {"a", "a",
                                 "c", "c"});
-  // skip nuphar, which will not throw error message but will ensure no out-of-bound access
-  // skip Openvino, which will not throw error message but will ensure no out-of-bound access
-  test4.Run(OpTester::ExpectResult::kExpectFailure,
-            "GatherElements op: Value in indices must be within bounds [-2 , 1]. Actual value is -3",
-            {kNupharExecutionProvider, kOpenVINOExecutionProvider});
+  test4.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 
   // 3D input - axis 1
   OpTester test5("GatherElements", 11);

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -78,6 +78,7 @@ void RunTypedTest() {
   // skip TensorRT because it doesn't support negative indices				  
   test4.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 
+#if 0
   // indices out of bounds
   OpTester test5("GatherElements", 11);
   test5.AddAttribute<int64_t>("axis", 1LL);
@@ -91,6 +92,7 @@ void RunTypedTest() {
                      {1, 1,
                       3, 3});
   test5.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+#endif
 
   // 3D input - axis 1
   OpTester test6("GatherElements", 11);
@@ -229,6 +231,7 @@ void RunTypedTest<std::string>() {
                                 "d", "d"});
   test3.Run();
 
+#if 0
   // indices out of bounds
   OpTester test4("GatherElements", 11);
   test4.AddAttribute<int64_t>("axis", 1LL);
@@ -242,6 +245,7 @@ void RunTypedTest<std::string>() {
                                {"a", "a",
                                 "c", "c"});
   test4.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+#endif
 
   // 3D input - axis 1
   OpTester test5("GatherElements", 11);


### PR DESCRIPTION
**Description**: GatherElements wouldn't distribute the work across multiple threads

**Motivation and Context**
A user was comparing the performance of Onnxruntime vs Pytorch and saw that the latest Pytorch was 2x faster than Onnxruntime. A profile showed that they were using all CPU cores but we were limited to 1.

There is a separate issue where they were using Onnxruntime inefficiently (there's a memcpy on every Run() call to copy the output tensor, using io-bindings avoids the memcpy).

Here's some performance data comparing the old vs new. Note that there is a slight perf hit for the single threaded case, as it has to divide up the work into independent chunks vs a slightly faster incremental calculation between chunks.

New version using 8 threads:

onnx model: 0.770249s after 10000 iterations
pytorch model: 3.669060s after 10000 iterations

New version limited to one thread:

onnx model: 3.474726s after 10000 iterations
pytorch model: 3.579055s after 10000 iterations

Old version:

onnx model: 2.905542s after 10000 iterations
pytorch model: 3.634197s after 10000 iterations

