### PR TITLE
[add] Add operator gemmfastgelu for ROCM

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -29,6 +29,7 @@ Do not modify directly.*
   * <a href="#com.microsoft.FusedMatMul">com.microsoft.FusedMatMul</a>
   * <a href="#com.microsoft.GatherND">com.microsoft.GatherND</a>
   * <a href="#com.microsoft.Gelu">com.microsoft.Gelu</a>
+  * <a href="#com.microsoft.GemmFastGelu">com.microsoft.GemmFastGelu</a>
   * <a href="#com.microsoft.GridSample">com.microsoft.GridSample</a>
   * <a href="#com.microsoft.Inverse">com.microsoft.Inverse</a>
   * <a href="#com.microsoft.Irfft">com.microsoft.Irfft</a>
@@ -1509,6 +1510,40 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
+</dl>
+
+
+### <a name="com.microsoft.GemmFastGelu"></a><a name="com.microsoft.gemmfastgelu">**com.microsoft.GemmFastGelu**</a>
+
+  It's a fusion of MatMul and FastGelu.
+
+#### Version
+
+This version of the operator has been available since version 1 of the 'com.microsoft' operator set.
+
+#### Inputs (2 - 3)
+
+<dl>
+<dt><tt>X</tt> : T</dt>
+<dd>input tensor</dd>
+<dt><tt>W</tt> : T</dt>
+<dd>input tensor</dd>
+<dt><tt>bias</tt> (optional) : T</dt>
+<dd>bias tensor</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T</dt>
+<dd>output tensor</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
+<dd>Constrain input and output types to float or half tensors.</dd>
 </dl>
 
 

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/rocm/bert/gemm_fast_gelu.h"
+#include "core/providers/cpu/math/gemm_helper.h"
+#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/shared_inc/fpgeneric.h"
+#include "contrib_ops/rocm/bert/fast_gelu_impl.h"
+#include "contrib_ops/rocm/bert/transformer_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      GemmFastGelu,                                                  \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      GemmFastGelu<T>);
+
+REGISTER_KERNEL_TYPED(float)
+REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(BFloat16)
+
+template <typename T>
+GemmFastGelu<T>::GemmFastGelu(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {
+  const TransformerOptions* options = TransformerOptions::GetInstance();
+  use_half2_ = !options->DisableHalf2();
+}
+
+template <typename T>
+Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
+  typedef typename ToHipType<T>::MappedType HipT;
+
+  const auto* X = ctx->Input<Tensor>(0);
+  const auto* W = ctx->Input<Tensor>(1);
+  const auto* bias = ctx->Input<Tensor>(2);
+
+  GemmHelper helper(X->Shape(), 0, W->Shape(), 0, TensorShape({}));
+
+  if (!helper.State().IsOK())
+    return helper.State();
+
+  int M = gsl::narrow_cast<int>(helper.M());
+  int N = gsl::narrow_cast<int>(helper.N());
+  int K = gsl::narrow_cast<int>(helper.K());
+  auto* Y = ctx->Output(0, {M, N});
+  auto gemm_buffer = GetScratchBuffer<T>(M * N);
+
+  HipT zero = ToHipType<T>::FromFloat(0.0f);
+  HipT alpha = ToHipType<T>::FromFloat(1.0f);
+  // Gemm, note that HIP assumes col-major, so Y(N,M) = alpha * op(W) x op(X) + beta * Y
+  ROCBLAS_RETURN_IF_ERROR(rocblasGemmHelper(
+      RocblasHandle(),
+      rocblas_operation_none,
+      rocblas_operation_none,
+      N, M, K,
+      &alpha,
+      reinterpret_cast<const HipT*>(W->template Data<T>()),
+      N,
+      reinterpret_cast<const HipT*>(X->template Data<T>()),
+      K,
+      // ideally we need to set the output buffer contents to 0 if bias is missing,
+      // but passing 0 for beta is cheaper and it will ignore any junk in the output buffer
+      &zero,
+      reinterpret_cast<HipT*>(gemm_buffer.get()), N));
+
+  int64_t fast_gelu_input_length = Y->Shape().Size();
+  int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
+  typedef typename ToHipType<T>::MappedType HipT;
+
+  if (!LaunchFastGeluKernel<HipT>(GetDeviceProp(),
+                                   Stream(),
+                                   static_cast<int>(fast_gelu_input_length),
+                                   static_cast<int>(bias_length),
+                                   reinterpret_cast<HipT*>(gemm_buffer.get()),
+                                   (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->template Data<T>()) : nullptr,
+                                   reinterpret_cast<HipT*>(Y->template MutableData<T>()),
+                                   use_half2_)) {
+    HIP_CALL(hipGetLastError());
+    return Status(common::ONNXRUNTIME, common::FAIL);
+  }
+
+  return Status::OK();
+}
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -12,15 +12,15 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-#define REGISTER_KERNEL_TYPED(T)                                     \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                     \
-      GemmFastGelu,                                                  \
-      kMSDomain,                                                     \
-      1,                                                             \
-      T,                                                             \
-      kRocmExecutionProvider,                                        \
-      (*KernelDefBuilder::Create())                                  \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      GemmFastGelu,                                               \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       GemmFastGelu<T>);
 
 REGISTER_KERNEL_TYPED(float)
@@ -126,23 +126,23 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   } else if (CanUseStridedBatchedGemm(X->Shape(), W->Shape(),
                                       transa, transb, stride_A, stride_B, stride_C, batch_count)) {
     ROCBLAS_RETURN_IF_ERROR(rocblasGemmStridedBatchedHelper(RocblasHandle(),
-                                                          transB,
-                                                          transA,
-                                                          N,
-                                                          M,
-                                                          K,
-                                                          &alpha,
-                                                          reinterpret_cast<const HipT*>(W->template Data<T>()),
-                                                          ldb,
-                                                          stride_B,
-                                                          reinterpret_cast<const HipT*>(X->template Data<T>()),
-                                                          lda,
-                                                          stride_A,
-                                                          &zero,
-                                                          reinterpret_cast<HipT*>(gemm_buffer.get()),
-                                                          ldc,
-                                                          stride_C,
-                                                          static_cast<int>(batch_count)));
+                                                            transB,
+                                                            transA,
+                                                            N,
+                                                            M,
+                                                            K,
+                                                            &alpha,
+                                                            reinterpret_cast<const HipT*>(W->template Data<T>()),
+                                                            ldb,
+                                                            stride_B,
+                                                            reinterpret_cast<const HipT*>(X->template Data<T>()),
+                                                            lda,
+                                                            stride_A,
+                                                            &zero,
+                                                            reinterpret_cast<HipT*>(gemm_buffer.get()),
+                                                            ldc,
+                                                            stride_C,
+                                                            static_cast<int>(batch_count)));
   } else {
     // Fill offsets when needed.
     helper.FillOffsets();
@@ -183,12 +183,12 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
 
   if (!LaunchFastGeluKernel<HipT>(Stream(),
-                                   static_cast<int>(fast_gelu_input_length),
-                                   static_cast<int>(bias_length),
-                                   reinterpret_cast<HipT*>(gemm_buffer.get()),
-                                   (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->template Data<T>()) : nullptr,
-                                   reinterpret_cast<HipT*>(Y->template MutableData<T>()),
-                                   false)) {
+                                  static_cast<int>(fast_gelu_input_length),
+                                  static_cast<int>(bias_length),
+                                  reinterpret_cast<HipT*>(gemm_buffer.get()),
+                                  (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->template Data<T>()) : nullptr,
+                                  reinterpret_cast<HipT*>(Y->template MutableData<T>()),
+                                  false)) {
     HIP_CALL(hipGetLastError());
     return Status(common::ONNXRUNTIME, common::FAIL);
   }

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -7,6 +7,7 @@
 #include "core/providers/rocm/shared_inc/fpgeneric.h"
 #include "contrib_ops/rocm/bert/fast_gelu_impl.h"
 #include "contrib_ops/rocm/bert/transformer_common.h"
+#include "core/providers/rocm/math/matmul_impl.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -33,45 +34,6 @@ GemmFastGelu<T>::GemmFastGelu(const OpKernelInfo& op_kernel_info) : RocmKernel(o
   tuning_ = options->IsTuningEnabled();
 }
 
