### PR TITLE
Update symbolic_shape_infer.py

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -38,13 +38,13 @@ def get_shape_from_type_proto(type_proto):
     if type_proto.tensor_type.HasField("shape"):
         return [get_dim_from_proto(d) for d in type_proto.tensor_type.shape.dim]
     else:
-        return None  # note no shape is different from shape without dim (scalar)
+        return []  # note no shape is different from shape without dim (scalar)
 
 
 def get_shape_from_value_info(vi):
     cls_type = vi.type.WhichOneof("value")
     if cls_type is None:
-        return None
+        return []
     if is_sequence(vi.type):
         if "tensor_type" == vi.type.sequence_type.elem_type.WhichOneof("value"):
             return get_shape_from_type_proto(vi.type.sequence_type.elem_type)


### PR DESCRIPTION
**Description**
Return empty array instead of `None`. Since the results of these methods are fed into loops returning `None` causes a crash in these situations.

**Motivation and Context**
Script for making a .onnx file ready for TensorRT was failing for quantized models.
