### PR TITLE
Fix load failure for onnx model with external data and slash (/) in path [Windows]

### DIFF
--- a/onnxruntime/core/platform/path_lib.cc
+++ b/onnxruntime/core/platform/path_lib.cc
@@ -14,7 +14,7 @@
 #ifdef _WIN32
 
 #if _GAMING_XBOX
-// Hacky, but the PathCch* APIs work on Xbox. Presumably PathCch.h needs to be updated to include the 
+// Hacky, but the PathCch* APIs work on Xbox. Presumably PathCch.h needs to be updated to include the
 // GAMES partition. It would be worthwhile to investigate this a bit more (or just use std::filesystem).
 #pragma push_macro("WINAPI_FAMILY")
 #undef WINAPI_FAMILY
@@ -95,12 +95,16 @@ Status RemoveFileSpec(PWSTR pszPath, size_t cchPath) {
 }  // namespace
 
 common::Status GetDirNameFromFilePath(const std::basic_string<ORTCHAR_T>& s, std::basic_string<ORTCHAR_T>& ret) {
-  std::wstring input = s;
-  if (input.empty()) {
+  if (s.empty()) {
     ret = ORT_TSTR(".");
     return Status::OK();
   }
+
   ret = s;
+
+  // Replace slash to backslash since we use PathCchRemoveBackslash
+  std::replace(ret.begin(), ret.end(), ORTCHAR_T('/'), ORTCHAR_T('\\'));
+
   auto st = onnxruntime::RemoveFileSpec(const_cast<wchar_t*>(ret.data()), ret.length() + 1);
   if (!st.IsOK()) {
     std::ostringstream oss;

--- a/onnxruntime/test/platform/path_lib_test.cc
+++ b/onnxruntime/test/platform/path_lib_test.cc
@@ -40,6 +40,26 @@ TEST(PathTest, windows_root) {
 TEST(PathTest, root) {
   PATH_EXPECT("\\", "\\");
 }
+
+TEST(PathTest, windows_slash_path_1) {
+  PATH_EXPECT("C:\\Windows", "C:/Windows/a.txt");
+}
+
+TEST(PathTest, windows_slash_path_2) {
+  PATH_EXPECT("C:\\Windows", "C:\\Windows/a.txt");
+}
+
+TEST(PathTest, windows_slash_path_3) {
+  PATH_EXPECT("C:\\Windows", "C:\\Windows//a.txt");
+}
+
+TEST(PathTest, windows_slash_path_4) {
+  PATH_EXPECT("C:\\Windows", "C:\\Windows\\\\system32/");
+}
+
+TEST(PathTest, windows_slash_path_5) {
+  PATH_EXPECT("C:\\Windows", "C:/Windows//system32/");
+}
 #else
 TEST(PathTest, simple) {
   PATH_EXPECT("/Windows", "/Windows/a.txt");


### PR DESCRIPTION
**Description**: 

GetDirNameFromFilePath currently assumes path using backslash. If user gives a ONNX model with external data, and path uses slash (/) instead of backslash (\\), ORT cannot extract the directory from path to locate external data file.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Related issues: https://github.com/microsoft/onnxruntime/issues/5418, #11708