-// StridedBatchedGemm can be used for the following GEMM computation
-// C[pnm] = A[pnk]*B[km] or C[pnm] = A[pnk]*B[pkm]
-static bool CanUseStridedBatchedGemm(const TensorShape& left_shape, const TensorShape& right_shape,
-                                     bool transa, bool transb,
-                                     int64_t& stride_A, int64_t& stride_B,
-                                     int64_t& stride_C, int64_t& batch_count) {
-  size_t left_num_dims = left_shape.NumDimensions();
-  size_t right_num_dims = right_shape.NumDimensions();
-
-  if (!(left_num_dims >= 3 && right_num_dims >= 2)) {
-    return false;
-  }
-
-  size_t left_leading_axis = left_num_dims - 2;
-  size_t right_leading_axis = right_num_dims - 2;
-  int64_t left_p = left_shape.SizeToDimension(left_num_dims - 2);
-  int64_t left_k = transa ? left_shape[left_leading_axis] : left_shape[left_num_dims - 1];
-
-  if (right_num_dims >= 3) {
-    int64_t right_p = right_shape.SizeToDimension(right_num_dims - 2);
-    if (left_p != right_p) {
-      return false;
-    }
-  }
-
-  int64_t right_k = transb ? right_shape[right_num_dims - 1] : right_shape[right_leading_axis];
-  if (left_k != right_k) {
-    return false;
-  }
-
-  int64_t n = transa ? left_shape[left_num_dims - 1] : left_shape[left_leading_axis];
-  int64_t m = transb ? right_shape[right_leading_axis] : right_shape[right_num_dims - 1];
-  stride_A = n * left_k;
-  stride_B = right_num_dims == 2 ? 0 : right_k * m;
-  stride_C = n * m;
-  batch_count = left_p;
-  return true;
-}
-
 template <typename T>
 Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   typedef typename ToHipType<T>::MappedType HipT;
@@ -82,13 +44,11 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   bool transa = false;
   bool transb = false;
+  bool trans_batch_a = false;
+  bool trans_batch_b = false;
 
   MatMulComputeHelper helper;
-  ORT_RETURN_IF_ERROR(helper.Compute(X->Shape(), W->Shape(), transa, transb, false, false, false));
-
-  const int N = static_cast<int>(helper.N());
-  const int M = static_cast<int>(helper.M());
-  const int K = static_cast<int>(helper.K());
+  ORT_RETURN_IF_ERROR(helper.Compute(X->Shape(), W->Shape(), transa, transb, trans_batch_a, trans_batch_b, false));
 
   auto gemm_buffer = GetScratchBuffer<T>(helper.OutputShape().Size());
   Tensor* Y = ctx->Output(0, helper.OutputShape());
@@ -97,86 +57,15 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   if (Y->Shape().Size() == 0)
     return Status::OK();
 
-  const HipT alpha = ToHipType<T>::FromFloat(1.0f);
-  const HipT zero = ToHipType<T>::FromFloat(0.0f);
+  const float alpha = 1.0f;
+  const float zero = 0.0f;
 
-  rocblas_operation transA = transa ? rocblas_operation_transpose : rocblas_operation_none;
-  rocblas_operation transB = transb ? rocblas_operation_transpose : rocblas_operation_none;
-  const int lda = helper.Lda(transa);
-  const int ldb = helper.Ldb(transb);
-  const int ldc = helper.Ldc();
-  int64_t stride_A, stride_B, stride_C, batch_count;
-
-  if (helper.OutputOffsets().size() == 1) {
-    ROCBLAS_RETURN_IF_ERROR(rocblasGemmHelper(
-        RocblasHandle(),
-        transB,
-        transA,
-        N,
-        M,
-        K,
-        &alpha,
-        reinterpret_cast<const HipT*>(W->template Data<T>()),
-        ldb,
-        reinterpret_cast<const HipT*>(X->template Data<T>()),
-        lda,
-        &zero,
-        reinterpret_cast<HipT*>(gemm_buffer.get()),
-        ldc));
-  } else if (CanUseStridedBatchedGemm(X->Shape(), W->Shape(),
-                                      transa, transb, stride_A, stride_B, stride_C, batch_count)) {
-    ROCBLAS_RETURN_IF_ERROR(rocblasGemmStridedBatchedHelper(RocblasHandle(),
-                                                            transB,
-                                                            transA,
-                                                            N,
-                                                            M,
-                                                            K,
-                                                            &alpha,
-                                                            reinterpret_cast<const HipT*>(W->template Data<T>()),
-                                                            ldb,
-                                                            stride_B,
-                                                            reinterpret_cast<const HipT*>(X->template Data<T>()),
-                                                            lda,
-                                                            stride_A,
-                                                            &zero,
-                                                            reinterpret_cast<HipT*>(gemm_buffer.get()),
-                                                            ldc,
-                                                            stride_C,
-                                                            static_cast<int>(batch_count)));
-  } else {
-    // Fill offsets when needed.
-    helper.FillOffsets();
-    RocmAsyncBuffer<const HipT*> left_arrays(this, helper.LeftOffsets().size());
-    RocmAsyncBuffer<const HipT*> right_arrays(this, helper.RightOffsets().size());
-    RocmAsyncBuffer<HipT*> output_arrays(this, helper.OutputOffsets().size());
-    MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const HipT*>(X->template Data<T>()),
-                                        helper.LeftOffsets(), left_arrays.CpuSpan());
-    MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const HipT*>(W->template Data<T>()),
-                                        helper.RightOffsets(), right_arrays.CpuSpan());
-    MatMulComputeHelper::OffsetToArrays(reinterpret_cast<HipT*>(gemm_buffer.get()),
-                                        helper.OutputOffsets(), output_arrays.CpuSpan());
-    ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu());
-    ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu());
-    ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu());
-
-    // note that onnxruntime OrtValue is row major, while rocblas is column major,
-    // so swap left/right operands
-    ROCBLAS_RETURN_IF_ERROR(rocblasGemmBatchedHelper(
-        RocblasHandle(),
-        transB,
-        transA,
-        N,
-        M,
-        K,
-        &alpha,
-        right_arrays.GpuPtr(),
-        ldb,
-        left_arrays.GpuPtr(),
-        lda,
-        &zero,
-        output_arrays.GpuPtr(),
-        ldc,
-        static_cast<int>(helper.OutputOffsets().size())));
+  if (MatMulImpl<T>(this, helper, reinterpret_cast<const T*>(X->template Data<T>()),
+                    reinterpret_cast<const T*>(W->template Data<T>()),
+                    reinterpret_cast<T*>(gemm_buffer.get()),
+                    X->Shape(), W->Shape(),
+                    transa, transb, trans_batch_a, trans_batch_b, alpha, zero) != Status::OK()) {
+    return Status(common::ONNXRUNTIME, common::FAIL);
   }
 
   int64_t fast_gelu_input_length = Y->Shape().Size();

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -29,12 +29,6 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 REGISTER_KERNEL_TYPED(BFloat16)
 
 template <typename T>
