### PR TITLE
Fix build errors when building with enable_memory_profile

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -886,7 +886,7 @@ class PlannerImpl {
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
       size_t max_pc = plan_.execution_plan.size();
       std::string node_arg_name;
-      ort_value_name_idx_map_.GetName(static_cast<int>(i), node_arg_name);
+      ORT_RETURN_IF_ERROR(ort_value_name_idx_map_.GetName(static_cast<int>(i), node_arg_name));
       auto node_arg = graph_viewer_.GetNodeArg(node_arg_name);
       plan_.allocation_plan[i].value_type = utils::GetMLDataType(*node_arg);
       plan_.allocation_plan[i].life_interval = std::pair<size_t, size_t>(0, max_pc);

--- a/onnxruntime/core/framework/memory_info.cc
+++ b/onnxruntime/core/framework/memory_info.cc
@@ -28,7 +28,7 @@ void MemoryInfo::GenerateTensorMap(const SequentialExecutionPlan* execution_plan
       continue;
     AllocInfoPerTensor mem_info;
     mem_info.mlvalue_index = value_idx;
-    value_name_idx_map.GetName(mem_info.mlvalue_index, mem_info.mlvalue_name);
+    ORT_THROW_IF_ERROR(value_name_idx_map.GetName(mem_info.mlvalue_index, mem_info.mlvalue_name));
     mem_info.lifetime_interval = execution_plan->allocation_plan[value_idx].life_interval;
     mem_info.reused_buffer = (execution_plan->allocation_plan[value_idx].alloc_kind != AllocKind::kReuse) ? value_idx : execution_plan->allocation_plan[value_idx].reused_buffer;
     //If the tensor is using memory outside of the scope, do not store it


### PR DESCRIPTION
**Description**: Fixes build errors discovered in issue #11607 

Errors are that a no_discard return value was being ignored when the #if block was enabled through --enable_memory_profile