### PR TITLE
Properly set output tensor in argmax_out operator

### DIFF
--- a/cmake/onnxruntime_eager.cmake
+++ b/cmake/onnxruntime_eager.cmake
@@ -10,7 +10,7 @@ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_eager_srcs})
 
 onnxruntime_add_static_library(onnxruntime_eager ${onnxruntime_eager_srcs})
 if(MSVC AND onnxruntime_ENABLE_EAGER_MODE)
-  set_source_files_properties("${ORTTRAINING_ROOT}/orttraining/eager/ort_aten.cpp" PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458")
+  set_source_files_properties("${ORTTRAINING_ROOT}/orttraining/eager/ort_aten.cpp" PROPERTIES COMPILE_FLAGS "/wd4100 /wd4458 /wd4505")
   set_source_files_properties("${ORTTRAINING_ROOT}/orttraining/eager/ort_customops.g.cpp" PROPERTIES COMPILE_FLAGS "/wd4100")
   set_source_files_properties("${ORTTRAINING_ROOT}/orttraining/eager/ort_backends.cpp" PROPERTIES COMPILE_FLAGS "/wd4100")
   set_source_files_properties("${ORTTRAINING_ROOT}/orttraining/eager/ort_hooks.cpp" PROPERTIES COMPILE_FLAGS "/wd4100")
@@ -32,5 +32,3 @@ set_target_properties(onnxruntime_eager PROPERTIES FOLDER "ONNXRuntime")
 if (onnxruntime_ENABLE_TRAINING)
   target_include_directories(onnxruntime_session PRIVATE ${ORTTRAINING_ROOT})
 endif()
-
-

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -804,17 +804,16 @@ at::Tensor& out) {
   }
   auto& invoker = GetORTInvoker(self.device());
 
+  int64_t l_axis = dim.has_value() ? *dim : 0;
+  bool keep_dim_effective = dim.has_value() ? keepdim : false;
   auto ort_input_self =
     create_ort_value(invoker, dim.has_value() ? self : self.reshape({-1}));
 
-  // Remove this hand signature once the generator can support this one line below.
-  int64_t l_axis = dim.has_value() ? *dim : 0;
-
   NodeAttributes attrs(2);
   attrs["axis"] = create_ort_attribute(
-  "axis", l_axis, at::ScalarType::Int);
+    "axis", l_axis, at::ScalarType::Int);
   attrs["keepdims"] = create_ort_attribute(
-  "keepdims", keepdim, at::ScalarType::Bool);
+    "keepdims", keep_dim_effective, at::ScalarType::Bool);
 
   std::vector<OrtValue> ort_outputs_0_ArgMax(1);
 

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -258,12 +258,65 @@ class OrtOpTests(unittest.TestCase):
 
     def test_argmax(self):
         device = self.get_device()
-        cpu_tensor = torch.rand(3, 5)
+        cpu_tensor = torch.rand(3, 5, 7, 8)
         ort_tensor = cpu_tensor.to(device)
