### PR TITLE
Move beamsearch shared initializers from subgraphs to main graph

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -972,7 +972,11 @@ class OnnxModel:
 
     def remove_duplicated_initializer(self):
         """Remove initializers with duplicated values, and only keep the first one.
-        It could help reduce size of models (like ALBert) with shared weights."""
+        It could help reduce size of models (like ALBert) with shared weights.
+        Note: this function does not process subgraph.
+        """
+        if len(self.graphs()) > 1:
+            logger.warning("remove_duplicated_initializer does not process subgraphs.")
 
         initializer_count = len(self.model.graph.initializer)
 
@@ -999,9 +1003,10 @@ class OnnxModel:
     def add_prefix_to_names(self, prefix: str):
         """Add prefix to initializer or intermediate outputs in graph. Main graph inputs and outputs are excluded.
         It could help avoid conflicting in name of node_args when merging two graphs.
+        Note: this function does not process subgraph.
         """
         if len(self.graphs()) > 1:
-            info.warning("add_prefix_to_names does not process subgraphs.")
+            logger.warning("add_prefix_to_names does not process subgraphs.")
 
         # Exclude the names of inputs and outputs of main graph (but not subgraphs)
         excluded = [i.name for i in self.model.graph.input] + [o.name for o in self.model.graph.output]

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -11,17 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import numpy as np
-from onnx import (
-    AttributeProto,
-    ModelProto,
-    NodeProto,
-    TensorProto,
-    external_data_helper,
-    helper,
-    numpy_helper,
-    onnx_pb,
-    save_model,
-)
+from onnx import AttributeProto, GraphProto, ModelProto, NodeProto, TensorProto, helper, numpy_helper, save_model
 from shape_infer_helper import SymbolicShapeInferenceHelper
 
 logger = logging.getLogger(__name__)
@@ -32,7 +22,7 @@ class OnnxModel:
         self.initialize(model)
 
     def initialize(self, model):
-        self.model = model
+        self.model: ModelProto = model
         self._node_name_suffix: Dict[str, int] = {}  # key is node name prefix, value is the last suffix generated
         self.shape_infer_helper = None
         self.all_graphs = None
@@ -87,11 +77,11 @@ class OnnxModel:
             for node in graph.node:
                 for attr in node.attribute:
                     if attr.type == AttributeProto.AttributeType.GRAPH:
-                        assert isinstance(attr.g, onnx_pb.GraphProto)
+                        assert isinstance(attr.g, GraphProto)
                         graph_queue.append(attr.g)
                     if attr.type == AttributeProto.AttributeType.GRAPHS:
                         for g in attr.graphs:
-                            assert isinstance(g, onnx_pb.GraphProto)
+                            assert isinstance(g, GraphProto)
                             graph_queue.append(g)
         return self.all_graphs
 
@@ -174,7 +164,6 @@ class OnnxModel:
             if node.input[j] == old_input_name:
                 node.input[j] = new_input_name
 
-    # This function is deprecated since we use onnxconverter-common
     def replace_input_of_all_nodes(self, old_input_name, new_input_name):
         for node in self.model.graph.node:
             OnnxModel.replace_node_input(node, old_input_name, new_input_name)
@@ -186,7 +175,6 @@ class OnnxModel:
             if node.output[j] == old_output_name:
                 node.output[j] = new_output_name
 
-    # This function is deprecated since we use onnxconverter-common
     def replace_output_of_all_nodes(self, old_output_name, new_output_name):
         for node in self.model.graph.node:
             OnnxModel.replace_node_output(node, old_output_name, new_output_name)
@@ -410,8 +398,7 @@ class OnnxModel:
                     if att.name == "value":
                         return numpy_helper.to_array(att.t)
 
-        # Fall back to intializer since constant folding might have been
-        # applied.
+        # Fall back to intializer since constant folding might have been applied.
         initializer = self.get_initializer(output_name)
         if initializer is not None:
             return numpy_helper.to_array(initializer)
@@ -538,16 +525,6 @@ class OnnxModel:
             kwargs["keep_io_types"] = True
 
         def float_to_float16_func():
-            # TODO: import from onnxconverter_common when it is stable
-            # try:
-            #    import onnxconverter_common as oc
-            #    from packaging.version import Version
-            #    if Version(oc.__version__) > Version("1.9.0"):
-            #        from onnxconverter_common.float16 import convert_float_to_float16
-            #        return convert_float_to_float16
-            # except ImportError:
-            #    pass
-
             from float16 import convert_float_to_float16
 
             return convert_float_to_float16
@@ -968,3 +945,79 @@ class OnnxModel:
             if opset.domain in ["", "ai.onnx"]:
                 return opset.version
         raise RuntimeError("ONNX model has no opset for default domain")
+
+    @staticmethod
+    def has_same_value(tensor1: TensorProto, tensor2: TensorProto) -> bool:
+        """Returns True when two tensors have same value.
+           Note that name can be different.
+
+        Args:
+            tensor1 (TensorProto): initializer 1
+            tensor2 (TensorProto): initializer 2
+
+        Returns:
+            bool: True when two intializers has same value.
+        """
+        if tensor1.data_type != tensor2.data_type or tensor1.dims != tensor2.dims:
+            return False
+        if tensor1.HasField("raw_data") and tensor2.HasField("raw_data"):
+            return tensor1.raw_data == tensor2.raw_data
+        return numpy_helper.to_array(tensor1) == numpy_helper.to_array(tensor2)
+
+    def remove_duplicated_initializer(self):
+        """Remove initializers with duplicated values, and only keep the first one.
+        It could help reduce size of models (like ALBert) with shared weights."""
+
+        initializer_count = len(self.model.graph.initializer)
+
+        same = [-1] * initializer_count
+        for i in range(initializer_count - 1):
+            if same[i] >= 0:
+                continue
+            for j in range(i + 1, initializer_count):
+                if OnnxModel.has_same_value(self.model.graph.initializer[i], self.model.graph.initializer[j]):
+                    same[j] = i
+
+        count = 0
+        for i in range(initializer_count):
+            if same[i] >= 0:
+                count += 1
+                self.replace_input_of_all_nodes(
+                    self.model.graph.initializer[i].name, self.model.graph.initializer[same[i]].name
+                )
+
+        if count > 0:
+            self.update_graph()
+            print(f"Removed {count} initializers with duplicated value")
+
+    def add_prefix_to_names(self, prefix: str):
+        """Add prefix to initializer or intermediate outputs in graph. Main graph inputs and outputs are excluded.
+        It could help avoid conflicting in name of node_args when merging two graphs.
+        """
+        if len(self.graphs()) > 1:
+            info.warning("add_prefix_to_names does not process subgraphs.")
+
+        # Exclude the names of inputs and outputs of main graph (but not subgraphs)
+        excluded = [i.name for i in self.model.graph.input] + [o.name for o in self.model.graph.output]
+
+        for initializer in self.model.graph.initializer:
+            if initializer.name not in excluded:
+                if prefix + initializer.name not in excluded:
+                    initializer.name = prefix + initializer.name
+
+        for node in self.model.graph.node:
+            # update name of node inputs
+            for j in range(len(node.input)):
+                if node.input[j] not in excluded:
+                    if prefix + node.input[j] not in excluded:
+                        node.input[j] = prefix + node.input[j]
+
+            # update name of node outputs
+            for j in range(len(node.output)):
+                if node.output[j] not in excluded:
+                    if prefix + node.output[j] not in excluded:
+                        node.output[j] = prefix + node.output[j]
+
+        for value_info in self.model.graph.value_info:
+            if value_info.name not in excluded:
+                value_info.name = prefix + value_info.name

--- a/onnxruntime/test/python/transformers/test_beam_search.py
+++ b/onnxruntime/test/python/transformers/test_beam_search.py
@@ -57,8 +57,11 @@ class TestBeamSearchGpt(unittest.TestCase):
         if os.path.exists(self.beam_search_onnx_path):
             os.remove(self.beam_search_onnx_path)
 
-    def run_beam_search(self, extra_arguments: str, sentences=None):
-        arguments = " ".join(self.default_arguments + [extra_arguments]).split()
+    def run_beam_search(self, extra_arguments: str, sentences=None, append_arguments=True):
+        if append_arguments:
+            arguments = " ".join(self.default_arguments + [extra_arguments]).split()
+        else:
+            arguments = extra_arguments.split()
 
         # Test CPU
         result = run(arguments, sentences=self.sentences if sentences is None else sentences)
@@ -91,6 +94,12 @@ class TestBeamSearchGpt(unittest.TestCase):
     def test_no_repeat_ngram(self):
         for ngram_size in [1, 2]:
             self.run_beam_search(f"--no_repeat_ngram_size {ngram_size}")
+
+    @pytest.mark.slow
+    def test_external_data(self):
+        self.run_beam_search(
+            f"-m gpt2 -e --output {self.beam_search_onnx_path}", sentences=None, append_arguments=False
+        )
 
 
 class TestBeamSearchT5(unittest.TestCase):
@@ -151,8 +160,11 @@ class TestBeamSearchT5(unittest.TestCase):
         if os.path.exists(self.encoder_onnx_path):
             os.remove(self.encoder_onnx_path)
 
-    def run_beam_search(self, extra_arguments: str, sentences=None):
-        arguments = " ".join(self.default_arguments + [extra_arguments]).split()
+    def run_beam_search(self, extra_arguments: str, sentences=None, append_arguments=True):
+        if append_arguments:
+            arguments = " ".join(self.default_arguments + [extra_arguments]).split()
+        else:
+            arguments = extra_arguments.split()
 
         # Test CPU
         result = run(arguments, sentences=self.sentences if sentences is None else sentences)
@@ -185,6 +197,14 @@ class TestBeamSearchT5(unittest.TestCase):
     def test_no_repeat_ngram(self):
         for ngram_size in [1, 2]:
             self.run_beam_search(f"--no_repeat_ngram_size {ngram_size}")
+
+    @pytest.mark.slow
+    def test_external_data(self):
+        self.run_beam_search(
+            f"-m t5-small --model_type t5 -e --output {self.beam_search_onnx_path}",
+            sentences=None,
+            append_arguments=False,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**: 

Move shared initializers to main graph to save memory. This could avoid duplicated initializers in encoder and decoder subgraphs.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
