### PR TITLE
Mark the end of APIs for release 1.12

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2529,6 +2529,7 @@ static constexpr OrtApi ort_api_1_to_12 = {
     &OrtApis::InvokeOp,
     &OrtApis::ReleaseOp,
     &OrtApis::SessionOptionsAppendExecutionProvider,
+    // End of Version 12 - DO NOT MODIFY ABOVE (see above text for more information)
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2545,6 +2545,7 @@ static_assert(offsetof(OrtApi, CreateSessionFromArrayWithPrepackedWeightsContain
 static_assert(offsetof(OrtApi, GetSparseTensorIndices) / sizeof(void*) == 191, "Size of version 9 API cannot change");
 static_assert(offsetof(OrtApi, SynchronizeBoundOutputs) / sizeof(void*) == 203, "Size of version 10 API cannot change");
 static_assert(offsetof(OrtApi, SessionOptionsAppendExecutionProvider_MIGraphX) / sizeof(void*) == 209, "Size of version 11 API cannot change");
+static_assert(offsetof(OrtApi, SessionOptionsAppendExecutionProvider) / sizeof(void*) == 216, "Size of version 12 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.12.0", "ORT_Version change detected, please follow below steps to ensure OrtApi is updated properly");


### PR DESCRIPTION
Mark the end of APIs for release 1.12.
