### PR TITLE
Improved OneDNN performance by preventing thread oversubscription

### DIFF
--- a/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
+++ b/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
@@ -10,7 +10,8 @@ extern "C" {
 /**
  * \param use_arena zero: false. non-zero: true.
  */
-ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena);
+ORT_API_STATUS( OrtSessionOptionsAppendExecutionProvider_Dnnl,
+                _In_ OrtSessionOptions* options, _In_ const OrtDnnlProviderOptions* dnnl_options);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -509,6 +509,24 @@ typedef struct OrtMIGraphXProviderOptions {
   int migraphx_int8_enable;  // enable MIGraphX INT8 precision. Default 0 = false, nonzero = true
 } OrtMIGraphXProviderOptions;
 
+/** \brief OneDNN Provider Options
+ *
+ * \see OrtApi::SessionOptionsAppendExecutionProvider_Dnnl
+ */
+typedef struct OrtDnnlProviderOptions {
+#ifdef __cplusplus
+  OrtDnnlProviderOptions() :  use_arena{true}, enable_training{false},
+                              optimize_threads{false}, ort_intra_op_threads{nullptr},
+                              onednn_threads{0}, ort_threads{0} {}
+#endif
+  int use_arena;              // If arena is used, use_arena 0 = not used, nonzero = used
+  int enable_training;        // Enable or disable training ops, enable_training 0 = not enabled, nonzero = enabled
+  int optimize_threads;       // If we should optimize threads, optimize_threads 0 = not optimized, nonzero = optimized
+  int* ort_intra_op_threads;  // Ptr needed to optimize ort threads, modifies the ort session options configuration
+  int onednn_threads;         // Number of threads we want oneDNN to use, onednn_threads 0 = using omp_get_max_threads()
+  int ort_threads;            // Number of threads for ORT to use, ort_threads 0 = steal 1/4 of onednn_threads for ort
+} OrtDnnlProviderOptions;
+
 /** \brief OpenVINO Provider Options
 *
 * \see OrtApi::SessionOptionsAppendExecutionProvider_OpenVINO

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -403,10 +403,10 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addCUD
  * Signature: (JJI)V
  */
 JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addDnnl
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint useArena) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong optsHandle) {
     (void)jobj;
   #ifdef USE_DNNL
-    checkOrtStatus(jniEnv,(const OrtApi*)apiHandle,OrtSessionOptionsAppendExecutionProvider_Dnnl((OrtSessionOptions*) handle,useArena));
+    checkOrtStatus(jniEnv, (const OrtApi*)apiHandle, OrtSessionOptionsAppendExecutionProvider_Dnnl((OrtSessionOptions*)handle, (const OrtDnnlProviderOptions*) optsHandle));
   #else
     (void)apiHandle;(void)handle;(void)useArena; // Parameters used when DNNL is defined.
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with DNNL support.");

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1135,8 +1135,8 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Rocm(c
   return s_library_rocm.Get().CreateExecutionProviderFactory(provider_options);
 }
 
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena) {
-  return s_library_dnnl.Get().CreateExecutionProviderFactory(use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* dnnl_options) {
+  return s_library_dnnl.Get().CreateExecutionProviderFactory(dnnl_options);
 }
 
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensorrt(int device_id) {
@@ -1291,9 +1291,9 @@ ProviderOptions GetProviderInfo_Cuda(const OrtCUDAProviderOptionsV2* provider_op
 
 }  // namespace onnxruntime
 
-ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena) {
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, _In_ const OrtDnnlProviderOptions* dnnl_options) {
   API_IMPL_BEGIN
-  auto factory = onnxruntime::CreateExecutionProviderFactory_Dnnl(use_arena);
+  auto factory = onnxruntime::CreateExecutionProviderFactory_Dnnl(dnnl_options);
   if (!factory) {
     return OrtApis::CreateStatus(ORT_FAIL, "OrtSessionOptionsAppendExecutionProvider_Dnnl: Failed to load shared library");
   }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -571,9 +571,35 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kDnnlExecutionProvider) {
 #ifdef USE_DNNL
-    return onnxruntime::CreateExecutionProviderFactory_Dnnl(
-               session_options.enable_cpu_mem_arena)
-        ->CreateProvider();
+    // Generate dnnl_options
+    OrtDnnlProviderOptions dnnl_options;
+
+    auto it = provider_options_map.find(type);
+    if (it != provider_options_map.end()) {
+      for (auto option : it->second) {
+        if (option.first == "num_of_threads") {
+          dnnl_options.onednn_threads = std::stoi(option.second);
+          if (dnnl_options.onednn_threads < 0) {
+            ORT_THROW("[ERROR] [OneDNN] The value for the key 'num_of_threads' should be greater than 0\n");
+            // If the user doesnt define num_threads, default to the number of physical cores for best performance
+          } else if (dnnl_options.onednn_threads == 0) {
+            std::vector<size_t> cpu_list = Env::Default().GetThreadAffinityMasks();
+            if (!cpu_list.empty() && cpu_list.size() > 1) {
+              dnnl_options.onednn_threads = static_cast<int>(cpu_list.size());
+            }
+          }
+        } else {
+          ORT_THROW("Invalid OneDNN EP option: ", option.first);
+        }
+      }
+    }
+
+    dnnl_options.use_arena = session_options.enable_cpu_mem_arena;
+    dnnl_options.optimize_threads = true;
+    dnnl_options.ort_intra_op_threads = const_cast<int*>(&session_options.intra_op_param.thread_pool_size);
+    dnnl_options.ort_threads = session_options.intra_op_param.thread_pool_size;
+
+    return onnxruntime::CreateExecutionProviderFactory_Dnnl(&dnnl_options)->CreateProvider();
 #endif
   } else if (type == kOpenVINOExecutionProvider) {
 #ifdef USE_OPENVINO

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -483,7 +483,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensor
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(const OrtMIGraphXProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(int device_id);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptions* params);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const OrtOpenVINOProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nuphar(bool, const char*);
 #ifdef USE_TVM

--- a/onnxruntime/test/global_thread_pools/test_inference.cc
+++ b/onnxruntime/test/global_thread_pools/test_inference.cc
@@ -74,7 +74,9 @@ static Ort::Session GetSessionObj(Ort::Env& env, T model_uri, int provider_type)
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = true;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return Ort::Session(nullptr);

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -35,9 +35,57 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kDnnlExecutionProvider) {
 #ifdef USE_DNNL
+    // Create runtime options
+    int enable_training = false;
+    int num_of_threads = 0;
+
+#ifdef _MSC_VER
+    std::string ov_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+    std::string ov_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+    std::istringstream ss(ov_string);
+    std::string token;
+    while (ss >> token) {
+      if (token == "") {
+        continue;
+      }
+      auto pos = token.find("|");
+      if (pos == std::string::npos || pos == 0 || pos == token.length()) {
+        ORT_THROW("[ERROR] [OneDNN] Use a '|' to separate the key and value for the run-time option you are trying to use.\n");
+      }
+
+      auto key = token.substr(0, pos);
+      auto value = token.substr(pos + 1);
+
+      if (key == "num_of_threads") {
+        std::stringstream sstream(value);
+        sstream >> num_of_threads;
+        if (num_of_threads < 0) {
+          ORT_THROW("[ERROR] [OneDNN] The value for the key 'num_of_threads' should be greater than 0\n");
+          // If the user doent define num_threads, default to the number of physical cores for best performance
+        } else if (num_of_threads == 0) {
+          std::vector<size_t> cpu_list = Env::Default().GetThreadAffinityMasks();
+          if (!cpu_list.empty() && cpu_list.size() > 1) {
+            num_of_threads = static_cast<int>(cpu_list.size());
+          }
+        }
+      } else {
+        ORT_THROW("[ERROR] [OneDNN] wrong key type entered. Choose from the following runtime key options that are available for OneDNN. ['num_of_threads']\n");
+      }
+    }
+
+    // Generate provider options
+    OrtDnnlProviderOptions options;
+    options.optimize_threads = true;
+    options.use_arena = performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0;
+    options.ort_intra_op_threads = const_cast<int*>(&performance_test_config.run_config.intra_op_num_threads);
+    options.onednn_threads = num_of_threads;
+    options.ort_threads = performance_test_config.run_config.intra_op_num_threads;
+    options.enable_training = enable_training;
+
     Ort::ThrowOnError(
-        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options,
-                                                      performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
+        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &options));
 #else
     ORT_THROW("DNNL is not supported in this build\n");
 #endif

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -651,7 +651,9 @@ TEST_P(ModelTest, Run) {
       }
 #ifdef USE_DNNL
       else if (provider_name == "dnnl") {
-        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, false));
+        OrtDnnlProviderOptions dnnl_options;
+        dnnl_options.use_arena = false;
+        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, &dnnl_options));
       }
 #endif
 #ifdef USE_NUPHAR

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -106,7 +106,9 @@ static void TestInference(Ort::Env& env, const std::basic_string<ORTCHAR_T>& mod
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = true;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return;

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -107,10 +107,23 @@ std::unique_ptr<IExecutionProvider> DefaultCudaExecutionProvider() {
 
 std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(bool enable_arena) {
 #ifdef USE_DNNL
-  if (auto factory = CreateExecutionProviderFactory_Dnnl(enable_arena ? 1 : 0))
+  OrtDnnlProviderOptions dnnl_options;
+  dnnl_options.use_arena = enable_arena ? 1 : 0;
+  dnnl_options.optimize_threads = false;
+  if (auto factory = CreateExecutionProviderFactory_Dnnl(&dnnl_options))
     return factory->CreateProvider();
 #else
   ORT_UNUSED_PARAMETER(enable_arena);
+#endif
+  return nullptr;
+}
+
+std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(const OrtDnnlProviderOptions* provider_options) {
+#ifdef USE_DNNL
+  if (auto factory = CreateExecutionProviderFactory_Dnnl(provider_options))
+    return factory->CreateProvider();
+#else
+  ORT_UNUSED_PARAMETER(provider_options);
 #endif
   return nullptr;
 }

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -12,7 +12,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_ArmNN(
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_CoreML(uint32_t);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptions* provider_options);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(const OrtCUDAProviderOptionsV2* provider_options);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* provider_options);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_MIGraphX(const OrtMIGraphXProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nnapi(
     uint32_t flags, const optional<std::string>& partitioning_stop_ops_list);

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -25,7 +25,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cuda(c
 #include <tuple>
 
 namespace onnxruntime {
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(const OrtDnnlProviderOptions* provider_options);
 }
 
 using namespace onnxruntime;
@@ -177,7 +177,10 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
 
     bool use_dnnl = flags.count("use_dnnl") > 0;
     if (use_dnnl) {
-      params.providers.emplace(kDnnlExecutionProvider, CreateExecutionProviderFactory_Dnnl(1));
+      OrtDnnlProviderOptions dnnl_options;
+      dnnl_options.use_arena = 1;
+      dnnl_options.optimize_threads = 0;
+      params.providers.emplace(kDnnlExecutionProvider, CreateExecutionProviderFactory_Dnnl(&dnnl_options));
     }
 
     std::string model_type = flags["model_type"].as<std::string>();


### PR DESCRIPTION
Users can now control the number of threads allocated to OneDNN and the default provider using OrtDnnlProviderOptions to fine tune performance according to each model op coverage. By default we improve thread distribution to prevent oversubscription.

Signed-off-by: Erick Muñoz [erick.munoz.alvarado@intel.com](mailto:erick.munoz.alvarado@intel.com)

**Description**: Previously OneDNN ep suffered from thread oversubscription due to ORT creating it's own thread pool and OneDNN creating another one, this update aims to fix this issue by making the number of threads used by OneDNN accessible to the user and setting the default threading options to be 3/4 of the available (Or user defined threads for OneDNN) and the remaining threads for default provider (This behavior can be overridden by the user explicitly defining the number of threads for OneDNN and for the default provider)

**Motivation and Context**
- Why is this change required? What problem does it solve?
Performance related fix, prevents thread oversubscription, improves performance on CPU and allows the user to customize thread distribution according to their workload.

- If it fixes an open issue, please link to the issue here.