### PR TITLE
Fix NonZero eager impl.

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen.py
+++ b/orttraining/orttraining/eager/opgen/opgen.py
@@ -3,13 +3,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from opgen.writer import SourceWriter as SourceWriter
-from opgen.parser import cpp_create_from_file as CPPParser
-import sys
-import os
-from opgen.generator import ORTGen as ORTGen
-from importlib.machinery import SourceFileLoader
 import argparse
+import os
+import sys
+from importlib.machinery import SourceFileLoader
+
+from opgen.generator import ORTGen as ORTGen
+from opgen.parser import cpp_create_from_file as CPPParser
+from opgen.writer import SourceWriter as SourceWriter
 
 parser = argparse.ArgumentParser(description="Generate ORT ATen operations")
 parser.add_argument(
@@ -24,7 +25,12 @@ parser.add_argument(
 args = parser.parse_args()
 ops_module = SourceFileLoader("opgen.customop", args.ops_module).load_module()
 
-ortgen = ORTGen(ops_module.ops, type_promotion_ops=ops_module.type_promotion_ops, custom_ops=args.custom_ops)
+ortgen = ORTGen(
+    ops_module.ops,
+    type_promotion_ops=ops_module.type_promotion_ops,
+    custom_ops=args.custom_ops,
+    aten_output_type=ops_module.aten_output_type,
+)
 
 regdecs_path = args.header_file
 print(f"INFO: Using RegistrationDeclarations from: {regdecs_path}")

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -68,7 +68,6 @@ unary_ops_with_out = [
     "hardsigmoid",
     "log",
     "neg",
-    "nonzero",
     "reciprocal",
     "round",
     "sigmoid",
@@ -92,7 +91,6 @@ unary_ops = [
     "det",
     "isinf",
     "isnan",
-    "nonzero",
     "relu",
     "selu",
 ]
@@ -169,6 +167,8 @@ hand_implemented = {
     "aten::equal": SignatureOnly(),
     "aten::_softmax": Softmax("self", axis="dim"),
     "aten::argmax.out": SignatureOnly(),
+    "aten::nonzero": Transpose(NonZero("self")),
+    "aten::nonzero.out": SignatureOnly(),
 }
 
 # Signature of gelu_backward was changed in this commit id 983ba5e585485ed61a0c0012ef6944f5685e3d97 and PR 61439

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -45,6 +45,7 @@ class GeluGrad(ONNXOp):
 
 ops = {}
 type_promotion_ops = []
+aten_output_type = []
 
 # the following op list is for ops that have a .out version. Often this is the only op needing to be implemented
 # and the regular and inplace(_) version derive from the .out.
@@ -167,10 +168,13 @@ hand_implemented = {
     "aten::equal": SignatureOnly(),
     "aten::_softmax": Softmax("self", axis="dim"),
     "aten::argmax.out": SignatureOnly(),
-    # nonzero should be Transpose(NonZero("self")), but output must be type long which generator doesn't support yet
-    "aten::nonzero": SignatureOnly(),
+    "aten::nonzero": Transpose(NonZero("self")),
     "aten::nonzero.out": SignatureOnly(),
 }
+
+# If the aten op expects a specific output type that differs from self
+# add the op and type tuple to aten_output_type
+aten_output_type.append(("aten::nonzero", "at::ScalarType::Long"))
 
 # Signature of gelu_backward was changed in this commit id 983ba5e585485ed61a0c0012ef6944f5685e3d97 and PR 61439
 # This is done to make sure it is backward and future compatible

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -167,7 +167,8 @@ hand_implemented = {
     "aten::equal": SignatureOnly(),
     "aten::_softmax": Softmax("self", axis="dim"),
     "aten::argmax.out": SignatureOnly(),
-    "aten::nonzero": Transpose(NonZero("self")),
+    # nonzero should be Transpose(NonZero("self")), but output must be type long which generator doesn't support yet
+    "aten::nonzero": SignatureOnly(),
     "aten::nonzero.out": SignatureOnly(),
 }
 

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -45,7 +45,7 @@ class GeluGrad(ONNXOp):
 
 ops = {}
 type_promotion_ops = []
-aten_output_type = []
+aten_output_type = {}
 
 # the following op list is for ops that have a .out version. Often this is the only op needing to be implemented
 # and the regular and inplace(_) version derive from the .out.
@@ -173,8 +173,8 @@ hand_implemented = {
 }
 
 # If the aten op expects a specific output type that differs from self
-# add the op and type tuple to aten_output_type
-aten_output_type.append(("aten::nonzero", "at::ScalarType::Long"))
+# add the op and type to aten_output_type
+aten_output_type["aten::nonzero"] = "at::ScalarType::Long"
 
 # Signature of gelu_backward was changed in this commit id 983ba5e585485ed61a0c0012ef6944f5685e3d97 and PR 61439
 # This is done to make sure it is backward and future compatible

--- a/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/custom_ops.py
@@ -1,14 +1,11 @@
 from copy import deepcopy
 
-from opgen.generator import AttrType, ONNXAttr
-
-from opgen.generator import (
-    ORTGen as ORTGen,
-    ONNXOp as ONNXOp,
-    SignatureOnly as SignatureOnly,
-    MakeTorchFallback as MakeTorchFallback,
-)
-
+from opgen.generator import AttrType
+from opgen.generator import MakeTorchFallback as MakeTorchFallback
+from opgen.generator import ONNXAttr
+from opgen.generator import ONNXOp as ONNXOp
+from opgen.generator import ORTGen as ORTGen
+from opgen.generator import SignatureOnly as SignatureOnly
 from opgen.onnxops import *
 
 ops = {
@@ -17,3 +14,4 @@ ops = {
 }
 
 type_promotion_ops = {}
+aten_output_type = {}

--- a/orttraining/orttraining/eager/opgen/opgen/generator.py
+++ b/orttraining/orttraining/eager/opgen/opgen/generator.py
@@ -118,7 +118,7 @@ class ORTGen:
         ops: Optional[Dict[str, ONNXOp]] = None,
         custom_ops: bool = False,
         type_promotion_ops: List = (),
-        aten_output_type: List = (),
+        aten_output_type: Dict = (),
     ):
         self._mapped_ops = {}
         if ops:
@@ -527,9 +527,8 @@ class ORTGen:
                 writer.write(".dtype(*promoted_type)")
 
             # do we need to set type on the returned value
-            aten_output_type = [v[1] for v in self.aten_output_type if v[0] == mapped_func.mapped_op_name]
-            if aten_output_type:
-                writer.write(f".dtype({aten_output_type.pop()})")
+            if mapped_func.mapped_op_name in self.aten_output_type:
+                writer.write(f".dtype({self.aten_output_type[mapped_func.mapped_op_name]})")
 
             writer.writeline(";")
 

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -957,57 +957,6 @@ at::Tensor& fill__Scalar(
   return self;
 }
 
-// aten::nonzero.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
-at::Tensor& nonzero_out(
-  const at::Tensor& self,
-  // *,
-  at::Tensor& out) {
-  ORT_LOG_FN(self, out);
-
-  if (
-    !IsSupportedType(self, {at::kBool,at::kBFloat16,at::kDouble,at::kHalf,at::kLong,at::kFloat,at::kByte,at::kShort,at::kInt})) {
-    return at::native::call_fallback_fn<
-      &at::native::cpu_fallback,
-      ATEN_OP(nonzero_out)>::call(self, out);
-  }
-  auto& invoker = GetORTInvoker(self.device());
-
-  auto ort_input_self = create_ort_value(invoker, self);
-
-  std::vector<OrtValue> ort_outputs_0_NonZero(1);
-
-  auto status = invoker.Invoke("NonZero", {
-    std::move(ort_input_self),
-  }, ort_outputs_0_NonZero, nullptr);
-
-  if (!status.IsOK())
-    throw std::runtime_error(
-      "ORT return failure status:" + status.ErrorMessage());
-
-  // We need to calculate the transpose output, get the original dims and a copy, then reverse the order in the copy.
-  auto originalDims =ort_outputs_0_NonZero[0].Get<onnxruntime::Tensor>().Shape();
-  auto transposeDims = ort_outputs_0_NonZero[0].Get<onnxruntime::Tensor>().Shape().AsShapeVector();
-  for (size_t i = 0; i < originalDims.NumDimensions(); i++) {
-    transposeDims[i] = originalDims[originalDims.NumDimensions() - i - 1];
-  }
-
-  // resize the output and then create output ort value to be updated.
-  resize_output(invoker, dynamic_cast<ORTTensorImpl*>(out.unsafeGetTensorImpl()), transposeDims);
-  auto ort_input_out = create_ort_value(invoker, out);
-
-  std::vector<OrtValue> ort_outputs_1_Transpose(1);
-  ort_outputs_1_Transpose[0] = ort_input_out;
-
-  status = invoker.Invoke("Transpose", {
-    std::move(ort_outputs_0_NonZero[0]),
-  }, ort_outputs_1_Transpose, nullptr);
-
-  if (!status.IsOK())
-    throw std::runtime_error(
-      "ORT return failure status:" + status.ErrorMessage());
-
-  return out;
-}
 
 // aten::nonzero(Tensor self) -> Tensor
 at::Tensor nonzero(
@@ -1049,6 +998,26 @@ at::Tensor nonzero(
   return aten_tensor_from_ort(
     std::move(ort_outputs_1_Transpose[0]),
     tensor_options);
+}
+
+
+// aten::nonzero.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+at::Tensor& nonzero_out(
+  const at::Tensor& self,
+  // *,
+  at::Tensor& out) {
+  ORT_LOG_FN(self, out);
+
+  auto temp = eager::aten::nonzero(self);
+
+  // resize out, then copy nonzero result into it.
+  auto& invoker = GetORTInvoker(self.device());
+  resize_output(invoker, dynamic_cast<ORTTensorImpl*>(out.unsafeGetTensorImpl()), temp.sizes());
+  auto ort_input_out = create_ort_value(invoker, out);
+  auto ort_temp = create_ort_value(invoker, temp);
+  copy(invoker, ort_temp, ort_input_out);
+
+  return out;
 }
 
 } // namespace aten

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -957,50 +957,6 @@ at::Tensor& fill__Scalar(
   return self;
 }
 
-
-// aten::nonzero(Tensor self) -> Tensor
-at::Tensor nonzero(
-  const at::Tensor& self) {
-  ORT_LOG_FN(self);
-
-  if (
-    !IsSupportedType(self, {at::kByte,at::kLong,at::kInt,at::kDouble,at::kFloat,at::kBFloat16,at::kHalf,at::kShort,at::kBool})) {
-    return at::native::call_fallback_fn<
-      &at::native::cpu_fallback,
-      ATEN_OP(nonzero)>::call(self);
-  }
-  auto& invoker = GetORTInvoker(self.device());
-
-  auto ort_input_self = create_ort_value(invoker, self);
-
-  std::vector<OrtValue> ort_outputs_0_NonZero(1);
-
-  auto status = invoker.Invoke("NonZero", {
-    std::move(ort_input_self),
-  }, ort_outputs_0_NonZero, nullptr);
-
-  if (!status.IsOK())
-    throw std::runtime_error(
-      "ORT return failure status:" + status.ErrorMessage());
-
-  std::vector<OrtValue> ort_outputs_1_Transpose(1);
-
-  status = invoker.Invoke("Transpose", {
-    std::move(ort_outputs_0_NonZero[0]),
-  }, ort_outputs_1_Transpose, nullptr);
-
-  if (!status.IsOK())
-    throw std::runtime_error(
-      "ORT return failure status:" + status.ErrorMessage());
-
-  // Once the generator can add .dtype(at::ScalarType::Long); this method can be generated
-  at::TensorOptions tensor_options = self.options().dtype(at::ScalarType::Long);
-  return aten_tensor_from_ort(
-    std::move(ort_outputs_1_Transpose[0]),
-    tensor_options);
-}
-
-
 // aten::nonzero.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 at::Tensor& nonzero_out(
   const at::Tensor& self,

--- a/orttraining/orttraining/eager/ort_aten.h
+++ b/orttraining/orttraining/eager/ort_aten.h
@@ -133,5 +133,12 @@ void resize_impl_ort_(
   ORTTensorImpl* self,
   at::IntArrayRef size);
 
+namespace aten {
+
+// aten::nonzero(Tensor self) -> Tensor
+at::Tensor nonzero(
+  const at::Tensor& self);
+
+} // namespace aten
 } // namespace eager
 } // namespace torch_ort

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -454,6 +454,20 @@ class OrtOpTests(unittest.TestCase):
                 assert cpu_tensor.dtype == ort_tensor.dtype
                 assert torch.equal(cpu_tensor, ort_tensor.to("cpu"))
 
