### PR TITLE
Add .net6 support to the C# nuget package.

### DIFF
--- a/csharp/OnnxRuntime.CSharp.proj
+++ b/csharp/OnnxRuntime.CSharp.proj
@@ -88,9 +88,6 @@ CMake creates a target to this project
     <MSBuild Projects="src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj"
              Targets="CopyMiscFiles;Pack"
             Properties="NoBuild=true;Platform=AnyCPU;PackageVersion=$(PackageVersion);OrtPackageId=$(OrtPackageId);SelectedTargets=All"/> 
-    <!-- orig
-             Properties="NoBuild=true;Platform=AnyCPU;PackageVersion=$(PackageVersion);OrtPackageId=$(OrtPackageId)"/>
-    -->
 
     <Message Importance="High" Text="Generating nuspec for the native Nuget package ..." />
     <Exec ContinueOnError="False" Command="python $(GenerateNuspecScript) --package_version $(PackageVersion) --package_name $(OrtPackageId) --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild) --execution_provider $(ExecutionProvider)" ConsoleToMSBuild="true">

--- a/csharp/OnnxRuntime.CSharp.proj
+++ b/csharp/OnnxRuntime.CSharp.proj
@@ -40,43 +40,8 @@ CMake creates a target to this project
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 
-  <Target Name="RestoreProjects" BeforeTargets="Build">
-    <Message Importance="High" Text="Restoring NuGet packages for CSharp projects..." />
-    <MSBuild Projects="src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj"
-             Targets="Restore" 
-             Properties="Platform=AnyCPU;OrtPackageId=$(OrtPackageId)" 
-             />
-    <MSBuild Projects="sample\Microsoft.ML.OnnxRuntime.InferenceSample\Microsoft.ML.OnnxRuntime.InferenceSample.csproj"
-             Targets="Restore" 
-             Properties="Platform=AnyCPU" 
-             />
-    <MSBuild Projects="test\Microsoft.ML.OnnxRuntime.Tests.Common\Microsoft.ML.OnnxRuntime.Tests.Common.csproj"
-             Targets="Restore" 
-             Properties="ProtocDirectory=$(ProtocDirectory)"
-             />
-    <MSBuild Projects="tools\Microsoft.ML.OnnxRuntime.PerfTool\Microsoft.ML.OnnxRuntime.PerfTool.csproj"
-             Targets="Restore" 
-             Properties="Platform=AnyCPU" 
-             />
-  </Target>
-
   <Target Name="Build">
-    <Message Importance="High" Text="Building CSharp projects..." />
- 
-    <MSBuild Projects="src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj"
-             Targets="ObtainPackageVersion;Build" 
-             Properties="Platform=AnyCPU;OrtPackageId=$(OrtPackageId)"/>
-    <MSBuild Projects="sample\Microsoft.ML.OnnxRuntime.InferenceSample\Microsoft.ML.OnnxRuntime.InferenceSample.csproj"
-             Targets="Build" 
-             Properties="Platform=AnyCPU"
-             />
-    <MSBuild Projects="test\Microsoft.ML.OnnxRuntime.Tests.Common\Microsoft.ML.OnnxRuntime.Tests.Common.csproj"
-             Targets="Build"
-             />
-    <MSBuild Projects="tools\Microsoft.ML.OnnxRuntime.PerfTool\Microsoft.ML.OnnxRuntime.PerfTool.csproj"
-             Targets="Build" 
-             Properties="Platform=AnyCPU"
-             />
+    <Error Text="Building via this file is not supported. Please build using the appropriate .sln file in this directory." />
   </Target>
 
   <Target Name="RunTest">
@@ -86,7 +51,7 @@ CMake creates a target to this project
     </Exec>
   </Target>
 
-   <Target Name="ObtainPackageVersion" BeforeTargets="CreatePackage;CreateWindowsAIPackage">
+   <Target Name="ObtainPackageVersion" BeforeTargets="Build;CreatePackage;CreateWindowsAIPackage">
     <ReadLinesFromFile File="..\VERSION_NUMBER">
       <Output TaskParameter="Lines" ItemName="MajorVersionNumber"/>
     </ReadLinesFromFile>   
@@ -122,7 +87,10 @@ CMake creates a target to this project
     <Message Importance="High" Text="Bundling managed assemblies into a NuGet package ..." />
     <MSBuild Projects="src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj"
              Targets="CopyMiscFiles;Pack"
+            Properties="NoBuild=true;Platform=AnyCPU;PackageVersion=$(PackageVersion);OrtPackageId=$(OrtPackageId);SelectedTargets=All"/> 
+    <!-- orig
              Properties="NoBuild=true;Platform=AnyCPU;PackageVersion=$(PackageVersion);OrtPackageId=$(OrtPackageId)"/>
+    -->
 
     <Message Importance="High" Text="Generating nuspec for the native Nuget package ..." />
     <Exec ContinueOnError="False" Command="python $(GenerateNuspecScript) --package_version $(PackageVersion) --package_name $(OrtPackageId) --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild) --execution_provider $(ExecutionProvider)" ConsoleToMSBuild="true">

