### PR TITLE
Fix Reduced Ops build pipeline

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2166,7 +2166,8 @@ TEST(CApiTest, TestCudaMemcpyToHostWithSequenceTensors) {
 
 #endif
 
-#if !defined(DISABLE_OPTIONAL_TYPE)
+// Reduced Ops build doesn't support OptionalHasElement (16) yet
+#if !defined(REDUCED_OPS_BUILD) && !defined(DISABLE_OPTIONAL_TYPE)
 TEST(CApiTest, GH_11717) {
   const auto* model_path = OPTIONAL_TYPE_GH_11717_MODEL;
   Ort::SessionOptions session_options{};


### PR DESCRIPTION
**Description**: The Reduced Ops pipeline broke with https://github.com/microsoft/onnxruntime/pull/11839 because the test model has an op that it is not included in the list of ops supported. This change disables the test for that pipeline

**Motivation and Context**
Fix Reduced Ops build pipeline