### PR TITLE
fix mpi in training build 

### DIFF
--- a/orttraining/orttraining/core/framework/communication/mpi/mpi_context.h
+++ b/orttraining/orttraining/core/framework/communication/mpi/mpi_context.h
@@ -7,10 +7,7 @@
 #include "core/common/logging/logging.h"
 #endif
 #include "orttraining/core/framework/distributed_run_context.h"
-
-#if defined(USE_MPI)
-#include <mpi.h>
-#endif
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 
 namespace onnxruntime {
 namespace training {

--- a/orttraining/orttraining/core/framework/communication/mpi/mpi_include.h
+++ b/orttraining/orttraining/core/framework/communication/mpi/mpi_include.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if defined(USE_MPI)
+#define OMPI_SKIP_MPICXX 1  // See https://github.com/open-mpi/ompi/issues/5157
+#include <mpi.h>
+#undef OMPI_SKIP_MPICXX
+
+#endif

--- a/orttraining/orttraining/core/framework/communication/mpi/mpi_utilities.h
+++ b/orttraining/orttraining/core/framework/communication/mpi/mpi_utilities.h
@@ -8,9 +8,8 @@
 #include "core/framework/op_kernel.h"
 #endif
 
-#ifdef USE_MPI
-#include <mpi.h>
-#endif
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
+
 namespace onnxruntime {
 namespace training {
 #ifdef USE_MPI

--- a/orttraining/orttraining/training_ops/cpu/communication/recv.cc
+++ b/orttraining/orttraining/training_ops/cpu/communication/recv.cc
@@ -4,7 +4,7 @@
 
 #include "orttraining/training_ops/cpu/communication/recv.h"
 
-#include <mpi.h>
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 
 #include "orttraining/training_ops/communication_common.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"

--- a/orttraining/orttraining/training_ops/cpu/communication/send.cc
+++ b/orttraining/orttraining/training_ops/cpu/communication/send.cc
@@ -3,7 +3,7 @@
 #if defined(USE_MPI)
 #include "orttraining/training_ops/cpu/communication/send.h"
 
-#include <mpi.h>
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 
 #include "orttraining/training_ops/communication_common.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"

--- a/orttraining/orttraining/training_ops/cuda/collective/nccl_common.cc
+++ b/orttraining/orttraining/training_ops/cuda/collective/nccl_common.cc
@@ -3,7 +3,7 @@
 
 #include "orttraining/training_ops/cuda/collective/nccl_common.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"
-#include <mpi.h>
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/communication/nccl_service.h
+++ b/orttraining/orttraining/training_ops/cuda/communication/nccl_service.h
@@ -15,7 +15,7 @@
 
 #include <nccl.h>
 
-#include <mpi.h>
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 
 namespace onnxruntime {
 namespace cuda {

--- a/orttraining/orttraining/training_ops/cuda/communication/recv.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/recv.cc
@@ -10,8 +10,8 @@
 #include "core/providers/cuda/nvtx_profile_context.h"
 #include "core/providers/cuda/cuda_check_memory.h"
 #include "core/providers/cuda/cuda_common.h"
-#include <mpi.h>
 
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"
 
 namespace onnxruntime {

--- a/orttraining/orttraining/training_ops/cuda/communication/send.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/send.cc
@@ -10,8 +10,8 @@
 #include "core/providers/cuda/nvtx_profile_context.h"
 #include "core/providers/cuda/cuda_check_memory.h"
 #include "core/providers/cuda/cuda_common.h"
-#include <mpi.h>
 
+#include "orttraining/core/framework/communication/mpi/mpi_include.h"
 #include "orttraining/core/framework/communication/mpi/mpi_context.h"
 
 namespace onnxruntime {


### PR DESCRIPTION
**Description**: fix mpi in training build .

In PTCA image, gcc has this version:
    gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0

Building ORT enable training will fail as below:
```
/home/pengwa/onnxruntime/cmake/external/onnx/onnx/defs/schema.cc:575:24: warning: unused parameter ‘description’ [-Wunused-parameter]
  575 |     const std::string& description,
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/home/pengwa/onnxruntime/cmake/external/onnx/onnx/defs/schema.cc: In member function ‘onnx::OpSchema& onnx::OpSchema::Output(int, const char*, const char*, const char*, onnx::OpSchema::FormalParameterOption, bool, int, onnx::OpSchema::DifferentiationCategory)’:
/home/pengwa/onnxruntime/cmake/external/onnx/onnx/defs/schema.cc:602:17: warning: unused parameter ‘description’ [-Wunused-parameter]
  602 |     const char* description,
      |     ~~~~~~~~~~~~^~~~~~~~~~~
In file included from /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/mpicxx.h:277,
                 from /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:2868,
                 from /home/pengwa/onnxruntime/orttraining/orttraining/training_ops/cuda/communication/nccl_service.h:18,
                 from /home/pengwa/onnxruntime/onnxruntime/core/session/provider_bridge_ort.cc:43:
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/op_inln.h: In member function ‘virtual void MPI::Op::Init(void (*)(const void*, void*, int, const MPI::Datatype&), bool)’:
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/op_inln.h:121:46: error: cast between incompatible function types from ‘void (*)(void*, void*, int*, ompi_datatype_t**, void (*)(void*, void*, int*, ompi_datatype_t**))’ to ‘void (*)(void*, void*, int*, ompi_datatype_t**)’ [-Werror=cast-function-type]
  121 |     (void)MPI_Op_create((MPI_User_function*) ompi_mpi_cxx_op_intercept,
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/op_inln.h:123:59: error: cast between incompatible function types from ‘void (*)(const void*, void*, int, const MPI::Datatype&)’ to ‘void (*)(void*, void*, int*, ompi_datatype_t**)’ [-Werror=cast-function-type]
  123 |     ompi_op_set_cxx_callback(mpi_op, (MPI_User_function*) func);
      |                                                           ^~~~
[ 42%] Building CXX object 
```

MPI C++ binding is not part of MPI lib, we did not use C++ bindings, so just skip including those headers. 
Check https://github.com/open-mpi/ompi/issues/5157 for more info. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
