### PR TITLE
[C# Tests] Add support for double tensor output in TestPreTrainedModels.

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         [Fact(DisplayName = "TestSessionOptions")]
         public void TestSessionOptions()
         {
-            // get instance to setup logging 
+            // get instance to setup logging
             var ortEnvInstance = OrtEnv.Instance();
 
             using (SessionOptions opt = new SessionOptions())
@@ -1938,7 +1938,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 var session = (deviceId.HasValue)
                     ? new InferenceSession(model, option)
                     : new InferenceSession(model);
-                float[] inputData = TestDataLoader.LoadTensorFromEmbeddedResource("bench.in"); 
+                float[] inputData = TestDataLoader.LoadTensorFromEmbeddedResource("bench.in");
                 float[] expectedOutput = TestDataLoader.LoadTensorFromEmbeddedResource("bench.expected_out");
                 var inputMeta = session.InputMetadata;
                 var tensor = new DenseTensor<float>(inputData, inputMeta["data_0"].Dimensions);
@@ -1956,6 +1956,21 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 return Math.Abs(x - y) <= (atol + rtol * Math.Abs(y));
             }
             public int GetHashCode(float x)
+            {
+                return x.GetHashCode();
+            }
+        }
+
+        internal class DoubleComparer : IEqualityComparer<double>
+        {
+            private double atol = 1e-3;
+            private double rtol = 1.7e-2;
+
+            public bool Equals(double x, double y)
+            {
+                return Math.Abs(x - y) <= (atol + rtol * Math.Abs(y));
+            }
+            public int GetHashCode(double x)
             {
                 return x.GetHashCode();
             }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -518,6 +518,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                                     {
                                         Assert.Equal(result.AsTensor<float>(), outputValue.AsTensor<float>(), new FloatComparer());
                                     }
+                                    else if (outputMeta.ElementType == typeof(double))
+                                    {
+                                        Assert.Equal(result.AsTensor<double>(), outputValue.AsTensor<double>(), new DoubleComparer());
+                                    }
                                     else if (outputMeta.ElementType == typeof(int))
                                     {
                                         Assert.Equal(result.AsTensor<int>(), outputValue.AsTensor<int>(), new ExactComparer<int>());
@@ -560,12 +564,12 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                                     }
                                     else
                                     {
-                                        Assert.True(false, "The TestPretrainedModels does not yet support output of type " + nameof(outputMeta.ElementType));
+                                        Assert.True(false, $"{nameof(TestPreTrainedModels)} does not yet support output of type {outputMeta.ElementType}");
                                     }
                                 }
                                 else
                                 {
-                                    Assert.True(false, "TestPretrainedModel cannot handle non-tensor outputs yet");
+                                    Assert.True(false, $"{nameof(TestPreTrainedModels)} cannot handle non-tensor outputs yet");
                                 }
                             }
                         }


### PR DESCRIPTION
**Description**
Add support for comparing double tensor output in TestPreTrainedModels.

**Motivation and Context**
Fix some test failures for ONNX tests that have double tensor outputs.
