### PR TITLE
Improved OneDNN performance by preventing thread oversubscription

### DIFF
--- a/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
+++ b/include/onnxruntime/core/providers/dnnl/dnnl_provider_factory.h
@@ -8,9 +8,10 @@ extern "C" {
 #endif
 
 /**
- * \param use_arena zero: false. non-zero: true.
+ * \param[in] dnnl_options configuration parameters for oneDnnl EP creation.
  */
-ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena);
+ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_Dnnl,
+               _In_ OrtSessionOptions* options, _In_ const OrtDnnlProviderOptions* dnnl_options);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -534,6 +534,23 @@ typedef struct OrtOpenVINOProviderOptions {
   unsigned char enable_dynamic_shapes;  ///< 0 = disabled, nonzero = enabled
 } OrtOpenVINOProviderOptions;
 
+/** \brief OneDNN Provider Options
+ *
+ * \see OrtApi::SessionOptionsAppendExecutionProvider_Dnnl
+ */
+typedef struct OrtDnnlProviderOptions {
+#ifdef __cplusplus
+  OrtDnnlProviderOptions() : use_arena{true}, enable_training{false}, optimize_threads{false}, 
+                             ort_intra_op_threads{nullptr}, onednn_threads{0}, ort_threads{0} {}
+#endif
+  int use_arena;              // If arena is used, use_arena 0 = not used, nonzero = used
+  int enable_training;        // Enable or disable training ops, enable_training 0 = not enabled, nonzero = enabled
+  int optimize_threads;       // If we should optimize threads, optimize_threads 0 = not optimized, nonzero = optimized
+  int* ort_intra_op_threads;  // Ptr needed to optimize ort threads, modifies the ort session options configuration
+  int onednn_threads;         // Number of threads we want oneDNN to use, onednn_threads 0 = omp_get_max_threads()
+  int ort_threads;            // Number of threads for ORT to use, ort_threads 0 = steal 1/4 of onednn_threads for ort
+} OrtDnnlProviderOptions;
+
 struct OrtApi;
 typedef struct OrtApi OrtApi;
 

--- a/onnxruntime/core/providers/dnnl/dnnl_provider_factory_creator.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_provider_factory_creator.h
@@ -7,9 +7,11 @@
 
 #include "core/providers/providers.h"
 