--- a/csharp/readme.md
+++ b/csharp/readme.md
@@ -1,0 +1,70 @@
+# ORT C# Managed Library
+
+The solution files here are used to produce nuget packages for the C# bindings.
+
+Note that the project naming is currently confusing and needs updating. 
+
+  - The Microsoft.ML.OnnxRuntime project produces the Microsoft.ML.OnnxRuntime.**Managed** nuget package.
+  - The Microsoft.ML.OnnxRuntime nuget package contains the native (i.e. C++) code for various platforms.
+
+## Solution files
+
+The main solution file is OnnxRuntime.CSharp.sln. This includes desktop and Xamarin mobile projects.
+OnnxRuntime.DesktopOnly.CSharp.sln is a copy of that with all the mobile projects removed. This is 
+due to there being no way to selectively exclude a csproj from the sln if Xamarin isn't available. 
+
+If changes are required, either update the main solution first and copy the relevant changes across,
+or copy the entire file and remove the mobile projects (anything with iOS, Android or Droid in the name). 
+
+## Development setup:
+
+### Requirements:
+
+NOTE: The usage of this solution is primarily for ORT developers creating the managed Microsoft.ML.OnnxRuntime.Managed 
+      nuget package. Due to that, the requirements are quite specific.
+
+Visual Studio 2022 v17.2.4 or later, with Xamarin workloads
+  - v17.2.4 installs dotnet sdk 6.0.301
+  - in theory you could use an earlier VS version and download dotnet SDK 6.0.300+ from https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+    - untested
+
+There's no good way to use Visual Studio 2022 17.3 Preview in a CI, so we currently have to build pre-.net6 targets
+using VS, and .net6 targets using dotnet. We can't build them all using dotnet as the xamarin targets require msbuild. 
+We can't package them using dotnet as that also requires msbuild.
+
+Once the official VS 2022 release supports .net6 and is available in the CI we can revert to the original simple 
+setup of building everything using msbuild.
+
+To test packaging locally you will also need nuget.exe. 
+Download from https://www.nuget.org/downloads. 
+Put in a folder (e.g. C:\Program Files (x86)\NuGet).
+Add that folder to your PATH. 
+
+### Magic incantations to build the nuget managed package locally:
+
+If we're starting with VS 2022 17.2.4 we should have dotnet sdk 6.0.301
+
+Make sure all the required workloads are installed
+  `dotnet workload install android ios maccatalyst macos`
+    - original example from [here](https://github.com/Sweekriti91/maui-samples/blob/swsat/devops/6.0/Apps/WeatherTwentyOne/devops/AzureDevOps/azdo_windows.yml): 
+      - `dotnet workload install android ios maccatalyst macos maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json`
+    - don't need 'maui' in this list until we update the sample/test apps
+    - didn't seem to need --source arg/s for local build. YMMV.
+
+Build pre-net6 targets
+  `msbuild -t:restore .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=PreNet6`
+  `msbuild -t:build .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=PreNet6`
+
+  Need to run msbuild twice - once to restore which creates some json configs that are needed like 
+  Microsoft.ML.OnnxRuntime\obj\project.assets.json, and once to build using the configs.
+
+Build net6 targets
+  `dotnet build .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=Net6`
+  
+  The dotnet build does the restore internally.
+
+Create project.assets.json in obj dir with all targets so the nuget package creation includes them all
+  `msbuild -t:restore .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=All`
+
+Create nuget package
+  `msbuild .\OnnxRuntime.CSharp.proj -t:CreatePackage -p:OrtPackageId=Microsoft.ML.OnnxRuntime -p:Configuration=Debug -p:Platform="Any CPU"`

--- a/csharp/sample/InferenceSample/Microsoft.ML.OnnxRuntime.InferenceSample.Forms.iOS/Microsoft.ML.OnnxRuntime.InferenceSample.Forms.iOS.csproj
+++ b/csharp/sample/InferenceSample/Microsoft.ML.OnnxRuntime.InferenceSample.Forms.iOS/Microsoft.ML.OnnxRuntime.InferenceSample.Forms.iOS.csproj
@@ -17,7 +17,7 @@
     <ProvisioningType>automatic</ProvisioningType>
   </PropertyGroup>
   <PropertyGroup>
-      <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,11 +67,11 @@
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup>
-      <OnnxNativeFrameworkPathPhone>..\..\..\..\build\iOS\iphoneos\Release\Release-iphoneos\onnxruntime.framework</OnnxNativeFrameworkPathPhone>
-      <OnnxNativeFrameworkPathSimulator>..\..\..\..\build\iOS\iphonesimulator\Release\Release-iphonesimulator\onnxruntime.framework</OnnxNativeFrameworkPathSimulator>
+    <OnnxNativeFrameworkPathPhone>..\..\..\..\build\iOS\iphoneos\Release\Release-iphoneos\onnxruntime.framework</OnnxNativeFrameworkPathPhone>
+    <OnnxNativeFrameworkPathSimulator>..\..\..\..\build\iOS\iphonesimulator\Release\Release-iphonesimulator\onnxruntime.framework</OnnxNativeFrameworkPathSimulator>
   </PropertyGroup>
   <PropertyGroup Condition="('$(Platform)' == 'iPhoneSimulator' AND Exists('$(OnnxNativeFrameworkPathSimulator)')) OR ('$(Platform)' == 'iPhone' AND Exists('$(OnnxNativeFrameworkPathPhone)'))">
-      <DefineConstants>__NATIVE_DEPENDENCIES_EXIST__</DefineConstants>
+    <DefineConstants>__NATIVE_DEPENDENCIES_EXIST__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -147,17 +147,17 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="System.Memory" Version="4.5.3" IncludeAssets="None" />
-      <NativeReference Condition=" '$(Platform)' == 'iPhoneSimulator' And Exists('$(OnnxNativeFrameworkPathSimulator)') " Include="$(OnnxNativeFrameworkPathSimulator)">
-          <Kind>Framework</Kind>
-          <ForceLoad>True</ForceLoad>
-          <IsCxx>True</IsCxx>
-        </NativeReference>
-        <NativeReference Condition=" '$(Platform)' == 'iPhone' And Exists('$(OnnxNativeFrameworkPathPhone)') " Include="$(OnnxNativeFrameworkPathPhone)">
-          <Kind>Framework</Kind>
-          <ForceLoad>True</ForceLoad>
-          <IsCxx>True</IsCxx>
-        </NativeReference>
+    <PackageReference Include="System.Memory" Version="4.5.3" IncludeAssets="None" />
+    <NativeReference Condition=" '$(Platform)' == 'iPhoneSimulator' And Exists('$(OnnxNativeFrameworkPathSimulator)') " Include="$(OnnxNativeFrameworkPathSimulator)">
+      <Kind>Framework</Kind>
+      <ForceLoad>True</ForceLoad>
+      <IsCxx>True</IsCxx>
+    </NativeReference>
+    <NativeReference Condition=" '$(Platform)' == 'iPhone' And Exists('$(OnnxNativeFrameworkPathPhone)') " Include="$(OnnxNativeFrameworkPathPhone)">
+      <Kind>Framework</Kind>
+      <ForceLoad>True</ForceLoad>
+      <IsCxx>True</IsCxx>
+    </NativeReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/AssemblyInfo.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/AssemblyInfo.shared.cs
@@ -1,7 +1,16 @@
+#if __XAMARIN__
 #if __IOS__
 [assembly: Foundation.LinkerSafe]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]
