### PR TITLE
Add option to disable symbolic shape inference in transformers optimization

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -143,7 +143,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
 
 #ifdef DEBUG_BEAM_SEARCH
   const IConsoleDumper* dumper = this->GetConsoleDumper();
-  for (size_t i = 0; i < encoder_feeds.size(); i++) {
+  for (int i = 0; i < this->encoder_subgraph_.num_subgraph_inputs; i++) {
     dumper->Print("encoder_feeds", static_cast<int>(i), true);
     dumper->Print("", encoder_feeds[i]);
   }

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -139,7 +139,6 @@ class SymbolicShapeInference:
             "Gather": self._infer_Gather,
             "GatherElements": self._infer_GatherElements,
             "GatherND": self._infer_GatherND,
-            "Gelu": self._pass_on_shape_and_type,
             "If": self._infer_If,
             "Loop": self._infer_Loop,
             "MatMul": self._infer_MatMul,
@@ -1535,7 +1534,7 @@ class SymbolicShapeInference:
             handle_negative_axis(ax, self._get_shape_rank(node, i + num_scan_states))
             for i, ax in enumerate(scan_input_axes)
         ]
-        # We may have cases where the subgraph has optionial inputs that appear in both subgraph's input and initializer,
+        # We may have cases where the subgraph has optional inputs that appear in both subgraph's input and initializer,
         # but not in the node's input. In such cases, the input model might be invalid, but let's skip those optional inputs.
         assert len(subgraph.input) >= len(node.input)
         subgraph_inputs = subgraph.input[: len(node.input)]

--- a/onnxruntime/python/tools/transformers/convert_beam_search.py
+++ b/onnxruntime/python/tools/transformers/convert_beam_search.py
@@ -677,7 +677,7 @@ def remove_shared_initializers(
         if value_info.name in mapping_initializers_2:
             value_info.name = mapping_initializers_2[value_info.name]
 
-    # Rename nodes inputs in graph 1:
+    # Rename nodes inputs in graph 2:
     for node in graph2.node:
         for j in range(len(node.input)):
             if node.input[j] in mapping_initializers_2:
@@ -853,8 +853,6 @@ def convert_model(args: argparse.Namespace):
         )
     else:
         node.attribute.append(onnx.helper.make_attribute("decoder", decoder_model.graph))
-
-    from onnx import TensorProto
 
     # graph inputs
     input_ids = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])

--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -14,6 +14,7 @@ import numpy as np
 import onnx
 from onnx import helper, numpy_helper
 from onnx import onnx_pb as onnx_proto
+from packaging import version
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +171,7 @@ def convert_float_to_float16(
     assert max_finite_val <= float(np.finfo(np.float16).max), "invalid max_finite_val. largest float16 value: 65504"
 
     func_infer_shape = None
-    if not disable_shape_infer and onnx.__version__ >= "1.2":
+    if not disable_shape_infer and version.parse(onnx.__version__) >= version.parse("1.2"):
         try:
             from onnx.shape_inference import infer_shapes
 

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -207,7 +207,10 @@ class FusionAttention(Fusion):
         v_bias = self.model.get_initializer(v_add.input[1]) or self.model.get_initializer(v_add.input[0])
 
         if q_weight is None:
-            print(f"{q_matmul.input[1]} is not initializer. Please set do_constant_folding=True in torch.onnx.export")
+            print(
+                f"{q_matmul.input[1]} is not initializer. "
+                + "Please set do_constant_folding=True in torch.onnx.export to unblock attention fusion"
+            )
             return None
         if not (k_weight and v_weight and q_bias and k_bias):
             return None
@@ -227,7 +230,8 @@ class FusionAttention(Fusion):
 
         if hidden_size > 0 and hidden_size != qw_in_size:
             logger.warning(
-                f"Input hidden size {hidden_size} is not same as weight matrix dimension of q,k,v paths {qw_in_size}, provide correct input hidden size or pass 0"
+                f"Input hidden size {hidden_size} is not same as weight matrix dimension of q,k,v paths {qw_in_size}. "
+                + "Please provide correct input hidden size or pass 0"
             )
 
         is_qkv_diff_dims = False

--- a/onnxruntime/python/tools/transformers/fusion_options.py
+++ b/onnxruntime/python/tools/transformers/fusion_options.py
@@ -31,7 +31,6 @@ class FusionOptions:
 
         if model_type == "gpt2":
             self.enable_skip_layer_norm = False
-            self.enable_shape_inference = False
 
     def use_raw_attention_mask(self, use_raw_mask=True):
         if use_raw_mask:

--- a/onnxruntime/python/tools/transformers/fusion_options.py
+++ b/onnxruntime/python/tools/transformers/fusion_options.py
@@ -24,10 +24,12 @@ class FusionOptions:
         self.enable_bias_skip_layer_norm = True
         self.enable_bias_gelu = True
         self.enable_gelu_approximation = False
+        self.enable_shape_inference = True
         self.attention_mask_format = AttentionMaskFormat.AttentionMask
 
         if model_type == "gpt2":
             self.enable_skip_layer_norm = False
+            self.enable_shape_inference = False
 
     def use_raw_attention_mask(self, use_raw_mask=True):
         if use_raw_mask:

--- a/onnxruntime/python/tools/transformers/fusion_options.py
+++ b/onnxruntime/python/tools/transformers/fusion_options.py
@@ -24,7 +24,9 @@ class FusionOptions:
         self.enable_bias_skip_layer_norm = True
         self.enable_bias_gelu = True
         self.enable_gelu_approximation = False
+
         self.enable_shape_inference = True
+
         self.attention_mask_format = AttentionMaskFormat.AttentionMask
 
         if model_type == "gpt2":
@@ -59,6 +61,8 @@ class FusionOptions:
             options.enable_bias_gelu = False
         if args.enable_gelu_approximation:
             options.enable_gelu_approximation = True
+        if args.disable_shape_inference:
+            options.enable_shape_inference = False
         if args.use_mask_index:
             options.use_raw_attention_mask(False)
         if args.no_attention_mask:
@@ -130,6 +134,14 @@ class FusionOptions:
             help="enable Gelu/BiasGelu to FastGelu conversion",
         )
         parser.set_defaults(enable_gelu_approximation=False)
