### PR TITLE
Create OrtEnv earlier in C# code 

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -49,6 +49,14 @@ namespace Microsoft.ML.OnnxRuntime
         public SessionOptions()
             : base(IntPtr.Zero, true)
         {
+            // Ensure we have an OrtEnv instance so the default logger is available.
+            // Calls via NativeMethods made prior to InferenceSession creation require the default logger for error
+            // output. 
+            // e.g. MakeSessionOptionWithCudaProvider calls AppendExecutionProvider_CUDA which calls 
+            //      NativeMethods.OrtSessionOptionsAppendExecutionProvider_CUDA
+            var ortEnv = OrtEnv.Instance();
+
+            // create the SessionOptions instance
             NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionOptions(out handle));
         }
 


### PR DESCRIPTION
**Description**: 
Trigger creation of OrtEnv in the C# SessionOptions constructor so that the default logger is available if any calls to NativeMethods made by SessionOptions fail internally.

Currently we do this in the C# InferenceSession class, but that is too late for any errors that come from adding EPs to the session options.

**Motivation and Context**
#11572