### PR TITLE
Deprecate APIs returning raw ptrs and provide replacements

### DIFF
--- a/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/experimental_onnxruntime_cxx_inline.h
@@ -35,9 +35,8 @@ inline std::vector<std::string> Session::GetInputNames() const {
   size_t node_count = GetInputCount();
   std::vector<std::string> out(node_count);
   for (size_t i = 0; i < node_count; i++) {
-    char* tmp = GetInputName(i, allocator);
-    out[i] = tmp;
-    allocator.Free(tmp);  // prevent memory leak
+    auto tmp = GetInputNameAllocated(i, allocator);
+    out[i] = tmp.get();
   }
   return out;
 }
@@ -47,9 +46,8 @@ inline std::vector<std::string> Session::GetOutputNames() const {
   size_t node_count = GetOutputCount();
   std::vector<std::string> out(node_count);
   for (size_t i = 0; i < node_count; i++) {
-    char* tmp = GetOutputName(i, allocator);
-    out[i] = tmp;
-    allocator.Free(tmp);  // prevent memory leak
+    auto tmp = GetOutputNameAllocated(i, allocator);
+    out[i] = tmp.get();
   }
   return out;
 }
@@ -59,9 +57,8 @@ inline std::vector<std::string> Session::GetOverridableInitializerNames() const 
   size_t init_count = GetOverridableInitializerCount();
   std::vector<std::string> out(init_count);
   for (size_t i = 0; i < init_count; i++) {
-    char* tmp = GetOverridableInitializerName(i, allocator);
-    out[i] = tmp;
-    allocator.Free(tmp);  // prevent memory leak
+    auto tmp = GetOverridableInitializerNameAllocated(i, allocator);
+    out[i] = tmp.get();
   }
   return out;
 }

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -656,16 +656,40 @@ inline char* Session::GetOutputName(size_t index, OrtAllocator* allocator) const
   return out;
 }
 
+inline Session::AllocatedStringPtr Session::GetInputNameAllocated(size_t index, OrtAllocator* allocator) const {
+  char* out;
+  ThrowOnError(GetApi().SessionGetInputName(p_, index, allocator, &out));
+  return AllocatedStringPtr(out, detail::AllocatedFree(allocator));
+}
+
+inline Session::AllocatedStringPtr Session::GetOutputNameAllocated(size_t index, OrtAllocator* allocator) const {
+  char* out;
+  ThrowOnError(GetApi().SessionGetOutputName(p_, index, allocator, &out));
+  return AllocatedStringPtr(out, detail::AllocatedFree(allocator));
+}
+
 inline char* Session::GetOverridableInitializerName(size_t index, OrtAllocator* allocator) const {
   char* out;
   ThrowOnError(GetApi().SessionGetOverridableInitializerName(p_, index, allocator, &out));
   return out;
 }
 
