### PR TITLE
Prevent unbounded growth of command allocator memory

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandAllocatorRing.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandAllocatorRing.h
@@ -28,26 +28,23 @@ namespace Dml
             }
         }
 
-        ID3D12CommandAllocator* GetCurrentAllocator()
+        ID3D12CommandAllocator* GetNextAllocator(GpuEvent nextCompletionEvent)
         {
-            CommandAllocatorInfo& allocatorInfo = m_commandAllocators[m_currentCommandAllocator];
+            size_t earliestOtherAllocator = (m_currentCommandAllocator + 1) % AllocatorCount; 
 
-            // Take the opportunity to reset the command allocator if possible.
-            if (allocatorInfo.completionEvent.IsSignaled())
-            {
-                ORT_THROW_IF_FAILED(allocatorInfo.Get()->Reset());
+            assert(!m_commandAllocators[m_currentCommandAllocator].completionEvent.IsSignaled() ||
+                    m_commandAllocators[earliestOtherAllocator].completionEvent.IsSignaled());
+
+            if (m_commandAllocators[earliestOtherAllocator].completionEvent.IsSignaled())
+            {                
+                ORT_THROW_IF_FAILED(m_commandAllocators[earliestOtherAllocator].Get()->Reset());
+                m_currentCommandAllocator = earliestOtherAllocator;
             }
+            
+            // Set the completion event for the current allocator so it can be reset eventually.
+            m_commandAllocators[m_currentCommandAllocator].completionEvent = nextCompletionEvent;
 
             return m_commandAllocators[m_currentCommandAllocator].Get();
-        }
-
-        void AdvanceAllocator(GpuEvent completionEvent)
-        {
-            // Set the completion event for the current allocator so it can be reset eventually.
-            m_commandAllocators[m_currentCommandAllocator].completionEvent = completionEvent;
-
-            // Advance to the next allocator.
-            m_currentCommandAllocator = (m_currentCommandAllocator + 1) % AllocatorCount;
         }
 
     private:

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandAllocatorRing.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandAllocatorRing.h
@@ -30,17 +30,17 @@ namespace Dml
 
         ID3D12CommandAllocator* GetNextAllocator(GpuEvent nextCompletionEvent)
         {
-            size_t earliestOtherAllocator = (m_currentCommandAllocator + 1) % AllocatorCount; 
+            size_t earliestOtherAllocator = (m_currentCommandAllocator + 1) % AllocatorCount;
 
             assert(!m_commandAllocators[m_currentCommandAllocator].completionEvent.IsSignaled() ||
                     m_commandAllocators[earliestOtherAllocator].completionEvent.IsSignaled());
 
             if (m_commandAllocators[earliestOtherAllocator].completionEvent.IsSignaled())
-            {                
+            {
                 ORT_THROW_IF_FAILED(m_commandAllocators[earliestOtherAllocator].Get()->Reset());
                 m_currentCommandAllocator = earliestOtherAllocator;
             }
-            
+
             // Set the completion event for the current allocator so it can be reset eventually.
             m_commandAllocators[m_currentCommandAllocator].completionEvent = nextCompletionEvent;
 


### PR DESCRIPTION
This addresses a memory leak with the DML execution provider due to D3D12 command allocators not being reset in certain models and timing conditions.

The fix is to avoid advancing the command allocator within a ring buffer until the executions associated with the next allocator have completed and that allocator may therefore be reset.

