### PR TITLE
Support per-test tolerances for ONNX tests

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -431,6 +431,7 @@ if (onnxruntime_DISABLE_EXCEPTIONS)
   add_compile_definitions("ORT_NO_EXCEPTIONS")
   add_compile_definitions("MLAS_NO_EXCEPTION")
   add_compile_definitions("ONNX_NO_EXCEPTIONS")
+  add_compile_definitions("JSON_NOEXCEPTION")  # https://json.nlohmann.me/api/macros/json_noexception/
 
   if (MSVC)
     string(REGEX REPLACE "/EHsc" "/EHs-c-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -857,7 +857,7 @@ if (onnxruntime_BUILD_WEBASSEMBLY)
   endif()
 endif()
 
-target_link_libraries(onnx_test_runner PRIVATE onnx_test_runner_common ${GETOPT_LIB_WIDE} ${onnx_test_libs})
+target_link_libraries(onnx_test_runner PRIVATE onnx_test_runner_common ${GETOPT_LIB_WIDE} ${onnx_test_libs} nlohmann_json::nlohmann_json)
 target_include_directories(onnx_test_runner PRIVATE ${ONNXRUNTIME_ROOT})
 if (onnxruntime_USE_ROCM)
   target_include_directories(onnx_test_runner PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/onnxruntime ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/orttraining)

--- a/docs/How_To_Update_ONNX_Dev_Notes.md
+++ b/docs/How_To_Update_ONNX_Dev_Notes.md
@@ -1,9 +1,11 @@
-This is a note only for ONNX Runtime developers.
+# How to update ONNX
 
-It's very often, you need to update the ONNX submodule to a newer version in the upstream. Please follow the steps below, don't miss any!
+This note is only for ONNX Runtime developers.
 
-1. Update the ONNX subfolder
-```
+If you need to update the ONNX submodule to a different version, follow the steps below.
+
+1. Update the ONNX submodule
+```sh
 cd cmake/external/onnx
 git remote update
 git reset --hard <commit_id>
@@ -15,22 +17,28 @@ git add onnx
 1. Update [cgmanifests/generated/cgmanifest.json](/cgmanifests/generated/cgmanifest.json).
 This file should be generated. See [cgmanifests/README](/cgmanifests/README.md) for instructions.
 
-1. Update [tools/ci_build/github/linux/docker/scripts/requirements.txt](/tools/ci_build/github/linux/docker/scripts/requirements.txt) and [tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt](/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt).
-Update the commit hash for `git+http://github.com/onnx/onnx.git@targetonnxcommithash#egg=onnx`.
+1. Update [tools/ci_build/github/linux/docker/scripts/requirements.txt](/tools/ci_build/github/linux/docker/scripts/requirements.txt)
+   and [tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt](/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt).
+   Update the commit hash for `git+http://github.com/onnx/onnx.git@targetonnxcommithash#egg=onnx`.
 
-1. If there is any change to `cmake/external/onnx/onnx/*.in.proto`, you need to regenerate OnnxMl.cs. [Building onnxruntime with Nuget](https://onnxruntime.ai/docs/build/inferencing.html#build-nuget-packages) will do this.
+1. If there is any change to `cmake/external/onnx/onnx/*.in.proto`, you need to regenerate OnnxMl.cs.
+   [Building onnxruntime with Nuget](https://onnxruntime.ai/docs/build/inferencing.html#build-nuget-packages) will do
+   this.
 
-1. If you are updating ONNX from a released tag to a new commit, please tell Changming deploying the new test data along with other test models to our CI build machines. This is to ensure that our tests cover every ONNX opset. 
+1. If you are updating ONNX from a released tag to a new commit, please ask Changming (@snnn) to deploy the new test
+   data along with other test models to our CI build machines. This is to ensure that our tests cover every ONNX opset.
 
 1. Send you PR, and **manually** queue a build for every packaging pipeline for your branch.
 
-1. If there is a build failure in stage "Check out of dated documents" in WebAssembly CI pipeline, update ONNX Runtime Web WebGL operator support document:
+1. If there is a build failure in stage "Check out of dated documents" in WebAssembly CI pipeline, update ONNX Runtime
+   Web WebGL operator support document:
    - Make sure Node.js is installed (see [Prerequisites](../js/README.md#Prerequisites) for instructions).
    - Follow step 1 in [js/Build](../js/README.md#Build-2) to install dependencies).
    - Follow instructions in [Generate document](../js/README.md#Generating-Document) to update document. Commit changes applied to file `docs/operators.md`.
 
-1. Usually there would be some unitest failures, because you introduced new test cases. Then you may need to update
+1. Usually some newly introduced tests will fail. Then you may need to update
 - [onnxruntime/test/onnx/main.cc](/onnxruntime/test/onnx/main.cc)
 - [onnxruntime/test/providers/cpu/model_tests.cc](/onnxruntime/test/providers/cpu/model_tests.cc)
 - [csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs](/csharp/test/Microsoft.ML.OnnxRuntime.Tests/InferenceTest.cs)
 - [onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc](/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc)
+- [onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc](/onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc)

--- a/js/node/test/test-runner.ts
+++ b/js/node/test/test-runner.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs-extra';
-import { InferenceSession, Tensor } from 'onnxruntime-common';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 import * as path from 'path';
 
-import { atol, assertTensorEqual, loadTensorFromFile, rtol, shouldSkipModel } from './test-utils';
+import {assertTensorEqual, atol, loadTensorFromFile, rtol, shouldSkipModel} from './test-utils';
 
 export function run(testDataFolder: string): void {
   const models = fs.readdirSync(testDataFolder);
@@ -14,7 +14,7 @@ export function run(testDataFolder: string): void {
     // read each model folders
     const modelFolder = path.join(testDataFolder, model);
     let modelPath: string;
-    const modelTestCases: Array<[Array<Tensor | undefined>, Array<Tensor | undefined>]> = [];
+    const modelTestCases: Array<[Array<Tensor|undefined>, Array<Tensor|undefined>]> = [];
     for (const currentFile of fs.readdirSync(modelFolder)) {
       const currentPath = path.join(modelFolder, currentFile);
       const stat = fs.lstatSync(currentPath);
@@ -24,14 +24,14 @@ export function run(testDataFolder: string): void {
           modelPath = currentPath;
         }
       } else if (stat.isDirectory()) {
-        const inputs: Array<Tensor | undefined> = [];
-        const outputs: Array<Tensor | undefined> = [];
+        const inputs: Array<Tensor|undefined> = [];
+        const outputs: Array<Tensor|undefined> = [];
         for (const dataFile of fs.readdirSync(currentPath)) {
           const dataFileFullPath = path.join(currentPath, dataFile);
           const ext = path.extname(dataFile);
 
           if (ext.toLowerCase() === '.pb') {
-            let tensor: Tensor | undefined;
+            let tensor: Tensor|undefined;
             try {
               tensor = loadTensorFromFile(dataFileFullPath);
             } catch (e) {
@@ -51,7 +51,7 @@ export function run(testDataFolder: string): void {
 
     // add cases
     describe(`${model}`, () => {
-      let session: InferenceSession | null = null;
+      let session: InferenceSession|null = null;
       let skipModel = shouldSkipModel(model, ['cpu']);
       if (!skipModel) {
         before(async () => {

--- a/js/node/test/test-runner.ts
+++ b/js/node/test/test-runner.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs-extra';
-import {InferenceSession, Tensor} from 'onnxruntime-common';
+import { InferenceSession, Tensor } from 'onnxruntime-common';
 import * as path from 'path';
 
-import {assertTensorEqual, loadTensorFromFile, shouldSkipModel} from './test-utils';
+import { atol, assertTensorEqual, loadTensorFromFile, rtol, shouldSkipModel } from './test-utils';
 
 export function run(testDataFolder: string): void {
   const models = fs.readdirSync(testDataFolder);
@@ -14,7 +14,7 @@ export function run(testDataFolder: string): void {
     // read each model folders
     const modelFolder = path.join(testDataFolder, model);
     let modelPath: string;
-    const modelTestCases: Array<[Array<Tensor|undefined>, Array<Tensor|undefined>]> = [];
+    const modelTestCases: Array<[Array<Tensor | undefined>, Array<Tensor | undefined>]> = [];
     for (const currentFile of fs.readdirSync(modelFolder)) {
       const currentPath = path.join(modelFolder, currentFile);
       const stat = fs.lstatSync(currentPath);
@@ -24,14 +24,14 @@ export function run(testDataFolder: string): void {
           modelPath = currentPath;
         }
       } else if (stat.isDirectory()) {
-        const inputs: Array<Tensor|undefined> = [];
-        const outputs: Array<Tensor|undefined> = [];
+        const inputs: Array<Tensor | undefined> = [];
+        const outputs: Array<Tensor | undefined> = [];
         for (const dataFile of fs.readdirSync(currentPath)) {
           const dataFileFullPath = path.join(currentPath, dataFile);
           const ext = path.extname(dataFile);
 
           if (ext.toLowerCase() === '.pb') {
-            let tensor: Tensor|undefined;
+            let tensor: Tensor | undefined;
             try {
               tensor = loadTensorFromFile(dataFileFullPath);
             } catch (e) {
@@ -51,7 +51,7 @@ export function run(testDataFolder: string): void {
 
     // add cases
     describe(`${model}`, () => {
-      let session: InferenceSession|null = null;
+      let session: InferenceSession | null = null;
       let skipModel = shouldSkipModel(model, ['cpu']);
       if (!skipModel) {
         before(async () => {
@@ -98,7 +98,7 @@ export function run(testDataFolder: string): void {
 
               let j = 0;
               for (const name of session.outputNames) {
-                assertTensorEqual(outputs[name], expectedOutputs[j++]!);
+                assertTensorEqual(outputs[name], expectedOutputs[j++]!, atol(model), rtol(model));
               }
             } else {
               throw new TypeError('session is null');

--- a/js/node/test/test-utils.ts
+++ b/js/node/test/test-utils.ts
@@ -3,9 +3,9 @@
 
 import assert from 'assert';
 import * as fs from 'fs-extra';
-import { jsonc } from 'jsonc';
+import {jsonc} from 'jsonc';
 import * as onnx_proto from 'onnx-proto';
-import { InferenceSession, Tensor } from 'onnxruntime-common';
+import {InferenceSession, Tensor} from 'onnxruntime-common';
 import * as path from 'path';
 
 export const TEST_ROOT = __dirname;
@@ -17,8 +17,8 @@ export const NODE_TESTS_ROOT = path.join(ORT_ROOT, 'cmake/external/onnx/onnx/bac
 export const SQUEEZENET_INPUT0_DATA: number[] = require(path.join(TEST_DATA_ROOT, 'squeezenet.input0.json'));
 export const SQUEEZENET_OUTPUT0_DATA: number[] = require(path.join(TEST_DATA_ROOT, 'squeezenet.output0.json'));
 
-export const BACKEND_TEST_SERIES_FILTERS: { [name: string]: string[] } =
-  jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc'));
+export const BACKEND_TEST_SERIES_FILTERS: {[name: string]: string[]} =
+    jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc'));
 
 
 export const NUMERIC_TYPE_MAP = new Map<Tensor.Type, new (len: number) => Tensor.DataType>([
@@ -54,7 +54,7 @@ export function createTestData(type: Tensor.Type, length: number): Tensor.DataTy
 }
 
 // a simple function to create a tensor for test
-export function createTestTensor(type: Tensor.Type, lengthOrDims?: number | number[]): Tensor {
+export function createTestTensor(type: Tensor.Type, lengthOrDims?: number|number[]): Tensor {
   let length = 100;
   let dims = [100];
   if (typeof lengthOrDims === 'number') {
@@ -70,22 +70,21 @@ export function createTestTensor(type: Tensor.Type, lengthOrDims?: number | numb
 
 // call the addon directly to make sure DLL is loaded
 export function warmup(): void {
-  describe('Warmup', async function () {
+  describe('Warmup', async function() {
     // eslint-disable-next-line no-invalid-this
     this.timeout(0);
     // we have test cases to verify correctness in other place, so do no check here.
     try {
       const session = await InferenceSession.create(path.join(TEST_DATA_ROOT, 'test_types_INT32.pb'));
-      await session.run({ input: new Tensor(new Float32Array(5), [1, 5]) }, { output: null }, {});
+      await session.run({input: new Tensor(new Float32Array(5), [1, 5])}, {output: null}, {});
     } catch (e) {
     }
   });
 }
 
 export function assertFloatEqual(
-  actual: number[] | Float32Array | Float64Array, expected: number[] | Float32Array | Float64Array,
-  atol?: number, rtol?: number): void {
-
+    actual: number[]|Float32Array|Float64Array, expected: number[]|Float32Array|Float64Array, atol?: number,
+    rtol?: number): void {
   const absolute_tol: number = atol ?? 1.0e-4;
   const relative_tol: number = 1 + (rtol ?? 1.0e-6);
 
@@ -129,14 +128,13 @@ export function assertFloatEqual(
 }
 
 export function assertDataEqual(
-  type: Tensor.Type, actual: Tensor.DataType, expected: Tensor.DataType, atol?: number, rtol?: number): void {
-
+    type: Tensor.Type, actual: Tensor.DataType, expected: Tensor.DataType, atol?: number, rtol?: number): void {
   switch (type) {
     case 'float32':
     case 'float64':
       assertFloatEqual(
-        actual as number[] | Float32Array | Float64Array, expected as number[] | Float32Array | Float64Array,
-        atol, rtol);
+          actual as number[] | Float32Array | Float64Array, expected as number[] | Float32Array | Float64Array, atol,
+          rtol);
       break;
 
     case 'uint8':
@@ -248,7 +246,7 @@ export function loadTensorFromFile(pbFile: string): Tensor {
         throw new Error(`not supported tensor type: ${tensorProto.dataType}`);
     }
     const transferredTypedArrayRawDataView =
-      new Uint8Array(transferredTypedArray.buffer, transferredTypedArray.byteOffset, tensorProto.rawData.byteLength);
+        new Uint8Array(transferredTypedArray.buffer, transferredTypedArray.byteOffset, tensorProto.rawData.byteLength);
     transferredTypedArrayRawDataView.set(tensorProto.rawData);
 
     return new Tensor(type, transferredTypedArray, dims);
@@ -280,18 +278,18 @@ export function shouldSkipModel(model: string, eps: string[]): boolean {
   return false;
 }
 
-const OVERRIDES: { [key: string]: (number | { [name: string]: number }) } =
-  jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc'));
+const OVERRIDES: {[key: string]: (number|{[name: string]: number})} =
+    jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc'));
 
 const ATOL_DEFAULT = OVERRIDES.atol_default as number;
 const RTOL_DEFAULT = OVERRIDES.rtol_default as number;
 
 export function atol(model: string): number {
-  const override = OVERRIDES.atol_overrides as { [name: string]: number };
+  const override = OVERRIDES.atol_overrides as {[name: string]: number};
   return override[model] ?? ATOL_DEFAULT;
 }
 
 export function rtol(model: string): number {
-  const override = OVERRIDES.rtol_overrides as { [name: string]: number };
+  const override = OVERRIDES.rtol_overrides as {[name: string]: number};
   return override[model] ?? RTOL_DEFAULT;
 }

--- a/js/node/test/test-utils.ts
+++ b/js/node/test/test-utils.ts
@@ -86,8 +86,8 @@ export function assertFloatEqual(
   actual: number[] | Float32Array | Float64Array, expected: number[] | Float32Array | Float64Array,
   atol?: number, rtol?: number): void {
 
-  absolute_tol = atol ?? 1.0e-4;
-  relative_tol = 1 + (rtol ?? 1.0e-6);
+  const absolute_tol: number = atol ?? 1.0e-4;
+  const relative_tol: number = 1 + (rtol ?? 1.0e-6);
 
   assert.strictEqual(actual.length, expected.length);
 

--- a/js/node/test/test-utils.ts
+++ b/js/node/test/test-utils.ts
@@ -86,8 +86,8 @@ export function assertFloatEqual(
   actual: number[] | Float32Array | Float64Array, expected: number[] | Float32Array | Float64Array,
   atol?: number, rtol?: number): void {
 
-  atol = atol ?? 1.0e-4;
-  rtol = rtol ?? 1.0e-6;
+  absolute_tol = atol ?? 1.0e-4;
+  relative_tol = 1 + (rtol ?? 1.0e-6);
 
   assert.strictEqual(actual.length, expected.length);
 
@@ -116,10 +116,10 @@ export function assertFloatEqual(
     //   test fail
     // endif
     //
-    if (Math.abs(a - b) < atol) {
+    if (Math.abs(a - b) < absolute_tol) {
       continue;  // absolute error check pass
     }
-    if (a !== 0 && b !== 0 && a * b > 0 && a / b < (1 + rtol) && b / a < (1 + rtol)) {
+    if (a !== 0 && b !== 0 && a * b > 0 && a / b < relative_tol && b / a < relative_tol) {
       continue;  // relative error check pass
     }
 
@@ -283,15 +283,15 @@ export function shouldSkipModel(model: string, eps: string[]): boolean {
 const OVERRIDES: { [key: string]: (number | { [name: string]: number }) } =
   jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc'));
 
-const ATOL_DEFAULT = OVERRIDES["atol_default"] as number;
-const RTOL_DEFAULT = OVERRIDES["rtol_default"] as number;
+const ATOL_DEFAULT = OVERRIDES.atol_default as number;
+const RTOL_DEFAULT = OVERRIDES.rtol_default as number;
 
 export function atol(model: string): number {
-  const override = OVERRIDES["atol_overrides"] as { [name: string]: number };
+  const override = OVERRIDES.atol_overrides as { [name: string]: number };
   return override[model] ?? ATOL_DEFAULT;
 }
 
 export function rtol(model: string): number {
-  const override = OVERRIDES["rtol_overrides"] as { [name: string]: number };
+  const override = OVERRIDES.rtol_overrides as { [name: string]: number };
   return override[model] ?? RTOL_DEFAULT;
 }

--- a/js/node/test/test-utils.ts
+++ b/js/node/test/test-utils.ts
@@ -20,6 +20,13 @@ export const SQUEEZENET_OUTPUT0_DATA: number[] = require(path.join(TEST_DATA_ROO
 export const BACKEND_TEST_SERIES_FILTERS: {[name: string]: string[]} =
     jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc'));
 
+const OVERRIDES: {
+  atol_default: number; rtol_default: number; atol_overrides: {[name: string]: number};
+  rtol_overrides: {[name: string]: number};
+} = jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc'));
+
+const ATOL_DEFAULT = OVERRIDES.atol_default;
+const RTOL_DEFAULT = OVERRIDES.rtol_default;
 
 export const NUMERIC_TYPE_MAP = new Map<Tensor.Type, new (len: number) => Tensor.DataType>([
   ['float32', Float32Array],
@@ -278,18 +285,10 @@ export function shouldSkipModel(model: string, eps: string[]): boolean {
   return false;
 }
 
-const OVERRIDES: {[key: string]: (number|{[name: string]: number})} =
-    jsonc.readSync(path.join(ORT_ROOT, 'onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc'));
-
-const ATOL_DEFAULT = OVERRIDES.atol_default as number;
-const RTOL_DEFAULT = OVERRIDES.rtol_default as number;
-
 export function atol(model: string): number {
-  const override = OVERRIDES.atol_overrides as {[name: string]: number};
-  return override[model] ?? ATOL_DEFAULT;
+  return OVERRIDES.atol_overrides[model] ?? ATOL_DEFAULT;
 }
 
 export function rtol(model: string): number {
-  const override = OVERRIDES.rtol_overrides as {[name: string]: number};
-  return override[model] ?? RTOL_DEFAULT;
+  return OVERRIDES.rtol_overrides[model] ?? RTOL_DEFAULT;
 }

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -781,9 +781,11 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         ORT_NOT_IMPLEMENTED(ToUTF8String(filename_str), " is not supported");
       }
 
+      const auto tolerance_key = ToUTF8String(my_dir_name);
+
       std::unique_ptr<ITestCase> l = CreateOnnxTestCase(ToUTF8String(test_case_name), std::move(model_info),
-                                                        tolerances.absolute(my_dir_name),
-                                                        tolerances.relative(my_dir_name));
+                                                        tolerances.absolute(tolerance_key),
+                                                        tolerances.relative(tolerance_key));
       process_function(std::move(l));
       return true;
     });
@@ -792,11 +794,11 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
 
 TestTolerances::TestTolerances(
     double absolute_default, double relative_default,
-    const std::unordered_map<std::string, double>& absolute_overrides,
-    const std::unordered_map<std::string, double>& relative_overrides) : absolute_default_(absolute_default),
-                                                                         relative_default_(relative_default),
-                                                                         absolute_overrides_(absolute_overrides),
-                                                                         relative_overrides_(relative_overrides) {}
+    const Map& absolute_overrides,
+    const Map& relative_overrides) : absolute_default_(absolute_default),
+                                     relative_default_(relative_default),
+                                     absolute_overrides_(absolute_overrides),
+                                     relative_overrides_(relative_overrides) {}
 
 double TestTolerances::absolute(const std::string& name) const {
   const auto iter = absolute_overrides_.find(name);

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <map>
 #include <regex>
+#include <string>
 
 using namespace onnxruntime;
 using namespace onnxruntime::common;

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -5,6 +5,14 @@
 
 #include "TestCase.h"
 
+#include <cctype>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <map>
+#include <regex>
+#include <string>
+
 #include "callback.h"
 #include "heap_buffer.h"
 #include "mem_buffer.h"
@@ -21,14 +29,6 @@
 #include "core/framework/allocator.h"
 #include "core/framework/TensorSeq.h"
 #include "re2/re2.h"
-
-#include <cctype>
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <map>
-#include <regex>
-#include <string>
 
 using namespace onnxruntime;
 using namespace onnxruntime::common;

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -24,8 +24,8 @@ class HeapBuffer;
 }
 }  // namespace onnxruntime
 
-//One test case is for one model file
-//One test case can contain multiple test data(input/output pairs)
+// One test case is for one model file
+// One test case can contain multiple test data(input/output pairs)
 class ITestCase {
  public:
   virtual void LoadTestData(size_t id, onnxruntime::test::HeapBuffer& b,
@@ -38,9 +38,9 @@ class ITestCase {
 
   virtual const std::string& GetTestCaseName() const = 0;
   virtual std::string GetTestCaseVersion() const = 0;
-  //a string to help identify the dataset
+  // a string to help identify the dataset
   virtual std::string GetDatasetDebugInfoString(size_t dataset_id) const = 0;
-  //The number of input/output pairs
+  // The number of input/output pairs
   virtual size_t GetDataCount() const = 0;
   virtual ~ITestCase() = default;
   virtual void GetPerSampleTolerance(double* value) const = 0;
@@ -83,8 +83,25 @@ std::unique_ptr<ITestCase> CreateOnnxTestCase(const std::string& test_case_name,
                                               double default_per_sample_tolerance,
                                               double default_relative_per_sample_tolerance);
 
+class TestTolerances {
+ public:
+  TestTolerances(
+      double absolute_default, double relative_default,
+      const std::unordered_map<std::string, double>& absolute_overrides,
+      const std::unordered_map<std::string, double>& relative_overrides);
+  TestTolerances() = delete;
+  double absolute(const std::string& test_name) const;
+  double relative(const std::string& test_name) const;
+
+ private:
+  double absolute_default_;
+  double relative_default_;
+  const std::unordered_map<std::string, double> absolute_overrides_;
+  const std::unordered_map<std::string, double> relative_overrides_;
+};
+
 void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths,
                const std::vector<std::basic_string<PATH_CHAR_TYPE>>& whitelisted_test_cases,
-               double default_per_sample_tolerance, double default_relative_per_sample_tolerance,
+               const TestTolerances& tolerances,
                const std::unordered_set<std::basic_string<ORTCHAR_T>>& disabled_tests,
                const std::function<void(std::unique_ptr<ITestCase>)>& process_function);

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -85,10 +85,11 @@ std::unique_ptr<ITestCase> CreateOnnxTestCase(const std::string& test_case_name,
 
 class TestTolerances {
  public:
+  typedef std::unordered_map<std::string, double> Map;
   TestTolerances(
       double absolute_default, double relative_default,
-      const std::unordered_map<std::string, double>& absolute_overrides,
-      const std::unordered_map<std::string, double>& relative_overrides);
+      const Map& absolute_overrides,
+      const Map& relative_overrides);
   TestTolerances() = delete;
   double absolute(const std::string& test_name) const;
   double relative(const std::string& test_name) const;
@@ -96,8 +97,8 @@ class TestTolerances {
  private:
   double absolute_default_;
   double relative_default_;
-  const std::unordered_map<std::string, double> absolute_overrides_;
-  const std::unordered_map<std::string, double> relative_overrides_;
+  const Map absolute_overrides_;
+  const Map relative_overrides_;
 };
 
 void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths,

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -4,6 +4,9 @@
 #include <set>
 #include <iostream>
 #include <fstream>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
 #ifdef _WIN32
 #include "getopt.h"
 #else
@@ -20,6 +23,7 @@
 #include "core/optimizer/graph_transformer_level.h"
 #include "core/framework/session_options.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
+#include "nlohmann/json.hpp"
 
 using namespace onnxruntime;
 
@@ -54,6 +58,27 @@ void usage() {
       "\n"
       "onnxruntime version: %s\n",
       OrtGetApiBase()->GetVersionString());
+}
+
+static TestTolerances LoadTestTolerances(bool enable_cuda, bool enable_openvino) {
+  const std::filesystem::path overrides_path("testdata/onnx_backend_test_series_overrides.jsonc");
+  const double absolute = 1e-3;
+  // when cuda is enabled, set it to a larger value for resolving random MNIST test failure
+  // when openvino is enabled, set it to a larger value for resolving MNIST accuracy mismatch
+  const double relative = enable_cuda ? 0.017 : enable_openvino ? 0.009
+                                                                : 1e-3;
+  std::unordered_map<std::string, double> absolute_overrides;
+  std::unordered_map<std::string, double> relative_overrides;
+  if (!std::filesystem::exists(overrides_path)) {
+    return TestTolerances(absolute, relative, absolute_overrides, relative_overrides);
+  };
+  const auto overrides_json = nlohmann::json::parse(
+      std::ifstream(overrides_path),
+      /*cb=*/nullptr, /*allow_exceptions=*/true, /*ignore_comments=*/true);
+  overrides_json["atol_overrides"].get_to(absolute_overrides);
+  overrides_json["rtol_overrides"].get_to(relative_overrides);
+  return TestTolerances(
+      overrides_json["atol_default"], overrides_json["rtol_default"], absolute_overrides, relative_overrides);
 }
 
 #ifdef _WIN32
@@ -301,12 +326,6 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
 
   std::vector<std::unique_ptr<ITestCase>> owned_tests;
   {
-    double per_sample_tolerance = 1e-3;
-    // when cuda is enabled, set it to a larger value for resolving random MNIST test failure
-    // when openvino is enabled, set it to a larger value for resolving MNIST accuracy mismatch
-    double relative_per_sample_tolerance = enable_cuda ? 0.017 : enable_openvino ? 0.009
-                                                                                 : 1e-3;
-
     Ort::SessionOptions sf;
 
     if (enable_cpu_mem_arena)
@@ -336,7 +355,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_openvino) {
 #ifdef USE_OPENVINO
-      //Setting default optimization level for OpenVINO can be overriden with -o option
+      // Setting default optimization level for OpenVINO can be overriden with -o option
       sf.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
       sf.AppendExecutionProvider_OpenVINO(OrtOpenVINOProviderOptions{});
 #else
@@ -407,7 +426,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
         }
         auto pos = token.find("|");
         if (pos == std::string::npos || pos == 0 || pos == token.length()) {
-          ORT_THROW(R"(Use a '|' to separate the key and value for 
+          ORT_THROW(R"(Use a '|' to separate the key and value for
 the run-time option you are trying to use.\n)");
         }
 
@@ -420,7 +439,7 @@ the run-time option you are trying to use.\n)");
             snpe_option_keys.push_back("runtime");
             values.push_back(value);
           } else {
-            ORT_THROW(R"(Wrong configuration value for the key 'runtime'. 
+            ORT_THROW(R"(Wrong configuration value for the key 'runtime'.
 select from 'CPU', 'GPU_FP32', 'GPU', 'GPU_FLOAT16', 'DSP', 'AIP_FIXED_TF'. \n)");
           }
         } else if (key == "priority") {
@@ -432,14 +451,14 @@ select from 'CPU', 'GPU_FP32', 'GPU', 'GPU_FLOAT16', 'DSP', 'AIP_FIXED_TF'. \n)"
             snpe_option_keys.push_back("buffer_type");
             values.push_back(value);
           } else {
-            ORT_THROW(R"(Wrong configuration value for the key 'buffer_type'. 
+            ORT_THROW(R"(Wrong configuration value for the key 'buffer_type'.
 select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
           }
         } else {
           ORT_THROW("Wrong key type entered. Choose from options: ['runtime', 'priority', 'buffer_type'] \n");
         }
       }
-      for (auto &it : values) {
+      for (auto& it : values) {
         snpe_option_values.push_back(it.c_str());
       }
       sf.AppendExecutionProvider_SNPE(snpe_option_keys.data(), snpe_option_values.data(), snpe_option_keys.size());
@@ -501,6 +520,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
       sf.SetGraphOptimizationLevel(graph_optimization_level);
     }
 
+    // TODO: Get these from onnx_backend_test_series_filters.jsonc.
     // Permanently exclude following tests because ORT support only opset staring from 7,
     // Please make no more changes to the list
     static const ORTCHAR_T* immutable_broken_tests[] =
@@ -565,13 +585,16 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
       all_disabled_tests.insert(std::begin(dnnl_disabled_tests), std::end(dnnl_disabled_tests));
     }
 #if !defined(__amd64__) && !defined(_M_AMD64)
-    //out of memory
+    // out of memory
     static const ORTCHAR_T* x86_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"), ORT_TSTR("mask_rcnn_keras"), ORT_TSTR("mask_rcnn"), ORT_TSTR("faster_rcnn"), ORT_TSTR("vgg19"), ORT_TSTR("coreml_VGG16_ImageNet")};
     all_disabled_tests.insert(std::begin(x86_disabled_tests), std::end(x86_disabled_tests));
 #endif
 
+    const TestTolerances tt = LoadTestTolerances(enable_cuda, enable_openvino);
+
     std::vector<ITestCase*> tests;
-    LoadTests(data_dirs, whitelisted_test_cases, per_sample_tolerance, relative_per_sample_tolerance,
+    LoadTests(data_dirs, whitelisted_test_cases,
+              tt,
               all_disabled_tests,
               [&owned_tests, &tests](std::unique_ptr<ITestCase> l) {
                 tests.push_back(l.get());
@@ -895,7 +918,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     broken_tests.insert({"tinyyolov3", "The parameter is incorrect"});
     broken_tests.insert({"mlperf_ssd_mobilenet_300", "unknown error"});
     broken_tests.insert({"mlperf_ssd_resnet34_1200", "unknown error"});
-    broken_tests.insert({"tf_inception_v1", "flaky test"});  //TODO: Investigate cause for flakiness
+    broken_tests.insert({"tf_inception_v1", "flaky test"});  // TODO: Investigate cause for flakiness
     broken_tests.insert({"faster_rcnn", "Linux: faster_rcnn:output=6383:shape mismatch, expect {77} got {57}"});
     broken_tests.insert({"split_zero_size_splits", "alloc failed"});
   }

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -63,7 +63,7 @@ static TestTolerances LoadTestTolerances(bool enable_cuda, bool enable_openvino)
   TestTolerances::Map absolute_overrides;
   TestTolerances::Map relative_overrides;
   std::ifstream overrides_ifstream(ConcatPathComponent<ORTCHAR_T>(
-      "testdata", "onnx_backend_test_series_overrides.jsonc"));
+      ORT_TSTR("testdata"), ORT_TSTR("onnx_backend_test_series_overrides.jsonc")));
   if (!overrides_ifstream.good()) {
     const double absolute = 1e-3;
     // when cuda is enabled, set it to a larger value for resolving random MNIST test failure

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -590,11 +590,9 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     all_disabled_tests.insert(std::begin(x86_disabled_tests), std::end(x86_disabled_tests));
 #endif
 
-    const TestTolerances tt = LoadTestTolerances(enable_cuda, enable_openvino);
-
     std::vector<ITestCase*> tests;
     LoadTests(data_dirs, whitelisted_test_cases,
-              tt,
+              LoadTestTolerances(enable_cuda, enable_openvino),
               all_disabled_tests,
               [&owned_tests, &tests](std::unique_ptr<ITestCase> l) {
                 tests.push_back(l.get());

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -71,7 +71,7 @@ static TestTolerances LoadTestTolerances(bool enable_cuda, bool enable_openvino)
     const double relative = enable_cuda ? 0.017 : enable_openvino ? 0.009
                                                                   : 1e-3;
     return TestTolerances(absolute, relative, absolute_overrides, relative_overrides);
-  };
+  }
   const auto overrides_json = nlohmann::json::parse(
       overrides_ifstream,
       /*cb=*/nullptr, /*allow_exceptions=*/true, /*ignore_comments=*/true);
@@ -355,7 +355,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_openvino) {
 #ifdef USE_OPENVINO
-      // Setting default optimization level for OpenVINO can be overriden with -o option
+      // Setting default optimization level for OpenVINO can be overridden with -o option
       sf.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
       sf.AppendExecutionProvider_OpenVINO(OrtOpenVINOProviderOptions{});
 #else

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -15,7 +15,7 @@ import onnx
 import onnx.backend.test.case.test_case
 import onnx.backend.test.runner
 
-from onnxruntime import backend
+import onnxruntime.backend as backend
 
 pytest_plugins = ("onnx.backend.test.report",)
 

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -15,7 +15,7 @@ import onnx
 import onnx.backend.test.case.test_case
 import onnx.backend.test.runner
 
-import onnxruntime.backend as backend
+import onnxruntime.backend as backend  # pylint: disable=consider-using-from-import
 
 pytest_plugins = ("onnx.backend.test.report",)
 

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -57,7 +57,7 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
         attrs = {}
         # TestCase changed from a namedtuple to a dataclass in ONNX 1.12.
         # We can just modify t_c.rtol and atol directly once ONNX 1.11 is no longer supported.
-        if isinstance(t_c, collections.namedtuple):  # type: ignore
+        if hasattr(t_c, "_asdict"):
             attrs = t_c._asdict()
         else:
             attrs = vars(t_c)
@@ -74,9 +74,9 @@ def load_jsonc(basename: str):
             os.path.dirname(os.path.realpath(__file__)),
             "testdata",
             basename,
-        )
-        encoding="utf-8"
-    ) as f: # pylint: disable=invalid-name
+        ),
+        encoding="utf-8",
+    ) as f:  # pylint: disable=invalid-name
         lines = f.readlines()
     lines = [x.split("//")[0] for x in lines]
     return json.loads("\n".join(lines))

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -196,6 +196,7 @@ def create_backend_test(test_name=None):
 
 
 def parse_args():
+    """Returns args parsed from sys.argv."""
     parser = argparse.ArgumentParser(
         os.path.basename(__file__),
         description="Run the ONNX backend tests using ONNXRuntime.",

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -57,7 +57,7 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
         attrs = {}
         # TestCase changed from a namedtuple to a dataclass in ONNX 1.12.
         # We can just modify t_c.rtol and atol directly once ONNX 1.11 is no longer supported.
-        if isinstance(t_c, collections.namedtuple):
+        if isinstance(t_c, collections.namedtuple):  # type: ignore
             attrs = t_c._asdict()
         else:
             attrs = vars(t_c)
@@ -82,7 +82,7 @@ def load_jsonc(basename: str):
     return json.loads("\n".join(lines))
 
 
-def create_backend_test(testname=None):
+def create_backend_test(test_name=None):
     overrides = load_jsonc("onnx_backend_test_series_overrides.jsonc")
     rtol_default = overrides["rtol_default"]
     atol_default = overrides["atol_default"]
@@ -96,8 +96,8 @@ def create_backend_test(testname=None):
     # Type not supported
     backend_test.exclude(r"(FLOAT16)")
 
-    if testname:
-        backend_test.include(testname + ".*")
+    if test_name:
+        backend_test.include(test_name + ".*")
     else:
         filters = load_jsonc("onnx_backend_test_series_filters.jsonc")
         current_failing_tests = filters["current_failing_tests"]
@@ -208,7 +208,7 @@ def parse_args():
     parser.add_argument(
         "-t",
         "--test-name",
-        dest="testname",
+        dest="test_name",
         type=str,
         help="Only run tests that match this value. Matching is regex based, and '.*' is automatically appended",
     )
@@ -223,5 +223,5 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    backend_test = create_backend_test(args.testname)
+    backend_test = create_backend_test(args.test_name)
     unittest.main()

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -1,4 +1,7 @@
 {
+    // If possible, add a test to onnx_backend_test_series_overrides.jsonc instead of this file.
+    // This file results in skipping tests, that one allows looser tolerance.
+    //
     // Tests that are failing temporarily and should be fixed
     "current_failing_tests": [
         "^test_adagrad",
@@ -40,7 +43,7 @@
         "^test_resize_downsample_scales_cubic_A_n0p5_exclude_outside_cpu", // NOT_IMPLEMENTED : Could not find an implementation for the node Resize(13)
         "^test_resize_downsample_scales_cubic_cpu",
         "^test_resize_downsample_scales_linear_cpu",
-        "^test_resize_downsample_scales_nearest_cpu", 
+        "^test_resize_downsample_scales_nearest_cpu",
         "^test_resize_downsample_sizes_cubic_cpu",
         "^test_resize_downsample_sizes_linear_pytorch_half_pixel_cpu",
         "^test_resize_downsample_sizes_nearest_cpu",
@@ -169,12 +172,12 @@
         "^test_sce.*",
         "^test_nllloss.*",
         "^test_gather_negative_indices.*",
-        "^test_reduce_sum_do_not_keepdims*",  // Does not support axes as input
+        "^test_reduce_sum_do_not_keepdims*", // Does not support axes as input
         "^test_reduce_sum_keepdims*",
         "^test_reduce_sum_default_axes_keepdims*",
         "^test_reduce_sum_negative_axes_keepdims*",
         "^test_reduce_sum_empty_axes_input_noop*",
-        "^test_unsqueeze_*",  // Does not support axes as input
+        "^test_unsqueeze_*", // Does not support axes as input
         "^test_sequence_insert_at_back",
         "^test_sequence_insert_at_front",
         "^test_loop13_seq",
@@ -204,15 +207,15 @@
         "^test_sce.*",
         "^test_nllloss.*",
         "^test_upsample_nearest.*",
-        "^test_reduce_sum_do_not_keepdims*",  // Does not support axes as input
+        "^test_reduce_sum_do_not_keepdims*", // Does not support axes as input
         "^test_reduce_sum_keepdims*",
         "^test_reduce_sum_default_axes_keepdims*",
         "^test_reduce_sum_negative_axes_keepdims*",
         "^test_reduce_sum_empty_axes_input_noop*",
         "^test_scatter_elements_with_negative_indices_cpu",
         "^test_sum_one_input_cpu",
-        "^test_unsqueeze_*",  // Does not support axes as input
-        "^test_squeeze_*",   // Does not support axes as input
+        "^test_unsqueeze_*", // Does not support axes as input
+        "^test_squeeze_*", // Does not support axes as input
         "^test_logsoftmax_*", // Does not support opset-13 yet
         "^test_softmax_*", // Does not support opset-13 yet
         "^test_pow", // Runs disabled pow tests from the "current_failing_tests" list at the top
@@ -234,7 +237,6 @@
         "^test_training_dropout_default_mask", // Runs but there's accuracy mismatch
         "^test_training_dropout_mask", // Runs but there's accuracy mismatch
         "^test_training_dropout_default" // Runs but there's accuracy mismatch
-
     ],
     // ORT first supported opset 7, so models with nodes that require versions prior to opset 7 are not supported
     "tests_with_pre_opset7_dependencies": [

--- a/onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_overrides.jsonc
@@ -1,0 +1,13 @@
+{
+    "rtol_default": 1e-3,
+    "atol_default": 1e-5,
+    // Key: str, the name of the test as defined by ONNX without any device suffix.
+    // Val: float, max absolute difference between expected and actual.
+    "atol_overrides": {
+        "test_dft": 1e-4,
+        "test_dft_axis": 1e-4
+    },
+    // Key: str, the name of the test as defined by ONNX without any device suffix.
+    // Val: float, max relative difference between expected and actual.
+    "rtol_overrides": {}
+}

--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -173,8 +173,6 @@ std::string GetTestDataPath() {
 static std::vector<ITestCase*> GetAllTestCases() {
   std::vector<ITestCase*> tests;
   std::vector<std::basic_string<PATH_CHAR_TYPE>> whitelistedTestCases;
-  double perSampleTolerance = 1e-3;
-  double relativePerSampleTolerance = 1e-3;
   std::unordered_set<std::basic_string<ORTCHAR_T>> allDisabledTests;
   std::vector<std::basic_string<PATH_CHAR_TYPE>> dataDirs;
   auto testDataPath = GetTestDataPath();
@@ -231,7 +229,7 @@ static std::vector<ITestCase*> GetAllTestCases() {
 #endif
 
   
-  WINML_EXPECT_NO_THROW(LoadTests(dataDirs, whitelistedTestCases, perSampleTolerance, relativePerSampleTolerance,
+  WINML_EXPECT_NO_THROW(LoadTests(dataDirs, whitelistedTestCases, TestTolerances(1e-3, 1e-3, {}, {}),
                                   allDisabledTests,
                                   [&tests](std::unique_ptr<ITestCase> l) {
                                     tests.push_back(l.get());


### PR DESCRIPTION
Prior to this every test shared the same global tolerances. This meant
that if an ONNX test failed due to a small but acceptable difference in
output, the only alternative was to disable the test entirely.

In op set 17, the DFT operator is being added. Without this change, the
tests for that operator fail because the output is off by about 5e-5.
It's better to keep test coverage for this new op rather than disable
the test entirely.

Also prior to this change, the global tolerances were not shared between
JavaScript, Python and C++ tests. Now they are.

Also update the JSON submodule, which is needed to get it to build with
exceptions disabled.

Unblocks https://github.com/microsoft/onnxruntime/issues/11640.