### PR TITLE
Accelerate Mac CI Workflow with shared cache

### DIFF
--- a/tools/ci_build/github/apple/set_sccache.sh
+++ b/tools/ci_build/github/apple/set_sccache.sh
@@ -18,3 +18,6 @@ if which sccache > /dev/null; then
 
   export PATH="${tmp_dir}:$PATH"
 fi
+
+export CC=clang
+export CXX=clang++

--- a/tools/ci_build/github/apple/set_sccache.sh
+++ b/tools/ci_build/github/apple/set_sccache.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+set -ex
+
+function write_sccache_stub() {
+  output=$1
+  binary=$(basename "${output}")
+
+  printf "#!/bin/sh\nif [ \$(ps auxc \$(ps auxc -o ppid \$\$ | grep \$\$ | rev | cut -d' ' -f1 | rev) | tr '\\\\n' ' ' | rev | cut -d' ' -f2 | rev) != sccache ]; then\n  exec sccache %s \"\$@\"\nelse\n  exec %s \"\$@\"\nfi" "$(which "${binary}")" "$(which "${binary}")" > "${output}"
+  chmod a+x "${output}"
+}
+
+if which sccache > /dev/null; then
+  # Create temp directory for sccache shims
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rfv ${tmp_dir}' EXIT
+  write_sccache_stub "${tmp_dir}/clang++"
+  write_sccache_stub "${tmp_dir}/clang"
+
+  export PATH="${tmp_dir}:$PATH"
+fi

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -49,7 +49,6 @@ jobs:
         source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
         export CC=clang
         export CXX=clang++
-        exprot SCCACHE_AZURE_CONNECTION_STRING=
         env
         ${{ parameters.BuildCommand }}
         # rerun

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -55,8 +55,12 @@ jobs:
         source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
         export CC=clang
         export CXX=clang++
-        export SCCACHE_DIR='$(Build.SourcesDirectory)/sccache'
+        # export SCCACHE_DIR='$(Build.SourcesDirectory)/sccache'
         env
+        if which sccache > /dev/null; then
+          sccache --show-stats
+          sccache --stop-server
+        fi
         ${{ parameters.BuildCommand }}
         # rerun
         # rm -rf '$(Build.SourcesDirectory)/build'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -41,10 +41,7 @@ jobs:
     - script: |
         set -e
         brew install sccache
-        export CC=clang
-        export CXX=clang++
         source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
-
 
         pushd .
         cd $(Build.SourcesDirectory)/cmake/external/protobuf

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -32,9 +32,9 @@ jobs:
     - task: NodeTool@0
       inputs:
         versionSpec: '16.x'
-    - task: AzureKeyVault@1
+    - task: AzureKeyVault@2
       inputs:
-        azureSubscription: 'AIInfraBuild'
+        connectedServiceName: 'AIInfraBuild'
         KeyVaultName: 'zhanyi-cache-test'
         SecretsFilter: 'zhanyi-conn-string'
         RunAsPreJob: false

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -49,13 +49,15 @@ jobs:
         source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
         export CC=clang
         export CXX=clang++
+        exprot SCCACHE_AZURE_CONNECTION_STRING=
         env
+        ${{ parameters.BuildCommand }}
+        # rerun
+        rm -rf '$(Build.SourcesDirectory)/build'
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - script: |
         set -e
-        rm -rf '$(Build.SourcesDirectory)/build'
-        ${{ parameters.BuildCommand }}
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -35,7 +35,7 @@ jobs:
     - script: |
         set -ex
         brew install sccache
-        source '$(Build.SourcesDirectory)/tools/ci_build/github/linux/apple/set_sccache.sh'
+        source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
         export CC=clang
         export CXX=clang++
         env

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -33,14 +33,6 @@ jobs:
       inputs:
         versionSpec: '16.x'
     - script: |
-        set -ex
-        brew install sccache
-        source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
-        export CC=clang
-        export CXX=clang++
-        env
-      displayName: 'Set Sccache'
-    - script: |
         set -e
         pushd .
         cd $(Build.SourcesDirectory)/cmake/external/protobuf
@@ -53,6 +45,11 @@ jobs:
         export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
         sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
         sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
+        brew install sccache
+        source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
+        export CC=clang
+        export CXX=clang++
+        env
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - script: |

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -40,6 +40,12 @@ jobs:
         RunAsPreJob: false
     - script: |
         set -e