+struct OrtDnnlProviderOptions;
+
 namespace onnxruntime {
 // defined in provider_bridge_ort.cc
 struct DnnlProviderFactoryCreator {
-  static std::shared_ptr<IExecutionProviderFactory> Create(int use_arena);
+  static std::shared_ptr<IExecutionProviderFactory> Create(const OrtDnnlProviderOptions* dnnl_options);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1143,8 +1143,9 @@ std::shared_ptr<IExecutionProviderFactory> RocmProviderFactoryCreator::Create(co
   return s_library_rocm.Get().CreateExecutionProviderFactory(provider_options);
 }
 
-std::shared_ptr<IExecutionProviderFactory> DnnlProviderFactoryCreator::Create(int use_arena) {
-  return s_library_dnnl.Get().CreateExecutionProviderFactory(use_arena);
+std::shared_ptr<IExecutionProviderFactory> 
+DnnlProviderFactoryCreator::Create(const OrtDnnlProviderOptions* dnnl_options) {
+  return s_library_dnnl.Get().CreateExecutionProviderFactory(dnnl_options);
 }
 
 std::shared_ptr<IExecutionProviderFactory> TensorrtProviderFactoryCreator::Create(int device_id) {
@@ -1299,9 +1300,11 @@ ProviderOptions GetProviderInfo_Cuda(const OrtCUDAProviderOptionsV2* provider_op
 
 }  // namespace onnxruntime
 
-ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl, _In_ OrtSessionOptions* options, int use_arena) {
+ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_Dnnl,
+                    _In_ OrtSessionOptions* options,
+                    _In_ const OrtDnnlProviderOptions* dnnl_options) {
   API_IMPL_BEGIN
-  auto factory = onnxruntime::DnnlProviderFactoryCreator::Create(use_arena);
+  auto factory = onnxruntime::DnnlProviderFactoryCreator::Create(dnnl_options);
   if (!factory) {
     return OrtApis::CreateStatus(ORT_FAIL, "OrtSessionOptionsAppendExecutionProvider_Dnnl: Failed to load shared library");
   }

--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
+++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
@@ -41,7 +41,9 @@ void addGlobalSchemaFunctions(pybind11::module& m) {
                 }()),
 #endif
 #ifdef USE_DNNL
-            onnxruntime::DnnlProviderFactoryCreator::Create(1),
+            OrtDnnlProviderOptions dnnl_options;
+            dnnl_options.use_arena = true;
+            onnxruntime::DnnlProviderFactoryCreator::Create(&dnnl_options),
 #endif
 #ifdef USE_OPENVINO
             onnxruntime::OpenVINOProviderFactoryCreator::Create(OrtOpenVINOProviderOptions()),

--- a/onnxruntime/test/global_thread_pools/test_inference.cc
+++ b/onnxruntime/test/global_thread_pools/test_inference.cc
@@ -74,7 +74,9 @@ static Ort::Session GetSessionObj(Ort::Env& env, T model_uri, int provider_type)
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = true;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return Ort::Session(nullptr);

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -388,7 +388,21 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
     }
     if (enable_dnnl) {
 #ifdef USE_DNNL
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(sf, enable_cpu_mem_arena ? 1 : 0));
+      // We set the intra op threads to default
+      int minimum_threads = 0;
+      // Generate dnnl_options to optimize dnnl performance
+      OrtDnnlProviderOptions dnnl_options;
+      dnnl_options.use_arena = enable_cpu_mem_arena ? 1 : 0;
+      dnnl_options.optimize_threads = true;
+      dnnl_options.ort_intra_op_threads = &minimum_threads;
+      // Get ideal thread config if possible
+      std::vector<size_t> cpu_list = Env::Default().GetThreadAffinityMasks();
+      if (!cpu_list.empty() && cpu_list.size() > 1) {
+        dnnl_options.onednn_threads = static_cast<int>(cpu_list.size());
+      }
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(sf, &dnnl_options));
+      // Set intra op threads
+      sf.SetIntraOpNumThreads(minimum_threads);
 #else
       fprintf(stderr, "DNNL is not supported in this build");
       return -1;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -36,9 +36,61 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
   const std::string& provider_name = performance_test_config.machine_config.provider_type_name;
   if (provider_name == onnxruntime::kDnnlExecutionProvider) {
 #ifdef USE_DNNL
+    // Create runtime options
+    int enable_training = false;
+    int num_of_threads = 0;
+
+#ifdef _MSC_VER
+    std::string ov_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+    std::string ov_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+    std::istringstream ss(ov_string);
+    std::string token;
+    while (ss >> token) {
+      if (token == "") {
+        continue;
+      }
+      auto pos = token.find("|");
+      if (pos == std::string::npos || pos == 0 || pos == token.length()) {
+        ORT_THROW(
+            "[ERROR] [OneDNN] Use a '|' to separate the key and value for the "
+            "run-time option you are trying to use.\n");
+      }
+
+      auto key = token.substr(0, pos);
+      auto value = token.substr(pos + 1);
+
+      if (key == "num_of_threads") {
+        std::stringstream sstream(value);
+        sstream >> num_of_threads;
+        if (num_of_threads < 0) {
+          ORT_THROW("[ERROR] [OneDNN] The value for the key 'num_of_threads' should be greater than 0\n");
+          // If the user doent define num_threads, default to the number of physical cores for best performance
+        } else if (num_of_threads == 0) {
+          std::vector<size_t> cpu_list = Env::Default().GetThreadAffinityMasks();
+          if (!cpu_list.empty() && cpu_list.size() > 1) {
+            num_of_threads = static_cast<int>(cpu_list.size());
+          }
+        }
+      } else {
+        ORT_THROW(
+            "[ERROR] [OneDNN] wrong key type entered. "
+            "Choose from the following runtime key options that are available for OneDNN. ['num_of_threads']\n");
+      }
+    }
+
+    // Generate provider options
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.optimize_threads = true;
+    dnnl_options.use_arena = performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0;
+    dnnl_options.ort_intra_op_threads = const_cast<int*>(&performance_test_config.run_config.intra_op_num_threads);
+    dnnl_options.onednn_threads = num_of_threads;
+    dnnl_options.ort_threads = performance_test_config.run_config.intra_op_num_threads;
+    dnnl_options.enable_training = enable_training;
+
     Ort::ThrowOnError(
-        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options,
-                                                      performance_test_config.run_config.enable_cpu_mem_arena ? 1 : 0));
+        OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
 #else
     ORT_THROW("DNNL is not supported in this build\n");
 #endif

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -651,7 +651,9 @@ TEST_P(ModelTest, Run) {
       }
 #ifdef USE_DNNL
       else if (provider_name == "dnnl") {
-        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, false));
+        OrtDnnlProviderOptions dnnl_options;
+        dnnl_options.use_arena = false;
+        ASSERT_ORT_STATUS_OK(OrtSessionOptionsAppendExecutionProvider_Dnnl(ortso, &dnnl_options));
       }
 #endif
 #ifdef USE_NUPHAR

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -107,7 +107,9 @@ static void TestInference(Ort::Env& env, const std::basic_string<ORTCHAR_T>& mod
 #endif
   } else if (provider_type == 2) {
 #ifdef USE_DNNL
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, 1));
+    OrtDnnlProviderOptions dnnl_options;
+    dnnl_options.use_arena = true;
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Dnnl(session_options, &dnnl_options));
     std::cout << "Running simple inference with dnnl provider" << std::endl;
 #else
     return;

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -105,12 +105,21 @@ std::unique_ptr<IExecutionProvider> DefaultCudaExecutionProvider() {
   return nullptr;
 }
 
