### PR TITLE
Added Ninja prerequisite

### DIFF
--- a/docs/build/web.md
+++ b/docs/build/web.md
@@ -39,6 +39,11 @@ There are 2 steps to build ONNX Runtime Web:
 - Python (3.8+): https://www.python.org/downloads/
   - python should be added to the PATH environment variable
 
+- Ninja: https://ninja-build.org/
+  ```sh
+  pip install ninja
+  ```
+
 - Prepare emsdk:
   emsdk should be automatically installed at `<ORT_ROOT>/cmake/external/emsdk/emsdk`. If the folder structure does not exist, run the following commands in `<ORT_ROOT>/` to install git submodules:
   ```sh


### PR DESCRIPTION
**Description**: Describe your changes.
Added Ninja prerequisite

**Motivation and Context**
This step is required for successful build of ORT Web
Without this installed on the env - the user will get this error - 
"CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool."