### PR TITLE
[doc] Add link to android testing in `Build for android` doc

### DIFF
--- a/docs/build/android.md
+++ b/docs/build/android.md
@@ -131,4 +131,4 @@ Android NNAPI Execution Provider can be built using building commands in [Androi
 
 ## Test Android changes using emulator
 
-If you want to test your changes in an Android build using the emulator, see [Testing Android Changes using the Emulator](https://github.com/microsoft/onnxruntime/blob/master/docs/Android_testing.md).
+See [Testing Android Changes using the Emulator](https://github.com/microsoft/onnxruntime/blob/master/docs/Android_testing.md).

--- a/docs/build/android.md
+++ b/docs/build/android.md
@@ -129,3 +129,6 @@ If you want to use NNAPI Execution Provider on Android, see [NNAPI Execution Pro
 
 Android NNAPI Execution Provider can be built using building commands in [Android Build instructions](#android-build-instructions) with `--use_nnapi`
 
+## Test Android changes using emulator
+
+If you want to test your changes in an Android build using the emulator, see [Testing Android Changes using the Emulator](../Android_testing.md).

--- a/docs/build/android.md
+++ b/docs/build/android.md
@@ -131,4 +131,4 @@ Android NNAPI Execution Provider can be built using building commands in [Androi
 
 ## Test Android changes using emulator
 
-If you want to test your changes in an Android build using the emulator, see [Testing Android Changes using the Emulator](../Android_testing.md).
+If you want to test your changes in an Android build using the emulator, see [Testing Android Changes using the Emulator](https://github.com/microsoft/onnxruntime/blob/master/docs/Android_testing.md).


### PR DESCRIPTION
Fixes #11720