### PR TITLE
Update signal operator contrib op definitions to match onnx opset 17

### DIFF
--- a/onnxruntime/contrib_ops/cpu/signal/dft.h
+++ b/onnxruntime/contrib_ops/cpu/signal/dft.h
@@ -9,10 +9,12 @@ namespace contrib {
 class DFT final : public OpKernel {
   bool is_onesided_ = true;
   int64_t axis_ = 0;
+  bool is_inverse_ = false;
  public:
   explicit DFT(const OpKernelInfo& info) : OpKernel(info) {
     is_onesided_ = static_cast<bool>(info.GetAttrOrDefault<int64_t>("onesided", 0));
     axis_ = info.GetAttrOrDefault<int64_t>("axis", 0);
+    is_inverse_ = info.GetAttrOrDefault<int64_t>("inverse", 0);
   }
   Status Compute(OpKernelContext* ctx) const override;
 };

--- a/onnxruntime/contrib_ops/cpu/signal/window_functions.cc
+++ b/onnxruntime/contrib_ops/cpu/signal/window_functions.cc
@@ -24,7 +24,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder().MayInplace(0, 0)
-        .TypeConstraint("T1", BuildKernelDefConstraints<int64_t>())
+        .TypeConstraint("T1", BuildKernelDefConstraints<int32_t, int64_t>())
         .TypeConstraint("T2", BuildKernelDefConstraints<float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t>()),
     HannWindow);
 
@@ -34,7 +34,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder().MayInplace(0, 0)
-        .TypeConstraint("T1", BuildKernelDefConstraints<int64_t>())
+        .TypeConstraint("T1", BuildKernelDefConstraints<int32_t, int64_t>())
         .TypeConstraint("T2", BuildKernelDefConstraints<float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t>()),
     HammingWindow);
 
@@ -44,7 +44,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder().MayInplace(0, 0)
-        .TypeConstraint("T1", BuildKernelDefConstraints<int64_t>())
+        .TypeConstraint("T1", BuildKernelDefConstraints<int32_t, int64_t>())
         .TypeConstraint("T2", BuildKernelDefConstraints<float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t>()),
     BlackmanWindow);
 
@@ -55,7 +55,7 @@ ONNX_OPERATOR_KERNEL_EX(
     1,
     kCpuExecutionProvider,
     KernelDefBuilder().MayInplace(0, 0)
-        .TypeConstraint("T1", BuildKernelDefConstraints<int64_t>())
+        .TypeConstraint("T1", BuildKernelDefConstraints<int32_t, int64_t>())
         .TypeConstraint("T2", BuildKernelDefConstraints<float>())
         .TypeConstraint("T3", BuildKernelDefConstraints<float, double, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t>()),
     MelWeightMatrix);
@@ -102,7 +102,7 @@ static Status create_cosine_sum_window(
     OpKernelContext* ctx,
     onnx::TensorProto_DataType output_datatype,
     float a0, float a1, float a2) {
-  
+
   // Get the size of the window
   auto size = get_scalar_value_from_tensor<int64_t>(ctx->Input<Tensor>(0));
 

--- a/onnxruntime/core/graph/signal_ops/signal_defs.cc
+++ b/onnxruntime/core/graph/signal_ops/signal_defs.cc
@@ -60,6 +60,78 @@ inline const ONNX_NAMESPACE::TensorShapeProto* getOptionalInputShape(ONNX_NAMESP
   }
 }
 
