### PR TITLE
[js/web] use package 'wasm-feature-detect'

### DIFF
--- a/js/web/package-lock.json
+++ b/js/web/package-lock.json
@@ -14,7 +14,8 @@
         "long": "^4.0.0",
         "onnx-proto": "^4.0.4",
         "onnxruntime-common": "file:../common",
-        "platform": "^1.3.6"
+        "platform": "^1.3.6",
+        "wasm-feature-detect": "^1.2.11"
       },
       "devDependencies": {
         "@chiragrupani/karma-chromium-edge-launcher": "^2.1.0",
@@ -6519,6 +6520,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz",
+      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w=="
+    },
     "node_modules/watchpack": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
@@ -12290,6 +12296,11 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
+    },
+    "wasm-feature-detect": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz",
+      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w=="
     },
     "watchpack": {
       "version": "2.1.1",

--- a/js/web/package.json
+++ b/js/web/package.json
@@ -12,12 +12,13 @@
   "version": "1.12.0",
   "jsdelivr": "dist/ort.min.js",
   "dependencies": {
-    "onnx-proto": "^4.0.4",
     "flatbuffers": "^1.12.0",
-    "long": "^4.0.0",
-    "platform": "^1.3.6",
     "guid-typescript": "^1.0.9",
-    "onnxruntime-common": "file:../common"
+    "long": "^4.0.0",
+    "onnx-proto": "^4.0.4",
+    "onnxruntime-common": "file:../common",
+    "platform": "^1.3.6",
+    "wasm-feature-detect": "^1.2.11"
   },
   "scripts": {
     "prepare": "tsc",


### PR DESCRIPTION
**Description**: The old feature detection implementation seems not working on some of the devices/browser combination. (see #11679 #11567)

This change consumes [wasm-feature-detect](https://github.com/GoogleChromeLabs/wasm-feature-detect) to detect features.

Need tests on:
- [ ] Windows/Chrome, No CO headers
- [ ] Windows/Chrome, with CO headers
- [ ] Mac/Safari, No CO headers
- [ ] Mac/Safari, with CO headers
- [ ] iOS/Safari, No CO headers
- [ ] iOS/Safari, with CO headers