-GemmFastGelu<T>::GemmFastGelu(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {
-  const TransformerOptions* options = TransformerOptions::GetInstance();
-  tuning_ = options->IsTuningEnabled();
-}
-
-template <typename T>
 Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   typedef typename ToHipType<T>::MappedType HipT;
 

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -2,16 +2,20 @@
 // Licensed under the MIT License.
 
 #include "contrib_ops/rocm/bert/gemm_fast_gelu.h"
-#include "core/providers/cpu/math/matmul_helper.h"
-#include "core/providers/rocm/rocm_common.h"
-#include "core/providers/rocm/shared_inc/fpgeneric.h"
+
 #include "contrib_ops/rocm/bert/fast_gelu_impl.h"
 #include "contrib_ops/rocm/bert/transformer_common.h"
+#include "core/providers/cpu/math/matmul_helper.h"
 #include "core/providers/rocm/math/matmul_impl.h"
+#include "core/providers/rocm/rocm_common.h"
+#include "core/providers/rocm/shared_inc/fpgeneric.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace rocm {
+
+using onnxruntime::rocm::MatMulImpl;
+using onnxruntime::rocm::ToHipType;
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/common/common.h"
+#include "core/providers/rocm/rocm_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+using namespace onnxruntime::rocm;
+
+template <typename T>
+class GemmFastGelu final : public RocmKernel {
+ public:
+  GemmFastGelu(const OpKernelInfo& op_kernel_info);
+  Status ComputeInternal(OpKernelContext* ctx) const override;
+  
+ private:
+  bool use_half2_;
+};
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
@@ -16,9 +16,9 @@ class GemmFastGelu final : public RocmKernel {
  public:
   GemmFastGelu(const OpKernelInfo& op_kernel_info);
   Status ComputeInternal(OpKernelContext* ctx) const override;
-  
+
  private:
-  bool use_half2_;
+  bool tuning_;
 };
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
@@ -14,7 +14,7 @@ using namespace onnxruntime::rocm;
 template <typename T>
 class GemmFastGelu final : public RocmKernel {
  public:
-  GemmFastGelu(const OpKernelInfo& op_kernel_info);
+  GemmFastGelu(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {}
   Status ComputeInternal(OpKernelContext* ctx) const override;
 
  private:

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.h
@@ -9,16 +9,13 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-using namespace onnxruntime::rocm;
+using onnxruntime::rocm::RocmKernel;
 
 template <typename T>
 class GemmFastGelu final : public RocmKernel {
  public:
   GemmFastGelu(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {}
   Status ComputeInternal(OpKernelContext* ctx) const override;
-
- private:
-  bool tuning_;
 };
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
@@ -95,6 +95,9 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, TransposeMatMul);  // backward compatibility
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, FusedMatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, BFloat16_float_BFloat16, LayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, GemmFastGelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, GemmFastGelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, GemmFastGelu);
 
 #ifdef ENABLE_ATEN
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kPytorchAtenDomain, 1, ATen);
@@ -198,6 +201,9 @@ Status RegisterRocmContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, FusedMatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, BFloat16_float_BFloat16, LayerNormalization)>,
       // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, FusedConv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, GemmFastGelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, GemmFastGelu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, GemmFastGelu)>,
 
 #ifdef ENABLE_ATEN
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kPytorchAtenDomain, 1, ATen)>,

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -9,6 +9,14 @@
 
 using namespace ::ONNX_NAMESPACE;
 
+namespace ONNX_NAMESPACE {
+void matmulShapeInference(
+    ONNX_NAMESPACE::InferenceContext& ctx,
+    int input1Idx,
+    int input2Idx);
+
+}  // namespace ONNX_NAMESPACE
+
 namespace onnxruntime {
 namespace contrib {
 
@@ -285,5 +293,22 @@ ONNX_MS_OPERATOR_SET_SCHEMA(BifurcationDetector, 1,
                                   // and current tokens length.
                                   // tokens_length = cur_tokens_length + bifurcation_index + 1.
                                 }));
+
+constexpr const char* GemmFastGelu_ver1_doc = R"DOC(
+It's a fusion of MatMul and FastGelu.)DOC";
+
+ONNX_MS_OPERATOR_SET_SCHEMA(GemmFastGelu, 1,
+                            OpSchema()
+                                .SetDoc(GemmFastGelu_ver1_doc)
+                                .Input(0, "X", "input tensor", "T")
+                                .Input(1, "W", "input tensor", "T")
+                                .Input(2, "bias", "bias tensor", "T", OpSchema::Optional)
+                                .Output(0, "Y", "output tensor", "T")
+                                .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output types to float or half tensors.")
+                                .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+                                  ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
+                                  ONNX_NAMESPACE::matmulShapeInference(ctx, 0, 1);
+                                }));
+
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -304,7 +304,8 @@ ONNX_MS_OPERATOR_SET_SCHEMA(GemmFastGelu, 1,
                                 .Input(1, "W", "input tensor", "T")
                                 .Input(2, "bias", "bias tensor", "T", OpSchema::Optional)
                                 .Output(0, "Y", "output tensor", "T")
-                                .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output types to float or half tensors.")
+                                .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
+                                                "Constrain input and output types to float or half tensors.")
                                 .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
                                   ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
                                   ONNX_NAMESPACE::matmulShapeInference(ctx, 0, 1);

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -74,6 +74,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, TransposeMatMul);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Trilu);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Unique);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, WordConvEmbedding);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu);
 
 class OpSet_Microsoft_ver1 {
  public:
@@ -142,6 +143,7 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Trilu)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, Unique)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, WordConvEmbedding)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu)>());
   }
 };
 }  // namespace contrib

--- a/onnxruntime/core/providers/rocm/math/matmul.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul.cc
@@ -2,38 +2,25 @@
 // Licensed under the MIT License.
 
 #include "core/providers/rocm/math/matmul.h"
-#include "core/providers/cpu/math/matmul_helper.h"
-#include "core/providers/rocm/shared_inc/fpgeneric.h"
-#include "core/providers/rocm/rocm_allocator.h"
+
+#include "core/providers/rocm/math/matmul_impl.h"
 
 namespace onnxruntime {
 namespace rocm {
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
-      MatMul,                                                     \
-      kOnnxDomain,                                                \
-      1, 8,                                                       \
-      T,                                                          \
-      kRocmExecutionProvider,                                     \
+      MatMul, kOnnxDomain, 1, 8, T, kRocmExecutionProvider,       \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);                                                 \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
-      MatMul,                                                     \
-      kOnnxDomain,                                                \
-      9, 12,                                                       \
-      T,                                                          \
-      kRocmExecutionProvider,                                     \
+      MatMul, kOnnxDomain, 9, 12, T, kRocmExecutionProvider,      \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);                                                 \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
-      MatMul,                                                     \
-      kOnnxDomain,                                                \
-      13,                                                          \
-      T,                                                          \
-      kRocmExecutionProvider,                                     \
+      MatMul, kOnnxDomain, 13, T, kRocmExecutionProvider,         \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);
@@ -43,54 +30,8 @@ REGISTER_KERNEL_TYPED(double)
 REGISTER_KERNEL_TYPED(MLFloat16)
 REGISTER_KERNEL_TYPED(BFloat16)
 
-// StridedBatchedGemm can be used for the following GEMM computation
-// C[pnm] = A[pnk]*B[km] or C[pnm] = A[pnk]*B[pkm]
-static bool CanUseStridedBatchedGemm(const TensorShape& left_shape, const TensorShape& right_shape,
-                                     bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
-                                     int64_t& stride_A, int64_t& stride_B, int64_t& stride_C, int64_t& batch_count) {
-  size_t left_num_dims = left_shape.NumDimensions();
-  size_t right_num_dims = right_shape.NumDimensions();
-
-  if (!(left_num_dims >= 3 && right_num_dims >= 2)) {
-    return false;
-  }
-
-  size_t left_leading_axis = trans_batch_a ? 0 : left_num_dims - 2;
-  size_t right_leading_axis = trans_batch_b ? 0 : right_num_dims - 2;
-  int64_t left_p = left_shape.SizeToDimension(left_num_dims - 2);
-  if (trans_batch_a) {
-    left_p = left_p * left_shape[left_num_dims - 2] / left_shape[0];
-  }
-  int64_t left_k = transa ? left_shape[left_leading_axis] : left_shape[left_num_dims - 1];
-
-  if (right_num_dims >= 3) {
-    int64_t right_p = right_shape.SizeToDimension(right_num_dims - 2);
-    if (trans_batch_b) {
-      right_p = right_p * right_shape[right_num_dims - 2] / right_shape[0];
-    }
-    if (left_p != right_p) {
-      return false;
-    }
-  }
-
-  int64_t right_k = transb ? right_shape[right_num_dims - 1] : right_shape[right_leading_axis];
-  if (left_k != right_k) {
-    return false;
-  }
-
-  int64_t n = transa ? left_shape[left_num_dims - 1] : left_shape[left_leading_axis];
-  int64_t m = transb ? right_shape[right_leading_axis] : right_shape[right_num_dims - 1];
-  stride_A = n * left_k / (trans_batch_a ? left_shape[0] : 1);
-  stride_B = right_num_dims == 2 ? 0 : right_k * m / (trans_batch_b ? right_shape[0] : 1);
-  stride_C = n * m;
-  batch_count = left_p;
-  return true;
-}
-
 template <typename T>
 Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
-  typedef typename ToHipType<T>::MappedType HipT;
-
   const Tensor* left_X = ctx->Input<Tensor>(0);
   const Tensor* right_X = ctx->Input<Tensor>(1);
 
@@ -106,94 +47,22 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   }
 
   MatMulComputeHelper helper;
