### PR TITLE
Pin protobuf version to 3.18.1

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -4,6 +4,6 @@ pytest
 setuptools>=41.4.0
 wheel
 git+http://github.com/onnx/onnx.git@be76ca7148396176784ba8733133b9fb1186ea0d#egg=onnx
-protobuf
+protobuf==3.18.1
 sympy==1.1.1
 flatbuffers


### PR DESCRIPTION
**Description**: 

Pin protobuf version to 3.18.1, which we use to build ONNX from source.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Protobuf just did a major version bump. If a python pb file was generated from an old version of protobuf, it may have compatibility issues with the latest protobuf. At this moment it's not clear how Google will manage this. 

I think it is a problem of ONNX, not ONNX Runtime.  Because ONNX generates python files from protobuf defs and release them, but ONNX Runtime doesn't. 

- If it fixes an open issue, please link to the issue here.
