### PR TITLE
Use memory mapped data for external data initializers with Cuda fix

### DIFF
--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -88,9 +88,8 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env,
   std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
   TensorShape tensor_shape{tensor_shape_vec};
 
-  auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU,
+  tensor = Tensor(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU,
                                            OrtAllocatorType::OrtDeviceAllocator));
-  tensor = std::move(*p_tensor);
 
   return common::Status::OK();
 }

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -6,8 +6,6 @@
 
 #include <functional>
 #include <limits>
-#include <ostream>
-#include <typeinfo>
 #include <core/common/status.h>
 
 #include "core/common/common.h"
@@ -314,6 +312,7 @@ common::Status SaveInitializedTensors(
 
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
       ort_value = *(session_options.initializers_to_share_map.at(name));
+      LOGS(logger, INFO) << "Using user supplied initializer with name (" << name << ").";
     } else {
       const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
 
@@ -418,6 +417,7 @@ common::Status SaveInputOutputNamesToNodeMapping(const onnxruntime::GraphViewer&
       // is consumed in the subgraph if there is an explicit consumer.
       // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes, its
       // location is the location of the value in the enclosing outer scope.
+
       // All this is setup in the planner, we just use the location from the plan here.
       for (const auto& input_def : node_implicit_inputs) {
         int arg_index;

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -70,10 +70,9 @@ struct ExtDataValueDeleter {
 // by the OrtValue's deleter
 static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                                         const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                                        Tensor& tensor, OrtCallback& ext_data_deleter)
-{
+                                                        Tensor& tensor, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  ORT_ENFORCE(! proto_path.empty());
+  ORT_ENFORCE(!proto_path.empty());
 
   void* ext_data_buf = nullptr;
   size_t ext_data_len = 0;
@@ -85,7 +84,7 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const st
   // nullptr for the allocator argument
   const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
   std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
-  TensorShape tensor_shape {tensor_shape_vec};
+  TensorShape tensor_shape{tensor_shape_vec};
 
   auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
   tensor = std::move(*p_tensor);
@@ -98,7 +97,6 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
                                              const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,
                                              OrtValue& ort_value, const DataTransferManager& data_transfer_mgr,
                                              bool use_device_allocator_for_initializers = false) {
-
   if (bool(alloc) == (m != nullptr)) {
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                   "DeserializeTensorProto() takes either pre-allocated buffer or an allocator!");
@@ -133,7 +131,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
       OrtCallback ext_data_deleter;
       ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter));
 
-      ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get() };
+      ExtDataValueDeleter deleter{ext_data_deleter, p_tensor.get()};
 
       MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
       ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -141,7 +141,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     // deserialize directly to CPU tensor
     if (utils::HasExternalData(tensor_proto)) {
       OrtCallback ext_data_deleter;
-      Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter);
+      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter));
 
       ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get() };
 
@@ -170,8 +170,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 
     OrtCallback ext_data_deleter;
     if (utils::HasExternalData(tensor_proto)) {
-      Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor, ext_data_deleter); //,
-      if (! st.IsOK()) { return st; }
+      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor, ext_data_deleter));
     } else {
       ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
     }
@@ -257,7 +256,7 @@ common::Status SaveInitializedTensors(
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
     auto location = exec_plan.GetLocation(ort_value_index).name;
     if (utils::HasExternalData(*entry->second) && (strcmp(location, CPU) == 0)) {
-      // exernal data will be memory mapped, no need to plan for its allocation
+      // external data will be memory mapped, no need to plan for its allocation
       continue;
     } else {
       // can not trace string tensor

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -88,7 +88,7 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env,
   TensorShape tensor_shape{tensor_shape_vec};
 
   auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU,
-              OrtAllocatorType::OrtDeviceAllocator));
+                                           OrtAllocatorType::OrtDeviceAllocator));
   tensor = std::move(*p_tensor);
 
   return common::Status::OK();
@@ -314,9 +314,9 @@ common::Status SaveInitializedTensors(
       bool use_device_allocator_for_initializers =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "0") == "1";
 
