### PR TITLE
[TVM EP][CI] Added TVMso EP testing into CI

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -1,16 +1,16 @@
 import os
 import sys
-import tvm
-import numpy
 import tempfile
 import unittest
-import onnxruntime
+from typing import Any, AnyStr, Dict, List, Tuple
 
-from typing import Dict, List, AnyStr, Tuple, Any
-from onnx import TensorProto, ModelProto, mapping
-from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
+import numpy
+import tvm
 from numpy.testing import assert_almost_equal
+from onnx import ModelProto, TensorProto, mapping
+from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
 
+import onnxruntime
 
 numpy.random.seed(32)
 

--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -1,54 +1,86 @@
 import numpy
-from numpy.testing import assert_almost_equal
-from onnx import TensorProto, numpy_helper
-from onnx.helper import make_graph, make_model, make_node, make_tensor, make_tensor_value_info, set_model_props
-
+import unittest
 import onnxruntime
 
-if "TvmExecutionProvider" not in onnxruntime.get_available_providers():
-    raise AssertionError("Unable to find 'TvmExecutionProvider' in %r." % onnxruntime.get_available_providers())
+from typing import Dict, List, AnyStr, Tuple, Any
+from onnx import TensorProto, ModelProto
+from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
+from numpy.testing import assert_almost_equal
 
-X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
-A = make_tensor_value_info("A", TensorProto.FLOAT, [None, None])
-B = make_tensor_value_info("B", TensorProto.FLOAT, [None, None])
-Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
-node1 = make_node("MatMul", ["X", "A"], ["XA"])
-node2 = make_node("Add", ["XA", "B"], ["Y"])
-graph = make_graph([node1, node2], "lr", [X, A, B], [Y])
-onnx_model = make_model(graph)
 
-a = numpy.random.randn(2, 2).astype(numpy.float32)
-b = numpy.random.randn(1, 2).astype(numpy.float32)
-x = numpy.random.randn(1, 2).astype(numpy.float32)
-data = {"A": a, "B": b, "X": x}
+numpy.random.seed(32)
 
-sess = onnxruntime.InferenceSession(onnx_model.SerializeToString(), providers=["CPUExecutionProvider"])
 
-y = sess.run(None, data)[0]
+def get_model_with_undefined_shapes() -> ModelProto:
+    X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
+    A = make_tensor_value_info("A", TensorProto.FLOAT, [None, None])
+    B = make_tensor_value_info("B", TensorProto.FLOAT, [None, None])
+    Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
+    node1 = make_node("MatMul", ["X", "A"], ["XA"])
+    node2 = make_node("Add", ["XA", "B"], ["Y"])
+    graph = make_graph([node1, node2], "lr", [X, A, B], [Y])
+    onnx_model = make_model(graph)
+    return onnx_model
 
-provider_options = dict(
-    target="llvm -mcpu=core-avx2",
-    target_host="llvm -mcpu=core-avx2",
-    opt_level=3,
-    freeze_weights=True,
-    tuning_file_path="",
-    tuning_type="Ansor",
-    input_names=" ".join(i.name for i in sess.get_inputs()),
-    input_shapes=" ".join(str(numpy.array(data[i.name].shape)) for i in sess.get_inputs()),
-)
 
-so = onnxruntime.SessionOptions()
-so.log_severity_level = 0
-so.log_verbosity_level = 0
-so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+def get_input_data_for_model_with_undefined_shapes() -> Dict[AnyStr, numpy.ndarray]:
+    a = numpy.random.randn(2, 2).astype(numpy.float32)
+    b = numpy.random.randn(1, 2).astype(numpy.float32)
+    x = numpy.random.randn(1, 2).astype(numpy.float32)
+    data = {"A": a, "B": b, "X": x}
+    return data
 
-sess = onnxruntime.InferenceSession(
-    onnx_model.SerializeToString(),
-    so,
-    providers=["TvmExecutionProvider"],
-    provider_options=[provider_options],
-)
 
-y_tvm = sess.run(None, data)[0]
+def get_input_names_and_shapes(data: Dict[AnyStr, numpy.ndarray]) -> Tuple[List[AnyStr], List[AnyStr]]:
+    keys = list(data.keys())
+    values = [data[key] for key in keys]
+    return (
+        list(data.keys()),
+        [str(value.shape).replace(",", "").replace("(", "[").replace(")", "]") for value in values]
+    )
 
