### PR TITLE
[NNAPI] Add int32_t as supported input data type and other minor gather op updates

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.cc
@@ -214,6 +214,9 @@ static Status GetInputDataType(
           initializers, *node_unit, name, scale, zero_point, ArgType::kInput));
       break;
     }
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      type = Type::TENSOR_INT32;
+      break;
       // case ONNX_NAMESPACE::TensorProto_DataType_INT8:
       // We also do not consider ONNX_NAMESPACE::TensorProto_DataType_INT8 case here, since that can only
       // be input 2 of Qlinear[Conv/MatMul], which has to be an initializer tensor and will be added

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2498,7 +2498,8 @@ void GatherOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const N
   const auto& indices_name = inputs[1].node_arg.Name();
   int32_t indices_data_type;
   GetType(node_unit.Inputs()[1].node_arg, indices_data_type);
-  if (Contains(model_builder.GetInitializerTensors(), indices_name) && indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+  if (Contains(model_builder.GetInitializerTensors(), indices_name) &&
+      indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
     // Skip the second input `indices` for Gather if it is an initializer
     model_builder.AddInitializerToSkip(indices_name);
   }
@@ -2523,7 +2524,8 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
 
   int32_t indices_data_type;
   GetType(node_unit.Inputs()[1].node_arg, indices_data_type);
-  if (Contains(model_builder.GetInitializerTensors(), input2) && indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+  if (Contains(model_builder.GetInitializerTensors(), input2) &&
+      indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
     // Add indices operand into nnapi
     const auto& indices_tensor = *initializers.at(input2);
     std::vector<uint8_t> unpacked_tensor;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2486,24 +2486,24 @@ Status FlattenOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, cons
 #pragma region op_gather
 
 class GatherOpBuilder : public BaseOpBuilder {
- public:
-  void AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const override;
+  /* public:
+   void AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const override; */
 
  private:
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const NodeUnit& node_unit) const override;
 };
 
-void GatherOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
+/* void GatherOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
   // Skip the second input `indices` for Gather
   const auto& inputs = node_unit.Inputs();
   model_builder.AddInitializerToSkip(inputs[1].node_arg.Name());  // indices
-}
+} */
 
 Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
   auto& shaper(model_builder.GetShaper());
   const auto& operand_indices(model_builder.GetOperandIndices());
   const auto& operand_types(model_builder.GetOperandTypes());
-  const auto& initializers(model_builder.GetInitializerTensors());
+  // const auto& initializers(model_builder.GetInitializerTensors());
   const auto& input1 = node_unit.Inputs()[0].node_arg.Name();
   const auto& input2 = node_unit.Inputs()[1].node_arg.Name();  // "indices"
   const auto& output = node_unit.Outputs()[0].node_arg.Name();
@@ -2516,39 +2516,39 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
   input_indices.push_back(operand_indices.at(input1));
   ADD_SCALAR_OPERAND(model_builder, input_indices, axis);
 
-  // Add indices operand into nnapi
-  const auto& indices_tensor = *initializers.at(input2);
-  std::vector<uint8_t> unpacked_tensor;
-  ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(indices_tensor, unpacked_tensor));
+  /*   // Add indices operand into nnapi
+    const auto& indices_tensor = *initializers.at(input2);
+    std::vector<uint8_t> unpacked_tensor;
+    ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(indices_tensor, unpacked_tensor));
 
-  const auto data_type = indices_tensor.data_type();
-  const auto indices_shape = indices_tensor.dims();
-  uint32_t size = 1;
-  Shape indices_dimen;
-  indices_dimen.reserve(indices_tensor.dims_size());
-  for (auto i = 0; i < indices_tensor.dims_size(); i++) {
-    size *= indices_shape[i];
-    indices_dimen.push_back(static_cast<uint32_t>(indices_shape[i]));
-  }
-
-  std::vector<int32_t> indices(size);
-  // see https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#type-punning-arrays for the usage of memcpy here
-  if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-    for (uint32_t i = 0; i < size; i++) {
-      int64_t index_i64;
-      memcpy(&index_i64, unpacked_tensor.data() + i * sizeof(int64_t), sizeof(int64_t));
-      indices[i] = SafeInt<int32_t>(index_i64);
+    const auto data_type = indices_tensor.data_type();
+    const auto indices_shape = indices_tensor.dims();
+    uint32_t size = 1;
+    Shape indices_dimen;
+    indices_dimen.reserve(indices_tensor.dims_size());
+    for (auto i = 0; i < indices_tensor.dims_size(); i++) {
+      size *= SafeInt<uint32_t>(indices_shape[i]);
+      indices_dimen.push_back(static_cast<uint32_t>(indices_shape[i]));
     }
-  } else if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
-    for (uint32_t i = 0; i < size; i++) {
-      int32_t index;
-      memcpy(&index, unpacked_tensor.data() + i * sizeof(int32_t), sizeof(int32_t));
-      indices[i] = SafeInt<int32_t>(index);
-    }
-  }
 
-  OperandType indices_operand_type(Type::TENSOR_INT32, indices_dimen);
-  ORT_RETURN_IF_ERROR(model_builder.AddOperandFromPersistMemoryBuffer(input2, indices.data(), indices_operand_type));
+    std::vector<int32_t> indices(size);
+    // see https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8#type-punning-arrays for the usage of memcpy here
+    if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+      for (uint32_t i = 0; i < size; i++) {
+        int64_t index_i64;
+        memcpy(&index_i64, unpacked_tensor.data() + i * sizeof(int64_t), sizeof(int64_t));
+        indices[i] = SafeInt<int32_t>(index_i64);
+      }
+    } else if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+      for (uint32_t i = 0; i < size; i++) {
+        int32_t index;
+        memcpy(&index, unpacked_tensor.data() + i * sizeof(int32_t), sizeof(int32_t));
+        indices[i] = SafeInt<int32_t>(index);
+      }
+    }
+
+    OperandType indices_operand_type(Type::TENSOR_INT32, indices_dimen);
+    ORT_RETURN_IF_ERROR(model_builder.AddOperandFromPersistMemoryBuffer(input2, indices.data(), indices_operand_type)); */
   input_indices.push_back(operand_indices.at(input2));
   ORT_RETURN_IF_ERROR(shaper.Gather(input1, input2, axis, output));
   const OperandType output_operand_type(operand_types.at(input1).type, shaper[output]);

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2496,7 +2496,9 @@ class GatherOpBuilder : public BaseOpBuilder {
 void GatherOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const NodeUnit& node_unit) const {
   const auto& inputs = node_unit.Inputs();
   const auto& indices_name = inputs[1].node_arg.Name();
-  if (Contains(model_builder.GetInitializerTensors(), indices_name)) {
+  int32_t indices_data_type;
+  GetType(node_unit.Inputs()[1].node_arg, indices_data_type);
+  if (Contains(model_builder.GetInitializerTensors(), indices_name) && indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
     // Skip the second input `indices` for Gather if it is an initializer
     model_builder.AddInitializerToSkip(indices_name);
   }
@@ -2519,7 +2521,9 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
   input_indices.push_back(operand_indices.at(input1));
   ADD_SCALAR_OPERAND(model_builder, input_indices, axis);
 
-  if (Contains(model_builder.GetInitializerTensors(), input2)) {
+  int32_t indices_data_type;
+  GetType(node_unit.Inputs()[1].node_arg, indices_data_type);
+  if (Contains(model_builder.GetInitializerTensors(), input2) && indices_data_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
     // Add indices operand into nnapi
     const auto& indices_tensor = *initializers.at(input2);
     std::vector<uint8_t> unpacked_tensor;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder.cc
@@ -2497,7 +2497,6 @@ void GatherOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const N
   const auto& inputs = node_unit.Inputs();
   const auto& indices_name = inputs[1].node_arg.Name();
   if (Contains(model_builder.GetInitializerTensors(), indices_name)) {
-    std::cout << "indices is an initializer" << std::endl;
     // Skip the second input `indices` for Gather if it is an initializer
     model_builder.AddInitializerToSkip(indices_name);
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2118,7 +2118,7 @@ class GatherOpSupportChecker : public BaseOpSupportChecker {
                          const OpSupportCheckParams& params) const override;
 };
 
-bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
+bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const NodeUnit& node_unit,
                                                const OpSupportCheckParams& /* params */) const {
   const auto& inputs = node_unit.Inputs();
   Shape input_shape;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2139,8 +2139,9 @@ bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
   }
 
   // Here in GatherOpSupportChecker::IsOpSupportedImpl, we removed the restriction that 2nd input "indices" must be an initializer
-  // to accommodate the support for some models such as modibleBERT.
-  // However, for other cases(such as int64 type), we still require indices of gather to be an initializer
+  // to accommodate the support for some models such as mobileBERT.
+  // However, for other cases(such as int64 type), we still require indices of gather to be an initializer as we will convert the data into int32 during model building
+  // to match the int32 indices type for NNAPI Gather.
   const auto& indices_name = inputs[1].node_arg.Name();
 
   int32_t indices_type;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2139,7 +2139,7 @@ bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
   }
 
   // Here in GatherOpSupportChecker::IsOpSupportedImpl, we removed the restriction that 2nd input "indices" must be an initializer
-  // to accomodate the support for some models such as modibleBERT.
+  // to accommodate the support for some models such as modibleBERT.
   // However, for other cases(such as int64 type), we still require indices of gather to be an initializer
 
   return true;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2138,11 +2138,9 @@ bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
     return false;
   }
 
-  /* const auto& indices_name = inputs[1].node_arg.Name();
-  if (!Contains(initializers, indices_name)) {
-    LOGS_DEFAULT(VERBOSE) << "Indices of Gather must be known";
-    return false;
-  } */
+  // Here in GatherOpSupportChecker::IsOpSupportedImpl, we removed the restriction that 2nd input "indices" must be an initializer
+  // to accomodate the support for some models such as modibleBERT.
+  // However, for other cases(such as int64 type), we still require indices of gather to be an initializer
 
   return true;
 }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2139,9 +2139,10 @@ bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
   }
 
   // Here in GatherOpSupportChecker::IsOpSupportedImpl, we removed the restriction that 2nd input "indices" must be an initializer