-      Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc, default_cpu_alloc, ort_value,
-
-                                         data_transfer_mgr, use_device_allocator_for_initializers);
+      Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc,
+                                         default_cpu_alloc, ort_value, data_transfer_mgr,
+                                         use_device_allocator_for_initializers);
       if (!st.IsOK()) {
         std::ostringstream oss;
         oss << "Deserialize tensor " << name << " failed." << st.ErrorMessage();

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -54,6 +54,61 @@ static common::Status AllocateBufferUsingDeviceAllocatorFromShapeAndType(const T
   return Status::OK();
 }
 
+// null (do nothing) allocator for tensors that wrap external data pointers which are
+// memory mapped or allocated without an ORT allocator; these pointers are instead
+// released with the deleter of the ORT value which holds the ext data tensor
+struct ExtDataNullAllocator : public IAllocator {
+  ExtDataNullAllocator() : IAllocator(OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator)) {}
+  void* Alloc(size_t size) override {
+    ORT_UNUSED_PARAMETER(size);
+    return nullptr;
+  }
+  void Free(void* p) override { ORT_UNUSED_PARAMETER(p); }
+};
+
+// deleter for external data tensors managed by an OrtValue; manages the release of
+// the tensor's data buffer (which points to the external data) and the tensor itself
+struct ExtDataValueDeleter {
+  OrtCallback ext_delete_cb;
+  Tensor* p_tensor;
+  void operator()(void*) noexcept {
+    this->ext_delete_cb.f(this->ext_delete_cb.param);
+    delete this->p_tensor;
+  }
+};
+
+// given a tensor proto with externdal data return an OrtValue with a tensor for
+// that data; the pointers for the tensor data and the tensor itself are owned
+// by the OrtValue's deleter
+static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
+                                                        const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                                        OrtValue& ort_value) {
+  ORT_ENFORCE(utils::HasExternalData(tensor_proto));
+  ORT_ENFORCE(!proto_path.empty());
+
+  void* ext_data_buf = nullptr;
+  size_t ext_data_len = 0;
+  OrtCallback ext_data_deleter;
+  ORT_RETURN_IF_ERROR(utils::GetExtDataFromTensorProto(env, proto_path.c_str(), tensor_proto,
+                                                       ext_data_buf, ext_data_len, ext_data_deleter));
+
+  // NB: creating a do-nothing allocator per tensor is wasteful; can perhaps be
+  // avoided if the Tensor class implements the do-nothing behavior when given a
+  // nullptr for the allocator argument
+  AllocatorPtr ext_data_alloc = std::make_shared<ExtDataNullAllocator>();
+  const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
+  std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
+  TensorShape tensor_shape{tensor_shape_vec};
+  MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
+
+  auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, ext_data_alloc);
+
+  ExtDataValueDeleter deleter{ext_data_deleter, p_tensor.get()};
+
+  ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);
+  return common::Status::OK();
+}
+
 static common::Status DeserializeTensorProto(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                              const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer* m,
                                              const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,
@@ -185,18 +240,28 @@ common::Status SaveInitializedTensors(
   }
 
   // tensors requiring a specific allocation order are traced first, to ensure they are allocated in order
+  // NB: vector with init allocation order may contain a subset of all tensors (or none at all)
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
-    // can not trace string tensor
-    ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() && entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);
-    ORT_RETURN_IF_ERROR(planner.Trace(entry->first, entry->second));
+    if (utils::HasExternalData(*entry->second)) {
+      // exernal data will be memory mapped, no need to plan for its allocation
+      continue;
+    } else {
+      // can not trace string tensor
+      ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() && entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);
+      ORT_RETURN_IF_ERROR(planner.Trace(entry->first, entry->second));
+    }
     initialized_tensors_to_allocate.erase(entry);
   }
 
   for (const auto& entry : initialized_tensors_to_allocate) {
     // We don't want to trace shared initializers since their memory is provided by the user
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
+      continue;
+    }
+    if (utils::HasExternalData(*entry.second)) {
+      // exernal data will be memory mapped, no need to plan for its allocation
       continue;
     }
     if (entry.second->data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
@@ -233,6 +298,14 @@ common::Status SaveInitializedTensors(
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
       ort_value = *(session_options.initializers_to_share_map.at(name));
       LOGS(logger, INFO) << "Using user supplied initializer with name (" << name << ").";
+    } else if (utils::HasExternalData(*entry.second)) {
+      const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
+      Status st = ExtDataTensorProtoToTensor(env, graph_loc, tensor_proto, ort_value);
+      if (!st.IsOK()) {
+        std::ostringstream oss;
+        oss << "Load of external data tensor " << name << " failed." << st.ErrorMessage();
+        return Status(st.Category(), st.Code(), oss.str());
+      }
     } else {
       const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
 

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -88,7 +88,6 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const st
 
   void* ext_data_buf = nullptr;
   size_t ext_data_len = 0;
-  // OrtCallback ext_data_deleter;
   ORT_RETURN_IF_ERROR(utils::GetExtDataFromTensorProto(env, proto_path.c_str(), tensor_proto,
                                                        ext_data_buf, ext_data_len, ext_data_deleter));
 

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -62,7 +62,7 @@ struct ExtDataValueDeleter {
   Tensor* p_tensor;
   void operator()(void*) noexcept {
     this->ext_delete_cb.f(this->ext_delete_cb.param);
-    delete this->p_tensor;
+    delete p_tensor;
   }
 };
 
@@ -88,7 +88,8 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env,
   std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
   TensorShape tensor_shape{tensor_shape_vec};
 
-  auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU, OrtAllocatorType::OrtDeviceAllocator));
+  auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU,
+              OrtAllocatorType::OrtDeviceAllocator));
   tensor = std::move(*p_tensor);
 
   return common::Status::OK();
