### PR TITLE
Extend lifetime of KernelDef when creating a standalone op

### DIFF
--- a/onnxruntime/core/session/standalone_op_invoker.cc
+++ b/onnxruntime/core/session/standalone_op_invoker.cc
@@ -398,11 +398,12 @@ onnxruntime::Status CreateOp(const OrtKernelInfo* info,
   kernel_def_builder->SetName(op_name);
   kernel_def_builder->SetDomain(domain);
   kernel_def_builder->SinceVersion(version);
+  auto kernel_def = kernel_def_builder->Build();
 
   static std::unordered_map<int, OrtValue> kEmptyValueMap;
   static OrtValueNameIdxMap kEmptyNameMap;
 
-  OpKernelInfo tmp_kernel_info(*node_ptr.get(), *kernel_def_builder->Build(), *ep, kEmptyValueMap, kEmptyNameMap, kernel_info->GetDataTransferManager());
+  OpKernelInfo tmp_kernel_info(*node_ptr.get(), *kernel_def, *ep, kEmptyValueMap, kEmptyNameMap, kernel_info->GetDataTransferManager());
   std::unique_ptr<onnxruntime::OpKernel> op_kernel;
 
   static FuncManager kFuncMgr;


### PR DESCRIPTION
During standalone op creation, kernel def must be kept alive since some ops are referring to it in constructor to get op_name.
As indicated here:
https://github.com/microsoft/onnxruntime/blob/0ee0b8cf1853fcf1fb3e2906122474f43fe548dd/onnxruntime/core/providers/cpu/math/softmax.h#L34

