### PR TITLE
Rework cmake for kernel_explorer

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -188,6 +188,8 @@ option(onnxruntime_ENABLE_CPUINFO "Enable cpuinfo" ON)
 # ATen fallback support
 option(onnxruntime_ENABLE_ATEN "Enable ATen fallback" OFF)
 
+option(onnxruntime_BUILD_KERNEL_EXPLORER "Build kernel_explorer for microbenchmark a small subset of important kernels" OFF)
+
 if (onnxruntime_USE_CUDA)
   set(onnxruntime_DISABLE_RTTI OFF)
 endif()
@@ -1287,6 +1289,14 @@ function(onnxruntime_configure_target target_name)
     set_target_properties(${target_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE)
   endif()
 
+  if (onnxruntime_BUILD_KERNEL_EXPLORER)
+    get_target_property(target_type ${target_name} TYPE)
+    if (target_type STREQUAL "MODULE_LIBRARY" OR target_type STREQUAL "SHARED_LIBRARY")
+      set_property(TARGET ${target_name}
+        APPEND_STRING PROPERTY LINK_FLAGS " -Xlinker --version-script=${ONNXRUNTIME_ROOT}/python/tools/kernel_explorer/version_script.lds ")
+    endif()
+  endif()
+
   # Keep BinSkim happy
   if(MSVC AND NOT onnxruntime_target_platform MATCHES "ARM")
     target_link_options(${target_name} PRIVATE "/CETCOMPAT")
@@ -2105,6 +2115,11 @@ if (onnxruntime_BUILD_WEBASSEMBLY)
 
   message(STATUS "WebAssembly Build is enabled")
   include(onnxruntime_webassembly.cmake)
+endif()
+
+if(onnxruntime_BUILD_KERNEL_EXPLORER)
+  message(STATUS "Kernel Explorer Build is enabled")
+  add_subdirectory(../onnxruntime/python/tools/kernel_explorer ${CMAKE_CURRENT_BINARY_DIR}/kernel_explorer EXCLUDE_FROM_ALL)
 endif()
 
 if (UNIX)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2119,7 +2119,7 @@ endif()
 
 if(onnxruntime_BUILD_KERNEL_EXPLORER)
   message(STATUS "Kernel Explorer Build is enabled")
-  add_subdirectory(../onnxruntime/python/tools/kernel_explorer ${CMAKE_CURRENT_BINARY_DIR}/kernel_explorer EXCLUDE_FROM_ALL)
+  include(onnxruntime_kernel_explorer.cmake)
 endif()
 
 if (UNIX)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -188,7 +188,7 @@ option(onnxruntime_ENABLE_CPUINFO "Enable cpuinfo" ON)
 # ATen fallback support
 option(onnxruntime_ENABLE_ATEN "Enable ATen fallback" OFF)
 
-option(onnxruntime_BUILD_KERNEL_EXPLORER "Build kernel_explorer for microbenchmark a small subset of important kernels" OFF)
+option(onnxruntime_BUILD_KERNEL_EXPLORER "Build Kernel Explorer for testing and profiling GPU kernels" OFF)
 
 if (onnxruntime_USE_CUDA)
   set(onnxruntime_DISABLE_RTTI OFF)

--- a/cmake/onnxruntime_kernel_explorer.cmake
+++ b/cmake/onnxruntime_kernel_explorer.cmake
@@ -23,7 +23,7 @@ onnxruntime_add_shared_library_module(kernel_explorer
   ${kernel_explorer_srcs}
   ${kernel_explorer_kernel_srcs}
   ${BERT_DIR}/timer.cc)
-set_target_properties(kernel_explorer PROPERTIES PREFIX "")
+set_target_properties(kernel_explorer PROPERTIES PREFIX "_")
 target_include_directories(kernel_explorer PUBLIC
   $<TARGET_PROPERTY:onnxruntime_pybind11_state,INCLUDE_DIRECTORIES>
   ${KERNEL_EXPLORER_ROOT})

--- a/cmake/onnxruntime_kernel_explorer.cmake
+++ b/cmake/onnxruntime_kernel_explorer.cmake
@@ -22,7 +22,7 @@ file(GLOB kernel_explorer_kernel_srcs CONFIGURE_DEPENDS "${KERNEL_EXPLORER_ROOT}
 onnxruntime_add_shared_library_module(kernel_explorer
   ${kernel_explorer_srcs}
   ${kernel_explorer_kernel_srcs}
-  ${BERT_DIR}/timer.cc)
+  ${BERT_DIR}/util.cc)
 set_target_properties(kernel_explorer PROPERTIES PREFIX "_")
 target_include_directories(kernel_explorer PUBLIC
   $<TARGET_PROPERTY:onnxruntime_pybind11_state,INCLUDE_DIRECTORIES>

--- a/onnxruntime/python/tools/kernel_explorer/CMakeLists.txt
+++ b/onnxruntime/python/tools/kernel_explorer/CMakeLists.txt
@@ -4,31 +4,40 @@
 project(kernel_explorer)
 cmake_minimum_required(VERSION 3.21)
 
-set(onnxruntime_DIR ../../../../onnxruntime/)
-include(${onnxruntime_DIR}/../cmake/external/pybind11.cmake)
+if(CMAKE_CXX_COMPILER MATCHES ".*hipcc$")
+  message(FATAL_ERROR "don't use hipcc!")
+endif()
 
-set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_COMPILER /opt/rocm/bin/hipcc)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+if(CMAKE_PROJECT_NAME STREQUAL "kernel_explorer")
+  message(FATAL_ERROR "kernel explorer cannot be built as a top-level project at the moment")
+endif()
 
-list(APPEND CMAKE_PREFIX_PATH ${onnxruntime_ROCM_HOME} ${onnxruntime_ROCM_HOME}/hip)
+if(NOT onnxruntime_ENABLE_PYTHON)
+  message(FATAL_ERROR "python is required but is not enabled")
+endif()
 
-find_package(hip)
-find_package(PythonLibs 3.8 EXACT REQUIRED)
+if(NOT HIP_FOUND)
+  message(FATAL_ERROR "hip is required but is not found")
+endif()
 
-set(onnxruntime_BERT_DIR ${onnxruntime_DIR}/contrib_ops/rocm/bert/)
-set(onnxruntime_KE_DIR ${onnxruntime_DIR}/python/tools/kernel_explorer/)
-include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${pybind11_INCLUDE_DIRS})
-include_directories(${onnxruntime_DIR})
+set(BERT_DIR ${REPO_ROOT}/onnxruntime/contrib_ops/rocm/bert/)
 