@@ -242,7 +243,7 @@ common::Status SaveInitializedTensors(
 
   // tensors requiring a specific allocation order are traced first, to ensure they are allocated in order
   // NB1: vector with init allocation order may contain a subset of all tensors (or none at all)
-  // NB2: only skip tracing and planing memory when data is external (i.e mmap) and on CPU.
+  // NB2: only skip tracing and planning memory when data is external (i.e mmap) and on CPU.
   //    when data is external and on GPU, need to copy first to cpu memory, then to gpu memory.
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
@@ -267,7 +268,7 @@ common::Status SaveInitializedTensors(
       continue;
     }
     if (utils::HasExternalData(*entry.second) && (strcmp(location, CPU) == 0)) {
-      // exernal data will be memory mapped, no need to plan for its allocation
+      // external data is memory mapped, no need to plan for its allocation
       continue;
     }
     if (entry.second->data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -312,7 +312,6 @@ common::Status SaveInitializedTensors(
     const char* name = (entry.second->name().empty()) ? "" : entry.second->name().c_str();
     OrtValue ort_value;
 
-    // auto location = exec_plan.GetLocation(ort_value_index).name;
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
       ort_value = *(session_options.initializers_to_share_map.at(name));
     } else {

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -7,6 +7,7 @@
 
 #include <core/common/status.h>
 
+#include "core/framework/ortdevice.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/framework/session_state_utils.h"
 #include "core/common/common.h"
@@ -247,8 +248,7 @@ common::Status SaveInitializedTensors(
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
-    auto location = exec_plan.GetLocation(ort_value_index).name;
-    if (!(utils::HasExternalData(*entry->second) && (strcmp(location, CPU) == 0))) {
+    if (!(utils::HasExternalData(*entry->second) && exec_plan.GetLocation(ort_value_index).device.Type() == OrtDevice::CPU)) {
       // can not trace string tensor
       ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() &&
                   entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <limits>
+#include <utility>
 #include <core/common/status.h>
 
 #include "core/common/common.h"
@@ -68,7 +69,8 @@ struct ExtDataValueDeleter {
 // given a tensor proto with externdal data return an OrtValue with a tensor for
 // that data; the pointers for the tensor data and the tensor itself are owned
 // by the OrtValue's deleter
-static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
+static inline common::Status ExtDataTensorProtoToTensor(const Env& env,
+                                                        const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                                         const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                                         Tensor& tensor, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
@@ -158,7 +160,8 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 
     OrtCallback ext_data_deleter;
     if (utils::HasExternalData(tensor_proto)) {
-      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor, ext_data_deleter));
+      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor,
+                                                     ext_data_deleter));
     } else {
       ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
     }
@@ -250,7 +253,8 @@ common::Status SaveInitializedTensors(
       continue;
     } else {
       // can not trace string tensor
-      ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() && entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);
+      ORT_ENFORCE(entry != initialized_tensors_to_allocate.end() &&
+                  entry->second->data_type() != ONNX_NAMESPACE::TensorProto_DataType_STRING);
       ORT_RETURN_IF_ERROR(planner.Trace(entry->first, entry->second));
     }
     initialized_tensors_to_allocate.erase(entry);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -66,7 +66,6 @@ struct ExtDataValueDeleter {
   }
 };
 
-
 static common::Status DeserializeTensorProto(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                              const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer* m,
                                              const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/graph/onnx_protobuf.h"
-#include "core/framework/session_state_utils.h"
-
 #include <functional>
 #include <limits>
 #include <utility>
+
 #include <core/common/status.h>
 
+#include "core/graph/onnx_protobuf.h"
+#include "core/framework/session_state_utils.h"
 #include "core/common/common.h"
 #include "core/common/logging/logging.h"
-
 #include "core/graph/graph_viewer.h"
 #include "core/framework/data_transfer_manager.h"
 #include "core/framework/graph_partitioner.h"

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -70,11 +70,7 @@ struct ExtDataNullAllocator : public IAllocator {
 struct ExtDataValueDeleter {
   OrtCallback ext_delete_cb;
   Tensor* p_tensor;
-  int id;
-  const logging::Logger& logger;
   void operator()(void*) noexcept {
-    LOGS(logger, INFO) << "deleting " << id;
-    std::cout << "deleting " << id << std::endl;
     this->ext_delete_cb.f(this->ext_delete_cb.param);
     delete this->p_tensor;
   }
@@ -85,7 +81,7 @@ struct ExtDataValueDeleter {
 // by the OrtValue's deleter
 static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                                         const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                                        Tensor& tensor, OrtCallback& ext_data_deleter) //, int id, const DataTransferManager& data_transfer_mgr, const logging::Logger& logger)
+                                                        Tensor& tensor, OrtCallback& ext_data_deleter)
 {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
   ORT_ENFORCE(! proto_path.empty());
@@ -103,14 +99,10 @@ static inline common::Status ExtDataTensorProtoToTensor(const Env& env, const st
   const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
   std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
   TensorShape tensor_shape {tensor_shape_vec};
-  // MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
 
   auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, ext_data_alloc);
   tensor = std::move(*p_tensor);
 
-  // ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get(), id, logger };
-  //
-  // ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);
   return common::Status::OK();
 }
 
@@ -118,10 +110,8 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
                                              const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer* m,
                                              const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,
                                              OrtValue& ort_value, const DataTransferManager& data_transfer_mgr,
-                                             const logging::Logger& logger,
                                              bool use_device_allocator_for_initializers = false) {
 
-  LOGS(logger, INFO) << "allocator is " << alloc->Info().name;
   if (bool(alloc) == (m != nullptr)) {
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
                   "DeserializeTensorProto() takes either pre-allocated buffer or an allocator!");
@@ -132,7 +122,6 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
   const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
   std::unique_ptr<Tensor> p_tensor;
   if (m != nullptr) {
-      // not here
     p_tensor = std::make_unique<Tensor>(type, tensor_shape, m->GetBuffer(), m->GetAllocInfo());
     if (m->GetLen() < p_tensor->SizeInBytes()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Internal error. The preallocated buffer is too small. Requires ",
@@ -153,16 +142,11 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
 
   if (p_tensor->Location().device.Type() == OrtDevice::CPU) {
     // deserialize directly to CPU tensor
-    LOGS(logger, INFO) << "deserialize directly to CPU tensor";
     if (utils::HasExternalData(tensor_proto)) {
-      // Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, ort_value,
-      //         [>TODO for debugging, delete later<] 0, data_transfer_mgr, logger);
-      LOGS(logger, INFO) << "deserialize directly to CPU tensor from external data";
       OrtCallback ext_data_deleter;
-      Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter); //,
-              // TODO for debugging, delete later 0, data_transfer_mgr, logger);
+      Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter);
 
-      ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get(), 0, logger };
+      ExtDataValueDeleter deleter { ext_data_deleter, p_tensor.get() };
 
       MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
       ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);
@@ -170,7 +154,6 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     }
     ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_tensor));
   } else {  // non-cpu tensor
-    LOGS(logger, INFO) << "deserialize to non-CPU tensor";
     if (tensor_proto.data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "string tensor is not supported for copying between allocators");
     }
