### PR TITLE
Add pipeline for building perf test binaries.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: BuildAndroidBinaries
+  type: boolean
+  default: true
+
+jobs:
+- ${{ if parameters.BuildAndroidBinaries }}:
+  # build binaries for Android
+  - template: templates/android-java-api-aar.yml
+    parameters:
+      buildConfig: 'Release'
+      buildSettings: '$(Build.SourcesDirectory)/tools/ci_build/github/android/default_full_aar_build_settings.json'
+      artifactName: 'onnxruntime-android-full-aar'
+      job_name_suffix: 'Full'
+      publish_executables: '1'
+      pool_name: 'Linux-CPU-2019'

--- a/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
@@ -13,4 +13,4 @@ jobs:
       artifactName: 'onnxruntime-android-full-aar'
       job_name_suffix: 'Full'
       publish_executables: '1'
-      pool_name: 'Linux-CPU-2019'
+      pool_name: 'Linux-CPU'


### PR DESCRIPTION
**Description**
Add initial pipeline for building perf test binaries. It only builds Android binaries now but can be expanded later.

**Motivation and Context**
Make it easier to obtain perf testing binaries. For both manual testing and automated perf tests.
