### PR TITLE
Update DML EP documentation opset to 13-15

### DIFF
--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -16,7 +16,7 @@ DirectML is a high-performance, hardware-accelerated DirectX 12 library for mach
 
 When used standalone, the DirectML API is a low-level DirectX 12 library and is suitable for high-performance, low-latency applications such as frameworks, games, and other real-time applications. The seamless interoperability of DirectML with Direct3D 12 as well as its low overhead and conformance across hardware makes DirectML ideal for accelerating machine learning when both high performance is desired, and the reliability and predictability of results across hardware is critical.
 
-The DirectML Execution Provider currently uses DirectML version [1.9.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.9.0) and supports up to ONNX opset 12 ([ONNX v1.7](https://github.com/onnx/onnx/releases/tag/v1.7.0)). Evaluating models which require a higher opset version is unsupported and will yield poor performance.
+The DirectML Execution Provider currently uses DirectML version [1.9.0](https://www.nuget.org/packages/Microsoft.AI.DirectML/1.9.0) and supports up to ONNX opset 15 ([ONNX v1.10](https://github.com/onnx/onnx/releases/tag/v1.10.0)). Evaluating models which require a higher opset version is unsupported and will yield poor performance.
 
 ## Contents
 {: .no_toc }


### PR DESCRIPTION
**Description**: Update documentation for current opset (opset 15 == ONNX1.10 https://github.com/onnx/onnx/blob/main/docs/Versioning.md).

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Documentation is stale.
- *If it fixes an open issue, please link to the issue here.* NA

