### PR TITLE
Use fixed point arithmetic for LITTLE core only

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -1069,7 +1069,7 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
           const bool is_half_pixel = coordinate_transform_mode_ == HALF_PIXEL;
           const bool is_align_corners = coordinate_transform_mode_ == ALIGN_CORNERS;
           if (CPUIDInfo::GetCPUIDInfo().IsCurrentCoreArmv8NarrowLd() &&
-	      !is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
+              !is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
               (is_half_pixel || is_align_corners || coordinate_transform_mode_ == ASYMMETRIC)) {
             NhwcUpsampleBilinearInteger(is_half_pixel, is_align_corners,
                                         static_cast<int32_t>(batch_size), static_cast<int32_t>(input_height), static_cast<int32_t>(input_width), static_cast<int32_t>(num_channels),
@@ -1077,7 +1077,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                                         X->Data<T>(),
                                         static_cast<int32_t>(output_height), static_cast<int32_t>(output_width),
                                         output_dims,
-                                        Y->MutableData<T>());
+                                        Y->MutableData<T>(),
+                                        static_cast<int32_t>((1 << 10) / height_scale), static_cast<int32_t>((1 << 10) / width_scale));
           } else {
             NhwcUpsampleBilinear(batch_size, num_channels, input_height, input_width, output_height, output_width,
                                  height_scale, width_scale, roi,

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/common/cpuid_info.h"
 #include "core/common/safeint.h"
 #include "core/platform/threadpool.h"
 #include "core/providers/cpu/tensor/upsample.h"
@@ -1067,7 +1068,8 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
         } else {
           const bool is_half_pixel = coordinate_transform_mode_ == HALF_PIXEL;
           const bool is_align_corners = coordinate_transform_mode_ == ALIGN_CORNERS;
-          if (!is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
+          if (CPUIDInfo::GetCPUIDInfo().IsCurrentCoreArmv8NarrowLd() &&
+	      !is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
               (is_half_pixel || is_align_corners || coordinate_transform_mode_ == ASYMMETRIC)) {
             NhwcUpsampleBilinearInteger(is_half_pixel, is_align_corners,
                                         static_cast<int32_t>(batch_size), static_cast<int32_t>(input_height), static_cast<int32_t>(input_width), static_cast<int32_t>(num_channels),

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -1072,19 +1072,23 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
               !is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
               (is_half_pixel || is_align_corners || coordinate_transform_mode_ == ASYMMETRIC)) {
             NhwcUpsampleBilinearInteger(is_half_pixel, is_align_corners,
-                                        static_cast<int32_t>(batch_size), static_cast<int32_t>(input_height), static_cast<int32_t>(input_width), static_cast<int32_t>(num_channels),
+                                        static_cast<int32_t>(batch_size),
+                                        static_cast<int32_t>(input_height), static_cast<int32_t>(input_width),
+                                        static_cast<int32_t>(num_channels),
                                         dims,
                                         X->Data<T>(),
                                         static_cast<int32_t>(output_height), static_cast<int32_t>(output_width),
                                         output_dims,
                                         Y->MutableData<T>(),
-                                        static_cast<int32_t>((1 << 10) / height_scale), static_cast<int32_t>((1 << 10) / width_scale));
+                                        static_cast<int32_t>((1 << 10) / height_scale),
+                                        static_cast<int32_t>((1 << 10) / width_scale));
           } else {
-            NhwcUpsampleBilinear(batch_size, num_channels, input_height, input_width, output_height, output_width,
-                                 height_scale, width_scale, roi,
-                                 use_extrapolation_, extrapolation_value_, X->Data<T>(),
-                                 Y->MutableData<T>(), alloc, get_original_coordinate_,
-                                 output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
+            NhwcUpsampleBilinear(
+                batch_size, num_channels, input_height, input_width, output_height, output_width,
+                height_scale, width_scale, roi,
+                use_extrapolation_, extrapolation_value_, X->Data<T>(),
+                Y->MutableData<T>(), alloc, get_original_coordinate_,
+                output_height * output_width * num_channels > 64 ? context->GetOperatorThreadPool() : nullptr);
           }
         }
         return Status::OK();

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -1065,9 +1065,11 @@ Status Upsample<T>::BaseCompute(OpKernelContext* context,
                            Y->MutableData<T>(), alloc, get_original_coordinate_,
                            output_height * output_width > 64 ? context->GetOperatorThreadPool() : nullptr);
         } else {
-          if (!is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_UINT8 &&
-              (coordinate_transform_mode_ == HALF_PIXEL || coordinate_transform_mode_ == ALIGN_CORNERS)) {
-            NhwcUpsampleBilinearInteger(coordinate_transform_mode_,
+          const bool is_half_pixel = coordinate_transform_mode_ == HALF_PIXEL;
+          const bool is_align_corners = coordinate_transform_mode_ == ALIGN_CORNERS;
+          if (!is_2D && Y->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT8 &&
+              (is_half_pixel || is_align_corners || coordinate_transform_mode_ == ASYMMETRIC)) {
+            NhwcUpsampleBilinearInteger(is_half_pixel, is_align_corners,
                                         static_cast<int32_t>(batch_size), static_cast<int32_t>(input_height), static_cast<int32_t>(input_width), static_cast<int32_t>(num_channels),
                                         dims,
                                         X->Data<T>(),

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -550,14 +550,11 @@ inline void NhwcUpsampleBilinearInteger(
     const T* input_data,
     const int32_t output_height, const int32_t output_width,
     const gsl::span<const int64_t>& output_dims,
-    T* output_data) {
+    T* output_data,
+    int32_t height_scale_10, int32_t width_scale_10) {
   assert(!is_half_pixel || !is_align_corners);
   assert(input_dims.size() == 4);
   assert(output_dims.size() == 4);
-  int32_t height_scale_10 =
-      ((1 << 10) * input_height + output_height / 2) / output_height;
-  int32_t width_scale_10 =
-      ((1 << 10) * input_width + output_width / 2) / output_width;
   if (is_align_corners && output_height > 1) {
     height_scale_10 =
         ((1 << 10) * (input_height - 1) + (output_height - 1) / 2) /
@@ -601,9 +598,8 @@ inline void NhwcUpsampleBilinearInteger(
               (input_y - (1 << 10) * y0) * (input_x - (1 << 10) * x0);
           const int64_t output_20 =
               output_20_ll + output_20_lu + output_20_rl + output_20_ru;
-          const int64_t round = (output_20 > 0) ? (1 << 19) : -(1 << 19);
           const T interpolation =
-              static_cast<T>((output_20 + round) / (1 << 20));
+              static_cast<T>(output_20 / (1 << 20));
           output_data[Offset(output_dims, b, y, x, c)] = interpolation;
         }
       }

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -6,6 +6,7 @@
 #ifndef SHARED_PROVIDER
 #include "core/framework/op_kernel.h"
 #endif
+#include <algorithm>
 #include <cmath>
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -515,6 +515,7 @@ void NhwcUpsampleBilinear(const int64_t batch_size,
   }
 }
 
+// TFLite are referred for the implementation.
 inline void ComputeInterpolationValuesInteger(
     const int32_t value, const int32_t scale_10, const bool is_half_pixel,
     const int32_t input_size, int32_t* scaled_value, int32_t* lower_bound,
@@ -530,11 +531,17 @@ inline void ComputeInterpolationValuesInteger(
       std::min((*scaled_value + (1 << 10) - 1) / (1 << 10), input_size - 1);
 }
 
+// TFLite are referred for the implementation.
 inline int Offset(const gsl::span<const int64_t>& dims_data, int i0, int i1, int i2, int i3) {
+  assert(dims_data.size() == 4);
+  assert(i0 >= 0 && i0 < dims_data[0]);
+  assert(i1 >= 0 && i1 < dims_data[1]);
+  assert(i2 >= 0 && i2 < dims_data[2]);
+  assert(i3 >= 0 && i3 < dims_data[3]);
   return static_cast<int>(((i0 * dims_data[1] + i1) * dims_data[2] + i2) * dims_data[3] + i3);
 }
 
-// Same as above but doesn't use any floating-point for the resize
+// TFLite are referred for the implementation.
 template <typename T>
 inline void NhwcUpsampleBilinearInteger(
     bool is_half_pixel, bool is_align_corners,
@@ -544,6 +551,9 @@ inline void NhwcUpsampleBilinearInteger(
     const int32_t output_height, const int32_t output_width,
     const gsl::span<const int64_t>& output_dims,
     T* output_data) {
+  assert(!is_half_pixel || !is_align_corners);
+  assert(input_dims.size() == 4);
+  assert(output_dims.size() == 4);
   int32_t height_scale_10 =
       ((1 << 10) * input_height + output_height / 2) / output_height;
   int32_t width_scale_10 =

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -119,6 +119,50 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear) {
   test.Run();
 }
 
+TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear) {
+  OpTester test("Resize", 13);
+  std::vector<float> roi{};
+  std::vector<float> scales{1.0f, 0.6f, 0.6f, 1.0f};
+
+  test.AddAttribute("mode", "linear");
+
+  constexpr int64_t N = 1, H = 2, W = 4, C = 1;
+  std::vector<float> X = {
+      1.0f, 2.0f, 3.0f, 4.0f,
+      5.0f, 6.0f, 7.0f, 8.0f};
+
+  test.AddInput<float>("X", {N, H, W, C}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("scales", {4}, scales);
+
+  std::vector<float> Y = {2.66666651f, 4.3333331f};
+
+  test.AddOutput<float>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
+  test.Run();
+}
+
+TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_int8) {
+  OpTester test("Resize", 13);
+  std::vector<float> roi{};
+  std::vector<float> scales{1.0f, 0.6f, 0.6f, 1.0f};
+
+  test.AddAttribute("mode", "linear");
+
+  constexpr int64_t N = 1, H = 2, W = 4, C = 1;
+  std::vector<int8_t> X = {
+      1, 2, 3, 4,
+      5, 6, 7, 8};
+
+  test.AddInput<int8_t>("X", {N, H, W, C}, X);
+  test.AddInput<float>("roi", {0}, roi);
+  test.AddInput<float>("scales", {4}, scales);
+
+  std::vector<int8_t> Y = {2, 4};
+
+  test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
+  test.Run();
+}
+
 // Since NNAPI(TFLite) only using the scale calulate using the input/output size
 // For the above test (ResizeOpLinearDownSampleTest_4DBilinear)
 // The output size is [1,1,2,4].*[1,1,0.6,0.6]=[1,1,1,2]
@@ -218,6 +262,35 @@ TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_4DBilinear_align_corners) {
 #endif
 }
 
+TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_align_corners_int8) {
+  // To test NNAPI EP, we need the sclaes/sizes to be in initializers
+  auto run_test = [](bool scales_in_initializer) {
+    OpTester test("Resize", 13);
+    std::vector<float> roi{};
+    std::vector<float> scales{1.0f, 0.6f, 0.6f, 1.0f};
+
+    test.AddAttribute("mode", "linear");
+    test.AddAttribute("coordinate_transformation_mode", "align_corners");
+
+    constexpr int64_t N = 1, H = 2, W = 4, C = 1;
+    std::vector<int8_t> X = {
+        1, 2, 3, 4,
+        5, 6, 7, 8};
+
+    test.AddInput<int8_t>("X", {N, H, W, C}, X);
+    test.AddInput<float>("roi", {0}, roi);
+    test.AddInput<float>("scales", {4}, scales, scales_in_initializer);
+
+    std::vector<int8_t> Y = {1, 4};
+
+    test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
+    test.Run();
+  };
+
+  run_test(false);
+  run_test(true);
+}
+
 TEST(ResizeOpTest, ResizeOpLinearDownSampleTest_2DBilinear_pytorch_half_pixel) {
   OpTester test("Resize", 13);
   std::vector<float> roi{};
@@ -279,6 +352,46 @@ TEST(ResizeOpTest, ResizeOpLinearUpSampleTest_4DBilinear_asymmetric) {
         7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 11.0f, 11.0f, 11.0f};
 
     test.AddOutput<float>("Y", {N, C, static_cast<int64_t>(H * scales[2]), static_cast<int64_t>(W * scales[3])}, Y);
+    test.Run();
+  };
+
+  run_test(false);
+  run_test(true);
+}
+
+TEST(ResizeOpTest, NhwcResizeOpLinearUpSampleTest_4DBilinear_asymmetric_int8) {
+  // To test NNAPI EP, we need the sclaes/sizes to be in initializers
+  auto run_test = [](bool scales_in_initializer) {
+    OpTester test("Resize", 13);
+    std::vector<float> roi{};
+    std::vector<float> scales{1.0f, 2.0f, 4.0f, 1.0f};
+
+    test.AddAttribute("mode", "linear");
+    test.AddAttribute("coordinate_transformation_mode", "asymmetric");
+
+    constexpr int64_t N = 2, H = 2, W = 2, C = 1;
+    std::vector<int8_t> X = {1, 3,
+                             4, 8,
+
+                             6, 2,
+                             7, 11};
+
+    test.AddInput<int8_t>("X", {N, H, W, C}, X);
+    test.AddInput<float>("roi", {0}, roi);
+    test.AddInput<float>("scales", {4}, scales, scales_in_initializer);
+
+    std::vector<int8_t> Y = {
+        1, 1, 2, 2, 3, 3, 3, 3,
+        2, 3, 4, 4, 5, 5, 5, 5,
+        4, 5, 6, 7, 8, 8, 8, 8,
+        4, 5, 6, 7, 8, 8, 8, 8,
+
+        6, 5, 4, 3, 2, 2, 2, 2,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        7, 8, 9, 10, 11, 11, 11, 11,
+        7, 8, 9, 10, 11, 11, 11, 11};
+
+    test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
     test.Run();
   };
 

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -138,7 +138,10 @@ TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear) {
   std::vector<float> Y = {2.66666651f, 4.3333331f};
 
   test.AddOutput<float>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-  test.Run();
+  //CUDA: result mismatch due to not implementing NHWC support
+  //ROCm: results mismatch
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kCudaExecutionProvider, kRocmExecutionProvider});
 }
 
 TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_int8) {
@@ -284,7 +287,8 @@ TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_align_corners_int
     std::vector<int8_t> Y = {1, 4};
 
     test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-    test.Run();
+    //TensorRT: results mismatch
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
 
   run_test(false);
@@ -392,7 +396,8 @@ TEST(ResizeOpTest, NhwcResizeOpLinearUpSampleTest_4DBilinear_asymmetric_int8) {
         7, 8, 9, 10, 11, 11, 11, 11};
 
     test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-    test.Run();
+    //TensorRT: results mismatch
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
 
   run_test(false);

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -138,8 +138,8 @@ TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear) {
   std::vector<float> Y = {2.66666651f, 4.3333331f};
 
   test.AddOutput<float>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-  //CUDA: result mismatch due to not implementing NHWC support
-  //ROCm: results mismatch
+  // CUDA: result mismatch due to not implementing NHWC support
+  // ROCm: results mismatch
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kCudaExecutionProvider, kRocmExecutionProvider});
 }