-assert_almost_equal(y, y_tvm)
+
+def get_cpu_output(onnx_model: ModelProto, data: Dict[AnyStr, numpy.ndarray]) -> List[numpy.ndarray]:
+    sess = onnxruntime.InferenceSession(onnx_model.SerializeToString(), providers=["CPUExecutionProvider"])
+    output = sess.run(None, data)
+    return output
+
+
+def get_tvm_output(onnx_model: ModelProto, data: Dict[AnyStr, numpy.ndarray], provider_options: Dict[AnyStr, Any]) -> List[numpy.ndarray]:
+    so = onnxruntime.SessionOptions()
+    so.log_severity_level = 0
+    so.log_verbosity_level = 0
+    so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+
+    sess = onnxruntime.InferenceSession(
+        onnx_model.SerializeToString(),
+        so,
+        providers=["TvmExecutionProvider"],
+        provider_options=[provider_options],
+    )
+
+    output = sess.run(None, data)
+    return output
+
+
+class TestTVM(unittest.TestCase):
+    def test_accuracy_for_model_with_undefined_shapes(self):
+        onnx_model = get_model_with_undefined_shapes()
+        data = get_input_data_for_model_with_undefined_shapes()
+
+        cpu_output = get_cpu_output(onnx_model, data)
+        names, shapes = get_input_names_and_shapes(data)
+        provider_options = dict(
+            target="llvm",
+            input_names=" ".join(names),
+            input_shapes=" ".join(shapes),
+        )
+        tvm_output = get_tvm_output(onnx_model, data, provider_options)
+
+        assert_almost_equal(cpu_output, tvm_output, decimal=5)
+
+
+if __name__ == '__main__':
+    if "TvmExecutionProvider" not in onnxruntime.get_available_providers():
+        raise AssertionError("Unable to find 'TvmExecutionProvider' in %r." % onnxruntime.get_available_providers())
+    unittest.main()

--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tvm
 import numpy
 import tempfile
@@ -12,6 +13,10 @@ from numpy.testing import assert_almost_equal
 
 
 numpy.random.seed(32)
+
+
+def is_windows():
+    return sys.platform.startswith("win")
 
 
 def get_model_with_dynamic_shapes() -> ModelProto:
@@ -126,7 +131,7 @@ def serialize_virtual_machine(vm_exec: tvm.runtime.vm.Executable) -> AnyStr:
     temp_directory = tempfile.mkdtemp()
     path_consts = os.path.join(temp_directory, "consts")
     vm_exec.move_late_bound_consts(path_consts, byte_limit=256)
-    lib_path = os.path.join(temp_directory, f"model.so")
+    lib_path = os.path.join(temp_directory, f"model.{'dll' if is_windows() else 'so'}")
     code_path = os.path.join(temp_directory, f"model.ro")
     code, lib = vm_exec.save()
     lib.export_library(lib_path)

--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -50,6 +50,7 @@ def get_model_with_fixed_shapes() -> ModelProto:
     """
     Create model with Static Shapes
     """
+
     def change_input_shape(model: ModelProto, ind: int, shape: Tuple) -> None:
         """
         Function to change the input form
@@ -81,6 +82,7 @@ def get_input_data_for_model_with_fixed_shapes(onnx_model: ModelProto) -> Dict[A
     """
     Create input data for model with static shapes
     """
+
     def get_onnx_input_names(model: ModelProto) -> List[AnyStr]:
         inputs = [node.name for node in model.graph.input]
         initializer = [node.name for node in model.graph.initializer]
@@ -193,6 +195,7 @@ class TestTVM(unittest.TestCase):
     """
     Unit tests for TVM EP
     """
+
     @staticmethod
     def test_accuracy_for_model_with_dynamic_shapes():
         """

--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -1,9 +1,12 @@
+import os
+import tvm
 import numpy
+import tempfile
 import unittest
 import onnxruntime
 
 from typing import Dict, List, AnyStr, Tuple, Any
-from onnx import TensorProto, ModelProto
+from onnx import TensorProto, ModelProto, mapping
 from onnx.helper import make_graph, make_model, make_node, make_tensor_value_info
 from numpy.testing import assert_almost_equal
 
@@ -11,7 +14,7 @@ from numpy.testing import assert_almost_equal
 numpy.random.seed(32)
 
 
-def get_model_with_undefined_shapes() -> ModelProto:
+def get_model_with_dynamic_shapes() -> ModelProto:
     X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
     A = make_tensor_value_info("A", TensorProto.FLOAT, [None, None])
     B = make_tensor_value_info("B", TensorProto.FLOAT, [None, None])
@@ -23,12 +26,54 @@ def get_model_with_undefined_shapes() -> ModelProto:
     return onnx_model
 
 