+std::function<void(OpSchema&)> CosineSumWindowOpDocGenerator(const char* name) {
+  return [name](OpSchema& schema) {
+    std::string doc;
+    POPULATE_OP_DOC_STR(
+        doc = R"DOC(
+Generates a {name} window as described in the paper https://ieeexplore.ieee.org/document/1455106.
+)DOC";
+        ReplaceAll(doc, "{name}", name););
+
+    schema.SetDoc(doc);
+    schema.Attr("output_datatype",
+                "The data type of the output tensor. "
+                "Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T2. "
+                "The default value is 1 = FLOAT. ",
+                AttributeProto::INT,
+                static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT));
+    schema.Attr("periodic",
+                "If 1, returns a window to be used as periodic function. If 0, return a symmetric window. "
+                "When 'periodic' is specified, hann computes a window of length size + 1 and returns the first size points. "
+                "The default value is 1. ",
+                AttributeProto::INT,
+                static_cast<int64_t>(1));
+    schema.Input(0,
+                 "size",
+                 "A scalar value indicating the length of the window.",
+                 "T1",
+                 OpSchema::Single,
+                 true,
+                 1,
+                 OpSchema::NonDifferentiable);
+    schema.Output(0,
+                  "output",
+                  "A Hann window with length: size. "
+                  "The output has the shape: [size].",
+                  "T2",
+                  OpSchema::Single,
+                  true,
+                  1,
+                  OpSchema::NonDifferentiable);
+    schema.TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+      // Update the output data type to the output_datatype
+      auto output_datatype = getAttribute(ctx, "output_datatype",
+                                          static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT));
+      updateOutputElemType(ctx, 0, static_cast<int32_t>(output_datatype));
+
+      if (!hasInputShape(ctx, 0)) {
+        // If no shape is available for the input, skip shape inference.
+        return;
+      }
+
+      const auto* size = ctx.getInputData(0);
+      if (size == nullptr) {
+        // Size is not available, so return early
+        return;
+      }
+
+      if (size->dims_size() != 0) {
+        fail_shape_inference("size input must be a scalar.");
+      }
+
+      auto size_value = get_scalar_value_from_tensor<int64_t>(size);
+      if (size_value <= 0) {
+        fail_shape_inference("size input must be greater than 0.");
+      }
+
+      ONNX_NAMESPACE::TensorShapeProto result_shape;
+      result_shape.add_dim()->set_dim_value(size_value);
+      updateOutputShape(ctx, 0, result_shape);
+    });
+  };
+}
+
 void RegisterSignalSchemas() {
   MS_SIGNAL_OPERATOR_SCHEMA(DFT)
       .SetDomain(kMSExperimentalDomain)
@@ -76,13 +148,22 @@ void RegisterSignalSchemas() {
             "This value must be less than signal_dimN, where signal_dimN is the number of dimensions in the signal.",
             AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
             static_cast<int64_t>(0))
+      .Attr("inverse",
+            "Whether to perform the inverse discrete fourier transform. By default this value is set to 0, which corresponds to false.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
       .Input(0,
              "input",
-             "For real multi-dimensional input, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][1]."
-             "For complex multi-dimensional input, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][2]."
-             "The first dimension is the batch dimension."
-             "The final dimension represents the real and imaginary parts of the value.",
-             "T1")
+             "For real input, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][1]. "
+             "For complex input, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][2]. "
+             "The first dimension is the batch dimension. "
+             "The following N dimentions correspond to the signal's dimensions. "
+             "The final dimension represents the real and imaginary parts of the value in that order.",
+             "T1",
+             OpSchema::Single,
+             true,
+             1,
+             OpSchema::NonDifferentiable)
       .Input(1,
              "dft_length",
              "The length of the signal."
@@ -97,39 +178,99 @@ void RegisterSignalSchemas() {
       .Output(0,
               "output",
               "The Fourier Transform of the input vector."
-              "The signal_dim at the specified axis is equal to the dft_length."
-              "If onesided is 0, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][2]."
-              "If axis=0 and onesided is 1, the following shape is expected: [batch_idx][floor(signal_dim1/2)+1][signal_dim2]...[signal_dimN][2]."
-              "If axis=1 and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][floor(signal_dim2/2)+1]...[signal_dimN][2]."
-              "If axis=N-1 and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[floor(signal_dimN/2)+1][2].",
+              "If onesided is 0, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[signal_dimN][2]. "
+              "If axis=0 and onesided is 1, the following shape is expected: [batch_idx][floor(signal_dim1/2)+1][signal_dim2]...[signal_dimN][2]. "
+              "If axis=1 and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][floor(signal_dim2/2)+1]...[signal_dimN][2]. "
+              "If axis=N-1 and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[floor(signal_dimN/2)+1][2]. "
+              "The signal_dim at the specified axis is equal to the dft_length.",
               "T1")
       .TypeConstraint(
-          "T1", 
+          "T1",
           {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
           "Constrain input and output types to float tensors.")
       .TypeConstraint(
           "T2",
-          {"tensor(int64)"},
+          {"tensor(int32)", "tensor(int64)"},
           "Constrain scalar length types to int64_t.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-          propagateElemTypeFromInputToOutput(ctx, 0, 0);
-          const int64_t batch_ndim = 1;
-
-          auto& input_shape = getInputShape(ctx, 0);
-          auto dim_size = static_cast<int64_t>(input_shape.dim_size());
-          auto has_component_dimension = dim_size > 2;
-
-          ONNX_NAMESPACE::TensorShapeProto result_shape_proto = input_shape;
-
-          bool axis = static_cast<bool>(getAttribute(ctx, "axis", 0));
           bool is_onesided = static_cast<bool>(getAttribute(ctx, "onesided", 0));
-          if (is_onesided) {
-              // Since signal_ndim = 1, and multidimensional DFT is not supported,
-              // only the single signal dim (1) needs to be updated
-              auto n_fft = input_shape.dim(1 + axis).dim_value();
-              result_shape_proto.mutable_dim(1 + axis)->set_dim_value((n_fft >> 1) + 1);
+          bool inverse = static_cast<bool>(getAttribute(ctx, "inverse", 0));
+
+          if (inverse && is_onesided) {
+              fail_shape_inference("is_onesided and inverse attributes cannot be enabled at the same time");
           }
 
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasInputShape(ctx, 0))
+          {
+              // If no shape is available for the input, skip shape inference...
+              return;
+          }
+
+          // In general the output shape will match the input shape exactly
+          // So initialize the output shape with the input shape
+          auto& input_shape = getInputShape(ctx, 0);
+          ONNX_NAMESPACE::TensorShapeProto result_shape_proto = input_shape;
+
+          // Get the axis where the DFT will be performed.
+          auto axis = static_cast<int>(getAttribute(ctx, "axis", 1));
+          auto rank = input_shape.dim_size();
+
+          if (!(-rank <= axis && axis < rank)) {
+              fail_shape_inference(
+                  "axis attribute value ",
+                  axis,
+                  " is invalid for a tensor of rank ",
+                  rank);
+          }
+
+          auto axis_idx = (axis >= 0 ? axis : axis + rank);
+
+          // If dft_length is specified, then we should honor the shape.
+          // Set the output dimension to match the dft_length on the axis.
+          // If onesided this will be adjusted later on...
+          const ONNX_NAMESPACE::TensorProto* dft_length = nullptr;
+          if (ctx.getNumInputs() >= 2 && ctx.getInputType(1) != nullptr) {
+              dft_length = ctx.getInputData(1);
+              if (dft_length == nullptr) {
+                  // If we cannot read the dft_length, we cannot infer shape
+                  // return...
+                  return;
+              }
+          }
+
+          if (nullptr != dft_length) {
+              if (dft_length->dims_size() != 0) {
+                  fail_shape_inference("dft_length input must be a scalar.");
+              }
+              auto dft_length_value = get_scalar_value_from_tensor<int64_t>(dft_length);
+              result_shape_proto.mutable_dim(axis_idx)->set_dim_value(dft_length_value);
+          }
+          // When DFT is onesided, the output shape is half the size of the input shape
+          // along the specified axis.
+          if (is_onesided) {
+              auto axis_dimension = result_shape_proto.dim(axis_idx);
+              // We need to update the output shape dimension along the specified axis,
+              // but sometimes the dimension will be a free dimension or be otherwise unset.
+              // Only perform inference when a input dimension value exists.
+              if (axis_dimension.has_dim_value())
+              {
+                  auto original_signal_size = axis_dimension.dim_value();
+                  auto half_signal_size = (original_signal_size >> 1) + 1;
+                  result_shape_proto.mutable_dim(axis_idx)->set_dim_value(half_signal_size);
+              }  else
+              {
+                  // Clear the value and param (which would otherwie be inherited from the input).
+                  result_shape_proto.mutable_dim(axis_idx)->clear_dim_value();
+                  result_shape_proto.mutable_dim(axis_idx)->clear_dim_param();
+              }
+          }
+
+          // Coerce the last dimension to 2.
+          auto dim_size = static_cast<int64_t>(result_shape_proto.dim_size());
+          auto has_component_dimension = dim_size > 2;
+
+          // This if check is retained in the contrib op and not the official spec for back compat
           if (has_component_dimension) {
               result_shape_proto.mutable_dim(static_cast<int>(dim_size - 1))->set_dim_value(2);
           } else {
@@ -208,19 +349,19 @@ void RegisterSignalSchemas() {
       .SinceVersion(1)
       .SetDoc(R"DOC(STFT)DOC")
       .Attr(
-          "onesided",
-          "If onesided is 1, only values for w in [0, 1, 2, ..., floor(n_fft/2) + 1] are returned because "
-          "the real-to-complex Fourier transform satisfies the conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. "
-          "Note if the input or window tensors are complex, then onesided output is not possible. "
-          "Enabling onesided with real inputs performs a Real-valued fast Fourier transform (RFFT)."
-          "When invoked with real or complex valued input, the default value is 1. "
-          "Values can be 0 or 1.",
-          AttributeProto::INT,
-          static_cast<int64_t>(1))
+           "onesided",
+           "If onesided is 1, only values for w in [0, 1, 2, ..., floor(n_fft/2) + 1] are returned because "
+           "the real-to-complex Fourier transform satisfies the conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. "
+           "Note if the input or window tensors are complex, then onesided output is not possible. "
+           "Enabling onesided with real inputs performs a Real-valued fast Fourier transform (RFFT)."
+           "When invoked with real or complex valued input, the default value is 1. "
+           "Values can be 0 or 1.",
+           AttributeProto::INT,
+           static_cast<int64_t>(1))
       .Input(0,
              "signal",
              "Input tensor representing a real or complex valued signal. "
-             "For real input, the following shape is expected: [batch_size][signal_length]. "
+             "For real input, the following shape is expected: [batch_size][signal_length][1]. "
              "For complex input, the following shape is expected: [batch_size][signal_length][2], where "
              "[batch_size][signal_length][0] represents the real component and [batch_size][signal_length][1] represents the imaginary component of the signal.",
              "T1",
@@ -257,9 +398,14 @@ void RegisterSignalSchemas() {
              OpSchema::NonDifferentiable)
       .Output(0,
               "output",
-              "The inverse fourier transform of the input vector,"
-              "using the same format as the input.",
-              "T1")
+              "The Short-time Fourier Transform of the signals."
+              "If onesided is 1, the output has the shape: [batch_size][frames][dft_unique_bins][2], where dft_unique_bins is frame_length // 2 + 1 (the unique components of the DFT) "
+              "If onesided is 0, the output has the shape: [batch_size][frames][frame_length][2], where frame_length is the length of the DFT.",
+              "T1",
+              OpSchema::Single,
+              true,
+              1,
+              OpSchema::NonDifferentiable)
       .TypeConstraint(
           "T1",
           {"tensor(float)",
@@ -269,158 +415,243 @@ void RegisterSignalSchemas() {
           "Constrain signal and output to float tensors.")
       .TypeConstraint(
           "T2",
-          {"tensor(int64)"},
+          {"tensor(int32)", "tensor(int64)"},
           "Constrain scalar length types to int64_t.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
             propagateElemTypeFromInputToOutput(ctx, 0, 0);
-            constexpr int64_t batch_ndim = 1;
-            constexpr int64_t component_ndim = 1;
 
-            // Get inputs
-            auto& input_shape = getInputShape(ctx, 0);
-            auto frame_step = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(1));
-            const ONNX_NAMESPACE::TensorShapeProto* window_input = nullptr;
-            try {
-                window_input = getOptionalInputShape(ctx, 2);
-            } catch (...) {
-                window_input = nullptr;
-            }
-
-            const ONNX_NAMESPACE::TensorShapeProto* frame_length_input = nullptr;
-            try {
-                frame_length_input = getOptionalInputShape(ctx, 3);
-            } catch (...) {
-                frame_length_input = nullptr;
-            }
-
-            // Determine the size of the DFT based on the 2 optional inputs window and frame_length. One must be set.
-            int64_t dft_size = 0;
-            if (window_input == nullptr && frame_length_input == nullptr) {
-                fail_type_inference("STFT expects to have at least one of these inputs set: [window, frame_length].");
-            } else if (window_input != nullptr && window_input->dim_size() > 0 && frame_length_input != nullptr) {
-                if (window_input->dim_size() != 1) {
-                fail_type_inference("STFT's window input, must have rank = 1.");
+                // Get signal size
+                // The signal size is needed to perform inference because the size of the signal
+                // is needed to compute the number of DFTs in the output.
+                //
+                // 1) Check if shape exists, return if not
+                // 2) Get the shape
+                // 3) Check if signal dim value exists, return if not
+                if (!hasInputShape(ctx, 0)) {
+                    return;
                 }
-                auto window_length = window_input->dim(0).dim_value();
-                auto frame_length = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(3));
-                if (window_length != frame_length) {
-                fail_type_inference("If STFT has both a window input and frame_length specified, the dimension of the window must match the frame_length specified!");
+
+                auto& input_shape = getInputShape(ctx, 0);
+                auto signal_dim = input_shape.dim(1);
+                if (!signal_dim.has_dim_value())
+                {
+                    return;
                 }
-                dft_size = window_length;
-            } else if (window_input != nullptr && window_input->dim_size() > 0) {
-                if (window_input->dim_size() != 1) {
-                fail_type_inference("STFT's window input, must have rank = 1.");
+                auto signal_size = signal_dim.dim_value();
+
+                // The frame step is a required input.
+                // Its value is needed to compute the number output nDFTs, so return early is missing.
+                const auto* frame_step = ctx.getInputData(1);
+                if (nullptr == frame_step) {
+                    return;
                 }
-                dft_size = window_input->dim(0).dim_value();
-            } else if (frame_length_input != nullptr) {
-                dft_size = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(3));
-            }
+                auto frame_step_value = get_scalar_value_from_tensor<int64_t>(frame_step);
 
-            bool is_onesided = static_cast<bool>(getAttribute(ctx, "onesided", 0));
-            if (is_onesided) {
-                dft_size = is_onesided ? ((dft_size >> 1) + 1) : dft_size;
-            }
+                // Determine the size of the DFT based on the 2 optional inputs window and frame_length.
+                // One must be set.
+                int64_t dft_size = -1;
+                const ONNX_NAMESPACE::TensorProto* frame_length = nullptr;
+                if (ctx.getNumInputs() >= 4 && ctx.getInputType(3) != nullptr) {
+                    frame_length = ctx.getInputData(3);
+                    if (frame_length == nullptr) {
+                        // If we cannot read the frame_length, we cannot infer shape
+                        // return...
+                        return;
+                    }
+                }
 
-            auto signal_size = input_shape.dim(1).dim_value();
-            auto n_dfts = static_cast<int64_t>(std::floor((signal_size - dft_size) / static_cast<float>(frame_step)) + 1);
+                const ONNX_NAMESPACE::TensorShapeProto* window_shape = nullptr;
+                if (ctx.getNumInputs() >= 3) {
+                    window_shape = getOptionalInputShape(ctx, 2);
+                } else {
+                    window_shape = nullptr;
+                }
 
-            // The output has the following shape: [batch_size][frames][dft_unique_bins][2]
-            ONNX_NAMESPACE::TensorShapeProto result_shape_proto;
-            result_shape_proto.add_dim()->set_dim_value(input_shape.dim(0).dim_value());  // batch size
-            result_shape_proto.add_dim()->set_dim_value(n_dfts);
-            result_shape_proto.add_dim()->set_dim_value(dft_size);
-            result_shape_proto.add_dim()->set_dim_value(2);
-            updateOutputShape(ctx, 0, result_shape_proto);
+                if (window_shape == nullptr && frame_length == nullptr)
+                {
+                    // STFT expects to have at least one of these inputs set: [window, frame_length],
+                    // but they may not be available at shape inference time
+                    return;
+                } else if (window_shape != nullptr && frame_length != nullptr)
+                {
+                    if (frame_length->dims_size() != 0) {
+                       fail_shape_inference("frame_length input must be scalar.");
+                    }
+                    auto frame_length_value = get_scalar_value_from_tensor<int64_t>(frame_length);
+
+                    // Ensure that the window length and the dft_length match.
+                    if (window_shape->dim_size() != 1) {
+                       fail_shape_inference("window input must have rank = 1.");
+                    }
+                    if (window_shape->dim(0).has_dim_value())
+                    {
+                        auto window_length = window_shape->dim(0).dim_value();
+                        if (window_length != frame_length_value)
+                        {
+                            fail_type_inference("If STFT has both a window input and frame_length specified, the dimension of the window must match the frame_length specified!");
+                        }
+                    }
+
+                    dft_size = frame_length_value;
+                } else if (window_shape != nullptr)
+                {
+                    // Ensure that the window length and the dft_length match.
+                    if (window_shape->dim_size() != 1) {
+                       fail_shape_inference("window input must have rank = 1.");
+                    }
+                    if (window_shape->dim(0).has_dim_value()) {
+                        dft_size = window_shape->dim(0).dim_value();
+                    } else {
+                        // Cannot determine the window size, and there is no frame_length,
+                        // So shape inference cannot proceed.
+                        return;
+                    }
+                } else if (frame_length != nullptr)
+                {
+                    if (frame_length->dims_size() != 0) {
+                       fail_shape_inference("frame_length input must be scalar.");
+                    }
+                    dft_size = get_scalar_value_from_tensor<int64_t>(frame_length);
+                }
+
+                bool is_onesided = static_cast<bool>(getAttribute(ctx, "onesided", 0));
+                if (is_onesided) {
+                    dft_size = is_onesided ? ((dft_size >> 1) + 1) : dft_size;
+                }
+
+                auto n_dfts = static_cast<int64_t>((signal_size - dft_size) / static_cast<float>(frame_step_value)) + 1;
+
+                // The output has the following shape: [batch_size][frames][dft_unique_bins][2]
+                ONNX_NAMESPACE::TensorShapeProto result_shape_proto;
+                result_shape_proto.add_dim()->set_dim_value(input_shape.dim(0).dim_value()); // batch size
+                result_shape_proto.add_dim()->set_dim_value(n_dfts);
+                result_shape_proto.add_dim()->set_dim_value(dft_size);
+                result_shape_proto.add_dim()->set_dim_value(2);
+                updateOutputShape(ctx, 0, result_shape_proto);
     });
 
   // Window Functions
   MS_SIGNAL_OPERATOR_SCHEMA(HannWindow)
       .SetDomain(kMSExperimentalDomain)
       .SinceVersion(1)
-      .SetDoc(R"DOC(HannWindow)DOC")
-      .Attr("output_datatype",
-            "The data type of the output tensor. "
-            "Strictly must be one of the types from DataType enum in TensorProto.",
-            AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
-            static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT))
-      .Input(0,
-             "size",
-             "A scalar value indicating the length of the Hann Window.",
-             "T1")
-      .Output(0,
-              "output",
-              "A Hann Window with length: size.",
-              "T2")
-      .TypeConstraint("T1", {"tensor(int64)"}, "")
-      .TypeConstraint("T2", {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)", "tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)"}, "")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        auto size = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(0));
-        if (size > 0) {
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          result_shape.add_dim()->set_dim_value(size);
-          updateOutputShape(ctx, 0, result_shape);
+      .FillUsing(CosineSumWindowOpDocGenerator("Hann"))
+        .TypeConstraint(
+          "T1",
+          {"tensor(int32)", "tensor(int64)"},
+        "Constrain the input size to int64_t.")
+        .TypeConstraint(
+          "T2",
+          ONNX_NAMESPACE::OpSchema::all_numeric_types_with_bfloat(),
+          "Constrain output types to numeric tensors.")
+        .FunctionBody(R"ONNX(
+        {
+          A0 = Constant <value = float {0.5}>()
+          A1 = Constant <value = float {0.5}>()
+          A2 = Constant <value = float {0.0}>()
+          Zero = Constant <value = float {0.0}>()
+          One = Constant <value = float {1.0}>()
+          Two = Constant <value = float {2.0}>()
+          Tau = Constant <value = float {6.2831853}>()
+          Size_FP = Cast <to = 1> (size)
+          AngularIncrement = Div (Tau, Size_FP)
+          Range = Range (Zero, Size_FP, One)
+          RangeAngular = Mul (Range, AngularIncrement)
+          TwoRangeAngular = Mul (RangeAngular, Two)
+          CosTwoRangeAngular = Cos (TwoRangeAngular)
+          A2_Component = Mul (A2, CosTwoRangeAngular)
+          CosRangeAngular = Cos (RangeAngular)
+          A1_Component = Mul (A1, CosRangeAngular)
+          Temp0 = Add (A1_Component, A2_Component)
+          Temp1 = Sub (A0, Temp0)
+          output = Cast <to : int = @output_datatype> (Temp1)
         }
-
-        propagateElemTypeFromAttributeToOutput(ctx, "output_datatype", 0);
-      });
+        )ONNX"
+        );
 
   MS_SIGNAL_OPERATOR_SCHEMA(HammingWindow)
       .SetDomain(kMSExperimentalDomain)
       .SinceVersion(1)
-      .SetDoc(R"DOC(HammingWindow)DOC")
-      .Attr("output_datatype",
-            "The data type of the output tensor. "
-            "Strictly must be one of the types from DataType enum in TensorProto.",
-            AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
-            static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT))
-      .Input(0,
-             "size",
-             "A scalar value indicating the length of the Hamming Window.",
-             "T1")
-      .Output(0,
-              "output",
-              "A Hamming Window with length: size.",
-              "T2")
-      .TypeConstraint("T1", {"tensor(int64)"}, "")
-      .TypeConstraint("T2", {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)", "tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)"}, "")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        auto size = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(0));
-        if (size > 0) {
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          result_shape.add_dim()->set_dim_value(size);
-          updateOutputShape(ctx, 0, result_shape);
+      .FillUsing(CosineSumWindowOpDocGenerator("Hamming"))
+        .TypeConstraint(
+          "T1",
+          {"tensor(int32)", "tensor(int64)"},
+        "Constrain the input size to int64_t.")
+        .TypeConstraint(
+          "T2",
+          ONNX_NAMESPACE::OpSchema::all_numeric_types_with_bfloat(),
+          "Constrain output types to numeric tensors.")
+        .FunctionBody(R"ONNX(
+        {
+          A0 = Constant <value = float {0.54347826087}>()
+          A1 = Constant <value = float {0.45652173913}>()
+          A2 = Constant <value = float {0.0}>()
+          Zero = Constant <value = float {0.0}>()
+          One = Constant <value = float {1.0}>()
+          Two = Constant <value = float {2.0}>()
+          Tau = Constant <value = float {6.2831853}>()
+          Size_FP = Cast <to = 1> (size)
+          AngularIncrement = Div (Tau, Size_FP)
+          Range = Range (Zero, Size_FP, One)
+          RangeAngular = Mul (Range, AngularIncrement)
+          TwoRangeAngular = Mul (RangeAngular, Two)
+          CosTwoRangeAngular = Cos (TwoRangeAngular)
+          A2_Component = Mul (A2, CosTwoRangeAngular)
+          CosRangeAngular = Cos (RangeAngular)
+          A1_Component = Mul (A1, CosRangeAngular)
+          Temp0 = Add (A1_Component, A2_Component)
+          Temp1 = Sub (A0, Temp0)
+          output = Cast <to : int = @output_datatype> (Temp1)
         }
-        propagateElemTypeFromAttributeToOutput(ctx, "output_datatype", 0);
-      });
+        )ONNX"
+        );
 
   MS_SIGNAL_OPERATOR_SCHEMA(BlackmanWindow)
       .SetDomain(kMSExperimentalDomain)
       .SinceVersion(1)
-      .SetDoc(R"DOC(BlackmanWindow)DOC")
-      .Attr("output_datatype",
-            "The data type of the output tensor. "
-            "Strictly must be one of the types from DataType enum in TensorProto.",
-            AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
-            static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT))
-      .Input(0,
-             "size",
-             "A scalar value indicating the length of the Blackman Window.",
-             "T1")
-      .Output(0,
-              "output",
-              "A Blackman Window with length: size.",
-              "T2")
-      .TypeConstraint("T1", {"tensor(int64)"}, "")
-      .TypeConstraint("T2", {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)", "tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)"}, "")
-      .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        auto size = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(0));
-        if (size > 0) {
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          result_shape.add_dim()->set_dim_value(size);
-          updateOutputShape(ctx, 0, result_shape);
+      .FillUsing(CosineSumWindowOpDocGenerator("Blackman"))
+        .TypeConstraint(
+          "T1",
+          {"tensor(int32)", "tensor(int64)"},
+        "Constrain the input size to int64_t.")
+        .TypeConstraint(
+          "T2",
+          ONNX_NAMESPACE::OpSchema::all_numeric_types_with_bfloat(),
+          "Constrain output types to numeric tensors.")
+        .FunctionBody(R"ONNX(
+        {
+          A0 = Constant <value = float {0.42}>()
+          A1 = Constant <value = float {0.5}>()
+          A2 = Constant <value = float {0.08}>()
+          Zero = Constant <value = float {0.0}>()
+          One = Constant <value = float {1.0}>()
+          Two = Constant <value = float {2.0}>()
+          Tau = Constant <value = float {6.2831853}>()
+          Size_FP = Cast <to = 1> (size)
+          AngularIncrement = Div (Tau, Size_FP)
+          Range = Range (Zero, Size_FP, One)
+          RangeAngular = Mul (Range, AngularIncrement)
+          TwoRangeAngular = Mul (RangeAngular, Two)
+          CosTwoRangeAngular = Cos (TwoRangeAngular)
+          A2_Component = Mul (A2, CosTwoRangeAngular)
+          CosRangeAngular = Cos (RangeAngular)
+          A1_Component = Mul (A1, CosRangeAngular)
+          Temp0 = Add (A1_Component, A2_Component)
+          Temp1 = Sub (A0, Temp0)
+          output = Cast <to : int = @output_datatype> (Temp1)
         }
-        propagateElemTypeFromAttributeToOutput(ctx, "output_datatype", 0);
-      });
+        )ONNX"
+        );
+
+static const char* MelWeightMatrix_ver17_doc = R"DOC(
+Generate a MelWeightMatrix that can be used to re-weight a Tensor containing a linearly sampled frequency spectra (from DFT or STFT) into num_mel_bins frequency information based on the [lower_edge_hertz, upper_edge_hertz] range on the mel scale.
+This function defines the mel scale in terms of a frequency in hertz according to the following formula:
+
+    mel(f) = 2595 * log10(1 + f/700)
+
+In the returned matrix, all the triangles (filterbanks) have a peak value of 1.0.
+
+The returned MelWeightMatrix can be used to right-multiply a spectrogram S of shape [frames, num_spectrogram_bins] of linear scale spectrum values (e.g. STFT magnitudes) to generate a "mel spectrogram" M of shape [frames, num_mel_bins].
+)DOC";
 
   MS_SIGNAL_OPERATOR_SCHEMA(MelWeightMatrix)
       .SetDomain(kMSExperimentalDomain)
