### PR TITLE
pin protobuf version to be compatible with onnx

### DIFF
--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -4,6 +4,6 @@ h5py
 numpy >= 1.16.6
 onnx
 packaging
-protobuf
+protobuf >= 3.12.2, <= 3.20.1
 sympy
 setuptools>=41.4.0


### PR DESCRIPTION
**Description**: Pinning the Protobuf version in training package to match ONNX requirements.

**Motivation and Context**
- Why is this change required? What problem does it solve?
ONNX requires Protobuf version between 3.12.2 and 3.20.1. This PR Pins the protobuf version in training package to match ONNX requirements, since training package has a dependency on ONNX. Without this change, in some environments installation fails. 


- If it fixes an open issue, please link to the issue here.
