### PR TITLE
missing #include <thrust/count.h> in non_max_suppression_impl.cu

### DIFF
--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 /* Modifications Copyright (c) Microsoft. */
 
+#include <thrust/count.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 


### PR DESCRIPTION
Otherwise, depending on cuda or hip thrust versions, transitive header inclusions miss thrust::count_if.