### PR TITLE
MeanVarianceNormalization CPU EP axes attribute validation

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.h
+++ b/onnxruntime/core/providers/cpu/tensor/mean_variance_normalization.h
@@ -105,10 +105,15 @@ class MeanVarianceNormalization_1 final : public MeanVarianceNormalization_0<T> 
     if (!info.GetAttrs("axes", axes).IsOK()) {
       axes = {0, 2, 3};
     }
-    if (find(axes.begin(), axes.end(), 1) != axes.end()) {
+    constexpr int64_t cross_channel_axes[] = {0, 1, 2, 3};
+    constexpr int64_t batch_spatial_axes[] = {0, 2, 3};
+
+    if (std::equal(std::begin(axes), std::end(axes), std::begin(cross_channel_axes), std::end(cross_channel_axes))) {
       this->across_channels_ = true;
-    } else {
+    } else if (std::equal(std::begin(axes), std::end(axes), std::begin(batch_spatial_axes), std::end(batch_spatial_axes))) {
       this->across_channels_ = false;
+    } else {
+      ORT_THROW("MeanVarianceNormalization CPU EP only supports NHW and NCHW reduction for axes attribute.");
     }
     this->normalize_variance_ = 1;
   }


### PR DESCRIPTION
**Description**: The CPU EP [MVN](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MeanVarianceNormalization) kernel doesn't actually support the `axes` parameter (any arbitrary axes), which caused some test failures when comparing against the DML EP (which fully supports `axes`). Not supporting them is *okay*, but what's worse is that the code silently returns the wrong results for unsupported combinations, like HW and NC, which get mapped incorrectly to NHW and NCHW respectively. This change more robustly checks the `axes` parameter, rather than just checking for the presence of axis 1 without checking the other axes, given the CPU EP only supports 4D NCHW and NHW.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- *If it fixes an open issue, please link to the issue here.* https://github.com/microsoft/onnxruntime/issues/1828

```
onnxruntime_test_all.exe
...
[==========] 3319 tests from 230 test suites ran. (372903 ms total)
[  PASSED  ] 3319 tests.
```