@@ -429,7 +660,7 @@ void RegisterSignalSchemas() {
       .Attr("output_datatype",
             "The data type of the output tensor. "
             "Strictly must be one of the types from DataType enum in TensorProto.",
-            AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
+            ONNX_NAMESPACE::AttributeProto::AttributeType::AttributeProto_AttributeType_INT,
             static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT))
       .Input(0,
              "num_mel_bins",
@@ -455,20 +686,53 @@ void RegisterSignalSchemas() {
               "output",
               "The MEL Matrix",
               "T3")
-      .TypeConstraint("T1", {"tensor(int64)"}, "")
-      .TypeConstraint("T2", {"tensor(float)", "tensor(float16)", "tensor(double)"}, "")
-      .TypeConstraint("T3", {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)", "tensor(int8)", "tensor(int16)", "tensor(int32)", "tensor(int64)"}, "")
+      .TypeConstraint(
+              "T1",
+              {"tensor(int32)", "tensor(int64)"},
+              "Constrain to integer tensors.")
+      .TypeConstraint(
+              "T2",
+              {"tensor(float)",
+                "tensor(float16)",
+                "tensor(double)",
+                "tensor(bfloat16)"},
+              "Constrain to float tensors")
+      .TypeConstraint(
+              "T3",
+              ONNX_NAMESPACE::OpSchema::all_numeric_types_with_bfloat(),
+              "Constrain to any numerical types.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-        auto num_mel_bins = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(0));
-        auto dft_length = get_scalar_value_from_tensor<int64_t>(ctx.getInputData(1));
-        if (num_mel_bins > 0 && dft_length > 0) {
-          ONNX_NAMESPACE::TensorShapeProto result_shape;
-          // Figure out how to specify one-sided???
-          result_shape.add_dim()->set_dim_value(static_cast<int64_t>(std::floor(dft_length / 2.f + 1)));
-          result_shape.add_dim()->set_dim_value(num_mel_bins);
-          updateOutputShape(ctx, 0, result_shape);
+        auto output_datatype = getAttribute(ctx, "output_datatype", static_cast<int64_t>(onnx::TensorProto_DataType::TensorProto_DataType_FLOAT));
+        updateOutputElemType(ctx, 0, static_cast<int32_t>(output_datatype));
+
+        if (!hasInputShape(ctx, 0) || !hasInputShape(ctx, 1)) {
+            return;
         }
-        propagateElemTypeFromAttributeToOutput(ctx, "output_datatype", 0);
+
+        const auto* num_mel_bins = ctx.getInputData(0);
+        const auto* dft_length = ctx.getInputData(1);
+        if (nullptr == num_mel_bins || nullptr == dft_length) {
+            return;
+        }
+
+        int64_t num_mel_bins_value = -1;
+        int64_t dft_length_value = -1;
+        if (num_mel_bins->dims_size() != 0) {
+            fail_shape_inference("num_mel_bins input must be scalar.");
+        }
+        num_mel_bins_value = get_scalar_value_from_tensor<int64_t>(num_mel_bins);
+
+        if (dft_length->dims_size() != 0) {
+            fail_shape_inference("dft_length input must be scalar.");
+        }
+        dft_length_value = get_scalar_value_from_tensor<int64_t>(dft_length);
+
+        if (num_mel_bins_value > 0 && dft_length_value > 0) {
+            ONNX_NAMESPACE::TensorShapeProto result_shape;
+            result_shape.add_dim()->set_dim_value(static_cast<int64_t>((dft_length_value >> 1) + 1));
+            result_shape.add_dim()->set_dim_value(num_mel_bins_value);
+            updateOutputShape(ctx, 0, result_shape);
+        }
       });
 }
 

--- a/winml/test/api/LearningModelSessionAPITest.cpp
+++ b/winml/test/api/LearningModelSessionAPITest.cpp
@@ -428,7 +428,10 @@ static void CloseSession()
 }
 
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
-static void WindowFunction(const wchar_t* window_operator_name, TensorKind kind) {
+static void WindowFunction(
+  const wchar_t* window_operator_name,
+  TensorKind kind,
+  const std::vector<float>& expected) {
   std::vector<int64_t> scalar_shape = {};
   std::vector<int64_t> output_shape = {32};
   auto double_data_type = TensorInt64Bit::CreateFromArray({}, {11});
@@ -458,22 +461,23 @@ static void WindowFunction(const wchar_t* window_operator_name, TensorKind kind)
   auto result = session.Evaluate(binding, L"");
 
   // Check results
-  printf("Output\n");
+  constexpr float error_threshold = .001f;
   if (kind == TensorKind::Float) {
     auto y_tensor = result.Outputs().Lookup(L"Output").as<TensorFloat>();
     auto y_ivv = y_tensor.GetAsVectorView();
     for (int i = 0; i < output_shape[0]; i++) {
-      printf("%f, ", y_ivv.GetAt(i));
+      WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i) - expected[i]) < error_threshold);
     }
   }
   if (kind == TensorKind::Double) {
     auto y_tensor = result.Outputs().Lookup(L"Output").as<TensorDouble>();
     auto y_ivv = y_tensor.GetAsVectorView();
     for (int i = 0; i < output_shape[0]; i++) {
-      printf("%f, ", y_ivv.GetAt(i));
+      WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i) - expected[i]) < error_threshold);
     }
   }
   printf("\n");