+#endif
+#else
+// .net 6 
+#if __IOS__
+[assembly: System.Reflection.AssemblyMetadata ("IsTrimmable", "True")]
+#elif __ANDROID__
+[assembly: global::System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+#endif
 #endif
 
 // Making these assembly's internals visible to the internal Test assembly

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
@@ -4,21 +4,58 @@
     <OrtPackageId Condition="'$(OrtPackageId)' == ''">Microsoft.ML.OnnxRuntime</OrtPackageId>
   </PropertyGroup>
 
-  <!-- only include the Xamarin mobile targets if we're building an ORT package, 
-       and only if the mobile workloads are installed -->
-  <Choose>
-    <When Condition="('$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime' OR '$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime.Gpu') AND Exists('$(MSBuildExtensionsPath)\Xamarin\Android') AND Exists('$(MSBuildExtensionsPath)\Xamarin\iOS')">
-      <PropertyGroup>
-        <TargetFrameworks>netstandard1.1;netstandard2.0;xamarinios10;monoandroid11.0;net5.0;netcoreapp3.1</TargetFrameworks>
-      </PropertyGroup>      
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <TargetFrameworks>netstandard1.1;netstandard2.0;net5.0;netcoreapp3.1</TargetFrameworks>
-      </PropertyGroup>    
-   </Otherwise>
-  </Choose>
+  <!-- 
+  Temporary setup until official Visual Studio 2022 release supports .net6, as the CIs require the official release.
+  We will be able to build all targets with VS once that happens.
+ 
+  Until then, we need to build the pre-.net6 targets with VS and the .net6 targets with dotnet.
   
+  The pre-.net6 Xamarin targets are optional and only included if the machine has the required workloads.
+
+  We have 3 scenarios
+    1) Build pre-net6 targets with VS - SelectedTargets=PreNet6
+    2) Build net6 targets - SelectedTargets=Net6
+    3) Run 'Pack' target to create nuget package from combination of 1 and 2 - SelectedTargets=All
+  
+  Default is PreNet6 so that existing projects will do the same thing.
+  -->
+  <PropertyGroup>
+    <SelectedTargets>PreNet6</SelectedTargets>
+    <BaseTargets>netstandard1.1;netstandard2.0;net5.0;netcoreapp3.1</BaseTargets>
+  </PropertyGroup>
+
+  <!-- only set the Xamarin mobile targets if we're building an ORT package, 
+       and only if the mobile workloads are installed -->
+  <PropertyGroup Condition="('$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime' OR 
+                             '$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime.Gpu') AND 
+                             Exists('$(MSBuildExtensionsPath)\Xamarin\Android') AND 
+                             Exists('$(MSBuildExtensionsPath)\Xamarin\iOS')">
+    <XamarinTargets>xamarinios10;monoandroid11.0</XamarinTargets>
+  </PropertyGroup>
+
+  <!-- only set the .net6 targets if we're building an ORT package.
+       we can add .net6 support to other packages later as needed -->
+  <PropertyGroup Condition="('$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime' OR 
+                             '$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime.Gpu')">
+    <!-- for now add net6.0-maccatalyst and skip net6.0-macos (used for native mac app) as it seems to need 
+         extra workload install steps for the latter to build successfully. -->
+    <Net6Targets>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos</Net6Targets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SelectedTargets)'=='PreNet6'">
+    <TargetFrameworks>$(BaseTargets);$(XamarinTargets)</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SelectedTargets)'=='Net6'">
+    <TargetFrameworks>$(Net6Targets)</TargetFrameworks>
+  </PropertyGroup>
+
+  <!-- nuget package creation -->
+  <PropertyGroup Condition="'$(SelectedTargets)'=='All'">
+    <TargetFrameworks>$(BaseTargets);$(XamarinTargets);$(Net6Targets)</TargetFrameworks>
+  </PropertyGroup>
+
+
   <PropertyGroup>
     <Platforms>AnyCPU;x86</Platforms>
     <LangVersion>7.2</LangVersion>
@@ -70,37 +107,91 @@
     <IsLinuxBuild Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinuxBuild> 
     <IsWindowsBuild Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindowsBuild> 
     <IsMacOSBuild Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsMacOSBuild>
+
+    <!-- $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) gives better results than 
+         $(TargetPlatformIdentifier). See https://github.com/dotnet/msbuild/issues/7359
+         Note there are slight differences in casing (e.g. macos vs macOS), so if we ever
+         change to use $(TargetPlatformIdentifier) we need to adjust for that.
+         
+    -->
+    <IsXamarinTarget Condition="$(TargetFramework.StartsWith('xamarinios')) OR 
+                                $(TargetFramework.StartsWith('monoandroid'))">true</IsXamarinTarget>
+    <IsAndroidTarget Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR 
+                                $(TargetFramework.StartsWith('monoandroid'))">true</IsAndroidTarget>
+    <IsIOSTarget Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR 
+                            $(TargetFramework.StartsWith('xamarinios'))">true</IsIOSTarget>
+    <IsMacTarget Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos' OR
+                            $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">true</IsMacTarget>
   </PropertyGroup>
 
