### PR TITLE
avoid duplicate input/output info in value info when serialize to graph proto

### DIFF
--- a/onnxruntime/core/graph/graph_proto_serializer.cc
+++ b/onnxruntime/core/graph/graph_proto_serializer.cc
@@ -5,8 +5,8 @@
 
 namespace onnxruntime {
 
-void GraphViewerToProto(const GraphViewer& graph_view, 
-                        ONNX_NAMESPACE::GraphProto& graph_proto, 
+void GraphViewerToProto(const GraphViewer& graph_view,
+                        ONNX_NAMESPACE::GraphProto& graph_proto,
                         bool include_initializer,
                         bool include_outer_scope_args) {
   graph_proto.set_name(graph_view.Name());
@@ -21,10 +21,18 @@ void GraphViewerToProto(const GraphViewer& graph_view,
   }
 
   for (const auto* value_info : graph_view.GetValueInfo()) {
-    *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
+    auto input_it = std::find_if(graph_view.GetInputsIncludingInitializers().begin(),
+                                 graph_view.GetInputsIncludingInitializers().end(),
+                                 [value_info](const NodeArg* arg) { return arg && arg->Name() == value_info->Name(); });
+    auto output_it = std::find_if(graph_view.GetOutputs().begin(),
+                                  graph_view.GetOutputs().end(),
+                                  [value_info](const NodeArg* arg) { return arg && arg->Name() == value_info->Name(); });
+    if (input_it == graph_view.GetInputsIncludingInitializers().end() &&
+        output_it == graph_view.GetOutputs().end())
+      *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
   }
 
-  if (include_outer_scope_args){
+  if (include_outer_scope_args) {
     // add the NodeArg info for outer scope NodeArgs so we capture the type information
     for (const auto& name : graph_view.GetOuterScopeNodeArgNames()) {
       auto* node_arg = graph_view.GetNodeArg(name);
@@ -32,7 +40,7 @@ void GraphViewerToProto(const GraphViewer& graph_view,
       *(graph_proto.mutable_value_info()->Add()) = node_arg->ToProto();
     }
   }
-  
+
   // Nodes must be sorted in Topological Order in the GraphProto per ONNX spec.
   for (auto& node_idx : graph_view.GetNodesInTopologicalOrder()) {
     const gsl::not_null<ONNX_NAMESPACE::NodeProto*> node_proto{graph_proto.add_node()};
@@ -51,7 +59,6 @@ void GraphViewerToProto(const GraphViewer& graph_view,
       *p_initializer = *(it.second);
       current_scope_initializer_set.insert(it.first);
     }
-
 
     // handle outer scope value which is a constant initializer
     if (include_outer_scope_args) {
@@ -72,4 +79,4 @@ void GraphViewerToProto(const GraphViewer& graph_view,
   }
 }
 
-}
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Avoid duplicate input/output info when serialize value info in graph proot.

**Motivation and Context**
fix issue #11921 