-FILE(GLOB kernel_srcs ${onnxruntime_KE_DIR}/kernels/*.cc)
-add_library(kernel_explorer SHARED kernel_explorer.cc ${onnxruntime_BERT_DIR}/util.cc ${kernel_srcs})
-target_link_libraries(kernel_explorer ${PYTHON_LIBRARIES})
+file(GLOB kernel_srcs CONFIGURE_DEPENDS "kernels/*.cc")
+add_library(kernel_explorer SHARED kernel_explorer.cc ${BERT_DIR}/timer.cc ${kernel_srcs})
 set_target_properties(kernel_explorer PROPERTIES PREFIX "")
+target_include_directories(kernel_explorer PUBLIC $<TARGET_PROPERTY:onnxruntime_pybind11_state,INCLUDE_DIRECTORIES> ".")
+target_link_libraries(kernel_explorer
+  PRIVATE
+    $<TARGET_PROPERTY:onnxruntime_pybind11_state,LINK_LIBRARIES>
+    ${HIP_LIB})
+target_compile_definitions(kernel_explorer
+  PUBLIC ROCM_USE_FLOAT16
+  PRIVATE $<TARGET_PROPERTY:onnxruntime_pybind11_state,COMPILE_DEFINITIONS>)
+target_compile_options(kernel_explorer PRIVATE "-xhip")
+# TODO: use predefined AMDGPU_TARGETS
+target_compile_options(kernel_explorer PRIVATE "--offload-arch=gfx906" "--offload-arch=gfx908" "--offload-arch=gfx90a")
+
+add_dependencies(kernel_explorer onnxruntime_pybind11_state)
 
 enable_testing()
 find_package(Python COMPONENTS Interpreter REQUIRED)

--- a/onnxruntime/python/tools/kernel_explorer/README.md
+++ b/onnxruntime/python/tools/kernel_explorer/README.md
@@ -1,12 +1,37 @@
-# Kernel Explorer 
+# Kernel Explorer
+
 Kernel Explorer hooks up GPU kernel code with a Python frontend to help develop, test, profile, and auto-tune GPU kernels.
 
-## Example Usage
-```
-mkdir build
-cd build
-cmake -D onnxruntime_ROCM_HOME=/opt/rocm ..
-cmake --build .
-pytest ../kernels --verbose
-python ../kernels/vector_add_test.py
+Kernel explorer mainly target for attention based models and the purpose is specific to it at the moment.
+
+## Build
+
+```bash
+#!/bin/bash
+
+set -ex
+
+build_dir="build"
+config="Release"
+
+rocm_home="/opt/rocm"
+rocm_version="5.1.1"
+
+./build.sh --update \
+    --build_dir ${build_dir} \
+    --config ${config} \
+    --cmake_generator Ninja \
+    --cmake_extra_defines \
+        CMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+        CMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+        CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        onnxruntime_BUILD_KERNEL_EXPLORER=ON \
+        onnxruntime_DISABLE_CONTRIB_OPS=ON \
+        onnxruntime_DISABLE_ML_OPS=ON \
+        onnxruntime_DEV_MODE=OFF \
+    --skip_submodule_sync --skip_tests \
+    --use_rocm --rocm_version=${rocm_version} --rocm_home=${rocm_home} --nccl_home=${rocm_home} \
+    --build_wheel \
+
+cmake --build ${build_dir}/${config} --target kernel_explorer
 ```

--- a/onnxruntime/python/tools/kernel_explorer/README.md
+++ b/onnxruntime/python/tools/kernel_explorer/README.md
@@ -2,7 +2,7 @@
 
 Kernel Explorer hooks up GPU kernel code with a Python frontend to help develop, test, profile, and auto-tune GPU kernels.
 
-Kernel explorer mainly target for attention based models and the purpose is specific to it at the moment.
+The initial scope is for BERT-like models with ROCM EP.
 
 ## Build
 

--- a/onnxruntime/python/tools/kernel_explorer/README.md
+++ b/onnxruntime/python/tools/kernel_explorer/README.md
@@ -1,10 +1,10 @@
 # Kernel Explorer
 
-Kernel Explorer hooks up GPU kernel code with a Python frontend to help develop, test, profile, and auto-tune GPU kernels.
-
-The initial scope is for BERT-like models with ROCM EP.
+Kernel Explorer hooks up GPU kernel code with a Python frontend to help develop, test, profile, and auto-tune GPU kernels. The initial scope is for BERT-like models with ROCM EP.
 
 ## Build
+
+Install `ninja` from system package manager or pip to speedup the building. If you don't have `ninja` installed, you can also set it to use the default cmake generator by removing the `--cmake_generator` option.
 
 ```bash
 #!/bin/bash
@@ -15,7 +15,6 @@ build_dir="build"
 config="Release"
 
 rocm_home="/opt/rocm"
-rocm_version="5.1.1"
 
 ./build.sh --update \
     --build_dir ${build_dir} \
@@ -30,8 +29,31 @@ rocm_version="5.1.1"
         onnxruntime_DISABLE_ML_OPS=ON \
         onnxruntime_DEV_MODE=OFF \
     --skip_submodule_sync --skip_tests \
-    --use_rocm --rocm_version=${rocm_version} --rocm_home=${rocm_home} --nccl_home=${rocm_home} \
+    --use_rocm --rocm_home=${rocm_home} --nccl_home=${rocm_home} \
     --build_wheel \
 
 cmake --build ${build_dir}/${config} --target kernel_explorer
 ```
+
+## Run
+
+Taking `vector_add_test.py` and build configuration with `build_dir="build"` and `config="Release"` in the previous section as an example.
+
+Set up the native library search path with the following environment variable:
+```bash
+export KERNEL_EXPLORER_BUILD_DIR=`realpath build/Release`
+```
+
+To test a kernel implementation, `pip install pytest` and then
+
+```bash
+pytest onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
+```
+
+To run the microbenchmarks:
+
+```bash
+python onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
+```
+
+Currently, kernel explorer mainly targets kernel developers, not the onnxruntime package end users, so it is not installed via `setup.py`.

--- a/onnxruntime/python/tools/kernel_explorer/common.h
+++ b/onnxruntime/python/tools/kernel_explorer/common.h
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/rocm/rocm_common.h"

--- a/onnxruntime/python/tools/kernel_explorer/common.h
+++ b/onnxruntime/python/tools/kernel_explorer/common.h
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-#pragma once
-
-#include "core/providers/rocm/rocm_common.h"

--- a/onnxruntime/python/tools/kernel_explorer/device_array.h
+++ b/onnxruntime/python/tools/kernel_explorer/device_array.h
@@ -10,6 +10,14 @@
 
 namespace py = pybind11;
 
+namespace onnxruntime {
+
+#ifdef NDEBUG
+#define HIP_ASSERT(x) x
+#else
+#define HIP_ASSERT(x) (assert((x)==hipSuccess))
+#endif
+
 class DeviceArray {
  public:
   DeviceArray(py::array x) {
@@ -41,3 +49,5 @@ class DeviceArray {
   ssize_t size_;
   ssize_t itemsize_;
 };
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/device_array.h
+++ b/onnxruntime/python/tools/kernel_explorer/device_array.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "common.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include "core/providers/rocm/rocm_common.h"
 #include "contrib_ops/rocm/bert/util.h"
 
 namespace py = pybind11;

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
@@ -9,6 +9,8 @@
 
 namespace py = pybind11;
 
+namespace onnxruntime {
+
 PYBIND11_MODULE(kernel_explorer, m) {
   py::class_<DeviceArray>(m, "DeviceArray")
     .def(py::init<py::array>())
@@ -16,3 +18,5 @@ PYBIND11_MODULE(kernel_explorer, m) {
   InitVectorAdd(m);
   InitFastGelu(m);
 }
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
@@ -13,8 +13,8 @@ namespace onnxruntime {
 
 PYBIND11_MODULE(kernel_explorer, m) {
   py::class_<DeviceArray>(m, "DeviceArray")
-    .def(py::init<py::array>())
-    .def("UpdateHostNumpyArray", &DeviceArray::UpdateHostNumpyArray);
+      .def(py::init<py::array>())
+      .def("UpdateHostNumpyArray", &DeviceArray::UpdateHostNumpyArray);
   InitVectorAdd(m);
   InitFastGelu(m);
 }

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
@@ -11,7 +11,7 @@ namespace py = pybind11;
 
 namespace onnxruntime {
 
-PYBIND11_MODULE(kernel_explorer, m) {
+PYBIND11_MODULE(_kernel_explorer, m) {
   py::class_<DeviceArray>(m, "DeviceArray")
       .def(py::init<py::array>())
       .def("UpdateHostNumpyArray", &DeviceArray::UpdateHostNumpyArray);

--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.cc
@@ -71,7 +71,7 @@ class FastGeluTunable: public Operator {
     .def("SetRepeats", &name<type, threads_per_block, vec_size>::SetRepeats)                              \
     .def("Profile", &name<type, threads_per_block, vec_size>::Profile)                                    \
     .def("Run", &name<type, threads_per_block, vec_size>::Run);
-  
+
 #define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, threads_per_block)  \
   REGISTER_OP(name, type, threads_per_block, 1)                      \
   REGISTER_OP(name, type, threads_per_block, 2)                      \
@@ -79,16 +79,16 @@ class FastGeluTunable: public Operator {
   REGISTER_OP(name, type, threads_per_block, 8)                      \
   REGISTER_OP(name, type, threads_per_block, 16)
 
-#define REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(name, type)  \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 64)             \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 128)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 192)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 256)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 320)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 384)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 448)            \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 512)         
-  
+#define REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(name, type) \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 64)            \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 128)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 192)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 256)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 320)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 384)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 448)           \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 512)
+
 void InitFastGelu(py::module m) {
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(FastGelu, half);
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(FastGelu, float);

--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.cc
@@ -13,6 +13,8 @@ using onnxruntime::contrib::rocm::LaunchFastGelu;
 using onnxruntime::contrib::rocm::FastGeluParams;
 using onnxruntime::contrib::rocm::FastGeluTunableOp;
 
+namespace onnxruntime {
+
 template <typename T, int ThreadsPerBlock, int VecSize>
 class FastGelu: public Operator {
  public:
@@ -97,3 +99,5 @@ void InitFastGelu(py::module m) {
     .def("Profile", &FastGeluTunable<half>::Profile)
     .def("Run", &FastGeluTunable<half>::Run);
 }
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu.h
@@ -7,4 +7,8 @@
 
 namespace py = pybind11;
 
+namespace onnxruntime {
+
 void InitFastGelu(py::module m);
+
+}

--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
@@ -3,10 +3,6 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-import sys
-
-sys.path.append("../build")
-
 import kernel_explorer as ke
 import numpy as np
 import pytest

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+"""Wrapper for native _kernel_explorer.so library"""
+
 import ctypes
 import os
 import sys

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -17,9 +17,8 @@ if not os.path.exists(build_dir):
 build_dir = os.path.realpath(build_dir)
 search_paths = [build_dir]
 
-# kernel explorer hooks up some underlaying functions for microbenchmark purpose. Some utility functions might also be
-# needed. We dlopen all this libraries to bring all those required symbols into global namespace so that we don't need
-# worry about linking.
+# As Kernel Explorer makes use of utility functions in ONNXRuntime, we dlopen all relevant libraries to bring required
+# symbols into global namespace, so that we don't need to worry about linking.
 library_files_to_load = [
     "onnxruntime_pybind11_state.so",
     "libonnxruntime_providers_shared.so",

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -40,7 +40,7 @@ for lib in library_files_to_load:
 # onnxruntime_pybind11_state and kernel_explorer
 sys.path.insert(0, build_dir)
 
-# pylint: disable=wrong-import-position, disable=unused-import, disable=wildcard-import
+# pylint: disable=wrong-import-position
 import onnxruntime_pybind11_state  # noqa
 
 # We need to call some functions to properly initialize so pointers in the library
@@ -49,5 +49,8 @@ onnxruntime_pybind11_state.get_available_providers()
 # use RTLD_GLOBAL to bring all symbols to global name space
 libraries = [ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL) for lib_path in library_to_load]
 
+# pylint: disable=wrong-import-position, disable=unused-import
 import _kernel_explorer  # noqa
+
+# pylint: disable=wrong-import-position, disable=unused-import, disable=wildcard-import
 from _kernel_explorer import *  # noqa

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import ctypes
+import os
+import sys
+
+build_dir = os.environ.get("KERNEL_EXPLORER_BUILD_DIR", None)
+if build_dir is None:
+    raise ValueError("Environment variable KERNEL_EXPLORER_BUILD_DIR is required")
+
+if not os.path.exists(build_dir):
+    raise ValueError(f"KERNEL_EXPLORER_BUILD_DIR ({build_dir}) points to nonexistent path")
+
+build_dir = os.path.realpath(build_dir)
+search_paths = [build_dir]
+
+# kernel explorer hooks up some underlaying functions for microbenchmark purpose. Some utility functions might also be
+# needed. We dlopen all this libraries to bring all those required symbols into global namespace so that we don't need
+# worry about linking.
+library_files_to_load = [
+    "onnxruntime_pybind11_state.so",
+    "libonnxruntime_providers_shared.so",
+    "libonnxruntime_providers_rocm.so"
+]
+
+library_to_load = []
+
+for lib in library_files_to_load:
+    for prefix in search_paths:
+        path = os.path.join(prefix, lib)
+        if os.path.exists(path):
+            library_to_load.append(path)
+            continue
+
+        raise EnvironmentError(f"cannot found {lib}")
+
+
+# onnxruntime_pybind11_state and kernel_explorer
+sys.path.insert(0, build_dir)
+
+import onnxruntime_pybind11_state
+
+# We need to call some functions to properly initialize so pointers in the library
+onnxruntime_pybind11_state.get_available_providers()
+
+# use RTLD_GLOBAL to bring all symbols to global name space
+libraries = [ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL) for lib_path in library_to_load]
+
+import _kernel_explorer
+from _kernel_explorer import *

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -23,7 +23,7 @@ search_paths = [build_dir]
 library_files_to_load = [
     "onnxruntime_pybind11_state.so",
     "libonnxruntime_providers_shared.so",
-    "libonnxruntime_providers_rocm.so"
+    "libonnxruntime_providers_rocm.so",
 ]
 
 library_to_load = []

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -40,7 +40,8 @@ for lib in library_files_to_load:
 # onnxruntime_pybind11_state and kernel_explorer
 sys.path.insert(0, build_dir)
 
-import onnxruntime_pybind11_state
+# pylint: disable=wrong-import-position, disable=unused-import, disable=wildcard-import
+import onnxruntime_pybind11_state  # noqa
 
 # We need to call some functions to properly initialize so pointers in the library
 onnxruntime_pybind11_state.get_available_providers()
@@ -48,5 +49,5 @@ onnxruntime_pybind11_state.get_available_providers()
 # use RTLD_GLOBAL to bring all symbols to global name space
 libraries = [ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL) for lib_path in library_to_load]
 
-import _kernel_explorer
-from _kernel_explorer import *
+import _kernel_explorer  # noqa
+from _kernel_explorer import *  # noqa

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cc
@@ -63,7 +63,7 @@ class VectorAddTunable: public Operator {
     .def("SetRepeats", &name<type, threads_per_block, vec_size>::SetRepeats)                              \
     .def("Profile", &name<type, threads_per_block, vec_size>::Profile)                                    \
     .def("Run", &name<type, threads_per_block, vec_size>::Run);
-  
+
 #define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, threads_per_block)  \
   REGISTER_OP(name, type, threads_per_block, 1)                      \
   REGISTER_OP(name, type, threads_per_block, 2)                      \
@@ -79,16 +79,15 @@ class VectorAddTunable: public Operator {
   REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 384)            \
   REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 448)            \
   REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 512)
-  
 
 void InitVectorAdd(py::module m) {
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(VectorAdd, half);
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK(VectorAdd, float);
   py::class_<VectorAddTunable<half>>(m, "VectorAdd_half_Tunable")
-    .def(py::init<DeviceArray&, DeviceArray&, DeviceArray&, int>())
-    .def("SetRepeats", &VectorAddTunable<half>::SetRepeats)
-    .def("Profile", &VectorAddTunable<half>::Profile)
-    .def("Run", &VectorAddTunable<half>::Run);
+      .def(py::init<DeviceArray&, DeviceArray&, DeviceArray&, int>())
+      .def("SetRepeats", &VectorAddTunable<half>::SetRepeats)
+      .def("Profile", &VectorAddTunable<half>::Profile)
+      .def("Run", &VectorAddTunable<half>::Run);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cc
@@ -9,6 +9,8 @@
 
 namespace py = pybind11;
 
+namespace onnxruntime {
+
 template <typename T, int ThreadsPerBlock, int VecSize>
 class VectorAdd: public Operator {
  public:
@@ -88,3 +90,5 @@ void InitVectorAdd(py::module m) {
     .def("Profile", &VectorAddTunable<half>::Profile)
     .def("Run", &VectorAddTunable<half>::Run);
 }
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.h
@@ -7,4 +7,8 @@
 
 namespace py = pybind11;
 
+namespace onnxruntime {
+
 void InitVectorAdd(py::module m);
+
+}

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
@@ -11,6 +11,8 @@
 using onnxruntime::contrib::rocm::CeilingDivision;
 using onnxruntime::contrib::rocm::AlignedVector;
 
+namespace onnxruntime {
+
 template <typename T, int VecSize>
 __global__ void VectorAddKernel(const T* __restrict__ x,
                                   const T* __restrict__ y,
@@ -53,3 +55,5 @@ void LaunchVectorAdd(hipStream_t stream, const T* x, const T* y, T* z, int n) {
                      0, stream,
                      x, y, z, n);
 }
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
@@ -15,8 +15,8 @@ namespace onnxruntime {
 
 template <typename T, int VecSize>
 __global__ void VectorAddKernel(const T* __restrict__ x,
-                                  const T* __restrict__ y,
-                                  T* __restrict__ z, int n) {
+                                const T* __restrict__ y,
+                                T* __restrict__ z, int n) {
   int i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
   using LoadT = AlignedVector<T, VecSize>;
 
@@ -31,7 +31,7 @@ __global__ void VectorAddKernel(const T* __restrict__ x,
 
     T z_vec[VecSize];
 
-    #pragma unroll
+#pragma unroll
     for (int j = 0; j < VecSize; j++) {
       z_vec[j] = x_vec[j] + y_vec[j];
     }
@@ -49,7 +49,7 @@ __global__ void VectorAddKernel(const T* __restrict__ x,
 
 template <typename T, int ThreadsPerBlock, int VecSize>
 void LaunchVectorAdd(hipStream_t stream, const T* x, const T* y, T* z, int n) {
-  hipLaunchKernelGGL((VectorAddKernel<T, VecSize>), 
+  hipLaunchKernelGGL((VectorAddKernel<T, VecSize>),
                      dim3(CeilingDivision(n, ThreadsPerBlock*VecSize)),
                      dim3(ThreadsPerBlock),
                      0, stream,

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_kernel.h
@@ -54,6 +54,7 @@ void LaunchVectorAdd(hipStream_t stream, const T* x, const T* y, T* z, int n) {
                      dim3(ThreadsPerBlock),
                      0, stream,
                      x, y, z, n);
+  HIP_CALL_THROW(hipGetLastError());
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_tunable_op.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_tunable_op.h
@@ -9,8 +9,8 @@
 #include "contrib_ops/rocm/bert/tunable_op.h"
 #include "python/tools/kernel_explorer/kernels/vector_add_kernel.h"
 
-using onnxruntime::contrib::rocm::OpParams;
 using onnxruntime::contrib::rocm::Op;
+using onnxruntime::contrib::rocm::OpParams;
 using onnxruntime::contrib::rocm::TunableOp;
 
 namespace onnxruntime {

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_tunable_op.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_tunable_op.h
@@ -13,6 +13,8 @@ using onnxruntime::contrib::rocm::OpParams;
 using onnxruntime::contrib::rocm::Op;
 using onnxruntime::contrib::rocm::TunableOp;
 
+namespace onnxruntime {
+
 template<typename T>
 struct VectorAddParams : OpParams {
   VectorAddParams(hipStream_t stream, const T* x, const T* y, T* z, int n) :
@@ -68,3 +70,5 @@ class VectorAddTunableOp : public TunableOp {
     return true;
   }
 };
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/version_script.lds
+++ b/onnxruntime/python/tools/kernel_explorer/version_script.lds
@@ -1,0 +1,6 @@
+# Export everything for building with kernel explorer,
+# so that we can reuse all those utilities functions
+VERS_0.0 {
+  global:
+    **;
+};


### PR DESCRIPTION
**Description**: Improve CMake for deep integration with ORT.

**Motivation and Context**
- Why is this change required? What problem does it solve?
   We are not able to reuse some of the ort utilities or libraries with the previous cmake integration. It makes it impossible to hooks ort function of microbenchmarking purpose. Improve the integration to solve the problem. 