-    <PropertyGroup Condition="'$(IsLinuxBuild)'=='true'">
-        <!--internal build related properties for Linux -->
-        <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Linux</OnnxRuntimeBuildDirectory>
-        <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)</NativeBuildOutputDir>
-    </PropertyGroup>
+  <!-- 
+    Properties that depend on the system we're building on.
+  -->
+  <PropertyGroup Condition="'$(IsLinuxBuild)'=='true'">
+      <!--internal build related properties for Linux -->
+      <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Linux</OnnxRuntimeBuildDirectory>
+      <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)</NativeBuildOutputDir>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(IsWindowsBuild)'=='true'">
-        <!--internal build related properties for Windows -->
-        <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Windows</OnnxRuntimeBuildDirectory>
-        <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)\$(Configuration)</NativeBuildOutputDir>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(IsWindowsBuild)'=='true'">
+      <!--internal build related properties for Windows -->
+      <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\Windows</OnnxRuntimeBuildDirectory>
+      <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)\$(Configuration)</NativeBuildOutputDir>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(IsMacOSBuild)'=='true'">
-        <!--internal build related properties for OSX -->
-        <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\MacOS</OnnxRuntimeBuildDirectory>
-        <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)</NativeBuildOutputDir>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(IsMacOSBuild)'=='true'">
+      <!--internal build related properties for OSX -->
+      <OnnxRuntimeBuildDirectory Condition="'$(OnnxRuntimeBuildDirectory)'==''">$(OnnxRuntimeCsharpRoot)\..\build\MacOS</OnnxRuntimeBuildDirectory>
+      <NativeBuildOutputDir>$(OnnxRuntimeBuildDirectory)\$(Configuration)</NativeBuildOutputDir>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="$(TargetFramework.StartsWith('xamarinios'))">
-      <DefineConstants>__IOS__;__MOBILE__;</DefineConstants>
-    </PropertyGroup>
+  <!-- 
+    Properties that depend on the target framework.
+  -->
+  <PropertyGroup Condition="'$(IsIOSTarget)'=='true' OR '$(IsAndroidTarget)'=='true'">
+    <OrtConstants>$(OrtConstants);__MOBILE__</OrtConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="$(TargetFramework.StartsWith('monoandroid'))">
-      <DefineConstants>__ANDROID__;__MOBILE__;</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(IsAndroidTarget)'=='true'">
+    <OrtConstants>$(OrtConstants);__ANDROID__</OrtConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" $(TargetFramework.StartsWith('net')) AND !$(TargetFramework.StartsWith('netstandard')) ">
-      <DefineConstants>__NETCOREAPP_NETFRAMEWORK__;</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(IsIOSTarget)'=='true'">
+    <OrtConstants>$(OrtConstants);__IOS__</OrtConstants>
+  </PropertyGroup>
+
+  <!-- CoreML is definitely valid on iOS and macOS -->
+  <PropertyGroup Condition="'$(IsIOSTarget)'=='true' OR '$(IsMacTarget)'=='true'">
+    <OrtConstants>$(OrtConstants);__ENABLE_COREML__</OrtConstants>
+  </PropertyGroup>
+
+  <!-- CoreML may be valid for one of these targets as they support macOS. we do a runtime check that the OS is
+       macOS before attempting to enable CoreML. This includes net5.0, netcoreapp3.1, net6.0
+       NOTE: $(TargetFrameworkIdentitier) may not be set yet, so we need to call GetTargetFrameworkIdentifier
+  -->
+  <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))=='.NETCoreApp' AND
+                            $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))==''">
+    <OrtConstants>$(OrtConstants);__ENABLE_COREML__</OrtConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsXamarinTarget)'=='true'">
+    <OrtConstants>$(OrtConstants);__XAMARIN__</OrtConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);$(OrtConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <!-- if you need to debug the conditions this output will help -->
+  <Target Name="DumpValues" BeforeTargets="PreBuildEvent">
+    <Message Text="TargetPlatform='$(TargetPlatform)' TargetPlatformIdentifier='$(TargetPlatformIdentifier)' " />
+    <Message Text="TargetFramework='$(TargetFramework)' TargetFrameworkIdentifier='$(TargetFrameworkIdentifier)' " />
+    <Message Text="[MSBuild]::GetTargetPlatformIdentifier(TargetFramework)='$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))' " />
+    <Message Text="[MSBuild]::GetTargetFrameworkIdentifier(TargetFramework)='$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))' " />
+    <Message Text="IsMacTarget='$(IsMacTarget)' IsIOSTarget='$(IsIOSTarget)' IsAndroidTarget='$(IsAndroidTarget)' IsXamarinTarget='$(IsXamarinTarget)'" />
+    <Message Text="OrtConstants='$(OrtConstants)' " />
+    <Message Text="TargetFrameworks='$(TargetFrameworks)' " />
+  </Target>
 
   <ItemGroup>
     <None Include="$(OnnxRuntimeCsharpRoot)\..\include\onnxruntime\core\session\onnxruntime_*.h"

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
@@ -17,7 +17,7 @@
     2) Build net6 targets - SelectedTargets=Net6
     3) Run 'Pack' target to create nuget package from combination of 1 and 2 - SelectedTargets=All
   
-  Default is PreNet6 so that existing projects will do the same thing.
+  Default is PreNet6 so that existing projects and CI builds will do the same thing unless explicitly updated.
   -->
   <PropertyGroup>
     <SelectedTargets>PreNet6</SelectedTargets>
@@ -37,8 +37,6 @@
        we can add .net6 support to other packages later as needed -->
   <PropertyGroup Condition="('$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime' OR 
                              '$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime.Gpu')">
-    <!-- for now add net6.0-maccatalyst and skip net6.0-macos (used for native mac app) as it seems to need 
-         extra workload install steps for the latter to build successfully. -->
     <Net6Targets>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos</Net6Targets>
   </PropertyGroup>
 
@@ -182,7 +180,7 @@
     <DefineConstants>$(DefineConstants);$(OrtConstants)</DefineConstants>
   </PropertyGroup>
 