-  // to accommodate the support for some models such as mobileBERT.
-  // However, for other cases(such as int64 type), we still require indices of gather to be an initializer as we will convert the data into int32 during model building
-  // to match the int32 indices type for NNAPI Gather.
+  // to accommodate the support for some models such as mobileBERT. It doesn't need to be an initializer for int32 as NNAPI Gather
+  // uses int32 for indices so the type matches.
+  // However, we still require indices of other types to be an initializer as we convert the data to int32 during model building.
+  // TODO: We could potentially support non-initializer inputs for the other types if we inserted a cast.
   const auto& indices_name = inputs[1].node_arg.Name();
 
   int32_t indices_type;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2118,7 +2118,7 @@ class GatherOpSupportChecker : public BaseOpSupportChecker {
                          const OpSupportCheckParams& params) const override;
 };
 
-bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /*initializers*/, const NodeUnit& node_unit,
+bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
                                                const OpSupportCheckParams& /* params */) const {
   const auto& inputs = node_unit.Inputs();
   Shape input_shape;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -2118,7 +2118,7 @@ class GatherOpSupportChecker : public BaseOpSupportChecker {
                          const OpSupportCheckParams& params) const override;
 };
 
-bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initializers, const NodeUnit& node_unit,
+bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& /*initializers*/, const NodeUnit& node_unit,
                                                const OpSupportCheckParams& /* params */) const {
   const auto& inputs = node_unit.Inputs();
   Shape input_shape;
@@ -2138,11 +2138,11 @@ bool GatherOpSupportChecker::IsOpSupportedImpl(const InitializedTensorSet& initi
     return false;
   }
 
-  const auto& indices_name = inputs[1].node_arg.Name();
+  /* const auto& indices_name = inputs[1].node_arg.Name();
   if (!Contains(initializers, indices_name)) {
     LOGS_DEFAULT(VERBOSE) << "Indices of Gather must be known";
     return false;
-  }
+  } */
 
   return true;
 }

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -224,78 +224,56 @@ TEST(GatherOpTest, Gather_axis1_indices2d) {
 }
 
 TEST(GatherOpTest, Gather_axis0_indicesInt32) {
-  // To test for NNAPI EP, we need the indices to be initializers
-  // NNAPI EP only supports float input data for now,
-  // the following two test cases cover int32_t indices with float input other than int64_t type for Nnapi
-  auto run_test = [](bool indices_is_initializer) {
-    OpTester test("Gather");
-    test.AddAttribute<int64_t>("axis", 0LL);
-    test.AddInput<float>("data", {2, 3, 4},
-                         {0.0f, 0.1f, 0.2f, 0.3f,
-                          1.0f, 1.1f, 1.2f, 1.3f,
-                          2.0f, 2.1f, 2.2f, 2.3f,
-                          10.0f, 10.1f, 10.2f, 10.3f,
-                          11.0f, 11.1f, 11.2f, 11.3f,
-                          12.0f, 12.1f, 12.2f, 12.3f});
-    test.AddInput<int32_t>("indices", {1}, {1}, indices_is_initializer);
-    test.AddOutput<float>("output", {1, 3, 4},
-                          {10.0f, 10.1f, 10.2f, 10.3f,
-                           11.0f, 11.1f, 11.2f, 11.3f,
-                           12.0f, 12.1f, 12.2f, 12.3f});
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 0LL);
+  test.AddInput<float>("data", {2, 3, 4},
+                       {0.0f, 0.1f, 0.2f, 0.3f,
+                        1.0f, 1.1f, 1.2f, 1.3f,
+                        2.0f, 2.1f, 2.2f, 2.3f,
+                        10.0f, 10.1f, 10.2f, 10.3f,
+                        11.0f, 11.1f, 11.2f, 11.3f,
+                        12.0f, 12.1f, 12.2f, 12.3f});
+  test.AddInput<int32_t>("indices", {1}, {1});
+  test.AddOutput<float>("output", {1, 3, 4},
+                        {10.0f, 10.1f, 10.2f, 10.3f,
+                         11.0f, 11.1f, 11.2f, 11.3f,
+                         12.0f, 12.1f, 12.2f, 12.3f});
 
-    test.Run();
-  };
-
-  run_test(false);
-  run_test(true);
+  test.Run();
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
-  // To test for NNAPI EP, we need the indices to be initializers
-  auto run_test = [](bool indices_is_initializer) {
-    OpTester test("Gather");
-    test.AddAttribute<int64_t>("axis", 0LL);
-    test.AddInput<float>("data", {3, 3},
-                         {0.0f, 0.1f, 0.2f,
-                          1.0f, 1.1f, 1.2f,
-                          2.0f, 2.1f, 2.2f});
-    test.AddInput<int32_t>("indices", {2, 2},
-                           {1, 0,
-                            2, 1},
-                           indices_is_initializer);
-    test.AddOutput<float>("output", {2, 2, 3},
-                          {1.0f, 1.1f, 1.2f, 0.0f, 0.1f, 0.2f,
-                           2.0f, 2.1f, 2.2f, 1.0f, 1.1f, 1.2f});
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 0LL);
+  test.AddInput<float>("data", {3, 3},
+                       {0.0f, 0.1f, 0.2f,
+                        1.0f, 1.1f, 1.2f,
+                        2.0f, 2.1f, 2.2f});
+  test.AddInput<int32_t>("indices", {2, 2},
+                         {1, 0,
+                          2, 1});
+  test.AddOutput<float>("output", {2, 2, 3},
+                        {1.0f, 1.1f, 1.2f, 0.0f, 0.1f, 0.2f,
+                         2.0f, 2.1f, 2.2f, 1.0f, 1.1f, 1.2f});
 
