### PR TITLE
Optimize t5 encoder in beam search

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -183,7 +183,10 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
         device_copy_func_ ? device_copy_func_ : BeamSearchCpuDeviceHelper::DeviceCopy<float>,
         device_copy_int32_func_ ? device_copy_int32_func_ : BeamSearchCpuDeviceHelper::DeviceCopy<int32_t>,
         create_encoder_inputs_func_ ? create_encoder_inputs_func_ : BeamSearchCpuDeviceHelper::CreateEncoderInputs,
-        update_decoder_feeds_func_ ? update_decoder_feeds_func_ : BeamSearchCpuDeviceHelper::UpdateDecoderFeeds<float>};
+        update_decoder_feeds_func_ ? update_decoder_feeds_func_ : BeamSearchCpuDeviceHelper::UpdateDecoderFeeds<float>,
+        expand_buffer_int32_func_ ? expand_buffer_int32_func_ : BeamSearchCpuDeviceHelper::ExpandBuffer<int32_t>,
+        expand_buffer_float_func_ ? expand_buffer_float_func_ : BeamSearchCpuDeviceHelper::ExpandBuffer<float>,
+        expand_buffer_float16_func_ ? expand_buffer_float16_func_ : BeamSearchCpuDeviceHelper::ExpandBuffer<MLFloat16>};
     ORT_RETURN_IF_ERROR(impl.Initialize());
 
     return impl.Execute(*encoder_feeds_fetches_manager_, *decoder_feeds_fetches_manager_);
@@ -198,7 +201,10 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
         device_copy_func_,
         device_copy_int32_func_,
         create_encoder_inputs_func_,
