### PR TITLE
Fix torch cpp ext build when CPU wheel is installed but GPU card is present

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,6 @@ exclude =
     ./orttraining,
     # ignore server code for now
     ./server,
+    # ignore issues from different git branches
+    ./.git,
 ignore = W503, E203


### PR DESCRIPTION
When a GPU hardware is detected, `ORTModule` tries to compile CUDA extensions, even when both PyTorch and ONNX Runtime are CPU-only. The result is a Torch C++ extensions build failure. This PR fixes this by only building CUDA extensions if `torch.cuda.is_available()` returns `True` *and* the installed ORT has CUDA/ROCM.  

Also there is a minor improvement for ATen operator that allows both "::op" and "aten::op" name for operators