+        brew install sccache
+        export CC=clang
+        export CXX=clang++
+        source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
+
+
         pushd .
         cd $(Build.SourcesDirectory)/cmake/external/protobuf
         cmake ./cmake -DCMAKE_INSTALL_PREFIX=$(Build.BinariesDirectory)/protobuf -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Relwithdebinfo
@@ -49,23 +55,14 @@ jobs:
         export PATH=$(Build.BinariesDirectory)/protobuf/bin:$PATH
         export ONNX_ML=1
         export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
-        sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
-        sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
-        brew install sccache
-        source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
-        export CC=clang
-        export CXX=clang++
-        # export SCCACHE_DIR='$(Build.SourcesDirectory)/sccache'
-        env
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server
         fi
+
+        sudo python3 -m pip install -r '$(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/requirements.txt'
+        sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
         ${{ parameters.BuildCommand }}
-        # rerun
-        # rm -rf '$(Build.SourcesDirectory)/build'
-        # export RUST_LOG=trace
-        # ${{ parameters.BuildCommand }}
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -56,13 +56,11 @@ jobs:
         rm -rf '$(Build.SourcesDirectory)/build'
         export RUST_LOG=trace
         ${{ parameters.BuildCommand }}
-      displayName: 'Build and Test OnnxRuntime lib for MacOS'
-    - script: |
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server
         fi
-      displayName: 'Show Sccache Stats'
+      displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -72,6 +72,7 @@ jobs:
         fi
       env:
         SCCACHE_AZURE_CONNECTION_STRING: '$(zhanyi-conn-string)'
+        SCCACHE_AZURE_BLOB_CONTAINER: 'zhanyi-sccache'
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -49,14 +49,15 @@ jobs:
         source '$(Build.SourcesDirectory)/tools/ci_build/github/apple/set_sccache.sh'
         export CC=clang
         export CXX=clang++
+        export SCCACHE_DIR='$(Build.SourcesDirectory)/sccache'
         env
         ${{ parameters.BuildCommand }}
         # rerun
         rm -rf '$(Build.SourcesDirectory)/build'
+        export RUST_LOG=trace
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - script: |
-        set -e
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -32,6 +32,12 @@ jobs:
     - task: NodeTool@0
       inputs:
         versionSpec: '16.x'
+    - task: AzureKeyVault@1
+      inputs:
+        azureSubscription: 'AIInfraBuild'
+        KeyVaultName: 'zhanyi-cache-test'
+        SecretsFilter: 'zhanyi-conn-string'
+        RunAsPreJob: false
     - script: |
         set -e
         pushd .
@@ -53,13 +59,15 @@ jobs:
         env
         ${{ parameters.BuildCommand }}
         # rerun
-        rm -rf '$(Build.SourcesDirectory)/build'
-        export RUST_LOG=trace
-        ${{ parameters.BuildCommand }}
+        # rm -rf '$(Build.SourcesDirectory)/build'
+        # export RUST_LOG=trace
+        # ${{ parameters.BuildCommand }}
         if which sccache > /dev/null; then
           sccache --show-stats
           sccache --stop-server
         fi
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: '$(zhanyi-conn-string)'
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -33,6 +33,14 @@ jobs:
       inputs:
         versionSpec: '16.x'
     - script: |
+        set -ex
+        brew install sccache
+        source '$(Build.SourcesDirectory)/tools/ci_build/github/linux/apple/set_sccache.sh'
+        export CC=clang
+        export CXX=clang++
+        env
+      displayName: 'Set Sccache'
+    - script: |
         set -e
         pushd .
         cd $(Build.SourcesDirectory)/cmake/external/protobuf
@@ -47,6 +55,15 @@ jobs:
         sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
+    - script: |
+        set -e
+        rm -rf '$(Build.SourcesDirectory)/build'
+        ${{ parameters.BuildCommand }}
+        if which sccache > /dev/null; then
+          sccache --show-stats
+          sccache --stop-server
+        fi
+      displayName: 'Show Sccache Stats'
     - task: PublishTestResults@2
       displayName: 'Publish unit test results'
       inputs:


### PR DESCRIPTION
**Description**: 


**Motivation and Context**
Mac resources in CI is limited and we couldn't scale up or scale out them.
There're only 3 threads in Mac agent, so the compilation is much slower than in other agents.
With this PR, the workflow duration could be saved by 70%.

**PS**
The storage name and location are just for testing, they would be changed.