### PR TITLE
Python backend: use packaging.version to parse ONNX version

### DIFF
--- a/onnxruntime/python/backend/backend.py
+++ b/onnxruntime/python/backend/backend.py
@@ -8,6 +8,7 @@ Implements ONNX's backend API.
 import os
 import unittest
 
+import packaging.version
 from onnx import ModelProto, helper, version
 from onnx.backend.base import Backend
 from onnx.checker import check_model
@@ -127,8 +128,8 @@ class OnnxRuntimeBackend(Backend):
             # check_model serializes the model anyways, so serialize the model once here
             # and reuse it below in the cls.prepare call to avoid an additional serialization
             # only works with onnx >= 1.10.0 hence the version check
-            onnx_version = tuple(map(int, (version.version.split(".")[:3])))
-            onnx_supports_serialized_model_check = onnx_version >= (1, 10, 0)
+            onnx_version = packaging.version.parse(version.version) or packaging.version.Version("0")
+            onnx_supports_serialized_model_check = onnx_version.release >= (1, 10, 0)
             bin_or_model = model.SerializeToString() if onnx_supports_serialized_model_check else model
             check_model(bin_or_model)
             opset_supported, error_message = cls.is_opset_supported(model)


### PR DESCRIPTION
Unlike the previous code, this handles version strings like "1.12.0rc3".

Unblocks https://github.com/microsoft/onnxruntime/issues/11640.