-    test.Run();
-  };
-
-  run_test(false);
-  run_test(true);
+  test.Run();
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_int32) {
-  // To test for NNAPI EP, we need the indices to be initializers
-  auto run_test = [](bool indices_is_initializer) {
-    OpTester test("Gather");
-    test.AddAttribute<int64_t>("axis", 1LL);
-    test.AddInput<int32_t>("data", {3, 3},
-                           {0, 1, 2,
-                            10, 11, 12,
-                            20, 21, 22});
-    test.AddInput<int32_t>("indices", {2, 2},
-                           {1, 0,
-                            2, 1},
-                           indices_is_initializer);
-    test.AddOutput<int32_t>("output", {3, 2, 2},
-                            {1, 0, 2, 1,
-                             11, 10, 12, 11,
-                             21, 20, 22, 21});
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
-  };
-
-  run_test(false);
-  run_test(true);
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 1LL);
+  test.AddInput<int32_t>("data", {3, 3},
+                         {0, 1, 2,
+                          10, 11, 12,
+                          20, 21, 22});
+  test.AddInput<int32_t>("indices", {2, 2},
+                         {1, 0,
+                          2, 1});
+  test.AddOutput<int32_t>("output", {3, 2, 2},
+                          {1, 0, 2, 1,
+                           11, 10, 12, 11,
+                           21, 20, 22, 21});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_uint32) {

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -34,7 +34,7 @@ TEST(GatherOpTest, Gather_axis0) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -61,7 +61,7 @@ TEST(GatherOpTest, Gather_negative_axis) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -89,7 +89,7 @@ TEST(GatherOpTest, Gather_invalid_axis) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -156,7 +156,7 @@ TEST(GatherOpTest, Gather_axis1) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -186,7 +186,7 @@ TEST(GatherOpTest, Gather_axis2) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -212,7 +212,7 @@ TEST(GatherOpTest, Gather_axis0_indices2d) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -239,7 +239,7 @@ TEST(GatherOpTest, Gather_axis1_indices2d) {
 
 #if defined(USE_NNAPI)
   run_test(true);
-#elif
+#else
   run_test(false);
 #endif
 }
@@ -267,11 +267,8 @@ TEST(GatherOpTest, Gather_axis0_indicesInt32) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
   run_test(true);
-#elif
   run_test(false);
-#endif
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
@@ -294,11 +291,8 @@ TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
   run_test(true);
-#elif
   run_test(false);
-#endif
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_int32) {

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -224,6 +224,8 @@ TEST(GatherOpTest, Gather_axis1_indices2d) {
 }
 
 TEST(GatherOpTest, Gather_axis0_indicesInt32) {
+  // NNAPI EP only supports float input data for now,
+  // the following two test cases cover int32_t indices with float input other than int64_t type for Nnapi
   OpTester test("Gather");
   test.AddAttribute<int64_t>("axis", 0LL);
   test.AddInput<float>("data", {2, 3, 4},

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -32,8 +32,11 @@ TEST(GatherOpTest, Gather_axis0) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_negative_axis) {
@@ -56,8 +59,11 @@ TEST(GatherOpTest, Gather_negative_axis) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_invalid_axis) {
@@ -81,8 +87,11 @@ TEST(GatherOpTest, Gather_invalid_axis) {
     test.Run(OpTester::ExpectResult::kExpectFailure, "axis must be in [-r, r-1]");
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_invalid_index_cpu) {
@@ -101,7 +110,7 @@ TEST(GatherOpTest, Gather_invalid_index_cpu) {
   ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigStrictShapeTypeInference, "0"));
   test.Run(so, OpTester::ExpectResult::kExpectFailure, "indices element out of data bounds, idx=1000 must be within the inclusive range [-3,2]",
            // On Cuda it is impossible to dereference indices memory on CPU so the check can not run
-           {kCudaExecutionProvider, kOpenVINOExecutionProvider, kDnnlExecutionProvider, kNupharExecutionProvider, kTensorrtExecutionProvider});
+           {kCudaExecutionProvider, kOpenVINOExecutionProvider, kDnnlExecutionProvider, kNupharExecutionProvider, kTensorrtExecutionProvider, kNnapiExecutionProvider});
 }
 
 #if defined(USE_CUDA) || defined(USE_ROCM)
@@ -145,8 +154,11 @@ TEST(GatherOpTest, Gather_axis1) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis2) {
@@ -172,8 +184,11 @@ TEST(GatherOpTest, Gather_axis2) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2d) {
@@ -195,8 +210,11 @@ TEST(GatherOpTest, Gather_axis0_indices2d) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d) {
@@ -219,8 +237,11 @@ TEST(GatherOpTest, Gather_axis1_indices2d) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis0_indicesInt32) {
@@ -246,8 +267,11 @@ TEST(GatherOpTest, Gather_axis0_indicesInt32) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
@@ -270,8 +294,11 @@ TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
     test.Run();
   };
 