-std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(bool enable_arena) {
+std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider() {
 #ifdef USE_DNNL
-  if (auto factory = DnnlProviderFactoryCreator::Create(enable_arena ? 1 : 0))
+  OrtDnnlProviderOptions dnnl_options;
+  if (auto factory = DnnlProviderFactoryCreator::Create(&dnnl_options))
+    return factory->CreateProvider();
+#endif
+  return nullptr;
+}
+
+std::unique_ptr<IExecutionProvider> DnnlExecutionProviderWithOptions(const OrtDnnlProviderOptions* params) {
+#ifdef USE_DNNL
+  if (auto factory = DnnlProviderFactoryCreator::Create(params))
     return factory->CreateProvider();
 #else
-  ORT_UNUSED_PARAMETER(enable_arena);
+  ORT_UNUSED_PARAMETER(params);
 #endif
   return nullptr;
 }

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -16,7 +16,8 @@ namespace test {
 // unique_ptr providers with default values for session registration
 std::unique_ptr<IExecutionProvider> DefaultCpuExecutionProvider(bool enable_arena = true);
 std::unique_ptr<IExecutionProvider> DefaultCudaExecutionProvider();
-std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider(bool enable_arena = true);
+std::unique_ptr<IExecutionProvider> DefaultDnnlExecutionProvider();
+std::unique_ptr<IExecutionProvider> DnnlExecutionProviderWithOptions(const OrtDnnlProviderOptions* params);
 std::unique_ptr<IExecutionProvider> DefaultNupharExecutionProvider(bool allow_unaligned_buffers = true);
 // std::unique_ptr<IExecutionProvider> DefaultTvmExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultTensorrtExecutionProvider();

--- a/orttraining/orttraining/models/mnist/main.cc
+++ b/orttraining/orttraining/models/mnist/main.cc
@@ -171,7 +171,10 @@ Status ParseArguments(int argc, char* argv[], MnistParameters& params) {
 #ifdef USE_DNNL
     bool use_dnnl = flags.count("use_dnnl") > 0;
     if (use_dnnl) {
-      params.providers.emplace(kDnnlExecutionProvider, DnnlProviderFactoryCreator::Create(1));
+      OrtDnnlProviderOptions dnnl_options;
+      dnnl_options.use_arena = 1;
+      dnnl_options.optimize_threads = 0;
+      params.providers.emplace(kDnnlExecutionProvider, DnnlProviderFactoryCreator::Create(&dnnl_options));
     }
 #endif
 

--- a/orttraining/orttraining/test/gradient/gradient_op_test_utils.cc
+++ b/orttraining/orttraining/test/gradient/gradient_op_test_utils.cc
@@ -146,7 +146,7 @@ void GradientOpTester::Run(
         else if (entry->Type() == onnxruntime::kCudaExecutionProvider)
           execution_provider = DefaultCudaExecutionProvider();
         else if (entry->Type() == onnxruntime::kDnnlExecutionProvider)
-          execution_provider = DefaultDnnlExecutionProvider(1);
+          execution_provider = DefaultDnnlExecutionProvider();
         else if (entry->Type() == onnxruntime::kNupharExecutionProvider)
           execution_provider = DefaultNupharExecutionProvider();
         else if (entry->Type() == onnxruntime::kTensorrtExecutionProvider)


### PR DESCRIPTION
Users can now control the number of threads allocated to OneDNN and the default provider using OrtDnnlProviderOptions to fine tune performance according to each model op coverage. By default we improve thread distribution to prevent oversubscription. An example on how to tune threads and use the available options can be found on the ort_test_session.cc on the perftest folder.

Signed-off-by: Erick Muñoz [erick.munoz.alvarado@intel.com](mailto:erick.munoz.alvarado@intel.com)

Description: Previously OneDNN ep suffered from thread oversubscription due to ORT creating it's own thread pool and OneDNN creating another one, this update aims to fix this issue by making the number of threads used by OneDNN accessible to the user and setting the default threading options to be 3/4 of the available (Or user defined threads for OneDNN) and the remaining threads for default provider (This behavior can be overridden by the user explicitly defining the number of threads for OneDNN and for the default provider)

Motivation and Context

Why is this change required? What problem does it solve?
Performance related fix, prevents thread oversubscription, improves performance on CPU and allows the user to customize thread distribution according to their workload.
If it fixes an open issue, please link to the issue here.