### PR TITLE
pin protobuf version 

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -8,3 +8,4 @@ git+http://github.com/onnx/onnx.git@be76ca7148396176784ba8733133b9fb1186ea0d#egg
 argparse
 sympy==1.1.1
 flatbuffers
+protobuf==3.18.1


### PR DESCRIPTION
**Description**: Describe your changes.
pin protobuf version to 3.18.1 

**Motivation and Context**
build pipeline failed because of the protobuf compatibility
pin protobuf version to 3.18.1 as a workaround