+
 }
 #endif
 
@@ -489,8 +493,6 @@ static void SaveSoftwareBitmap(const wchar_t* filename, winrt::Windows::Graphics
 
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
 static void DiscreteFourierTransform_2D() {
-
-  printf("\nN-Dimensional Discrete Fourier Transform\n");
 
   using namespace winrt::Windows::Storage;
   using namespace winrt::Windows::Storage::Streams;
@@ -514,12 +516,26 @@ static void DiscreteFourierTransform_2D() {
   auto width = corrected_image.SoftwareBitmap().PixelWidth();
   auto height = corrected_image.SoftwareBitmap().PixelHeight();
 
-  std::vector<int64_t> shape = {1, 1, height, width};
+  std::vector<int64_t> input_shape = {1, 1, height, width};
   std::vector<int64_t> output_shape = {1, 1, height, width};
+
+  printf("N-Dimensional Discrete Fourier Transform");
+  printf("\n  Input Shape: [");
+  for (size_t i = 0; i < input_shape.size(); i++) {
+    printf("%d,", static_cast<int>(input_shape[i]));
+  }
+  printf("]");
+  printf("\n  Expected Output Shape: [");
+  for (size_t i = 0; i < output_shape.size(); i++) {
+    printf("%d,", static_cast<int>(output_shape[i]));
+  }
+  printf("]");
+  printf("\n  Axis: [1,2]");
+  printf("\n  Is Onesided: false");
 
   auto builder =
       LearningModelBuilder::Create(13)
-        .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input.Signal", TensorKind::Float, shape))
+        .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input.Signal", TensorKind::Float, input_shape))
         .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output.Spectra", TensorKind::Float, output_shape))
         .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output.Inverse", TensorKind::Float, output_shape))
         .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output.Error", TensorKind::Float, output_shape))
@@ -529,19 +545,19 @@ static void DiscreteFourierTransform_2D() {
             .SetOutput(L"reshaped", L"reshaped_output"))
       .Operators().Add(Operator(L"DFT", MS_EXPERIMENTAL_DOMAIN)
           .SetInput(L"input", L"reshaped_output")
-          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(0)}))
+          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(1)}))
           .SetOutput(L"output", L"DFT.Output.1"))
        .Operators().Add(Operator(L"DFT", MS_EXPERIMENTAL_DOMAIN)
           .SetInput(L"input", L"DFT.Output.1")
-          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(1)}))
+          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(2)}))
           .SetOutput(L"output", L"DFT.Output.2"))
        .Operators().Add(Operator(L"IDFT", MS_EXPERIMENTAL_DOMAIN)
           .SetInput(L"input", L"DFT.Output.2")
-          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(1)}))
+          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(2)}))
           .SetOutput(L"output", L"IDFT.Output.1"))
        .Operators().Add(Operator(L"IDFT", MS_EXPERIMENTAL_DOMAIN)
           .SetInput(L"input", L"IDFT.Output.1")
-          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(0)}))
+          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(1)}))
           .SetOutput(L"output", L"IDFT.Output.2"))
         .Operators().Add(Operator(L"ReduceSumSquare")
           .SetInput(L"data", L"DFT.Output.2")
@@ -593,7 +609,7 @@ static void DiscreteFourierTransform_2D() {
   auto result = session.Evaluate(binding, L"");
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::micro> evaluate_duration_in_microseconds = end - start;
-  printf("Evaluate Took: %fus\n", evaluate_duration_in_microseconds.count());
+  printf("\n  Evaluate Took: %fus\n", evaluate_duration_in_microseconds.count());
 
   auto error = result.Outputs().Lookup(L"Output.Error").as<TensorFloat>();
   auto error_ivv = error.GetAsVectorView();
@@ -602,73 +618,94 @@ static void DiscreteFourierTransform_2D() {
     WINML_EXPECT_TRUE(abs(error_ivv.GetAt(i)) < error_threshold);
   }
 
+  /*
+  * Output input, output and model
   SaveSoftwareBitmap(L"fft2d.jpg", spectra.SoftwareBitmap());
   SaveSoftwareBitmap(L"fft2d_inverse.jpg", inverse.SoftwareBitmap());
   builder.Save(L"fft2d.onnx");
+  */
+
+  printf("\n");
 }
 
+template <typename T>
 static void DiscreteFourierTransform(
-    const std::vector<std::complex<float>>& input,
-    const std::vector<int64_t>& shape,
+    const std::vector<T>& input,
+    const std::vector<int64_t>& input_shape,
     const std::vector<std::complex<float>>& expected_output,
     size_t axis,
     size_t dft_length,
     bool is_onesided = false) {
-  auto axis_dim = axis + 1;
-  printf("\nDiscrete Fourier Transform [axis=%d, is_onesided=%s]\n", static_cast<int>(axis_dim), is_onesided ? "true" : "false");
-
-  std::vector<int64_t> output_shape = shape;
-
-  uint32_t input_stride = 2;
-  if (shape.size() == 2 || shape[shape.size() - 1] == 1) {
-    input_stride = 1;
-  }
-
+  // Calculate expected output shape
+  auto output_shape = input_shape;
   if (output_shape.size() != 2) {
+    // If the input is not 2 dimensional, the last dimension is the complex component.
+    // DFT should always output complex results, and so we can comfortably coerce the last dim to 2
     output_shape[output_shape.size() - 1] = 2;
+  } else {
+    // DFT should always output complex results. If input was 2 dimensional (real), we can comfortably append the last dim as 2
+    output_shape.push_back(2);
   }
-  output_shape[axis_dim] = is_onesided ? (1 + (shape[axis_dim] >> 1)) : shape[axis_dim];
+  output_shape[axis] = is_onesided ? (1 + (dft_length >> 1)) : dft_length;
+
+  printf("Discrete Fourier Transform");
+  printf("\n  Input Shape: [");
+  for (size_t i = 0; i < input_shape.size(); i++) {
+    printf("%d,", static_cast<int>(input_shape[i]));
+  }
+  printf("]");
+  printf("\n  Expected Output Shape: [");
+  for (size_t i = 0; i < output_shape.size(); i++) {
+    printf("%d,", static_cast<int>(output_shape[i]));
+  }
+  printf("]");
+  printf("\n  Axis: %d", static_cast<int>(axis));
+  printf("\n  DFT Length: %d", static_cast<int>(dft_length));
+  printf("\n  Is Onesided: %s", is_onesided ? "true" : "false");
 
   auto model =
-      LearningModelBuilder::Create(13)
-        .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input.Signal", TensorKind::Float, shape))
-        .Inputs().AddConstant(L"Input.DFTLength", TensorInt64Bit::CreateFromArray({}, {INT64(dft_length)}))
-        .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output.Spectra", TensorKind::Float, output_shape))
-        .Operators().Add(Operator(L"DFT", MS_EXPERIMENTAL_DOMAIN)
-          .SetInput(L"input", L"Input.Signal")
-          .SetInput(L"dft_length", L"Input.DFTLength")
-          .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(axis)}))
-          .SetAttribute(L"onesided", TensorInt64Bit::CreateFromArray({}, {is_onesided}))
-          .SetOutput(L"output", L"Output.Spectra"))
-        .CreateModel();
+    LearningModelBuilder::Create(13)
+      .Inputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Input.Signal", TensorKind::Float, input_shape))
+      .Inputs().AddConstant(L"Input.DFTLength", TensorInt64Bit::CreateFromArray({}, {INT64(dft_length)}))
+      .Outputs().Add(LearningModelBuilder::CreateTensorFeatureDescriptor(L"Output.Spectra", TensorKind::Float, output_shape))
+      .Operators().Add(Operator(L"DFT", MS_EXPERIMENTAL_DOMAIN)
+        .SetInput(L"input", L"Input.Signal")
+        .SetInput(L"dft_length", L"Input.DFTLength")
+        .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(axis)}))
+        .SetAttribute(L"onesided", TensorInt64Bit::CreateFromArray({}, {is_onesided}))
+        .SetOutput(L"output", L"Output.Spectra"))
+      .CreateModel();
 
   LearningModelSession session(model);
   LearningModelBinding binding(session);
 
