### PR TITLE
To enable running a model with missing optional inputs

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -182,7 +182,8 @@ class Session:
             if input.name not in feed_input_names and not input.type.startswith("optional"):
                 missing_input_names.append(input.name)
         if missing_input_names:
-            raise ValueError("Required inputs ({}) are missing from input feed ({}).".format(",".join(missing_input_names), "".join(",", feed_input_names)))
+            raise ValueError("Required inputs ({}) are missing from input feed ({}).".format(
+                ",".join(missing_input_names), ",".join(feed_input_names)))
 
     def run(self, output_names, input_feed, run_options=None):
         """

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -182,7 +182,7 @@ class Session:
             if input.name not in feed_input_names and not input.type.startswith("optional"):
                 missing_input_names.append(input.name)
         if missing_input_names:
-            raise ValueError("Required inputs ({}) are missing from input feed ({}).".format("".join(",", missing_input_names), "".join(",", feed_input_names)))
+            raise ValueError("Required inputs ({}) are missing from input feed ({}).".format(",".join(missing_input_names), "".join(",", feed_input_names)))
 
     def run(self, output_names, input_feed, run_options=None):
         """

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -175,6 +175,15 @@ class Session:
         """
         self._enable_fallback = True
 
+    def _validate_input(self, feed_input_names):
+        # import pdb; pdb.set_trace()
+        missing_input_names = []
+        for input in self._inputs_meta:
+            if input.name not in feed_input_names and not input.type.startswith("optional"):
+                missing_input_names.append(input.name)
+        if missing_input_names:
+            raise ValueError("Required inputs ({}) are missing from input feed ({}).".format("".join(",", missing_input_names), "".join(",", feed_input_names)))
+
     def run(self, output_names, input_feed, run_options=None):
         """
         Compute the predictions.
@@ -189,11 +198,7 @@ class Session:
 
             sess.run([output_name], {input_name: x})
         """
-        num_required_inputs = len(self._inputs_meta)
-        num_inputs = len(input_feed)
-        # the graph may have optional inputs used to override initializers. allow for that.
-        if num_inputs < num_required_inputs:
-            raise ValueError("Model requires {} inputs. Input Feed contains {}".format(num_required_inputs, num_inputs))
+        self._validate_input(list(input_feed.keys()))
         if not output_names:
             output_names = [output.name for output in self._outputs_meta]
         try:
@@ -235,11 +240,7 @@ class Session:
             ort_values = [OrtValue(v) for v in result]
             return ort_values
 
-        num_required_inputs = len(self._inputs_meta)
-        num_inputs = len(input_dict_ort_values)
-        # the graph may have optional inputs used to override initializers. allow for that.
-        if num_inputs < num_required_inputs:
-            raise ValueError("Model requires {} inputs. Input Feed contains {}".format(num_required_inputs, num_inputs))
+        self._validate_input(list(input_dict_ort_values.keys()))
         if not output_names:
             output_names = [output.name for output in self._outputs_meta]
         try:


### PR DESCRIPTION
**Description**: 
When a model has optional inputs, ort session shall be able to run the model with feed not having data for the optional inputs.

**Motivation and Context**
So that we can run those type of models without providing optional input data.