+
+        # Setup test
         cpu_result = torch.argmax(cpu_tensor, dim=1)
         ort_result = torch.argmax(ort_tensor, dim=1)
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert cpu_result.dim() == ort_result.dim()
+
+        # Setup test
+        cpu_result = torch.argmax(cpu_tensor, dim=1, keepdim=True)
+        ort_result = torch.argmax(ort_tensor, dim=1, keepdim=True)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+
+        # Setup test
+        cpu_result = torch.argmax(cpu_tensor)
+        ort_result = torch.argmax(ort_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+
+        # Setup test
+        cpu_result = torch.argmax(cpu_tensor)
+        ort_result = torch.argmax(ort_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+
+        # Setup test
+        cpu_out_tensor = torch.tensor([], dtype=torch.long)
+        ort_out_tensor = cpu_out_tensor.to(device)
+
+        cpu_result = torch.argmax(cpu_tensor, out=cpu_out_tensor)
+        ort_result = torch.argmax(ort_tensor, out=ort_out_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+        assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
+        assert cpu_out_tensor.dim() == ort_out_tensor.dim()
+
+        # Setup test
+        cpu_out_tensor = torch.tensor([], dtype=torch.long)
+        ort_out_tensor = cpu_out_tensor.to(device)
+
+        cpu_result = torch.argmax(cpu_tensor, dim=1, out=cpu_out_tensor)
+        ort_result = torch.argmax(ort_tensor, dim=1, out=ort_out_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+        assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
+        assert cpu_out_tensor.dim() == ort_out_tensor.dim()
+
+        # Setup test
+        cpu_out_tensor = torch.tensor([], dtype=torch.long)
+        ort_out_tensor = cpu_out_tensor.to(device)
+
+        cpu_result = torch.argmax(cpu_tensor, dim=1, keepdim=True, out=cpu_out_tensor)
+        ort_result = torch.argmax(ort_tensor, dim=1, keepdim=True, out=ort_out_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+        assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
+        assert cpu_out_tensor.dim() == ort_out_tensor.dim()
 
     def test_masked_select(self):
         device = self.get_device()

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -261,34 +261,33 @@ class OrtOpTests(unittest.TestCase):
         cpu_tensor = torch.rand(3, 5, 7, 8)
         ort_tensor = cpu_tensor.to(device)
 
-        # Setup test
+        # Scenario: basic (no dim parameters)
+        cpu_result = torch.argmax(cpu_tensor)
+        ort_result = torch.argmax(ort_tensor)
+        assert torch.allclose(cpu_result, ort_result.cpu())
+        assert cpu_result.dim() == ort_result.dim()
+
+        # Scenario: specify dim parameter
         cpu_result = torch.argmax(cpu_tensor, dim=1)
         ort_result = torch.argmax(ort_tensor, dim=1)
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert cpu_result.dim() == ort_result.dim()
 
-        # Setup test
+        # Scenario: specify dim and keepdim parameters
         cpu_result = torch.argmax(cpu_tensor, dim=1, keepdim=True)
         ort_result = torch.argmax(ort_tensor, dim=1, keepdim=True)
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert cpu_result.dim() == ort_result.dim()
 
-        # Setup test
-        cpu_result = torch.argmax(cpu_tensor)
-        ort_result = torch.argmax(ort_tensor)
+        # Scenario: specify negative dim value
+        cpu_result = torch.argmax(cpu_tensor, dim=-1)
+        ort_result = torch.argmax(ort_tensor, dim=-1)
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert cpu_result.dim() == ort_result.dim()
 
-        # Setup test
-        cpu_result = torch.argmax(cpu_tensor)
-        ort_result = torch.argmax(ort_tensor)
-        assert torch.allclose(cpu_result, ort_result.cpu())
-        assert cpu_result.dim() == ort_result.dim()
-
-        # Setup test
+        # Scenario: basic out (no dim parameters)
         cpu_out_tensor = torch.tensor([], dtype=torch.long)
         ort_out_tensor = cpu_out_tensor.to(device)
-
         cpu_result = torch.argmax(cpu_tensor, out=cpu_out_tensor)
         ort_result = torch.argmax(ort_tensor, out=ort_out_tensor)
         assert torch.allclose(cpu_result, ort_result.cpu())
@@ -296,10 +295,9 @@ class OrtOpTests(unittest.TestCase):
         assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
         assert cpu_out_tensor.dim() == ort_out_tensor.dim()
 
-        # Setup test
+        # Scenario: out with dim parameter
         cpu_out_tensor = torch.tensor([], dtype=torch.long)
         ort_out_tensor = cpu_out_tensor.to(device)
-
         cpu_result = torch.argmax(cpu_tensor, dim=1, out=cpu_out_tensor)
         ort_result = torch.argmax(ort_tensor, dim=1, out=ort_out_tensor)
         assert torch.allclose(cpu_result, ort_result.cpu())
@@ -307,10 +305,9 @@ class OrtOpTests(unittest.TestCase):
         assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
         assert cpu_out_tensor.dim() == ort_out_tensor.dim()
 
-        # Setup test
+        # Scenario: out with dim and keepdim parameters
         cpu_out_tensor = torch.tensor([], dtype=torch.long)
         ort_out_tensor = cpu_out_tensor.to(device)
-
         cpu_result = torch.argmax(cpu_tensor, dim=1, keepdim=True, out=cpu_out_tensor)
         ort_result = torch.argmax(ort_tensor, dim=1, keepdim=True, out=ort_out_tensor)
         assert torch.allclose(cpu_result, ort_result.cpu())


### PR DESCRIPTION
## Status
I think the approach in #12233 is better, and I think that PR will supersede this one shortly...

**Description**: set output tensor in argmax_out operator

This change updates the implementation or the `argmax_out` operator to 1) set the output tensor correctly and 2) remove the unnecessary use of a temporary tensor to store intermediate result of argmax operation.

The previous implementation of the `argmax_out` operator did not correctly update the out tensor - it replaced the ort_value instead of the memory backing the ort_value. To properly update the output tensor, we need to calculate the expected shape of the out tensor. We do this by leveraging utility methods in PyTorch to calculate the expected shape of a tensor given the dimension and keepdim parameters.

**Notes**
The PyTorch utility methods to calculate the expected shape of a tensor from a reduction operation are located in `aten/src/ATen/native/ReduceOpsUtils.h` in the PyTorch repository. Including this file results in warnings around unused functions that we need to handle by suppressing this particular warning.

If we deem this warning suppression as to much, we can instead re-implement the logic to calculate the expected tensor shape.