### PR TITLE
[FIX] python package pipeline build docker images issue

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
@@ -5,11 +5,6 @@ ARG DEVTOOLSET_ROOTPATH=
 ARG LD_LIBRARY_PATH_ARG=
 ARG PREPEND_PATH=
 
-# Updating the CUDA Linux GPG Repository Key ( https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/ )
-RUN rm -rf /etc/yum.repos.d/cuda.repo && \
-    rpm --erase gpg-pubkey-7fa2af80* && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
-
 #We need both CUDA and manylinux. But the CUDA Toolkit End User License Agreement says NVIDIA CUDA Driver Libraries(libcuda.so, libnvidia-ptxjitcompiler.so) are only distributable in applications that meet this criteria:
 #1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and
 #2. The resulting application is packaged as a Docker container and distributed to users on Docker Hub or the NVIDIA GPU Cloud only.
@@ -39,6 +34,11 @@ COPY build_scripts/install-entrypoint.sh \
      build_scripts/update-system-packages.sh \
      build_scripts/build_utils.sh \
      /build_scripts/
+
+# Updating the CUDA Linux GPG Repository Key ( https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/ )
+RUN rm -rf /etc/yum.repos.d/cuda.repo && \
+    rpm --erase gpg-pubkey-7fa2af80* && \
+    yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
 
 RUN /build_scripts/install-entrypoint.sh && rm -rf /build_scripts
 COPY manylinux-entrypoint /usr/local/bin/manylinux-entrypoint

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_training_cuda10_2
@@ -5,6 +5,11 @@ ARG DEVTOOLSET_ROOTPATH=
 ARG LD_LIBRARY_PATH_ARG=
 ARG PREPEND_PATH=
 
+# Updating the CUDA Linux GPG Repository Key ( https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/ )
+RUN rm -rf /etc/yum.repos.d/cuda.repo && \
+    rpm --erase gpg-pubkey-7fa2af80* && \
+    yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+
 #We need both CUDA and manylinux. But the CUDA Toolkit End User License Agreement says NVIDIA CUDA Driver Libraries(libcuda.so, libnvidia-ptxjitcompiler.so) are only distributable in applications that meet this criteria:
 #1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and
 #2. The resulting application is packaged as a Docker container and distributed to users on Docker Hub or the NVIDIA GPU Cloud only.

--- a/tools/ci_build/github/linux/docker/build_scripts/install-build-packages.sh
+++ b/tools/ci_build/github/linux/docker/build_scripts/install-build-packages.sh
@@ -29,6 +29,7 @@ fi
 
 
 if [ "${PACKAGE_MANAGER}" == "yum" ]; then
+	yum -y update
 	yum -y install ${COMPILE_DEPS}
 	yum clean all
 	rm -rf /var/cache/yum

--- a/tools/ci_build/github/linux/docker/build_scripts/install-build-packages.sh
+++ b/tools/ci_build/github/linux/docker/build_scripts/install-build-packages.sh
@@ -29,7 +29,6 @@ fi
 
 
 if [ "${PACKAGE_MANAGER}" == "yum" ]; then
-	yum -y update
 	yum -y install ${COMPILE_DEPS}
 	yum clean all
 	rm -rf /var/cache/yum


### PR DESCRIPTION
**Description**: Describe your changes.
1. Update GPG key on nvidia/cuda:10.2-cudnn7-devel-centos7
2. Fix xz-devel package install path, from centos update resposity now

pipeline:
before fixed
cuda102 : https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=213514&view=results
cuda113 : https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=213516&view=logs&j=944e7fad-cfca-55bf-8b7d-235f638848c7&t=114f5d66-3f50-55d5-1615-7a9ca34a7d29&s=51ef5c58-f132-591a-ec02-8cb7bbe3803a
rocm : https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=669884&view=logs&j=10e46199-55d8-5ff1-152f-93d8f028b288&t=adc2d7e7-a89b-5018-7a82-2ef24bd55cb1&s=51ef5c58-f132-591a-ec02-8cb7bbe3803a

after fixed
cuda102: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=213628&view=results
cuda113: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=213623&view=results
rocm : https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=670301&view=results
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
