### PR TITLE
Correcting a typo in the path for ort-nighty 

### DIFF
--- a/onnxruntime/python/tools/transformers/notebooks/Inference_GPT2_with_OnnxRuntime_on_CPU.ipynb
+++ b/onnxruntime/python/tools/transformers/notebooks/Inference_GPT2_with_OnnxRuntime_on_CPU.ipynb
@@ -57,7 +57,7 @@
     "# This notebook requires onnxruntime 1.12.0 or later, use ort-nightly package until 1.12 is released.\n",
     "# Please do not install both onnxruntime and ort-nightly at the same time.\n",
     "#!{sys.executable} -m pip install onnxruntime==1.12.0\n",
-    "!{sys.executable} -m pip install -i https://test.pypi.org/simple/ ort-nightly >>pip_output.txt\n",
+    "!{sys.executable} -m pip install -i https://test.pypi.org/simple/ort-nightly >>pip_output.txt\n",
     "\n",
     "# Install other packages used in this notebook.\n",
     "!{sys.executable} -m pip install transformers==4.18.0 onnx==1.11.0 psutil pytz pandas py-cpuinfo py3nvml netron coloredlogs ipywidgets --no-warn-script-location >>pip_output.txt"


### PR DESCRIPTION

**Description**
Removed the unnecessary space in the link `https://test.pypi.org/simple/ ort-nightly >>pip_output.txt`

**Motivation and Context**
In the previous version, the URL link gave a 404 error. Because of this ort-nightly would not install, the onnxruntime package was missing.