-  <!-- if you need to debug the conditions this output will help -->
+  <!-- debug output - makes finding/fixing any issues with the the conditions easy.
   <Target Name="DumpValues" BeforeTargets="PreBuildEvent">
     <Message Text="TargetPlatform='$(TargetPlatform)' TargetPlatformIdentifier='$(TargetPlatformIdentifier)' " />
     <Message Text="TargetFramework='$(TargetFramework)' TargetFrameworkIdentifier='$(TargetFrameworkIdentifier)' " />
@@ -192,6 +190,7 @@
     <Message Text="OrtConstants='$(OrtConstants)' " />
     <Message Text="TargetFrameworks='$(TargetFrameworks)' " />
   </Target>
+  -->
 
   <ItemGroup>
     <None Include="$(OnnxRuntimeCsharpRoot)\..\include\onnxruntime\core\session\onnxruntime_*.h"

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -837,7 +837,9 @@ namespace Microsoft.ML.OnnxRuntime
 #if __ANDROID__
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_Nnapi(IntPtr /*(OrtSessionOptions*)*/ options, uint nnapi_flags);
-#else
+#endif
+
+#if __ENABLE_COREML__
         // CoreML is available on iOS and macOS so we can't exclude based on __MOBILE__ && __IOS__
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_CoreML(IntPtr /*(OrtSessionOptions*)*/ options, uint coreml_flags);
@@ -994,9 +996,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DSessionOptionsAppendExecutionProvider SessionOptionsAppendExecutionProvider;
 
-        #endregion
+#endregion
 
-        #region RunOptions API
+#region RunOptions API
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /*(OrtStatus*)*/ DOrtCreateRunOptions(out IntPtr /* OrtRunOptions** */ runOptions);
@@ -1040,9 +1042,9 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtRunOptionsUnsetTerminate(IntPtr /* OrtRunOptions* */ options);
         public static DOrtRunOptionsUnsetTerminate OrtRunOptionsUnsetTerminate;
 
-        #endregion
+#endregion
 
