### PR TITLE
make xnnpack build for ort-web

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -906,7 +906,7 @@ if (onnxruntime_ENABLE_CPUINFO)
   else()
     # if xnnpack is enabled in a wasm build it needs clog from cpuinfo, but we won't internally use cpuinfo
     # so we don't set CPUINFO_SUPPORTED in the CXX flags below.
-    if (onnxruntime_BUILD_WEBASSEMBLY AND NOT onnxruntime_USE_XNNPACK) 
+    if (onnxruntime_BUILD_WEBASSEMBLY AND NOT onnxruntime_USE_XNNPACK)
       set(CPUINFO_SUPPORTED FALSE)
     else()
       set(CPUINFO_SUPPORTED TRUE)
@@ -937,8 +937,8 @@ if (CPUINFO_SUPPORTED)
     set(IOS ON CACHE INTERNAL "")
     set(IOS_ARCH "${CMAKE_OSX_ARCHITECTURES}" CACHE INTERNAL "")
   endif()
-  
-  # if this is a wasm build with xnnpack (only type of wasm build where cpuinfo is involved) 
+
+  # if this is a wasm build with xnnpack (only type of wasm build where cpuinfo is involved)
   # we do not use cpuinfo in ORT code, so don't define CPUINFO_SUPPORTED.
   if (NOT onnxruntime_BUILD_WEBASSEMBLY)
     string(APPEND CMAKE_CXX_FLAGS " -DCPUINFO_SUPPORTED")
@@ -985,8 +985,8 @@ include(eigen)
 set(onnxruntime_EXTERNAL_LIBRARIES onnx onnx_proto ${PROTOBUF_LIB} re2::re2)
 
 if(NOT onnxruntime_DISABLE_ABSEIL)
-  set(ABSEIL_LIBS absl::inlined_vector absl::flat_hash_set 
-    absl::flat_hash_map absl::node_hash_set absl::node_hash_map absl::base absl::throw_delegate absl::raw_hash_set 
+  set(ABSEIL_LIBS absl::inlined_vector absl::flat_hash_set
+    absl::flat_hash_map absl::node_hash_set absl::node_hash_map absl::base absl::throw_delegate absl::raw_hash_set
     absl::hash absl::city absl::low_level_hash absl::raw_logging_internal)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${ABSEIL_LIBS})
 else()
@@ -1301,7 +1301,7 @@ function(onnxruntime_configure_target target_name)
     set_target_properties(${target_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
     set_target_properties(${target_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE)
   endif()
-  
+
   # Keep BinSkim happy
   if(MSVC AND NOT onnxruntime_target_platform MATCHES "ARM")
     target_link_options(${target_name} PRIVATE "/CETCOMPAT")
@@ -1542,7 +1542,7 @@ if (onnxruntime_USE_XNNPACK)
 
   set(XNNPACK_DIR external/XNNPACK)
   set(XNNPACK_INCLUDE_DIR ${XNNPACK_DIR}/include)
-  set(XNNPACK_USE_SYSTEM_LIBS ON CACHE INTERNAL "")  
+  set(XNNPACK_USE_SYSTEM_LIBS ON CACHE INTERNAL "")
   set(XNNPACK_BUILD_TESTS OFF CACHE INTERNAL "")
   set(XNNPACK_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
   set(FP16_BUILD_TESTS OFF CACHE INTERNAL "")
@@ -1550,14 +1550,14 @@ if (onnxruntime_USE_XNNPACK)
   set(CLOG_SOURCE_DIR "${PYTORCH_CPUINFO_DIR}/deps/clog")
   set(CPUINFO_SOURCE_DIR ${PYTORCH_CPUINFO_DIR})
 
-  add_subdirectory(external/FP16)  
+  add_subdirectory(external/FP16)
   add_subdirectory(external/pthreadpool)
   add_subdirectory(external/XNNPACK)
 
   set_target_properties(fp16 PROPERTIES FOLDER "External/Xnnpack")
   set_target_properties(pthreadpool PROPERTIES FOLDER "External/Xnnpack")
   set_target_properties(XNNPACK PROPERTIES FOLDER "External/Xnnpack")
-  
+
   set(onnxruntime_EXTERNAL_LIBRARIES_XNNPACK XNNPACK pthreadpool)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK})
 
@@ -1570,28 +1570,29 @@ if (onnxruntime_USE_XNNPACK)
     message("Adding WebAssembly Source Files to XNNPACK")
     set(wasm_src_patterns "${XNNPACK_DIR}/src/wasm-*.c"
                           "${XNNPACK_DIR}/src/*-wasm-*.c"
-                          "${XNNPACK_DIR}/src/*-wasm.c")  
+                          "${XNNPACK_DIR}/src/*-wasm.c")
     set(wasm32_asm_src_patterns "${XNNPACK_DIR}/src/wasm_shr_*.S")
 
     file(GLOB_RECURSE XNNPACK_WASM_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasm_src_patterns})
     file(GLOB_RECURSE XNNPACK_WASM32_ASM_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasm32_asm_src_patterns})
