### PR TITLE
Correctly unpack tensor values

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -256,7 +256,7 @@ Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_d
                              ") does not match the data size(", tensor.field_size(), ") in proto");         \
     auto& data = tensor.field_name();                                                                       \
     for (auto data_iter = data.cbegin(); data_iter != data.cend(); ++data_iter)                             \
-      *p_data++ = *reinterpret_cast<const T*>(data_iter);                                                   \
+      *p_data++ = static_cast<T>(*data_iter);                                                               \
     return Status::OK();                                                                                    \
   }
 


### PR DESCRIPTION
**Description**: Describe your changes.

Suggested by snnn at [1]. This change fixes two issues:

* protobuf 3.20 incompatibility
* Potential incorrect results on big-endian machines (see discussions
  around [1])

Closes https://github.com/microsoft/onnxruntime/issues/11129

[1] https://github.com/microsoft/onnxruntime/issues/11129#issuecomment-1109168989

**Motivation and Context**
See 2 bullet items and the linked issue above