-        #region Allocator/MemoryInfo API
+#region Allocator/MemoryInfo API
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* (OrtStatus*)*/ DOrtCreateMemoryInfo(
@@ -1181,9 +1183,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtAllocatorFree OrtAllocatorFree;
 
-        #endregion Allocator/MemoryInfo API
+#endregion Allocator/MemoryInfo API
 
-        #region IoBinding API
+#region IoBinding API
 
         /// <summary>
         /// Create OrtIoBinding instance that is used to bind memory that is allocated
@@ -1371,9 +1373,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtSetLanguageProjection OrtSetLanguageProjection;
 
-        #endregion IoBinding API
+#endregion IoBinding API
 
-        #region ModelMetadata API
+#region ModelMetadata API
 
         /// <summary>
         /// Gets the ModelMetadata associated with an InferenceSession
@@ -1492,9 +1494,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtReleaseModelMetadata OrtReleaseModelMetadata;
 
-        #endregion ModelMetadata API
+#endregion ModelMetadata API
 
-        #region Tensor/OnnxValue API
+#region Tensor/OnnxValue API
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /*(OrtStatus*)*/ DOrtGetValue(IntPtr /*(OrtValue*)*/ value,
@@ -1651,9 +1653,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtReleaseValue OrtReleaseValue;
 
-        #endregion
+#endregion
 
-        #region Misc API
+#region Misc API
 
         /// <summary>
         /// Queries all the execution providers supported in the native onnxruntime shared library
@@ -1693,7 +1695,7 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtReleasePrepackedWeightsContainer OrtReleasePrepackedWeightsContainer;
 
-        #endregion
+#endregion
 
         public static byte[] GetPlatformSerializedString(string str)
         {

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -337,8 +337,8 @@ namespace Microsoft.ML.OnnxRuntime
             NativeApiStatus.VerifySuccess(
                 NativeMethods.OrtSessionOptionsAppendExecutionProvider_CoreML(handle, (uint)coremlFlags));
 #else
-#if !__ANDROID__
-            // the CoreML EP entry point is registered unless this is Android but is only valid if this is OSX
+#if __ENABLE_COREML__
+            // only attempt if this is OSX
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 NativeApiStatus.VerifySuccess(

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.iOS/Microsoft.ML.OnnxRuntime.Tests.iOS.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.iOS/Microsoft.ML.OnnxRuntime.Tests.iOS.csproj
@@ -1,221 +1,208 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-        <ProjectGuid>{19446672-EBA3-4BA6-8DFB-AB2A85AC9AA4}</ProjectGuid>
-        <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <TemplateGuid>{edc1b0fa-90cd-4038-8fad-98fe74adb368}</TemplateGuid>
-        <OutputType>Exe</OutputType>
-        <RootNamespace>Microsoft.ML.OnnxRuntime.Tests.iOS</RootNamespace>
-        <AssemblyName>Microsoft.ML.OnnxRuntime.Tests.iOS</AssemblyName>
-        <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-        <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
-        <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <ProvisioningType>automatic</ProvisioningType>
-        <SignAssembly>true</SignAssembly> <!-- need signing for friend access to the internals of the Tensors assembly -->
-        <AssemblyOriginatorKeyFile>..\..\OnnxRuntime.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-        <MtouchExtraArgs>--nowarn:0109</MtouchExtraArgs>
-        <NoWarn>CS8002</NoWarn>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>portable</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-        <DefineConstants>DEBUG</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchArch>x86_64</MtouchArch>
-        <MtouchLink>None</MtouchLink>
-        <MtouchDebug>true</MtouchDebug>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-        <DebugType>none</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchLink>None</MtouchLink>
-        <MtouchArch>x86_64</MtouchArch>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>portable</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\iPhone\Debug</OutputPath>
-        <DefineConstants>DEBUG</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <MtouchArch>ARM64</MtouchArch>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <CodesignKey>iPhone Developer</CodesignKey>
-        <MtouchDebug>true</MtouchDebug>
-        <MtouchLink>SdkOnly</MtouchLink>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-        <DebugType>none</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\iPhone\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-        <MtouchArch>ARM64</MtouchArch>
-        <CodesignKey>iPhone Distribution</CodesignKey>
-        <MtouchLink>Full</MtouchLink>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <MtouchUseLlvm>true</MtouchUseLlvm>
-        <MtouchExtraArgs>--nowarn:0109 --linkskip=Microsoft.ML.OnnxRuntime.Tests.iOS --linkskip=Microsoft.ML.OnnxRuntime.Tests.Common --linkskip=Microsoft.ML.OnnxRuntime.Tests.Devices</MtouchExtraArgs>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <OnnxNativeFrameworkPathPhone>..\..\..\build\iOS\iphoneos\Release\Release-iphoneos\onnxruntime.framework</OnnxNativeFrameworkPathPhone>
-        <OnnxNativeFrameworkPathSimulator>..\..\..\build\iOS\iphonesimulator\Release\Release-iphonesimulator\onnxruntime.framework</OnnxNativeFrameworkPathSimulator>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="('$(Platform)' == 'iPhoneSimulator' AND Exists('$(OnnxNativeFrameworkPathSimulator)')) OR ('$(Platform)' == 'iPhone' AND Exists('$(OnnxNativeFrameworkPathPhone)'))">
-        <DefineConstants>__NATIVE_DEPENDENCIES_EXIST__</DefineConstants>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Reference Include="System" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Core" />
-        <Reference Include="Xamarin.iOS" />
-        <Reference Include="System.Numerics" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="xunit.runner.devices">
-        <Version>2.5.25</Version>
-      </PackageReference>
-      <PackageReference Include="xunit">
-        <Version>2.4.1</Version>
-      </PackageReference>
-      <PackageReference Include="Google.Protobuf" Version="3.17.3" />
-      <PackageReference Include="Xamarin.Forms">
-        <Version>5.0.0.2083</Version>
-      </PackageReference>
-      <PackageReference Include="System.Memory" Version="4.5.3" IncludeAssets="None" />
-      <PackageReference Include="Xamarin.TestCloud.Agent">
-        <Version>0.22.2</Version>
-      </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon1024.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon167.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon120.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon152.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon180.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon29.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon40.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon58.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon76.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon80.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon87.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon20.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-        <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon60.png">
-            <Visible>false</Visible>
-        </ImageAsset>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Folder Include="Resources\" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <InterfaceDefinition Include="LaunchScreen.storyboard" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="Info.plist" />
-        <None Include="Entitlements.plist" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Compile Include="Main.cs" />
-        <Compile Include="AppDelegate.cs" />
-    </ItemGroup>
-
-    <ItemGroup Condition="('$(Platform)' == 'iPhoneSimulator' AND Exists('$(OnnxNativeFrameworkPathSimulator)')) OR ('$(Platform)' == 'iPhone' AND Exists('$(OnnxNativeFrameworkPathPhone)'))">
-        <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\InferenceTest.cs">
-          <Link>InferenceTest.cs</Link>
-        </Compile>
-        <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\OrtIoBindingAllocationTest.cs">
-          <Link>OrtIoBindingAllocationTest.cs</Link>
-        </Compile>
-        <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\Tensors\TensorTests.cs">
-          <Link>TensorTests.cs</Link>
-        </Compile>
-        <Compile Include="InferenceTest.ios.cs" />
-        <ProjectReference Include="..\..\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj">
-            <Project>{584B53B3-359D-4DC2-BCD8-530B5D4685AD}</Project>
-            <Name>Microsoft.ML.OnnxRuntime</Name>
-        </ProjectReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <NativeReference Condition=" '$(Platform)' == 'iPhoneSimulator' And Exists('$(OnnxNativeFrameworkPathSimulator)') " Include="$(OnnxNativeFrameworkPathSimulator)">
-            <Kind>Framework</Kind>
-            <ForceLoad>True</ForceLoad>
-            <IsCxx>True</IsCxx>
-        </NativeReference>
-        <NativeReference Condition=" '$(Platform)' == 'iPhone' And Exists('$(OnnxNativeFrameworkPathPhone)') " Include="$(OnnxNativeFrameworkPathPhone)">
-            <Kind>Framework</Kind>
-            <ForceLoad>True</ForceLoad>
-            <IsCxx>True</IsCxx>
-        </NativeReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\Microsoft.ML.OnnxRuntime.Tests.Common.csproj">
-        <Project>{04FA49F0-AA23-4EE5-B455-6E12FFAD29E6}</Project>
-        <Name>Microsoft.ML.OnnxRuntime.Tests.Common</Name>
-      </ProjectReference>
-      <ProjectReference Include="..\Microsoft.ML.OnnxRuntime.Tests.Devices\Microsoft.ML.OnnxRuntime.Tests.Devices.csproj">
-        <Project>{30431891-3929-4394-8049-75055B92315F}</Project>
-        <Name>Microsoft.ML.OnnxRuntime.Tests.Devices</Name>
-      </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{19446672-EBA3-4BA6-8DFB-AB2A85AC9AA4}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{edc1b0fa-90cd-4038-8fad-98fe74adb368}</TemplateGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Microsoft.ML.OnnxRuntime.Tests.iOS</RootNamespace>
+    <AssemblyName>Microsoft.ML.OnnxRuntime.Tests.iOS</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <ProvisioningType>automatic</ProvisioningType>
+    <!-- need signing for friend access to the internals of the Tensors assembly -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\OnnxRuntime.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
+    <MtouchExtraArgs>--nowarn:0109</MtouchExtraArgs>
+    <NoWarn>CS8002</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchLink>Full</MtouchLink>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchExtraArgs>--nowarn:0109 --linkskip=Microsoft.ML.OnnxRuntime.Tests.iOS --linkskip=Microsoft.ML.OnnxRuntime.Tests.Common --linkskip=Microsoft.ML.OnnxRuntime.Tests.Devices</MtouchExtraArgs>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OnnxNativeFrameworkPathPhone>..\..\..\build\iOS\iphoneos\Release\Release-iphoneos\onnxruntime.framework</OnnxNativeFrameworkPathPhone>
+    <OnnxNativeFrameworkPathSimulator>..\..\..\build\iOS\iphonesimulator\Release\Release-iphonesimulator\onnxruntime.framework</OnnxNativeFrameworkPathSimulator>
+  </PropertyGroup>
+  <PropertyGroup Condition="('$(Platform)' == 'iPhoneSimulator' AND Exists('$(OnnxNativeFrameworkPathSimulator)')) OR ('$(Platform)' == 'iPhone' AND Exists('$(OnnxNativeFrameworkPathPhone)'))">
+    <DefineConstants>__NATIVE_DEPENDENCIES_EXIST__</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <AppExtensionDebugBundleId />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.runner.devices">
+      <Version>2.5.25</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>5.0.0.2083</Version>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.3" IncludeAssets="None" />
+    <PackageReference Include="Xamarin.TestCloud.Agent">
+      <Version>0.22.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon1024.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon167.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon120.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon152.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon180.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon29.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon40.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon58.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon76.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon80.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon87.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon20.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon60.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="LaunchScreen.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="('$(Platform)' == 'iPhoneSimulator' AND Exists('$(OnnxNativeFrameworkPathSimulator)')) OR ('$(Platform)' == 'iPhone' AND Exists('$(OnnxNativeFrameworkPathPhone)'))">
+    <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\InferenceTest.cs">
+      <Link>InferenceTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\OrtIoBindingAllocationTest.cs">
+      <Link>OrtIoBindingAllocationTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\Tensors\TensorTests.cs">
+      <Link>TensorTests.cs</Link>
+    </Compile>
+    <Compile Include="InferenceTest.ios.cs" />
+    <ProjectReference Include="..\..\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj">
+        <Project>{584B53B3-359D-4DC2-BCD8-530B5D4685AD}</Project>
+        <Name>Microsoft.ML.OnnxRuntime</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <NativeReference Condition=" '$(Platform)' == 'iPhoneSimulator' And Exists('$(OnnxNativeFrameworkPathSimulator)') " Include="$(OnnxNativeFrameworkPathSimulator)">
+      <Kind>Framework</Kind>
+      <ForceLoad>True</ForceLoad>
+      <IsCxx>True</IsCxx>
+    </NativeReference>
+    <NativeReference Condition=" '$(Platform)' == 'iPhone' And Exists('$(OnnxNativeFrameworkPathPhone)') " Include="$(OnnxNativeFrameworkPathPhone)">
+      <Kind>Framework</Kind>
+      <ForceLoad>True</ForceLoad>
+      <IsCxx>True</IsCxx>
+    </NativeReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.ML.OnnxRuntime.Tests.Common\Microsoft.ML.OnnxRuntime.Tests.Common.csproj">
+      <Project>{04FA49F0-AA23-4EE5-B455-6E12FFAD29E6}</Project>
+      <Name>Microsoft.ML.OnnxRuntime.Tests.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.ML.OnnxRuntime.Tests.Devices\Microsoft.ML.OnnxRuntime.Tests.Devices.csproj">
+      <Project>{30431891-3929-4394-8049-75055B92315F}</Project>
+      <Name>Microsoft.ML.OnnxRuntime.Tests.Devices</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -423,7 +423,9 @@ jobs:
 - job: NuGet_Packaging_GPU
   workspace:
     clean: all
-  pool: 'Win-CPU-2021'
+  # we need to use the 2022 pool to create the nuget package with both pre-net6+Xamarin and net6 targets.
+  # VS2019 has no support for net6 and we need to use msbuild (from the VS install) to do the packing
+  pool: 'Azure-Pipelines-EO-Windows2022-aiinfra'
   variables:
     breakCodesignValidationInjection: ${{ parameters.DoEsrp }}
   dependsOn:
@@ -465,7 +467,7 @@ jobs:
       artifactName: 'drop-extra'
       targetPath: '$(Build.BinariesDirectory)/extra-artifact'
 
-  #Reconstruct the build dir
+  # Reconstruct the build dir
   - task: PowerShell@2
     displayName: 'PowerShell Script'
     inputs:
@@ -487,22 +489,45 @@ jobs:
     inputs:
       versionSpec: 5.7.0
 
-  - task: MSBuild@1
-    displayName: 'Restore NuGet Packages'
+  - task: PowerShell@2
+    displayName: Install .NET 6 workloads
     inputs:
-      solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
-      platform: 'Any CPU'
-      configuration: RelWithDebInfo
-      msbuildArguments: '-t:restore -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu"'
+      targetType: 'inline'
+      script: |
+        dotnet workload install android ios maccatalyst macos
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
+    
+  - task: PowerShell@2
+    displayName: Build .NET 6 targets using dotnet
+    inputs:
+      targetType: 'inline'
+      # we don't specify 'Any CPU' as the platform here because if we do it gets added to the output path
+      #   e.g. csharp\src\Microsoft.ML.OnnxRuntime\bin\Any CPU\RelWithDebInfo\net6.0-ios\ 
+      # which is inconsistent with the msbuild output path for the pre-.net6 targets 
+      #   e.g. csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo\monoandroid11.0
+      # and makes it harder to do the packing
+      # 
+      # 'Any CPU' is the default (first 'mixed' platform specified in the csproj) so this should be fine.
+      script: |
+        dotnet build .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=Net6 -p:Configuration=RelWithDebInfo -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu" -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'
+    displayName: 'Restore NuGet Packages and create project.assets.json for pre-.net6 targets'
+    inputs:
+      solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+      platform: 'Any CPU'
+      configuration: RelWithDebInfo
+      msbuildArguments: '-t:restore -p:SelectedTargets=PreNet6 -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu"'
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
+
+  - task: MSBuild@1
+    displayName: 'Build C# for pre-.net6 targets'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       configuration: RelWithDebInfo
       platform: 'Any CPU'
-      msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu" -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}'
+      msbuildArguments: '-p:SelectedTargets=PreNet6 -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId="Microsoft.ML.OnnxRuntime.Gpu" -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}'
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - template: templates/win-esrp-dll.yml
@@ -510,6 +535,15 @@ jobs:
       FolderPath: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo'
       DisplayName: 'ESRP - Sign C# dlls'
       DoEsrp: ${{ parameters.DoEsrp }}
+
+  - task: MSBuild@1
+    displayName: Update projects.assets.json will combined list of all target frameworks
+    inputs:
+      solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
+      platform: 'Any CPU'
+      configuration: RelWithDebInfo
+      msbuildArguments: '-t:restore -p:SelectedTargets=All -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
     displayName: 'Build Nuget Packages'
@@ -582,7 +616,7 @@ jobs:
     displayName: 'Run Roslyn Analyzers'
     inputs:
       userProvideBuildInfo: msBuildInfo
-      msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
+      msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=Microsoft.ML.OnnxRuntime.Gpu'
     condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
 
   - template: templates/component-governance-component-detection-steps.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -325,7 +325,9 @@ jobs:
 - job: NuGet_Packaging_CPU
   workspace:
     clean: all
-  pool: 'Win-CPU-2021'
+  # we need to use the 2022 pool to create the nuget package with both pre-net6+Xamarin and net6 targets.
+  # VS2019 has no support for net6 and we need to use msbuild (from the VS install) to do the packing
+  pool: 'Azure-Pipelines-EO-Windows2022-aiinfra'
   variables:
     OrtPackageId: ${{ parameters.OrtNugetPackageId }}
     breakCodesignValidationInjection: ${{ parameters.DoEsrp }}
@@ -409,7 +411,7 @@ jobs:
     workingDirectory: '$(Build.BinariesDirectory)/nuget-artifact'
     displayName: 'List artifacts'
 
-  #Reconstruct the build dir
+  # Reconstruct the build dir
   - task: PowerShell@2
     displayName: 'Extract native libraries for addition to nuget native package'
     inputs:
@@ -425,22 +427,45 @@ jobs:
     inputs:
       versionSpec: 5.7.0
 
-  - task: MSBuild@1
-    displayName: 'Restore NuGet Packages'
+  - task: PowerShell@2
+    displayName: Install .NET 6 workloads
     inputs:
-      solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
-      platform: 'Any CPU'
-      configuration: RelWithDebInfo
-      msbuildArguments: '-t:restore -p:OrtPackageId=$(OrtPackageId)'
+      targetType: 'inline'
+      script: |
+        dotnet workload install android ios maccatalyst macos
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
+    
+  - task: PowerShell@2  
+    displayName: Build Microsoft.ML.OnnxRuntime .NET 6 targets using dotnet
+    inputs:
+      targetType: 'inline'
+      # we don't specify 'Any CPU' as the platform here because if we do it gets added to the output path
+      #   e.g. csharp\src\Microsoft.ML.OnnxRuntime\bin\Any CPU\RelWithDebInfo\net6.0-ios\ 
+      # which is inconsistent with the msbuild output path for the pre-.net6 targets 
+      #   e.g. csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo\monoandroid11.0
+      # and makes it harder to do the packing
+      # 
+      # 'Any CPU' is the default (first 'mixed' platform specified in the csproj) so this should be fine.
+      script: |
+        dotnet build .\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj -p:SelectedTargets=Net6  -p:Configuration=RelWithDebInfo -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'
+    displayName: 'Restore NuGet Packages and create project.assets.json for pre-.net6 targets'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       platform: 'Any CPU'
       configuration: RelWithDebInfo
-      msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}'
+      msbuildArguments: '-t:restore -p:SelectedTargets=PreNet6 -p:OrtPackageId=$(OrtPackageId)'
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
+
+  - task: MSBuild@1
+    displayName: 'Build C# for pre-.net6 targets'
+    inputs:
+      solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
+      platform: 'Any CPU'
+      configuration: RelWithDebInfo
+      msbuildArguments: '-p:SelectedTargets=PreNet6 -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }}'
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - template: win-esrp-dll.yml
@@ -448,6 +473,15 @@ jobs:
       FolderPath: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo'
       DisplayName: 'ESRP - Sign C# dlls'
       DoEsrp: ${{ parameters.DoEsrp }}
+
+  - task: MSBuild@1
+    displayName: Update projects.assets.json will combined list of all target frameworks
+    inputs:
+      solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
+      platform: 'Any CPU'
+      configuration: RelWithDebInfo
+      msbuildArguments: '-t:restore -p:SelectedTargets=All -p:OrtPackageId=$(OrtPackageId)'
+      workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
     displayName: 'Build Nuget Packages'
@@ -513,7 +547,7 @@ jobs:
     displayName: 'Run Roslyn Analyzers'
     inputs:
       userProvideBuildInfo: msBuildInfo
-      msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
+      msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln -p:configuration="RelWithDebInfo" -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId)'
     condition: and(succeeded(), eq('${{ parameters.DoCompliance }}', true))
 
   - template: component-governance-component-detection-steps.yml


### PR DESCRIPTION
**Description**: 
Currently requires jumping through a lot of hoops due to .net 6 only being supported in the preview release of VS 2022.

Build existing targets using msbuild.
Add .net6 targets and build using dotnet.
Create nuget package with combined targets.

A few misc automated changes from VS to spacing and adding a couple of properties.

NOTE: I have manually checked the nuget package and support for all platforms appeared to be there. Was able to create a test maui app and run on both Windows and the Android simulator. I will add a Maui project to the InferenceSample solution separately.

**Motivation and Context**
Support .net 6 apps.