### PR TITLE
include coreml_provider_factory.h in macos build instead of coreml_ex…

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -36,7 +36,7 @@ then
     strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
     ln -s $LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.dylib
     # copy the CoreML EP header for macOS build (libs with .dylib ext)
-    cp $SOURCE_DIR/onnxruntime/core/providers/coreml/coreml_execution_provider.h  $BINARY_DIR/$ARTIFACT_NAME/include
+    cp $SOURCE_DIR/include/onnxruntime/core/providers/coreml/coreml_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include
 elif [[ $LIB_NAME == *.so.* ]]
 then
     ln -s $LIB_NAME $BINARY_DIR/$ARTIFACT_NAME/lib/libonnxruntime.so


### PR DESCRIPTION
Fixes https://github.com/microsoft/onnxruntime/issues/11973

Not sure if that 'include' part of the path is necessary or not..
