### PR TITLE
Update EP compile API deprecation warning message.

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -205,7 +205,7 @@ class IExecutionProvider {
   };
 
   // Fusion approach that is suppported
-  // !!! The "Function" FusionStyle will be deprecated soon.
+  // !!! The "Function" FusionStyle is deprecated.
   // !!! If your EP is using this fusion style, please migrate it to "FilteredGraphViewer" style.
   enum class FusionStyle {
     // The node fusion will create an onnxruntime::Function based Node that contains a completely new Graph instance
@@ -223,14 +223,14 @@ class IExecutionProvider {
 
   virtual FusionStyle GetFusionStyle() const {
     // All the ORT build in EP has migrate to FilteredGraphViewer style except Nuphar.
-    // For newer EPs, please avoid use Function style as it will be deprecated soon.
+    // For newer EPs, please avoid use Function style as it is deprecated.
     return FusionStyle::FilteredGraphViewer;
   }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
   /**
-  * !!!! This API will be deprecated soon. If your execution provider overrides this API
+  * !!!! This API is deprecated. If your execution provider overrides this API
   * !!!! Please migrate it to the "Compile" API with FusedNodeAndGraph type.
   Given a list of fused_node, return create_state/compute/release_state func for each node.
   */

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -237,7 +237,7 @@ static Node* PlaceNode(Graph& graph, const IndexedSubGraph& capability,
         // Here we temporary keep the function body for DML fusion
         // Need to remove it after migrate DML to the Compile-based approach.
         // TODO2: Nuphar is out of maintain, keep it with old API temporarily.
-        // We want to deprecate Nuphar soon.
+        // We want to remove Nuphar soon.
         if (fusion_style == IExecutionProvider::FusionStyle::Function ||
             provider_type == kDmlExecutionProvider ||
             provider_type == kNupharExecutionProvider) {
@@ -357,17 +357,17 @@ static Status PartitionOnnxFormatModelImpl(Graph& graph, FuncManager& func_mgr,
   // for example, it want to JIT an optimized kernel for LSTM with a given shape.
   if (!nodes_to_compile.empty()) {
     std::vector<NodeComputeInfo> node_compute_funcs;
-    // !!! The Function style fusion will be deprecated soon.
+    // !!! The Function style fusion is deprecated.
     if (fusion_style == IExecutionProvider::FusionStyle::Function) {
       // TODO: Nuphar is out of maintain. Use the old api temporarily.
-      // We want to deprecate it soon.
+      // We want to remove it soon.
       // Create a Function based node where the fused nodes have a new Graph instance.
       static std::once_flag legacy_compile_method_warning_flag;
       std::call_once(
           legacy_compile_method_warning_flag, [](std::string_view ep_type) {
-            LOGS_DEFAULT(WARNING) << "Execution Provider: " << ep_type << " is still using Funciton style Compile API, "
-                                  << " which will be deprecated soon, please migrate to the new Compile API based on "
-                                  << " FilteredGraphViewer. ";
+            LOGS_DEFAULT(WARNING) << "Execution Provider: " << ep_type << " is still using Function style Compile API "
+                                     "which is deprecated and will be removed soon. Please migrate to the new Compile "
+                                     "API based on FilteredGraphViewer.";
           },
           type);
       ORT_RETURN_IF_ERROR(current_ep.Compile(nodes_to_compile, node_compute_funcs));


### PR DESCRIPTION
**Description**
Minor wording update to warning message to clarify that the function style Compile API is deprecated now and will be removed soon.
Also updated some code comments.

**Motivation and Context**
Clarify warning message.