-  ORT_RETURN_IF_ERROR(helper.Compute(left_X->Shape(), right_X->Shape(), transa, transb, trans_batch_a_, trans_batch_b_, false));
+  ORT_RETURN_IF_ERROR(helper.Compute(left_X->Shape(), right_X->Shape(), transa,
+                                     transb, trans_batch_a_, trans_batch_b_,
+                                     false));
 
   Tensor* Y = ctx->Output(0, helper.OutputShape());
 
   // Bail out early if the output is going to be empty
-  if (Y->Shape().Size() == 0)
-    return Status::OK();
+  if (Y->Shape().Size() == 0) return Status::OK();
 
-  const HipT alpha = ToHipType<T>::FromFloat(alpha_);
-  const HipT zero = ToHipType<T>::FromFloat(0.0f);
-
-  rocblas_operation transA = transa ? rocblas_operation_transpose : rocblas_operation_none;
-  rocblas_operation transB = transb ? rocblas_operation_transpose : rocblas_operation_none;
-  const int lda = helper.Lda(transa);
-  const int ldb = helper.Ldb(transb);
-  const int ldc = helper.Ldc();
-  int64_t stride_A, stride_B, stride_C, batch_count;
-
-  if (helper.OutputOffsets().size() == 1) {
-    ROCBLAS_RETURN_IF_ERROR(rocblasGemmHelper(
-        Base::RocblasHandle(),
-        transB,
-        transA,
-        static_cast<int>(helper.N()),
-        static_cast<int>(helper.M()),
-        static_cast<int>(helper.K()),
-        &alpha,
-        reinterpret_cast<const HipT*>(right_X->template Data<T>()),
-        ldb,
-        reinterpret_cast<const HipT*>(left_X->template Data<T>()),
-        lda,
-        &zero,
-        reinterpret_cast<HipT*>(Y->template MutableData<T>()),
-        ldc));
-    return Status::OK();
-  } else if (CanUseStridedBatchedGemm(left_X->Shape(), right_X->Shape(),
-                                      transa, transb, trans_batch_a_, trans_batch_b_, stride_A, stride_B, stride_C, batch_count)) {
-    ROCBLAS_RETURN_IF_ERROR(rocblasGemmStridedBatchedHelper(Base::RocblasHandle(),
-                                                          transB,
-                                                          transA,
-                                                          static_cast<int>(helper.N()),
-                                                          static_cast<int>(helper.M()),
-                                                          static_cast<int>(helper.K()),
-                                                          &alpha,
-                                                          reinterpret_cast<const HipT*>(right_X->template Data<T>()),
-                                                          ldb,
-                                                          stride_B,
-                                                          reinterpret_cast<const HipT*>(left_X->template Data<T>()),
-                                                          lda,
-                                                          stride_A,
-                                                          &zero,
-                                                          reinterpret_cast<HipT*>(Y->template MutableData<T>()),
-                                                          ldc,
-                                                          stride_C,
-                                                          static_cast<int>(batch_count)));
-    return Status::OK();
+  if (MatMulImpl<T>(this, helper, reinterpret_cast<const T*>(left_X->template Data<T>()),
+                    reinterpret_cast<const T*>(right_X->template Data<T>()),
+                    reinterpret_cast<T*>(Y->template MutableData<T>()),
+                    left_X->Shape(), right_X->Shape(),
+                    transa, transb, trans_batch_a_, trans_batch_b_, alpha_, 0.0f) != Status::OK()) {
+    return Status(common::ONNXRUNTIME, common::FAIL);
   }
-
-  // Fill offsets when needed.
-  helper.FillOffsets();
-  RocmAsyncBuffer<const HipT*> left_arrays(this, helper.LeftOffsets().size());
-  RocmAsyncBuffer<const HipT*> right_arrays(this, helper.RightOffsets().size());
-  RocmAsyncBuffer<HipT*> output_arrays(this, helper.OutputOffsets().size());
-  MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const HipT*>(left_X->template Data<T>()), helper.LeftOffsets(), left_arrays.CpuSpan());
-  MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const HipT*>(right_X->template Data<T>()), helper.RightOffsets(), right_arrays.CpuSpan());
-  MatMulComputeHelper::OffsetToArrays(reinterpret_cast<HipT*>(Y->template MutableData<T>()), helper.OutputOffsets(), output_arrays.CpuSpan());
-  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu());
-  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu());
-  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu());
-
-  // note that onnxruntime OrtValue is row major, while rocblas is column major,
-  // so swap left/right operands
-  ROCBLAS_RETURN_IF_ERROR(rocblasGemmBatchedHelper(
-      Base::RocblasHandle(),
-      transB,
-      transA,
-      static_cast<int>(helper.N()),
-      static_cast<int>(helper.M()),
-      static_cast<int>(helper.K()),
-      &alpha,
-      right_arrays.GpuPtr(),
-      ldb,
-      left_arrays.GpuPtr(),
-      lda,
-      &zero,
-      output_arrays.GpuPtr(),
-      ldc,
-      static_cast<int>(helper.OutputOffsets().size())));
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/rocm/math/matmul.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul.cc
@@ -10,17 +10,29 @@ namespace rocm {
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
-      MatMul, kOnnxDomain, 1, 8, T, kRocmExecutionProvider,       \
+      MatMul,                                                     \
+      kOnnxDomain,                                                \
+      1, 8,                                                       \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);                                                 \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
-      MatMul, kOnnxDomain, 9, 12, T, kRocmExecutionProvider,      \
+      MatMul,                                                     \
+      kOnnxDomain,                                                \
+      9, 12,                                                      \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);                                                 \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
-      MatMul, kOnnxDomain, 13, T, kRocmExecutionProvider,         \
+      MatMul,                                                     \
+      kOnnxDomain,                                                \
+      13,                                                         \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       MatMul<T>);

--- a/onnxruntime/core/providers/rocm/math/matmul.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/rocm/math/matmul.h"
 