-def get_input_data_for_model_with_undefined_shapes() -> Dict[AnyStr, numpy.ndarray]:
+def get_model_with_fixed_shapes() -> ModelProto:
+    def change_input_shape(model: ModelProto, ind: int, shape: Tuple) -> None:
+        dims = model.graph.input[ind].type.tensor_type.shape.dim
+        assert len(dims) == len(shape), "Input rank and new shape rank do not match."
+        for i, new_dim in enumerate(shape):
+            model.graph.input[ind].type.tensor_type.shape.dim[i].dim_value = new_dim
+    dynamic_model = get_model_with_dynamic_shapes()
+    change_input_shape(dynamic_model, 0, (1, 2))    # X
+    change_input_shape(dynamic_model, 1, (2, 2))    # A
+    change_input_shape(dynamic_model, 2, (1, 2))    # B
+    return dynamic_model
+
+
+def get_input_data_for_model_with_dynamic_shapes() -> Dict[AnyStr, numpy.ndarray]:
     a = numpy.random.randn(2, 2).astype(numpy.float32)
     b = numpy.random.randn(1, 2).astype(numpy.float32)
     x = numpy.random.randn(1, 2).astype(numpy.float32)
     data = {"A": a, "B": b, "X": x}
     return data
+
+
+def get_input_data_for_model_with_fixed_shapes(onnx_model: ModelProto) -> Dict[AnyStr, numpy.ndarray]:
+    def get_onnx_input_names(model: ModelProto) -> List[AnyStr]:
+        inputs = [node.name for node in model.graph.input]
+        initializer = [node.name for node in model.graph.initializer]
+        inputs = list(set(inputs) - set(initializer))
+        return sorted(inputs)
+
+    def get_onnx_input_types(model: ModelProto) -> List[numpy.dtype]:
+        input_names = get_onnx_input_names(model)
+        return [
+            mapping.TENSOR_TYPE_TO_NP_TYPE[node.type.tensor_type.elem_type]
+            for node in sorted(model.graph.input, key=lambda node: node.name) if node.name in input_names
+        ]
+
+    def get_onnx_input_shapes(model: ModelProto) -> List[List[int]]:
+        input_names = get_onnx_input_names(model)
+        return [
+            [dv.dim_value for dv in node.type.tensor_type.shape.dim]
+            for node in sorted(model.graph.input, key=lambda node: node.name) if node.name in input_names
+        ]
+
+    input_names = get_onnx_input_names(onnx_model)
+    input_shapes = get_onnx_input_shapes(onnx_model)
+    input_types = get_onnx_input_types(onnx_model)
+    assert len(input_names) == len(input_types) == len(input_shapes)
+    random_inputs = [numpy.random.uniform(size=shape).astype(dtype) for shape, dtype in zip(input_shapes, input_types)]
+    return {key: value for key, value in zip(input_names, random_inputs)}
 
 
 def get_input_names_and_shapes(data: Dict[AnyStr, numpy.ndarray]) -> Tuple[List[AnyStr], List[AnyStr]]:
@@ -63,10 +108,33 @@ def get_tvm_output(onnx_model: ModelProto, data: Dict[AnyStr, numpy.ndarray], pr
     return output
 
 
+def compile_virtual_machine(model: ModelProto, target_str: AnyStr) -> tvm.runtime.vm.Executable:
+    ir_mod, params = tvm.relay.frontend.from_onnx(
+        model,
+        opset=model.opset_import[0].version,
+        freeze_params=True,
+    )
+    target = tvm.target.Target(target=target_str, host=target_str)
+    return tvm.relay.backend.vm.compile(ir_mod, target)
+
+
+def serialize_virtual_machine(vm_exec: tvm.runtime.vm.Executable) -> AnyStr:
+    temp_directory = tempfile.mkdtemp()
+    path_consts = os.path.join(temp_directory, "consts")
+    vm_exec.move_late_bound_consts(path_consts, byte_limit=256)
+    lib_path = os.path.join(temp_directory, f"model.so")
+    code_path = os.path.join(temp_directory, f"model.ro")
+    code, lib = vm_exec.save()
+    lib.export_library(lib_path)
+    with open(code_path, "wb") as fo:
+        fo.write(code)
+    return temp_directory
+
+
 class TestTVM(unittest.TestCase):
-    def test_accuracy_for_model_with_undefined_shapes(self):
-        onnx_model = get_model_with_undefined_shapes()
-        data = get_input_data_for_model_with_undefined_shapes()
+    def test_accuracy_for_model_with_dynamic_shapes(self):
+        onnx_model = get_model_with_dynamic_shapes()
+        data = get_input_data_for_model_with_dynamic_shapes()
 
         cpu_output = get_cpu_output(onnx_model, data)
         names, shapes = get_input_names_and_shapes(data)
@@ -74,6 +142,22 @@ class TestTVM(unittest.TestCase):
             target="llvm",
             input_names=" ".join(names),
             input_shapes=" ".join(shapes),
+        )
+        tvm_output = get_tvm_output(onnx_model, data, provider_options)
+
+        assert_almost_equal(cpu_output, tvm_output, decimal=5)
+
+    def test_accuracy_for_tvm_so(self):
+        onnx_model = get_model_with_fixed_shapes()
+        data = get_input_data_for_model_with_fixed_shapes(onnx_model)
+
+        cpu_output = get_cpu_output(onnx_model, data)
+
+        compiled_vm_exec = compile_virtual_machine(onnx_model, target_str="llvm")
+        so_folder = serialize_virtual_machine(compiled_vm_exec)
+        provider_options = dict(
+            target="llvm",
+            so_folder=so_folder,
         )
         tvm_output = get_tvm_output(onnx_model, data, provider_options)
 

