### PR TITLE
Add Learning Rate Scheduler C API

### DIFF
--- a/orttraining/orttraining/test/training_api/trainer/trainer.cc
+++ b/orttraining/orttraining/test/training_api/trainer/trainer.cc
@@ -258,7 +258,13 @@ int RunTraining(const TestRunnerParameters& params) {
 
   const int64_t total_step_count = params.num_train_epochs * num_of_batches_per_epoch;
   const int64_t warmup_step_count = total_step_count / 3;
-  ORT_RETURN_ON_ERROR(g_ort_training_api->RegisterLinearLRScheduler(session, warmup_step_count, total_step_count));
+  auto lr_scheduler_parameters = std::make_unique<OrtLinearLRSchedulerParameters>(
+    OrtLinearLRSchedulerParameters{
+    .warmup_step_count = warmup_step_count,
+    .total_step_count = total_step_count
+    }).get();
+  ORT_RETURN_ON_ERROR(g_ort_training_api->RegisterLRScheduler(
+    session, reinterpret_cast<void*>(lr_scheduler_parameters), OrtLRSchedulerType::LinearLRScheduler, nullptr));
 
   std::cout << "Initialization completed. Now starting training loop." << std::endl;
   const int64_t stabilized_perf_start_step = 0;

--- a/orttraining/orttraining/test/training_api/trainer/trainer.cc
+++ b/orttraining/orttraining/test/training_api/trainer/trainer.cc
@@ -256,13 +256,9 @@ int RunTraining(const TestRunnerParameters& params) {
   onnxruntime::training::test::training_api::SyntheticDataLoader data_loader;
   InitSyntheticDataLoader(data_loader, params, num_of_batches_per_epoch);
 
-  const int64_t total_step_count = params.num_train_epochs * num_of_batches_per_epoch;
-  const int64_t warmup_step_count = total_step_count / 3;
-  auto lr_scheduler_parameters = std::make_unique<OrtLinearLRSchedulerParameters>(
-    OrtLinearLRSchedulerParameters{
-    .warmup_step_count = warmup_step_count,
-    .total_step_count = total_step_count
-    }).get();
+  auto lr_scheduler_parameters = std::make_unique<OrtLinearLRSchedulerParameters>().get();
+  lr_scheduler_parameters->total_step_count = params.num_train_epochs * num_of_batches_per_epoch;
+  lr_scheduler_parameters->warmup_step_count = lr_scheduler_parameters->total_step_count / 3;
   ORT_RETURN_ON_ERROR(g_ort_training_api->RegisterLRScheduler(
     session, reinterpret_cast<void*>(lr_scheduler_parameters), OrtLRSchedulerType::LinearLRScheduler, nullptr));
 

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -157,7 +157,10 @@ struct OrtTrainingApi {
   *
   * This function allows users to set the learning rate for the training session. The current
   * learning rate is maintained by the training session and can be overwritten by invoking
-  * this function with the desired learning rate.
+  * this function with the desired learning rate. This function should not be used when a valid
+  * learning rate scheduler is registered. It should be used either to set the learning rate
+  * derived from a custom learning rate scheduler or to set the learning rate constant to be used
+  * throughout the training session.
   * Please note that this function does not set the initial learning rate that may be needed
   * by the predefined learning rate schedulers. To set the initial learning rate for learning
   * rate schedulers, please look at the function `RegisterLRScheduler`.
@@ -208,6 +211,8 @@ struct OrtTrainingApi {
   * Takes a scheduler step that updates the learning rate that is being used by the training session.
   * This function should typically be called before invoking the optimizer step for each round,
   * or as determined necessary to update the learning rate being used by the training session.
+  * Please note that a valid predefined learning rate scheduler must be first registered to invoke this
+  * function.
   *
   * \param[in] sess The training session that has the registered learning rate scheduler.
   *

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -9,6 +9,15 @@
 ORT_RUNTIME_CLASS(TrainingSession);  /// Type that enables performing training for the given user models.
 ORT_RUNTIME_CLASS(CheckpointState);  /// Type that holds the training states for the training session.
 
+typedef enum OrtLRSchedulerType {
+  LinearLRScheduler
+} OrtLRSchedulerType;
+
+typedef struct OrtLinearLRSchedulerParameters {
+  int64_t warmup_step_count;
+  int64_t total_step_count;
+} OrtLinearLRSchedulerParameters;
+
 struct OrtTrainingApi {
   /** \brief Load a checkpoint state from directory on disk into checkpoint_state.
   *
@@ -144,7 +153,7 @@ struct OrtTrainingApi {
                   size_t inputs_len, _In_reads_(inputs_len) const OrtValue* const* inputs,
                   size_t outputs_len, _Inout_updates_all_(outputs_len) OrtValue** outputs);
 
-  /** \brief Set the learning rate for this training session.
+  /** \brief Sets the learning rate for this training session.
   *
   * This function allows users to set the learning rate for the training session. The training
   * session by default starts with a learning rate of 0.001. It can be overwritten by invoking
@@ -175,22 +184,21 @@ struct OrtTrainingApi {
   ORT_API2_STATUS(OptimizerStep, _Inout_ OrtTrainingSession* sess,
                   _In_opt_ const OrtRunOptions* run_options);
 
-  /** \brief Registers the use of a linear learning rate scheduler for the training session.
+  /** \brief Registers the use of the given learning rate scheduler for the training session.
   *
-  * Register a linear learning rate scheduler that decays the learning rate by linearly updated
-  * multiplicative factor from the initial learning rate set on the training session to 0. The decay
-  * is performed after the initial warm up phase where the learning rate is linearly incremented
-  * from 0 to the initial learning rate set on the training session.
+  * Register a learning rate scheduler identified by the given enum with the given
+  * learning rate scheduler parameters. Optionally specify the initial learning rate
+  * that should be used with this training session.
   *
   * \param[in] sess The training session that should use the linear learning rate scheduler.
-  * \param[in] warmup_step_count The number of steps in the warm up phase.
-  * \param[in] total_step_count The total number of training steps.
+  * \param[in] lr_scheduler_parameters Learning rate scheduler parameters struct.
+  * \param[in] initial_lr The initial learning rate to be used by the training session.
   *
   * \snippet{doc} snippets.dox OrtStatus Return Value
   *
   */
-  ORT_API2_STATUS(RegisterLinearLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ int64_t warmup_step_count,
-                  _In_ int64_t total_step_count);
+  ORT_API2_STATUS(RegisterLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ void* lr_scheduler_parameters,
+                  _In_ enum OrtLRSchedulerType lr_scheduler_type, _In_opt_ const float* initial_lr);
 
   /** \brief Update the learning rate based on the registered learing rate scheduler.
   *

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -144,6 +144,20 @@ struct OrtTrainingApi {
                   size_t inputs_len, _In_reads_(inputs_len) const OrtValue* const* inputs,
                   size_t outputs_len, _Inout_updates_all_(outputs_len) OrtValue** outputs);
 
+  /** \brief Set the learning rate for this training session.
+  *
+  * This function allows users to set the learning rate for the training session. The training
+  * session by default starts with a learning rate of 0.001. It can be overwritten by invoking
+  * this function with the desired learning rate.
+  *
+  * \param[in] sess The training session on which the learning rate needs to be set.
+  * \param[in] learning_rate Desired learning rate to set.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(SetLearningRate, _Inout_ OrtTrainingSession* sess, _In_ float learning_rate);
+
   /** \brief Performs the weight updates for the trainable parameters using the optimizer model.
   *
   * This function performs the weight update step that updates the trainable parameters such that they
@@ -160,6 +174,36 @@ struct OrtTrainingApi {
   */
   ORT_API2_STATUS(OptimizerStep, _Inout_ OrtTrainingSession* sess,
                   _In_opt_ const OrtRunOptions* run_options);
+
+  /** \brief Registers the use of a linear learning rate scheduler for the training session.
+  *
+  * Register a linear learning rate scheduler that decays the learning rate by linearly updated
+  * multiplicative factor from the initial learning rate set on the training session to 0. The decay
+  * is performed after the initial warm up phase where the learning rate is linearly incremented
+  * from 0 to the initial learning rate set on the training session.
+  *
+  * \param[in] sess The training session that should use the linear learning rate scheduler.
+  * \param[in] warmup_step_count The number of steps in the warm up phase.
+  * \param[in] total_step_count The total number of training steps.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(RegisterLinearLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ int64_t warmup_step_count,
+                  _In_ int64_t total_step_count);
+
+  /** \brief Update the learning rate based on the registered learing rate scheduler.
+  *
+  * Takes a scheduler step that updates the learning rate that is being used by the training session.
+  * This function should typically be called before invoking the optimizer step for each round,
+  * or as determined necessary to update the learning rate being used by the training session.
+  *
+  * \param[in] sess The training session that has the registered learning rate scheduler.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(SchedulerStep, _Inout_ OrtTrainingSession* sess);
 
   /** \brief Frees up the memory used up by the training session.
   *

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -155,9 +155,12 @@ struct OrtTrainingApi {
 
   /** \brief Sets the learning rate for this training session.
   *
-  * This function allows users to set the learning rate for the training session. The training
-  * session by default starts with a learning rate of 0.001. It can be overwritten by invoking
+  * This function allows users to set the learning rate for the training session. The current
+  * learning rate is maintained by the training session and can be overwritten by invoking
   * this function with the desired learning rate.
+  * Please note that this function does not set the initial learning rate that may be needed
+  * by the predefined learning rate schedulers. To set the initial learning rate for learning
+  * rate schedulers, please look at the function `RegisterLRScheduler`.
   *
   * \param[in] sess The training session on which the learning rate needs to be set.
   * \param[in] learning_rate Desired learning rate to set.
@@ -188,7 +191,7 @@ struct OrtTrainingApi {
   *
   * Register a learning rate scheduler identified by the given enum with the given
   * learning rate scheduler parameters. Optionally specify the initial learning rate
-  * that should be used with this training session.
+  * that should be used with this learning rate scheduler and training session.
   *
   * \param[in] sess The training session that should use the linear learning rate scheduler.
   * \param[in] lr_scheduler_parameters Learning rate scheduler parameters struct.

--- a/orttraining/orttraining/training_api/include/optimizer.h
+++ b/orttraining/orttraining/training_api/include/optimizer.h
@@ -73,6 +73,12 @@ struct Optimizer {
     return Status::OK();
   }
 
+  inline Status SetInitialLearningRate(float initial_lr) {
+    optimizer_state_.initial_lr = initial_lr;
+    optimizer_state_.learning_rate = initial_lr;
+    return Status::OK();
+  }
+
  private:
   int64_t GetStep() const {
     return optimizer_state_.step;

--- a/orttraining/orttraining/training_api/include/optimizer.h
+++ b/orttraining/orttraining/training_api/include/optimizer.h
@@ -68,14 +68,14 @@ struct Optimizer {
 
   Status LoadStateDict(const OptimizerCheckpointState& optimizer_checkpoint_states);
 
+  inline Status SetLearningRate(float lr) {
+    optimizer_state_.learning_rate = lr;
+    return Status::OK();
+  }
+
  private:
   int64_t GetStep() const {
     return optimizer_state_.step;
-  }
-
-  Status SetLearningRate(float lr) {
-    optimizer_state_.learning_rate = lr;
-    return Status::OK();
   }
 
   // Generates optimizer momentum states for applicable optimizer types

--- a/orttraining/orttraining/training_api/include/ort_training_apis.h
+++ b/orttraining/orttraining/training_api/include/ort_training_apis.h
@@ -29,8 +29,8 @@ ORT_API_STATUS_IMPL(SetLearningRate, _Inout_ OrtTrainingSession* sess, _In_ floa
 
 ORT_API_STATUS_IMPL(OptimizerStep, _Inout_ OrtTrainingSession* session, _In_opt_ const OrtRunOptions* run_options);
 
-ORT_API_STATUS_IMPL(RegisterLinearLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ int64_t warmup_step_count,
-                    _In_ int64_t total_step_count);
+ORT_API_STATUS_IMPL(RegisterLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ void* lr_scheduler_parameters,
+                    _In_ enum OrtLRSchedulerType lr_scheduler_type, _In_opt_ const float* initial_lr);
 
 ORT_API_STATUS_IMPL(SchedulerStep, _Inout_ OrtTrainingSession* sess);
 

--- a/orttraining/orttraining/training_api/include/ort_training_apis.h
+++ b/orttraining/orttraining/training_api/include/ort_training_apis.h
@@ -25,7 +25,14 @@ ORT_API_STATUS_IMPL(EvalStep, _In_ const OrtTrainingSession* session, _In_opt_ c
                     size_t inputs_len, _In_reads_(input_len) const OrtValue* const* inputs,
                     size_t outputs_len, _Inout_updates_all_(outputs_len) OrtValue** outputs);
 
+ORT_API_STATUS_IMPL(SetLearningRate, _Inout_ OrtTrainingSession* sess, _In_ float learning_rate);
+
 ORT_API_STATUS_IMPL(OptimizerStep, _Inout_ OrtTrainingSession* session, _In_opt_ const OrtRunOptions* run_options);
+
+ORT_API_STATUS_IMPL(RegisterLinearLRScheduler, _Inout_ OrtTrainingSession* sess, _In_ int64_t warmup_step_count,
+                    _In_ int64_t total_step_count);
+
+ORT_API_STATUS_IMPL(SchedulerStep, _Inout_ OrtTrainingSession* sess);
 
 ORT_API_STATUS_IMPL(LoadCheckpoint, _In_ const ORTCHAR_T* checkpoint_path,
                     _Outptr_ OrtCheckpointState** checkpoint_state);

--- a/orttraining/orttraining/training_api/include/training_session.h
+++ b/orttraining/orttraining/training_api/include/training_session.h
@@ -32,7 +32,8 @@ class TrainingSession {
                   const ModelIdentifiers& model_identifiers);
 
   Status RegisterScheduler(const std::function<
-                           std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler);
+                               std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler,
+                           std::optional<float> initial_lr);
 
   size_t GetTrainModeOutputCount() const noexcept;
 

--- a/orttraining/orttraining/training_api/include/training_session.h
+++ b/orttraining/orttraining/training_api/include/training_session.h
@@ -5,6 +5,7 @@
 #include "core/common/common.h"
 #include "module.h"
 #include "optimizer.h"
+#include "lr_scheduler.h"
 #include "checkpoint.h"
 
 namespace onnxruntime {
@@ -30,6 +31,9 @@ class TrainingSession {
                   const std::unordered_map<std::string, std::shared_ptr<Parameter>>& parameters,
                   const ModelIdentifiers& model_identifiers);
 
+  Status RegisterScheduler(const std::function<
+                           std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler);
+
   size_t GetTrainModeOutputCount() const noexcept;
 
   size_t GetEvalModeOutputCount() const noexcept;
@@ -46,6 +50,10 @@ class TrainingSession {
 
   Status OptimizerStep(const RunOptions& run_options);
 
+  Status SetLearningRate(float learning_rate) noexcept;
+
+  Status SchedulerStep() noexcept;
+
   Status CreateCheckpointState(CheckpointState& chkpt_state, bool save_optimizer_state) const;
 
  private:
@@ -53,7 +61,8 @@ class TrainingSession {
 
   const std::unordered_map<std::string, std::shared_ptr<Parameter>> named_parameters_;
   std::unique_ptr<Module> module_;
-  std::unique_ptr<Optimizer> optimizer_;
+  std::shared_ptr<Optimizer> optimizer_;
+  std::unique_ptr<LRSchedulerBase> scheduler_;
 };
 }  // namespace api
 }  // namespace training

--- a/orttraining/orttraining/training_api/training_session.cc
+++ b/orttraining/orttraining/training_api/training_session.cc
@@ -25,7 +25,7 @@ Status TrainingSession::RegisterScheduler(
     const std::function<std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler,
     std::optional<float> initial_lr) {
   scheduler_ = std::move(get_scheduler(optimizer_));
-  ORT_ENFORCE(scheduler_, "The provided instance of the learning rate scheduler is a nullptr.");
+  ORT_RETURN_IF_NOT(scheduler_, "The provided instance of the learning rate scheduler is a nullptr.");
 
   if (initial_lr.has_value()) {
     ORT_RETURN_IF_ERROR(optimizer_->SetInitialLearningRate(initial_lr.value()));
@@ -78,6 +78,7 @@ Status TrainingSession::SetLearningRate(float learning_rate) noexcept {
 }
 
 Status TrainingSession::SchedulerStep() noexcept {
+  ORT_RETURN_IF_NOT(scheduler_, "No learning rate schedler was registered. Please register a valid learning rate scheduler");
   return scheduler_->Step();
 }
 

--- a/orttraining/orttraining/training_api/training_session.cc
+++ b/orttraining/orttraining/training_api/training_session.cc
@@ -21,8 +21,8 @@ TrainingSession::TrainingSession(const Environment& session_env,
                            session_options, session_env, providers)
                      : std::unique_ptr<Optimizer>()} {}
 
-Status TrainingSession::RegisterScheduler(const std::function<
-                                          std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler) {
+Status TrainingSession::RegisterScheduler(
+    const std::function<std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler) {
   scheduler_ = std::move(get_scheduler(optimizer_));
   ORT_ENFORCE(scheduler_, "The provided instance of the learning rate scheduler is a nullptr.");
 

--- a/orttraining/orttraining/training_api/training_session.cc
+++ b/orttraining/orttraining/training_api/training_session.cc
@@ -22,9 +22,14 @@ TrainingSession::TrainingSession(const Environment& session_env,
                      : std::unique_ptr<Optimizer>()} {}
 
 Status TrainingSession::RegisterScheduler(
-    const std::function<std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler) {
+    const std::function<std::unique_ptr<LRSchedulerBase>(std::shared_ptr<Optimizer>)>& get_scheduler,
+    std::optional<float> initial_lr) {
   scheduler_ = std::move(get_scheduler(optimizer_));
   ORT_ENFORCE(scheduler_, "The provided instance of the learning rate scheduler is a nullptr.");
+
+  if (initial_lr.has_value()) {
+    ORT_RETURN_IF_ERROR(optimizer_->SetInitialLearningRate(initial_lr.value()));
+  }
 
   return Status::OK();
 }


### PR DESCRIPTION
This pull request adds an API for registering a scheduler with the training session.

```cc
// c api
OrtTrainingSession* session;
g_ort_training_api->CreateTrainingSession(env, session_options, checkpoint_state,
                                          training_model.c_str(), eval_model.c_str(),
                                          optimizer_model.c_str(), &session));

// Set the initial learning rate.
g_ort_training_api->SetLearningRate(session, learning_rate);

// Register the linear leaning rate scheduler.
g_ort_training_api->RegisterLinearLRScheduler(session, warm_up_step_count, total_step_count);

// Take a scheduler step.
g_ort_training_api->SchedulerStep(session);
```