### PR TITLE
[java] First part of the JNI error handling rewrite

### DIFF
--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -82,11 +82,11 @@ jint convertFromONNXDataFormat(ONNXTensorElementDataType type) {
             return 3;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   // maps to c type int16_t
             return 4;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:      // maps to c type uint32_t
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  // maps to c type uint32_t
             return 5;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   // maps to c type int32_t
             return 6;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:      // maps to c type uint64_t
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:  // maps to c type uint64_t
             return 7;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:   // maps to c type int64_t
             return 8;
@@ -94,7 +94,7 @@ jint convertFromONNXDataFormat(ONNXTensorElementDataType type) {
             return 9;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   // maps to c type float
             return 10;
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:      // maps to c type double
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:  // maps to c type double
             return 11;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:  // maps to c++ type std::string
             return 12;
@@ -1029,19 +1029,23 @@ jint convertErrorCode(OrtErrorCode code) {
     }
 }
 
-void checkOrtStatus(JNIEnv *jniEnv, const OrtApi * api, OrtStatus * status) {
-    if (status == NULL) return;
+OrtErrorCode checkOrtStatus(JNIEnv *jniEnv, const OrtApi * api, OrtStatus * status) {
+    if (status == NULL) {
+        return ORT_OK;
+    }
     const char* message = api->GetErrorMessage(status);
+    OrtErrorCode errCode = api->GetErrorCode(status);
     size_t len = strlen(message)+1;
     char* copy = malloc(sizeof(char)*len);
     if (copy == NULL) {
       throwOrtException(jniEnv, 1, "Not enough memory");
-      return;
+      return ORT_FAIL;
     }
     memcpy(copy,message,len);
-    int messageId = convertErrorCode(api->GetErrorCode(status));
+    int messageId = convertErrorCode(errCode);
     api->ReleaseStatus(status);
     throwOrtException(jniEnv,messageId,copy);
+    return errCode;
 }
 
 jsize safecast_size_t_to_jsize(size_t v) {

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -73,7 +73,7 @@ jint throwOrtException(JNIEnv *env, int messageId, const char *message);
 
 jint convertErrorCode(OrtErrorCode code);
 
-void checkOrtStatus(JNIEnv * env, const OrtApi * api, OrtStatus * status);
+OrtErrorCode checkOrtStatus(JNIEnv * env, const OrtApi * api, OrtStatus * status);
 
 #ifdef __cplusplus
 }

--- a/java/src/main/native/ai_onnxruntime_OnnxMap.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxMap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -19,14 +19,17 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxMap_getStringKeys
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract key
     OrtValue* keys;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,0,allocator,&keys));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,0,allocator,&keys));
+    if (code == ORT_OK) {
+      // Convert to Java String array
+      jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
 
-    // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
+      api->ReleaseValue(keys);
 
-    api->ReleaseValue(keys);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*
@@ -41,13 +44,16 @@ JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxMap_getLongKeys
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract key
     OrtValue* keys;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,0,allocator,&keys));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,0,allocator,&keys));