--- a/onnxruntime/test/python/onnxruntime_test_python_tvm.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_tvm.py
@@ -37,6 +37,7 @@ def get_model_with_fixed_shapes() -> ModelProto:
         assert len(dims) == len(shape), "Input rank and new shape rank do not match."
         for i, new_dim in enumerate(shape):
             model.graph.input[ind].type.tensor_type.shape.dim[i].dim_value = new_dim
+
     dynamic_model = get_model_with_dynamic_shapes()
     change_input_shape(dynamic_model, 0, (1, 2))  # X
     change_input_shape(dynamic_model, 1, (2, 2))  # A

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1976,7 +1976,7 @@ def tvm_run_python_tests(build_dir, configs):
         cwd = get_config_build_dir(build_dir, config)
         if is_windows():
             cwd = os.path.join(cwd, config)
-        python_path = str((Path(build_dir) / config / "_deps" / "tvm-src" / "python").resolve())
+        python_path = os.path.join(build_dir, config, "_deps", "tvm-src", "python")
         run_subprocess([sys.executable, "onnxruntime_test_python_tvm.py"], cwd=cwd, python_path=python_path)
 
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2678,7 +2678,10 @@ def main():
         if args.enable_pybind and not args.skip_onnx_tests and args.use_nuphar:
             nuphar_run_python_tests(build_dir, configs)
 
-        if args.enable_pybind and args.use_tvm:
+        # TODO(agladyshev):
+        # to support Windows, we need to update .github/workflows/windows.yml
+        # and add to the PATH variable the following value: C:Program Files\LLVM\bin
+        if args.enable_pybind and args.use_tvm and not is_windows():
             tvm_run_python_tests(build_dir, configs)
 
         # run node.js binding tests

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1977,7 +1977,9 @@ def tvm_run_python_tests(build_dir, configs):
         if is_windows():
             cwd = os.path.join(cwd, config)
         python_path = os.path.join(build_dir, config, "_deps", "tvm-src", "python")
-        run_subprocess([sys.executable, "onnxruntime_test_python_tvm.py"], cwd=cwd, python_path=python_path)
+        run_subprocess(
+            [sys.executable, "onnxruntime_test_python_tvm.py"], cwd=cwd, python_path=os.path.abspath(python_path)
+        )
 
 
 def run_nodejs_tests(nodejs_binding_dir):

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1973,13 +1973,11 @@ def nuphar_run_python_tests(build_dir, configs):
 
 def tvm_run_python_tests(build_dir, configs):
     for config in configs:
-        if config == "Debug":
-            continue
         cwd = get_config_build_dir(build_dir, config)
         if is_windows():
             cwd = os.path.join(cwd, config)
-        dll_path = os.path.join(build_dir, config, "_deps", "tvm-build", config)
-        run_subprocess([sys.executable, "onnxruntime_test_python_tvm.py"], cwd=cwd, dll_path=dll_path)
+        python_path = str((Path(build_dir) / config / "_deps" / "tvm-src" / "python").resolve())
+        run_subprocess([sys.executable, "onnxruntime_test_python_tvm.py"], cwd=cwd, python_path=python_path)
 
 
 def run_nodejs_tests(nodejs_binding_dir):
@@ -2680,7 +2678,7 @@ def main():
         if args.enable_pybind and not args.skip_onnx_tests and args.use_nuphar:
             nuphar_run_python_tests(build_dir, configs)
 
-        if args.enable_pybind and not args.skip_onnx_tests and args.use_tvm:
+        if args.enable_pybind and args.use_tvm:
             tvm_run_python_tests(build_dir, configs)
 
         # run node.js binding tests


### PR DESCRIPTION
In one of our previous [PR#11389](https://github.com/microsoft/onnxruntime/pull/11389) we added the ability to use precompiled `.so` libraries.
In this PR, we add testing for this functionality into public ORT CI.

Also in this PR, small refactor was carried out for test of model with dynamic shapes.