### PR TITLE
Memory optimization in LongFormer Attention

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
@@ -107,7 +107,7 @@ Status LongformerAttention<T>::ComputeInternal(OpKernelContext* context) const {
   int k = hidden_size;
 
   size_t qkv_size = batch_size * sequence_length * 3 * hidden_size * element_size;
-  auto gemm_buffer = GetScratchBuffer<T>(qkv_size);
+  auto gemm_buffer = GetScratchBuffer<void>(qkv_size);
 
   typedef typename ToCudaType<T>::MappedType CudaT;
   CudaT one = ToCudaType<T>::FromFloat(1.0f);
@@ -148,7 +148,7 @@ Status LongformerAttention<T>::ComputeInternal(OpKernelContext* context) const {
   // Fully connection for global projection.
   // Note that Q only need handle global query tokens if we split GEMM to global Q/K/V separately.
   // When there is no global token, need not run glboal GEMM.
-  auto global_gemm_buffer = GetScratchBuffer<T>(max_num_global > 0 ? qkv_size : 0);
+  auto global_gemm_buffer = GetScratchBuffer<void>(max_num_global > 0 ? qkv_size : 0);
 
   if (max_num_global > 0) {
     CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(


### PR DESCRIPTION
`qkv_size` already has `element_size` cooked into it. While getting scratch buffer of that size, we don't need to template again on the element type parameter `T`. It should decrease the peak memory memory usage by a factor of the element size.
