### PR TITLE
Disable DML command list reuse for Xbox

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -95,6 +95,11 @@ namespace Dml::GraphDescBuilder
             reuseCommandList = true;
         }
 
+#ifdef _GAMING_XBOX
+        // #40265989
+        reuseCommandList = false;
+#endif
+
         auto constantCpuGraphInputGetter = [&transferredInitializerMap](const std::string& argName)
         {
             ComPtr<OnnxTensorWrapper> tensorWrapper;


### PR DESCRIPTION
Disables the command-list reuse optimization in the DML EP for Xbox. This needs more investigation, but it causes some models to hang indefinitely in ID3D12Fence::SetEventOnCompletion (fence never gets signaled).