+#include "core/providers/cpu/math/matmul_helper.h"
 #include "core/providers/rocm/math/matmul_impl.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.cc
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Modifications: Remove cudaDeviceProp in LaunchFastGeluKernel.
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/rocm/math/matmul_impl.h"
+#include "core/providers/rocm/rocm_allocator.h"
+#include "core/providers/rocm/rocm_kernel.h"
+
+using namespace onnxruntime::rocm;
+
+namespace onnxruntime {
+namespace rocm {
+
+// StridedBatchedGemm can be used for the following GEMM computation
+// C[pnm] = A[pnk]*B[km] or C[pnm] = A[pnk]*B[pkm]
+static bool CanUseStridedBatchedGemm(const TensorShape& left_shape,
+                                     const TensorShape& right_shape,
+                                     bool transa, bool transb,
+                                     bool trans_batch_a, bool trans_batch_b,
+                                     int64_t& stride_A, int64_t& stride_B,
+                                     int64_t& stride_C, int64_t& batch_count) {
+  size_t left_num_dims = left_shape.NumDimensions();
+  size_t right_num_dims = right_shape.NumDimensions();
+
+  if (!(left_num_dims >= 3 && right_num_dims >= 2)) {
+    return false;
+  }
+
+  size_t left_leading_axis = trans_batch_a ? 0 : left_num_dims - 2;
+  size_t right_leading_axis = trans_batch_b ? 0 : right_num_dims - 2;
+  int64_t left_p = left_shape.SizeToDimension(left_num_dims - 2);
+  if (trans_batch_a) {
+    left_p = left_p * left_shape[left_num_dims - 2] / left_shape[0];
+  }
+  int64_t left_k =
+      transa ? left_shape[left_leading_axis] : left_shape[left_num_dims - 1];
+
+  if (right_num_dims >= 3) {
+    int64_t right_p = right_shape.SizeToDimension(right_num_dims - 2);
+    if (trans_batch_b) {
+      right_p = right_p * right_shape[right_num_dims - 2] / right_shape[0];
+    }
+    if (left_p != right_p) {
+      return false;
+    }
+  }
+
+  int64_t right_k = transb ? right_shape[right_num_dims - 1]
+                           : right_shape[right_leading_axis];
+  if (left_k != right_k) {
+    return false;
+  }
+
+  int64_t n =
+      transa ? left_shape[left_num_dims - 1] : left_shape[left_leading_axis];
+  int64_t m = transb ? right_shape[right_leading_axis]
+                     : right_shape[right_num_dims - 1];
+  stride_A = n * left_k / (trans_batch_a ? left_shape[0] : 1);
+  stride_B = right_num_dims == 2 ? 0 : right_k * m / (trans_batch_b ? right_shape[0] : 1);
+  stride_C = n * m;
+  batch_count = left_p;
+  return true;
+}
+
+template <typename T>
+Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
+                  const T* left_x_data, const T* right_x_data, T* output_y_data,
+                  const TensorShape& left_shape, const TensorShape& right_shape,
+                  bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                  const float t_alpha, const float t_zero) {
+  typedef typename ToHipType<T>::MappedType HipT;
+
+  const HipT alpha = ToHipType<T>::FromFloat(t_alpha);
+  const HipT zero = ToHipType<T>::FromFloat(t_zero);
+
+  rocblas_operation transA = transa ? rocblas_operation_transpose : rocblas_operation_none;
+  rocblas_operation transB = transb ? rocblas_operation_transpose : rocblas_operation_none;
+  const int lda = helper.Lda(transa);
+  const int ldb = helper.Ldb(transb);
+  const int ldc = helper.Ldc();
+  int64_t stride_A, stride_B, stride_C, batch_count;
+
+  if (helper.OutputOffsets().size() == 1) {
+    ROCBLAS_RETURN_IF_ERROR(rocblasGemmHelper(
+        op->RocblasHandle(), transB, transA, static_cast<int>(helper.N()),
+        static_cast<int>(helper.M()), static_cast<int>(helper.K()), &alpha,
+        reinterpret_cast<const HipT*>(right_x_data), ldb,
+        reinterpret_cast<const HipT*>(left_x_data), lda, &zero,
+        reinterpret_cast<HipT*>(output_y_data), ldc));
+    return Status::OK();
+  } else if (CanUseStridedBatchedGemm(left_shape, right_shape,
+                                      transa, transb, trans_batch_a, trans_batch_b,
+                                      stride_A, stride_B, stride_C, batch_count)) {
+    ROCBLAS_RETURN_IF_ERROR(rocblasGemmStridedBatchedHelper(
+        op->RocblasHandle(), transB, transA, static_cast<int>(helper.N()),
+        static_cast<int>(helper.M()), static_cast<int>(helper.K()), &alpha,
+        reinterpret_cast<const HipT*>(right_x_data), ldb, stride_B,
+        reinterpret_cast<const HipT*>(left_x_data), lda, stride_A, &zero,
+        reinterpret_cast<HipT*>(output_y_data), ldc, stride_C,
+        static_cast<int>(batch_count)));
+    return Status::OK();
+  }
+
+  // Fill offsets when needed.
+  helper.FillOffsets();
+  RocmKernel::RocmAsyncBuffer<const HipT*> left_arrays(op, helper.LeftOffsets().size());
+  RocmKernel::RocmAsyncBuffer<const HipT*> right_arrays(op, helper.RightOffsets().size());
+  RocmKernel::RocmAsyncBuffer<HipT*> output_arrays(op, helper.OutputOffsets().size());
+  MatMulComputeHelper::OffsetToArrays(
+      reinterpret_cast<const HipT*>(left_x_data),
+      helper.LeftOffsets(), left_arrays.CpuSpan());
+  MatMulComputeHelper::OffsetToArrays(
+      reinterpret_cast<const HipT*>(right_x_data),
+      helper.RightOffsets(), right_arrays.CpuSpan());
+  MatMulComputeHelper::OffsetToArrays(
+      reinterpret_cast<HipT*>(output_y_data),
+      helper.OutputOffsets(), output_arrays.CpuSpan());
+  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu());
+  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu());
+  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu());
+
+  // note that onnxruntime OrtValue is row major, while rocblas is column major,
+  // so swap left/right operands
+  ROCBLAS_RETURN_IF_ERROR(rocblasGemmBatchedHelper(
+      op->RocblasHandle(), transB, transA, static_cast<int>(helper.N()),
+      static_cast<int>(helper.M()), static_cast<int>(helper.K()), &alpha,
+      right_arrays.GpuPtr(), ldb,
+      left_arrays.GpuPtr(), lda, &zero,
+      output_arrays.GpuPtr(), ldc,
+      static_cast<int>(helper.OutputOffsets().size())));
+  return Status::OK();
+}
+
+template Status MatMulImpl<float>(const RocmKernel* op, MatMulComputeHelper& helper,
+                                  const float* left_x_data, const float* right_x_data, float* output_y_data,
+                                  const TensorShape& left_shape, const TensorShape& right_shape,
+                                  bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                                  const float t_alpha, const float t_zero);
+template Status MatMulImpl<double>(const RocmKernel* op, MatMulComputeHelper& helper,
+                                   const double* left_x_data, const double* right_x_data, double* output_y_data,
+                                   const TensorShape& left_shape, const TensorShape& right_shape,
+                                   bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                                   const float t_alpha, const float t_zero);
+template Status MatMulImpl<MLFloat16>(const RocmKernel* op, MatMulComputeHelper& helper,
+                                      const MLFloat16* left_x_data, const MLFloat16* right_x_data, MLFloat16* output_y_data,
+                                      const TensorShape& left_shape, const TensorShape& right_shape,
+                                      bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                                      const float t_alpha, const float t_zero);
+template Status MatMulImpl<BFloat16>(const RocmKernel* op, MatMulComputeHelper& helper,
+                                     const BFloat16* left_x_data, const BFloat16* right_x_data, BFloat16* output_y_data,
+                                     const TensorShape& left_shape, const TensorShape& right_shape,
+                                     bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                                     const float t_alpha, const float t_zero);
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.cc
@@ -6,6 +6,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/rocm/math/matmul_impl.h"
+
 #include "core/providers/rocm/rocm_allocator.h"
 #include "core/providers/rocm/rocm_kernel.h"
 

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.cc
@@ -9,8 +9,6 @@
 #include "core/providers/rocm/rocm_allocator.h"
 #include "core/providers/rocm/rocm_kernel.h"
 
-using namespace onnxruntime::rocm;
-
 namespace onnxruntime {
 namespace rocm {
 
@@ -134,26 +132,58 @@ Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
   return Status::OK();
 }
 
-template Status MatMulImpl<float>(const RocmKernel* op, MatMulComputeHelper& helper,
-                                  const float* left_x_data, const float* right_x_data, float* output_y_data,
-                                  const TensorShape& left_shape, const TensorShape& right_shape,
-                                  bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
-                                  const float t_alpha, const float t_zero);
-template Status MatMulImpl<double>(const RocmKernel* op, MatMulComputeHelper& helper,
-                                   const double* left_x_data, const double* right_x_data, double* output_y_data,
-                                   const TensorShape& left_shape, const TensorShape& right_shape,
-                                   bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
-                                   const float t_alpha, const float t_zero);
-template Status MatMulImpl<MLFloat16>(const RocmKernel* op, MatMulComputeHelper& helper,
-                                      const MLFloat16* left_x_data, const MLFloat16* right_x_data, MLFloat16* output_y_data,
-                                      const TensorShape& left_shape, const TensorShape& right_shape,
-                                      bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
-                                      const float t_alpha, const float t_zero);
-template Status MatMulImpl<BFloat16>(const RocmKernel* op, MatMulComputeHelper& helper,
-                                     const BFloat16* left_x_data, const BFloat16* right_x_data, BFloat16* output_y_data,
-                                     const TensorShape& left_shape, const TensorShape& right_shape,
-                                     bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
-                                     const float t_alpha, const float t_zero);
+template Status MatMulImpl<float>(const RocmKernel* op,
+                                  MatMulComputeHelper& helper,
+                                  const float* left_x_data,
+                                  const float* right_x_data,
+                                  float* output_y_data,
+                                  const TensorShape& left_shape,
+                                  const TensorShape& right_shape,
+                                  bool transa,
+                                  bool transb,
+                                  bool trans_batch_a,
+                                  bool trans_batch_b,
+                                  const float t_alpha,
+                                  const float t_zero);
+template Status MatMulImpl<double>(const RocmKernel* op,
+                                   MatMulComputeHelper& helper,
+                                   const double* left_x_data,
+                                   const double* right_x_data,
+                                   double* output_y_data,
+                                   const TensorShape& left_shape,
+                                   const TensorShape& right_shape,
+                                   bool transa,
+                                   bool transb,
+                                   bool trans_batch_a,
+                                   bool trans_batch_b,
+                                   const float t_alpha,
+                                   const float t_zero);
+template Status MatMulImpl<MLFloat16>(const RocmKernel* op,
+                                      MatMulComputeHelper& helper,
+                                      const MLFloat16* left_x_data,
+                                      const MLFloat16* right_x_data,
+                                      MLFloat16* output_y_data,
+                                      const TensorShape& left_shape,
+                                      const TensorShape& right_shape,
+                                      bool transa,
+                                      bool transb,
+                                      bool trans_batch_a,
+                                      bool trans_batch_b,
+                                      const float t_alpha,
+                                      const float t_zero);
+template Status MatMulImpl<BFloat16>(const RocmKernel* op,
+                                     MatMulComputeHelper& helper,
+                                     const BFloat16* left_x_data,
+                                     const BFloat16* right_x_data,
+                                     BFloat16* output_y_data,
+                                     const TensorShape& left_shape,
+                                     const TensorShape& right_shape,
+                                     bool transa,
+                                     bool transb,
+                                     bool trans_batch_a,
+                                     bool trans_batch_b,
+                                     const float t_alpha,
+                                     const float t_zero);
 
 }  // namespace rocm
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.h
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Modifications: Remove cudaDeviceProp in LaunchFastGeluKernel.
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/rocm/shared_inc/fpgeneric.h"
+#include "core/providers/rocm/rocm_kernel.h"
+#include "core/providers/cpu/math/matmul_helper.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+template <typename T>
+Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
+                  const T* left_x_data, const T* right_x_data, T* output_y_data,
+                  const TensorShape& left_shape, const TensorShape& right_shape,
+                  bool transa, bool transb, bool trans_batch_a, bool trans_batch_b,
+                  const float t_alpha, const float t_zero);
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.h
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "core/providers/rocm/shared_inc/fpgeneric.h"
-#include "core/providers/rocm/rocm_kernel.h"
 #include "core/providers/cpu/math/matmul_helper.h"
