### PR TITLE
RoiAlign CPU EP add warning for max mode with samples != 1

### DIFF
--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -154,9 +154,9 @@ static void PreCalcForBilinearInterpolate(const int64_t height, const int64_t wi
 }
 
 template <typename T>
-void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, float spatial_scale, int64_t batch_size,
-                     int64_t height, int64_t width, int64_t sampling_ratio, const T* bottom_rois, int64_t num_roi_cols,
-                     T* top_data, RoiAlignMode mode, bool half_pixel, const int64_t* batch_indices_ptr, ThreadPool* ttp) {
+void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, float spatial_scale, int64_t height,
+                     int64_t width, int64_t sampling_ratio, const T* bottom_rois, int64_t num_roi_cols, T* top_data,
+                     RoiAlignMode mode, bool half_pixel, const int64_t* batch_indices_ptr, ThreadPool* ttp) {
   int64_t n_rois = output_shape[0];
   int64_t channels = output_shape[1];
   int64_t pooled_height = output_shape[2];
@@ -170,8 +170,7 @@ void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, floa
       int64_t index_n = n * channels * pooled_width * pooled_height;
 
       const T* offset_bottom_rois = bottom_rois + n * num_roi_cols;
-      auto roi_batch_ind = batch_indices_ptr[n];
-      roi_batch_ind = (static_cast<uint64_t>(roi_batch_ind) < static_cast<uint64_t>(batch_size)) ? roi_batch_ind : 0;
+      const auto roi_batch_ind = batch_indices_ptr[n];
 
       // Do not using rounding; this implementation detail is critical
       T offset = half_pixel ? (T)0.5 : (T)0.0;
@@ -319,7 +318,6 @@ Status RoiAlign<T>::Compute(OpKernelContext* context) const {
   auto& Y = *context->Output(0, {num_rois, num_channels, this->output_height_, this->output_width_});
 
   RoiAlignForward<T>(Y.Shape(), X_ptr->Data<T>(), this->spatial_scale_,
-                     x_dims[0],  // batch
                      x_dims[2],  // height
                      x_dims[3],  // width
                      this->sampling_ratio_, rois_ptr->Data<T>(), num_roi_cols, Y.template MutableData<T>(), this->mode_, this->half_pixel_,

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -154,9 +154,9 @@ static void PreCalcForBilinearInterpolate(const int64_t height, const int64_t wi
 }
 
 template <typename T>
-void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, float spatial_scale, int64_t height,
-                     int64_t width, int64_t sampling_ratio, const T* bottom_rois, int64_t num_roi_cols, T* top_data,
-                     RoiAlignMode mode, bool half_pixel, const int64_t* batch_indices_ptr, ThreadPool* ttp) {
+void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, float spatial_scale, int64_t batch_size,
+                     int64_t height, int64_t width, int64_t sampling_ratio, const T* bottom_rois, int64_t num_roi_cols,
+                     T* top_data, RoiAlignMode mode, bool half_pixel, const int64_t* batch_indices_ptr, ThreadPool* ttp) {
   int64_t n_rois = output_shape[0];
   int64_t channels = output_shape[1];
   int64_t pooled_height = output_shape[2];
@@ -170,7 +170,8 @@ void RoiAlignForward(const TensorShape& output_shape, const T* bottom_data, floa
       int64_t index_n = n * channels * pooled_width * pooled_height;
 
       const T* offset_bottom_rois = bottom_rois + n * num_roi_cols;
-      const auto roi_batch_ind = batch_indices_ptr[n];
+      auto roi_batch_ind = batch_indices_ptr[n];
+      roi_batch_ind = (static_cast<uint64_t>(roi_batch_ind) < static_cast<uint64_t>(batch_size)) ? roi_batch_ind : 0;
 
       // Do not using rounding; this implementation detail is critical
       T offset = half_pixel ? (T)0.5 : (T)0.0;
@@ -318,6 +319,7 @@ Status RoiAlign<T>::Compute(OpKernelContext* context) const {
   auto& Y = *context->Output(0, {num_rois, num_channels, this->output_height_, this->output_width_});
 
   RoiAlignForward<T>(Y.Shape(), X_ptr->Data<T>(), this->spatial_scale_,
+                     x_dims[0],  // batch
                      x_dims[2],  // height
                      x_dims[3],  // width
                      this->sampling_ratio_, rois_ptr->Data<T>(), num_roi_cols, Y.template MutableData<T>(), this->mode_, this->half_pixel_,

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.h
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.h
@@ -29,7 +29,6 @@ class RoiAlignBase {
       } else {
         ORT_THROW("Invalid mode of value ", mode, " specified. It should be either avg or max");
       }
-      mode_ = mode == "avg" ? RoiAlignMode::avg : RoiAlignMode::max;
     }
 
     // output_height
@@ -63,6 +62,13 @@ class RoiAlignBase {
         half_pixel_ = true;
       else
         half_pixel_ = false;
+    }
+
+    if (mode_ == RoiAlignMode::max && sampling_ratio_ != 1) {
+      // TODO(fdwr): Issue #6146. ORT 1.13 will correct the incorrect summation of max mode with PR #7354.
+      LOGS_DEFAULT(WARNING) << "The existing summation for max mode and sampling ratios besides 1 is incorrect "
+                            << "and will be fixed in the next ORT 1.13 release. Thus the results of RoiAlign "
+                            << "will be different.";
     }
   }
 


### PR DESCRIPTION
**Description**: The CPU EP implementation of RoiAlign is incorrect per [ONNX](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RoiAlign) for `mode` == `max` when the sample count is > 1 either when `sampling_ratio` is explicitly > 1 or when the `sampling_ratio` == 0 and is dynamically computed > 1. See https://github.com/microsoft/onnxruntime/issues/6146. Emit a warning for compatibility in ORT 1.12, as it will be fixed in ORT 1.13 via https://github.com/microsoft/onnxruntime/pull/7354.

**Motivation and Context**
- *Why is this change required? What problem does it solve?* 
A warning should be emitted so people have some time to update their models, such as `mask_rcnn_R_50_FPN_1x.onnx` which shows small differences in model output (this change mimic's Jacky's https://github.com/microsoft/onnxruntime/pull/11984).
- *If it fixes an open issue, please link to the issue here.*
https://github.com/microsoft/onnxruntime/issues/6146
The actual fix is [PR 7354](https://github.com/microsoft/onnxruntime/pull/7354), which introduces small differences in the output.