### PR TITLE
Add runtime options API for ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -14,7 +14,6 @@ from onnxruntime import set_seed
 from onnxruntime.capi import build_and_package_info as ort_info
 
 from ._fallback import ORTModuleFallbackException, ORTModuleInitException, _FallbackPolicy, wrap_exception
-from ._graph_execution_manager import _SkipCheck
 from .torch_cpp_extensions import is_installed as is_torch_cpp_extensions_installed
 
 
@@ -49,9 +48,6 @@ ORTMODULE_FALLBACK_POLICY = (
 )
 ORTMODULE_FALLBACK_RETRY = False
 ORTMODULE_IS_DETERMINISTIC = torch.are_deterministic_algorithms_enabled()
-ORTMODULE_SKIPCHECK_POLICY = _SkipCheck(
-    _SkipCheck.SKIP_CHECK_DEVICE | _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT
-)
 ONNXRUNTIME_CUDA_VERSION = ort_info.cuda_version if hasattr(ort_info, "cuda_version") else None
 ONNXRUNTIME_ROCM_VERSION = ort_info.rocm_version if hasattr(ort_info, "rocm_version") else None
 

--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -6,12 +6,15 @@
 import os
 import sys
 import warnings
+
 import torch
 from packaging import version
 
 from onnxruntime import set_seed
 from onnxruntime.capi import build_and_package_info as ort_info
-from ._fallback import _FallbackPolicy, ORTModuleFallbackException, ORTModuleInitException, wrap_exception
+
+from ._fallback import ORTModuleFallbackException, ORTModuleInitException, _FallbackPolicy, wrap_exception
+from ._graph_execution_manager import _SkipCheck
 from .torch_cpp_extensions import is_installed as is_torch_cpp_extensions_installed
 
 
@@ -45,7 +48,9 @@ ORTMODULE_FALLBACK_POLICY = (
 )
 ORTMODULE_FALLBACK_RETRY = False
 ORTMODULE_IS_DETERMINISTIC = torch.are_deterministic_algorithms_enabled()
-
+ORTMODULE_SKIPCHECK_POLICY = _SkipCheck(
+    _SkipCheck.SKIP_CHECK_DEVICE | _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT
+)
 ONNXRUNTIME_CUDA_VERSION = ort_info.cuda_version if hasattr(ort_info, "cuda_version") else None
 ONNXRUNTIME_ROCM_VERSION = ort_info.rocm_version if hasattr(ort_info, "rocm_version") else None
 
@@ -118,6 +123,8 @@ def _are_deterministic_algorithms_enabled():
     return ORTMODULE_IS_DETERMINISTIC
 
 
+from .debug_options import DebugOptions, LogLevel  # noqa: E402
+from .runtime_options import RuntimeOptions  # noqa: E402
+
 # ORTModule must be loaded only after all validation passes
 from .ortmodule import ORTModule  # noqa: E402
-from .debug_options import DebugOptions, LogLevel  # noqa: E402

--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -34,7 +34,8 @@ def _defined_from_envvar(name, default_value, warn=True):
 ################################################################################
 # All global constant goes here, before ORTModule is imported ##################
 # NOTE: To *change* values in runtime, import onnxruntime.training.ortmodule and
-# assign them new values. Importing them directly do not propagate changes.
+# assign them new values, or use the runtime_options option to ORTModule.
+# Importing them directly do not propagate changes.
 ################################################################################
 ONNX_OPSET_VERSION = 14
 MINIMUM_RUNTIME_PYTORCH_VERSION_STR = "1.8.1"
@@ -124,7 +125,7 @@ def _are_deterministic_algorithms_enabled():
 
 
 from .debug_options import DebugOptions, LogLevel  # noqa: E402
-from .runtime_options import RuntimeOptions  # noqa: E402
 
 # ORTModule must be loaded only after all validation passes
 from .ortmodule import ORTModule  # noqa: E402
