### PR TITLE
Add warning about future computation change for ConvTranspose with auto_pad

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.h
@@ -25,7 +25,14 @@ namespace onnxruntime {
 template <typename T>
 class ConvTranspose : public OpKernel {
  public:
-  ConvTranspose(const OpKernelInfo& info) : OpKernel(info), conv_transpose_attrs_(info) {}
+  ConvTranspose(const OpKernelInfo& info) : OpKernel(info), conv_transpose_attrs_(info) {
+    if (auto_pad == AutoPadType::SAME_UPPER || auto_pad == AutoPadType::SAME_LOWER) {
+      // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
+      LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"
+                            << " SAME_UPPER/SAME_LOWER will be fixed in next ORT 1.13 release and hence the"
+                            << " results of ConvTranspose operator using the above auto_pad type(s) will be different.";
+    }
+  }
 
   Status PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
                  /*out*/ bool& is_packed,

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.h
@@ -26,13 +26,8 @@ template <typename T>
 class ConvTranspose : public OpKernel {
  public:
   ConvTranspose(const OpKernelInfo& info) : OpKernel(info), conv_transpose_attrs_(info) {
-    AutoPadType auto_pad = AutoPadType::NOTSET;
-    std::string auto_pad_str;
-    auto status = info.GetAttr<std::string>("auto_pad", &auto_pad_str);
-    if (status.IsOK()) {
-      auto_pad = StringToAutoPadType(auto_pad_str);
-    }
-    if (auto_pad == AutoPadType::SAME_UPPER || auto_pad == AutoPadType::SAME_LOWER) {
+    if (conv_transpose_attrs_.auto_pad == AutoPadType::SAME_UPPER ||
+        conv_transpose_attrs_.auto_pad == AutoPadType::SAME_LOWER) {
       // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
       LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"
                             << " SAME_UPPER/SAME_LOWER will be fixed in next ORT 1.13 release and hence the"

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.h
@@ -26,6 +26,12 @@ template <typename T>
 class ConvTranspose : public OpKernel {
  public:
   ConvTranspose(const OpKernelInfo& info) : OpKernel(info), conv_transpose_attrs_(info) {
+    AutoPadType auto_pad = AutoPadType::NOTSET;
+    std::string auto_pad_str;
+    auto status = info.GetAttr<std::string>("auto_pad", &auto_pad_str);
+    if (status.IsOK()) {
+      auto_pad = StringToAutoPadType(auto_pad_str);
+    }
     if (auto_pad == AutoPadType::SAME_UPPER || auto_pad == AutoPadType::SAME_LOWER) {
       // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
       LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,13 +176,17 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
-    // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
-    LOGS_DEFAULT(WARNING) << "The pad result for SAME_UPPER and SAME_LOWER will be corrected in next ORT 1.13 release.";
+    if (pad_type != AutoPadType::NOTSET) {
+      // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
+      LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"
+                            << " SAME_UPPER/SAME_LOWER/VALID will be fixed in next ORT 1.13 release and hence the"
+                            << " results of ConvTranspose operator using the above auto_pad type(s) will be different.";
+    }
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;
       pad_tail = total_pad / 2;
     } else {
-      // for pad_type is NOTSET, SAME_LOWER or VALID
+      // for pad_type is SAME_LOWER or VALID
       // set pad_head as total_pad/2, pad_tail as total_pad-total_pad/2.
       // That said, we pad more on tail when total_pad is odd.
       pad_head = total_pad / 2;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,8 +176,8 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
-    // TODO (#9740) ORT 1.13 we will correct the logic in the following lines
-    LOGS_DEFAULT(WARNING) << "The pad result for SAME_UPPER and SAME_LOWER will be corrected in next ORT 1.13.";
+    // TODO (#9740) ORT 1.13 will correct the logic by switching them to meet ONNX spec
+    LOGS_DEFAULT(WARNING) << "The pad result for SAME_UPPER and SAME_LOWER will be corrected in next ORT 1.13 release.";
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;
       pad_tail = total_pad / 2;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,17 +176,11 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
-    if (pad_type == AutoPadType::SAME_UPPER || pad_type == AutoPadType::SAME_LOWER) {
-      // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
-      LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"
-                            << " SAME_UPPER/SAME_LOWER will be fixed in next ORT 1.13 release and hence the"
-                            << " results of ConvTranspose operator using the above auto_pad type(s) will be different.";
-    }
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;
       pad_tail = total_pad / 2;
     } else {
-      // for pad_type is SAME_LOWER
+      // for pad_type is NOTSET, SAME_LOWER or VALID
       // set pad_head as total_pad/2, pad_tail as total_pad-total_pad/2.
       // That said, we pad more on tail when total_pad is odd.
       pad_head = total_pad / 2;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,6 +176,8 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
+    // TODO (#9740) ORT 1.13 we will correct the logic in the following lines
+    LOGS_DEFAULT(WARNING) << "The pad result for SAME_UPPER and SAME_LOWER will be corrected in next ORT 1.13.";
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;
       pad_tail = total_pad / 2;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,7 +176,7 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
-    // TODO (#9740) ORT 1.13 will correct the logic by switching them to meet ONNX spec
+    // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
     LOGS_DEFAULT(WARNING) << "The pad result for SAME_UPPER and SAME_LOWER will be corrected in next ORT 1.13 release.";
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose_attributes.h
@@ -176,17 +176,17 @@ struct ConvTransposeAttributes : public ConvAttributes {
 
   void DistributePadding(AutoPadType pad_type, const int64_t& total_pad,
                          int64_t& pad_head, int64_t& pad_tail) const {
-    if (pad_type != AutoPadType::NOTSET) {
+    if (pad_type == AutoPadType::SAME_UPPER || pad_type == AutoPadType::SAME_LOWER) {
       // TODO(jcwchen): #9740 ORT 1.13 will correct the logic by switching them to meet ONNX spec
       LOGS_DEFAULT(WARNING) << "The existing bug in the padding distribution for auto_pad type"
-                            << " SAME_UPPER/SAME_LOWER/VALID will be fixed in next ORT 1.13 release and hence the"
+                            << " SAME_UPPER/SAME_LOWER will be fixed in next ORT 1.13 release and hence the"
                             << " results of ConvTranspose operator using the above auto_pad type(s) will be different.";
     }
     if (pad_type == AutoPadType::SAME_UPPER) {  // pad more on head when total_pad is odd.
       pad_head = total_pad - total_pad / 2;
       pad_tail = total_pad / 2;
     } else {
-      // for pad_type is SAME_LOWER or VALID
+      // for pad_type is SAME_LOWER
       // set pad_head as total_pad/2, pad_tail as total_pad-total_pad/2.
       // That said, we pad more on tail when total_pad is odd.
       pad_head = total_pad / 2;


### PR DESCRIPTION
**Description**:
Add a warning about future computation change for ConvTranspose with auto_pad (SAME_UPPER and SAME_LOWER).

Perhaps we can just merge this PR to ORT's 1.12 release branch and merge my fix #9740 into the main branch?

**Motivation and Context**
Warning for future fix: #9740 in next ORT 1.13 release since it might compromise backward compatibility.

I am not sure whether it is the right way to show backward compatibility warning. Please review it. Thanks!
cc @pranavsharma, @hariharans29