-        update_decoder_feeds_fp16_func_};
+        update_decoder_feeds_fp16_func_,
+        expand_buffer_int32_func_,
+        expand_buffer_float_func_,
+        expand_buffer_float16_func_};
 
     ORT_RETURN_IF_ERROR(impl.Initialize());
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.h
@@ -74,9 +74,15 @@ class BeamSearch : public IControlFlowKernel {
   // device helpers for encoder-decoder model like T5
   void SetDeviceHelpers_EncoderDecoder(
       const BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<float>& update_decoder_feeds_func,
-      const BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<MLFloat16>& update_decoder_feeds_fp16_func) {
+      const BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<MLFloat16>& update_decoder_feeds_fp16_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<int32_t>& expand_buffer_int32_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<float>& expand_buffer_float_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<MLFloat16>& expand_buffer_float16_func) {
     update_decoder_feeds_func_ = update_decoder_feeds_func;
     update_decoder_feeds_fp16_func_ = update_decoder_feeds_fp16_func;
+    expand_buffer_int32_func_ = expand_buffer_int32_func;
+    expand_buffer_float_func_ = expand_buffer_float_func;
+    expand_buffer_float16_func_ = expand_buffer_float16_func;
   }
 
  private:
@@ -105,6 +111,10 @@ class BeamSearch : public IControlFlowKernel {
 
   BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<float> update_decoder_feeds_func_;
   BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<MLFloat16> update_decoder_feeds_fp16_func_;
+
+  BeamSearchDeviceHelper::ExpandBufferFunc<int32_t> expand_buffer_int32_func_;
+  BeamSearchDeviceHelper::ExpandBufferFunc<float> expand_buffer_float_func_;
+  BeamSearchDeviceHelper::ExpandBufferFunc<MLFloat16> expand_buffer_float16_func_;
 
   //------------------------------------------------------------
   // Subgraph and FeedsFetchesManager re-used for each subgraph execution.

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.cc
@@ -62,11 +62,11 @@ void ExpandInputs(const OrtValue& input, int num_beams, AllocatorPtr allocator, 
 
 template <typename T>
 Status ExpandBuffer(void* stream,
-                  const OrtValue& input,
-                  int num_beams,
-                  AllocatorPtr allocator,
-                  OrtValue& expanded,
-                  bool only_copy_shape) {
+                    const OrtValue& input,
+                    int num_beams,
+                    AllocatorPtr allocator,
+                    OrtValue& expanded,
+                    bool only_copy_shape) {
   // Input shape (batch_size, xxx). The input is required with data type T.
   // Output shape (batch_size * num_beams, xxx)
   ORT_UNUSED_PARAMETER(stream);

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.cc
@@ -276,7 +276,7 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
     gsl::copy(source, target);
     if (beam_batch_size == batch_beam_size) {
       current_logits += input_length * vocab_size;
-    } else if (beam_batch_size == batch_size && i != 0 && i % num_beams == 0) {
+    } else if (beam_batch_size == batch_size && i % num_beams == num_beams - 1) {
       current_logits += input_length * vocab_size;
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
@@ -107,13 +107,12 @@ using UpdateGptFeedsFunc = std::function<Status(
 using CreateEncoderInputsFunc = std::function<Status(
     const Tensor* original_encoder_input_ids,
     const OrtValue* attn_mask_value,
-    int num_beams,
     int pad_token_id,
     int start_token_id,
     AllocatorPtr allocator,
-    OrtValue& expanded_encoder_input_ids,
-    OrtValue& expanded_encoder_attention_mask,
-    OrtValue& expanded_decoder_input_ids)>;
+    OrtValue& encoder_input_ids,
+    OrtValue& encoder_attention_mask,
+    OrtValue& decoder_input_ids)>;
 
 // Update decoder inputs given decoder outputs of last iteration (for encoder-decoder model like T5).
 template <typename T>
@@ -212,13 +211,12 @@ Status UpdateGptFeeds(
 Status CreateEncoderInputs(
     const Tensor* original_encoder_input_ids,
     const OrtValue* attn_mask_value,
-    int num_beams,
     int pad_token_id,
     int start_token_id,
     AllocatorPtr allocator,
-    OrtValue& expanded_encoder_input_ids,
-    OrtValue& expanded_encoder_attention_mask,
-    OrtValue& expanded_decoder_input_ids);
+    OrtValue& encoder_input_ids,
+    OrtValue& encoder_attention_mask,
+    OrtValue& decoder_input_ids);
 
 // Update decoder inputs given decoder outputs of last iteration.
 template <typename T>
@@ -243,6 +241,9 @@ Status UpdateDecoderFeeds(
 // ---------------------------------------------------------------
 template <typename T>
 void ExpandInputs(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
+
+template <typename T>
+void ExpandCaches(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
 
 }  // namespace BeamSearchCpuDeviceHelper
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
@@ -243,10 +243,7 @@ template <typename T>
 void ExpandInputs(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
 
 template <typename T>
-void ExpandCaches(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
-
-template <typename T>
-void ExpandHiddenStates(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
+void ExpandBuffer(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded, bool only_copy_shape);
 
 }  // namespace BeamSearchCpuDeviceHelper
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
@@ -245,6 +245,9 @@ void ExpandInputs(const OrtValue& input, int num_beams, AllocatorPtr allocator, 
 template <typename T>
 void ExpandCaches(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
 
+template <typename T>
+void ExpandHiddenStates(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
+
 }  // namespace BeamSearchCpuDeviceHelper
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_device_helper.h
@@ -131,7 +131,17 @@ using UpdateDecoderFeedsFunc = std::function<Status(
     int current_length,
     transformers::Sequences& sequences,
     const transformers::IConsoleDumper* dumper)>;
+
+template <typename T>
+using ExpandBufferFunc = std::function<Status(
+    void* stream,
+    const OrtValue& input,
+    int num_beams,
+    AllocatorPtr allocator,
+    OrtValue& expanded,
+    bool only_copy_shape)>;
 }  // namespace BeamSearchDeviceHelper
+
 
 // These are CPU specific device helper implementations
 namespace BeamSearchCpuDeviceHelper {
@@ -243,7 +253,13 @@ template <typename T>
 void ExpandInputs(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded);
 
 template <typename T>
-void ExpandBuffer(const OrtValue& input, int num_beams, AllocatorPtr allocator, OrtValue& expanded, bool only_copy_shape);
+Status ExpandBuffer(
+    void* stream,
+    const OrtValue& input,
+    int num_beams,
+    AllocatorPtr allocator,
+    OrtValue& expanded,
+    bool only_copy_shape);
 
 }  // namespace BeamSearchCpuDeviceHelper
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -95,7 +95,7 @@ struct BeamSearchCpuState : public IBeamSearchCpuState {
     this->sequences.Init(this->sequences_space, static_cast<int>(batch_beam_size), sequence_length, max_length);
   }
 
-  // Copy input_ids to sequences[0]
+  // Copy expanded input_ids to sequences[0]
   void SetSequence(gsl::span<const int32_t> input_ids_in_cpu,
                    size_t batch_beam_size,
                    int max_length,
@@ -105,6 +105,21 @@ struct BeamSearchCpuState : public IBeamSearchCpuState {
       for (int j = 0; j < sequence_length; j++) {
         const size_t index = SafeInt<gsl::index>(i) * max_length + j;
         sequences_0[index] = input_ids_in_cpu[SafeInt<gsl::index>(i) * sequence_length + j];
+      }
+    }
+  }
+
+  // Copy unexpanded input_ids to sequences[0]
+  void SetSequence(gsl::span<const int32_t> input_ids_in_cpu,
+                   size_t batch_beam_size,
+                   int beam_size,
+                   int max_length,
+                   int sequence_length) {
+    gsl::span<int32_t> sequences_0 = sequences_space;
+    for (size_t i = 0; i < batch_beam_size; i++) {
+      for (int j = 0; j < sequence_length; j++) {
+        const size_t index = SafeInt<gsl::index>(i) * max_length + j;
+        sequences_0[index] = input_ids_in_cpu[SafeInt<gsl::index>(i) * sequence_length * beam_size + j];
       }
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -119,7 +119,7 @@ struct BeamSearchCpuState : public IBeamSearchCpuState {
     for (size_t i = 0; i < batch_beam_size; i++) {
       for (int j = 0; j < sequence_length; j++) {
         const size_t index = SafeInt<gsl::index>(i) * max_length + j;
-        sequences_0[index] = input_ids_in_cpu[SafeInt<gsl::index>(i) * sequence_length * beam_size + j];
+        sequences_0[index] = input_ids_in_cpu[SafeInt<gsl::index>(i / beam_size) * sequence_length + j];
       }
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -115,7 +115,6 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
       encoder_input_ids,
       encoder_attn_mask_value,
       this->implicit_inputs_,
-      parameters->num_beams,
       parameters->pad_token_id,
       parameters->decoder_start_token_id,
       encoder_feeds,
@@ -150,9 +149,10 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
   // Initialize resources
   // ------------------------------------
 
-  // Copy expanded_decoder_input_ids (in CPU) to sequence. It contains decoder_start_token_id for each beam.
+  // Copy decoder_input_ids (in CPU) to sequence. It contains decoder_start_token_id for each beam.
   cpu_state.SetSequence(expanded_decoder_input_ids.Get<Tensor>().DataAsSpan<int32_t>(),
                         static_cast<size_t>(parameters->BatchBeamSize()),
+                        parameters->num_beams,
                         parameters->max_length,
                         parameters->sequence_length);
 
@@ -211,6 +211,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
                                                              encoder_fetches,
                                                              decoder_feeds,
                                                              this->device_copy_int32_func_,
+                                                             parameters->num_beams,
                                                              this->cuda_stream_));
   }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -110,7 +110,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
                  this->IsCuda());
 
   IAllocatorUniquePtr<char> buffer;
-  OrtValue expanded_decoder_input_ids;  // Tensor in CPU, and it will be used to initialize sequence in cpu_state
+  OrtValue decoder_input_ids;  // Tensor in CPU, and it will be used to initialize sequence in cpu_state
   ORT_RETURN_IF_ERROR(this->encoder_subgraph_.CreateInitialFeeds(
       encoder_input_ids,
       encoder_attn_mask_value,
@@ -121,7 +121,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
       this->create_encoder_inputs_func_,
       this->add_to_feeds_func_,
       buffer,
-      expanded_decoder_input_ids));
+      decoder_input_ids));
 
   ORT_RETURN_IF_ERROR(utils::ExecuteSubgraph(this->encoder_session_state_,
                                              encoder_feeds_fetches_manager,
@@ -150,7 +150,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
   // ------------------------------------
 
   // Copy decoder_input_ids (in CPU) to sequence. It contains decoder_start_token_id for each beam.
-  cpu_state.SetSequence(expanded_decoder_input_ids.Get<Tensor>().DataAsSpan<int32_t>(),
+  cpu_state.SetSequence(decoder_input_ids.Get<Tensor>().DataAsSpan<int32_t>(),
                         static_cast<size_t>(parameters->BatchBeamSize()),
                         parameters->num_beams,
                         parameters->max_length,

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -33,7 +33,10 @@ class BeamSearchT5 : public BeamSearchBase<T> {
                const BeamSearchDeviceHelper::DeviceCopyFunc<float>& device_copy_func,
                const BeamSearchDeviceHelper::DeviceCopyFunc<int32_t>& device_copy_int32_func,
                const BeamSearchDeviceHelper::CreateEncoderInputsFunc& create_encoder_inputs_func,
-               const BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<T>& update_decoder_feeds_func)
+               const BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<T>& update_decoder_feeds_func,
+               const BeamSearchDeviceHelper::ExpandBufferFunc<int32_t>& expand_buffer_int32_func,
+               const BeamSearchDeviceHelper::ExpandBufferFunc<float>& expand_buffer_float_func,
+               const BeamSearchDeviceHelper::ExpandBufferFunc<MLFloat16>& expand_buffer_float16_func)
       : BeamSearchBase<T>(context, decoder_session_state, thread_pool,
                           cuda_stream, cuda_dumper, params,
                           topk_func, process_logits_func, device_copy_func, device_copy_int32_func),
@@ -43,7 +46,10 @@ class BeamSearchT5 : public BeamSearchBase<T> {
         add_to_feeds_func_(add_to_feeds_func),
         init_beam_state_func_(init_beam_state_func),
         create_encoder_inputs_func_(create_encoder_inputs_func),
-        update_decoder_feeds_func_(update_decoder_feeds_func) {
+        update_decoder_feeds_func_(update_decoder_feeds_func),
+        expand_buffer_int32_func_(expand_buffer_int32_func),
+        expand_buffer_float_func_(expand_buffer_float_func),
+        expand_buffer_float16_func_(expand_buffer_float16_func) {
   }
 
   // Execute beam search in iterations util stopping criteria is reached.
@@ -62,6 +68,9 @@ class BeamSearchT5 : public BeamSearchBase<T> {
 
   BeamSearchDeviceHelper::CreateEncoderInputsFunc create_encoder_inputs_func_;
   BeamSearchDeviceHelper::UpdateDecoderFeedsFunc<T> update_decoder_feeds_func_;
+  BeamSearchDeviceHelper::ExpandBufferFunc<int32_t> expand_buffer_int32_func_;
+  BeamSearchDeviceHelper::ExpandBufferFunc<float> expand_buffer_float_func_;
+  BeamSearchDeviceHelper::ExpandBufferFunc<MLFloat16> expand_buffer_float16_func_;
 };
 
 template <typename T>
@@ -211,6 +220,9 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
                                                              encoder_fetches,
                                                              decoder_feeds,
                                                              this->device_copy_int32_func_,
+                                                             this->expand_buffer_int32_func_,
+                                                             this->expand_buffer_float_func_,
+                                                             this->expand_buffer_float16_func_,
                                                              parameters->num_beams,
                                                              this->cuda_stream_));
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -146,10 +146,12 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
 
   // The encoder_attention_mask is copied from the second input of encoder.
   OrtValue expanded_decoder_attention_masks;
-  BeamSearchCpuDeviceHelper::ExpandInputs<int32_t>(encoder_feeds[1],
+  std::cout << "expanded_decoder_attention_masks 149" << std::endl;
+  BeamSearchCpuDeviceHelper::ExpandBuffer<int32_t>(encoder_feeds[1],
                                                    num_beam,
                                                    allocator,
-                                                   expanded_decoder_attention_masks);
+                                                   expanded_decoder_attention_masks, false);
+  std::cout << "after crash 149" << std::endl;
   decoder_feeds.push_back(expanded_decoder_attention_masks);
 
   // When first_past_input_index_ == 3, the encoder_hidden_states and past states are copied from the second output
@@ -158,11 +160,11 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
   for (size_t j = 4 - first_past_input_index_; j < encoder_fetches.size(); j++) {
     if (j == 1) {
       OrtValue expanded_hidden_states;
-      BeamSearchCpuDeviceHelper::ExpandHiddenStates<float>(encoder_fetches[j], num_beam, allocator, expanded_hidden_states);
+      BeamSearchCpuDeviceHelper::ExpandBuffer<float>(encoder_fetches[j], num_beam, allocator, expanded_hidden_states, true);
       decoder_feeds.push_back(expanded_hidden_states);
     } else {
       OrtValue expanded_cache;
-      BeamSearchCpuDeviceHelper::ExpandCaches<float>(encoder_fetches[j], num_beam, allocator, expanded_cache);
+      BeamSearchCpuDeviceHelper::ExpandBuffer<float>(encoder_fetches[j], num_beam, allocator, expanded_cache, false);
       decoder_feeds.push_back(expanded_cache);
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -156,9 +156,15 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
   // of encoder.
   // When first_past_input_index_ == 2, the past states are copied from the second output of encoder.
   for (size_t j = 4 - first_past_input_index_; j < encoder_fetches.size(); j++) {
-    OrtValue expanded_cache;
-    BeamSearchCpuDeviceHelper::ExpandCaches<float>(encoder_fetches[j], num_beam, allocator, expanded_cache);
-    decoder_feeds.push_back(expanded_cache);
+    if (j == 1) {
+      OrtValue expanded_hidden_states;
+      BeamSearchCpuDeviceHelper::ExpandHiddenStates<float>(encoder_fetches[j], num_beam, allocator, expanded_hidden_states);
+      decoder_feeds.push_back(expanded_hidden_states);
+    } else {
+      OrtValue expanded_cache;
+      BeamSearchCpuDeviceHelper::ExpandCaches<float>(encoder_fetches[j], num_beam, allocator, expanded_cache);
+      decoder_feeds.push_back(expanded_cache);
+    }
   }
 
   // Pass through implicit inputs.

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -149,18 +149,13 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
 
   // The encoder_attention_mask is copied from the second input of encoder.
   OrtValue expanded_decoder_attention_masks;
-  std::cout << "expanded_decoder_attention_masks 149" << std::endl;
   ORT_RETURN_IF_ERROR(expand_buffer_int32_func(stream,
                                                encoder_feeds[1],
                                                num_beam,
                                                allocator,
                                                expanded_decoder_attention_masks,
                                                false));
-  // BeamSearchCpuDeviceHelper::ExpandBuffer<int32_t>(encoder_feeds[1],
-  //                                                  num_beam,
-  //                                                  allocator,
-  //                                                  expanded_decoder_attention_masks, false);
-  std::cout << "after crash 149" << std::endl;
+
   decoder_feeds.push_back(expanded_decoder_attention_masks);
 
   // When first_past_input_index_ == 3, the encoder_hidden_states and past states are copied from the second output
@@ -168,6 +163,7 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
   // When first_past_input_index_ == 2, the past states are copied from the second output of encoder.
   for (size_t j = 4 - first_past_input_index_; j < encoder_fetches.size(); j++) {
     if (j == 1) {
+      ORT_RETURN_IF(has_hidden_state_ == false, "Invalid hidden_states expension: has_hidden_state_ == false");
       OrtValue expanded_hidden_states;
       if (is_output_float16_) {
         ORT_RETURN_IF_ERROR(expand_buffer_float16_func(stream,
@@ -184,8 +180,6 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
                                                      expanded_hidden_states,
                                                      true));
       }
-
-      //BeamSearchCpuDeviceHelper::ExpandBuffer<float>(encoder_fetches[j], num_beam, allocator, expanded_hidden_states, true);
       decoder_feeds.push_back(expanded_hidden_states);
     } else {
       OrtValue expanded_cache;
@@ -204,7 +198,6 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
                                                      expanded_cache,
                                                      false));
       }
-      //BeamSearchCpuDeviceHelper::ExpandBuffer<float>(encoder_fetches[j], num_beam, allocator, expanded_cache, false);
       decoder_feeds.push_back(expanded_cache);
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -167,11 +167,11 @@ Status T5DecoderSubgraph::CreateInitialFeeds(
       OrtValue expanded_hidden_states;
       if (is_output_float16_) {
         ORT_RETURN_IF_ERROR(expand_buffer_float16_func(stream,
-                                                      encoder_fetches[j],
-                                                      num_beam,
-                                                      allocator,
-                                                      expanded_hidden_states,
-                                                      true));
+                                                       encoder_fetches[j],
+                                                       num_beam,
+                                                       allocator,
+                                                       expanded_hidden_states,
+                                                       true));
       } else {
         ORT_RETURN_IF_ERROR(expand_buffer_float_func(stream,
                                                      encoder_fetches[j],

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.h
@@ -28,6 +28,7 @@ class T5DecoderSubgraph : public Subgraph {
       const std::vector<OrtValue>& encoder_fetches,
       std::vector<OrtValue>& decoder_feeds,
       const BeamSearchDeviceHelper::DeviceCopyFunc<int32_t>& device_copy_int32_func,
+      int num_beam,
       void* stream);
 
   Status Validate(const std::vector<const NodeArg*>& subgraph_inputs,

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.h
@@ -28,6 +28,9 @@ class T5DecoderSubgraph : public Subgraph {
       const std::vector<OrtValue>& encoder_fetches,
       std::vector<OrtValue>& decoder_feeds,
       const BeamSearchDeviceHelper::DeviceCopyFunc<int32_t>& device_copy_int32_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<int32_t>& expand_buffer_int32_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<float>& expand_buffer_float_func,
+      const BeamSearchDeviceHelper::ExpandBufferFunc<MLFloat16>& expand_buffer_float16_func,
       int num_beam,
       void* stream);
 

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
@@ -96,24 +96,23 @@ Status T5EncoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_i
 
 // Create inputs for first inference of subgraph.
 Status T5EncoderSubgraph::CreateInitialFeeds(
-    const Tensor& encoder_input_ids,
+    const Tensor& original_encoder_input_ids,
     const OrtValue* attn_mask_value,
     const std::vector<const OrtValue*>& implicit_inputs,
-    int num_beams,
     int pad_token_id,
     int start_token_id,
     std::vector<OrtValue>& feeds,
     const BeamSearchDeviceHelper::CreateEncoderInputsFunc& create_encoder_inputs_func,
     const BeamSearchDeviceHelper::AddToFeedsFunc& add_to_feeds_func,
     IAllocatorUniquePtr<char>& buffer,
-    OrtValue& expanded_decoder_input_ids) {
+    OrtValue& decoder_input_ids) {
   ORT_ENFORCE(session_state_ != nullptr, "Setup must be called before CreateInitialFeeds");
 
   // The ordering is the same as used in Setup.
   feeds.reserve(static_cast<size_t>(num_subgraph_inputs) + static_cast<size_t>(num_implicit_inputs));
 
   // Allocate subgraph inputs to be same device as encoder_input_ids.
-  AllocatorPtr cpu_allocator = session_state_->GetAllocator(encoder_input_ids.Location());
+  AllocatorPtr cpu_allocator = session_state_->GetAllocator(original_encoder_input_ids.Location());
   if (cpu_allocator == nullptr) {
     const IExecutionProvider* provider = GetProvider();
     cpu_allocator = provider->GetAllocator(0, OrtMemTypeDefault);
@@ -121,22 +120,21 @@ Status T5EncoderSubgraph::CreateInitialFeeds(
   ORT_RETURN_IF(cpu_allocator == nullptr, "cpu_allocator shouldn't be nullptr");
 
   // TODO(tianleiwu): expand the outputs instead of inputs to save computation.
-  OrtValue expanded_encoder_input_ids;
-  OrtValue expanded_encoder_attention_mask;
-  ORT_RETURN_IF_ERROR(create_encoder_inputs_func(&encoder_input_ids,
+  OrtValue encoder_input_ids;
+  OrtValue encoder_attention_mask;
+  ORT_RETURN_IF_ERROR(create_encoder_inputs_func(&original_encoder_input_ids,
                                                  attn_mask_value,
-                                                 num_beams,
                                                  pad_token_id,
                                                  start_token_id,
                                                  cpu_allocator,
-                                                 expanded_encoder_input_ids,
-                                                 expanded_encoder_attention_mask,
-                                                 expanded_decoder_input_ids));
+                                                 encoder_input_ids,
+                                                 encoder_attention_mask,
+                                                 decoder_input_ids));
 
   const IExecutionProvider* provider = GetProvider();
   ORT_RETURN_IF_ERROR(add_to_feeds_func(
       provider,
-      {expanded_encoder_input_ids, expanded_encoder_attention_mask, expanded_decoder_input_ids},
+      {encoder_input_ids, encoder_attention_mask, decoder_input_ids},
       feeds,
       buffer));
 

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.h
@@ -24,7 +24,6 @@ class T5EncoderSubgraph : public Subgraph {
       const Tensor& encoder_input_ids,
       const OrtValue* attn_mask_value,
       const std::vector<const OrtValue*>& implicit_inputs,
-      int num_beams,
       int pad_token_id,
       int start_token_id,
       std::vector<OrtValue>& feeds,

--- a/onnxruntime/contrib_ops/cuda/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/beam_search.cc
@@ -49,7 +49,10 @@ BeamSearch::BeamSearch(const OpKernelInfo& info)
                        BeamSearchCudaDeviceHelper::UpdateGptFeeds<MLFloat16>);
 
   SetDeviceHelpers_EncoderDecoder(BeamSearchCudaDeviceHelper::UpdateDecoderFeeds<float>,
-                                  BeamSearchCudaDeviceHelper::UpdateDecoderFeeds<MLFloat16>);
+                                  BeamSearchCudaDeviceHelper::UpdateDecoderFeeds<MLFloat16>,
+                                  BeamSearchCudaDeviceHelper::ExpandBuffer<int32_t>,
+                                  BeamSearchCudaDeviceHelper::ExpandBuffer<float>,
+                                  BeamSearchCudaDeviceHelper::ExpandBuffer<MLFloat16>);
 
   SetConsoleDumper(&g_cuda_dumper);
 }

--- a/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.cc
@@ -231,16 +231,18 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   gsl::span<T>& next_token_logits = beam_state->next_token_logits;
 
   // TODO(tianleiwu): use one kernel to replace a loop of memory copy.
-  const CudaT* current_logits = logits_data + (input_length - 1) * vocab_size;
-  for (int i = 0; i < batch_beam_size; i++) {
-    gsl::span<const T> source(reinterpret_cast<const T*>(current_logits), vocab_size);
-    gsl::span<T> target = next_token_logits.subspan(i * vocab_size, vocab_size);
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(target.data(), source.data(), sizeof(T) * vocab_size,
-                                         cudaMemcpyDeviceToDevice, cuda_stream));
-    if (beam_batch_size == batch_beam_size) {
-      current_logits += input_length * vocab_size;
-    } else if (beam_batch_size == batch_size && i % num_beams == num_beams - 1) {
-      current_logits += input_length * vocab_size;
+  if (input_length > 1 || beam_batch_size == batch_size) {
+    const CudaT* current_logits = logits_data + (input_length - 1) * vocab_size;
+    for (int i = 0; i < batch_beam_size; i++) {
+      gsl::span<const T> source(reinterpret_cast<const T*>(current_logits), vocab_size);
+      gsl::span<T> target = next_token_logits.subspan(i * vocab_size, vocab_size);
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(target.data(), source.data(), sizeof(T) * vocab_size,
+                                           cudaMemcpyDeviceToDevice, cuda_stream));
+      if (beam_batch_size == batch_beam_size) {
+        current_logits += input_length * vocab_size;
+      } else if (beam_batch_size == batch_size && i % num_beams == num_beams - 1) {
+        current_logits += input_length * vocab_size;
+      }
     }
   }
 
@@ -254,7 +256,9 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
 
   // The output will be float for consideration of precision and easy integration with remaining parts.
   float* Y_data = next_token_scores.data();
-  const CudaT* X_data = reinterpret_cast<const CudaT*>(next_token_logits.data());
+  const CudaT* X_data = (input_length == 1 && beam_batch_size == batch_beam_size) ?
+                        logits_data :
+                        reinterpret_cast<const CudaT*>(next_token_logits.data());
 
   dispatch_blockwise_softmax_forward<CudaT, float, float, true>(
       cuda_stream, Y_data, X_data, vocab_size, vocab_size, batch_size * num_beams);

--- a/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.cc
@@ -239,7 +239,7 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
                                          cudaMemcpyDeviceToDevice, cuda_stream));
     if (beam_batch_size == batch_beam_size) {
       current_logits += input_length * vocab_size;
-    } else if (beam_batch_size == batch_size && i != 0 && i % num_beams == 0) {
+    } else if (beam_batch_size == batch_size && i % num_beams == num_beams - 1) {
       current_logits += input_length * vocab_size;
     }
   }

--- a/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/beam_search_device_helper.h
@@ -97,6 +97,15 @@ Status UpdateDecoderFeeds(
     transformers::Sequences& sequences,
     const transformers::IConsoleDumper* dumper);
 
+template <typename T>
+Status ExpandBuffer(
+    void* stream,
+    const OrtValue& input,
+    int num_beams,
+    AllocatorPtr allocator,
+    OrtValue& expanded,
+    bool only_copy_shape);
+
 }  // namespace BeamSearchCudaDeviceHelper
 }  // namespace contrib
 }  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Describe your changes.
Run EncoderDecoderInit with original inputs and expand the output.
zcode(cpu) inference time 17s -> 11s

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
