### PR TITLE
DML EP ResNet50 opset 15 fails in ONNX checker for FusedBatchNormalization lacking training_mode attribute

### DIFF
--- a/onnxruntime/core/graph/dml_ops/dml_defs.cc
+++ b/onnxruntime/core/graph/dml_ops/dml_defs.cc
@@ -108,6 +108,7 @@ void RegisterDmlSchemas() {
     .Attr("spatial", "", AttributeProto::INT, static_cast<int64_t>(1))
     .Attr("epsilon", "", AttributeProto::FLOAT, 1e-5f)
     .Attr("momentum", "", AttributeProto::FLOAT, 0.9f)
+    .Attr("training_mode", "", AttributeProto::INT, static_cast<int64_t>(0))
     .Input(0, "X", "", "T")
     .Input(1, "scale", "", "T")
     .Input(2, "B", "", "T")


### PR DESCRIPTION
**Description**: ResNet 50 fails to execute with opset 15 (opset 12 works fine) via the DML EP because the ONNX checker/validator code sees an unrecognized "training_mode" attribute. The fusion code unifies BatchNorm + Relu and copies the attributes, including new default values for attributes that aren't even in the model (you won't find "training_mode" in the file). This just adds that attribute to `FusedBatchNormalization` under `com.microsoft.dml` (and so shouldn't affect other EP's).

**Motivation and Context**
- *Why is this change required? What problem does it solve?*  A popular model fails.
- *If it fixes an open issue, please link to the issue here.* NA