### PR TITLE
Add baseline gemm for kernel explorer

### DIFF
--- a/cmake/onnxruntime_kernel_explorer.cmake
+++ b/cmake/onnxruntime_kernel_explorer.cmake
@@ -34,9 +34,13 @@ target_link_libraries(kernel_explorer
 target_compile_definitions(kernel_explorer
   PUBLIC ROCM_USE_FLOAT16
   PRIVATE $<TARGET_PROPERTY:onnxruntime_pybind11_state,COMPILE_DEFINITIONS>)
+
+# handle kernel_explorer sources as hip language
 target_compile_options(kernel_explorer PRIVATE "-xhip")
 # TODO: use predefined AMDGPU_TARGETS
 target_compile_options(kernel_explorer PRIVATE "--offload-arch=gfx906" "--offload-arch=gfx908" "--offload-arch=gfx90a")
+# https://github.com/ROCm-Developer-Tools/HIP/blob/4514f350849b1090954295f8f87a5f8d78bd781b/hip-lang-config.cmake.in
+target_link_libraries(kernel_explorer PRIVATE ${CLANGRT_BUILTINS})
 
 add_dependencies(kernel_explorer onnxruntime_pybind11_state)
 

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
@@ -6,6 +6,7 @@
 #include "python/tools/kernel_explorer/device_array.h"
 #include "python/tools/kernel_explorer/kernels/vector_add.h"
 #include "python/tools/kernel_explorer/kernels/fast_gelu.h"
+#include "python/tools/kernel_explorer/kernels/gemm.h"
 
 namespace py = pybind11;
 
@@ -17,6 +18,7 @@ PYBIND11_MODULE(_kernel_explorer, m) {
       .def("UpdateHostNumpyArray", &DeviceArray::UpdateHostNumpyArray);
   InitVectorAdd(m);
   InitFastGelu(m);
+  InitGemm(m);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <type_traits>
+
+#include <pybind11/pybind11.h>
+#include <rocblas.h>
+
+#include "common.h"
+#include "device_array.h"
+#include "operator.h"
+
+namespace py = pybind11;
+
+namespace onnxruntime {
+
+enum class BlasOp {
+  N,
+  T,
+  // C,
+};
+
+// assume row majored
+template <typename T>
+class GemmBase : public Operator {
+ public:
+  GemmBase(
+      BlasOp opa, BlasOp opb,
+      int64_t m, int64_t n, int64_t k,
+      double alpha,
+      DeviceArray& a, int64_t lda,
+      DeviceArray& b, int64_t ldb,
+      double beta,
+      DeviceArray& c, int64_t ldc)
+      : Operator(),
+        opa_(opa),
+        opb_(opb),
+        m_(m),
+        n_(n),
+        k_(k),
+        alpha_(alpha),
+        a_(reinterpret_cast<T*>(a.ptr())),
+        lda_(lda),
+        b_(reinterpret_cast<T*>(b.ptr())),
+        ldb_(ldb),
+        beta_(beta),
+        c_(reinterpret_cast<T*>(c.ptr())),
+        ldc_(ldc) {}
+
+ protected:
+  BlasOp opa_;
+  BlasOp opb_;
+  int64_t m_;
+  int64_t n_;
+  int64_t k_;
+  T alpha_;
+  T* a_;
+  int64_t lda_;
+  T* b_;
+  int64_t ldb_;
+  T beta_;
+  T* c_;
+  int64_t ldc_;
+};
+
+template <typename T>
+class RocBlasGemm : public GemmBase<T> {
+ public:
+  RocBlasGemm(BlasOp opa, BlasOp opb,
+              int64_t m, int64_t n, int64_t k,
+              double alpha,
+              DeviceArray& a, int64_t lda,
+              DeviceArray& b, int64_t ldb,
+              double beta,
+              DeviceArray& c, int64_t ldc)
+      : GemmBase<T>(opa, opb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc),
+        opa_(opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose),
+        opb_(opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose) {
+    ROCBLAS_CALL_THROW(rocblas_create_handle(&rocblas_handle_));
+  }
+
+  ~RocBlasGemm() {
+    ROCBLAS_CALL_THROW(rocblas_destroy_handle(rocblas_handle_));
+    rocblas_handle_ = nullptr;
+  }
+
+  void Run() override;
+
+ private:
+  rocblas_handle rocblas_handle_;
+  rocblas_operation opa_;
+  rocblas_operation opb_;
+};
+
+template <>
+void RocBlasGemm<float>::Run() {
+  ROCBLAS_CALL_THROW(
+      rocblas_sgemm(this->rocblas_handle_, this->opa_, this->opb_,
+                    this->m_, this->n_, this->k_,
+                    &(this->alpha_),
+                    this->a_, this->lda_,
+                    this->b_, this->ldb_,
+                    &(this->beta_),
+                    this->c_, this->ldc_));
+}
+
+template <>
+void RocBlasGemm<rocblas_half>::Run() {
+  ROCBLAS_CALL_THROW(
+      rocblas_hgemm(this->rocblas_handle_, this->opa_, this->opb_,
+                    this->m_, this->n_, this->k_,
+                    &(this->alpha_),
+                    this->a_, this->lda_,
+                    this->b_, this->ldb_,
+                    &(this->beta_),
+                    this->c_, this->ldc_));
+}
+
+void InitGemm(py::module mod) {
+  auto blas_op = mod.def_submodule("blas_op");
+
+  py::enum_<BlasOp>(blas_op, "BlasOp")
+      .value("N", BlasOp::N, "Passthrough")
+      .value("T", BlasOp::T, "Transpose")
+      .export_values();
+
+  // float
+  py::class_<RocBlasGemm<float>>(mod, "RocblasGemm_float")
+      .def(py::init<BlasOp, BlasOp, int64_t, int64_t, int64_t, double, DeviceArray&, int64_t, DeviceArray&, int64_t, double, DeviceArray&, int64_t>())
+      .def("SetRepeats", &RocBlasGemm<float>::SetRepeats)
+      .def("Profile", &RocBlasGemm<float>::Profile)
+      .def("Run", &RocBlasGemm<float>::Run);
+
+  // half
+  py::class_<RocBlasGemm<rocblas_half>>(mod, "RocblasGemm_half")
+      .def(py::init<BlasOp, BlasOp, int64_t, int64_t, int64_t, double, DeviceArray&, int64_t, DeviceArray&, int64_t, double, DeviceArray&, int64_t>())
+      .def("SetRepeats", &RocBlasGemm<rocblas_half>::SetRepeats)
+      .def("Profile", &RocBlasGemm<rocblas_half>::Profile)
+      .def("Run", &RocBlasGemm<rocblas_half>::Run);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <type_traits>
+#include "python/tools/kernel_explorer/kernels/gemm.h"
 
+#include <type_traits>
 #include <pybind11/pybind11.h>
 
 #include "core/providers/rocm/rocm_common.h"
-#include "device_array.h"
-#include "operator.h"
-
 #include "core/providers/rocm/shared_inc/fpgeneric.h"
+#include "python/tools/kernel_explorer/device_array.h"
+#include "python/tools/kernel_explorer/operator.h"
 
 namespace py = pybind11;
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -5,7 +5,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include "common.h"
+#include "core/providers/rocm/rocm_common.h"
 #include "device_array.h"
 #include "operator.h"
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -20,7 +20,8 @@ enum class BlasOp {
   T,
 };
 
-// assume row majored
+// We don't assume the implementation is row-majored or column-majored. But for testing convenience, we assume all
+// our wrappers have row-majored convention, since it is the native layout to numpy and pytorch.
 template <typename T>
 class GemmBase : public Operator {
  public:
@@ -85,12 +86,14 @@ class RocBlasGemm : public GemmBase<T> {
   }
 
   void Run() {
+    // NOTE: rocblas assume the storage is column-majored, swapping A and B makes it have the same interface
+    // as those with row-majored convention.
     ROCBLAS_CALL_THROW(
-        rocblasGemmHelper(this->rocblas_handle_, this->opa_, this->opb_,
-                          this->m_, this->n_, this->k_,
+        rocblasGemmHelper(this->rocblas_handle_, this->opb_, this->opa_,
+                          this->n_, this->m_, this->k_,
                           &(this->alpha_),
-                          this->a_, this->lda_,
                           this->b_, this->ldb_,
+                          this->a_, this->lda_,
                           &(this->beta_),
                           this->c_, this->ldc_));
   }

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -118,11 +118,11 @@ void InitGemm(py::module mod) {
       .def("Run", &RocBlasGemm<float>::Run);
 
   // half
-  py::class_<RocBlasGemm<BFloat16>>(mod, "RocblasGemm_half")
+  py::class_<RocBlasGemm<half>>(mod, "RocblasGemm_half")
       .def(py::init<BlasOp, BlasOp, int64_t, int64_t, int64_t, double, DeviceArray&, int64_t, DeviceArray&, int64_t, double, DeviceArray&, int64_t>())
-      .def("SetRepeats", &RocBlasGemm<BFloat16>::SetRepeats)
-      .def("Profile", &RocBlasGemm<BFloat16>::Profile)
-      .def("Run", &RocBlasGemm<BFloat16>::Run);
+      .def("SetRepeats", &RocBlasGemm<half>::SetRepeats)
+      .def("Profile", &RocBlasGemm<half>::Profile)
+      .def("Run", &RocBlasGemm<half>::Run);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -87,7 +87,8 @@ class RocBlasGemm : public GemmBase<T> {
 
   void Run() {
     // NOTE: rocblas assume the storage is column-majored, swapping A and B makes it have the same interface
-    // as those with row-majored convention.
+    // as those with row-majored convention. That is, if you treat the storage as row-majored but view the matrices as
+    // transposed, then by using the property Transpose(A*B) = Tranpose(B)*Transpose(A), the correctness is obvious.
     ROCBLAS_CALL_THROW(
         rocblasGemmHelper(this->rocblas_handle_, this->opb_, this->opa_,
                           this->n_, this->m_, this->k_,

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -18,7 +18,6 @@ namespace onnxruntime {
 enum class BlasOp {
   N,
   T,
-  // C,
 };
 
 // assume row majored

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace onnxruntime {
+
+void InitGemm(py::module mod);
+
+}

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -1,0 +1,100 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import sys
+from itertools import product
+
+import kernel_explorer as ke
+import numpy as np
+import pytest
+
+
+def dtype_to_bytes(dtype):
+    type_map = {
+        "float16": 2,
+        "float32": 4,
+    }
+    return type_map[dtype]
+
+
+def dtype_to_funcs(dtype):
+    type_map = {
+        "float16": list(filter(lambda x: "RocblasGemm_half" in x, dir(ke))),
+        "float32": list(filter(lambda x: "RocblasGemm_float" in x, dir(ke))),
+    }
+    return type_map[dtype]
+
+
+def _test_gemm(size, dtype, func):
+    m, k, n = size
+
+    np.random.seed(0)
+    a = (np.random.rand(m, k).astype(dtype) - 0.5) * 2
+    b = (np.random.rand(k, n).astype(dtype) - 0.5) * 2
+    c = np.zeros((m, n)).astype(dtype)
+
+    dev_a = ke.DeviceArray(a)
+    dev_b = ke.DeviceArray(b)
+    dev_c = ke.DeviceArray(c)
+
+    f = getattr(ke, func)
+    va = f(ke.blas_op.N, ke.blas_op.N, n, m, k, 1.0, dev_b, n, dev_a, k, 0.0, dev_c, n)
+    va.Run()
+
+    dev_c.UpdateHostNumpyArray()
+
+    ref_c = a @ b
+
+    rtol = 1e-3 if dtype == "float16" else 1e-5
+    atol = 1e-3 if dtype == "float16" else 1e-5
+    np.testing.assert_allclose(ref_c, c, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "size",
+    # product([5, 9], repeat=3)
+    product([1, 3, 4, 16, 124, 125, 126, 127, 128, 129, 130, 131, 132], repeat=3),
+)
+def test_gemm_all_sizes(size):
+    # FIXME: float16 is causing high roundoff error here!
+    # dtypes = ["float16", "float32"]
+    dtypes = ["float32"]
+    for dtype in dtypes:
+        for f in dtype_to_funcs(dtype):
+            _test_gemm(size, dtype, f)
+
+
+def profile_gemm_func(size, dtype, func):
+    m, k, n = size
+
+    np.random.seed(0)
+    a = np.random.rand(m, k).astype(dtype)
+    b = np.random.rand(k, n).astype(dtype)
+    c = np.zeros((m, n)).astype(dtype)
+
+    dev_a = ke.DeviceArray(a)
+    dev_b = ke.DeviceArray(b)
+    dev_c = ke.DeviceArray(c)
+
+    f = getattr(ke, func)
+    va = f(ke.blas_op.N, ke.blas_op.N, n, m, k, 1.0, dev_b, n, dev_a, k, 0.0, dev_c, n)
+    t = va.Profile()
+
+    print(dtype, size, f, f"{t*1000:.2f} us")  # , f"{size*3*(dtype_to_bytes(dtype))*1e3/t/1e9:.2f} GB/s")
+
+
+def profile():
+    sizes = product(list(range(64, 512 + 1, 64)), repeat=3)
+    dtypes = ["float16", "float32"]
+    for dt in dtypes:
+        for f in dtype_to_funcs(dt):
+            for s in sizes:
+                profile_gemm_func(s, dt, f)
+            print()
+        print()
+
+
+if __name__ == "__main__":
+    profile()

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -47,7 +47,7 @@ def _test_gemm(func, dtype: str, m: int, n: int, k: int, transa=False, transb=Fa
     ldb = b_shape[1]
     alpha = 1.0
     beta = 0.0
-    my_gemm = f(opb, opa, n, m, k, alpha, dev_b, ldb, dev_a, lda, beta, dev_c, n)
+    my_gemm = f(opa, opb, m, n, k, alpha, dev_a, lda, dev_b, ldb, beta, dev_c, n)
     my_gemm.Run()
     dev_c.UpdateHostNumpyArray()
 
@@ -93,7 +93,7 @@ def profile_gemm_func(func, dtype, m, n, k):
     ldb = b_shape[1]
     alpha = 1.0
     beta = 0.0
-    my_gemm = f(opb, opa, n, m, k, alpha, dev_b, ldb, dev_a, lda, beta, dev_c, n)
+    my_gemm = f(opa, opb, m, n, k, alpha, dev_a, lda, dev_b, ldb, beta, dev_c, n)
     time_ms = my_gemm.Profile()
 
     time_us = time_ms * 1000

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-import sys
 from itertools import product
 
 import kernel_explorer as ke

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -74,32 +74,51 @@ def test_gemm_all_cases(dtype, size, transab):
         _test_gemm(f, dtype, *size, *transab)
 
 
-def profile_gemm_func(size, dtype, func):
-    m, k, n = size
+def profile_gemm_func(func, dtype, m, n, k):
+    a_shape = (m, k)
+    b_shape = (k, n)
 
     np.random.seed(0)
-    a = np.random.rand(m, k).astype(dtype)
-    b = np.random.rand(k, n).astype(dtype)
-    c = np.zeros((m, n)).astype(dtype)
+    a = (np.random.rand(*a_shape) * 2 - 1).astype(dtype)
+    b = (np.random.rand(*b_shape) * 2 - 1).astype(dtype)
+    my_c = np.zeros((m, n), dtype=dtype)
 
     dev_a = ke.DeviceArray(a)
     dev_b = ke.DeviceArray(b)
-    dev_c = ke.DeviceArray(c)
+    dev_c = ke.DeviceArray(my_c)
 
     f = getattr(ke, func)
-    va = f(ke.blas_op.N, ke.blas_op.N, n, m, k, 1.0, dev_b, n, dev_a, k, 0.0, dev_c, n)
-    t = va.Profile()
+    opa = ke.blas_op.N
+    opb = ke.blas_op.N
+    lda = a_shape[1]
+    ldb = b_shape[1]
+    alpha = 1.0
+    beta = 0.0
+    my_gemm = f(opb, opa, n, m, k, alpha, dev_b, ldb, dev_a, lda, beta, dev_c, n)
+    time_ms = my_gemm.Profile()
 
-    print(dtype, size, f, f"{t*1000:.2f} us")  # , f"{size*3*(dtype_to_bytes(dtype))*1e3/t/1e9:.2f} GB/s")
+    time_us = time_ms * 1000
+    tflops = (m * k * n * 2) / (time_ms * 1e-3) / 1e12
+
+    print(f"RocBLAS GEMM {dtype} m={m:<4} k={k:<4} n={n:<4}, {time_us:>8.4f} us, {tflops:>5.2f} tflops")
 
 
 def profile():
-    sizes = product(list(range(64, 512 + 1, 64)), repeat=3)
-    dtypes = ["float16", "float32"]
-    for dt in dtypes:
-        for f in dtype_to_funcs(dt):
-            for s in sizes:
-                profile_gemm_func(s, dt, f)
+    dtypes = ["float32", "float16"]
+    bert_sizes = [
+        # m, k, n
+        (384, 384, 64),
+        (384, 768, 768),
+        (384, 768, 3072),
+        (384, 1024, 1024),
+        (384, 1024, 4096),
+        (384, 3072, 768),
+        (384, 4096, 1024),
+    ]
+    for dtype in dtypes:
+        for f in dtype_to_funcs(dtype):
+            for m, k, n in bert_sizes:
+                profile_gemm_func(f, dtype, m, k, n)
             print()
         print()
 


### PR DESCRIPTION
**Description**:

Add rocblas gemm wrapper for GEMM, serve as a baseline for future composable kernels GEMM

**Motivation and Context**
- Why is this change required? What problem does it solve?
   We'd like to introduce aggressive GEMM related kernels fusing for attention module in the future. This lay the bedrock for future microbenchmarking when composable kernels is introduced.
