### PR TITLE
Refine ONNX model path in Nuget CI

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -54,7 +54,7 @@ dir test\Microsoft.ML.OnnxRuntime.EndToEndTests\packages\
 
 IF "%PACKAGENAME%"=="Microsoft.ML.OnnxRuntime.Gpu" (
   set TESTONGPU=ON
-  %dn% test -p:DefineConstants=USE_TENSORRT test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --filter TensorRT 
+  %dn% test -p:DefineConstants=USE_TENSORRT test\Microsoft.ML.OnnxRuntime.EndToEndTests\Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --filter TensorRT
 
   IF NOT errorlevel 0 (
     @echo "Failed to build or execute the end-to-end test"

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -8,7 +8,7 @@ SET TargetFramework=netcoreapp5.0
 SET TargetArch=x64
 SET dn="C:\Program Files\dotnet\dotnet"
 SET CurrentOnnxRuntimeVersion=""
-SET ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="%OnnxRuntimeBuildDirectory%/models"
+SET ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH=%OnnxRuntimeBuildDirectory%\models
 
 SET LocalNuGetRepo=%1
 IF NOT "%2"=="" (SET TargetFramework=%2)

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.bat
@@ -8,6 +8,7 @@ SET TargetFramework=netcoreapp5.0
 SET TargetArch=x64
 SET dn="C:\Program Files\dotnet\dotnet"
 SET CurrentOnnxRuntimeVersion=""
+SET ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="%OnnxRuntimeBuildDirectory%/models"
 
 SET LocalNuGetRepo=%1
 IF NOT "%2"=="" (SET TargetFramework=%2)

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -18,13 +18,9 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
-    # TODO(#12040): The test should figure out the opset version from the model file. Remove it from the path.
-    ONNX_DIR="${BUILD_SOURCESDIRECTORY}/cmake/external/onnx"
-    ONNX_VERSION_NUMBER=$(cat "${ONNX_DIR}/VERSION_NUMBER" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-    OPSET_VERSION=$(grep "${ONNX_VERSION_NUMBER}" "${ONNX_DIR}/docs/Versioning.md" | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
     mkdir -p "${BUILD_BINARIESDIRECTORY}/models"
-    ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERSION}"
-    export OnnxModelRootPath="${BUILD_BINARIESDIRECTORY}/models"
+    ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/onnx_node_tests"
+    export ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="${BUILD_BINARIESDIRECTORY}/models"
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -18,11 +18,15 @@ echo "Current NuGet package version is $CurrentOnnxRuntimeVersion"
 
 if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
+    # TODO(#12040): The test should figure out the opset version from the model file. Remove it from the path.
+    ONNX_DIR="${BUILD_SOURCESDIRECTORY}/cmake/external/onnx"
+    ONNX_VERSION_NUMBER=$(cat "${ONNX_DIR}/VERSION_NUMBER" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    OPSET_VERSION=$(grep "${ONNX_VERSION_NUMBER}" "${ONNX_DIR}/docs/Versioning.md" | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
     mkdir -p "${BUILD_BINARIESDIRECTORY}/models"
-    ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/onnx_node_tests"
+    ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERSION}"
+    export ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="${BUILD_BINARIESDIRECTORY}/models"
   fi
   # Run C# tests
-  export ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="${BUILD_BINARIESDIRECTORY}/models"
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json
   if [ $? -ne 0 ]; then
     echo "Failed to restore nuget packages for the test project"

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -20,9 +20,9 @@ if [ $RunTestCsharp = "true" ]; then
   if [[ $IsMacOS == "True" || $IsMacOS == "true" ]]; then
     mkdir -p "${BUILD_BINARIESDIRECTORY}/models"
     ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/onnx_node_tests"
-    export ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="${BUILD_BINARIESDIRECTORY}/models"
   fi
   # Run C# tests
+  export ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH="${BUILD_BINARIESDIRECTORY}/models"
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json
   if [ $? -ne 0 ]; then
     echo "Failed to restore nuget packages for the test project"

--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -24,6 +24,7 @@ if [ $RunTestCsharp = "true" ]; then
     OPSET_VERSION=$(grep "${ONNX_VERSION_NUMBER}" "${ONNX_DIR}/docs/Versioning.md" | sed -E "s/${ONNX_VERSION_NUMBER}\|[^|]+\|([0-9]+)\|.*/\1/")
     mkdir -p "${BUILD_BINARIESDIRECTORY}/models"
     ln -s "${ONNX_DIR}/onnx/backend/test/data/node" "${BUILD_BINARIESDIRECTORY}/models/opset${OPSET_VERSION}"
+    export OnnxModelRootPath="${BUILD_BINARIESDIRECTORY}/models"
   fi
   # Run C# tests
   dotnet restore $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj -s $LocalNuGetRepo -s https://api.nuget.org/v3/index.json

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -486,6 +486,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 {
                     var inMeta = session.InputMetadata;
                     string testDataDirNamePattern = "test_data*";
+                    if (onnxModelFileName.Contains("opset9") && onnxModelFileName.Contains("LSTM_Seq_lens_unpacked"))
+                    {
+                        Console.WriteLine($"Change data folder's pattern for LSTM_Seq_lens_unpacked in opset 9.");
+                        testDataDirNamePattern = "seq_lens*"; // discrepancy in data directory
+                    }
                     foreach (var testDataDir in modelDir.EnumerateDirectories(testDataDirNamePattern))
                     {
                         var inputContainer = new List<NamedOnnxValue>();
@@ -810,13 +815,13 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
         static string GetTestModelsDir()
         {
-            // Get test path from enviroment.
+            // Get test path from environment.
             // Expected folder structure:
             //   ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-            //     modelsl_in_opset9
+            //     models_in_opset9
             //       test_add
             //         add.onnx
-            //     modelsl_in_opset17
+            //     models_in_opset17
             //       test_add
             //         add.onnx
             //       test_layernorm
@@ -826,8 +831,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             //         resnet.onnx
             var name = "ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH";
             var path = Environment.GetEnvironmentVariable(name);
+            Console.WriteLine($"Load ONNX models from root folder: {path}");
             if (path == null) {
-              throw new Exception($"The environment variable {name} must be set. See comments in GetTestModelsDir(...) for details.");
+              throw new Exception($"The environment variable {name} must be set to a directory containing ONNX models to test. E.g., <the directory>/models_in_opset<n>/model/model.onnx. See comments in GetTestModelsDir(...) for details.");
             }
             return path;
         }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -410,23 +410,22 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         public static IEnumerable<object[]> GetModelsForTest()
         {
             var modelsDir = GetTestModelsDir();
-            Console.WriteLine($"modelsDir: {modelsDir}");
+            Console.WriteLine($"Load ONNX models from folder: {modelsDir}");
             var modelsDirInfo = new DirectoryInfo(modelsDir);
-            Console.WriteLine($"1 modelsDirInfo.FullName: {modelsDirInfo.FullName}");
             var skipModels = GetSkippedModels(modelsDirInfo);
-            Console.WriteLine($"2 modelsDirInfo.FullName: {modelsDirInfo.FullName}");
+            // Iterate thgough all direct sub-folders in modelsDir.
             foreach (var modelGroupDir in modelsDirInfo.EnumerateDirectories())
             {
-                Console.WriteLine($"3 modelGroupDir: {modelGroupDir}");
+                // Iterate thgough all ONNX model folder in every sub-folder.
                 foreach (var modelDir in modelGroupDir.EnumerateDirectories())
                 {
-                    Console.WriteLine($"modelDir: {modelDir.FullName}");
+                    Console.WriteLine($"Found ONNX model: {modelDir.FullName}");
                     if (!skipModels.ContainsKey(modelDir.Name))
                     {
                         yield return new object[] { modelDir.FullName };
                     }
-                } //model
-            } //opset
+                } //model folder.
+            } //model group folder, e.g., opset9, opset10, etc.
         }
 
         public static IEnumerable<object[]> GetSkippedModelForTest()
@@ -811,9 +810,21 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
         static string GetTestModelsDir()
         {
+            // Get test path from enviroment.
+            // Expected folder structure:
+            //   OnnxModelRootPath
+            //     modelsl_in_opset9
+            //       test_add
+            //         add.onnx
+            //     modelsl_in_opset17
+            //       test_add
+            //         add.onnx
+            //       test_layernorm
+            //         layer_norm.onnx
+            //     custom_models
+            //       custom_vision
+            //         resnet.onnx
             var path = Environment.GetEnvironmentVariable("OnnxModelRootPath");
-            //var path = "C:\\Users\\wechi\\repos\\onnxruntime\\build\\Windows\\models";
-            Console.WriteLine($"OnnxModelRootPath: {path}");
             return path;
         }
     }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -824,8 +824,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             //     custom_models
             //       custom_vision
             //         resnet.onnx
-            var path = Environment.GetEnvironmentVariable("ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH");
-            Assert.NotNull(path, "The environment variable ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH must be set. See comments in GetTestModelsDir(...) for details.");
+            var name = "ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH";
+            var path = Environment.GetEnvironmentVariable(name);
+            if (path == null) {
+              throw new Exception($"The environment variable {name} must be set. See comments in GetTestModelsDir(...) for details.");
+            }
             return path;
         }
     }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -812,7 +812,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         {
             // Get test path from enviroment.
             // Expected folder structure:
-            //   OnnxModelRootPath
+            //   ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
             //     modelsl_in_opset9
             //       test_add
             //         add.onnx
@@ -824,7 +824,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             //     custom_models
             //       custom_vision
             //         resnet.onnx
-            var path = Environment.GetEnvironmentVariable("OnnxModelRootPath");
+            var path = Environment.GetEnvironmentVariable("ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH");
+            Assert.NotNull(path, "The environment variable ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH must be set. See comments in GetTestModelsDir(...) for details.");
             return path;
         }
     }

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -17,8 +17,6 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
-  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -17,6 +17,8 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
+  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
+    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -18,7 +18,7 @@ jobs:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
   - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-    value: '$(Build.BinariesDirectory)/model'
