### PR TITLE
Add tests for all unary aten ops supported in eager mode

### DIFF
--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -10,11 +10,11 @@ import onnxruntime_pybind11_state as torch_ort
 import torch
 from parameterized import parameterized
 
-### OPS - is a list of list of [test_operator, test_tensor]
+# OPS - is a list of  list of [test_operator, the tested_tensor]
 ops = [
     ["abs", torch.tensor([-1, -2, 3, -6, -7])],
     ["acos"],
-    ["acosh", torch.rand(6).uniform_(1, 9999)],  ### limits[1,INF]
+    ["acosh", torch.rand(6).uniform_(1, 9999)],  # limits[1,INF]
     ["asinh"],
     ["atanh", torch.rand(6).uniform_(-1, 1)],
     ["asin", torch.rand(6).uniform_(-1, 1)],
@@ -47,11 +47,11 @@ ops = [
 
 
 def rename_func_to_op(testcase_func, param_num, param):
-    return "test_%s" % (parameterized.to_safe_name(str(param.args[0])))
+    return f"test_{parameterized.to_safe_name(str(param.args[0]))}"
 
 
 def rename_func_to_inplace(testcase_func, param_num, param):
-    return "test_%s_" % (parameterized.to_safe_name(str(param.args[0])))
+    return f"test_{parameterized.to_safe_name(str(param.args[0]))}_"
 
 
 class OrtOpTests(unittest.TestCase):
@@ -242,17 +242,8 @@ class OrtOpTests(unittest.TestCase):
 
     @parameterized.expand(ops, name_func=rename_func_to_op)
     def test_op(self, test_name, tensor_test=torch.rand(6)):
-        device = self.get_device()
-
-        cpu_tensor = tensor_test
-        ort_tensor = cpu_tensor.to(device)
-
-        cpu_result_func = "torch." + test_name + "(cpu_tensor)"
-        ort_result_func = "torch." + test_name + "(ort_tensor)"
-
-        cpu_result = eval(compile(cpu_result_func, "<string>", "eval"))
-        ort_result = eval(compile(ort_result_func, "<string>", "eval"))
-
+        cpu_result = eval(compile("torch." + test_name + "(tensor_test)", "<string>", "eval"))
+        ort_result = eval(compile("torch." + test_name + "(tensor_test.to(self.get_device()))", "<string>", "eval"))
         assert torch.allclose(cpu_result, ort_result.cpu())
 
     @parameterized.expand(ops, name_func=rename_func_to_inplace)

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -54,83 +54,6 @@ def rename_func_to_inplace(testcase_func, param_num, param):
     return "test_%s_" % (parameterized.to_safe_name(str(param.args[0])))
 
 
-ops = [
-    ["abs", torch.tensor([-1, -2, 3, -6, -7])],
-    [
-        "acos",
-    ],
-    ["acosh", torch.rand(6).uniform_(1, 9999)],  ### limits[1,INF]
-    [
-        "asinh",
-    ],
-    ["atanh", torch.rand(6).uniform_(-1, 1)],
-    ["asin", torch.rand(6).uniform_(-1, 1)],
-    [
-        "atan",
-    ],
-    [
-        "ceil",
-    ],
-    [
-        "cos",
-    ],
-    [
-        "cosh",
-    ],
-    [
-        "erf",
-    ],
-    [
-        "exp",
-    ],
-    [
-        "floor",
-    ],
-    # ["isnan",       torch.tensor([1, float('nan'), 2])]]
-    ["log", torch.abs(torch.rand(6)) + 0.5],
-    [
-        "reciprocal",
-    ],
-    ["neg", torch.randn(10)],
-    [
-        "round",
-    ],
-    [
-        "relu",
-    ],
-    # ["selu",        torch.randn(10)]]
-    [
-        "sigmoid",
-    ],
-    [
-        "sin",
-    ],
-    [
-        "sinh",
-    ],
-    ["sqrt", torch.randn(10).uniform_(1, 9999)],
-    [
-        "tan",
-    ],
-    [
-        "tanh",
-    ],
-]
-# ["nonzero",    torch.tensor([0, 2, 1, 3])]]
-# ["sign",        ]]
-# ["hardsigmoid", ],
-# ["isinf",       ],
-# ["det"          ]]
-
-
-def rename_func_to_op(testcase_func, param_num, param):
-    return "test_%s" % (parameterized.to_safe_name(str(param.args[0])))
-
-
-def rename_func_to_inplace(testcase_func, param_num, param):
-    return "test_%s_" % (parameterized.to_safe_name(str(param.args[0])))
-
-
 class OrtOpTests(unittest.TestCase):
     """test cases for supported eager ops"""
 
@@ -317,6 +240,33 @@ class OrtOpTests(unittest.TestCase):
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert cpu_result.dim() == ort_result.dim()
 
+    @parameterized.expand(ops, name_func=rename_func_to_op)
+    def test_op(self, test_name, tensor_test=torch.rand(6)):
+        device = self.get_device()
+
+        cpu_tensor = tensor_test
+        ort_tensor = cpu_tensor.to(device)
+
+        cpu_result_func = "torch." + test_name + "(cpu_tensor)"
+        ort_result_func = "torch." + test_name + "(ort_tensor)"
+
+        cpu_result = eval(cpu_result_func)
+        ort_result = eval(ort_result_func)
+
+        assert torch.allclose(cpu_result, ort_result.cpu())
+
+    @parameterized.expand(ops, name_func=rename_func_to_inplace)
+    def test_op_inplace(self, test_name, tensor_test=torch.rand(6)):
+        device = self.get_device()
+
+        cpu_tensor = tensor_test
+        ort_tensor = cpu_tensor.to(device)
+
+        eval("torch." + test_name + "_(cpu_tensor)")
+        eval("torch." + test_name + "_(ort_tensor)")
+
+        assert torch.allclose(cpu_tensor, ort_tensor.cpu())
+
     def test_resize(self):
         device = self.get_device()
 
@@ -374,26 +324,6 @@ class OrtOpTests(unittest.TestCase):
 
         self.assertEqual(cpu_tensor.size(), ort_tensor.size())
         self.assertTrue(torch.allclose(cpu_tensor, ort_tensor.cpu()))
-
-    def test_abs(self):
-        device = self.get_device()
-        cpu_tensor = torch.tensor([-1, -2, 3, -6, -7])
-        ort_tensor = cpu_tensor.to(device)
-
-        cpu_result = torch.abs(cpu_tensor)
-        ort_result = torch.abs(ort_tensor)
-
-        assert torch.equal(cpu_result, ort_result.cpu())
-
-    def test_abs_(self):
-        device = self.get_device()
-        cpu_tensor = torch.tensor([-1, -2, 3, -6, -7])
-        ort_tensor = cpu_tensor.to(device)
-
-        torch.abs_(cpu_tensor)
-        torch.abs_(ort_tensor)
-
-        assert torch.equal(cpu_tensor, ort_tensor.cpu())
 
     def test_abs_out(self):
         device = self.get_device()
@@ -526,6 +456,4 @@ class OrtOpTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
-    ##delocate the list
-    ops.clear()
+    unittest.main()

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -250,8 +250,8 @@ class OrtOpTests(unittest.TestCase):
         cpu_result_func = "torch." + test_name + "(cpu_tensor)"
         ort_result_func = "torch." + test_name + "(ort_tensor)"
 
-        cpu_result = eval(cpu_result_func)
-        ort_result = eval(ort_result_func)
+        cpu_result = eval(compile(cpu_result_func, "<string>", "eval"))
+        ort_result = eval(compile(ort_result_func, "<string>", "eval"))
 
         assert torch.allclose(cpu_result, ort_result.cpu())
 
@@ -262,8 +262,8 @@ class OrtOpTests(unittest.TestCase):
         cpu_tensor = tensor_test
         ort_tensor = cpu_tensor.to(device)
 
-        eval("torch." + test_name + "_(cpu_tensor)")
-        eval("torch." + test_name + "_(ort_tensor)")
+        eval(compile("torch." + test_name + "_(cpu_tensor)", "<string>", "eval"))
+        eval(compile("torch." + test_name + "_(ort_tensor)", "<string>", "eval"))
 
         assert torch.allclose(cpu_tensor, ort_tensor.cpu())
 

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -4,49 +4,132 @@
 # pylint: disable=missing-docstring
 
 import unittest
-from parameterized import parameterized
 
 import numpy as np
 import onnxruntime_pybind11_state as torch_ort
 import torch
+from parameterized import parameterized
 
-ops= [["abs",         torch.tensor([-1, -2, 3, -6, -7])],
-     ["acos",        ],
-     ["acosh",       torch.rand(6).uniform_(1,9999)],              ### limits[1,INF]
-     ["asinh",       ],
-     ["atanh",       torch.rand(6).uniform_(-1,1)],
-     ["asin",        torch.rand(6).uniform_(-1,1)],
-     ["atan",        ],
-     ["ceil",        ],
-     ["cos",         ],
-     ["cosh",        ],
-     ["erf",         ],
-     ["exp",          ],
-     ["floor",       ],
-     # ["isnan",       torch.tensor([1, float('nan'), 2])]]
-     ["log",         torch.abs(torch.rand(6))+0.5],
-     ["reciprocal",  ],
-     ["neg",         torch.randn(10)],
-     ["round",       ],
-     ["relu",        ],
-     #["selu",        torch.randn(10)]]
-     ["sigmoid",     ],
-     ["sin",         ],
-     ["sinh",        ],
-     ["sqrt",        torch.randn(10).uniform_(1,9999)],
-     ["tan",         ],
-     ["tanh",        ]]
-     #["nonzero",    torch.tensor([0, 2, 1, 3])]]
-     #["sign",        ]]
-     #["hardsigmoid", ],
-     # ["isinf",       ],
-     # ["det"          ]]
+### OPS - is a list of list of [test_operator, test_tensor]
+ops = [
+    ["abs", torch.tensor([-1, -2, 3, -6, -7])],
+    ["acos"],
+    ["acosh", torch.rand(6).uniform_(1, 9999)],  ### limits[1,INF]
+    ["asinh"],
+    ["atanh", torch.rand(6).uniform_(-1, 1)],
+    ["asin", torch.rand(6).uniform_(-1, 1)],
+    ["atan"],
+    ["ceil"],
+    ["cos"],
+    ["cosh"],
+    ["erf"],
+    ["exp"],
+    ["floor"],
+    # ["isnan",       torch.tensor([1, float('nan'), 2])]]
+    ["log", torch.abs(torch.rand(6)) + 0.5],
+    ["reciprocal"],
+    ["neg", torch.randn(10)],
+    ["round"],
+    ["relu"],
+    # ["selu",        torch.randn(10)]]
+    ["sigmoid"],
+    ["sin"],
+    ["sinh"],
+    ["sqrt", torch.randn(10).uniform_(1, 9999)],
+    ["tan"],
+    ["tanh"],
+]
+# ["nonzero",    torch.tensor([0, 2, 1, 3])]]
+# ["sign",        ]]
+# ["hardsigmoid", ],
+# ["isinf",       ],
+# ["det"          ]]
+
 
 def rename_func_to_op(testcase_func, param_num, param):
-    return "test_%s" %(parameterized.to_safe_name(str(param.args[0])))
+    return "test_%s" % (parameterized.to_safe_name(str(param.args[0])))
+
 
 def rename_func_to_inplace(testcase_func, param_num, param):
-    return "test_%s_" %(parameterized.to_safe_name(str(param.args[0])))
+    return "test_%s_" % (parameterized.to_safe_name(str(param.args[0])))
+
+
+ops = [
+    ["abs", torch.tensor([-1, -2, 3, -6, -7])],
+    [
+        "acos",
+    ],
+    ["acosh", torch.rand(6).uniform_(1, 9999)],  ### limits[1,INF]
+    [
+        "asinh",
+    ],
+    ["atanh", torch.rand(6).uniform_(-1, 1)],
+    ["asin", torch.rand(6).uniform_(-1, 1)],
+    [
+        "atan",
+    ],
+    [
+        "ceil",
+    ],
+    [
+        "cos",
+    ],
+    [
+        "cosh",
+    ],
+    [
+        "erf",
+    ],
+    [
+        "exp",
+    ],
+    [
+        "floor",
+    ],
+    # ["isnan",       torch.tensor([1, float('nan'), 2])]]
+    ["log", torch.abs(torch.rand(6)) + 0.5],
+    [
+        "reciprocal",
+    ],
+    ["neg", torch.randn(10)],
+    [
+        "round",
+    ],
+    [
+        "relu",
+    ],
+    # ["selu",        torch.randn(10)]]
+    [
+        "sigmoid",
+    ],
+    [
+        "sin",
+    ],
+    [
+        "sinh",
+    ],
+    ["sqrt", torch.randn(10).uniform_(1, 9999)],
+    [
+        "tan",
+    ],
+    [
+        "tanh",
+    ],
+]
+# ["nonzero",    torch.tensor([0, 2, 1, 3])]]
+# ["sign",        ]]
+# ["hardsigmoid", ],
+# ["isinf",       ],
+# ["det"          ]]
+
+
+def rename_func_to_op(testcase_func, param_num, param):
+    return "test_%s" % (parameterized.to_safe_name(str(param.args[0])))
+
+
+def rename_func_to_inplace(testcase_func, param_num, param):
+    return "test_%s_" % (parameterized.to_safe_name(str(param.args[0])))
+
 
 class OrtOpTests(unittest.TestCase):
     """test cases for supported eager ops"""
@@ -382,19 +465,45 @@ class OrtOpTests(unittest.TestCase):
             assert torch.equal(cpu_float_float_result, ort_float_float_result.to("cpu"))
             assert torch.equal(cpu_float_float_not_result, ort_float_float_not_result.to("cpu"))
 
-
-    @parameterized.expand(ops,name_func=rename_func_to_op)
+    @parameterized.expand(ops, name_func=rename_func_to_op)
     def test_op(self, test_name, tensor_test=torch.rand(6)):
         device = self.get_device()
 
         cpu_tensor = tensor_test
         ort_tensor = cpu_tensor.to(device)
 
-        cpu_result_func="torch."+test_name+"(cpu_tensor)"
-        ort_result_func="torch."+test_name+"(ort_tensor)"
+        cpu_result_func = "torch." + test_name + "(cpu_tensor)"
+        ort_result_func = "torch." + test_name + "(ort_tensor)"
 
-        cpu_result= eval(cpu_result_func)
-        ort_result= eval(ort_result_func)
+        cpu_result = eval(cpu_result_func)
+        ort_result = eval(ort_result_func)
+
+        assert torch.allclose(cpu_result, ort_result.cpu())
+
+    @parameterized.expand(ops, name_func=rename_func_to_inplace)
+    def test_op_inplace(self, test_name, tensor_test=torch.rand(6)):
+        device = self.get_device()
+
+        cpu_tensor = tensor_test
+        ort_tensor = cpu_tensor.to(device)
+
+        eval("torch." + test_name + "_(cpu_tensor)")
+        eval("torch." + test_name + "_(ort_tensor)")
+
+        assert torch.allclose(cpu_tensor, ort_tensor.cpu())
+
+    @parameterized.expand(ops, name_func=rename_func_to_op)
+    def test_op(self, test_name, tensor_test=torch.rand(6)):
+        device = self.get_device()
+
+        cpu_tensor = tensor_test
+        ort_tensor = cpu_tensor.to(device)
+
+        cpu_result_func = "torch." + test_name + "(cpu_tensor)"
+        ort_result_func = "torch." + test_name + "(ort_tensor)"
+
+        cpu_result = eval(cpu_result_func)
+        ort_result = eval(ort_result_func)
 
         assert torch.allclose(cpu_result, ort_result.cpu())
 
@@ -403,18 +512,18 @@ class OrtOpTests(unittest.TestCase):
     ##                  1. calling to exclude the tests
     ##                  2. and in that fuction we loading the ops (ops can be in another file)
 
-    @parameterized.expand(ops, name_func=rename_func_to_inplace )
-    def test_op_inplace(self, test_name , tensor_test=torch.rand(6)):
+    @parameterized.expand(ops, name_func=rename_func_to_inplace)
+    def test_op_inplace(self, test_name, tensor_test=torch.rand(6)):
         device = self.get_device()
 
         cpu_tensor = tensor_test
         ort_tensor = cpu_tensor.to(device)
 
-        eval("torch."+test_name+"_(cpu_tensor)")
-        eval("torch."+test_name+"_(ort_tensor)")
-
+        eval("torch." + test_name + "_(cpu_tensor)")
+        eval("torch." + test_name + "_(ort_tensor)")
 
         assert torch.allclose(cpu_tensor, ort_tensor.cpu())
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
@@ -7,3 +7,4 @@ h5py
 sklearn
 numpy
 pandas
+parameterized

--- a/tools/ci_build/github/windows/eager/requirements.txt
+++ b/tools/ci_build/github/windows/eager/requirements.txt
@@ -3,3 +3,4 @@ wheel
 numpy
 typing_extensions
 torch==1.11.0
+parameterized


### PR DESCRIPTION
**Description**: Describe your changes.
   Add tests for all uniary aten ops supported in eager mode
**Motivation and Context**
- Why is this change required? What problem does it solve?
   Support eager mode (see that it's working the ops)
- If it fixes an open issue, please link to the issue here.
