### PR TITLE
Add binary comparators to the OneDNN (dnnl) execution provider

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -17,6 +17,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Div", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("DynamicQuantizeLinear", std::unique_ptr<DnnlNodeCapability>(new DnnlDynamicQuantizeLinearNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Elu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Equal", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Erf", std::unique_ptr<DnnlNodeCapability>(new DnnlErfNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Exp", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("FastGelu", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
@@ -25,8 +26,12 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("Gemm", std::unique_ptr<DnnlNodeCapability>(new DnnlGemmNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("GlobalAveragePool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("GlobalMaxPool", std::unique_ptr<DnnlNodeCapability>(new DnnlPoolNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Greater", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("GreaterOrEqual", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("LayerNormalization", std::unique_ptr<DnnlNodeCapability>(new DnnlLayerNormalizationNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("LeakyRelu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Less", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("LessOrEqual", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Log", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("LRN", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("MatMul", std::unique_ptr<DnnlNodeCapability>(new DnnlMatMulNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.cc
@@ -104,6 +104,9 @@ dnnl::memory::data_type DnnlTensor::Type() const {
       return dnnl::memory::data_type::s8;
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
       return dnnl::memory::data_type::u8;
+      // Same here, we use u8 as the handler for bool
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+      return dnnl::memory::data_type::u8;
     default:
       ORT_THROW("Unsupported data type: ", data_type);
   }

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -163,7 +163,7 @@ int Product(dnnl::memory::dims d) {
 }
 
 void DnnlSubgraphPrimitive::AddKernels() {
-  std::unordered_set<std::string> binary_ops = {"Add", "Div", "Mul", "Sub"};
+  std::unordered_set<std::string> binary_ops = {"Add", "Div", "Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual", "Mul", "Sub"};
   std::unordered_set<std::string> elementwise_ops = {"Abs", "Elu", "Exp", "LeakyRelu", "Log", "Relu", "Round", "Sigmoid", "Softplus", "Sqrt", "Tanh"};
   std::unordered_set<std::string> pool_ops = {"AveragePool", "GlobalAveragePool", "GlobalMaxPool", "MaxPool"};
   std::unordered_set<std::string> reduce_ops = {"ReduceL1", "ReduceL2", "ReduceLogSum", "ReduceLogSumExp", "ReduceMax", "ReduceMean", "ReduceMin", "ReduceProd", "ReduceSum", "ReduceSumSquare"};

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_util.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_util.cc
@@ -21,10 +21,15 @@ dnnl::algorithm OrtOperatorToDnnlAlgorithm(std::string op) {
           {"Abs", dnnl::algorithm::eltwise_abs},
           {"BiasGelu", dnnl::algorithm::eltwise_gelu_erf},
           {"Elu", dnnl::algorithm::eltwise_elu},  // algorithm requires alpha value
+          {"Equal", dnnl::algorithm::binary_eq},
           {"Exp", dnnl::algorithm::eltwise_exp},
           {"FastGelu", dnnl::algorithm::eltwise_gelu_tanh},
           {"Gelu", dnnl::algorithm::eltwise_gelu_erf},
+          {"Greater", dnnl::algorithm::binary_gt},
+          {"GreaterOrEqual", dnnl::algorithm::binary_ge},
           {"LeakyRelu", dnnl::algorithm::eltwise_relu},  // algorithm requires alpha value
+          {"Less", dnnl::algorithm::binary_lt},
+          {"LessOrEqual", dnnl::algorithm::binary_le},
           {"Log", dnnl::algorithm::eltwise_log},
           {"Relu", dnnl::algorithm::eltwise_relu},
           {"Round", dnnl::algorithm::eltwise_round},


### PR DESCRIPTION
**Description**: 
Add "Equal", "Greater", "GreaterOrEqual", "Less", and "LessOrEqual" operators for the DNNL execution provider

**Motivation and Context**
- Why is this change required? What problem does it solve?
Helps expand the ONNX Operators covered by the DNN exeuciton provider.
- If it fixes an open issue, please link to the issue here.