+    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -17,7 +17,7 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
-  - name: OnnxModelRootPath
+  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
     value: '$(Build.BinariesDirectory)/model'
 
   steps:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -17,8 +17,10 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
-  steps:
+  - name: OnnxModelRootPath
+    value: '$(Build.BinariesDirectory)/model'
 
+  steps:
   - task: DownloadPipelineArtifact@0
     displayName: 'Download Signed NuGet'
     inputs:
@@ -38,7 +40,7 @@ jobs:
   - task: CmdLine@2
     displayName: 'Create symlink for test models'
     inputs:
-      script: |     
+      script: |
          ln -sf /data/models $(Build.BinariesDirectory)
 
   - task: Bash@3
@@ -54,7 +56,7 @@ jobs:
       DisableMlOps: $(DisableMlOps)
       IsReleaseBuild: $(IsReleaseBuild)
       PACKAGENAME: ${{ parameters.NugetPackageName }}
-        
+
   - template: ../../templates/component-governance-component-detection-steps.yml
     parameters :
       condition : 'always'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -14,7 +14,7 @@ jobs:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
   - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-    value: '$(Build.BinariesDirectory)/model'
+    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -13,6 +13,9 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
+  - name: OnnxModelRootPath
+    value: '$(Build.BinariesDirectory)/model'
+
   steps:
   - task: DownloadPipelineArtifact@0
     displayName: 'Download Pipeline Artifact - Signed NuGet'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -13,8 +13,6 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