+  auto is_real_input = input_shape.size() == 2 || input_shape[input_shape.size() - 1] == 1;
+  uint32_t input_stride = is_real_input ? 1 : 2;
+
+  // Populate binding
   auto input_begin = const_cast<float*>(reinterpret_cast<const float*>(input.data()));
   auto input_floats = winrt::array_view<float>(input_begin, static_cast<uint32_t>(input.size() * input_stride));
-  // Populate binding
-  binding.Bind(L"Input.Signal", TensorFloat::CreateFromArray(shape, input_floats));
+  binding.Bind(L"Input.Signal", TensorFloat::CreateFromArray(input_shape, input_floats));
 
   // Evaluate
   auto start = std::chrono::high_resolution_clock::now();
   auto result = session.Evaluate(binding, L"");
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double, std::micro> evaluate_duration_in_microseconds = end - start;
-  printf("Evaluate Took: %fus\n", evaluate_duration_in_microseconds.count());
+  printf("\n  Evaluate Took: %fus", evaluate_duration_in_microseconds.count());
 
-   // Check results
-   printf("Output.Spectra\n");
-   auto y_tensor = result.Outputs().Lookup(L"Output.Spectra").as<TensorFloat>();
-   auto y_ivv = y_tensor.GetAsVectorView();
-   for (uint32_t i = 0; i < y_ivv.Size(); i += 2) {
-     // Check results
-     constexpr float error_threshold = .001f;
-     WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i) - expected_output[i / 2].real()) < error_threshold);
-     WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i + 1) - expected_output[i / 2].imag()) < error_threshold);
-   }
-   printf("\n");
+  // Check results
+  auto y_tensor = result.Outputs().Lookup(L"Output.Spectra").as<TensorFloat>();
+  auto y_ivv = y_tensor.GetAsVectorView();
+  for (uint32_t i = 0; i < y_ivv.Size(); i += 2) {
+    // Check results
+    constexpr float error_threshold = .001f;
+    WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i) - expected_output[i / 2].real()) < error_threshold);
+    WINML_EXPECT_TRUE(abs(y_ivv.GetAt(i + 1) - expected_output[i / 2].imag()) < error_threshold);
+  }
+  printf("\n\n");
 }