-  run_test(false);
+#if defined(USE_NNAPI)
   run_test(true);
+#elif
+  run_test(false);
+#endif
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_int32) {

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -32,11 +32,8 @@ TEST(GatherOpTest, Gather_axis0) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_negative_axis) {
@@ -59,11 +56,8 @@ TEST(GatherOpTest, Gather_negative_axis) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_invalid_axis) {
@@ -87,11 +81,8 @@ TEST(GatherOpTest, Gather_invalid_axis) {
     test.Run(OpTester::ExpectResult::kExpectFailure, "axis must be in [-r, r-1]");
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_invalid_index_cpu) {
@@ -154,11 +145,8 @@ TEST(GatherOpTest, Gather_axis1) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis2) {
@@ -184,11 +172,8 @@ TEST(GatherOpTest, Gather_axis2) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2d) {
@@ -210,11 +195,8 @@ TEST(GatherOpTest, Gather_axis0_indices2d) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d) {
@@ -237,11 +219,8 @@ TEST(GatherOpTest, Gather_axis1_indices2d) {
     test.Run();
   };
 
-#if defined(USE_NNAPI)
-  run_test(true);
-#else
   run_test(false);
-#endif
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis0_indicesInt32) {

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -267,8 +267,8 @@ TEST(GatherOpTest, Gather_axis0_indicesInt32) {
     test.Run();
   };
 
-  run_test(true);
   run_test(false);
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
@@ -291,25 +291,32 @@ TEST(GatherOpTest, Gather_axis0_indices2dInt32) {
     test.Run();
   };
 
-  run_test(true);
   run_test(false);
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_int32) {
-  OpTester test("Gather");
-  test.AddAttribute<int64_t>("axis", 1LL);
-  test.AddInput<int32_t>("data", {3, 3},
-                         {0, 1, 2,
-                          10, 11, 12,
-                          20, 21, 22});
-  test.AddInput<int32_t>("indices", {2, 2},
-                         {1, 0,
-                          2, 1});
-  test.AddOutput<int32_t>("output", {3, 2, 2},
-                          {1, 0, 2, 1,
-                           11, 10, 12, 11,
-                           21, 20, 22, 21});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  // To test for NNAPI EP, we need the indices to be initializers
+  auto run_test = [](bool indices_is_initializer) {
+    OpTester test("Gather");
+    test.AddAttribute<int64_t>("axis", 1LL);
+    test.AddInput<int32_t>("data", {3, 3},
+                           {0, 1, 2,
+                            10, 11, 12,
+                            20, 21, 22});
+    test.AddInput<int32_t>("indices", {2, 2},
+                           {1, 0,
+                            2, 1},
+                           indices_is_initializer);
+    test.AddOutput<int32_t>("output", {3, 2, 2},
+                            {1, 0, 2, 1,
+                             11, 10, 12, 11,
+                             21, 20, 22, 21});
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: Input batch size is inconsistent
+  };
+
+  run_test(false);
+  run_test(true);
 }
 
 TEST(GatherOpTest, Gather_axis1_indices2d_uint32) {


### PR DESCRIPTION
**Description**: Describe your changes.

- Expand supported tensor data type for NNAPI EP, added int32_t type
- Remove restrictions for indices of gather op to be an initializer
- other minor unit tests update

**Motivation and Context**

Accommodate for the support of MobileBERT. 
Indices input of Gather in mobileBERT model is not an initializer type, but as it is int32_t, we can directly use it.
