### PR TITLE
RFC: register fallback CPU kernel

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
 import torch
-from opgen.generator import MakeTorchFallback as MakeTorchFallback
 from opgen.generator import ONNXOp as ONNXOp
 from opgen.generator import ORTGen as ORTGen
 from opgen.generator import SignatureOnly as SignatureOnly

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -128,16 +128,6 @@ hand_implemented = {
     "aten::min": ReduceMin("self", keepdims=1),
     "aten::_cat": Concat("tensors", "dim"),
     "aten::fill_.Scalar": ConstantOfShape("self", value="value"),
-    "aten::ne.Scalar": MakeTorchFallback(),
-    "aten::ne.Scalar_out": MakeTorchFallback(),
-    "aten::ne.Tensor_out": MakeTorchFallback(),
-    "aten::eq.Tensor": MakeTorchFallback(),
-    "aten::eq.Tensor_out": MakeTorchFallback(),
-    "aten::bitwise_and.Tensor_out": MakeTorchFallback(),
-    "aten::masked_select": MakeTorchFallback(),
-    "aten::_local_scalar_dense": MakeTorchFallback(),
-    "aten::gt.Scalar_out": MakeTorchFallback(),
-    "aten::equal": MakeTorchFallback(),
     "aten::_softmax": Softmax("self", axis="dim"),
 }
 

--- a/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
@@ -6,7 +6,6 @@ from opgen.generator import (
     ORTGen as ORTGen,
     ONNXOp as ONNXOp,
     SignatureOnly as SignatureOnly,
-    MakeTorchFallback as MakeTorchFallback,
 )
 
 from opgen.onnxops import *

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -633,6 +633,11 @@ at::Tensor slice_Tensor(
     std::move(ot),
     self.options());
 }
+// Register default CPU fallback for operations without
+// specific registered implemention
+TORCH_LIBRARY_IMPL(_, ORT, m) {
+  m.fallback(torch::CppFunction::makeFromBoxedFunction<&at::native::cpu_fallback>());
+}
 
 } // namespace aten
 


### PR DESCRIPTION
New contributor here - appreciate any feedback, context I might be missing, or questions! 

**Description**: register fallback CPU kernel for eager mode operations

**Motivation and Context**
Currently, if a PyTorch operation is run against ORT backend that results in an aten operation without an explicitly registered implementation, the operation will fail. ONNX has explicitly registered "TorchFallback" implementations for several operations which are not supported in onnxruntime, but if an operation is encountered that is not explicitly registered, the operation will fail.

This change is to:

1. Register a fallback CPU kernel so any unregistered operations will automatically fallback to the fallback CPU kernel.
2. Remove unused `MakeTorchFallback` logic

The intention is to enable all operations targeting ORT backend to succeed (albeit with performance hit) without explicitly registering CPU fallback for individual operations.

**Background**

This change leverages the boxed CPU fallback kernel introduced in pytorch/pytorch#58065. This allows backends to register a single boxed fallback CPU kernel that gets called if there is no other registration for the operation.

**Future Work**
A future change could be to log the calls to fallback CPU kernel in order to identify operations that are not handled by onnxrutime. This would have advantages over having the model crash, in that we could get a list of all unsupported operations in a single run, rather than iterating through 1) running model and crashing on unsupported operation, 2) registering operation, 3) re-running model to find next missing unsupported operation.

**Questions**:

 - Is adding a fallback CPU kernel the right direction? Is there a reason we would want to explicitly register all operations that we want to fallback to Torch?
 -  This PR removes now unused logic (contained in isolated commits). If we don't want to remove the now unused logic, these commits can be backed out
 - Any thoughts on future work to log calls to fallback CPU kernel? Assuming that is something that is of interest, we could include that work in this PR or add in separate PR.