### PR TITLE
[Abseil/CMake] Adding URL_HASH

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -18,6 +18,7 @@ FetchContent_Declare(
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/abseil-cpp"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/abseil-cpp"
     URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip
+    URL_HASH SHA1=ce61532df974d00025b1220408ce1c900d81baf2
     PATCH_COMMAND ${ABSL_PATCH_COMMAND}
 )
 
@@ -25,11 +26,9 @@ FetchContent_MakeAvailable(abseil_cpp)
 FetchContent_GetProperties(abseil_cpp SOURCE_DIR)
 
 if (GDK_PLATFORM)
-  # Abseil considers any partition that is NOT in the WINAPI_PARTITION_APP a viable platform 
+  # Abseil considers any partition that is NOT in the WINAPI_PARTITION_APP a viable platform
   # for Win32 symbolize code (which depends on dbghelp.lib); this logic should really be flipped
   # to only include partitions that are known to support it (e.g. DESKTOP). As a workaround we
   # tell Abseil to pretend we're building an APP.
   target_compile_definitions(absl_symbolize PRIVATE WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP)
 endif()
-
-


### PR DESCRIPTION
**Description**: Describe your changes.

Adding URL_HASH so that an existing archive can be used from disk. Needed for building without an internet connection.

**Motivation and Context**
- Why is this change required? What problem does it solve?

Needed for package maintenance that implies no internet connection at build time

- If it fixes an open issue, please link to the issue here.

None
