### PR TITLE
Template implementation wasn't built, linker issues

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -2,57 +2,11 @@
 // Licensed under the MIT License.
 
 #include "qlinear_global_average_pool.h"
-#include "core/util/math_cpuonly.h"
-#include "core/providers/common.h"
-#include "core/platform/threadpool.h"
-#include "core/util/math.h"
-#include "core/mlas/inc/mlas.h"
-#include <functional>
 
 using onnxruntime::concurrency::ThreadPool;
 
 namespace onnxruntime {
 namespace contrib {
-
-template <typename T8Bits>
-Status ComputeQLinearGlobalAvgPool(
-    const T8Bits* x,
-    float x_scale,
-    T8Bits x_zero_point,
-    T8Bits* y,
-    float y_scale,
-    T8Bits y_zero_point,
-    int64_t N,
-    int64_t C,
-    int64_t image_size,
-    bool channels_last,
-    concurrency::ThreadPool* tp) {
-  if (!channels_last || C == 1) {
-    auto worker = [=](std::ptrdiff_t first, std::ptrdiff_t last) {
-      const T8Bits* input = (const T8Bits*)(x + (first * image_size));
-      T8Bits* output = (T8Bits*)(y + first);
-      std::vector<int32_t> acc_buffer(MlasQLinearSafePaddingElementCount(sizeof(int32_t), last - first));
-      MlasQLinearGlobalAveragePoolNchw(input, x_scale, x_zero_point, output, y_scale, y_zero_point, last - first, image_size, acc_buffer.data());
-    };
-    concurrency::ThreadPool::TryParallelFor(
-        tp, static_cast<std::ptrdiff_t>(N * C), {1.0 * image_size, 1.0, 8.0 * image_size}, worker);
-  } else {
-    auto worker = [=](std::ptrdiff_t first, std::ptrdiff_t last) {
-      const T8Bits* input = x + first * C * image_size;
-      T8Bits* output = y + first * C;
-      std::vector<int32_t> acc_buffer(MlasQLinearSafePaddingElementCount(sizeof(int32_t), C));
-      std::vector<T8Bits> zero_buffer(MlasQLinearSafePaddingElementCount(sizeof(T8Bits), C), 0);
-      MlasQLinearGlobalAveragePoolNhwc(
-          input, x_scale, x_zero_point, output, y_scale, y_zero_point,
-          last - first, image_size, C, C, acc_buffer.data(), zero_buffer.data());
-    };
-    concurrency::ThreadPool::TryParallelFor(
-        tp, static_cast<std::ptrdiff_t>(N),
-        {1.0 * image_size * C, 1.0 * C, 8.0 * image_size * C},
-        worker);
-  }
-  return Status::OK();
-}
 
 Status QLinearGlobalAveragePool::Compute(OpKernelContext* context) const {
   const auto tensor_x_scale = context->Input<Tensor>(1);

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.h
@@ -37,3 +37,5 @@ Status ComputeQLinearGlobalAvgPool(
 
 }  // namespace contrib
 }  // namespace onnxruntime
+
+#include "qlinear_global_average_pool.inl"

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.inl
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.inl
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "qlinear_global_average_pool.h"
+#include "core/util/math_cpuonly.h"
+#include "core/providers/common.h"
+#include "core/platform/threadpool.h"
+#include "core/util/math.h"
+#include "core/mlas/inc/mlas.h"
+#include <functional>
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T8Bits>
+Status ComputeQLinearGlobalAvgPool(
+    const T8Bits* x,
+    float x_scale,
+    T8Bits x_zero_point,
+    T8Bits* y,
+    float y_scale,
+    T8Bits y_zero_point,
+    int64_t N,
+    int64_t C,
+    int64_t image_size,
+    bool channels_last,
+    concurrency::ThreadPool* tp) {
+  if (!channels_last || C == 1) {
+    auto worker = [=](std::ptrdiff_t first, std::ptrdiff_t last) {
+      const T8Bits* input = (const T8Bits*)(x + (first * image_size));
+      T8Bits* output = (T8Bits*)(y + first);
+      std::vector<int32_t> acc_buffer(MlasQLinearSafePaddingElementCount(sizeof(int32_t), last - first));
+      MlasQLinearGlobalAveragePoolNchw(input, x_scale, x_zero_point, output, y_scale, y_zero_point, last - first, image_size, acc_buffer.data());
+    };
+    concurrency::ThreadPool::TryParallelFor(
+        tp, static_cast<std::ptrdiff_t>(N * C), {1.0 * image_size, 1.0, 8.0 * image_size}, worker);
+  } else {
+    auto worker = [=](std::ptrdiff_t first, std::ptrdiff_t last) {
+      const T8Bits* input = x + first * C * image_size;
+      T8Bits* output = y + first * C;
+      std::vector<int32_t> acc_buffer(MlasQLinearSafePaddingElementCount(sizeof(int32_t), C));
+      std::vector<T8Bits> zero_buffer(MlasQLinearSafePaddingElementCount(sizeof(T8Bits), C), 0);
+      MlasQLinearGlobalAveragePoolNhwc(
+          input, x_scale, x_zero_point, output, y_scale, y_zero_point,
+          last - first, image_size, C, C, acc_buffer.data(), zero_buffer.data());
+    };
+    concurrency::ThreadPool::TryParallelFor(
+        tp, static_cast<std::ptrdiff_t>(N),
+        {1.0 * image_size * C, 1.0 * C, 8.0 * image_size * C},
+        worker);
+  }
+  return Status::OK();
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Describe your changes.

Template implementation wasn't built for the linker, this splits it out to an .inl but I am not sure if this is the correct way or if some of the `#include`'s could live in the .cc instead of the .inl so it needs some eyes on it.

**Motivation and Context**
- Why is this change required? What problem does it solve?

```
FAILED: libonnxruntime.so.1.11.1 
: && /usr/bin/c++ -fPIC -O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer -fcf-protection -mtune=generic -march=x86-64-v3 -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -DCPUINFO_SUPPORTED -O2 -g -DNDEBUG -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION  -Wl,-z,relro,-z,now -Wl,--as-needed -Wl,-rpath='$ORIGIN'   -Xlinker --version-script=/buildstream/carbonOS/pkgs/xr/onnxruntime.bst/_builddir/onnxruntime.lds -Xlinker --no-undefined -Xlinker --gc-sections -z noexecstack  -Wl,--gc-sections -shared -Wl,-soname,libonnxruntime.so.1.11.1 -o libonnxruntime.so.1.11.1 CMakeFiles/onnxruntime.dir/generated_source.c.o  libonnxruntime_session.a  libonnxruntime_optimizer.a  libonnxruntime_providers.a  libonnxruntime_framework.a  libonnxruntime_graph.a  libonnxruntime_util.a  libonnxruntime_mlas.a  libonnxruntime_common.a  libonnxruntime_flatbuffers.a  libonnx.a  libonnx_proto.a  external/protobuf/cmake/libprotobuf-lite.a  external/re2/libre2.a  external/abseil-cpp/absl/base/libabsl_base.a  external/abseil-cpp/absl/base/libabsl_throw_delegate.a  external/abseil-cpp/absl/container/libabsl_raw_hash_set.a  external/abseil-cpp/absl/hash/libabsl_hash.a  external/abseil-cpp/absl/hash/libabsl_city.a  external/abseil-cpp/absl/hash/libabsl_low_level_hash.a  external/abseil-cpp/absl/base/libabsl_raw_logging_internal.a  external/flatbuffers/libflatbuffers.a  external/pytorch_cpuinfo/libcpuinfo.a  external/pytorch_cpuinfo/deps/clog/libclog.a  external/nsync/libnsync_cpp.a  -ldl  -lrt  external/abseil-cpp/absl/hash/libabsl_hash.a  external/abseil-cpp/absl/hash/libabsl_city.a  external/abseil-cpp/absl/hash/libabsl_low_level_hash.a  external/abseil-cpp/absl/types/libabsl_bad_variant_access.a  external/abseil-cpp/absl/strings/libabsl_cord.a  external/abseil-cpp/absl/strings/libabsl_cordz_info.a  external/abseil-cpp/absl/strings/libabsl_cord_internal.a  external/abseil-cpp/absl/strings/libabsl_cordz_functions.a  external/abseil-cpp/absl/strings/libabsl_cordz_handle.a  external/abseil-cpp/absl/container/libabsl_raw_hash_set.a  external/abseil-cpp/absl/types/libabsl_bad_optional_access.a  external/abseil-cpp/absl/container/libabsl_hashtablez_sampler.a  external/abseil-cpp/absl/profiling/libabsl_exponential_biased.a  external/abseil-cpp/absl/synchronization/libabsl_synchronization.a  external/abseil-cpp/absl/synchronization/libabsl_graphcycles_internal.a  external/abseil-cpp/absl/debugging/libabsl_stacktrace.a  external/abseil-cpp/absl/debugging/libabsl_symbolize.a  external/abseil-cpp/absl/base/libabsl_malloc_internal.a  external/abseil-cpp/absl/debugging/libabsl_debugging_internal.a  external/abseil-cpp/absl/debugging/libabsl_demangle_internal.a  external/abseil-cpp/absl/time/libabsl_time.a  external/abseil-cpp/absl/strings/libabsl_strings.a  external/abseil-cpp/absl/base/libabsl_throw_delegate.a  external/abseil-cpp/absl/numeric/libabsl_int128.a  external/abseil-cpp/absl/strings/libabsl_strings_internal.a  external/abseil-cpp/absl/base/libabsl_base.a  external/abseil-cpp/absl/base/libabsl_raw_logging_internal.a  external/abseil-cpp/absl/base/libabsl_log_severity.a  external/abseil-cpp/absl/base/libabsl_spinlock_wait.a  -lrt  external/abseil-cpp/absl/time/libabsl_civil_time.a  external/abseil-cpp/absl/time/libabsl_time_zone.a && :
/usr/bin/ld: libonnxruntime_providers.a(qlinear_pool.cc.o): in function `onnxruntime::common::Status onnxruntime::contrib::QLinearAveragePool::ComputeImpl<unsigned char>(onnxruntime::OpKernelContext*) const':
/buildstream/carbonOS/pkgs/xr/onnxruntime.bst/onnxruntime/contrib_ops/cpu/quantization/qlinear_pool.cc:577: undefined reference to `onnxruntime::common::Status onnxruntime::contrib::ComputeQLinearGlobalAvgPool<unsigned char>(unsigned char const*, float, unsigned char, unsigned char*, float, unsigned char, long, long, long, bool, onnxruntime::concurrency::ThreadPool*)'
/usr/bin/ld: libonnxruntime_providers.a(qlinear_pool.cc.o): in function `onnxruntime::common::Status onnxruntime::contrib::QLinearAveragePool::ComputeImpl<signed char>(onnxruntime::OpKernelContext*) const':
/buildstream/carbonOS/pkgs/xr/onnxruntime.bst/onnxruntime/contrib_ops/cpu/quantization/qlinear_pool.cc:577: undefined reference to `onnxruntime::common::Status onnxruntime::contrib::ComputeQLinearGlobalAvgPool<signed char>(signed char const*, float, signed char, signed char*, float, signed char, long, long, long, bool, onnxruntime::concurrency::ThreadPool*)'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

- If it fixes an open issue, please link to the issue here.

Can't find it being an issue yet for anyone else, could be a GCC 12 thing?