+
 #endif
 
 template <typename T>
@@ -752,11 +789,11 @@ static void STFT(size_t batch_size, size_t signal_size, size_t dft_size,
 
   // Create signal binding
   auto signal = MakeMiddleC<float>(signal_size, sample_rate);
-  printf("\n");
-  printf("Input.TimeSignal:\n");
-  for (size_t i = 0; i < dft_size; i++) {
-    printf("%f, ", signal[i]);
-  }
+  //printf("\n");
+  //printf("Input.TimeSignal:\n");
+  //for (size_t i = 0; i < dft_size; i++) {
+  //  printf("%f, ", signal[i]);
+  //}
 
   // Bind
   binding.Bind(L"Input.TimeSignal", TensorFloat::CreateFromArray(input_shape, signal));
@@ -764,6 +801,7 @@ static void STFT(size_t batch_size, size_t signal_size, size_t dft_size,
   // Evaluate
   auto result = session.Evaluate(binding, L"");
 
+  /*
   printf("\n");
   printf("Output.HannWindow\n");
   auto window_tensor = result.Outputs().Lookup(L"Output.HannWindow").as<TensorFloat>();
@@ -772,20 +810,22 @@ static void STFT(size_t batch_size, size_t signal_size, size_t dft_size,
     printf("%f, ", window_ivv.GetAt(i));
   }
   printf("\n");
-  //printf("Output.STFT\n");
-  //// Check results
-  //auto y_tensor = result.Outputs().Lookup(L"Output.STFT").as<TensorFloat>();
-  //auto y_ivv = y_tensor.GetAsVectorView();
-  //auto size = y_ivv.Size();
-  //WINML_EXPECT_EQUAL(size, n_dfts * output_shape[2] * 2);
-  //for (size_t dft_idx = 0; dft_idx < n_dfts; dft_idx++) {
-  //  for (size_t i = 0; INT64(i) < output_shape[2]; i++) {
-  //    auto real_idx = static_cast<uint32_t>((i * 2) + (2 * dft_idx * output_shape[2]));
-  //    printf("(%d, %f , %fi), ", static_cast<uint32_t>(i), y_ivv.GetAt(real_idx), y_ivv.GetAt(real_idx + 1));
-  //  }
-  //}
-  //
-  //printf("\n");
+
+  printf("Output.STFT\n");
+  // Check results
+  auto y_tensor = result.Outputs().Lookup(L"Output.STFT").as<TensorFloat>();
+  auto y_ivv = y_tensor.GetAsVectorView();
+  auto size = y_ivv.Size();
+  WINML_EXPECT_EQUAL(size, n_dfts * output_shape[2] * 2);
+  for (size_t dft_idx = 0; dft_idx < n_dfts; dft_idx++) {
+    for (size_t i = 0; INT64(i) < output_shape[2]; i++) {
+      auto real_idx = static_cast<uint32_t>((i * 2) + (2 * dft_idx * output_shape[2]));
+      printf("(%d, %f , %fi), ", static_cast<uint32_t>(i), y_ivv.GetAt(real_idx), y_ivv.GetAt(real_idx + 1));
+    }
+  }
+
+  printf("\n");
+  */
 }
 #endif
 
@@ -809,6 +849,7 @@ static void ModelBuilding_MelWeightMatrix() {
 
   auto result = session.Evaluate(binding, L"");
 
+  /*
   printf("\n");
   printf("Output.MelWeightMatrix\n");
   {
@@ -818,6 +859,7 @@ static void ModelBuilding_MelWeightMatrix() {
       printf("%f, ", y_ivv.GetAt(i));
     }
   }
+  */
 
   printf("\n");
 #endif
@@ -1073,6 +1115,42 @@ static void ModelBuilding_ConstantMatmul() {
 
 static void ModelBuilding_DiscreteFourierTransform() {
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
+  std::vector<float> legacy_real_input =
+  {
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+  };
+
+  std::vector<std::complex<float>> legacy_real_expected_axis_0_two_sided = {
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+  };
+  DiscreteFourierTransform(legacy_real_input, {1, 8}, legacy_real_expected_axis_0_two_sided, 1, 8, false /*onesided*/);
+
+  std::vector<float> real_input =
+  {
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+      1.00f, 2.00, 3.00f, 4.00f, 5.00f, 6.00f, 7.00f, 8.00f,
+    };
+
+  std::vector<std::complex<float>> real_expected_axis_0_two_sided = {
+    {5.000f, 0.000f}, {10.000f, 0.000f}, {15.000f, 0.000f}, {20.000f, 0.000f}, {25.000f, 0.000f}, {30.000f, 0.000f}, {35.000f, 0.000f}, {40.000f, 0.000f},
+    {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
+    {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
+    {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
+    {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f},
+  };
+  DiscreteFourierTransform(real_input, {1, 5, 8, 1}, real_expected_axis_0_two_sided, 1, 5, false /*onesided*/);
+
+  std::vector<std::complex<float>> real_expected_axis_1_two_sided = {
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+    {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
+  };
+  DiscreteFourierTransform(real_input, {1, 5, 8, 1}, real_expected_axis_1_two_sided, 2, 8, false /*onesided*/);
 
   std::vector<std::complex<float>> input =
   {
@@ -1102,7 +1180,7 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
     {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}, {-0.000f, 0.000f}
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided, 0, 5, false /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided, 1, 5, false /*onesided*/);
 
   std::vector<std::complex<float>> expected_axis_0_two_sided_small_dft_length = {
     {4.000f, 0.000f}, {8.000f, 0.000f}, {12.000f, 0.000f}, {16.000f, 0.000f}, {20.000f, 0.000f}, {24.000f, 0.000f}, {28.000f, 0.000f}, {32.000f, 0.000f},
@@ -1115,7 +1193,7 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {-0.000f, 0.000f}, {0.000f, 0.000f}, {-0.000f, 0.000f}, {0.000f, 0.000f},
     {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided_small_dft_length, 0, 4, false /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided_small_dft_length, 1, 4, false /*onesided*/);
 
   std::vector<std::complex<float>> expected_axis_0_two_sided_bigger_dft_length = {
     {5.000000f, 0.000000f},   {10.000000f, 0.000000f},  {15.000000f, 0.000000f},  {20.000000f, 0.000000f},  {25.000000f, 0.000000f},  {30.000000f, 0.000000f},  {35.000000f, 0.000000f},  {40.000000f, 0.000000f},
@@ -1125,14 +1203,14 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {0.500000f, 0.866025f},   {1.000001f, 1.732051f},   {1.500001f, 2.598076f},   {2.000001f, 3.464102f},   {2.500002f, 4.330127f},   {3.000002f, 5.196153f},   {3.500002f, 6.062179f},   {4.000003f, 6.928204f},
     {-0.500000f, 0.866026f},  {-1.000000f, 1.732052f},  {-1.500000f, 2.598077f},  {-2.000000f, 3.464104f},  {-2.500000f, 4.330130f},  {-2.999999f, 5.196155f},  {-3.500000f, 6.062181f},  {-4.000000f, 6.928207f},
 
-    {10.000000f, 5.000000f},  {20.000000f, 10.000000f}, {30.000000f, 15.000000f}, {40.000000f, 20.000000f}, {50.000000f, 25.000000f},  {60.000000f, 30.000000f},  {70.000000f, 35.000000f},  {80.000000f, 40.000000f}, 
+    {10.000000f, 5.000000f},  {20.000000f, 10.000000f}, {30.000000f, 15.000000f}, {40.000000f, 20.000000f}, {50.000000f, 25.000000f},  {60.000000f, 30.000000f},  {70.000000f, 35.000000f},  {80.000000f, 40.000000f},
     {-0.133975f, -2.232050f}, {-0.267949f, -4.464101f}, {-0.401925f, -6.696153f}, {-0.535898f, -8.928202f}, {-0.669872f, -11.160252f}, {-0.803849f, -13.392305f}, {-0.937822f, -15.624352f}, {-1.071796f, -17.856403f},
     {1.866025f, -1.232051f},  {3.732050f, -2.464102f},  {5.598075f, -3.696153f},  {7.464101f, -4.928204f},  {9.330126f, -6.160254f},   {11.196151f, -7.392306f},  {13.062176f, -8.624355f},  {14.928202f, -9.856407f},
     {2.000000f, 0.999999f},   {4.000001f, 1.999998f},   {6.000001f, 2.999998f},   {8.000002f, 3.999997f},   {10.000003f, 4.999996f},   {12.000002f, 5.999995f},   {14.000003f, 6.999995f},   {16.000004f, 7.999993f},
     {0.133975f, 2.232051f},   {0.267951f, 4.464102f},   {0.401926f, 6.696153f},   {0.535901f, 8.928205f},   {0.669876f, 11.160257f},   {0.803851f, 13.392306f},   {0.937826f, 15.624360f},   {1.071802f, 17.856409f},
     {-1.866026f, 1.232052f},  {-3.732052f, 2.464104f},  {-5.598077f, 3.696155f},  {-7.464104f, 4.928207f},  {-9.330130f, 6.160261f},   {-11.196154f, 7.392309f},  {-13.062180f, 8.624363f},  {-14.928207f, 9.856415f},
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided_bigger_dft_length, 0, 6, false /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_two_sided_bigger_dft_length, 1, 6, false /*onesided*/);
 
   std::vector<std::complex<float>> expected_axis_0_one_sided = {
     {5.000f, 0.000f}, {10.000f, 0.000f}, {15.000f, 0.000f}, {20.000f, 0.000f}, {25.000f, 0.000f}, {30.000f, 0.000f}, {35.000f, 0.000f}, {40.000f, 0.000f},
@@ -1143,7 +1221,7 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {-0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f},
     {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {0.000f, 0.000f}, {-0.000f, 0.000f}, {0.000f, 0.000f}, {-0.000f, 0.000f}, {0.000f, 0.000f},
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_one_sided, 0, 5, true /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_0_one_sided, 1, 5, true /*onesided*/);
 
   std::vector<std::complex<float>> expected_axis_1_two_sided = {
     {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f}, {-4.000f, -1.657f}, {-4.000f, -4.000f}, {-4.000f, -9.657f},
@@ -1158,7 +1236,7 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {72.000f, 36.000f}, {-17.657f, 15.314f}, {-12.000f, 4.000f}, {-9.657f, -0.686f}, {-8.000f, -4.000f}, {-6.343f, -7.314f}, {-4.000f, -12.000f}, {1.657f, -23.314f},
     {72.000f, 36.000f}, {-17.657f, 15.314f}, {-12.000f, 4.000f}, {-9.657f, -0.686f}, {-8.000f, -4.000f}, {-6.343f, -7.314f}, {-4.000f, -12.000f}, {1.657f, -23.314f},
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_1_two_sided, 1, 8, false /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_1_two_sided, 2, 8, false /*onesided*/);
 
   std::vector<std::complex<float>> expected_axis_1_one_sided = {
     {36.000f, 0.000f}, {-4.000f, 9.657f}, {-4.000f, 4.000f}, {-4.000f, 1.657f}, {-4.000f, 0.000f},
@@ -1172,7 +1250,7 @@ static void ModelBuilding_DiscreteFourierTransform() {
     {72.000f, 36.000f}, {-17.657f, 15.314f}, {-12.000f, 4.000f}, {-9.657f, -0.686f}, {-8.000f, -4.000f},
     {72.000f, 36.000f}, {-17.657f, 15.314f}, {-12.000f, 4.000f}, {-9.657f, -0.686f}, {-8.000f, -4.000f},
   };
-  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_1_one_sided, 1, 8, true /*onesided*/);
+  DiscreteFourierTransform(input, {2, 5, 8, 2}, expected_axis_1_one_sided, 2, 8, true /*onesided*/);
 
   DiscreteFourierTransform_2D();
 
@@ -1193,9 +1271,10 @@ static void DiscreteFourierTransformInverse(size_t axis) {
                              .SetInput(L"input", L"Input.TimeSignal")
                              .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(axis)}))
                              .SetOutput(L"output", L"Output.Spectra"))
-          .Operators().Add(Operator(L"IDFT", MS_EXPERIMENTAL_DOMAIN)
+          .Operators().Add(Operator(L"DFT", MS_EXPERIMENTAL_DOMAIN)
                              .SetInput(L"input", L"Output.Spectra")
                              .SetAttribute(L"axis", TensorInt64Bit::CreateFromArray({}, {INT64(axis)}))
+                             .SetAttribute(L"inverse", TensorInt64Bit::CreateFromArray({}, {INT64(1)}))
                              .SetOutput(L"output", L"Output.Inverse"))
           .CreateModel();
 
@@ -1239,29 +1318,56 @@ static void DiscreteFourierTransformInverse(size_t axis) {
 
 static void ModelBuilding_DiscreteFourierTransformInverseIdentity() {
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
-  DiscreteFourierTransformInverse(0);
   DiscreteFourierTransformInverse(1);
+  DiscreteFourierTransformInverse(2);
 #endif
 }
 
 static void ModelBuilding_HannWindow() {
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
-  WindowFunction(L"HannWindow", TensorKind::Float);
-  WindowFunction(L"HannWindow", TensorKind::Double);
+  auto expected = std::vector<float> {
+    0.000000f, 0.009607f, 0.038060f, 0.084265f, 0.146447f,
+    0.222215f, 0.308658f, 0.402455f, 0.500000f, 0.597545f,
+    0.691342f, 0.777785f, 0.853553f, 0.915735f, 0.961940f,
+    0.990393f, 1.000000f, 0.990393f, 0.961940f, 0.915735f,
+    0.853553f, 0.777785f, 0.691342f, 0.597545f, 0.500000f,
+    0.402455f, 0.308658f, 0.222215f, 0.146447f, 0.084265f,
+    0.038060f, 0.009607f
+  };
+  WindowFunction(L"HannWindow", TensorKind::Float, expected);
+  WindowFunction(L"HannWindow", TensorKind::Double, expected);
 #endif
 }
 
 static void ModelBuilding_HammingWindow() {
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
-  WindowFunction(L"HammingWindow", TensorKind::Float);
-  WindowFunction(L"HammingWindow", TensorKind::Double);
+  auto expected = std::vector<float> {
+    0.086957f, 0.095728f, 0.121707f, 0.163894f, 0.220669f,
+    0.289848f, 0.368775f, 0.454415f, 0.543478f, 0.632541f,
+    0.718182f, 0.797108f, 0.866288f, 0.923062f, 0.965249f,
+    0.991228f, 1.000000f, 0.991228f, 0.965249f, 0.923062f,
+    0.866288f, 0.797108f, 0.718182f, 0.632541f, 0.543478f,
+    0.454415f, 0.368775f, 0.289848f, 0.220669f, 0.163894f,
+    0.121707f, 0.095728f
+  };
+  WindowFunction(L"HammingWindow", TensorKind::Float, expected);
+  WindowFunction(L"HammingWindow", TensorKind::Double, expected);
 #endif
 }
 
 static void ModelBuilding_BlackmanWindow() {
 #if !defined(BUILD_INBOX) && defined(BUILD_MS_EXPERIMENTAL_OPS)
-  WindowFunction(L"BlackmanWindow", TensorKind::Float);
-  WindowFunction(L"BlackmanWindow", TensorKind::Double);
+  auto expected = std::vector<float> {
+    0.000000f, 0.003518f, 0.014629f, 0.034880f, 0.066447f,
+    0.111600f, 0.172090f, 0.248544f, 0.340000f, 0.443635f,
+    0.554773f, 0.667170f, 0.773553f, 0.866349f, 0.938508f,
+    0.984303f, 1.000000f, 0.984303f, 0.938508f, 0.866349f,
+    0.773553f, 0.667170f, 0.554773f, 0.443635f, 0.340000f,
+    0.248544f, 0.172090f, 0.111600f, 0.066447f, 0.034880f,
+    0.014629f, 0.003518f
+  };
+  WindowFunction(L"BlackmanWindow", TensorKind::Float, expected);
+  WindowFunction(L"BlackmanWindow", TensorKind::Double, expected);
 #endif
 }
 


### PR DESCRIPTION
Update signal operator contrib op definitions to match onnx opset 17

1) Implement all of the signal operators included in opset 17 as part of the existing contrib operator implementations
2) The new operator defs from the ONNX spec are additive, and should not contradict with the old contrib op definitions. The only exception is for DFT, where the new operator definition prohibits 2 dimensional real valued input, while the old contrib operator allowed it. This property of the old contrib op has been maintained, and a test has been added to ensure that it continues to work.
3) Additional tests have been added to make sure that axis and dft_length are correctly applied.