+
+        parser.add_argument(
+            "--disable_shape_inference",
+            required=False,
+            action="store_true",
+            help="disable symbolic shape inference",
+        )
+        parser.set_defaults(disable_shape_inference=False)
 
         parser.add_argument(
             "--use_mask_index",

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -40,18 +40,13 @@ class FusionSkipLayerNormalization(Fusion):
         if len(self.model.get_parents(add)) != 2:
             return
 
+        # shape_infer_helper can not handle subgraphs so we do not return when shape_infer_helper is None.
         if self.shape_infer_helper is not None:
             if not self.shape_infer_helper.compare_shape(add.input[0], add.input[1]):
                 logger.debug(
                     f"skip skiplayernorm fusion since shape of inputs ({add.input[0]}, {add.input[1]}) are not same"
                 )
                 return
-        else:
-            # shape_infer_helper can not handle subgraphs. Current work around is to disable skiplayernorm fusion
-            # longterm todo: support subgraph in symbolic_shape_infer or support add broadcasting in skiplayernorm op
-            logger.warning(
-                "symbolic shape infer failed. it's safe to ignore this message if there is no issue with optimized model"
-            )
 
         gather_path = self.model.match_parent_path(add, ["Gather"], [None])
         if gather_path is not None and self.model.find_graph_input(gather_path[0].input[1]) is None:

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -25,17 +25,20 @@ class OnnxModel:
         self.model: ModelProto = model
         self._node_name_suffix: Dict[str, int] = {}  # key is node name prefix, value is the last suffix generated
         self.shape_infer_helper = None
+        self.enable_shape_infer = False
         self.all_graphs = None
 
     def infer_runtime_shape(self, dynamic_axis_mapping={}, update=False):
-        if self.shape_infer_helper is None or update:
-            self.shape_infer_helper = SymbolicShapeInferenceHelper(self.model)
+        if self.enable_shape_infer:
+            if self.shape_infer_helper is None or update:
+                self.shape_infer_helper = SymbolicShapeInferenceHelper(self.model)
 
-        try:
-            if self.shape_infer_helper.infer(dynamic_axis_mapping):
-                return self.shape_infer_helper
-        except:
-            print("failed in shape inference", sys.exc_info()[0])
+            try:
+                if self.shape_infer_helper.infer(dynamic_axis_mapping):
+                    return self.shape_infer_helper
+            except:
+                self.enable_shape_infer = False  # disable shape inference to suppress same error message.
+                print("failed in shape inference", sys.exc_info()[0])
 
         return None
 

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -25,8 +25,11 @@ class OnnxModel:
         self.model: ModelProto = model
         self._node_name_suffix: Dict[str, int] = {}  # key is node name prefix, value is the last suffix generated
         self.shape_infer_helper = None
-        self.enable_shape_infer = False
+        self.enable_shape_infer = True
         self.all_graphs = None
+
+    def disable_shape_inference(self):
+        self.enable_shape_infer = False
 
     def infer_runtime_shape(self, dynamic_axis_mapping={}, update=False):
         if self.enable_shape_infer:

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -338,7 +338,8 @@ class BertOnnxModel(OnnxModel):
         self.prune_graph()
 
     def optimize(self, options: Optional[FusionOptions] = None, add_dynamic_axes: bool = False):
-        self.enable_shape_infer = options.enable_shape_inference
+        if (options is not None) and not options.enable_shape_inference:
+            self.disable_shape_inference()
 
         # Remove cast nodes that having same data type of input and output based on symbolic shape inference.
         self.utils.remove_useless_cast_nodes()

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 
 from logging import getLogger
-from typing import List
+from typing import List, Optional
 
 from fusion_attention import AttentionMask, FusionAttention
 from fusion_biasgelu import FusionBiasGelu
@@ -337,7 +337,9 @@ class BertOnnxModel(OnnxModel):
         self.clean_graph()
         self.prune_graph()
 
-    def optimize(self, options: FusionOptions = None, add_dynamic_axes=False):
+    def optimize(self, options: Optional[FusionOptions] = None, add_dynamic_axes: bool = False):
+        self.enable_shape_infer = options.enable_shape_inference
+
         # Remove cast nodes that having same data type of input and output based on symbolic shape inference.
         self.utils.remove_useless_cast_nodes()
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -12,7 +12,7 @@
 # For Bert model file like name.onnx, optimized model for GPU or CPU from OnnxRuntime will output as
 # name_ort_gpu.onnx or name_ort_cpu.onnx in the same directory.
 #
-# This script is retained for experiment purpose. Useful senarios like the following:
+# This script is retained for experiment purpose. Useful scenarios like the following:
 #  (1) Change model from fp32 to fp16 for mixed precision inference in GPU with Tensor Core.
 #  (2) Change input data type from int64 to int32.
 #  (3) Some model cannot be handled by OnnxRuntime, and you can modify this script to get optimized model.
@@ -142,7 +142,8 @@ def optimize_by_fusion(
 
     if model.producer_name and producer != model.producer_name:
         logger.warning(
-            f"Model producer not matched: Expect {producer}, Got {model.producer_name} {model.producer_version}. Please specify correct --model_type parameter."
+            f"Model producer not matched: Expect {producer}, Got {model.producer_name} {model.producer_version}."
+            + "Please specify correct --model_type parameter."
         )
 
     if optimization_options is None:
@@ -168,7 +169,7 @@ def optimize_model(
     num_heads: int = 0,
     hidden_size: int = 0,
     optimization_options: Optional[FusionOptions] = None,
-    opt_level: int = None,
+    opt_level: Optional[int] = None,
     use_gpu: bool = False,
     only_onnxruntime: bool = False,
 ):
@@ -213,7 +214,7 @@ def optimize_model(
     if model_type != "bert" and (num_heads == 0 or hidden_size == 0):
         logger.warning("Please specify parameters of num_heads and hidden_size when model_type is not 'bert'")
 
-    (optimizer_class, producer, default_opt_level) = MODEL_TYPES[model_type]
+    (optimizer_class, _producer, default_opt_level) = MODEL_TYPES[model_type]
 
     if opt_level is None:
         opt_level = default_opt_level
@@ -226,7 +227,8 @@ def optimize_model(
             if only_onnxruntime
             else [
                 "MatMulScaleFusion",
-                "MatMulAddFusion" "SimplifiedLayerNormFusion",
+                "MatMulAddFusion",
+                "SimplifiedLayerNormFusion",
                 "GemmActivationFusion",
                 "BiasSoftmaxFusion",
             ]
@@ -238,7 +240,7 @@ def optimize_model(
             disabled_optimizers=disabled_optimizers,
         )
     elif opt_level == 1:
-        # basic optimizations (like constant folding and cast elimation) are not specified to exection provider.
+        # basic optimizations (like constant folding and cast elimination) are not specified to execution provider.
         # CPU provider is used here so that there is no extra node for GPU memory copy.
         temp_model_path = optimize_by_onnxruntime(input, use_gpu=False, opt_level=1)
 
@@ -255,7 +257,7 @@ def optimize_model(
     # Remove the temporary model.
     if temp_model_path:
         os.remove(temp_model_path)
-        logger.debug("Remove tempoary model: {}".format(temp_model_path))
+        logger.debug("Remove temporary model: {}".format(temp_model_path))
 
     return optimizer
 

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -3,8 +3,10 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import logging
 import os
 import sys
+from typing import Dict, Optional
 
 import onnx
 
@@ -17,59 +19,53 @@ else:
 
 from symbolic_shape_infer import SymbolicShapeInference, get_shape_from_type_proto, sympy
 
+logger = logging.getLogger(__name__)
+
 
 class SymbolicShapeInferenceHelper(SymbolicShapeInference):
-    def __init__(
-        self,
-        model,
-        verbose=0,
-        int_max=2**31 - 1,
-        auto_merge=True,
-        guess_output_rank=False,
-    ):
+    def __init__(self, model, verbose=0, int_max=2**31 - 1, auto_merge=True, guess_output_rank=False):
         super().__init__(int_max, auto_merge, guess_output_rank, verbose)
-        self.model_ = onnx.ModelProto()
-        self.model_.CopyFrom(model)
-        self.all_shapes_inferred_ = False
-        self.inferred_ = False
+        self.model_ = model
+        self.all_shapes_inferred_: bool = False
+        self.is_inferred_: bool = False
+        self.dynamic_axis_mapping_: Optional[Dict[str, int]] = None
 
-    # The goal is to remove dynamic_axis_mapping
-    def infer(self, dynamic_axis_mapping):
-        if self.inferred_:
+    def infer(self, dynamic_axis_mapping: Optional[Dict[str, int]], max_runs: int = 32):
+        """Run shape inference, and try replace dynamic axis from string to integer when mapping is provided.
+
+        Args:
+            dynamic_axis_mapping (_type_): a dictionary with name of dynamic axis as key, like {"batch_size" : 4}
+            max_runs (int, optional): limit maximum number of runs to avoid infinite loop. Defaults to 32.
+
+        Returns:
+            bool: whether all shapes has been inferred or not.
+        """
+        if self.is_inferred_:
+            if self.dynamic_axis_mapping_ != dynamic_axis_mapping:
+                logger.warning("different dynamic_axis_mapping is used in shape inference.")
+
             return self.all_shapes_inferred_
 
-        self.dynamic_axis_mapping_ = dynamic_axis_mapping  # e.g {"batch_size" : 4, "seq_len" :7}
+        self.dynamic_axis_mapping_ = dynamic_axis_mapping
 
         self._preprocess(self.model_)
+
+        count = 0
         while self.run_:
+            logger.debug(f"shape infer run {count}")
             self.all_shapes_inferred_ = self._infer_impl()
+            count += 1
+            if max_runs > 0 and count >= max_runs:
+                break
 
-        self.inferred_ = True
+        self.is_inferred_ = True
         return self.all_shapes_inferred_
-
-    # override _preprocess() to avoid unnecessary model copy since ctor copies the model
-    def _preprocess(self, in_mp):
-        self.out_mp_ = in_mp
-        self.graph_inputs_ = dict([(i.name, i) for i in list(self.out_mp_.graph.input)])
-        self.initializers_ = dict([(i.name, i) for i in self.out_mp_.graph.initializer])
-        self.known_vi_ = dict([(i.name, i) for i in list(self.out_mp_.graph.input)])
-        self.known_vi_.update(
-            dict(
-                [
-                    (
-                        i.name,
-                        onnx.helper.make_tensor_value_info(i.name, i.data_type, list(i.dims)),
-                    )
-                    for i in self.out_mp_.graph.initializer
-                ]
-            )
-        )
 
     # Override _get_sympy_shape() in symbolic_shape_infer.py to ensure shape inference by giving the actual value of dynamic axis
     def _get_sympy_shape(self, node, idx):
         sympy_shape = []
         for d in self._get_shape(node, idx):
-            if type(d) == str:
+            if isinstance(d, str):
                 if d in self.dynamic_axis_mapping_.keys():
                     sympy_shape.append(self.dynamic_axis_mapping_[d])
                 elif d in self.symbolic_dims_:
@@ -77,25 +73,28 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
                 else:
                     sympy_shape.append(sympy.Symbol(d, integer=True))
             else:
-                assert None != d
+                assert d is not None
                 sympy_shape.append(d)
         return sympy_shape
 
     def get_edge_shape(self, edge):
-        assert self.all_shapes_inferred_ == True
+        assert self.all_shapes_inferred_
         if edge not in self.known_vi_:
             print("Cannot retrieve the shape of " + str(edge))
             return None
+
         type_proto = self.known_vi_[edge].type
         shape = get_shape_from_type_proto(type_proto)
-        for i in range(len(shape)):
-            d = shape[i]
-            if type(d) == str and d in self.dynamic_axis_mapping_.keys():
-                shape[i] = self.dynamic_axis_mapping_[d]
+
+        if shape is not None and self.dynamic_axis_mapping_ is not None:
+            for i, d in enumerate(shape):
+                if isinstance(d, str) and d in self.dynamic_axis_mapping_.keys():
+                    shape[i] = self.dynamic_axis_mapping_[d]
+
         return shape
 
     def compare_shape(self, edge, edge_other):
-        assert self.all_shapes_inferred_ == True
+        assert self.all_shapes_inferred_
         shape = self.get_edge_shape(edge)
         shape_other = self.get_edge_shape(edge_other)
         if shape is None or shape_other is None:

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -84,7 +84,7 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
     def get_edge_shape(self, edge):
         assert self.all_shapes_inferred_ == True
         if edge not in self.known_vi_:
-            print("Cannot retrive the shape of " + str(edge))
+            print("Cannot retrieve the shape of " + str(edge))
             return None
         type_proto = self.known_vi_[edge].type
         shape = get_shape_from_type_proto(type_proto)

--- a/onnxruntime/python/tools/transformers/shape_infer_helper.py
+++ b/onnxruntime/python/tools/transformers/shape_infer_helper.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import sys
-from typing import Dict, Optional
+from typing import Dict
 
 # In ORT Package the symbolic_shape_infer.py is in ../tools
 file_path = os.path.dirname(__file__)
@@ -84,7 +84,7 @@ class SymbolicShapeInferenceHelper(SymbolicShapeInference):
             edge (str): name of edge
 
         Returns:
-            _type_: Optional[List[int]]
+            Optional[List[int]]: the shape, or None if shape is unknown
         """
         assert self.all_shapes_inferred_
         if edge not in self.known_vi_:

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -8,13 +8,15 @@
 
 # For live logging, use the command: pytest -o log_cli=true --log-cli-level=DEBUG
 
-import os
+import shutil
 import unittest
 
 import pytest
+import torch
 from model_loader import get_fusion_test_model, get_test_data_path
 from onnx import TensorProto, load_model
 from parity_utilities import find_transformers_source
+from transformers.utils import is_tf2onnx_available, is_tf_available
 
 if find_transformers_source():
     from benchmark_helper import ConfigModifier, OptimizerInfo, Precision
@@ -72,8 +74,6 @@ class TestBertOptimization(unittest.TestCase):
         validate_model=True,
     ):
         # Remove cached model so that CI machine will have space
-        import shutil
-
         shutil.rmtree("./cache_models", ignore_errors=True)
         shutil.rmtree("./onnx_models", ignore_errors=True)
         # expect fusion result list have the following keys
@@ -81,8 +81,6 @@ class TestBertOptimization(unittest.TestCase):
         model_fusion_statistics = {}
 
         input_names = MODELS[model_name][0]
-
-        import torch
 
         config_modifier = ConfigModifier(None)
         fusion_options = None
@@ -117,10 +115,6 @@ class TestBertOptimization(unittest.TestCase):
 
     def _test_optimizer_on_tf_model(self, model_name, expected_fusion_result_list, inputs_count, validate_model=True):
         # Remove cached model so that CI machine will have space
-        import shutil
-
-        from transformers.utils import is_tf2onnx_available, is_tf_available
-
         if not is_tf_available() or not is_tf2onnx_available():
             return
 
@@ -133,8 +127,6 @@ class TestBertOptimization(unittest.TestCase):
         print("testing mode ", model_name)
         print("testing input number = ", inputs_count)
         input_names = MODELS[model_name][0]
-
-        import torch
 
         config_modifier = ConfigModifier(None)
         fusion_options = None

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -16,7 +16,7 @@ import torch
 from model_loader import get_fusion_test_model, get_test_data_path
 from onnx import TensorProto, load_model
 from parity_utilities import find_transformers_source
-from transformers.utils import is_tf2onnx_available, is_tf_available
+from transformers import is_tf_available
 
 if find_transformers_source():
     from benchmark_helper import ConfigModifier, OptimizerInfo, Precision
@@ -114,10 +114,10 @@ class TestBertOptimization(unittest.TestCase):
         self.assertEqual(fusion_result_list, expected_fusion_result_list)
 
     def _test_optimizer_on_tf_model(self, model_name, expected_fusion_result_list, inputs_count, validate_model=True):
-        # Remove cached model so that CI machine will have space
-        if not is_tf_available() or not is_tf2onnx_available():
+        if not is_tf_available():
             return
 
+        # Remove cached model so that CI machine will have space
         shutil.rmtree("./cache_models", ignore_errors=True)
         shutil.rmtree("./onnx_models", ignore_errors=True)
 

--- a/onnxruntime/test/python/transformers/test_shape_infer_helper.py
+++ b/onnxruntime/test/python/transformers/test_shape_infer_helper.py
@@ -1,6 +1,8 @@
 import unittest
 
+import onnx
 import pytest
+import torch
 from parity_utilities import find_transformers_source
 
 if find_transformers_source():
@@ -19,7 +21,6 @@ class SymbolicShapeInferenceHelperTest(unittest.TestCase):
     def _load_onnx(self, model_name):
         input_names = MODELS[model_name][0]
         base_path = "../onnx_models/"
-        import torch
 
         config_modifier = ConfigModifier(None)
         fusion_options = None
@@ -45,8 +46,6 @@ class SymbolicShapeInferenceHelperTest(unittest.TestCase):
                 fusion_options,
             )
         model_path = base_path + model_name.replace("-", "_") + "_1.onnx"
-        import onnx
-
         return onnx.load_model(model_path)
 
     # TODO: use a static lightweight model for test

--- a/onnxruntime/test/python/transformers/test_shape_infer_helper.py
+++ b/onnxruntime/test/python/transformers/test_shape_infer_helper.py
@@ -4,12 +4,12 @@ import pytest
 from parity_utilities import find_transformers_source
 
 if find_transformers_source():
-    from benchmark_helper import OptimizerInfo, Precision
+    from benchmark_helper import ConfigModifier, OptimizerInfo, Precision
     from huggingface_models import MODELS
     from onnx_exporter import export_onnx_model_from_pt
     from shape_infer_helper import SymbolicShapeInferenceHelper
 else:
-    from onnxruntime.transformers.benchmark_helper import OptimizerInfo, Precision
+    from onnxruntime.transformers.benchmark_helper import ConfigModifier, OptimizerInfo, Precision
     from onnxruntime.transformers.huggingface_models import MODELS
     from onnxruntime.transformers.onnx_exporter import export_onnx_model_from_pt
     from onnxruntime.transformers.shape_infer_helper import SymbolicShapeInferenceHelper
@@ -21,13 +21,17 @@ class SymbolicShapeInferenceHelperTest(unittest.TestCase):
         base_path = "../onnx_models/"
         import torch
 
+        config_modifier = ConfigModifier(None)
+        fusion_options = None
+        model_class = "AutoModel"
         with torch.no_grad():
             export_onnx_model_from_pt(
                 model_name,
                 MODELS[model_name][1],
                 MODELS[model_name][2],
                 MODELS[model_name][3],
-                None,
+                model_class,
+                config_modifier,
                 "../cache_models",
                 base_path,
                 input_names[:1],
@@ -38,6 +42,7 @@ class SymbolicShapeInferenceHelperTest(unittest.TestCase):
                 True,
                 False,
                 {},
+                fusion_options,
             )
         model_path = base_path + model_name.replace("-", "_") + "_1.onnx"
         import onnx


### PR DESCRIPTION
**Description**: 

Symbolic shape inference have issues on some transformers model from PyTorch 1.12. Each time we used shape inference, there will be a warning that shape inference has issue. Too many such warnings distracting users.

Changes:
(1) Add --disable_shape_inference in optimizer.py
(2) Avoid run shape inference in infinite loop by setting max times to 32
(3) When symbolic shape inference failed, we will disable it in OnnxModel so that we will not call it again to avoid same error message.
(4) Update some test which missed config_modifier changes
(5) Update a few comments with spelling errors etc.
(6) Disable some tests (xlm and flautbert) that failed with PyTorch 1.12.

Note that some fusion tests (bert and albert) also failed with PyTorch 1.12. We need fix them later.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
