### PR TITLE
temporarily allow CI failure for browserstack tests

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/web-browserstack-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-browserstack-ci.yml
@@ -7,6 +7,7 @@ jobs:
 - job: build_onnxruntime_web_browserstack
   pool: Onnxruntime-BrowserStack-for-Web
   timeoutInMinutes: 30
+  continueOnError: true
   workspace:
     clean: all
   steps:
@@ -99,4 +100,3 @@ jobs:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'
     condition: always()
-


### PR DESCRIPTION
**Description**: The browser stack CI for ORT web is failing. I need more time to investigate. In order not to block the other PRs I set the test to allow failures.

After full investigation and fix, this change should be reverted.