@@ -185,13 +168,11 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
       // If the provided allocator is an arena-based allocator, the call to Alloc() will tap into memory from the arena
       // (may expand it if there isn't a chunk that can be allotted to the memory request).
       // If the provided allocator is non-arena based, the device specific Alloc() call will be used to allocate the necessary memory.
-      // LOGS(logger, INFO) << "deserialize to non-CPU tensor using default cpu alloc";
       p_deserialize_tensor = std::make_unique<Tensor>(type, tensor_shape, default_cpu_alloc);
     }
 
     OrtCallback ext_data_deleter;
     if (utils::HasExternalData(tensor_proto)) {
-      //
       Status st = ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor, ext_data_deleter); //,
       if (! st.IsOK()) { return st; }
     } else {
@@ -199,9 +180,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     }
     // TODO!! Need a temp buffer allocator for non-escape buffers that maybe too big for stack allocation.
 
-    // LOGS(logger, INFO) << "copying temp tensor to final destination";
     Status copy_status = data_transfer_mgr.CopyTensor(*p_deserialize_tensor, *p_tensor);
-    // LOGS(logger, INFO) << "done copying temp tensor to final destination";
     if (!copy_status.IsOK()) {
       if (copy_status.ErrorMessage().empty()) {
         // The windows execution provider does not return any error message today for CopyTensor since it is
@@ -268,7 +247,6 @@ common::Status SaveInitializedTensors(
   for (const auto& entry : initialized_tensor_set) {
     int ort_value_index;
     ORT_RETURN_IF_ERROR(ort_value_name_idx_map.GetIdx(entry.first, ort_value_index));
-    std::cout << "xxx first " << entry.first << std::endl;
     if (use_user_supplied_initializer(entry.first)) {
       user_supplied_initializer_ids.insert(ort_value_index);
     }
@@ -280,9 +258,9 @@ common::Status SaveInitializedTensors(
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
-    // auto location = exec_plan.GetLocation(ort_value_index).name;
-    // if (utils::HasExternalData(*entry->second) && (strcmp(location, CPU) == 0)) {
-    if (utils::HasExternalData(*entry->second)) {
+    auto location = exec_plan.GetLocation(ort_value_index).name;
+    if (utils::HasExternalData(*entry->second) && (strcmp(location, CPU) == 0)) {
+    // if (utils::HasExternalData(*entry->second)) {
       // exernal data will be memory mapped, no need to plan for its allocation
       continue;
     } else {
@@ -294,13 +272,13 @@ common::Status SaveInitializedTensors(
   }
 
   for (const auto& entry : initialized_tensors_to_allocate) {
-    // auto location = exec_plan.GetLocation(entry.first).name;
+    auto location = exec_plan.GetLocation(entry.first).name;
     // We don't want to trace shared initializers since their memory is provided by the user
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
       continue;
     }
-    // if (utils::HasExternalData(*entry.second) && (strcmp(location, CPU) == 0)) {
-    if (utils::HasExternalData(*entry.second) ) {
+    if (utils::HasExternalData(*entry.second) && (strcmp(location, CPU) == 0)) {
+    // if (utils::HasExternalData(*entry.second) ) {
       // exernal data will be memory mapped, no need to plan for its allocation
       continue;
     }
@@ -328,7 +306,6 @@ common::Status SaveInitializedTensors(
   }
 
   OrtCallback deleter{nullptr, nullptr};
-  LOGS(logger, INFO) << "planner is type " << typeid(planner).name();
 
   // 3. create weight tensors based on weights buffer
   for (const auto& entry : id_to_initialized_tensor) {
@@ -337,26 +314,9 @@ common::Status SaveInitializedTensors(
     OrtValue ort_value;
 
     // auto location = exec_plan.GetLocation(ort_value_index).name;
-    // LOGS(logger, INFO) << "XXX location " << location;
     if (user_supplied_initializer_ids.find(entry.first) != user_supplied_initializer_ids.end()) {
       ort_value = *(session_options.initializers_to_share_map.at(name));
-      // LOGS(logger, INFO) << "Using user supplied initializer with name (" << name << ").";
-    }
-    // else if (utils::HasExternalData(*entry.second) && (strcmp(location, CPU) == 0)) {
-    // else if (utils::HasExternalData(*entry.second)) {
-    //   const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
-    //   Status st = ExtDataTensorProtoToTensor(env, graph_loc, tensor_proto, ort_value, entry.first, data_transfer_mgr, logger);
-    //   if (! st.IsOK()) {
-    //     std::ostringstream oss;
-    //     oss << "Load of external data tensor " << name << " failed." << st.ErrorMessage();
-    //     return Status(st.Category(), st.Code(), oss.str());
-    //   }
-    //   if (strcmp(location, CPU) == 0) {
-    //     // destination is not on cpu, gotta copy
-    //     // TODO
-    //   }
-    // }
-    else {
+    } else {
       const ONNX_NAMESPACE::TensorProto& tensor_proto = *(entry.second);
 
       std::optional<MemBuffer> m;
@@ -365,9 +325,9 @@ common::Status SaveInitializedTensors(
       ORT_RETURN_IF_ERROR(planner.GetPreallocatedBuffer(ort_value_index, name, m, alloc));
       bool use_device_allocator_for_initializers =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsUseDeviceAllocatorForInitializers, "0") == "1";
-      // LOGS(logger, INFO) << "use_device_allocator_for_initializers " << use_device_allocator_for_initializers;
 
       Status st = DeserializeTensorProto(env, graph_loc, tensor_proto, (m.has_value()) ? &*m : nullptr, alloc, default_cpu_alloc, ort_value,
+
                                          data_transfer_mgr, use_device_allocator_for_initializers);
       if (!st.IsOK()) {
         std::ostringstream oss;
@@ -447,6 +407,15 @@ common::Status SaveInputOutputNamesToNodeMapping(const onnxruntime::GraphViewer&
     // implicit inputs to a node could come directly from a feed, so we need to make sure they have an entry too
     const auto& node_implicit_inputs = node.ImplicitInputDefs();
     if (!node_implicit_inputs.empty()) {
+      // In the main graph, the location of the implicit input(s) is the location it
+      // is consumed in the main graph if there is an explicit consumer.
+      // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes and
+      // all of them have been partitioned to the same EP, its location is the
+      // location of the non-CPU device corresponding to the EP.
+      // If multiple EPs are involved, then the planned location for such implicit inputs
+      // just default to CPU (as there is ambiguity involved as to which non-CPU device is
+      // most optimal)
+
       // In nested subgraphs, the location of the implicit input(s) is the location it
       // is consumed in the subgraph if there is an explicit consumer.
       // If the only consumer(s) are implicit consumers (i.e.) other control flow nodes, its

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -238,7 +238,9 @@ common::Status SaveInitializedTensors(
   }
 
   // tensors requiring a specific allocation order are traced first, to ensure they are allocated in order
-  // NB: vector with init allocation order may contain a subset of all tensors (or none at all)
+  // NB1: vector with init allocation order may contain a subset of all tensors (or none at all)
+  // NB2: only skip tracing and planing memory when data is external (i.e mmap) and on CPU.
+  //    when data is external and on GPU, need to copy first to cpu memory, then to gpu memory.
   auto initialized_tensors_to_allocate = id_to_initialized_tensor;
   for (int ort_value_index : initializer_allocation_order) {
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -66,6 +66,35 @@ struct ExtDataValueDeleter {
   }
 };
 
+// given a tensor proto with externdal data return an OrtValue with a tensor for
+// that data; the pointers for the tensor data and the tensor itself are owned
+// by the OrtValue's deleter
+static inline common::Status ExtDataTensorProtoToTensor(const Env& env,
+                                                        const std::basic_string<PATH_CHAR_TYPE>& proto_path,
+                                                        const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                                        Tensor& tensor, OrtCallback& ext_data_deleter) {
+  ORT_ENFORCE(utils::HasExternalData(tensor_proto));
+  ORT_ENFORCE(!proto_path.empty());
+
+  void* ext_data_buf = nullptr;
+  size_t ext_data_len = 0;
+  ORT_RETURN_IF_ERROR(utils::GetExtDataFromTensorProto(env, proto_path.c_str(), tensor_proto,
+                                                       ext_data_buf, ext_data_len, ext_data_deleter));
+
+  // NB: creating a do-nothing allocator per tensor is wasteful; can perhaps be
+  // avoided if the Tensor class implements the do-nothing behavior when given a
+  // nullptr for the allocator argument
+  const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
+  std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
+  TensorShape tensor_shape{tensor_shape_vec};
+
+  auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, ext_data_buf, OrtMemoryInfo(CPU,
+                                           OrtAllocatorType::OrtDeviceAllocator));
+  tensor = std::move(*p_tensor);
+
+  return common::Status::OK();
+}
+
 static common::Status DeserializeTensorProto(const Env& env, const std::basic_string<PATH_CHAR_TYPE>& proto_path,
                                              const ONNX_NAMESPACE::TensorProto& tensor_proto, const MemBuffer* m,
                                              const AllocatorPtr& alloc, const AllocatorPtr& default_cpu_alloc,
@@ -98,19 +127,20 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
       p_tensor = std::make_unique<Tensor>(type, tensor_shape, alloc);
     }
   }
+
   if (p_tensor->Location().device.Type() == OrtDevice::CPU) {
     // deserialize directly to CPU tensor
-    OrtCallback ext_data_deleter;
-    ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_tensor, ext_data_deleter));
     if (utils::HasExternalData(tensor_proto)) {
-      // NB: when data is external and is on CPU, give the OrtValue the special deleter since the data is not
-      // owned by OrtValue nor Tensor.
+      OrtCallback ext_data_deleter;
+      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_tensor, ext_data_deleter));
+
       ExtDataValueDeleter deleter{ext_data_deleter, p_tensor.get()};
 
       MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();
       ort_value.Init(p_tensor.release(), ml_tensor_type, deleter);
       return common::Status::OK();
     }
+    ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_tensor));
   } else {  // non-cpu tensor
     if (tensor_proto.data_type() == ONNX_NAMESPACE::TensorProto_DataType_STRING) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "string tensor is not supported for copying between allocators");
@@ -129,7 +159,13 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
       p_deserialize_tensor = std::make_unique<Tensor>(type, tensor_shape, default_cpu_alloc);
     }
 
-    ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
+    OrtCallback ext_data_deleter;
+    if (utils::HasExternalData(tensor_proto)) {
+      ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor,
+                                                     ext_data_deleter));
+    } else {
+      ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
+    }
     // TODO!! Need a temp buffer allocator for non-escape buffers that maybe too big for stack allocation.
 
     Status copy_status = data_transfer_mgr.CopyTensor(*p_deserialize_tensor, *p_tensor);

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -103,6 +103,8 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     OrtCallback ext_data_deleter;
     ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_tensor, ext_data_deleter));
     if (utils::HasExternalData(tensor_proto)) {
+      // NB: when data is external and is on CPU, give the OrtValue the special deleter since the data is not
+      // owned by OrtValue nor Tensor.
       ExtDataValueDeleter deleter{ext_data_deleter, p_tensor.get()};
 
       MLDataType ml_tensor_type = DataTypeImpl::GetType<Tensor>();

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -257,7 +257,6 @@ common::Status SaveInitializedTensors(
     const auto entry = initialized_tensors_to_allocate.find(ort_value_index);
     auto location = exec_plan.GetLocation(ort_value_index).name;
     if (utils::HasExternalData(*entry->second) && (strcmp(location, CPU) == 0)) {
-    // if (utils::HasExternalData(*entry->second)) {
       // exernal data will be memory mapped, no need to plan for its allocation
       continue;
     } else {
@@ -275,7 +274,6 @@ common::Status SaveInitializedTensors(
       continue;
     }
     if (utils::HasExternalData(*entry.second) && (strcmp(location, CPU) == 0)) {
-    // if (utils::HasExternalData(*entry.second) ) {
       // exernal data will be memory mapped, no need to plan for its allocation
       continue;
     }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -586,15 +586,26 @@ Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
                                  const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                  void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  ORT_ENFORCE(model_path);
   std::basic_string<ORTCHAR_T> tensor_proto_dir;
-  ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
+  if (model_path != nullptr) {
+    ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
+  }
   const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str();
   std::basic_string<ORTCHAR_T> external_data_file_path;
   FileOffsetType file_offset;
-  SafeInt<size_t> raw_data_safe_len;
+  SafeInt<size_t> raw_data_safe_len = 0;
   ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset,
                                           raw_data_safe_len));
+
+  size_t file_length;
+  ORT_RETURN_IF_ERROR(env.GetFileLength(external_data_file_path.c_str(), file_length));
+
+  SafeInt<FileOffsetType> end_of_read(file_offset);
+  end_of_read += raw_data_safe_len;
+  ORT_RETURN_IF(file_offset < 0 || end_of_read > gsl::narrow<FileOffsetType>(file_length),
+                  "External initializer: ", tensor_proto.name(),
+                  " offset: ", file_offset, " size to read: ", static_cast<size_t>(raw_data_safe_len),
+                  " given file_length: ", file_length, " are out of bounds or can not be read in full.");
   ORT_RETURN_IF_ERROR(GetFileContent(env, external_data_file_path.c_str(), file_offset, raw_data_safe_len,
                                      ext_data_buf, ext_data_deleter));
   ext_data_len = raw_data_safe_len;

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -582,6 +582,23 @@ static Status GetFileContent(
   return Status::OK();
 }
 
+Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter)
+{
+  ORT_ENFORCE(utils::HasExternalData(tensor_proto));
+  ORT_ENFORCE(model_path);
+  std::basic_string<ORTCHAR_T> tensor_proto_dir;
+  ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
+  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str();
+  std::basic_string<ORTCHAR_T> external_data_file_path;
+  FileOffsetType file_offset;
+  SafeInt<size_t> raw_data_safe_len;
+  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset, raw_data_safe_len));
+  ORT_RETURN_IF_ERROR(GetFileContent(env, external_data_file_path.c_str(), file_offset, raw_data_safe_len, ext_data_buf, ext_data_deleter));
+  ext_data_len = raw_data_safe_len;
+  return Status::OK();
+}
+
 #define CASE_PROTO(X, Y)                                                      \
   case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_##X:        \
     ORT_RETURN_IF_ERROR(                                                      \

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -671,6 +671,7 @@ Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "string tensor can not have raw data");
   }
 
