### PR TITLE
[js/web] use windowed Chrome for perf mode

### DIFF
--- a/js/web/karma.conf.js
+++ b/js/web/karma.conf.js
@@ -77,7 +77,8 @@ module.exports = function (config) {
     browserSocketTimeout: 60000,
     hostname: getMachineIpAddress(),
     customLaunchers: {
-      ChromeTest: { base: 'ChromeHeadless', flags: ['--window-size=1,1', '--enable-features=SharedArrayBuffer'] },
+      ChromeTest: { base: 'ChromeHeadless', flags: ['--enable-features=SharedArrayBuffer'] },
+      ChromePerf: { base: 'Chrome', flags: ['--window-size=1,1', '--enable-features=SharedArrayBuffer'] },
       ChromeDebug: { debug: true, base: 'Chrome', flags: ['--remote-debugging-port=9333', '--enable-features=SharedArrayBuffer'] },
 
       //

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -451,7 +451,11 @@ function run(config: Test.Config) {
     // STEP 5. use Karma to run test
     npmlog.info('TestRunnerCli.Run', '(5/5) Running karma to start test runner...');
     const karmaCommand = path.join(npmBin, 'karma');
-    const browser = getBrowserNameFromEnv(args.env, args.debug);
+    const browser = getBrowserNameFromEnv(
+        args.env,
+        args.bundleMode === 'perf' ? 'perf' :
+            args.debug             ? 'debug' :
+                                     'test');
     const karmaArgs = ['start', `--browsers ${browser}`];
     if (args.debug) {
       karmaArgs.push('--log-level info --timeout-mocha 9999999');
@@ -552,10 +556,10 @@ function saveConfig(config: Test.Config) {
   fs.writeJSONSync(path.join(TEST_ROOT, './testdata-config.json'), config);
 }
 
-function getBrowserNameFromEnv(env: TestRunnerCliArgs['env'], debug?: boolean) {
+function getBrowserNameFromEnv(env: TestRunnerCliArgs['env'], mode: 'debug'|'perf'|'test') {
   switch (env) {
     case 'chrome':
-      return debug ? 'ChromeDebug' : 'ChromeTest';
+      return selectChromeBrowser(mode);
     case 'edge':
       return 'Edge';
     case 'firefox':
@@ -568,5 +572,16 @@ function getBrowserNameFromEnv(env: TestRunnerCliArgs['env'], debug?: boolean) {
       return process.env.ORT_WEB_TEST_BS_BROWSERS!;
     default:
       throw new Error(`env "${env}" not supported.`);
+  }
+}
+
+function selectChromeBrowser(mode: 'debug'|'perf'|'test') {
+  switch (mode) {
+    case 'debug':
+      return 'ChromeDebug';
+    case 'perf':
+      return 'ChromePerf';
+    default:
+      return 'ChromeTest';
   }
 }


### PR DESCRIPTION
**Description**: WebGL is very slow in ChromeHeadless. So for perf mode, we use Chrome instead of ChromeHeadless.