### PR TITLE
Remove the redundant black check in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,21 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: black
-        uses: reviewdog/action-black@v3
+      - name: flake8
+        uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.github_token }}
           # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
           reporter: github-pr-check
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with a warning.
-          level: error
-          filter_mode: file
-      - name: flake8
-        uses: reviewdog/action-flake8@v3
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
           level: error
           filter_mode: file
       - name: pyflakes


### PR DESCRIPTION
We have two black checks in CI for different scopes (PR, full repo). Now that the repo level black check is required, we can remove the PR level check.