### PR TITLE
Fix bug where onnxruntime_USE_NCCL flag would default to ON

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -885,7 +885,7 @@ def generate_build_tree(
         "-Donnxruntime_ENABLE_TRAINING_TORCH_INTEROP=" + ("ON" if args.enable_training_torch_interop else "OFF"),
         # Enable advanced computations such as AVX for some traininig related ops.
         "-Donnxruntime_ENABLE_CPU_FP16_OPS=" + ("ON" if args.enable_training else "OFF"),
-        "-Donnxruntime_USE_NCCL=" + ("OFF" if args.disable_nccl else "ON"),
+        "-Donnxruntime_USE_NCCL=" + ("ON" if args.enable_training and not args.disable_nccl else "OFF"),
         "-Donnxruntime_BUILD_BENCHMARKS=" + ("ON" if args.build_micro_benchmarks else "OFF"),
         "-Donnxruntime_USE_ROCM=" + ("ON" if args.use_rocm else "OFF"),
         "-DOnnxruntime_GCOV_COVERAGE=" + ("ON" if args.code_coverage else "OFF"),


### PR DESCRIPTION
**Description**: Change onnxruntime_USE_NCCL flag behavior: flag is ON when training is enabled and NCCL is not disabled. Flag is OFF otherwise.

**Motivation and Context**
With training not enabled and tensorRT not enabled, the onnxruntime_USE_NCCL flag defaults to ON, causing ORT build to fail on my Linux machine with gcc 9.4.0. 

Build would fail with error "/include: not a directory" due to the modified directory options of cmake. onnxruntime_USE_NCCL flag is set to ON if the disable_NCCL arg/flag is not set (which is not ON by default).  This occurs on line 888 of build.py.

With onnxruntime_USE_NCCL flag ON, but with CUDA and tensorRT not enabled, the path "/include" gets added to the directory options of cmake, which is not a directory on my machine, causing the build to fail. This occurs on line 45 of onnxruntime_framework.cmake.

![09e5ba8f-3bff-4e79-83fe-fa7190d7d060](https://user-images.githubusercontent.com/59740888/179326932-02f9acbb-8ac7-4846-8864-d1909c812fa4.jpg)
