### PR TITLE
Exclude c files from cpplint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          flags: --linelength=120
+          flags: --linelength=120 --exclude=*.c
           filter: "-runtime/references"
 
   lint-js:


### PR DESCRIPTION
**Description**: Exclude c files from cpplint

**Motivation and Context**

cpplint previously applies cpp styles to c files. This change excludes c files from being linted by cpplint.