-  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -13,7 +13,7 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
-  - name: OnnxModelRootPath
+  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
     value: '$(Build.BinariesDirectory)/model'
 
   steps:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_macos.yml
@@ -13,6 +13,8 @@ jobs:
   variables:
   - name: OnnxRuntimeBuildDirectory
     value: '$(Build.BinariesDirectory)'
+  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
+    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: DownloadPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -19,8 +19,8 @@ jobs:
     value: 'ON'
   - name: runCodesignValidationInjection
     value: false
-  - name: TestOnnxModelPath
-    value: 'C:\\local\\models'
+  - name: OnnxModelRootPath
+    value: '$(Build.BinariesDirectory)/model'
 
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -19,8 +19,6 @@ jobs:
     value: 'ON'
   - name: runCodesignValidationInjection
     value: false
-  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
-    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: UsePythonVersion@0
@@ -73,7 +71,6 @@ jobs:
     displayName: 'Run End to End Test (C#) .Net Core x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
-      ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -83,7 +80,6 @@ jobs:
         displayName: 'Run End to End Test (C#) .Net Core x86'
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
-          ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   # TODO: Add .Net Framework AnyCPU test task
 
@@ -94,7 +90,6 @@ jobs:
     displayName: 'Run End to End Test (C#) .NetFramework x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
