### PR TITLE
[Lint] Replace Pyright with mypy for type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           filter_mode: diff_context
-          lib: true
+          pyright_flags: --ignoreexternal
       - name: pylint
         uses: dciborow/action-pylint@0.0.7
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,8 @@ jobs:
           reporter: github-pr-check
           level: info
           filter_mode: file
-      - uses: tsuyoshicho/action-mypy@v3
+      - name: mypy
+        uses: tsuyoshicho/action-mypy@v3
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,14 +44,12 @@ jobs:
           reporter: github-pr-check
           level: info
           filter_mode: file
-      - name: pyright
-        uses: jordemort/action-pyright@v1
+      - uses: tsuyoshicho/action-mypy@v3
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          filter_mode: diff_context
-          pyright_flags: --ignoreexternal
+          workdir: .
       - name: pylint
         uses: dciborow/action-pylint@0.0.7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,16 @@ convention = "google"
 [tool.pylint.'MESSAGES CONTROL']
 disable = ["format", "line-too-long", "import-error", "no-name-in-module"]
 
-[tool.pyright]
-exclude = ["onnxruntime/core/flatbuffers/*"]
-reportMissingImports = false
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = True
+warn_redundant_casts = True
+warn_return_any = true
+show_error_codes = True
+show_column_numbers = True
+check_untyped_defs = True
+warn_unused_ignores = False
+
+exclude = [
+    "^onnxruntime/core/flatbuffers/\\.py$",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ disable = ["format", "line-too-long", "import-error", "no-name-in-module"]
 
 [tool.mypy]
 python_version = "3.9"
-ignore_missing_imports = True
-warn_redundant_casts = True
+ignore_missing_imports = true
+warn_redundant_casts = true
 warn_return_any = true
-show_error_codes = True
-show_column_numbers = True
-check_untyped_defs = True
-warn_unused_ignores = False
+show_error_codes = true
+show_column_numbers = true
+check_untyped_defs = true
+warn_unused_ignores = false
 
 exclude = [
     "^onnxruntime/core/flatbuffers/\\.py$",


### PR DESCRIPTION
**Description**: Replace Pyright with mypy for type checking

**Motivation and Context**

Pyright is not very configurable and creates noises around unimportable names. Replacing with mypy.
