### PR TITLE
remove identity in transformers model graph fusion

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -140,6 +140,7 @@ class SymbolicShapeInference:
             "GatherElements": self._infer_GatherElements,
             "GatherND": self._infer_GatherND,
             "Gelu": self._pass_on_shape_and_type,
+            "Identity": self._pass_on_shape_and_type,
             "If": self._infer_If,
             "Loop": self._infer_Loop,
             "MatMul": self._infer_MatMul,

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -338,6 +338,8 @@ class BertOnnxModel(OnnxModel):
         self.prune_graph()
 
     def optimize(self, options: FusionOptions = None, add_dynamic_axes=False):
+        self.utils.remove_identify_nodes()
+
         # Remove cast nodes that having same data type of input and output based on symbolic shape inference.
         self.utils.remove_useless_cast_nodes()
 


### PR DESCRIPTION
**Description**: 

PyTorch v1.12 export model has Identity nodes even with constant folding enabled in torch.onnx.export. Those Identity nodes causes problem in transformers graph fusion because some fusion expect input to be initializer.

Add a preprocessing to remove those Identity nodes.

Also add symbolic shape inference function for Identity operator.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

It is a walkround for https://github.com/microsoft/onnxruntime/issues/12192. After this change, the optimized fp32 model can run symbolic shape inference, and no more infinite loop. It did not fix the root cause or infinite loop bug in symbolic shape inference.