-    
+
     message(DEBUG "XNNPACK_WASM_MICROKERNEL_SRCS:${XNNPACK_WASM_MICROKERNEL_SRCS}")
     message(DEBUG "XNNPACK_WASM32_ASM_MICROKERNEL_SRCS:${XNNPACK_WASM32_ASM_MICROKERNEL_SRCS}")
 
     target_sources(XNNPACK PRIVATE ${XNNPACK_WASM_MICROKERNEL_SRCS}
                                     ${XNNPACK_WASM32_ASM_MICROKERNEL_SRCS})
 
-    if (onnxruntime_ENABLE_WEBASSEMBLY_SIMD)        
+    if (onnxruntime_ENABLE_WEBASSEMBLY_SIMD)
       target_compile_options(XNNPACK PRIVATE "-msimd128")
 
       set(wasmsimd_src_patterns "${XNNPACK_DIR}/src/wasmsimd-*.c"
                                 "${XNNPACK_DIR}/src/*-wasmsimd-*.c"
-                                "${XNNPACK_DIR}/src/*-wasmsimd.c")
+                                "${XNNPACK_DIR}/src/*-wasmsimd.c"
+                                "${XNNPACK_DIR}/src/*/wasmsimd.c")
 
       file(GLOB_RECURSE XNNPACK_WASMSIMD_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasmsimd_src_patterns})
       message(DEBUG "XNNPACK_WASMSIMD_MICROKERNEL_SRCS:${XNNPACK_WASMSIMD_MICROKERNEL_SRCS}")
-      
+
       target_sources(XNNPACK PRIVATE ${XNNPACK_WASMSIMD_MICROKERNEL_SRCS})
     endif()
   endif()
@@ -2036,7 +2037,7 @@ endif()
 
 set(ONNXRUNTIME_TARGETS onnxruntime_common onnxruntime_graph onnxruntime_framework onnxruntime_util onnxruntime_providers onnxruntime_optimizer onnxruntime_session onnxruntime_mlas onnxruntime_flatbuffers)
 if (onnxruntime_USE_NUPHAR_TVM)
-  list(APPEND ONNXRUNTIME_TARGETS onnxruntime_codegen_tvm)  
+  list(APPEND ONNXRUNTIME_TARGETS onnxruntime_codegen_tvm)
 endif()
 if (onnxruntime_ENABLE_EAGER_MODE)
   if (NOT onnxruntime_ENABLE_TRAINING OR NOT onnxruntime_ENABLE_PYTHON)
@@ -2205,4 +2206,3 @@ if (onnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS)
     COMMENT "Installing protobuf"
   )
 endif()
-

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -174,6 +174,9 @@ else()
     onnxruntime_util
     re2::re2
   )
+  if (onnxruntime_USE_XNNPACK)
+    target_link_libraries(onnxruntime_webassembly PRIVATE XNNPACK)
+  endif()
 
   if (onnxruntime_ENABLE_TRAINING OR onnxruntime_ENABLE_TRAINING_OPS)
     target_link_libraries(onnxruntime_webassembly PRIVATE tensorboard)

--- a/js/web/package-lock.json
+++ b/js/web/package-lock.json
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -7726,9 +7726,9 @@
       }
     },
     "acorn": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-walk": {

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -4,6 +4,9 @@
 #include "api.h"
 
 #include "core/session/onnxruntime_cxx_api.h"
+#ifdef USE_XNNPACK
+#include "core/providers/xnnpack/xnnpack_provider_factory.h"
+#endif
 
 #include <iostream>
 #include <vector>
@@ -112,7 +115,9 @@ OrtSessionOptions* OrtCreateSessionOptions(size_t graph_optimization_level,
   // Enable ORT CustomOps in onnxruntime-extensions
   RETURN_NULLPTR_IF_ERROR(EnableOrtCustomOps, session_options);
 #endif
-
+#if defined(USE_XNNPACK)
+  (void)OrtSessionOptionsAppendExecutionProvider_Xnnpack(session_options);
+#endif
   return session_options;
 }
 


### PR DESCRIPTION
changes to make xnnpack build for ort-web.

1 more change is needed to cmake/external/XNNPACK/CmakeLists.txt:
```
-ELSEIF(NOT CMAKE_SYSTEM_NAME MATCHES "^(Darwin|Linux|Android|Windows|CYGWIN|MSYS)$")
+ELSEIF(NOT CMAKE_SYSTEM_NAME MATCHES "^(Darwin|Linux|Android|Windows|CYGWIN|MSYS|Emscripten)$")
```