### PR TITLE
[TVM EP] update set input method for VirtualMachine

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -8,7 +8,7 @@
                "repositoryUrl": "https://github.com/abseil/abseil-cpp.git"
             }
          }
-      },   
+      },
       {
         "component": {
           "Type": "maven",
@@ -46,7 +46,7 @@
          "component": {
             "type": "git",
             "git": {
-               "commitHash": "ffd5f70370642c909222f9a4cae8400023dacbdc",
+               "commitHash": "bc492acd7677dd7875b14f9ee46beef658955441",
                "repositoryUrl": "https://github.com/apache/tvm.git"
             },
             "comments": "needed for TVM EP"

--- a/cmake/external/tvm.cmake
+++ b/cmake/external/tvm.cmake
@@ -4,7 +4,7 @@ if (onnxruntime_USE_TVM)
   FetchContent_Declare(
     tvm
     GIT_REPOSITORY https://github.com/apache/tvm.git
-    GIT_TAG        ffd5f70370642c909222f9a4cae8400023dacbdc
+    GIT_TAG        bc492acd7677dd7875b14f9ee46beef658955441
   )
 
   FetchContent_GetProperties(tvm)

--- a/onnxruntime/core/providers/tvm/tvm_allocator.cc
+++ b/onnxruntime/core/providers/tvm/tvm_allocator.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <tvm/runtime/device_api.h>
+
 #include "tvm_allocator.h"
 #include "core/framework/allocatormgr.h"
 #include "core/framework/session_state.h"
@@ -14,7 +16,7 @@ void* TVMAllocator::Alloc(size_t size) {
   void* p = nullptr;
   if (size > 0) {
     DLDataType dl_type{kDLInt, 8, 1};
-    int err = TVMDeviceAllocDataSpace(ctx, size, 128, dl_type, reinterpret_cast<void**>(&p));
+    int err = TVMDeviceAllocDataSpace(ctx, size, ::tvm::runtime::kAllocAlignment, dl_type, reinterpret_cast<void**>(&p));
     CHECK_EQ(err, 0);
     return p;
   }

--- a/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_ubuntu.sh
@@ -42,6 +42,7 @@ PACKAGE_LIST="autotools-dev \
 	libssl1.1 \
 	libkrb5-3 \
 	libtinfo-dev \
+	libtinfo5 \
 	libtool \
 	openssh-server \
 	aria2 \

--- a/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
+++ b/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
@@ -3,5 +3,3 @@ set -e -x
 
 PYTHON_EXE=$1
 ${PYTHON_EXE} -m pip install decorator scipy
-
-sudo apt-get update && sudo apt-get install -y libtinfo5

--- a/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
+++ b/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
@@ -3,3 +3,5 @@ set -e -x
 
 PYTHON_EXE=$1
 ${PYTHON_EXE} -m pip install decorator scipy
+
+apt-get update && apt-get install -y libtinfo5

--- a/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
+++ b/tools/ci_build/github/linux/tvm/install_tvm_test_dependencies.sh
@@ -4,4 +4,4 @@ set -e -x
 PYTHON_EXE=$1
 ${PYTHON_EXE} -m pip install decorator scipy
 
-apt-get update && apt-get install -y libtinfo5
+sudo apt-get update && sudo apt-get install -y libtinfo5


### PR DESCRIPTION
1. Update TVM where memory issue was fixed for NDArray created from DLTensor
2. update TVM_VM_SetInputs method to upstream with current TVM API

Note: it is update of #11247 which was reverted due to problem in TVM build. Be carefully during CI tests.
