### PR TITLE
Remove filter_mode input from pyflakes GitHub action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,6 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          filter_mode: file
       - name: misspell # Check spellings as well
         uses: reviewdog/action-misspell@v1
         with:


### PR DESCRIPTION
Previously it triggered:

`Warning: Unexpected input(s) 'filter_mode', valid inputs are ['entryPoint', 'args', 'github_token', 'level', 'reporter']`