+inline Session::AllocatedStringPtr Session::GetOverridableInitializerNameAllocated(size_t index, OrtAllocator* allocator) const {
+  char* out;
+  ThrowOnError(GetApi().SessionGetOverridableInitializerName(p_, index, allocator, &out));
+  return AllocatedStringPtr(out, detail::AllocatedFree(allocator));
+}
+
 inline char* Session::EndProfiling(OrtAllocator* allocator) const {
   char* out;
   ThrowOnError(GetApi().SessionEndProfiling(p_, allocator, &out));
   return out;
+}
+
+inline Session::AllocatedStringPtr Session::EndProfilingAllocated(OrtAllocator* allocator) const {
+  char* out;
+  ThrowOnError(GetApi().SessionEndProfiling(p_, allocator, &out));
+  return AllocatedStringPtr(out, detail::AllocatedFree(allocator));
 }
 
 inline uint64_t Session::GetProfilingStartTimeNs() const {

--- a/onnxruntime/test/onnx/dataitem_request.cc
+++ b/onnxruntime/test/onnx/dataitem_request.cc
@@ -84,10 +84,9 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
   size_t output_count = session_.GetOutputCount();
   std::vector<std::string> output_names(output_count);
   for (size_t i = 0; i != output_count; ++i) {
-    char* output_name = session_.GetOutputName(i, default_allocator_);
+    auto output_name = session_.GetOutputNameAllocated(i, default_allocator_);
     assert(output_name != nullptr);
-    output_names[i] = output_name;
-    Ort::ThrowOnError(Ort::GetApi().AllocatorFree(default_allocator_, output_name));
+    output_names[i] = output_name.get();
   }
 
   TIME_SPEC start_time;

--- a/onnxruntime/test/opaque_api/test_opaque_api.cc
+++ b/onnxruntime/test/opaque_api/test_opaque_api.cc
@@ -204,14 +204,14 @@ TEST(OpaqueApiTest, RunModelWithOpaqueInputOutput) {
     // Expecting one input
     size_t num_input_nodes = session.GetInputCount();
     EXPECT_EQ(num_input_nodes, 1U);
-    const char* input_name = session.GetInputName(0, allocator);
+    auto input_name = session.GetInputNameAllocated(0, allocator);
 
     size_t num_output_nodes = session.GetOutputCount();
     EXPECT_EQ(num_output_nodes, 1U);
-    const char* output_name = session.GetOutputName(0, allocator);
+    auto output_name = session.GetOutputNameAllocated(0, allocator);
 
-    const char* const input_names[] = {input_name};
-    const char* const output_names[] = {output_name};
+    const char* const input_names[] = {input_name.get()};
+    const char* const output_names[] = {output_name.get()};
 
     // Input
     const std::string input_string{"hi, hello, high, highest"};

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -529,10 +529,9 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
   output_names_.resize(output_count);
   Ort::AllocatorWithDefaultOptions a;
   for (size_t i = 0; i != output_count; ++i) {
-    char* output_name = session_.GetOutputName(i, a);
+    auto output_name = session_.GetOutputNameAllocated(i, a);
     assert(output_name != nullptr);
-    output_names_[i] = output_name;
-    a.Free(output_name);
+    output_names_[i] = output_name.get();
   }
   output_names_raw_ptr.resize(output_count);
   for (size_t i = 0; i != output_count; ++i) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1422,9 +1422,10 @@ TEST(CApiTest, override_initializer) {
   size_t init_count = session.GetOverridableInitializerCount();
   ASSERT_EQ(init_count, 1U);
 
-  char* f1_init_name = session.GetOverridableInitializerName(0, allocator.get());
-  ASSERT_TRUE(strcmp("F1", f1_init_name) == 0);
-  allocator->Free(f1_init_name);
+  {
+    auto f1_init_name = session.GetOverridableInitializerNameAllocated(0, allocator.get());
+    ASSERT_TRUE(strcmp("F1", f1_init_name.get()) == 0);
+  }
 
   Ort::TypeInfo init_type_info = session.GetOverridableInitializerTypeInfo(0);
   ASSERT_EQ(ONNX_TYPE_TENSOR, init_type_info.GetONNXType());
@@ -1466,10 +1467,10 @@ TEST(CApiTest, end_profiling) {
   session_options_1.EnableProfiling("profile_prefix");
 #endif
   Ort::Session session_1(*ort_env, MODEL_WITH_CUSTOM_MODEL_METADATA, session_options_1);
-  char* profile_file = session_1.EndProfiling(allocator.get());
-
-  ASSERT_TRUE(std::string(profile_file).find("profile_prefix") != std::string::npos);
-  allocator->Free(profile_file);
+  {
+    auto profile_file = session_1.EndProfilingAllocated(allocator.get());
+    ASSERT_TRUE(std::string(profile_file.get()).find("profile_prefix") != std::string::npos);
+  }
   // Create session with profiling disabled
   Ort::SessionOptions session_options_2;
 #ifdef _WIN32
@@ -1478,9 +1479,10 @@ TEST(CApiTest, end_profiling) {
   session_options_2.DisableProfiling();
 #endif
   Ort::Session session_2(*ort_env, MODEL_WITH_CUSTOM_MODEL_METADATA, session_options_2);
-  profile_file = session_2.EndProfiling(allocator.get());
-  ASSERT_TRUE(std::string(profile_file) == std::string());
-  allocator->Free(profile_file);
+  {
+    auto profile_file = session_2.EndProfilingAllocated(allocator.get());
+    ASSERT_TRUE(std::string(profile_file.get()) == std::string());
+  }
 }
 
 TEST(CApiTest, get_profiling_start_time) {


### PR DESCRIPTION
**Description**: 
Deprecate APIs that return pointes to buffers that are allocated using an instance of `OrtAllocator.`
Provide replacements that return smart pointers with bound allocator pointers. Those release buffers automatically.

**Motivation and Context**
These buffers require explicit deallocation using the same allocator that allocated them.
However, there is not a convenient and exception-safe way of doing it without customer writing additional code.
The end results the customers often leak those buffers.