+from .runtime_options import RuntimeOptions  # noqa: E402

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -99,7 +99,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         # Update constant ONNX_OPSET_VERSION with env var ORTMODULE_ONNX_OPSET_VERSION
         # if defined.
         ortmodule.ONNX_OPSET_VERSION = ortmodule._defined_from_envvar(
-            "ORTMODULE_ONNX_OPSET_VERSION", runtime_options.exporter_options.opset_version, warn=True
+            "ORTMODULE_ONNX_OPSET_VERSION", runtime_options.exporter_options.onnx_opset_version, warn=True
         )
 
         # TrainingAgent or InferenceAgent
@@ -107,7 +107,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
         # default is enabled, if not define in os env
-        self._skip_check = runtime_options.skipcheck_policy
+        self._skip_check = ortmodule.ORTMODULE_SKIPCHECK_POLICY
         if os.getenv("ORTMODULE_SKIPCHECK_POLICY") is not None:
             self._skip_check = reduce(
                 lambda x, y: x | y,

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -107,7 +107,9 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
         # default is enabled, if not define in os env
-        self._skip_check = ortmodule.ORTMODULE_SKIPCHECK_POLICY
+        self._skip_check = _SkipCheck(
+            _SkipCheck.SKIP_CHECK_DEVICE | _SkipCheck.SKIP_CHECK_BUILD_GRADIENT | _SkipCheck.SKIP_CHECK_EXECUTION_AGENT
+        )
         if os.getenv("ORTMODULE_SKIPCHECK_POLICY") is not None:
             self._skip_check = reduce(
                 lambda x, y: x | y,

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -99,7 +99,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         # Update constant ONNX_OPSET_VERSION with env var ORTMODULE_ONNX_OPSET_VERSION
         # if defined.
         ortmodule.ONNX_OPSET_VERSION = ortmodule._defined_from_envvar(
-            "ORTMODULE_ONNX_OPSET_VERSION", self._runtime_options.exporter_options.opset_version, warn=True
+            "ORTMODULE_ONNX_OPSET_VERSION", runtime_options.exporter_options.opset_version, warn=True
         )
 
         # TrainingAgent or InferenceAgent
@@ -107,7 +107,7 @@ class GraphExecutionManager(GraphExecutionInterface):
 
         # indicators of some logic have been executed previously thus could be skipped for faster training
         # default is enabled, if not define in os env
-        self._skip_check = ortmodule.ORTMODULE_SKIPCHECK_POLICY
+        self._skip_check = runtime_options.skipcheck_policy
         if os.getenv("ORTMODULE_SKIPCHECK_POLICY") is not None:
             self._skip_check = reduce(
                 lambda x, y: x | y,
@@ -317,6 +317,8 @@ class GraphExecutionManager(GraphExecutionInterface):
         session_options.use_deterministic_compute = _are_deterministic_algorithms_enabled()
         # default to PRIORITY_BASED execution order
         session_options.execution_order = onnxruntime.ExecutionOrder.PRIORITY_BASED
+        if self._runtime_options.graph_optimization_level is not None:
+            session_options.graph_optimization_level = self._runtime_options.graph_optimization_level
         # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
         session_options.log_severity_level = int(self._debug_options.logging.log_level)
 

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager_factory.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager_factory.py
@@ -3,16 +3,19 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from ._training_manager import TrainingManager
-from ._inference_manager import InferenceManager
-from .debug_options import DebugOptions
 from ._fallback import _FallbackManager
+from ._inference_manager import InferenceManager
+from ._training_manager import TrainingManager
+from .debug_options import DebugOptions
+from .runtime_options import RuntimeOptions
 
 
 class GraphExecutionManagerFactory(object):
-    def __init__(self, module, debug_options: DebugOptions, fallback_manager: _FallbackManager):
-        self._training_manager = TrainingManager(module, debug_options, fallback_manager)
-        self._inference_manager = InferenceManager(module, debug_options, fallback_manager)
+    def __init__(
+        self, module, debug_options: DebugOptions, runtime_options: RuntimeOptions, fallback_manager: _FallbackManager
+    ):
+        self._training_manager = TrainingManager(module, debug_options, runtime_options, fallback_manager)
+        self._inference_manager = InferenceManager(module, debug_options, runtime_options, fallback_manager)
 
     def __call__(self, is_training):
         if is_training:

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -3,15 +3,18 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils, _io, _logger, _are_deterministic_algorithms_enabled, _use_deterministic_algorithms
-from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo, _SkipCheck
-from ._execution_agent import InferenceAgent
-from .debug_options import DebugOptions
-from ._fallback import ORTModuleFallbackException, _FallbackPolicy, _FallbackManager
+import warnings
+
+import torch
 
 from onnxruntime.capi import _pybind_state as C
-import torch
-import warnings
+
+from . import _are_deterministic_algorithms_enabled, _io, _logger, _use_deterministic_algorithms, _utils
+from ._execution_agent import InferenceAgent
+from ._fallback import ORTModuleFallbackException, _FallbackManager, _FallbackPolicy
+from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo, _SkipCheck
+from .debug_options import DebugOptions
+from .runtime_options import RuntimeOptions
 
 
 class InferenceManager(GraphExecutionManager):
@@ -20,8 +23,10 @@ class InferenceManager(GraphExecutionManager):
     InferenceManager is resposible for building and running the forward graph of the inference model
     """
 
-    def __init__(self, model, debug_options: DebugOptions, fallback_manager: _FallbackManager):
-        super().__init__(model, debug_options, fallback_manager)
+    def __init__(
+        self, model, debug_options: DebugOptions, runtime_options: RuntimeOptions, fallback_manager: _FallbackManager
+    ):
+        super().__init__(model, debug_options, runtime_options, fallback_manager)
         self._export_mode = torch.onnx.TrainingMode.EVAL
 
     @staticmethod

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_factory.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_factory.py
@@ -2,13 +2,16 @@
 # Licensed under the MIT License.
 # _torch_module_factory.py
 
+from ._fallback import _FallbackManager
 from ._torch_module_ort import TorchModuleORT
 from .debug_options import DebugOptions
-from ._fallback import _FallbackManager
+from .runtime_options import RuntimeOptions
 
 
 class TorchModuleFactory:
-    def __call__(self, module, debug_options: DebugOptions, fallback_manager: _FallbackManager):
+    def __call__(
+        self, module, debug_options: DebugOptions, runtime_options: RuntimeOptions, fallback_manager: _FallbackManager
+    ):
         """Creates a TorchModule instance based on the input module."""
 
-        return TorchModuleORT(module, debug_options, fallback_manager)
+        return TorchModuleORT(module, debug_options, runtime_options, fallback_manager)

--- a/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
+++ b/orttraining/orttraining/python/training/ortmodule/_torch_module_ort.py
@@ -4,6 +4,7 @@
 
 from . import _io, _utils
 from .debug_options import DebugOptions
+from .runtime_options import RuntimeOptions
 from ._graph_execution_manager_factory import GraphExecutionManagerFactory
 from ._torch_module_interface import TorchModuleInterface
 from ._fallback import _FallbackManager, ORTModuleTorchModelException, wrap_exception
@@ -16,13 +17,21 @@ T = TypeVar("T", bound="torch.nn.Module")
 
 
 class TorchModuleORT(TorchModuleInterface):
-    def __init__(self, module: torch.nn.Module, debug_options: DebugOptions, fallback_manager: _FallbackManager):
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        debug_options: DebugOptions,
+        runtime_options: RuntimeOptions,
+        fallback_manager: _FallbackManager,
+    ):
         super().__init__(module)
         self._flattened_module = _io._FlattenedModule(module)
 
         _utils.patch_torch_module_ort_forward_method(self)
 
-        self._execution_manager = GraphExecutionManagerFactory(self._flattened_module, debug_options, fallback_manager)
+        self._execution_manager = GraphExecutionManagerFactory(
+            self._flattened_module, debug_options, runtime_options, fallback_manager
+        )
 
     def _apply(self, fn):
         """Override original method to delegate execution to the flattened PyTorch user module"""

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -15,6 +15,7 @@ from ._execution_agent import TrainingAgent
 from ._fallback import ORTModuleFallbackException, _FallbackManager, _FallbackPolicy
 from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo, _SkipCheck
 from .debug_options import DebugOptions
+from .runtime_options import RuntimeOptions
 
 
 class TrainingManager(GraphExecutionManager):
@@ -23,8 +24,10 @@ class TrainingManager(GraphExecutionManager):
     TrainingManager is responsible for building and running the forward and backward graph of the training model
     """
 
-    def __init__(self, model, debug_options: DebugOptions, fallback_manager: _FallbackManager):
-        super().__init__(model, debug_options, fallback_manager)
+    def __init__(
+        self, model, debug_options: DebugOptions, runtime_options: RuntimeOptions, fallback_manager: _FallbackManager
+    ):
+        super().__init__(model, debug_options, runtime_options, fallback_manager)
         self._export_mode = torch.onnx.TrainingMode.TRAINING
         self._forward_class = self._create_autofunction_class()
 

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -59,7 +59,7 @@ class ORTModule(torch.nn.Module):
 
         # Fallback settings
         self._fallback_manager = _FallbackManager(
-            pytorch_module=module, policy=runtime_options.fallback_policy, retry=runtime_options.fallback_retry
+            pytorch_module=module, policy=ortmodule.ORTMODULE_FALLBACK_POLICY, retry=ortmodule.ORTMODULE_FALLBACK_RETRY
         )
 
         try:

--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -59,7 +59,7 @@ class ORTModule(torch.nn.Module):
 
         # Fallback settings
         self._fallback_manager = _FallbackManager(
-            pytorch_module=module, policy=ortmodule.ORTMODULE_FALLBACK_POLICY, retry=ortmodule.ORTMODULE_FALLBACK_RETRY
+            pytorch_module=module, policy=runtime_options.fallback_policy, retry=runtime_options.fallback_retry
         )
 
         try:

--- a/orttraining/orttraining/python/training/ortmodule/runtime_options.py
+++ b/orttraining/orttraining/python/training/ortmodule/runtime_options.py
@@ -2,12 +2,8 @@
 # Licensed under the MIT License.
 # runtime_options.py
 
-import os
-
 from onnxruntime import GraphOptimizationLevel
 from onnxruntime.training import ortmodule
-
-from ._fallback import _FallbackPolicy
 
 
 class _ExporterOptions:

--- a/orttraining/orttraining/python/training/ortmodule/runtime_options.py
+++ b/orttraining/orttraining/python/training/ortmodule/runtime_options.py
@@ -141,7 +141,9 @@ class RuntimeOptions:
         export_extra_args={},
         enable_custom_autograd=False,
         disable_custom_ops=False,
+        graph_optimization_level=None,
         fallback_policy=ortmodule.ORTMODULE_FALLBACK_POLICY,
+        fallback_retry=ortmodule.ORTMODULE_FALLBACK_RETRY,
         skipcheck_policy=ortmodule.ORTMODULE_SKIPCHECK_POLICY,
     ):
         self._exporter_options = _ExporterOptions(
@@ -156,8 +158,11 @@ class RuntimeOptions:
 
         if enable_custom_autograd:
             ortmodule._custom_autograd_function()
+
         self._disable_custom_ops = disable_custom_ops
+        self._graph_optimization_level = graph_optimization_level
         self._fallback_policy = fallback_policy
+        self._fallback_retry = fallback_retry
         self._skipcheck_policy = skipcheck_policy
 
     @property
@@ -171,3 +176,27 @@ class RuntimeOptions:
         """Accessor for the ORTModule flag to disable custom ops."""
 
         return self._disable_custom_ops
+
+    @property
+    def graph_optimization_level(self):
+        """Accessor for the ORTModule graph optimization level."""
+
+        return self._graph_optimization_level
+
+    @property
+    def fallback_policy(self):
+        """Accessor for the ORTModule fallback policy."""
+
+        return self._fallback_policy
+
+    @property
+    def fallback_retry(self):
+        """Accessor for the ORTModule option for fallback retry."""
+
+        return self._fallback_retry
+
+    @property
+    def skipcheck_policy(self):
+        """Accessor for the ORTModule skipcheck policy."""
+
+        return self._skipcheck_policy

--- a/orttraining/orttraining/python/training/ortmodule/runtime_options.py
+++ b/orttraining/orttraining/python/training/ortmodule/runtime_options.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# runtime_options.py
+
+import os
+
+from onnxruntime.training import ortmodule
+
+from ._fallback import _FallbackPolicy
+
+
+class _ExporterOptions:
+    """Configurable option for PyTorch ONNX exporter."""
+
+    _path_environment_key = "ORTMODULE_SAVE_ONNX_PATH"
+
+    def __init__(
+        self,
+        opset_version,
+        do_constant_folding,
+        export_modules_as_functions,
+        export_params,
+        keep_initializers_as_inputs,
+        use_static_shapes,
+        exporter_extra_args,
+    ):
+        self._opset_version, self._export_modules_as_functions, self._exporter_extra_args = self._validate(
+            opset_version, export_modules_as_functions, exporter_extra_args
+        )
+
+        self._do_constant_folding = self._validate_and_extract_flag(do_constant_folding, "do_constant_folding")
+        self._export_params = self._validate_and_extract_flag(export_params, "export_params")
+        self._keep_initializers_as_inputs = self._validate_and_extract_flag(
+            keep_initializers_as_inputs, "keep_initializers_as_inputs"
+        )
+        self._use_static_shapes = self._validate_and_extract_flag(use_static_shapes, "use_static_shapes")
+
+    def _validate_and_extract_flag(self, flag, str):
+        # check if flag is an instance of Boolean
+        if not isinstance(flag, bool):
+            raise TypeError(f"Expected {str} of type bool, got {type(flag)}.")
+        return flag
+
+    def _validate(self, opset_version, export_modules_as_functions, exporter_extra_args):
+        # check if opset_version is an int
+        if not isinstance(opset_version, int):
+            raise TypeError(f"Expected opset_version of type int, got {type(opset_version)}.")
+
+        if export_modules_as_functions and opset_version < 15:
+            raise ValueError(
+                "`export_modules_as_functions` is not supported for `opset_version` < 15."
+                "This is because `opset_version` < 15 implies IR version < 8, which means "
+                "no local function support. "
+            )
+
+        is_bool = isinstance(export_modules_as_functions, bool)
+        is_set = isinstance(export_modules_as_functions, set) and len(export_modules_as_functions) > 0
+        if not (is_bool or is_set):
+            raise TypeError(
+                "Expected export_modules_as_functions of type bool or set of type of nn.Module,"
+                f"got {type(export_modules_as_functions)}."
+            )
+        if is_set:
+            for v in export_modules_as_functions:
+                if not isinstance(v, type):
+                    raise TypeError(f"Expected export_modules_as_functions item of type of nn.Module, got {type(v)}.")
+
+        if not isinstance(exporter_extra_args, dict):
+            raise TypeError(f"Expected exporter_extra_args of type dict, got {type(exporter_extra_args)}.")
+
+        return opset_version, export_modules_as_functions, exporter_extra_args
+
+    @property
+    def opset_version(self):
+        """Accessor for ONNX opset version configuration."""
+
+        return self._opset_version
+
+    @property
+    def do_constant_folding(self):
+        """Accessor for exporter flag to enable constant folding."""
+
+        return self._do_constant_folding
+
+    @property
+    def export_modules_as_functions(self):
+        """Accessor for exporter option to export modules as functions."""
+
+        return self._export_modules_as_functions
+
+    @property
+    def export_params(self):
+        """Accessor for exporter flag to export parameters."""
+
+        return self._export_params
+
+    @property
+    def keep_initializers_as_inputs(self):
+        """Accessor for exporter flag to keep initializers as inputs."""
+
+        return self._keep_initializers_as_inputs
+
+    @property
+    def use_static_shapes(self):
+        """Accessor for exporter flag to use static shapes."""
+
+        return self._use_static_shapes
+
+    @property
+    def exporter_extra_args(self):
+        """Accessor for extra arguments to the exporter."""
+
+        return self._exporter_extra_args
+
+
+class RuntimeOptions:
+    """Configurable runtime options for ORTModule.
+
+    Args:
+        save_onnx (:obj:`bool`, optional): Configure ORTModule to save onnx models. Defaults to False.
+            The output directory of the onnx models by default is set to the current working directory.
+            To change the output directory, the environment variable "ORTMODULE_SAVE_ONNX_PATH" can be
+            set to the destination directory path.
+
+    Raises:
+        OSError: If save_onnx is True and output directory is not writable.
+        TypeError: If save_onnx is True and name_prefix is not a valid string. Or if
+            log_level is not an instance of LogLevel.
+        ValueError: If save_onnx is True and name_prefix is an empty string.
+
+    """
+
+    def __init__(
+        self,
+        opset_version=ortmodule.ONNX_OPSET_VERSION,
+        do_constant_folding=False,
+        export_modules_as_functions=False,
+        export_params=False,
+        keep_initializers_as_inputs=True,
+        use_static_shapes=False,
+        export_extra_args={},
+        enable_custom_autograd=False,
+        disable_custom_ops=False,
+        fallback_policy=ortmodule.ORTMODULE_FALLBACK_POLICY,
+        skipcheck_policy=ortmodule.ORTMODULE_SKIPCHECK_POLICY,
+    ):
+        self._exporter_options = _ExporterOptions(
+            opset_version,
+            do_constant_folding,
+            export_modules_as_functions,
+            export_params,
+            keep_initializers_as_inputs,
+            use_static_shapes,
+            export_extra_args,
+        )
+
+        if enable_custom_autograd:
+            ortmodule._custom_autograd_function()
+        self._disable_custom_ops = disable_custom_ops
+        self._fallback_policy = fallback_policy
+        self._skipcheck_policy = skipcheck_policy
+
+    @property
+    def exporter_options(self):
+        """Accessor for the exporter configuration."""
+
+        return self._exporter_options
+
+    @property
+    def disable_custom_ops(self):
+        """Accessor for the ORTModule flag to disable custom ops."""
+
+        return self._disable_custom_ops

--- a/orttraining/orttraining/python/training/ortmodule/runtime_options.py
+++ b/orttraining/orttraining/python/training/ortmodule/runtime_options.py
@@ -138,7 +138,7 @@ class RuntimeOptions:
         use_static_shapes (:obj:`bool`, optional, default False): ORTModule exporter flag to use static output shapes.
             By default the exported model will have dynamic shapes for all input and output tensors.
 
-        export_extra_args (:obj:`dict`, optional, default Empty): Extra arguments to specify to the ORTModule Torch ONNX exporter.
+        exporter_extra_args (:obj:`dict`, optional, default Empty): Extra arguments to specify to the ORTModule Torch ONNX exporter.
             Refer to https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for documentation on exporter arguments.
 
         enable_custom_autograd (:obj:`bool`, optional, default False): Enable custom autograd.Function support for ORTModule.
@@ -168,7 +168,7 @@ class RuntimeOptions:
         export_params=False,
         keep_initializers_as_inputs=True,
         use_static_shapes=False,
-        export_extra_args={},
+        exporter_extra_args={},
         enable_custom_autograd=False,
         disable_custom_ops=False,
         graph_optimization_level=None,
@@ -180,7 +180,7 @@ class RuntimeOptions:
             export_params,
             keep_initializers_as_inputs,
             use_static_shapes,
-            export_extra_args,
+            exporter_extra_args,
         )
 
         if enable_custom_autograd:

--- a/orttraining/orttraining/python/training/ortmodule/runtime_options.py
+++ b/orttraining/orttraining/python/training/ortmodule/runtime_options.py
@@ -188,11 +188,12 @@ class RuntimeOptions:
 
         self._disable_custom_ops = disable_custom_ops
 
-        if not isinstance(graph_optimization_level, GraphOptimizationLevel):
-            raise TypeError(
-                "Expected graph_optimization_level of type onnxruntime.GraphOptimizationLevel, "
-                f"got {type(graph_optimization_level)}."
-            )
+        if graph_optimization_level is not None:
+            if not isinstance(graph_optimization_level, GraphOptimizationLevel):
+                raise TypeError(
+                    "Expected graph_optimization_level of type onnxruntime.GraphOptimizationLevel, "
+                    f"got {type(graph_optimization_level)}."
+                )
 
         self._graph_optimization_level = graph_optimization_level
 


### PR DESCRIPTION
**Description**: Add runtime options API for ORTModule

**Motivation and Context**
- Setting any runtime options in ORTModule currently requires either using an internal API or using undocumented environment variables. This PR introduces a `runtime_options` argument to `ORTModule` which can be used to set several options related to the ORTModule (torch-onnx) exporter or the runtime session. This is similar to the corresponding `debug_options` argument currently present to set debug options in ORTModule.

The available runtime options at the moment are:
- **onnx_opset_version** (`int`, optional, default 14): Configure ORTModule exporter to use this ONNX opset version.
            To change the opset version, the environment variable "ORTMODULE_ONNX_OPSET_VERSION" can also be used.
- **do_constant_folding** (`bool`, optional): Configure ORTModule export to apply the constant-folding optimization.
            Defaults to False. Constant-folding will replace some of the ops that have all constant inputs with pre-computed
            constant nodes.
- **export_modules_as_functions** (`bool` or set of python:type of nn.Module, optional, default False): ORTModule exporter
            flag to enable exporting all nn.Module forward calls as local functions in ONNX. Or a set to indicate the particular
            types of modules to export as local functions in ONNX. This feature requires onnx_opset_version >= 15, otherwise the
            export will fail. This is because onnx_opset_version < 15 implies IR version < 8, which means no local function support.
- **export_params** (`bool`, optional, default False): ORTModule exporter flag to export all model parameters.
            If True, all parameters will be exported. Set this to False if you want to export an untrained model. In this case,
            the exported model will first take all of its parameters as arguments.
- **keep_initializers_as_inputs** (`bool`, optional, default True): ORTModule exporter flag to keep initializers as inputs.
            If True, all the initializers (typically corresponding to parameters) in the exported graph will also be added as inputs
            to the graph. If False, initializers are not added as inputs to the graph, and only the non-parameter inputs are added as inputs.
            This may allow for better optimizations (e.g. constant folding) by backends/runtimes.
- **use_static_shapes** (`bool`, optional, default False): ORTModule exporter flag to use static output shapes.
            By default the exported model will have dynamic shapes for all input and output tensors.
- **exporter_extra_args** (`dict`, optional, default Empty): Extra arguments to specify to the ORTModule Torch ONNX exporter.
            Refer to https://pytorch.org/docs/stable/onnx.html#torch.onnx.export for documentation on exporter arguments.
- **enable_custom_autograd** (:obj:`bool`, optional, default False): Enable custom autograd.Function support for ORTModule.
            This will enable ``autograd.Function``s to be exported as ``PythonOp`` in ONNX.
- **disable_custom_ops** (`bool`, optional, default False): Disable custom ops support in ORTModule.
            This flag will disable custom ATen ops and custom gradients in ORTModule.
* **graph_optimization_level** (`onnxruntime.GraphOptimizationLevel`, optional, default None): Choose the graph optimization
            level for ORTModule runtime session. The available graph optimization levels are:
  - ``onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL``: Disable all optimizations
  - ``onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC``: Constant folding and other optimizations that only use ONNX operators
  - ``onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED``: Optimizations using custom operators, excluding NCHWc and NHWC layout optimizers
  - ``onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL``: Enable all optimizations (default)
 
### Raises:
- **TypeError**: If an invalid type for a runtime option is specified.
- **ValueError**: If an invalid runtime option value is specified. 