### PR TITLE
Fix wasm static lib in sub-project

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -72,11 +72,14 @@ function(bundle_static_library bundled_target_name)
   endforeach()
 
   add_library(${bundled_target_name} STATIC IMPORTED GLOBAL)
+  set_target_properties(${bundled_target_name}
+    PROPERTIES
+      IMPORTED_LOCATION ${bundled_target_full_name})
   foreach(target_name IN ITEMS ${ARGN})
-    set_target_properties(${bundled_target_name}
-      PROPERTIES
-        IMPORTED_LOCATION ${bundled_target_full_name}
-        INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${target_name},INTERFACE_INCLUDE_DIRECTORIES>)
+    set_property(TARGET ${bundled_target_name} APPEND
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${target_name},INTERFACE_INCLUDE_DIRECTORIES>)
+    set_property(TARGET ${bundled_target_name} APPEND
+      PROPERTY INTERFACE_COMPILE_DEFINITIONS $<TARGET_PROPERTY:${target_name},INTERFACE_COMPILE_DEFINITIONS>)
   endforeach()
   add_dependencies(${bundled_target_name} bundling_target)
 endfunction()

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -72,6 +72,9 @@ function(bundle_static_library bundled_target_name)
   endforeach()
 
   add_library(${bundled_target_name} STATIC IMPORTED GLOBAL)
+  set_target_properties(${bundled_target_name}
+    PROPERTIES
+      IMPORTED_LOCATION ${bundled_target_full_name})
   foreach(target_name IN ITEMS ${ARGN})
     set_property(TARGET ${bundled_target_name} APPEND
       PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${target_name},INTERFACE_INCLUDE_DIRECTORIES>)

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -71,7 +71,7 @@ function(bundle_static_library bundled_target_name)
     add_dependencies(bundling_target ${target_name})
   endforeach()
 
-  add_library(${bundled_target_name} STATIC IMPORTED)
+  add_library(${bundled_target_name} STATIC IMPORTED GLOBAL)
   foreach(target_name IN ITEMS ${ARGN})
     set_target_properties(${bundled_target_name}
       PROPERTIES


### PR DESCRIPTION
**Description**: 
1. By default, imported libraries are only visible in the directory in which it is created, unlike normal libraries (https://cmake.org/cmake/help/v3.9/command/add_library.html#imported-libraries). It hinders onnxruntime to be used as a sub-project.
2. The INTERFACE_INCLUDE_DIRECTORIES of the imported target is obviously wrong because of override.
3. INTERFACE_COMPILE_DEFINITIONS (for example `ONNX_ML=1`) should also be populated (and all INTERFACE_* properties indeed). 

**Motivation and Context**
- Why is this change required? What problem does it solve?
I'm refactoring [onnxsim](https://github.com/daquexian/onnx-simplifier) to run it on the web.