@@ -166,7 +166,7 @@ TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_int8) {
   test.Run();
 }
 
-// Since NNAPI(TFLite) only using the scale calulate using the input/output size
+// Since NNAPI(TFLite) only using the scale calculate using the input/output size
 // For the above test (ResizeOpLinearDownSampleTest_4DBilinear)
 // The output size is [1,1,2,4].*[1,1,0.6,0.6]=[1,1,1,2]
 // NNAPI will recaluclate the scales as the output size divided by input size
@@ -287,7 +287,7 @@ TEST(ResizeOpTest, NhwcResizeOpLinearDownSampleTest_4DBilinear_align_corners_int
     std::vector<int8_t> Y = {1, 4};
 
     test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-    //TensorRT: results mismatch
+    // TensorRT: results mismatch
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
 
@@ -396,7 +396,7 @@ TEST(ResizeOpTest, NhwcResizeOpLinearUpSampleTest_4DBilinear_asymmetric_int8) {
         7, 8, 9, 10, 11, 11, 11, 11};
 
     test.AddOutput<int8_t>("Y", {N, static_cast<int64_t>(H * scales[1]), static_cast<int64_t>(W * scales[2]), C}, Y);
-    //TensorRT: results mismatch
+    // TensorRT: results mismatch
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
   };
 


### PR DESCRIPTION
Use fixed point arithmetic for NhwcUpsampleBilinear to avoid floating point
computation. TFLite are referred for the implementation.