+  // NB: exit early when data is external, avoid calling UnpackTensor (which copies).
   if (endian::native == endian::little && raw_data != nullptr && callback.f != nullptr && utils::HasExternalData(tensor_proto)) {
     return Status::OK();
   }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -582,25 +582,6 @@ static Status GetFileContent(
   return Status::OK();
 }
 
-Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
-                                 const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter) {
-  ORT_ENFORCE(utils::HasExternalData(tensor_proto));
-  ORT_ENFORCE(model_path);
-  std::basic_string<ORTCHAR_T> tensor_proto_dir;
-  ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
-  const ORTCHAR_T* t_prot_dir_s = tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str();
-  std::basic_string<ORTCHAR_T> external_data_file_path;
-  FileOffsetType file_offset;
-  SafeInt<size_t> raw_data_safe_len;
-  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset,
-                                          raw_data_safe_len));
-  ORT_RETURN_IF_ERROR(GetFileContent(env, external_data_file_path.c_str(), file_offset, raw_data_safe_len,
-                                     ext_data_buf, ext_data_deleter));
-  ext_data_len = raw_data_safe_len;
-  return Status::OK();
-}
-
 #define CASE_PROTO(X, Y)                                                      \
   case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_##X:        \
     ORT_RETURN_IF_ERROR(                                                      \

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -583,8 +583,7 @@ static Status GetFileContent(
 }
 
 Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter)
