### PR TITLE
Fix armnn provider

### DIFF
--- a/onnxruntime/core/providers/armnn/nn/pool.cc
+++ b/onnxruntime/core/providers/armnn/nn/pool.cc
@@ -30,7 +30,7 @@ thread_local std::map<OpKernel*, armnn::NetworkId> MaxPoolV8<T>::maxPoolLayers;
 template <typename T>
 armnn::IRuntimePtr MaxPoolV8<T>::run = armnn::IRuntimePtr(nullptr, nullptr);
 
-armnn::Pooling2dDescriptor createDescriptor(std::vector<int64_t> pads, std::vector<int64_t> strides, std::vector<int64_t> kernel_shape, armnn::PoolingAlgorithm pool_type, onnxruntime::PoolAttributes pool_attrs){
+armnn::Pooling2dDescriptor createDescriptor(TensorShapeVector pads, TensorShapeVector strides, TensorShapeVector kernel_shape, armnn::PoolingAlgorithm pool_type, onnxruntime::PoolAttributes pool_attrs){
 
   std::vector<int64_t> armnnStrides(2);
   armnnStrides[0] = (strides.size() == 2) ? strides[1] : 1;
@@ -91,7 +91,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& x_shape = X->Shape();
 
-  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  auto dilations(PoolBase::pool_attrs_.dilations);
   std::vector<int64_t> armnnDilations(2);
   armnnDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   armnnDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
@@ -108,10 +108,10 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
     return s;
   }
 
-  std::vector<int64_t> pads = PoolBase::pool_attrs_.pads;
-  std::vector<int64_t> strides = PoolBase::pool_attrs_.strides;
-  std::vector<int64_t> kernel_shape = PoolBase::pool_attrs_.kernel_shape;
-
+  auto pads = PoolBase::pool_attrs_.pads;
+  auto strides = PoolBase::pool_attrs_.strides;
+  auto kernel_shape = PoolBase::pool_attrs_.kernel_shape;
+  
   if (PoolBase::pool_attrs_.global_pooling) {
     const auto& input_dims = x_shape.GetDims();
     kernel_shape.assign(input_dims.begin() + 2, input_dims.end());
@@ -119,7 +119,7 @@ Status Pool<T, PoolType>::Compute(OpKernelContext* context) const {
     pads.assign(kernel_shape.size(), 0);
   }
 
-  std::vector<int64_t> output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  auto output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
   Tensor* Y = context->Output(0, TensorShape(output_dims));
 
   const T* x_data = X->template Data<T>();
@@ -200,7 +200,7 @@ Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
   const TensorShape& x_shape = X->Shape();
 
-  std::vector<int64_t> dilations(PoolBase::pool_attrs_.dilations);
+  auto dilations(PoolBase::pool_attrs_.dilations);
   std::vector<int64_t> armnnDilations(2);
   armnnDilations[0] = (dilations.size() == 2) ? dilations[1] : 1;
   armnnDilations[1] = (!dilations.empty()) ? dilations[0] : 1;
@@ -211,9 +211,9 @@ Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
     return s;
   }
 
-  std::vector<int64_t> pads = PoolBase::pool_attrs_.pads;
-  std::vector<int64_t> strides = PoolBase::pool_attrs_.strides;
-  std::vector<int64_t> kernel_shape = PoolBase::pool_attrs_.kernel_shape;
+  auto pads = PoolBase::pool_attrs_.pads;
+  auto strides = PoolBase::pool_attrs_.strides;
+  auto kernel_shape = PoolBase::pool_attrs_.kernel_shape;
 
   if (PoolBase::pool_attrs_.global_pooling) {
     const auto& input_dims = x_shape.GetDims();
@@ -222,7 +222,7 @@ Status MaxPoolV8<T>::Compute(OpKernelContext* context) const {
     pads.assign(kernel_shape.size(), 0);
   }
 
-  std::vector<int64_t> output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  auto output_dims = PoolBase::pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
   Tensor* Y = context->Output(0, TensorShape(output_dims));
 
   const T* x_data = X->template Data<T>();

--- a/onnxruntime/core/providers/armnn/tensor/concat.cc
+++ b/onnxruntime/core/providers/armnn/tensor/concat.cc
@@ -39,7 +39,7 @@ Status Concat<T>::Compute(OpKernelContext* ctx) const {
   LOGS_DEFAULT(VERBOSE) << "axis: " << axis_;
   LOGS_DEFAULT(VERBOSE) << std::endl;
 
-  std::vector<int64_t> output_dims = input_tensors[0]->Shape().GetDims();
+  auto output_dims = input_tensors[0]->Shape().AsShapeVector();
 
   // 'Concat' mode
   if (!is_stack_) {

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -702,7 +702,7 @@ TEST_P(ModelTest, Run) {
 #endif
 #ifdef USE_ARMNN
       else if (provider_name == "armnn") {
-        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_ArmNN(ortso));
+        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_ArmNN(ortso, 0));
       }
 #endif
       OrtSession* ort_session;


### PR DESCRIPTION
**Description**
Fixes some types in pool.cc, conv.cc, and concat.cc to match recent definitions of `ConvPadVector` and `TensorShapeVector`
Builds on top of #11448 which provides a similar fix for the ACL EP

**Motivation and Context**
- Fixes compilation of the ArmNN EP