### PR TITLE
Make symbolic shape inference script support external weight

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2390,14 +2390,14 @@ def parse_arguments():
         default=0,
     )
     parser.add_argument(
-        "--save_as_exteranl_data",
+        "--save_as_external_data",
         help="Saving an ONNX model to external data",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "--all_tensors_to_one_file",
-        help="Saving all the exteranl data to one file",
+        help="Saving all the external data to one file",
         action="store_true",
         default=False,
     )
@@ -2408,7 +2408,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--external_data_size_threshold",
-        help="The size threshold for exteranl data",
+        help="The size threshold for external data",
         type=int,
         default=1024,
     )

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2430,7 +2430,15 @@ if __name__ == "__main__":
     )
     if args.output and out_mp:
         if args.save_as_exteranl_data:
-            onnx.save_model(out_mp, args.output, save_as_external_data=True, all_tensors_to_one_file=args.all_tensors_to_one_file, location=args.external_data_location, size_threshold=args.external_data_size_threshold, convert_attribute=False)
+            onnx.save_model(
+                out_mp,
+                args.output,
+                save_as_external_data=True,
+                all_tensors_to_one_file=args.all_tensors_to_one_file,
+                location=args.external_data_location,
+                size_threshold=args.external_data_size_threshold,
+                convert_attribute=False
+            )
         else:
             onnx.save(out_mp, args.output)
         logger.info("Done!")

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2437,7 +2437,7 @@ if __name__ == "__main__":
                 all_tensors_to_one_file=args.all_tensors_to_one_file,
                 location=args.external_data_location,
                 size_threshold=args.external_data_size_threshold,
-                convert_attribute=False
+                convert_attribute=False,
             )
         else:
             onnx.save(out_mp, args.output)

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2389,6 +2389,29 @@ def parse_arguments():
         type=int,
         default=0,
     )
+    parser.add_argument(
+        "--save_as_exteranl_data",
+        help="Saving an ONNX model to external data",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--all_tensors_to_one_file",
+        help="Saving all the exteranl data to one file",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--external_data_location",
+        help="The file location to save the external file",
+        default="./",
+    )
+    parser.add_argument(
+        "--external_data_size_threshold",
+        help="The size threshold for exteranl data",
+        type=int,
+        default=1024,
+    )
     return parser.parse_args()
 
 
@@ -2406,5 +2429,8 @@ if __name__ == "__main__":
         args.verbose,
     )
     if args.output and out_mp:
-        onnx.save(out_mp, args.output)
+        if args.save_as_exteranl_data:
+            onnx.save_model(out_mp, args.output, save_as_external_data=True, all_tensors_to_one_file=args.all_tensors_to_one_file, location=args.external_data_location, size_threshold=args.external_data_size_threshold, convert_attribute=False)
+        else:
+            onnx.save(out_mp, args.output)
         logger.info("Done!")

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2429,7 +2429,7 @@ if __name__ == "__main__":
         args.verbose,
     )
     if args.output and out_mp:
-        if args.save_as_exteranl_data:
+        if args.save_as_external_data:
             onnx.save_model(
                 out_mp,
                 args.output,


### PR DESCRIPTION
Some large models with external weight need to run shape inference script. But current shape inference script doesn't support saving model to external data.
The onnx api already has this feature of support of saving onnx model external data, we can simply leverage it.