### PR TITLE
Update .flake8 to exclude .git directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,8 @@ per-file-ignores =
     __init__.py:F401
 format = [flake8 PEP8 ERROR] %(path)s:%(row)d:%(col)d: %(code)s %(text)s
 exclude =
+    # ignore the .git directory
+    ./.git,
     # ignore default build directory
     ./build,
     # ignore external dependency files


### PR DESCRIPTION
**Description**: This change helps to avoid CI failure caused by any python script being scanned ( eg. ./.git/logs/refs/remotes/<any_branch>/unformatted.py)

recent failures that blocks CI: https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=164&_a=summary