### PR TITLE
Fix orttraining-linux-ci-pipeline - Symbolic shape infer

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -727,7 +727,7 @@ def is_docker():
 def install_python_deps(numpy_version=""):
     dep_packages = ["setuptools", "wheel", "pytest"]
     dep_packages.append("numpy=={}".format(numpy_version) if numpy_version else "numpy>=1.16.6")
-    dep_packages.append("sympy>=1.1")
+    dep_packages.append("sympy>=1.10")
     dep_packages.append("packaging")
     dep_packages.append("cerberus")
     run_subprocess([sys.executable, "-m", "pip", "install"] + dep_packages)

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -5,5 +5,5 @@ setuptools>=41.4.0
 wheel
 onnx==1.12.0
 protobuf==3.18.1
-sympy==1.1.1
+sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -6,6 +6,6 @@ setuptools>=41.4.0
 wheel>=0.35.1
 onnx==1.12.0
 argparse
-sympy==1.1.1
+sympy==1.10.1
 flatbuffers
 protobuf==3.18.1


### PR DESCRIPTION
**Description**: Describe your changes.

fix symbolic shape error due to upgraded numpy + legacy sympy

    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/onnxruntime/tools/symbolic_shape_infer.py", line 2127, in _infer_impl
      self.dispatcher_[node.op_type](node)
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/onnxruntime/tools/symbolic_shape_infer.py", line 1700, in _infer_Slice
      new_sympy_shape[i] = sympy.simplify((e - s + t + (-1 if t > 0 else 1)) // t)
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sympy/simplify/simplify.py", line 508, in simplify
      expr = sympify(expr)
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sympy/core/sympify.py", line 266, in sympify
      return func(np.asscalar(a))
    File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/numpy/__init__.py", line 311, in __getattr__
      raise AttributeError("module {!r} has no attribute "
  AttributeError: module 'numpy' has no attribute 'asscalar'

June 23, numpy upgraded on PYPI. The sympy version we used is old, which used a deprecated numpy function. 

  Collecting sympy==1.1.1
    Downloading sympy-1.1.1.tar.gz (4.6 MB)
  
  Collecting numpy>=1.16.6
    Downloading numpy-1.23.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.1/17.1 MB 137.9 MB/s eta 0:00:00

The version controlled sympy for orttraining-linux-ci-pipeline is:

    $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt

But I fixed other two places for parity. Let me know if you think they are not required. 


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
