### PR TITLE
Xinyazhang/ngram repeat v1

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -569,6 +569,11 @@ if(onnxruntime_USE_XNNPACK)
   list(APPEND onnxruntime_test_providers_libs onnxruntime_providers_xnnpack)
 endif()
 
+if(onnxruntime_USE_ROCM)
+  find_library(HIP_LIB amdhip64 REQUIRED)
+  list(APPEND onnxruntime_test_providers_libs ${HIP_LIB})
+endif()
+
 
 if(WIN32)
   if (onnxruntime_USE_NUPHAR_TVM)

--- a/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
@@ -131,7 +131,7 @@ Status RegisterRocmContribKernels(KernelRegistry& kernel_registry) {
       // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, ComplexMul)>,
       // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, ComplexMulConj)>,
       // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, ComplexMulConj)>,
-      // BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, NGramRepeatBlock)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, NGramRepeatBlock)>,
 
       // These ops were experimental ops in onnx domain which have been removed now. We add them here as
       // contrib ops to maintain backward compatibility

--- a/onnxruntime/test/common/rocm_op_test_utils.h
+++ b/onnxruntime/test/common/rocm_op_test_utils.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "test/util/include/default_providers.h"
+#ifdef USE_ROCM
+#include "hip/hip_runtime_api.h"
+#endif
+
+namespace onnxruntime {
+namespace test {
+
+inline bool HasRocmEnvironment(int min_rocm_architecture) {
+  if (DefaultRocmExecutionProvider().get() == nullptr) {
+    return false;
+  }
+
+  if (min_rocm_architecture == 0) {
+    return true;
+  }
+
+  int rocm_architecture = 0;
+
+#ifdef USE_ROCM
+  int currentRocmDevice = 0;
+  if (hipSuccess != hipGetDevice(&currentRocmDevice)) {
+    return false;
+  }
+  if (hipSuccess != hipDeviceSynchronize()) {
+    return false;
+  }
+  hipDeviceProp_t prop;
+  if (hipSuccess != hipGetDeviceProperties(&prop, currentRocmDevice)) {
+    return false;
+  }
+
+  rocm_architecture = prop.major * 100 + prop.minor * 10;
+#endif
+
+  return rocm_architecture >= min_rocm_architecture;
+}
+
+
+}
+}

--- a/onnxruntime/test/contrib_ops/ngram_repeat_block_op_test.cc
+++ b/onnxruntime/test/contrib_ops/ngram_repeat_block_op_test.cc
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
+#include "test/common/rocm_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 
 namespace onnxruntime {
@@ -29,6 +30,11 @@ TEST(NGramRepeatBlockTest, NGramSize_3) {
   if (HasCudaEnvironment(0)) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+  if (HasRocmEnvironment(0)) {
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultRocmExecutionProvider());
     tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
   }
 


### PR DESCRIPTION
**Description**: Add HasRocmEnvironment and enable NGramRepeatBlockTest for ROCm.

**Motivation and Context**
- Utility function to test the availability of ROCm at runtime, similar to `HasCudaEnvironment`
- NGramRepeatBlock has already been implemented for ROCm but the testing was not enabled because there was no function to detect the availability of ROCm. 

