### PR TITLE
Fix building DNNL EP with GCC 12

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc
@@ -274,7 +274,7 @@ void DnnlReduce::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
         if (src_dims[i] != 1) {
           auto dims_span = gsl::make_span(src_dims);
           ORT_ENFORCE(src_dims[i] == 1, "Dimension of input ", i, " must be 1 instead of ", src_dims[i],
-                      ". shape=", dims_span);
+                      ". shape=", TensorShape(dims_span));
         }
         ++j;
         continue;


### PR DESCRIPTION
This issue is similar to [1], where template two-phase lookups break the
build. Apparently GCC 12 is now as strict as Clang:

```
[ 69%] Building CXX object CMakeFiles/onnxruntime_providers_dnnl.dir/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc.o
In file included from /build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/common.h:36,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:19,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h:11,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.h:5,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc:3:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h: In instantiation of ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&) [with T = gsl::span<long int>; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   recursively required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = long unsigned int; Args = {const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = const char*; Args = {long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:46:17:   required from ‘std::string onnxruntime::detail::MakeStringImpl(const Args& ...) [with Args = {const char*, long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:93:32:   required from ‘std::string onnxruntime::MakeString(const Args& ...) [with Args = {char [20], long unsigned int, char [23], long int, char [9], gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc:276:11:   required from here
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: error: no match for ‘operator<<’ (operand types are ‘std::ostringstream’ {aka ‘std::__cxx11::basic_ostringstream<char>’} and ‘const gsl::span<long int>’)
   33 |   ss << t;
      |   ~~~^~~~
In file included from /usr/include/c++/12.1.0/istream:39,
                 from /usr/include/c++/12.1.0/sstream:38,
                 from /build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/common.h:27:
/usr/include/c++/12.1.0/ostream:108:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  108 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:108:36: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘std::basic_ostream<char>::__ostream_type& (*)(std::basic_ostream<char>::__ostream_type&)’ {aka ‘std::basic_ostream<char>& (*)(std::basic_ostream<char>&)’}
  108 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
      |                  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/ostream:117:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ios_type& (*)(__ios_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>; __ios_type = std::basic_ios<char>]’
  117 |       operator<<(__ios_type& (*__pf)(__ios_type&))
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:117:32: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘std::basic_ostream<char>::__ios_type& (*)(std::basic_ostream<char>::__ios_type&)’ {aka ‘std::basic_ios<char>& (*)(std::basic_ios<char>&)’}
  117 |       operator<<(__ios_type& (*__pf)(__ios_type&))
      |                  ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/ostream:127:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::ios_base& (*)(std::ios_base&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  127 |       operator<<(ios_base& (*__pf) (ios_base&))
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:127:30: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘std::ios_base& (*)(std::ios_base&)’
  127 |       operator<<(ios_base& (*__pf) (ios_base&))
      |                  ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/ostream:166:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  166 |       operator<<(long __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:166:23: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘long int’
  166 |       operator<<(long __n)
      |                  ~~~~~^~~
/usr/include/c++/12.1.0/ostream:170:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  170 |       operator<<(unsigned long __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:170:32: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘long unsigned int’
  170 |       operator<<(unsigned long __n)
      |                  ~~~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:174:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(bool) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  174 |       operator<<(bool __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:174:23: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘bool’
  174 |       operator<<(bool __n)
      |                  ~~~~~^~~
In file included from /usr/include/c++/12.1.0/ostream:833:
/usr/include/c++/12.1.0/bits/ostream.tcc:91:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(short int) [with _CharT = char; _Traits = std::char_traits<char>]’
   91 |     basic_ostream<_CharT, _Traits>::
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:92:22: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘short int’
   92 |     operator<<(short __n)
      |                ~~~~~~^~~
/usr/include/c++/12.1.0/ostream:181:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(short unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  181 |       operator<<(unsigned short __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:181:33: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘short unsigned int’
  181 |       operator<<(unsigned short __n)
      |                  ~~~~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/bits/ostream.tcc:105:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char; _Traits = std::char_traits<char>]’
  105 |     basic_ostream<_CharT, _Traits>::
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:106:20: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘int’
  106 |     operator<<(int __n)
      |                ~~~~^~~
/usr/include/c++/12.1.0/ostream:192:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  192 |       operator<<(unsigned int __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:192:31: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘unsigned int’
  192 |       operator<<(unsigned int __n)
      |                  ~~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:201:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long long int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  201 |       operator<<(long long __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:201:28: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘long long int’
  201 |       operator<<(long long __n)
      |                  ~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:205:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long long unsigned int) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  205 |       operator<<(unsigned long long __n)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:205:37: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘long long unsigned int’
  205 |       operator<<(unsigned long long __n)
      |                  ~~~~~~~~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:220:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(double) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  220 |       operator<<(double __f)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:220:25: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘double’
  220 |       operator<<(double __f)
      |                  ~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:224:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(float) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  224 |       operator<<(float __f)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:224:24: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘float’
  224 |       operator<<(float __f)
      |                  ~~~~~~^~~
/usr/include/c++/12.1.0/ostream:232:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(long double) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  232 |       operator<<(long double __f)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:232:30: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘long double’
  232 |       operator<<(long double __f)
      |                  ~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:245:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(const void*) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
  245 |       operator<<(const void* __p)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:245:30: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘const void*’
  245 |       operator<<(const void* __p)
      |                  ~~~~~~~~~~~~^~~
/usr/include/c++/12.1.0/ostream:250:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>; std::nullptr_t = std::nullptr_t]’
  250 |       operator<<(nullptr_t)
      |       ^~~~~~~~
/usr/include/c++/12.1.0/ostream:250:18: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘std::nullptr_t’
  250 |       operator<<(nullptr_t)
      |                  ^~~~~~~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:119:5: note: candidate: ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(__streambuf_type*) [with _CharT = char; _Traits = std::char_traits<char>; __streambuf_type = std::basic_streambuf<char>]’
  119 |     basic_ostream<_CharT, _Traits>::
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:120:34: note:   no known conversion for argument 1 from ‘const gsl::span<long int>’ to ‘std::basic_ostream<char>::__streambuf_type*’ {aka ‘std::basic_streambuf<char>*’}
  120 |     operator<<(__streambuf_type* __sbin)
      |                ~~~~~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/c++/12.1.0/bits/basic_string.h:48,
                 from /usr/include/c++/12.1.0/string:53,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h:7:
/usr/include/c++/12.1.0/string_view:672:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, basic_string_view<_CharT, _Traits>)’
  672 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
      |     ^~~~~~~~
/usr/include/c++/12.1.0/string_view:672:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   ‘gsl::span<long int>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/bits/basic_string.h:3883:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
 3883 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
      |     ^~~~~~~~
/usr/include/c++/12.1.0/bits/basic_string.h:3883:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   ‘const gsl::span<long int>’ is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
   33 |   ss << t;
      |   ~~~^~~~
In file included from /usr/include/c++/12.1.0/bits/ios_base.h:46,
                 from /usr/include/c++/12.1.0/streambuf:41,
                 from /usr/include/c++/12.1.0/bits/streambuf_iterator.h:35,
                 from /usr/include/c++/12.1.0/iterator:66,
                 from /usr/include/oneapi/dnnl/dnnl.hpp:28,
                 from /usr/include/dnnl.hpp:20,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h:10:
/usr/include/c++/12.1.0/system_error:279:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const error_code&)’
  279 |     operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/system_error:279:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘const std::error_code&’
   33 |   ss << t;
      |   ~~~^~~~
In file included from /usr/include/c++/12.1.0/memory:77,
                 from /usr/include/oneapi/dnnl/dnnl.hpp:29:
/usr/include/c++/12.1.0/bits/shared_ptr.h:70:5: note: candidate: ‘template<class _Ch, class _Tr, class _Tp, __gnu_cxx::_Lock_policy _Lp> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __shared_ptr<_Tp, _Lp>&)’
   70 |     operator<<(std::basic_ostream<_Ch, _Tr>& __os,
      |     ^~~~~~~~
/usr/include/c++/12.1.0/bits/shared_ptr.h:70:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   ‘const gsl::span<long int>’ is not derived from ‘const std::__shared_ptr<_Tp, _Lp>’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:507:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, _CharT)’
  507 |     operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:507:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘gsl::span<long int>’)
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:517:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, char)’
  517 |     operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:517:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘char’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:523:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char)’
  523 |     operator<<(basic_ostream<char, _Traits>& __out, char __c)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:523:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘char’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:534:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, signed char)’
  534 |     operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:534:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘signed char’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:539:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, unsigned char)’
  539 |     operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:539:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘unsigned char’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:598:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const _CharT*)’
  598 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:598:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   mismatched types ‘const _CharT*’ and ‘gsl::span<long int>’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:302:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const char*)’
  302 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/bits/ostream.tcc:302:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘const char*’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:615:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const char*)’
  615 |     operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:615:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘const char*’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:628:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const signed char*)’
  628 |     operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:628:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘const signed char*’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:633:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const unsigned char*)’
  633 |     operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:633:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘t’ (type ‘const gsl::span<long int>’) to type ‘const unsigned char*’
   33 |   ss << t;
      |   ~~~^~~~
/usr/include/c++/12.1.0/ostream:754:5: note: candidate: ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&)’
  754 |     operator<<(_Ostream&& __os, const _Tp& __x)
      |     ^~~~~~~~
/usr/include/c++/12.1.0/ostream:754:5: note:   template argument deduction/substitution failed:
/usr/include/c++/12.1.0/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::__cxx11::basic_ostringstream<char>&; _Tp = gsl::span<long int>]’:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   recursively required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = long unsigned int; Args = {const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = const char*; Args = {long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:46:17:   required from ‘std::string onnxruntime::detail::MakeStringImpl(const Args& ...) [with Args = {const char*, long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:93:32:   required from ‘std::string onnxruntime::MakeString(const Args& ...) [with Args = {char [20], long unsigned int, char [23], long int, char [9], gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc:276:11:   required from here
/usr/include/c++/12.1.0/ostream:754:5: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
In file included from /build/python-onnxruntime/src/onnxruntime/build/_deps/abseil_cpp-src/absl/container/inlined_vector.h:40,
                 from /build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/inlined_containers_fwd.h:18,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:21:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h: In instantiation of ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&) [with T = gsl::span<long int>; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   recursively required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = long unsigned int; Args = {const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:39:17:   required from ‘void onnxruntime::detail::MakeStringImpl(std::ostringstream&, const T&, const Args& ...) [with T = const char*; Args = {long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::ostringstream = std::__cxx11::basic_ostringstream<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:46:17:   required from ‘std::string onnxruntime::detail::MakeStringImpl(const Args& ...) [with Args = {const char*, long unsigned int, const char*, long int, const char*, gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:93:32:   required from ‘std::string onnxruntime::MakeString(const Args& ...) [with Args = {char [20], long unsigned int, char [23], long int, char [9], gsl::span<long int>}; std::string = std::__cxx11::basic_string<char>]’
/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc:276:11:   required from here
/usr/include/c++/12.1.0/cstddef:123:5: note: candidate: ‘template<class _IntegerType> constexpr std::__byte_op_t<_IntegerType> std::operator<<(byte, _IntegerType)’
  123 |     operator<<(byte __b, _IntegerType __shift) noexcept
      |     ^~~~~~~~
/usr/include/c++/12.1.0/cstddef:123:5: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/include/onnxruntime/core/common/make_string.h:33:6: note:   cannot convert ‘ss’ (type ‘std::ostringstream’ {aka ‘std::__cxx11::basic_ostringstream<char>’}) to type ‘std::byte’
   33 |   ss << t;
      |   ~~~^~~~
In file included from /build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl:25,
                 from /build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/shared_library/provider_api.h:15:
/build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl-lite.hpp:1477:37: note: candidate: ‘template<class IntegerType, class> constexpr gsl::byte gsl::operator<<(byte, IntegerType)’
 1477 |   gsl_api inline gsl_constexpr byte operator<<(byte b, IntegerType shift) gsl_noexcept {
      |                                     ^~~~~~~~
/build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl-lite.hpp:1477:37: note:   template argument deduction/substitution failed:
/build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl-lite.hpp:237:5: error: no type named ‘type’ in ‘struct std::enable_if<false, gsl::detail::enabler>’
  237 |   , typename = typename std::enable_if<(VA), gsl::detail::enabler>::type
      |     ^~~~~~~~
/build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl-lite.hpp:1405:3: note: in expansion of macro ‘gsl_REQUIRES_T’
 1405 |   gsl_REQUIRES_T((std::is_integral<T>::value))
      |   ^~~~~~~~~~~~~~
/build/python-onnxruntime/src/onnxruntime/onnxruntime/gsl/gsl-lite.hpp:1476:31: note: in expansion of macro ‘gsl_ENABLE_IF_INTEGRAL_T’
 1476 |   template <class IntegerType gsl_ENABLE_IF_INTEGRAL_T(IntegerType)>
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/onnxruntime_providers_dnnl.dir/build.make:342: CMakeFiles/onnxruntime_providers_dnnl.dir/build/python-onnxruntime/src/onnxruntime/onnxruntime/core/providers/dnnl/subgraph/dnnl_reduce.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1611: CMakeFiles/onnxruntime_providers_dnnl.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Error messages above are from gcc 12.1.0 on Arch Linux.

[1] https://github.com/microsoft/onnxruntime/pull/10014

**Description**: Describe your changes.

**Motivation and Context**

To improve onnxruntime compatibility with the latest GCC.

There is no related issue but a related PR, and it's mentioned above.