-      ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -105,7 +100,6 @@ jobs:
         enabled: false
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
-          ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - template: ../../templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -19,8 +19,8 @@ jobs:
     value: 'ON'
   - name: runCodesignValidationInjection
     value: false
-  - name: OnnxModelRootPath
-    value: '$(Build.BinariesDirectory)/model'
+  - name: ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH
+    value: '$(Build.BinariesDirectory)/models'
 
   steps:
   - task: UsePythonVersion@0

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -73,7 +73,7 @@ jobs:
     displayName: 'Run End to End Test (C#) .Net Core x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
-      TestOnnxModelPath: ${TestOnnxModelPath}
+      ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -83,7 +83,7 @@ jobs:
         displayName: 'Run End to End Test (C#) .Net Core x86'
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
-          TestOnnxModelPath: ${TestOnnxModelPath}
+          ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   # TODO: Add .Net Framework AnyCPU test task
 
@@ -94,7 +94,7 @@ jobs:
     displayName: 'Run End to End Test (C#) .NetFramework x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
-      TestOnnxModelPath: ${TestOnnxModelPath}
+      ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -105,7 +105,7 @@ jobs:
         enabled: false
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
-          TestOnnxModelPath: ${TestOnnxModelPath}
+          ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: ${ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH}
 
   - template: ../../templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -19,12 +19,14 @@ jobs:
     value: 'ON'
   - name: runCodesignValidationInjection
     value: false
+  - name: TestOnnxModelPath
+    value: 'C:\\local\\models'
 
   steps:
   - task: UsePythonVersion@0
-    inputs: 
-      versionSpec: '3.7' 
-      addToPath: true 
+    inputs:
+      versionSpec: '3.7'
+      addToPath: true
       architecture: x64
 
   - task: NuGetToolInstaller@0
@@ -45,7 +47,7 @@ jobs:
       filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'
       arguments: 'amd64'
       modifyEnvironment: true
-  
+
   - task: DownloadPipelineArtifact@0
     displayName: 'Download Pipeline Artifact'
     inputs:
@@ -62,11 +64,6 @@ jobs:
     parameters:
       packageFolder: '$(Build.BinariesDirectory)\nuget-artifact'
 
-  - script: |
-     mklink /D /J models C:\local\models
-    workingDirectory: '$(Build.BinariesDirectory)'
-    displayName: 'Create models link'
-
   # TODO: Add .Net Core AnyCPU test task
 
   - script: |
@@ -76,6 +73,7 @@ jobs:
     displayName: 'Run End to End Test (C#) .Net Core x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
+      TestOnnxModelPath: ${TestOnnxModelPath}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -85,6 +83,7 @@ jobs:
         displayName: 'Run End to End Test (C#) .Net Core x86'
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
+          TestOnnxModelPath: ${TestOnnxModelPath}
 
   # TODO: Add .Net Framework AnyCPU test task
 
@@ -95,6 +94,7 @@ jobs:
     displayName: 'Run End to End Test (C#) .NetFramework x64'
     env:
       PACKAGENAME: ${{ parameters.NugetPackageName }}
+      TestOnnxModelPath: ${TestOnnxModelPath}
 
   - ${{ if ne(parameters['Skipx86Tests'], 'true') }}:
       - script: |
@@ -105,6 +105,7 @@ jobs:
         enabled: false
         env:
           PACKAGENAME: ${{ parameters.NugetPackageName }}
+          TestOnnxModelPath: ${TestOnnxModelPath}
 
   - template: ../../templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_win.yml
@@ -62,6 +62,11 @@ jobs:
     parameters:
       packageFolder: '$(Build.BinariesDirectory)\nuget-artifact'
 