-{
+                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
   ORT_ENFORCE(model_path);
   std::basic_string<ORTCHAR_T> tensor_proto_dir;

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -582,7 +582,8 @@ static Status GetFileContent(
   return Status::OK();
 }
 
-Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
+Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
+                                 const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                  void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
   ORT_ENFORCE(model_path);
@@ -592,8 +593,10 @@ Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, co
   std::basic_string<ORTCHAR_T> external_data_file_path;
   FileOffsetType file_offset;
   SafeInt<size_t> raw_data_safe_len;
-  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset, raw_data_safe_len));
-  ORT_RETURN_IF_ERROR(GetFileContent(env, external_data_file_path.c_str(), file_offset, raw_data_safe_len, ext_data_buf, ext_data_deleter));
+  ORT_RETURN_IF_ERROR(GetExternalDataInfo(tensor_proto, t_prot_dir_s, external_data_file_path, file_offset,
+                                          raw_data_safe_len));
+  ORT_RETURN_IF_ERROR(GetFileContent(env, external_data_file_path.c_str(), file_offset, raw_data_safe_len,
+                                     ext_data_buf, ext_data_deleter));
   ext_data_len = raw_data_safe_len;
   return Status::OK();
 }

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -584,7 +584,7 @@ static Status GetFileContent(
 
 Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
                                  const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter) {
+                                 void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter) {
   ORT_ENFORCE(utils::HasExternalData(tensor_proto));
   ORT_ENFORCE(model_path);
   std::basic_string<ORTCHAR_T> tensor_proto_dir;
@@ -634,34 +634,10 @@ Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
   void* raw_data = nullptr;
   SafeInt<size_t> raw_data_len = 0;
   AutoDelete deleter_for_file_data;
+  OrtCallback& d = deleter_for_file_data.d;
 
   if (utils::HasExternalData(tensor_proto)) {
-    // Get the external data info
-    std::basic_string<ORTCHAR_T> external_data_file_path;
-    FileOffsetType file_offset;
-    std::basic_string<ORTCHAR_T> tensor_proto_dir;
-    if (model_path != nullptr) {
-      ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));
-    }
-    ORT_RETURN_IF_ERROR(GetExternalDataInfo(
-        tensor_proto,
-        tensor_proto_dir.size() == 0 ? nullptr : tensor_proto_dir.c_str(),
-        external_data_file_path, file_offset, raw_data_len));
-
-    size_t file_length;
-    ORT_RETURN_IF_ERROR(env.GetFileLength(external_data_file_path.c_str(), file_length));
-
-    SafeInt<FileOffsetType> end_of_read(file_offset);
-    end_of_read += raw_data_len;
-    ORT_RETURN_IF(file_offset < 0 || end_of_read > gsl::narrow<FileOffsetType>(file_length),
-                  "External initializer: ", tensor_proto.name(),
-                  " offset: ", file_offset, " size to read: ", static_cast<size_t>(raw_data_len), " given file_length: ", file_length,
-                  " are out of bounds or can not be read in full.");
-
-    // load the file
-    ORT_RETURN_IF_ERROR(GetFileContent(
-        env, external_data_file_path.c_str(), file_offset, raw_data_len,
-        raw_data, deleter_for_file_data.d));
+    ORT_RETURN_IF_ERROR(GetExtDataFromTensorProto(env, model_path, tensor_proto, raw_data, raw_data_len, d));
   } else if (utils::HasRawData(tensor_proto)) {
     raw_data = const_cast<char*>(tensor_proto.raw_data().data());
     // TODO The line above has const-correctness issues. Below is a possible fix which copies the tensor_proto data

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -650,7 +650,6 @@ Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
         env, external_data_file_path.c_str(), file_offset, raw_data_len,
         raw_data, callback));
     const DataTypeImpl* const type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
