### PR TITLE
Make C# runtest.sh automatically set latest opset

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -19,7 +19,7 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
     mkdir -p $BUILD_BINARIESDIRECTORY/models
-    ln -s $BUILD_SOURCESDIRECTORY/cmake/external/onnx/onnx/backend/test/data/node $BUILD_BINARIESDIRECTORY/models/opset16
+    ln -s $BUILD_SOURCESDIRECTORY/cmake/external/onnx/onnx/backend/test/data/node $BUILD_BINARIESDIRECTORY/models/opset17
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json
@@ -29,7 +29,7 @@ if [ $RunTestCsharp = "true" ]; then
   fi
 
   if [ $PACKAGENAME = "Microsoft.ML.OnnxRuntime.Gpu" ]; then
-    export TESTONGPU=ON 
+    export TESTONGPU=ON
     dotnet test -p:DefineConstants=USE_CUDA $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed
     if [ $? -ne 0 ]; then
       echo "Failed to build or execute the end-to-end test"

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -19,10 +19,11 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
     # TODO(#12040): The test should figure out the opset version from the model file. Remove it from the path.
-    ONNX_VERSION_NUMBER=$(cat cmake/external/onnx/VERSION_NUMBER | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-    OPSET_VERSION=$(grep ${ONNX_VERSION_NUMBER} cmake/external/onnx/docs/Versioning.md | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
+    ONNX_DIR=${BUILD_SOURCESDIRECTORY}/cmake/external/onnx
+    ONNX_VERSION_NUMBER=$(cat ${ONNX_DIR}/VERSION_NUMBER | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    OPSET_VERSION=$(grep ${ONNX_VERSION_NUMBER} ${ONNX_DIR}/docs/Versioning.md | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
     mkdir -p $BUILD_BINARIESDIRECTORY/models
-    ln -s ${BUILD_SOURCESDIRECTORY}/cmake/external/onnx/onnx/backend/test/data/node ${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERISON}
+    ln -s ${ONNX_DIR}/onnx/backend/test/data/node ${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERISON}
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -19,11 +19,11 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
     # TODO(#12040): The test should figure out the opset version from the model file. Remove it from the path.
-    ONNX_DIR=${BUILD_SOURCESDIRECTORY}/cmake/external/onnx
-    ONNX_VERSION_NUMBER=$(cat ${ONNX_DIR}/VERSION_NUMBER | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-    OPSET_VERSION=$(grep ${ONNX_VERSION_NUMBER} ${ONNX_DIR}/docs/Versioning.md | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
-    mkdir -p $BUILD_BINARIESDIRECTORY/models
-    ln -s ${ONNX_DIR}/onnx/backend/test/data/node ${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERISON}
+    ONNX_DIR="${BUILD_SOURCESDIRECTORY}/cmake/external/onnx"
+    ONNX_VERSION_NUMBER=$(cat "${ONNX_DIR}/VERSION_NUMBER" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    OPSET_VERSION=$(grep "${ONNX_VERSION_NUMBER}" "${ONNX_DIR}/docs/Versioning.md" | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
+    mkdir -p "${BUILD_BINARIESDIRECTORY}/models"
+    ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERSION}"
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -18,8 +18,11 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
+    # TODO(#12040): The test should figure out the opset version from the model file. Remove it from the path.
+    ONNX_VERSION_NUMBER=$(cat cmake/external/onnx/VERSION_NUMBER | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    OPSET_VERSION=$(grep ${ONNX_VERSION_NUMBER} cmake/external/onnx/docs/Versioning.md | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
     mkdir -p $BUILD_BINARIESDIRECTORY/models
-    ln -s $BUILD_SOURCESDIRECTORY/cmake/external/onnx/onnx/backend/test/data/node $BUILD_BINARIESDIRECTORY/models/opset17
+    ln -s ${BUILD_SOURCESDIRECTORY}/cmake/external/onnx/onnx/backend/test/data/node ${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERISON}
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Should have been part of https://github.com/microsoft/onnxruntime/pull/11924

This is hacky as hell. The proper fix is tracked by https://github.com/microsoft/onnxruntime/issues/12040.

Proposing this now to unblock the release if we can't fix it properly quickly.