### PR TITLE
Add ability to author float initializers

### DIFF
--- a/orttraining/orttraining/python/training/onnxblock/building_blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/building_blocks.py
@@ -3,10 +3,11 @@
 # _building_blocks.py
 
 from abc import ABC, abstractmethod
+
 import onnx
 
-import onnxruntime.training.onnxblock.model_accessor as accessor
 import onnxruntime.training.onnxblock._graph_utils as graph_utils
+import onnxruntime.training.onnxblock.model_accessor as accessor
 
 
 class Block(ABC):
@@ -178,3 +179,19 @@ class Log(_UnaryOp):
 class Neg(_UnaryOp):
     def __init__(self):
         super(Neg, self).__init__("Neg")
+
+
+class Value(Block):
+    """Creates an initializer and adds it to the onnx model."""
+    def __init__(self, value):
+        self._value = value
+
+    def build(self):
+        # create the graph initializer for the exponent
+        initializer_name = graph_utils.generate_random_graph_name("initializer")
+        accessor.global_accessor.model.graph.initializer.append(
+            onnx.helper.make_tensor(
+                initializer_name, onnx.TensorProto.FLOAT, [1], [self._value]
+            )
+        )
+        return initializer_name

--- a/orttraining/orttraining/python/training/onnxblock/building_blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/building_blocks.py
@@ -176,9 +176,13 @@ class Neg(_UnaryOp):
 
 
 class Constant(Block):
-    """Creates an initializer and adds it to the onnx model."""
+    """Creates a float initializer and adds it to the onnx model."""
+
+    # TODO: Add ability to add all sorts of initializers (not just floats).
 
     def __init__(self, value_float):
+        super().__init__()
+
         self._value = value_float
 
     def build(self):

--- a/orttraining/orttraining/python/training/onnxblock/building_blocks.py
+++ b/orttraining/orttraining/python/training/onnxblock/building_blocks.py
@@ -51,9 +51,7 @@ class _BinaryOp(Block):
 
         # create the graph node for sub
         node_input_names = [input_name1, input_name2]
-        node_output_name = graph_utils.generate_random_graph_name(
-            f"{self._op_name.lower()}_output"
-        )
+        node_output_name = graph_utils.generate_random_graph_name(f"{self._op_name.lower()}_output")
         node_output_names = [node_output_name]
         node = onnx.helper.make_node(
             self._op_name,
@@ -102,9 +100,7 @@ class Pow(Block):
         # create the graph initializer for the exponent
         pow_node_exponent_name = graph_utils.generate_random_graph_name("pow_exponent")
         onnx_model.graph.initializer.append(
-            onnx.helper.make_tensor(
-                pow_node_exponent_name, onnx.TensorProto.FLOAT, [1], [self._exponent]
-            )
+            onnx.helper.make_tensor(pow_node_exponent_name, onnx.TensorProto.FLOAT, [1], [self._exponent])
         )
 
         # create the graph node for pow
@@ -137,9 +133,7 @@ class _UnaryOp(Block):
 
         # create the graph node for this unary op
         node_input_names = [input_name]
-        node_output_name = graph_utils.generate_random_graph_name(
-            f"{self._op_name.lower()}_output"
-        )
+        node_output_name = graph_utils.generate_random_graph_name(f"{self._op_name.lower()}_output")
         node_output_names = [node_output_name]
         node = onnx.helper.make_node(
             self._op_name,
@@ -181,17 +175,16 @@ class Neg(_UnaryOp):
         super(Neg, self).__init__("Neg")
 
 
-class Value(Block):
+class Constant(Block):
     """Creates an initializer and adds it to the onnx model."""
-    def __init__(self, value):
-        self._value = value
+
+    def __init__(self, value_float):
+        self._value = value_float
 
     def build(self):
         # create the graph initializer for the exponent
         initializer_name = graph_utils.generate_random_graph_name("initializer")
         accessor.global_accessor.model.graph.initializer.append(
-            onnx.helper.make_tensor(
-                initializer_name, onnx.TensorProto.FLOAT, [1], [self._value]
-            )
+            onnx.helper.make_tensor(initializer_name, onnx.TensorProto.FLOAT, [1], [self._value])
         )
         return initializer_name

--- a/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
+++ b/orttraining/orttraining/test/python/orttraining_test_onnxblock.py
@@ -620,8 +620,8 @@ def test_weighted_average_model_composition(model_type):
 
             self.loss1 = onnxblock.loss.CrossEntropyLoss()
             self.loss2 = onnxblock.loss.CrossEntropyLoss()
-            self.w1 = onnxblock.building_blocks.Value(w1)
-            self.w2 = onnxblock.building_blocks.Value(w2)
+            self.w1 = onnxblock.building_blocks.Constant(w1)
+            self.w2 = onnxblock.building_blocks.Constant(w2)
             self.mul = onnxblock.building_blocks.Mul()
             self.add = onnxblock.building_blocks.Add()
 
@@ -641,4 +641,4 @@ def test_weighted_average_model_composition(model_type):
     # When / Then no error occurs
     weighted_model = WeightedAvg(random.random(), random.random())
     with onnxblock.onnx_model(onnx_model):
-        output_name = weighted_model(onnx_model.graph.output[0].name, onnx_model.graph.output[1].name)
+        _ = weighted_model(onnx_model.graph.output[0].name, onnx_model.graph.output[1].name)


### PR DESCRIPTION
This pull request adds a way to author float initializers. Example usage:

```py
class WeightedAvg(model_type):
    def __init__(self, w1, w2):
        super(WeightedAvg, self).__init__()

        self.loss1 = onnxblock.loss.CrossEntropyLoss()
        self.loss2 = onnxblock.loss.CrossEntropyLoss()
        self.w1 = onnxblock.building_blocks.Constant(w1)
        self.w2 = onnxblock.building_blocks.Constant(w2)
        self.mul = onnxblock.building_blocks.Mul()
        self.add = onnxblock.building_blocks.Add()

    def build(self, loss_input_name1, loss_input_name2):
        return self.add(
            self.mul(self.w1(), self.loss1(loss_input_name1, labels_name="labels1")),
            self.mul(self.w2(), self.loss2(loss_input_name2, labels_name="labels2")),
        )

weighted_model = WeightedAvg(4.0, 1.5)
with onnxblock.onnx_model(onnx_model):
    weighted_averaged_output = weighted_model(loss_input1, loss_input2)
```