+#include "core/providers/rocm/rocm_kernel.h"
 
 namespace onnxruntime {
 namespace rocm {

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/util/math.h"
+#include <gtest/gtest.h>
+#include "test/common/tensor_op_test_utils.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/providers/provider_test_utils.h"
+#include "core/platform/threadpool.h"
+#include "core/util/thread_utils.h"
+
+using namespace onnxruntime::test;
+
+namespace onnxruntime {
+namespace test {
+namespace gemmfastgelu {
+
+#if defined(USE_ROCM)
+static void RunGemmFastGeluGpuTest(const std::vector<float>& input_data, const std::vector<float>& weight_data,
+                               const std::vector<float>& bias_data, const std::vector<float>& output_data,
+                               const std::vector<int64_t>& input_dims, const std::vector<int64_t>& weight_dims,
+                               const std::vector<int64_t>& bias_dims, const std::vector<int64_t>& output_dims,
+                               bool has_bias, bool use_float16 = false) {
+  OpTester tester("GemmFastGelu", 1, onnxruntime::kMSDomain);
+
+  if (use_float16) {
+    tester.AddInput<MLFloat16>("X", input_dims, ToFloat16(input_data));
+    tester.AddInput<MLFloat16>("W", weight_dims, ToFloat16(weight_data));
+    if (has_bias) {
+      tester.AddInput<MLFloat16>("bias", bias_dims, ToFloat16(bias_data));
+    }
+    tester.AddOutput<MLFloat16>("Y", output_dims, ToFloat16(output_data));
+  } else {
+    tester.AddInput<float>("X", input_dims, input_data);
+    tester.AddInput<float>("W", weight_dims, weight_data);
+    if (has_bias) {
+      tester.AddInput<float>("bias", bias_dims, bias_data);
+    }
+    tester.AddOutput<float>("Y", output_dims, output_data);
+  }
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultRocmExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif
+
+TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat32) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int dense_size = 6;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.7f, -0.5f, 0.7f, 1.2f,
+      0.3f, 0.1f, 0.8f, -1.6f,
+      0.9f, -0.1f, 3.0f, 2.f,
+      0.4f, -0.7f, -0.3f, 0.6f};
+
+  std::vector<float> bias_data = {};
+
+  std::vector<float> output_data = {
+    3.4894,  1.8455,  0.0260,  0.2229, -0.1003,  0.0902,
+    -0.1323, -0.0953,  0.0778,  0.2152,  0.6715, -0.0240
+  };
+
+  std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> weight_dims = {hidden_size, dense_size};
+  std::vector<int64_t> bias_dims = {dense_size};
+  std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
+#if defined(USE_ROCM)
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, false);
+#endif
+}
+
+TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int dense_size = 6;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.7f, -0.5f, 0.7f, 1.2f,
+      0.3f, 0.1f, 0.8f, -1.6f,
+      0.9f, -0.1f, 3.0f, 2.f,
+      0.4f, -0.7f, -0.3f, 0.6f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
+
+  std::vector<float> output_data = {
+    2.9862,  2.4849,  1.1177,  2.4329, -0.1681,  0.3988,
+    -0.0702, -0.1633,  1.2190,  2.4225,  0.1428,  0.2229
+  };
+
+   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> weight_dims = {hidden_size, dense_size};
+  std::vector<int64_t> bias_dims = {dense_size};
+  std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
+#if defined(USE_ROCM)
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, true);
+#endif
+}
+
+
+// // CUDA and ROCm only for Float16 and BFloat16 type.
+// #if defined(USE_ROCM)
+// TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
+//   int batch_size = 1;
+//   int sequence_length = 2;
+//   int hidden_size = 4;
+
+//   std::vector<float> input_data = {
+//       0.8f, -0.5f, 0.0f, 1.f,
+//       0.5f, 0.2f, 0.3f, -0.6f};
+
+//   std::vector<float> bias_data = {
+//       -0.5f, 0.6f, 1.2f, 2.1f};
+
+//   std::vector<float> output_data = {
+//       0.1851806640625f, 0.054046630859375f, 1.0615234375f, 3.095703125f,
+//       0, 0.63037109375f, 1.3984375f, 1.3984375f};
+
+//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+//   std::vector<int64_t> bias_dims = {hidden_size};
+//   std::vector<int64_t> output_dims = input_dims;
+
+//   RunGemmFastGeluGpuTest(input_data, bias_data, output_data, input_dims, bias_dims, output_dims, true, true);
+// }
+
+// TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
+//   int batch_size = 1;
+//   int sequence_length = 2;
+//   int hidden_size = 4;
+
+//   std::vector<float> input_data = {
+//       0.8f, -0.5f, 0.0f, 1.f,
+//       0.5f, 0.2f, 0.3f, -0.6f};
+
+//   std::vector<float> bias_data = {};
+
+//   std::vector<float> output_data = {
+//       0.63037109375f, -0.154296875f, 0.0f, 0.8408203125f,
+//       0.345703125f, 0.11578369140625f, 0.1854248046875f, -0.1646728515625f };
+
+//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+//   std::vector<int64_t> bias_dims = {};
+//   std::vector<int64_t> output_dims = input_dims;
+
+//   RunGemmFastGeluGpuTest(input_data, bias_data, output_data, input_dims, bias_dims, output_dims, false, true);
+// }
+
+// TEST(FastGeluTest, FastGeluWithBias_BFloat16) {
+// #ifdef USE_CUDA
+//   int min_cuda_architecture = 530;
+//   if (!HasCudaEnvironment(min_cuda_architecture)) {
+//     LOGS_DEFAULT(WARNING) << "Hardware NOT support BFP16";
+//     return;
+//   }
+// #endif
+//   OpTester tester("FastGelu", 1, onnxruntime::kMSDomain);
+
+//   int batch_size = 1;
+//   int sequence_length = 2;
+//   int hidden_size = 4;
+
+//   std::vector<float> X = {
+//       0.8f, -0.5f, 0.0f, 1.f,
+//       0.5f, 0.2f, 0.3f, -0.6f};
+
+//   std::vector<float> B = {
+//       -0.5f, 0.6f, 1.2f, 2.1f};
+
+//   std::vector<float> Y = {
+//       0.1851806640625f, 0.054046630859375f, 1.0615234375f, 3.095703125f,
+//       0, 0.63037109375f, 1.3984375f, 1.3984375f};
+
+//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+//   std::vector<int64_t> bias_dims = {hidden_size};
+//   std::vector<int64_t> output_dims = input_dims;
+
+//   std::vector<BFloat16> f_X = FloatsToBFloat16s(X);
+//   std::vector<BFloat16> f_B = FloatsToBFloat16s(B);
+//   std::vector<BFloat16> f_Y = FloatsToBFloat16s(Y);
+
+//   tester.AddInput<BFloat16>("X", input_dims, f_X);
+//   tester.AddInput<BFloat16>("bias", bias_dims, f_B);
+//   tester.AddOutput<BFloat16>("Y", output_dims, f_Y);
+
+//   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+//   execution_providers.push_back(DefaultRocmExecutionProvider());
+//   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+// }
+// #endif
+
+}  // namespace gemmfastgelu
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -70,6 +70,7 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat32) {
     -0.1323, -0.0953,  0.0778,  0.2152,  0.6715, -0.0240
   };
 
