### PR TITLE
Support uploading EP perf data to a dev database.

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/post.py
+++ b/onnxruntime/python/tools/tensorrt/perf/post.py
@@ -50,8 +50,8 @@ def parse_arguments():
     parser.add_argument("-u", "--report_url", help="Report Url", required=True)
     parser.add_argument("-t", "--trt_version", help="Tensorrt Version", required=True)
     parser.add_argument("-b", "--branch", help="Branch", required=True)
-    parser.add_argument("-k", "--kusto_conn", help="Kusto connection URL", required=True)
-    parser.add_argument("-d", "--database", help="Database name", required=True)
+    parser.add_argument("--kusto_conn", help="Kusto connection URL", required=True)
+    parser.add_argument("--database", help="Database name", required=True)
     parser.add_argument(
         "-d",
         "--commit_datetime",

--- a/onnxruntime/python/tools/tensorrt/perf/post.py
+++ b/onnxruntime/python/tools/tensorrt/perf/post.py
@@ -36,11 +36,6 @@ from perf_utils import (
     trt_fp16,
 )
 
-# database connection strings
-CLUSTER_INGEST = "https://ingest-onnxruntimedashboarddb.southcentralus.kusto.windows.net"
-DATABASE_NAME = "ep_perf_dashboard"
-
-
 def parse_arguments():
     """
     Parses command-line arguments and returns an object with each argument as a field.
@@ -54,6 +49,8 @@ def parse_arguments():
     parser.add_argument("-u", "--report_url", help="Report Url", required=True)
     parser.add_argument("-t", "--trt_version", help="Tensorrt Version", required=True)
     parser.add_argument("-b", "--branch", help="Branch", required=True)
+    parser.add_argument("-k", "--kusto_conn", help="Kusto connection URL", required=True)
+    parser.add_argument("-d", "--database", help="Database name", required=True)
     parser.add_argument(
         "-d",
         "--commit_datetime",
@@ -234,7 +231,7 @@ def get_session(session, model_group):
     return session
 
 
-def write_table(ingest_client, table, table_name, upload_time, identifier):
+def write_table(ingest_client, database_name, table, table_name, upload_time, identifier):
     """
     Uploads the provided table to the database. This function also appends the upload time and unique run identifier
     to the table.
@@ -253,7 +250,7 @@ def write_table(ingest_client, table, table_name, upload_time, identifier):
     table = table.assign(UploadTime=str(upload_time))
     table = table.assign(Identifier=identifier)
     ingestion_props = IngestionProperties(
-        database=DATABASE_NAME,
+        database=database_name,
         table=table_name,
         data_format=DataFormat.CSV,
         report_level=ReportLevel.FailuresAndSuccesses,
@@ -286,7 +283,7 @@ def main():
     args = parse_arguments()
 
     # connect to database
-    kcsb_ingest = KustoConnectionStringBuilder.with_az_cli_authentication(CLUSTER_INGEST)
+    kcsb_ingest = KustoConnectionStringBuilder.with_az_cli_authentication(args.kusto_conn)
     ingest_client = QueuedIngestClient(kcsb_ingest)
     identifier = get_identifier(args.commit_datetime, args.commit_hash, args.trt_version, args.branch)
     upload_time = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
@@ -355,6 +352,7 @@ def main():
             db_table_name = "ep_model_" + table
             write_table(
                 ingest_client,
+                args.database,
                 table_results[table],
                 db_table_name,
                 upload_time,

--- a/onnxruntime/python/tools/tensorrt/perf/post.py
+++ b/onnxruntime/python/tools/tensorrt/perf/post.py
@@ -36,6 +36,7 @@ from perf_utils import (
     trt_fp16,
 )
 
+
 def parse_arguments():
     """
     Parses command-line arguments and returns an object with each argument as a field.

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -182,7 +182,7 @@ jobs:
           inlineScript: |
             short_hash=$(git rev-parse --short HEAD) &&
             commit_date=$(git log -1 --date=iso-strict --pretty=format:%cd) &&
-            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch) -k $(kustoConn) -d $(database)
+            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch) --kusto_con $(kustoConn) --database $(database)
     
     - template: templates/component-governance-component-detection-steps.yml
       parameters :

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -182,7 +182,7 @@ jobs:
           inlineScript: |
             short_hash=$(git rev-parse --short HEAD) &&
             commit_date=$(git log -1 --date=iso-strict --pretty=format:%cd) &&
-            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch) --kusto_con $(kustoConn) --database $(database)
+            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch) --kusto_conn $(kustoConn) --database $(database)
     
     - template: templates/component-governance-component-detection-steps.yml
       parameters :

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -182,7 +182,7 @@ jobs:
           inlineScript: |
             short_hash=$(git rev-parse --short HEAD) &&
             commit_date=$(git log -1 --date=iso-strict --pretty=format:%cd) &&
-            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch)
+            python3 $(Build.SourcesDirectory)/onnxruntime/python/tools/tensorrt/perf/post.py -r $(Build.SourcesDirectory)/Artifact/result -c $short_hash -d $commit_date -u "$(reportUrl)?buildId=$(Build.BuildId)" -t ${{ parameters.TrtVersion }} -b $(branch) -k $(kustoConn) -d $(database)
     
     - template: templates/component-governance-component-detection-steps.yml
       parameters :


### PR DESCRIPTION
**Description**: This PR allows uploading benchmarking data to a separate (e.g., development or test) database by making the database name and URL configurable.

**Motivation and Context**
Currently, these benchmarking scripts hardcode the database into which data is uploaded. This makes it cumbersome to test new features. This PR allows the user of the `post.py` script to specify the database. Additionally, the associated pipeline now stores database information in pipeline variables.
