### PR TITLE
OnnxRuntime Eager: Implement log_softmax with ONNX Ops

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -170,7 +170,7 @@ hand_implemented = {
     "aten::argmax.out": SignatureOnly(),
     "aten::nonzero": Transpose(NonZero("self")),
     "aten::nonzero.out": SignatureOnly(),
-    "aten::_log_softmax.out": MakeTorchFallback(),
+    "aten::_log_softmax.out": SignatureOnly(),
     "aten::nll_loss_forward.output": MakeTorchFallback(),
     "aten::nll_loss_backward.grad_input": MakeTorchFallback(),
     "aten::_log_softmax_backward_data.out": MakeTorchFallback(),

--- a/orttraining/orttraining/eager/opgen/opgen/generator.py
+++ b/orttraining/orttraining/eager/opgen/opgen/generator.py
@@ -198,10 +198,6 @@ class ORTGen:
         writer.writeline('#include "ort_aten.h"')
         writer.writeline('#include "ort_log.h"')
         writer.writeline()
-        writer.writeline(
-            '#define CHECK_STATUS(status) if(!status.IsOK()) { std::stringstream err; err << "ORT return failure (line " << __LINE__ << "): " << status.ErrorMessage(); throw std::runtime_error(err.str()); }'
-        )
-        writer.writeline()
         writer.push_namespace("torch_ort")
         writer.push_namespace("eager")
         writer.writeline()

--- a/orttraining/orttraining/eager/ort_aten.h
+++ b/orttraining/orttraining/eager/ort_aten.h
@@ -11,6 +11,8 @@
 #include "ort_log.h"
 #include "ort_tensor.h"
 
+#define CHECK_STATUS(status) if(!status.IsOK()) { std::stringstream err; err << "ORT return failure (line " << __LINE__ << "): " << status.ErrorMessage(); throw std::runtime_error(err.str()); }
+
 namespace torch_ort {
 namespace eager {
 

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -232,6 +232,17 @@ class OrtOpTests(unittest.TestCase):
         ort_result = torch.softmax(ort_tensor, dim=1)
         assert torch.allclose(cpu_result, ort_result.cpu())
 
+    def test_log_softmax(self):
+        device = self.get_device()
+        cpu_tensor = torch.rand(3, 5)
+        ort_tensor = cpu_tensor.to(device)
+        cpu_result_a = torch.log_softmax(cpu_tensor, dim=1)
+        ort_result_a = torch.log_softmax(ort_tensor, dim=1)
+        assert torch.allclose(cpu_result_a, ort_result_a.cpu())
+        cpu_result_b = torch.log_softmax(cpu_tensor, dim=0)
+        ort_result_b = torch.log_softmax(ort_tensor, dim=0)
+        assert torch.allclose(cpu_result_b, ort_result_b.cpu())
+
     def test_addmm(self):
         device = self.get_device()
         size = 4


### PR DESCRIPTION
**Description**: Provide implementation for `_log_softmax_out` using ONNX Ops `LogSoftmax` and `Transpose`, per definition [here](https://cs.github.com/pytorch/pytorch/blob/master/torch/onnx/symbolic_opset9.py#L1889).

- Move `CHECK_STATUS` macro to shared header (from generator) so it can be used by both generated and non-generated code.
- Test for log_softmax specifying different dimensions to verify both transpose and non-transpose cases.
- Implementation for `_log_softmax_out` using `SignatureOnly` prototype.


**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