+    def test_nonzero_out(self):
+        device = self.get_device()
+        cpu_tensor = torch.tensor([[[-1, 0, 1], [0, 1, 0]], [[0, 1, 0], [-1, 0, 1]]])
+        ort_tensor = cpu_tensor.to(device)
+
+        cpu_out_tensor = torch.tensor([], dtype=torch.long)
+        ort_out_tensor = cpu_out_tensor.to(device)
+
+        cpu_result = torch.nonzero(cpu_tensor, out=cpu_out_tensor)
+        ort_result = torch.nonzero(ort_tensor, out=ort_out_tensor)
+
+        assert torch.equal(cpu_out_tensor, ort_out_tensor.to("cpu"))
+        assert torch.equal(cpu_result, ort_result.to("cpu"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -42,7 +42,6 @@ ops = [
 # the following unary ops not been tested:
 # ["isnan",       torch.tensor([1, float('nan'), 2])]]
 # ["selu",        torch.randn(10)]]
-# ["nonzero",    torch.tensor([0, 2, 1, 3])]]
 # ["sign",        ]]
 # ["hardsigmoid", ],
 # ["isinf",       ],
@@ -454,19 +453,32 @@ class OrtOpTests(unittest.TestCase):
                 assert cpu_tensor.dtype == ort_tensor.dtype
                 assert torch.equal(cpu_tensor, ort_tensor.to("cpu"))
 
-    def test_nonzero_out(self):
+    # tests both nonzero and nonzero.out
+    def test_nonzero(self):
         device = self.get_device()
-        cpu_tensor = torch.tensor([[[-1, 0, 1], [0, 1, 0]], [[0, 1, 0], [-1, 0, 1]]])
-        ort_tensor = cpu_tensor.to(device)
 
-        cpu_out_tensor = torch.tensor([], dtype=torch.long)
-        ort_out_tensor = cpu_out_tensor.to(device)
+        for cpu_tensor in [
+            torch.tensor([[[-1, 0, 1], [0, 1, 0]], [[0, 1, 0], [-1, 0, 1]]], dtype=torch.long),
+            torch.tensor([[[-1, 0, 1], [0, 1, 0]], [[0, 1, 0], [-1, 0, 1]]], dtype=torch.float),
+        ]:
+            ort_tensor = cpu_tensor.to(device)
 
-        cpu_result = torch.nonzero(cpu_tensor, out=cpu_out_tensor)
-        ort_result = torch.nonzero(ort_tensor, out=ort_out_tensor)
+            cpu_out_tensor = torch.tensor([], dtype=torch.long)
+            ort_out_tensor = cpu_out_tensor.to(device)
 
-        assert torch.equal(cpu_out_tensor, ort_out_tensor.to("cpu"))
-        assert torch.equal(cpu_result, ort_result.to("cpu"))
+            # nonzero.out
+            cpu_result = torch.nonzero(cpu_tensor, out=cpu_out_tensor)
+            ort_result = torch.nonzero(ort_tensor, out=ort_out_tensor)
+            assert torch.equal(cpu_out_tensor, ort_out_tensor.to("cpu"))
+            assert torch.equal(cpu_result, ort_result.to("cpu"))
+
+            # nonzero
+            cpu_result = torch.nonzero(cpu_tensor)
+            ort_result = torch.nonzero(ort_tensor)
+            assert torch.equal(cpu_result, ort_result.to("cpu"))
+
+            # check result between nonzero.out and nonzero
+            assert torch.equal(ort_result.to("cpu"), ort_out_tensor.to("cpu"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**: Nonzero is not a typical unary op as the output shape is not the same as the input self tensor.

**Motivation and Context**
The current nonzero implementation in eager mode is not correctly aligned with aten behavior. First Onnx produces an output that is transposed to that of aten and pytorch. Second the output is a list of indexes and not the same shape as the input tensor. For those reasons, we need to directly implement both nonzero and nonzero.out.