### PR TITLE
Add DONT_VECTORIZE flag to cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -80,6 +80,7 @@ option(onnxruntime_TENSORRT_PLACEHOLDER_BUILDER "Instantiate Placeholder TensorR
 option(onnxruntime_ENABLE_LTO "Enable link time optimization" OFF)
 option(onnxruntime_CROSS_COMPILING "Cross compiling onnx runtime" OFF)
 option(onnxruntime_GCOV_COVERAGE "Compile with options necessary to run code coverage" OFF)
+option(onnxruntime_DONT_VECTORIZE "Do not vectorize operations in Eigen" OFF)
 
 #It's preferred to turn it OFF when onnxruntime is dynamically linked to PROTOBUF. But Tensort always required the full version of protobuf.
 cmake_dependent_option(onnxruntime_USE_FULL_PROTOBUF "Link to libprotobuf instead of libprotobuf-lite when this option is ON" OFF "NOT onnxruntime_USE_TENSORRT" ON)
@@ -489,6 +490,10 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 if (MSVC)
   add_definitions(-DEIGEN_HAS_CONSTEXPR -DEIGEN_HAS_VARIADIC_TEMPLATES -DEIGEN_HAS_CXX11_MATH -DEIGEN_HAS_CXX11_ATOMIC
           -DEIGEN_STRONG_INLINE=inline)
+endif()
+
+if ( onnxruntime_DONT_VECTORIZE )
+  add_definitions(-DEIGEN_DONT_VECTORIZE=1)
 endif()
 
 if (onnxruntime_CROSS_COMPILING)


### PR DESCRIPTION
Closes #10058

In #10058, we showed that some ONNX operators (e.g. log, exp, ...) produce (ever so slightly) different results depending on the length of the input data that they are operating on. As discussed in https://gitlab.com/libeigen/eigen/-/issues/2413 this is because Eigen is using different code paths depending on the length of the input data. For 32bit and 64bit floats on most architectures, Eigen will operate on the input data in packets of 4 and use its own optimized routines to compute log, exp, and other basic operations. On the remainder of the data, Eigen will use std::log, std::exp, etc from the C++ standard library.

In most applications these discrepancies probably don't matter. But for those applications, where they do, I'm adding a `onnxruntime_DONT_VECTORIZE` flag that will then tell Eigen to use the standard library functions on all elements on the input data. This flag is passed through to Eigen as `-DEIGEN_DONT_VECTORIZE=1`. When I build the onnxruntime with that flag, the examples in #10058 produce the same results regardless of the length of the input data.