+
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
   std::vector<int64_t> bias_dims = {dense_size};
@@ -115,95 +116,122 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
 }
 
 
-// // CUDA and ROCm only for Float16 and BFloat16 type.
-// #if defined(USE_ROCM)
-// TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
-//   int batch_size = 1;
-//   int sequence_length = 2;
-//   int hidden_size = 4;
+// CUDA and ROCm only for Float16 and BFloat16 type.
+#if defined(USE_ROCM)
+TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int dense_size = 6;
 
-//   std::vector<float> input_data = {
-//       0.8f, -0.5f, 0.0f, 1.f,
-//       0.5f, 0.2f, 0.3f, -0.6f};
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
 
-//   std::vector<float> bias_data = {
-//       -0.5f, 0.6f, 1.2f, 2.1f};
+  std::vector<float> weight_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.7f, -0.5f, 0.7f, 1.2f,
+      0.3f, 0.1f, 0.8f, -1.6f,
+      0.9f, -0.1f, 3.0f, 2.f,
+      0.4f, -0.7f, -0.3f, 0.6f};
 
-//   std::vector<float> output_data = {
-//       0.1851806640625f, 0.054046630859375f, 1.0615234375f, 3.095703125f,
-//       0, 0.63037109375f, 1.3984375f, 1.3984375f};
+  std::vector<float> bias_data = {};
 
-//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
-//   std::vector<int64_t> bias_dims = {hidden_size};
-//   std::vector<int64_t> output_dims = input_dims;
+  std::vector<float> output_data = {
+    3.4902,  1.8467,  0.0259,  0.2227, -0.1005,  0.0901,
+    -0.1324, -0.0955,  0.0778,  0.2156,  0.6714, -0.0241
+  };
 
-//   RunGemmFastGeluGpuTest(input_data, bias_data, output_data, input_dims, bias_dims, output_dims, true, true);
-// }
 
-// TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
-//   int batch_size = 1;
-//   int sequence_length = 2;
-//   int hidden_size = 4;
+  std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> weight_dims = {hidden_size, dense_size};
+  std::vector<int64_t> bias_dims = {dense_size};
+  std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, false);
+}
 
-//   std::vector<float> input_data = {
-//       0.8f, -0.5f, 0.0f, 1.f,
-//       0.5f, 0.2f, 0.3f, -0.6f};
+TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int dense_size = 6;
 
-//   std::vector<float> bias_data = {};
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
 
-//   std::vector<float> output_data = {
-//       0.63037109375f, -0.154296875f, 0.0f, 0.8408203125f,
-//       0.345703125f, 0.11578369140625f, 0.1854248046875f, -0.1646728515625f };
+  std::vector<float> weight_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.7f, -0.5f, 0.7f, 1.2f,
+      0.3f, 0.1f, 0.8f, -1.6f,
+      0.9f, -0.1f, 3.0f, 2.f,
+      0.4f, -0.7f, -0.3f, 0.6f};
 
-//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
-//   std::vector<int64_t> bias_dims = {};
-//   std::vector<int64_t> output_dims = input_dims;
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
-//   RunGemmFastGeluGpuTest(input_data, bias_data, output_data, input_dims, bias_dims, output_dims, false, true);
-// }
+  std::vector<float> output_data = {
+    2.9883,  2.4844,  1.1182,  2.4316, -0.1680,  0.3984,
+    -0.0701, -0.1633,  1.2178,  2.4219,  0.1426,  0.2227
+  };
 
-// TEST(FastGeluTest, FastGeluWithBias_BFloat16) {
-// #ifdef USE_CUDA
-//   int min_cuda_architecture = 530;
-//   if (!HasCudaEnvironment(min_cuda_architecture)) {
-//     LOGS_DEFAULT(WARNING) << "Hardware NOT support BFP16";
-//     return;
-//   }
-// #endif
-//   OpTester tester("FastGelu", 1, onnxruntime::kMSDomain);
+  std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> weight_dims = {hidden_size, dense_size};
+  std::vector<int64_t> bias_dims = {dense_size};
+  std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, true);
+}
 
-//   int batch_size = 1;
-//   int sequence_length = 2;
-//   int hidden_size = 4;
+TEST(GemmFastGeluTest, GemmFastGeluWithBias_BFloat16) {
+  OpTester tester("GemmFastGelu", 1, onnxruntime::kMSDomain);
 
-//   std::vector<float> X = {
-//       0.8f, -0.5f, 0.0f, 1.f,
-//       0.5f, 0.2f, 0.3f, -0.6f};
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int dense_size = 6;
 
-//   std::vector<float> B = {
-//       -0.5f, 0.6f, 1.2f, 2.1f};
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
 
-//   std::vector<float> Y = {
-//       0.1851806640625f, 0.054046630859375f, 1.0615234375f, 3.095703125f,
-//       0, 0.63037109375f, 1.3984375f, 1.3984375f};
+  std::vector<float> weight_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f,
+      0.7f, -0.5f, 0.7f, 1.2f,
+      0.3f, 0.1f, 0.8f, -1.6f,
+      0.9f, -0.1f, 3.0f, 2.f,
+      0.4f, -0.7f, -0.3f, 0.6f};
 
-//   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
-//   std::vector<int64_t> bias_dims = {hidden_size};
-//   std::vector<int64_t> output_dims = input_dims;
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
-//   std::vector<BFloat16> f_X = FloatsToBFloat16s(X);
-//   std::vector<BFloat16> f_B = FloatsToBFloat16s(B);
-//   std::vector<BFloat16> f_Y = FloatsToBFloat16s(Y);
+  std::vector<float> output_data = {
+    2.9883,  2.4844,  1.1182,  2.4316, -0.1680,  0.3984,
+    -0.0701, -0.1633,  1.2178,  2.4219,  0.1426,  0.2227
+  };
 
-//   tester.AddInput<BFloat16>("X", input_dims, f_X);
-//   tester.AddInput<BFloat16>("bias", bias_dims, f_B);
-//   tester.AddOutput<BFloat16>("Y", output_dims, f_Y);
+  std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> weight_dims = {hidden_size, dense_size};
+  std::vector<int64_t> bias_dims = {dense_size};
+  std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
 