-    std::vector<int64_t> tensor_shape_vec = utils::GetTensorShapeFromTensorProto(tensor_proto);
     TensorShape tensor_shape{tensor_shape_vec};
     auto p_tensor = std::make_unique<Tensor>(type, tensor_shape, raw_data, OrtMemoryInfo(CPU,
                                              OrtAllocatorType::OrtDeviceAllocator));

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -75,6 +75,11 @@ ONNXTensorElementDataType GetTensorElementType(const ONNX_NAMESPACE::TensorProto
 template <size_t alignment>
 common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& tensor_proto, size_t* out);
 
+// Given a tensor proto with external data obtain a pointer to the data and its length.
+// The ext_data_deleter argument is updated with a callback that owns/releases the data.
+Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
+
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer
 // If AttributeProto contains a TensorProto, this tensor proto is converted as is including the case when the
 // the data location is external. i.e. it does not load the external data.

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -55,6 +55,10 @@ common::Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* tensor_prot
  */
 common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
                                    const ONNX_NAMESPACE::TensorProto& tensor_proto,
+                                   Tensor& tensor, OrtCallback&);
+
+common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
+                                   const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                    Tensor& tensor);
 
 /** Creates a TensorProto from a Tensor.

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -80,7 +80,8 @@ common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& 
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
 common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
                                          const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                         void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter);
+                                         void*& ext_data_buf, SafeInt<size_t>& ext_data_len,
+                                         OrtCallback& ext_data_deleter);
 
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer
 // If AttributeProto contains a TensorProto, this tensor proto is converted as is including the case when the

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -77,7 +77,8 @@ common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& 
 
 // Given a tensor proto with external data obtain a pointer to the data and its length.
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
-common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
+common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
+                                         const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                          void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
 
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -77,7 +77,7 @@ common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& 
 
 // Given a tensor proto with external data obtain a pointer to the data and its length.
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
-Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
+common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                  void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
 
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -52,7 +52,7 @@ common::Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* tensor_prot
  * @param tensor_proto  source data
  * @param tensorp       destination empty tensor
  * @return
-*/
+ */
 common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
                                    const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                    Tensor& tensor);