+  - script: |
+     mklink /D /J models C:\local\models
+    workingDirectory: '$(Build.BinariesDirectory)'
+    displayName: 'Create models link'
+
   # TODO: Add .Net Core AnyCPU test task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/win-ci-2019.yml
@@ -47,7 +47,7 @@ jobs:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
     ${{ if eq(parameters.EnableLto, true) }}:
       build_py_lto_flag: --enable_lto
-    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
+    ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: '${{Build.BinariesDirectory)/models}}'
 
   steps:
     - checkout: self

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/win-ci-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/win-ci-2019.yml
@@ -47,6 +47,7 @@ jobs:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
     ${{ if eq(parameters.EnableLto, true) }}:
       build_py_lto_flag: --enable_lto
+    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
 
   steps:
     - checkout: self
@@ -71,9 +72,9 @@ jobs:
         versionSpec: '16.x'
 
     - task: UsePythonVersion@0
-      inputs: 
-        versionSpec: '3.7' 
-        addToPath: true 
+      inputs:
+        versionSpec: '3.7'
+        addToPath: true
         architecture: ${{ parameters.BuildArch }}
 
     - task: BatchScript@1
@@ -94,10 +95,10 @@ jobs:
        $Env:CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildArch }}-windows-static"
        python setup.py bdist_wheel
        python -m pip uninstall -y onnx -qq
-       Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}   
+       Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
       workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'
       displayName: 'Install ONNX'
-    
+
     - task: PythonScript@0
       displayName: 'Generate cmake config'
       inputs:
@@ -155,7 +156,7 @@ jobs:
           msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=${{ parameters.OrtPackageId }}'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
-    - ${{ if in(parameters['sln_platform'], 'Win32', 'x64') }}:      
+    - ${{ if in(parameters['sln_platform'], 'Win32', 'x64') }}:
       - ${{ if eq(parameters.BuildCSharp, true) }}:
         - task: DotNetCoreCLI@2
           displayName: 'Test C#'

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -43,10 +43,11 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
+    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
   workspace:
     clean: all
   pool: 'Win-CPU-2019'
-  timeoutInMinutes:  300  
+  timeoutInMinutes:  300
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -77,10 +78,10 @@ jobs:
   - script: |
      set ORT_DOXY_SRC=$(Build.SourcesDirectory)
      set ORT_DOXY_OUT=$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}
-     mkdir %ORT_DOXY_SRC% 
+     mkdir %ORT_DOXY_SRC%
      mkdir %ORT_DOXY_OUT%
      "C:\Program Files\doxygen\bin\doxygen.exe" $(Build.SourcesDirectory)\tools\ci_build\github\Doxyfile_csharp.cfg
-     
+
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'API Documentation Check and generate'
 
@@ -152,7 +153,7 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'    
+    displayName: 'Build C#'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       configuration: '${{ parameters.BuildConfig }}'
@@ -167,7 +168,7 @@ jobs:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj'
-          configuration: '${{ parameters.BuildConfig }}'          
+          configuration: '${{ parameters.BuildConfig }}'
           arguments: '--configuration ${{ parameters.BuildConfig }} -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) --blame'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
@@ -175,14 +176,14 @@ jobs:
       - powershell: |
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Install onnxruntime wheel'
 
   - ${{ if eq(parameters.RunOnnxRuntimeTests, true) }}:
       - powershell: |
          python $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019"  --build_shared_lib --enable_onnx_tests ${{ parameters.additionalBuildFlags }}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Run tests'
 
@@ -213,7 +214,7 @@ jobs:
         displayName: 'Create Security Analysis Report'
         inputs:
           SDLNativeRules: true
-          
+
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish Security Analysis Logs'
         continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -43,7 +43,7 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
+    OnnxModelRootPath: '$(Build.BinariesDirectory)/models'
   workspace:
     clean: all
   pool: 'Win-CPU-2019'

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -43,7 +43,7 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-    OnnxModelRootPath: '$(Build.BinariesDirectory)/models'
+    ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: '$(Build.BinariesDirectory)/models'
   workspace:
     clean: all
   pool: 'Win-CPU-2019'

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -20,7 +20,7 @@ parameters:
 - name: isX86
   type: boolean
   default: false
