### PR TITLE
enable the extensions custom build for java and android

### DIFF
--- a/cmake/external/extensions.cmake
+++ b/cmake/external/extensions.cmake
@@ -23,7 +23,8 @@ endif()
 
 # when onnxruntime-extensions is not a subdirectory of onnxruntime,
 # output binary directory must be explicitly specified.
-add_subdirectory(${onnxruntime_EXTENSIONS_PATH} ${onnxruntime_EXTENSIONS_PATH}/_subbuild EXCLUDE_FROM_ALL)
+# and the output binary path is the same as CMake FetchContent pattern
+add_subdirectory(${onnxruntime_EXTENSIONS_PATH} ${CMAKE_BINARY_DIR}/_deps/extensions-subbuild EXCLUDE_FROM_ALL)
 
 # target library or executable are defined in CMakeLists.txt of onnxruntime-extensions
 target_include_directories(ocos_operators PRIVATE ${RE2_INCLUDE_DIR} external/json/include)

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -117,6 +117,10 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_creat
     OrtSessionOptions* opts;
     checkOrtStatus(jniEnv,api,api->CreateSessionOptions(&opts));
     checkOrtStatus(jniEnv,api,api->SetInterOpNumThreads(opts, 1));
+#ifdef ENABLE_EXTENSION_CUSTOM_OPS
+    // including all custom ops from onnxruntime-extensions
+    checkOrtStatus(jniEnv,api,api->EnableOrtCustomOps(opts));
+#endif
     // Commented out due to constant OpenMP warning as this API is invalid when running with OpenMP.
     // Not sure how to detect that from within the C API though.
     //checkOrtStatus(jniEnv,api,api->SetIntraOpNumThreads(opts, 1));


### PR DESCRIPTION
**Description**: Describe your changes.
Build the onnxruntime-extensions as a static library and is linked to onnxruntime java binary.
Only enabled for the custom build when the user specifies the --onnxruntime_USE_EXTENSIONS

**Motivation and Context**
- Why is this change required? What problem does it solve?
Enable this feature for onnxruntime android developer who needs the custom op from onnxruntime-extensions.


- If it fixes an open issue, please link to the issue here.
