### PR TITLE
Split the GPU pipeline to 3 different machine pools

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -41,6 +41,9 @@ parameters:
   
 - name: ORT_EP_NAME
   type: string
+  
+- name: MachinePool
+  type: string
 
 - name: DocUpdateNeeded
   displayName: Run Tests?
@@ -58,7 +61,7 @@ jobs:
     DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}    
   workspace:
     clean: all
-  pool: 'Win-GPU-2019'
+  pool: ${{ parameters.MachinePool }}
   timeoutInMinutes:  300  
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -20,6 +20,7 @@ stages:
         RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
         RunStaticCodeAnalysis: false
         ORT_EP_NAME: CUDA
+        MachinePool: onnxruntime-Win2019-GPU
         DocUpdateNeeded: true
 
 
@@ -38,6 +39,7 @@ stages:
         RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
         RunStaticCodeAnalysis: false
         ORT_EP_NAME: CUDA
+        MachinePool: onnxruntime-Win2019-GPU-training
         isTraining: true
      
 - stage: dml
@@ -48,11 +50,12 @@ stages:
         BuildConfig: 'RelWithDebInfo'
         EnvSetupScript: setup_env.bat
         buildArch: x64
-        additionalBuildFlags: --enable_pybind --use_dml --enable_wcos  --use_winml --cmake_extra_defines CMAKE_SYSTEM_VERSION=10.0.18362.0
+        additionalBuildFlags: --enable_pybind --use_dml --enable_wcos  --use_winml
         msbuildPlatform: x64
         isX86: false
         job_name_suffix: x64_RelWithDebInfo
         RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
         RunStaticCodeAnalysis: false
-        ORT_EP_NAME: DML     
+        ORT_EP_NAME: DML
+        MachinePool: onnxruntime-Win2019-GPU-dml
 


### PR DESCRIPTION
**Description**:  
Split the GPU pipeline to 3 different machine pools

**Motivation and Context**
- Why is this change required? What problem does it solve?

These machines are stateful. Their states get preserved across pipelines and pipeline runs. While it improves build performance, it also make things harder to debug. We don't have a need to let them share the same pool. It was in such setting when our machine pools are not dynamically scalable. Now they are. 


- If it fixes an open issue, please link to the issue here.