-  
+
 - name: isTraining
   type: boolean
   default: false
@@ -37,11 +37,11 @@ parameters:
 - name: RunStaticCodeAnalysis
   displayName: Run Static Code Analysis
   type: boolean
-  default: true  
-  
+  default: true
+
 - name: ORT_EP_NAME
   type: string
-  
+
 - name: MachinePool
   type: string
 
@@ -55,14 +55,15 @@ jobs:
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true    
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}    
+    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}
+    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}
-  timeoutInMinutes:  300  
+  timeoutInMinutes:  300
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -93,10 +94,10 @@ jobs:
   - script: |
      set ORT_DOXY_SRC=$(Build.SourcesDirectory)
      set ORT_DOXY_OUT=$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}
-     mkdir %ORT_DOXY_SRC% 
+     mkdir %ORT_DOXY_SRC%
      mkdir %ORT_DOXY_OUT%
      "C:\Program Files\doxygen\bin\doxygen.exe" $(Build.SourcesDirectory)\tools\ci_build\github\Doxyfile_csharp.cfg
-     
+
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'API Documentation Check and generate'
 
@@ -175,7 +176,7 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'    
+    displayName: 'Build C#'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       configuration: '${{ parameters.BuildConfig }}'
@@ -190,7 +191,7 @@ jobs:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj'
-          configuration: '${{ parameters.BuildConfig }}'          
+          configuration: '${{ parameters.BuildConfig }}'
           arguments: '--configuration ${{ parameters.BuildConfig }} -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:DefineConstants=USE_${{ parameters.ORT_EP_NAME }} --blame'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
@@ -198,14 +199,14 @@ jobs:
       - powershell: |
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Install onnxruntime wheel'
 
   - ${{ if eq(parameters.RunOnnxRuntimeTests, true) }}:
       - powershell: |
          python $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019"  --build_shared_lib --enable_onnx_tests ${{ parameters.additionalBuildFlags }}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Run tests'
 
@@ -234,16 +235,16 @@ jobs:
           rulesetName: Custom
           customRuleset: $(Build.SourcesDirectory)\cmake\Sdl.ruleset
           publishXML: true
-          
+
       - task: SdtReport@2
         displayName: 'Create Security Analysis Report'
         inputs:
           SDLNativeRules: true
-    
+
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish Security Analysis Logs'
         continueOnError: true
-   
+
       - task: PostAnalysis@2
         displayName: 'Guardian Break v2'
         inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -59,7 +59,7 @@ jobs:
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
     DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}
-    OnnxModelRootPath: '${{Build.BinariesDirectory)/models}}'
+    OnnxModelRootPath: '$(Build.BinariesDirectory)/models'
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -59,7 +59,7 @@ jobs:
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
     DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}
-    OnnxModelRootPath: '$(Build.BinariesDirectory)/models'
+    ORT_CSHARP_TEST_ONNX_MODEL_ROOT_PATH: '$(Build.BinariesDirectory)/models'
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}


### PR DESCRIPTION
Fix #12040. This PR removes most of the `opset` uses in C# test code. The only use of `opset` now is to workaround a special filename only used in a `opset9` test.
```C#
if (onnxModelFileName.Contains("opset9") && onnxModelFileName.Contains("LSTM_Seq_lens_unpacked"))
  {
    Console.WriteLine($"Change data folder's pattern for LSTM_Seq_lens_unpacked in opset 9.");
    testDataDirNamePattern = "seq_lens*"; // discrepancy in data directory
}
```
After this PR, we can expose `opset` from `InferenceSesson` and completely remove `opset` in C# test code; for example,
```C#
if (session.GetOpSet("onnx") == 9 && onnxModelFileName.Contains("LSTM_Seq_lens_unpacked"))
  {
    Console.WriteLine($"Change data folder's pattern for LSTM_Seq_lens_unpacked in opset 9.");
    testDataDirNamePattern = "seq_lens*"; // discrepancy in data directory
}

```
It also adds a new environment variable to define model path to test Nuget packages, so it's more explicit to see where the test models come from.
