### PR TITLE
Add OffscreenCanvas support to WebGL backend

### DIFF
--- a/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
+++ b/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
@@ -83,7 +83,18 @@ export function createNewWebGLContext(contextId?: 'webgl'|'webgl2'): WebGLContex
   throw new Error('WebGL is not supported');
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+declare let OffscreenCanvas: {
+  new(width: number, height: number): HTMLCanvasElement;
+};
+
 function createCanvas(): HTMLCanvasElement {
+  if (typeof document === 'undefined') {
+    if (typeof OffscreenCanvas === 'undefined') {
+      throw new TypeError('failed to create canvas: OffscreenCanvas is not supported');
+    }
+    return new OffscreenCanvas(1, 1);
+  }
   const canvas: HTMLCanvasElement = document.createElement('canvas');
   canvas.width = 1;
   canvas.height = 1;

--- a/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
+++ b/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
@@ -84,9 +84,7 @@ export function createNewWebGLContext(contextId?: 'webgl'|'webgl2'): WebGLContex
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-declare let OffscreenCanvas: {
-  new(width: number, height: number): HTMLCanvasElement;
-};
+declare let OffscreenCanvas: {new (width: number, height: number): HTMLCanvasElement;};
 
 function createCanvas(): HTMLCanvasElement {
   if (typeof document === 'undefined') {

--- a/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
+++ b/js/web/lib/onnxjs/backends/webgl/webgl-context-factory.ts
@@ -84,7 +84,7 @@ export function createNewWebGLContext(contextId?: 'webgl'|'webgl2'): WebGLContex
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-declare let OffscreenCanvas: {new (width: number, height: number): HTMLCanvasElement;};
+declare let OffscreenCanvas: {new (width: number, height: number): HTMLCanvasElement};
 
 function createCanvas(): HTMLCanvasElement {
   if (typeof document === 'undefined') {


### PR DESCRIPTION
**Description**: Enables fallback to OffscreenCanvas when DOM not available (i.e. in worker threads) when possible for the WebGL backend of ONNX Runtime Web.

**Motivation and Context**
- This allows users to run ONNX Runtime Web in a Web Worker to avoid hanging the main thread. This improves responsiveness and makes timers work properly. It's most noticeable while compiling shaders.
- Fixes #9458
