### PR TITLE
OneDNN EP: Re-Enable softmax for all opset versions

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -276,23 +276,9 @@ bool DnnlReduceNodeCapability::IsDimensionSupported(const Node* node) const {
 bool DnnlSoftmaxNodeCapability::Supported(const Node* node, const GraphViewer& graph_viewer) const {
   ORT_UNUSED_PARAMETER(graph_viewer);
   if (!IsTypeSupported(node)) return false;
-  if (!IsAttributeSupported(node)) return false;
   return true;
 }
 
-//DNNL Softmax supports opset version of 13 and above, or only axis value of 2 for opset version < 13
-bool DnnlSoftmaxNodeCapability::IsAttributeSupported(const Node* node) const {
-  const NodeAttributes& attributes = node->GetAttributes();
-  auto opset = node->SinceVersion();
-  auto attr = attributes.find("axis");
-  int64_t axis = 1;
-  if (attr != attributes.end() && attr->second().i() == 0) {
-    axis = attr->second().i();
-  }
-  if (opset < 13 && axis != 2)
-    return false;
-  return true;
-}
 
 
 // DnnlMatMulNodeCapability class


### PR DESCRIPTION
Change: Re-enabling softmax for all opset versions.

Description: We had disabled softmax for a certain opset and attribute combo as it was failing the test cases.
With the updated code, now we can support softmax for all the attribute and opset versions, so this change just removes that check.

EP: OneDNN / DNNL
