### PR TITLE
Include opset 15 in Conv+BatchNormalization fusion

### DIFF
--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -151,7 +151,7 @@ bool ConvBNFusion::SatisfyCondition(const Graph& graph, const Node& node, const 
   }
 
   const auto& next_node = *node.OutputNodesBegin();
-  if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "BatchNormalization", {7, 9, 14}) ||
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(next_node, "BatchNormalization", {7, 9, 14, 15}) ||
       next_node.GetInputEdgesCount() != 1 ||
       // Make sure the two nodes do not span execution providers.
       next_node.GetExecutionProviderType() != node.GetExecutionProviderType()) {


### PR DESCRIPTION
**Description**: Adds the missing opset version for BatchNormalization 15.

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Performance regresses if a user upgrades to opset 15.
- *If it fixes an open issue, please link to the issue here.* NA

**Verification**

Verified the fusion is happening for opset 15 (and that batch normalization is *not* being executed, via debugger):

- The fusion now happens for opset 15 like 14 and earlier, for homogeneous inputs (all same input data type, float16, float32...).
- It does not happen for heterogeneous inputs (nor did it before), leaving it as two separate operators. There's an existing check for same data type, which is no worse than before. We just don't want to regress the *existing* scenario of same input types.

![image](https://user-images.githubusercontent.com/1809166/175196596-b278eff5-d519-401b-a822-4765f9a39eba.png)

**Tests run**

`onnxruntime_perf_test.exe -e cpu -I -r 1 -u o:\out.onnx testmodel.onnx`
`onnxruntime_perf_test.exe -e dml -I -r 1 -u o:\out.onnx testmodel.onnx`
`te.exe OnnxConformanceTests.dll /name:*ConvBatch*`

Mini-test model added to the WindowsAI ONNX conformance suite:

```
ir_version: 4
producer_name: "OnnxConformanceTest"
graph {
  node {
    input: "ConvX"
    input: "ConvW"
    input: "ConvB"
    output: "ConvY"
    op_type: "Conv"
    attribute {
      name: "auto_pad"
      s: "NOTSET"
      type: STRING
    }
    attribute {
      name: "strides"
      ints: 1
      ints: 1
      type: INTS
    }
    attribute {
      name: "dilations"
      ints: 1
      ints: 1
      type: INTS
    }
    attribute {
      name: "kernel_shape"
      ints: 1
      ints: 5
      type: INTS
    }
    attribute {
      name: "pads"
      ints: 0
      ints: 0
      ints: 0
      ints: 0
      type: INTS
    }
    domain: ""
  }
  node {
    input: "ConvY"
    input: "BatchNormalizationScale"
    input: "BatchNormalizationB"
    input: "BatchNormalizationMean"
    input: "BatchNormalizationVar"
    output: "BatchNormalizationY"
    op_type: "BatchNormalization"
    attribute {
      name: "momentum"
      f: 2
      type: FLOAT
    }
    attribute {
      name: "epsilon"
      f: 0
      type: FLOAT
    }
    domain: ""
  }
  name: "Conv+BatchNormalization_fusion"
  initializer {
    dims: 1
    dims: 1
    dims: 1
    dims: 5
    data_type: 1
    name: "ConvW"
    raw_data: "\000\000\200?\000\000\000@\000\000@@\000\000\000@\000\000\200?"
  }
  initializer {
    dims: 1
    data_type: 1
    name: "ConvB"
    raw_data: "\000\000\200?"
  }
  initializer {
    dims: 1
    data_type: 1
    name: "BatchNormalizationScale"
    raw_data: "\000\000\200?"
  }
  initializer {
    dims: 1
    data_type: 1
    name: "BatchNormalizationB"
    raw_data: "\000\000\000\000"
  }
  initializer {
    dims: 1
    data_type: 1
    name: "BatchNormalizationMean"
    raw_data: "\000\000\000\000"
  }
  initializer {
    dims: 1
    data_type: 1
    name: "BatchNormalizationVar"
    raw_data: "\000\000\200?"
  }
  input {
    name: "ConvX"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 2
          }
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 10
          }
        }
      }
    }
  }
  output {
    name: "BatchNormalizationY"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 2
          }
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 1
          }
          dim {
            dim_value: 6
          }
        }
      }
    }
  }
}
opset_import {
  domain: ""
  version: 7
}
opset_import {
  domain: ""
  version: 15
}
```

```
{
  "tests": [
    {
      "graph_name": "Conv+BatchNormalization fusion",
      "version": 15,
      "nodes": [
        {
          "op_type": "Conv",
          "version": 15,
          "auto_pad": "NOTSET",
          "strides": [1,1],
          "dilations": [1,1],
          "kernel_shape": [1,5],
          "pads": [0,0, 0,0], // ONNX Runtime requires 2 * N, even if 1D input.
          "inputs": {
            "ConvX": {}, //"X": {"dims": [2,1,1,10], "function": "iota"},
            "ConvW": [[[[1,2,3,2,1]]]],
            "ConvB": [1]
          },
          "outputs": {
            "ConvY": {} // "Y": {"dims": [2,1,1,6], "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]},
          },
          "T": "float32"
        },
        {
          "op_type": "BatchNormalization",
          "version": 15,
          "inputs": {
            "ConvY": {}, // "X": {"dims": [2,1,1,6], "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]},
            "BatchNormalizationScale": [1],
            "BatchNormalizationB": [0],
            "BatchNormalizationMean": [0],
            "BatchNormalizationVar": [1]
          },
          "momentum": 2.0,
          "epsilon": 0,
          "outputs": {
            "BatchNormalizationY": {} // "Y": [[[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]],
          },
          "T": "float32",
          "verification": { "relative_tolerance": 0.00001 }
        }
      ], // nodes
      "inputs": {
        "ConvX": {
          "type": "float32",
          "dims": [2,1,1,10],
          "function": "iota"
        }
      },
      "outputs": {
        "BatchNormalizationY": {
          "type": "float32",
          "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]
        }
      }
    },
    {
      "graph_name": "Conv+BatchNormalization fusion mixed input data types",
      "version": 15,
      "nodes": [
        {
          "op_type": "Conv",
          "version": 15,
          "auto_pad": "NOTSET",
          "strides": [1,1],
          "dilations": [1,1],
          "kernel_shape": [1,5],
          "pads": [0,0, 0,0], // ONNX Runtime requires 2 * N, even if 1D input.
          "inputs": {
            "ConvX": {}, //"X": {"dims": [2,1,1,10], "function": "iota"},
            "ConvW": {"type": "float16", "value": [[[[1,2,3,2,1]]]]},
            "ConvB": {"type": "float16", "value": [1]}
          },
          "outputs": {
            "ConvY": {} // "Y": {"dims": [2,1,1,6], "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]},
          },
          "T": "float16"
        },
        {
          "op_type": "BatchNormalization",
          "version": 15,
          "inputs": {
            "ConvY": {}, // "X": {"dims": [2,1,1,6], "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]},
            "BatchNormalizationScale": {"type": "float32", "value": [1]},
            "BatchNormalizationB": {"type": "float32", "value": [0]},
            "BatchNormalizationMean": [0],
            "BatchNormalizationVar": [1]
          },
          "momentum": 2.0,
          "epsilon": 0,
          "outputs": {
            "BatchNormalizationY": {} // "Y": [[[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]]],
          },
          "T": "float16",
          "verification": { "relative_tolerance": 0.00001 }
        }
      ], // nodes
      "inputs": {
        "ConvX": {
          "type": "float16",
          "dims": [2,1,1,10],
          "function": "iota"
        }
      },
      "outputs": {
        "BatchNormalizationY": {
          "type": "float16",
          "value": [[[[19,28,37,46,55,64]]], [[[109,118,127,136,145,154]]]]
        }
      }
    }
  ], // tests

  "schema": [
    {
      "op_type": "BatchNormalization",
      "version": 7,
      "attributes": {
        "epsilon": {"type": "float32"},
        "momentum": {"type": "float32"},
        "spatial": {"type": "int64"} // defaults to 1/true.
      },
      "inputs": {
        "X": {"type": "T"},
        "scale": {"type": "T"},
        "B": {"type": "T"},
        "mean": {"type": "T"},
        "var": {"type": "T"}
      },
      "outputs": {
        "Y": {"type": "T"},
        "mean": {"type": "T"},
        "var": {"type": "T"},
        "saved_mean": {"type": "T"},
        "saved_var": {"type": "T"}
      },
      "types": {"T": ["float32", "float16", "float64"]}
    },
    {
      "op_type": "BatchNormalization",
      "version": 9, // Removes 'spatial' attribute.
      "attributes": {
        "epsilon": {"type": "float32"},
        "momentum": {"type": "float32"}
      },
      "inputs": {
        "X": {"type": "T"},
        "scale": {"type": "T"},
        "B": {"type": "T"},
        "mean": {"type": "T"},
        "var": {"type": "T"}
      },
      "outputs": {
        "Y": {"type": "T"},
        "mean": {"type": "T"},
        "var": {"type": "T"},
        "saved_mean": {"type": "T"},
        "saved_var": {"type": "T"}
      },
      "types": {"T": ["float32", "float16", "float64"]}
    },
    {
      "op_type": "BatchNormalization",
      // Adds 'training_mode' attribute.
      // Renames input mean/var with prefix input_*.
      // Consolidates output mean and variance to running_*.
      // Adds bfloat16.
      "version": 14,
      "attributes": {
        "epsilon": {"type": "float32"},
        "momentum": {"type": "float32"},
        "training_mode": {"type": "int64"} // default = 0
      },
      "inputs": {
        "X": {"type": "T"},
        "scale": {"type": "T"},
        "B": {"type": "T"},
        "input_mean": {"type": "U"},
        "input_var": {"type": "U"}
      },
      "outputs": {
        "Y": {"type": "T"},
        "running_mean": {"type": "U"},
        "running_var": {"type": "U"}
      },
      "types": {
        "T": ["float32", "float16", "bfloat16", "float64"],
        "U": ["float32", "float16", "bfloat16", "float64"]
      }
    },
    {
      "op_type": "BatchNormalization",
      "version": 15, // Allows scale and bias data type to differ from input X type.
      "attributes": {
        "epsilon": {"type": "float32"},
        "momentum": {"type": "float32"},
        "training_mode": {"type": "int64"} // default = 0
      },
      "inputs": {
        "X": {"type": "T"},
        "scale": {"type": "T1"},
        "B": {"type": "T1"},
        "input_mean": {"type": "T2"},
        "input_var": {"type": "T2"}
      },
      "outputs": {
        "Y": {"type": "T"},
        "running_mean": {"type": "T2"},
        "running_var": {"type": "T2"}
      },
      "types": {
        "T": ["float32", "float16", "bfloat16", "float64"],
        "T1": ["float32", "float16", "bfloat16", "float64"],
        "T2": ["float32", "float16", "bfloat16", "float64"]
      }
    },
    {
      "op_type": "Conv",
      "version": 1,
      "attributes": {
        "auto_pad": {"type": "string8"}, // "SAME_UPPER", "SAME_LOWER", "VALID"
        "dilations": {"type": "int64"}, // list, defaults = 1
        "group": {"type": "int64"}, // default = 1
        "kernel_shape": {"type": "int64"}, // list, default = input tensor W
        "pads": {"type": "int64"}, // list [x1_begin, x2_begin...x1_end, x2_end,...], defaults = 0
        "strides": {"type": "int64"} // list, defaults = 1
      },
      "inputs": {
        "X": {"type": "T"},
        "W": {"type": "T"},
        "B": {"type": "T"} // optional, size M
      },
      "outputs": {
        "Y": {"type": "T"}
      },
      "types": {"T": ["float32", "float16", "float64"]}
    },
    {
      "op_type": "Conv",
      "version": 15, // No difference from 1 or 11 (except clarification that strides default to 1).
      "attributes": {
        "auto_pad": {"type": "string8"}, // "SAME_UPPER", "SAME_LOWER", "VALID", "NOTSET"
        "dilations": {"type": "int64"}, // list, defaults = 1
        "group": {"type": "int64"}, // default = 1
        "kernel_shape": {"type": "int64"}, // list, default = input tensor W
        "pads": {"type": "int64"}, // list [x1_begin, x2_begin...x1_end, x2_end,...], defaults = 0
        "strides": {"type": "int64"} // list, defaults = 1
      },
      "inputs": {
        "X": {"type": "T"},
        "W": {"type": "T"},
        "B": {"type": "T"} // optional, size M
      },
      "outputs": {
        "Y": {"type": "T"}
      },
      "types": {"T": ["float32", "float16", "float64"]}
    }
  ]
}
```