-//   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-//   execution_providers.push_back(DefaultRocmExecutionProvider());
-//   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
-// }
-// #endif
+  std::vector<BFloat16> f_X = FloatsToBFloat16s(input_data);
+  std::vector<BFloat16> f_W = FloatsToBFloat16s(weight_data);
+  std::vector<BFloat16> f_B = FloatsToBFloat16s(bias_data);
+  std::vector<BFloat16> f_Y = FloatsToBFloat16s(output_data);
+
+  tester.AddInput<BFloat16>("X", input_dims, f_X);
+  tester.AddInput<BFloat16>("W", weight_dims, f_W);
+  tester.AddInput<BFloat16>("bias", bias_dims, f_B);
+  tester.AddOutput<BFloat16>("Y", output_dims, f_Y);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultRocmExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif
 
 }  // namespace gemmfastgelu
 }  // namespace test

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -15,10 +15,10 @@ namespace gemmfastgelu {
 
 #if defined(USE_ROCM)
 static void RunGemmFastGeluGpuTest(const std::vector<float>& input_data, const std::vector<float>& weight_data,
-                               const std::vector<float>& bias_data, const std::vector<float>& output_data,
-                               const std::vector<int64_t>& input_dims, const std::vector<int64_t>& weight_dims,
-                               const std::vector<int64_t>& bias_dims, const std::vector<int64_t>& output_dims,
-                               bool has_bias, bool use_float16 = false) {
+                                   const std::vector<float>& bias_data, const std::vector<float>& output_data,
+                                   const std::vector<int64_t>& input_dims, const std::vector<int64_t>& weight_dims,
+                                   const std::vector<int64_t>& bias_dims, const std::vector<int64_t>& output_dims,
+                                   bool has_bias, bool use_float16 = false) {
   OpTester tester("GemmFastGelu", 1, onnxruntime::kMSDomain);
 
   if (use_float16) {
@@ -64,10 +64,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat32) {
   std::vector<float> bias_data = {};
 
   std::vector<float> output_data = {
-    3.4894,  1.8455,  0.0260,  0.2229, -0.1003,  0.0902,
-    -0.1323, -0.0953,  0.0778,  0.2152,  0.6715, -0.0240
-  };
-
+      3.4894, 1.8455, 0.0260, 0.2229, -0.1003, 0.0902,
+      -0.1323, -0.0953, 0.0778, 0.2152, 0.6715, -0.0240};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -102,9 +100,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-    2.9862,  2.4849,  1.1177,  2.4329, -0.1681,  0.3988,
-    -0.0702, -0.1633,  1.2190,  2.4225,  0.1428,  0.2229
-  };
+      2.9862, 2.4849, 1.1177, 2.4329, -0.1681, 0.3988,
+      -0.0702, -0.1633, 1.2190, 2.4225, 0.1428, 0.2229};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -116,7 +113,6 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
                          true);
 #endif
 }
-
 
 // CUDA and ROCm only for Float16 and BFloat16 type.
 #if defined(USE_ROCM)
@@ -141,10 +137,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
   std::vector<float> bias_data = {};
 
   std::vector<float> output_data = {
-    3.4902,  1.8467,  0.0259,  0.2227, -0.1005,  0.0901,
-    -0.1324, -0.0955,  0.0778,  0.2156,  0.6714, -0.0241
-  };
-
+      3.4902, 1.8467, 0.0259, 0.2227, -0.1005, 0.0901,
+      -0.1324, -0.0955, 0.0778, 0.2156, 0.6714, -0.0241};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -177,9 +171,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-    2.9883,  2.4844,  1.1182,  2.4316, -0.1680,  0.3984,
-    -0.0701, -0.1633,  1.2178,  2.4219,  0.1426,  0.2227
-  };
+      2.9883, 2.4844, 1.1182, 2.4316, -0.1680, 0.3984,
+      -0.0701, -0.1633, 1.2178, 2.4219, 0.1426, 0.2227};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -214,9 +207,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBias_BFloat16) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-    2.9883,  2.4844,  1.1182,  2.4316, -0.1680,  0.3984,
-    -0.0701, -0.1633,  1.2178,  2.4219,  0.1426,  0.2227
-  };
+      2.9883, 2.4844, 1.1182, 2.4316, -0.1680, 0.3984,
+      -0.0701, -0.1633, 1.2178, 2.4219, 0.1426, 0.2227};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/util/math.h"
 #include <gtest/gtest.h>
+#include "core/util/math.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "core/platform/threadpool.h"
 #include "core/util/thread_utils.h"
-
-using namespace onnxruntime::test;
 
 namespace onnxruntime {
 namespace test {
@@ -76,7 +74,9 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat32) {
   std::vector<int64_t> bias_dims = {dense_size};
   std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
 #if defined(USE_ROCM)
-  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, false);
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data,
+                         input_dims, weight_dims, bias_dims, output_dims,
+                         false);
 #endif
 }
 
@@ -106,12 +106,14 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
     -0.0702, -0.1633,  1.2190,  2.4225,  0.1428,  0.2229
   };
 
-   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
+  std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
   std::vector<int64_t> bias_dims = {dense_size};
   std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
 #if defined(USE_ROCM)
-  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, true);
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data,
+                         input_dims, weight_dims, bias_dims, output_dims,
+                         true);
 #endif
 }
 
@@ -148,7 +150,9 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
   std::vector<int64_t> bias_dims = {dense_size};
   std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
-  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, false);
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data,
+                         input_dims, weight_dims, bias_dims, output_dims,
+                         false);
 }
 
 TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
@@ -181,7 +185,9 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
   std::vector<int64_t> bias_dims = {dense_size};
   std::vector<int64_t> output_dims = {batch_size, sequence_length, dense_size};
-  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data, input_dims, weight_dims, bias_dims, output_dims, true);
+  RunGemmFastGeluGpuTest(input_data, weight_data, bias_data, output_data,
+                         input_dims, weight_dims, bias_dims, output_dims,
+                         true);
 }
 
 TEST(GemmFastGeluTest, GemmFastGeluWithBias_BFloat16) {

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -64,8 +64,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat32) {
   std::vector<float> bias_data = {};
 
   std::vector<float> output_data = {
-      3.4894, 1.8455, 0.0260, 0.2229, -0.1003, 0.0902,
-      -0.1323, -0.0953, 0.0778, 0.2152, 0.6715, -0.0240};
+      3.4894f, 1.8455f, 0.0260f, 0.2229f, -0.1003f, 0.0902f,
+      -0.1323f, -0.0953f, 0.0778f, 0.2152f, 0.6715f, -0.0240f};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -100,8 +100,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat32) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-      2.9862, 2.4849, 1.1177, 2.4329, -0.1681, 0.3988,
-      -0.0702, -0.1633, 1.2190, 2.4225, 0.1428, 0.2229};
+      2.9862f, 2.4849f, 1.1177f, 2.4329f, -0.1681f, 0.3988f,
+      -0.0702f, -0.1633f, 1.2190f, 2.4225f, 0.1428f, 0.2229f};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -137,8 +137,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithoutBiasFloat16) {
   std::vector<float> bias_data = {};
 
   std::vector<float> output_data = {
-      3.4902, 1.8467, 0.0259, 0.2227, -0.1005, 0.0901,
-      -0.1324, -0.0955, 0.0778, 0.2156, 0.6714, -0.0241};
+      3.4902f, 1.8467f, 0.0259f, 0.2227f, -0.1005f, 0.0901f,
+      -0.1324f, -0.0955f, 0.0778f, 0.2156f, 0.6714f, -0.0241f};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -171,8 +171,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBiasFloat16) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-      2.9883, 2.4844, 1.1182, 2.4316, -0.1680, 0.3984,
-      -0.0701, -0.1633, 1.2178, 2.4219, 0.1426, 0.2227};
+      2.9883f, 2.4844f, 1.1182f, 2.4316f, -0.1680f, 0.3984f,
+      -0.0701f, -0.1633f, 1.2178f, 2.4219f, 0.1426f, 0.2227f};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};
@@ -207,8 +207,8 @@ TEST(GemmFastGeluTest, GemmFastGeluWithBias_BFloat16) {
       -0.5f, 0.6f, 1.2f, 2.1f, -0.6f, 0.4f};
 
   std::vector<float> output_data = {
-      2.9883, 2.4844, 1.1182, 2.4316, -0.1680, 0.3984,
-      -0.0701, -0.1633, 1.2178, 2.4219, 0.1426, 0.2227};
+      2.9883f, 2.4844f, 1.1182f, 2.4316f, -0.1680f, 0.3984f,
+      -0.0701f, -0.1633f, 1.2178f, 2.4219f, 0.1426f, 0.2227f};
 
   std::vector<int64_t> input_dims = {batch_size, sequence_length, hidden_size};
   std::vector<int64_t> weight_dims = {hidden_size, dense_size};

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -5,8 +5,8 @@
 #include "core/platform/threadpool.h"
 #include "core/util/math.h"
 #include "core/util/thread_utils.h"
-#include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 
 namespace onnxruntime {

--- a/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gemm_fastgelu_op_test.cc
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
+#include "core/platform/threadpool.h"
 #include "core/util/math.h"
+#include "core/util/thread_utils.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
-#include "core/platform/threadpool.h"
-#include "core/util/thread_utils.h"
 
 namespace onnxruntime {
 namespace test {


### PR DESCRIPTION
**Description**: Describe your changes.

Add a new operator GemmFastGelu on ROCM EP. Fused by MatMul + FastGelu.
It's a base implementation and the performance is the same as sequential execution of MatMul + FastGelu.
Will add composable_kernel(https://github.com/ROCmSoftwarePlatform/composable_kernel) implementation for fused GemmFastGelu.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
