### PR TITLE
Fix windows eager build break by pinning to torch version 1.11.0

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
@@ -1,6 +1,6 @@
 --pre
 -f https://download.pytorch.org/whl/cpu/torch_stable.html
-torch>=1.10.0
+torch==1.11.0
 setuptools>=41.4.0
 cerberus
 h5py

--- a/tools/ci_build/github/windows/eager/requirements.txt
+++ b/tools/ci_build/github/windows/eager/requirements.txt
@@ -2,5 +2,4 @@ setuptools
 wheel
 numpy
 typing_extensions
-torch
-
+torch==1.11.0


### PR DESCRIPTION
**Description**: Pin windows eager build to torch version 1.11.0

**Motivation and Context**
Torch 1.1.2.0 was released, and it introduces new types (SymInt) and removes functions (like _cat) and more. Until we are ready to support it, we will pin to version 1.11.0.