+    if (code == ORT_OK) {
+      jlongArray output = createLongArrayFromTensor(jniEnv, api, keys);
 
-    jlongArray output = createLongArrayFromTensor(jniEnv, api, keys);
+      api->ReleaseValue(keys);
 
-    api->ReleaseValue(keys);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*
@@ -62,14 +68,17 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxMap_getStringValues
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract value
     OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    if (code == ORT_OK) {
+      // Convert to Java String array
+      jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, values);
 
-    // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, values);
+      api->ReleaseValue(values);
 
-    api->ReleaseValue(values);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*
@@ -84,13 +93,16 @@ JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxMap_getLongValues
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract value
     OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    if (code == ORT_OK) {
+      jlongArray output = createLongArrayFromTensor(jniEnv, api, values);
 
-    jlongArray output = createLongArrayFromTensor(jniEnv, api, values);
+      api->ReleaseValue(values);
 
-    api->ReleaseValue(values);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*
@@ -105,13 +117,16 @@ JNIEXPORT jfloatArray JNICALL Java_ai_onnxruntime_OnnxMap_getFloatValues
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract value
     OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    if (code == ORT_OK) {
+      jfloatArray output = createFloatArrayFromTensor(jniEnv, api, values);
 
-    jfloatArray output = createFloatArrayFromTensor(jniEnv, api, values);
+      api->ReleaseValue(values);
 
-    api->ReleaseValue(values);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*
@@ -126,13 +141,16 @@ JNIEXPORT jdoubleArray JNICALL Java_ai_onnxruntime_OnnxMap_getDoubleValues
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Extract value
     OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,1,allocator,&values));
+    if (code == ORT_OK) {
+      jdoubleArray output = createDoubleArrayFromTensor(jniEnv, api, values);
 
-    jdoubleArray output = createDoubleArrayFromTensor(jniEnv, api, values);
+      api->ReleaseValue(values);
 
-    api->ReleaseValue(values);
-
-    return output;
+      return output;
+    } else {
+      return NULL;
+    }
 }
 
 /*

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -33,22 +33,24 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxRuntime_getAvailableProvi
   int numProviders = 0;
 
   // Extract the provider array
-  checkOrtStatus(jniEnv,api,api->GetAvailableProviders(&providers,&numProviders));
+  jobjectArray providerArray = NULL;
+  OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetAvailableProviders(&providers,&numProviders));
+  if (code == ORT_OK) {
+    // Convert to Java String Array
+    char *stringClassName = "java/lang/String";
+    jclass stringClazz = (*jniEnv)->FindClass(jniEnv, stringClassName);
+    providerArray = (*jniEnv)->NewObjectArray(jniEnv,numProviders,stringClazz,NULL);
 
-  // Convert to Java String Array
-  char *stringClassName = "java/lang/String";
-  jclass stringClazz = (*jniEnv)->FindClass(jniEnv, stringClassName);
-  jobjectArray providerArray = (*jniEnv)->NewObjectArray(jniEnv,numProviders,stringClazz,NULL);
+    for (int i = 0; i < numProviders; i++) {
+      // Read out the provider name and convert it to a java.lang.String
+      jstring provider = (*jniEnv)->NewStringUTF(jniEnv,providers[i]);
+      (*jniEnv)->SetObjectArrayElement(jniEnv, providerArray, i, provider);
+    }
 
-  for (int i = 0; i < numProviders; i++) {
-    // Read out the provider name and convert it to a java.lang.String
-    jstring provider = (*jniEnv)->NewStringUTF(jniEnv,providers[i]);
-    (*jniEnv)->SetObjectArrayElement(jniEnv, providerArray, i, provider);
+    // Release providers
+    // if this fails we return immediately anyway
+    checkOrtStatus(jniEnv,api,api->ReleaseAvailableProviders(providers,numProviders));
+    providers = NULL;
   }
-
-  // Release providers
-  checkOrtStatus(jniEnv,api,api->ReleaseAvailableProviders(providers,numProviders));
-  providers = NULL;
-
   return providerArray;
 }

--- a/java/src/main/native/ai_onnxruntime_OnnxSequence.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxSequence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -16,20 +16,25 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringKeys
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jobjectArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract keys from element
+      OrtValue* keys;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,0,allocator,&keys));
 
-    // Extract keys from element
-    OrtValue* keys;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,0,allocator,&keys));
+      if (code == ORT_OK) {
+        // Convert to Java String array
+        output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
-
-    api->ReleaseValue(keys);
-    api->ReleaseValue(element);
-
+      // Keys is valid, so release
+      api->ReleaseValue(keys);
+    }
     return output;
 }
 
@@ -43,19 +48,25 @@ JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxSequence_getLongKeys
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jlongArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract keys from element
+      OrtValue* keys;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,0,allocator,&keys));
 
-    // Extract keys from element
-    OrtValue* keys;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,0,allocator,&keys));
+      if (code == ORT_OK) {
+        // Convert to Java long array
+        output = createLongArrayFromTensor(jniEnv, api, keys);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    jlongArray output = createLongArrayFromTensor(jniEnv, api, keys);
-
-    api->ReleaseValue(keys);
-    api->ReleaseValue(element);
-
+      // Keys is valid, so release
+      api->ReleaseValue(keys);
+    }
     return output;
 }
 
@@ -69,20 +80,25 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringValues
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jobjectArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract values from element
+      OrtValue* values;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
 
-    // Extract values from element
-    OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
+      if (code == ORT_OK) {
+        // Convert to Java String array
+        output = createStringArrayFromTensor(jniEnv, api, allocator, values);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, values);
-
-    api->ReleaseValue(values);
-    api->ReleaseValue(element);
-
+      // values is valid, so release
+      api->ReleaseValue(values);
+    }
     return output;
 }
 
@@ -96,19 +112,25 @@ JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxSequence_getLongValues
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jlongArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract values from element
+      OrtValue* values;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
 
-    // Extract values from element
-    OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
+      if (code == ORT_OK) {
+        // Convert to Java long array
+        output = createLongArrayFromTensor(jniEnv, api, values);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    jlongArray output = createLongArrayFromTensor(jniEnv, api, values);
-
-    api->ReleaseValue(values);
-    api->ReleaseValue(element);
-
+      // values is valid, so release
+      api->ReleaseValue(values);
+    }
     return output;
 }
 
@@ -122,19 +144,25 @@ JNIEXPORT jfloatArray JNICALL Java_ai_onnxruntime_OnnxSequence_getFloatValues
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jfloatArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract values from element
+      OrtValue* values;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
 
-    // Extract values from element
-    OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
+      if (code == ORT_OK) {
+        // Convert to Java float array
+        output = createFloatArrayFromTensor(jniEnv, api, values);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    jfloatArray output = createFloatArrayFromTensor(jniEnv, api,values);
-
-    api->ReleaseValue(values);
-    api->ReleaseValue(element);
-
+      // values is valid, so release
+      api->ReleaseValue(values);
+    }
     return output;
 }
 
@@ -148,19 +176,25 @@ JNIEXPORT jdoubleArray JNICALL Java_ai_onnxruntime_OnnxSequence_getDoubleValues
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jdoubleArray output = NULL;
     // Extract element
     OrtValue* element;
-    checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValue((OrtValue*)handle,index,allocator,&element));
+    if (code == ORT_OK) {
+      // Extract values from element
+      OrtValue* values;
+      code = checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
 
-    // Extract values from element
-    OrtValue* values;
-    checkOrtStatus(jniEnv,api,api->GetValue(element,1,allocator,&values));
+      if (code == ORT_OK) {
+        // Convert to Java double array
+        output = createDoubleArrayFromTensor(jniEnv, api, values);
+        // Release if valid
+        api->ReleaseValue(element);
+      }
 
-    jdoubleArray output = createDoubleArrayFromTensor(jniEnv, api,values);
-
-    api->ReleaseValue(values);
-    api->ReleaseValue(element);
-
+      // values is valid, so release
+      api->ReleaseValue(values);
+    }
     return output;
 }
 
@@ -176,22 +210,34 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStrings
     OrtValue* sequence = (OrtValue*) handle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
 
+    jobjectArray outputArray = NULL;
+
     // Get the element count of this sequence
     size_t count;
-    checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    if (code == ORT_OK) {
+      jclass stringClazz = (*jniEnv)->FindClass(jniEnv,"java/lang/String");
+      outputArray = (*jniEnv)->NewObjectArray(jniEnv,safecast_size_t_to_jsize(count),stringClazz, NULL);
+      for (size_t i = 0; i < count; i++) {
+          // Extract element
+          OrtValue* element;
+          code = checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+          if (code == ORT_OK) {
+            jobject str = createStringFromStringTensor(jniEnv,api,allocator,element);
+            if (str == NULL) {
+              api->ReleaseValue(element);
+              // bail out as exception has been thrown
+              return NULL;
+            }
+            (*jniEnv)->SetObjectArrayElement(jniEnv, outputArray, i, str);
 
-    jclass stringClazz = (*jniEnv)->FindClass(jniEnv,"java/lang/String");
-    jobjectArray outputArray = (*jniEnv)->NewObjectArray(jniEnv,safecast_size_t_to_jsize(count),stringClazz, NULL);
-    for (size_t i = 0; i < count; i++) {
-        // Extract element
-        OrtValue* element;
-        checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
-
-        createStringFromStringTensor(jniEnv,api,allocator,element);
-
-        api->ReleaseValue(element);
+            api->ReleaseValue(element);
+          } else {
+              // bail out as exception has been thrown
+              return NULL;
+          }
+      }
     }
-
     return outputArray;
 }
 
@@ -206,32 +252,46 @@ JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxSequence_getLongs
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* sequence = (OrtValue*) handle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jlongArray outputArray = NULL;
 
     // Get the element count of this sequence
     size_t count;
-    checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    if (code == ORT_OK) {
+      int64_t* values;
+      code = checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(int64_t)*count,(void**)&values));
+      if (code == ORT_OK) {
+        for (size_t i = 0; i < count; i++) {
+            // Extract element
+            OrtValue* element;
+            code = checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+            if (code == ORT_OK) {
+              // Extract the values
+              int64_t* arr;
+              code = checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
+              if (code == ORT_OK) {
+                values[i] = arr[0];
+              } else {
+                // bail out as exception has been thrown
+                api->ReleaseValue(element);
+                checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+                return NULL;
+              }
 
-    int64_t* values;
-    checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(int64_t)*count,(void**)&values));
+              api->ReleaseValue(element);
+            } else {
+              // bail out as exception has been thrown
+              checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+              return NULL;
+            }
+        }
 
-    for (size_t i = 0; i < count; i++) {
-        // Extract element
-        OrtValue* element;
-        checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+        outputArray = (*jniEnv)->NewLongArray(jniEnv,safecast_size_t_to_jsize(count));
+        (*jniEnv)->SetLongArrayRegion(jniEnv, outputArray,0,safecast_size_t_to_jsize(count),(jlong*)values);
 
-        // Extract the values
-        int64_t* arr;
-        checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
-        values[i] = arr[0];
-
-        api->ReleaseValue(element);
+        checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+      }
     }
-
-    jlongArray outputArray = (*jniEnv)->NewLongArray(jniEnv,safecast_size_t_to_jsize(count));
-    (*jniEnv)->SetLongArrayRegion(jniEnv, outputArray,0,safecast_size_t_to_jsize(count),(jlong*)values);
-
-    checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
-
     return outputArray;
 }
 
@@ -246,32 +306,46 @@ JNIEXPORT jfloatArray JNICALL Java_ai_onnxruntime_OnnxSequence_getFloats
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* sequence = (OrtValue*) handle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jfloatArray outputArray = NULL;
 
     // Get the element count of this sequence
     size_t count;
-    checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    if (code == ORT_OK) {
+      float* values;
+      code = checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(float)*count,(void**)&values));
+      if (code == ORT_OK) {
+        for (size_t i = 0; i < count; i++) {
+            // Extract element
+            OrtValue* element;
+            code = checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+            if (code == ORT_OK) {
+              // Extract the values
+              float* arr;
+              code = checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
+              if (code == ORT_OK) {
+                values[i] = arr[0];
+              } else {
+                // bail out as exception has been thrown
+                api->ReleaseValue(element);
+                checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+                return NULL;
+              }
 
-    float* values;
-    checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(float)*count,(void**)&values));
+              api->ReleaseValue(element);
+            } else {
+              // bail out as exception has been thrown
+              checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+              return NULL;
+            }
+        }
 
-    for (size_t i = 0; i < count; i++) {
-        // Extract element
-        OrtValue* element;
-        checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+        outputArray = (*jniEnv)->NewFloatArray(jniEnv,safecast_size_t_to_jsize(count));
+        (*jniEnv)->SetFloatArrayRegion(jniEnv, outputArray,0,safecast_size_t_to_jsize(count),values);
 
-        // Extract the values
-        float* arr;
-        checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
-        values[i] = arr[0];
-
-        api->ReleaseValue(element);
+        checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+      }
     }
-
-    jfloatArray outputArray = (*jniEnv)->NewFloatArray(jniEnv,safecast_size_t_to_jsize(count));
-    (*jniEnv)->SetFloatArrayRegion(jniEnv,outputArray,0,safecast_size_t_to_jsize(count),values);
-
-    checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
-
     return outputArray;
 }
 
@@ -286,32 +360,46 @@ JNIEXPORT jdoubleArray JNICALL Java_ai_onnxruntime_OnnxSequence_getDoubles
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* sequence = (OrtValue*) handle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+    jdoubleArray outputArray = NULL;
 
     // Get the element count of this sequence
     size_t count;
-    checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetValueCount(sequence,&count));
+    if (code == ORT_OK) {
+      double* values;
+      code = checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(double)*count,(void**)&values));
+      if (code == ORT_OK) {
+        for (size_t i = 0; i < count; i++) {
+            // Extract element
+            OrtValue* element;
+            code = checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+            if (code == ORT_OK) {
+              // Extract the values
+              double* arr;
+              code = checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
+              if (code == ORT_OK) {
+                values[i] = arr[0];
+              } else {
+                // bail out as exception has been thrown
+                api->ReleaseValue(element);
+                checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+                return NULL;
+              }
 
-    double* values;
-    checkOrtStatus(jniEnv,api,api->AllocatorAlloc(allocator,sizeof(double)*count,(void**)&values));
+              api->ReleaseValue(element);
+            } else {
+              // bail out as exception has been thrown
+              checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+              return NULL;
+            }
+        }
 
-    for (size_t i = 0; i < count; i++) {
-        // Extract element
-        OrtValue* element;
-        checkOrtStatus(jniEnv,api,api->GetValue(sequence,(int)i,allocator,&element));
+        outputArray = (*jniEnv)->NewDoubleArray(jniEnv,safecast_size_t_to_jsize(count));
+        (*jniEnv)->SetDoubleArrayRegion(jniEnv, outputArray,0,safecast_size_t_to_jsize(count),values);
 
-        // Extract the values
-        double* arr;
-        checkOrtStatus(jniEnv,api,api->GetTensorMutableData(element,(void**)&arr));
-        values[i] = arr[0];
-
-        api->ReleaseValue(element);
+        checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
+      }
     }
-
-    jdoubleArray outputArray = (*jniEnv)->NewDoubleArray(jniEnv,safecast_size_t_to_jsize(count));
-    (*jniEnv)->SetDoubleArrayRegion(jniEnv,outputArray,0,safecast_size_t_to_jsize(count),values);
-
-    checkOrtStatus(jniEnv,api,api->AllocatorFree(allocator,values));
-
     return outputArray;
 }
 

--- a/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_RunOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -99,9 +99,13 @@ JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OrtSession_00024RunOptions_getRunT
   const OrtApi* api = (const OrtApi*) apiHandle;
   const char* runTagStr;
   // This is a reference to the C str, and should not be freed.
-  checkOrtStatus(jniEnv,api,api->RunOptionsGetRunTag((OrtRunOptions*)nativeHandle,&runTagStr));
-  jstring runTag = (*jniEnv)->NewStringUTF(jniEnv,runTagStr);
-  return runTag;
+  OrtErrorCode code = checkOrtStatus(jniEnv,api,api->RunOptionsGetRunTag((OrtRunOptions*)nativeHandle,&runTagStr));
+  if (code == ORT_OK) {
+    jstring runTag = (*jniEnv)->NewStringUTF(jniEnv,runTagStr);
+    return runTag;
+  } else {
+    return NULL;
+  }
 }
 
 /*

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -611,4 +611,3 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_addROC
     throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"This binary was not compiled with ROCM support.");
   #endif
 }
-


### PR DESCRIPTION
**Description**: This fixes error handling in the JNI code in OnnxMap, OnnxSequence, OnnxRuntime, RunOptions. SessionOptions and OrtEnvironment are correct as is.

The bulk of the work will be in rewriting OnnxTensor, OnnxSparseTensor (after the merge of #10653) and OrtSession, along with the helper methods in OrtJniUtil.

**Motivation and Context**
- Why is this change required? What problem does it solve? The current native interop code doesn't return control to Java immediately on throwing an exception from an ORT error code, which can cause incorrect interactions with native ORT, and issues with exception propagation on the Java side.
- If it fixes an open issue, please link to the issue here. Partial work towards solving #11451.