@@ -78,7 +78,7 @@ common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& 
 // Given a tensor proto with external data obtain a pointer to the data and its length.
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
 common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path, const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                 void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
+                                         void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
 
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer
 // If AttributeProto contains a TensorProto, this tensor proto is converted as is including the case when the
@@ -406,7 +406,7 @@ inline bool HasModelVersion(const ONNX_NAMESPACE::ModelProto& m_proto) {
 }
 
 inline bool HasName(const ONNX_NAMESPACE::NodeProto& node_proto) {
-  //XXX: Figure out proto3 style
+  // XXX: Figure out proto3 style
   return node_proto.has_name();
 }
 #endif

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -10,6 +10,7 @@
 #include "core/common/common.h"
 #include "core/common/path.h"
 #include "core/common/status.h"
+#include "core/common/safeint.h"
 #include "core/framework/endian_utils.h"
 #include "core/framework/allocator.h"
 #include "core/framework/ort_value.h"
@@ -79,7 +80,7 @@ common::Status GetSizeInBytesFromTensorProto(const ONNX_NAMESPACE::TensorProto& 
 // The ext_data_deleter argument is updated with a callback that owns/releases the data.
 common::Status GetExtDataFromTensorProto(const Env& env, const ORTCHAR_T* model_path,
                                          const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                         void*& ext_data_buf, size_t& ext_data_len, OrtCallback& ext_data_deleter);
+                                         void*& ext_data_buf, SafeInt<size_t>& ext_data_len, OrtCallback& ext_data_deleter);
 
 // Convert the AttributeProto from a Constant node into a TensorProto that can be used as an initializer
 // If AttributeProto contains a TensorProto, this tensor proto is converted as is including the case when the

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -55,10 +55,6 @@ common::Status TensorProtoToMLValue(const Env& env, const ORTCHAR_T* tensor_prot
  */
 common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
                                    const ONNX_NAMESPACE::TensorProto& tensor_proto,
-                                   Tensor& tensor, OrtCallback&);
-
-common::Status TensorProtoToTensor(const Env& env, const ORTCHAR_T* model_path,
-                                   const ONNX_NAMESPACE::TensorProto& tensor_proto,
                                    Tensor& tensor);
 
 /** Creates a TensorProto from a Tensor.


### PR DESCRIPTION
**Description**: Reinstate #11127 with Cuda fix.

**Motivation and Context**
- Fixes https://github.com/microsoft/onnxruntime/issues/11511

**Details**
- #11127 causes the Cuda crash because when data is external, it skips the `data_transfer_mgr.CopyTensor(*p_deserialize_tensor, *p_tensor)` that happens inside `DeserializeTensorProto`. `data_transfer_mgr.CopyTensor` copies tensor data from CPU memory to GPU memory. Skipping it yields an illegal memory access down the line.
- Move `HasExternalData` from `SaveInitializedTensors` to `DeserializeTensorProto`
- In `DeserializeTensorProto` the new logic is as follow:
```
temp_tensor = Tensor()
if tensor.location == 'CPU':
    if tensor.has_external_data:
        ExtDataTensorProtoToTensor(..., temp_tensor, ...)
        ort_value.Init(temp_tensor, ...)
        return
    TensorProtoToTensor(..., temp_tensor, ...)
else:
    # non-cpu destination
    temp_deserialized_tensor = Tensor()
    if tensor.location == 'CPU':
        if tensor.has_external_data:
            ExtDataTensorProtoToTensor(..., temp_deserialized_tensor, ...)
        else:
            TensorProtoToTensor(..., temp_deserialized_tensor, ...)
    data_transfer_mgr.CopyTensor(temp_deserrialized_tensor, temp_tensor)
    ort_value.Init(temp_tensor, ...)
```
- Built and tested on the following environment:
  - centos 7
  - cuda 11.3
  - GCC 7.5
  - python 3.7
  - build command 
```
CUDACXX=XXX ./build.sh --build_dir=$PWD/../build --config=Release --update --build --parallel --build_shared_lib \
    --build_wheel --use_cuda --cuda_home XXX --cudnn_home XXX --cmake_extra_defines \
    onnxruntime_RUN_ONNX_TESTS=OFF onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_BUILD_MS_EXPERIMENTAL_OPS=OFF \
    CMAKE_EXPORT_COMPILE_COMMANDS=ON CMAKE_INSTALL_PREFIX=$PWD/../install CMAKE_C_COMPILER=ZZZ CMAKE_CXX_COMPILER=ZZZ
```
- Confirmed that there is no segmentation fault when running the reproduction script from #11511.
- Test suite passes
```
...
[----------] Global test environment tear-down
[==========] 3403 tests from 234 test suites ran. (99530 ms total)
[  PASSED  ] 3403 tests.

  YOU HAVE 7 DISABLED TESTS
```
- Comparison between versions
```
ort version 1.8.1 # after Chen's PR https://github.com/microsoft/onnxruntime/commit/4a4488baaead3479fec191fdd2d2686b6f243408
VmPeak:  2398852 kB
VmHWM:    620068 kB
VmRSS:    620068 kB
load time 1.6055119670927525
###
ort version 1.12.0 # this PR
VmPeak:  2397316 kB
VmHWM:    605652 kB
VmRSS:    605652 kB
load time 0.6550158001482487
###
ort version 1.7.0
VmPeak:  2951908 kB
VmHWM:    847712 kB
VmRSS:    847712 kB
load time 0.5580546036362648
```
We note the significant reduction in memory thanks to @chenfucn 's PR going from 1.7 to 1.8. This PR retains this low memory footprint but also brings down the load time.