### PR TITLE
Fix minor python and cpp  warnings from previous PR.

### DIFF
--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -917,7 +917,9 @@ at::Tensor& fill__Scalar(
   ORT_LOG_FN(self, value);
 
   if (
-    !IsSupportedType(self, {at::kHalf,at::kFloat,at::kInt,at::kDouble,at::kByte,at::kShort,at::kLong,at::kBFloat16,at::kBool})) {
+    std::vector<at::ScalarType> supportedTypes =
+      {at::kHalf, at::kFloat, at::kInt, at::kDouble, at::kByte, at::kShort, at::kLong, at::kBFloat16, at::kBool};
+    !IsSupportedType(self, supportedTypes)) {
     std::cout << "fill__Scalar - Fell back to cpu!\n";
     return at::native::call_fallback_fn<
       &at::native::cpu_fallback,


### PR DESCRIPTION
**Description**: In the [PR 12018 ](https://github.com/microsoft/onnxruntime/pull/12018) a few fixable python and cpp warning were introduced that this PR cleans up. Also adding a comment on the intent of test_mul_bool and out testing on test_ones.

**Motivation and Context**
- When iterating in Python, use a list instead of a set and don't use reserved words
- Fix long line in cpp
- Clarify test_mul_bool intent for future developers.
- fill_ implements torch.ones under the covers but in previous pr verification on the out param was not added so adding it here.
