### PR TITLE
Document standalone ops for 1.12.0

### DIFF
--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -37,7 +37,7 @@ A new op can be registered with ONNX Runtime using the Custom Operator API in [o
 * [Using Custom Ops with TF2ONNX](https://github.com/microsoft/onnxruntime-extensions/blob/main/tutorials/tf2onnx_custom_ops_tutorial.ipynb): This notebook covers converting a TF model using an existing custom op, defining new custom ops in Python to use in conversion, and defining new custom ops in C++.
 
 ## Calling a native operator from custom operator
-Since 1.12.0, onnxruntime allows its native operators to be called directly by a custom operator through APIs.
+Since 1.12.0, onnxruntime allows its native operators to be called directly by a custom operator through [API](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/include/onnxruntime/core/session/onnxruntime_cxx_api.h#L1156).
 
 Steps are:
 

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -37,7 +37,7 @@ A new op can be registered with ONNX Runtime using the Custom Operator API in [o
 * [Using Custom Ops with TF2ONNX](https://github.com/microsoft/onnxruntime-extensions/blob/main/tutorials/tf2onnx_custom_ops_tutorial.ipynb): This notebook covers converting a TF model using an existing custom op, defining new custom ops in Python to use in conversion, and defining new custom ops in C++.
 
 ## Calling a native operator from custom operator
-To simplify implementation of custom operators, nativeonnxruntime operators can directly be invoked. For example, some custom ops might have to do GEMM or TopK in between other computations. 
+To simplify implementation of custom operators, native onnxruntime operators can directly be invoked. For example, some custom ops might have to do GEMM or TopK in between other computations. 
 This may also be useful for preprocessing and postprocessing on a node, such as Conv, for state management purpose. To achieve this, the Conv node can be wrapped up by a custom operator such as CustomConv,
 within which the input and output could be cached and processed.
 

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -36,6 +36,14 @@ A new op can be registered with ONNX Runtime using the Custom Operator API in [o
 
 * [Using Custom Ops with TF2ONNX](https://github.com/microsoft/onnxruntime-extensions/blob/main/tutorials/tf2onnx_custom_ops_tutorial.ipynb): This notebook covers converting a TF model using an existing custom op, defining new custom ops in Python to use in conversion, and defining new custom ops in C++.
 
+## Calling a native operator from custom operator
+Since 1.12.0, onnxruntime allows its native operators to be called from within a custom operator through APIs.
+Steps are:
+1. Create a native operator instance by providing type constraints and attributes.
+2. Call the operator by feeding with inputs and outputs.
+3. Recycle the operator.
+Please see examples [here](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
+
 ## CUDA custom ops
 When a model is run on a GPU, ONNX Runtime will insert a `MemcpyToHost` op before a CPU custom op and append a `MemcpyFromHost` after it to make sure tensors are accessible throughout calling.
 

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -45,8 +45,9 @@ Steps are:
 2. Call the operator by feeding inputs and outputs.
 3. Recycle the operator.
 
+Note that the native op will be created on the same executioin provider as the custom op.
 Please see examples [here](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
-By the feature, custom ops could be built on native operators not only for utilizing its functionality but also for customizations like state management, or pre-processing of inputs.
+With the feature, custom ops are empowered by native operators not only for functionalities but also for customizations like state management, or pre-processing of inputs.
 
 ## CUDA custom ops
 When a model is run on a GPU, ONNX Runtime will insert a `MemcpyToHost` op before a CPU custom op and append a `MemcpyFromHost` after it to make sure tensors are accessible throughout calling.

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -37,12 +37,16 @@ A new op can be registered with ONNX Runtime using the Custom Operator API in [o
 * [Using Custom Ops with TF2ONNX](https://github.com/microsoft/onnxruntime-extensions/blob/main/tutorials/tf2onnx_custom_ops_tutorial.ipynb): This notebook covers converting a TF model using an existing custom op, defining new custom ops in Python to use in conversion, and defining new custom ops in C++.
 
 ## Calling a native operator from custom operator
-Since 1.12.0, onnxruntime allows its native operators to be called from within a custom operator through APIs.
+Since 1.12.0, onnxruntime allows its native operators to be called directly by a custom operator through APIs.
+
 Steps are:
+
 1. Create a native operator instance by providing type constraints and attributes.
-2. Call the operator by feeding with inputs and outputs.
+2. Call the operator by feeding inputs and outputs.
 3. Recycle the operator.
+
 Please see examples [here](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
+By the feature, custom ops could be built on native operators not only for utilizing its functionality but also for customizations like state management, or pre-processing of inputs.
 
 ## CUDA custom ops
 When a model is run on a GPU, ONNX Runtime will insert a `MemcpyToHost` op before a CPU custom op and append a `MemcpyFromHost` after it to make sure tensors are accessible throughout calling.

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -45,8 +45,9 @@ Steps are:
 2. Call the operator by feeding inputs and outputs.
 3. Recycle the operator.
 
-Note that the native op will be created on the same executioin provider as the custom op.
 Please see examples [here](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
+
+Note that the native op will be created on the same executioin provider as the custom op.
 With the feature, custom ops are empowered by native operators not only for functionalities but also for customizations like state management, or pre-processing of inputs.
 
 ## CUDA custom ops

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -37,18 +37,13 @@ A new op can be registered with ONNX Runtime using the Custom Operator API in [o
 * [Using Custom Ops with TF2ONNX](https://github.com/microsoft/onnxruntime-extensions/blob/main/tutorials/tf2onnx_custom_ops_tutorial.ipynb): This notebook covers converting a TF model using an existing custom op, defining new custom ops in Python to use in conversion, and defining new custom ops in C++.
 
 ## Calling a native operator from custom operator
-Since 1.12.0, onnxruntime allows its native operators to be called directly by a custom operator through [API](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/include/onnxruntime/core/session/onnxruntime_cxx_api.h#L1156).
+To simplify implementation of custom operators, nativeonnxruntime operators can directly be invoked. For example, some custom ops might have to do GEMM or TopK in between other computations. 
+This may also be useful for preprocessing and postprocessing on a node, such as Conv, for state management purpose. To achieve this, the Conv node can be wrapped up by a custom operator such as CustomConv,
+within which the input and output could be cached and processed.
 
-Steps are:
+This feature is supported from ONNX Runtime 1.12.0+. See: [API](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/include/onnxruntime/core/session/onnxruntime_cxx_api.h#L1156)
+and [examples](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
 
-1. Create a native operator instance by providing type constraints and attributes.
-2. Call the operator by feeding inputs and outputs.
-3. Recycle the operator.
-
-Please see examples [here](https://github.com/microsoft/onnxruntime/blob/ced7c2deac958391414d2bbf951f86e2fc904b05/onnxruntime/test/shared_lib/custom_op_utils.cc#L210).
-
-Note that the native op will be created on the same executioin provider as the custom op.
-With the feature, custom ops are empowered by native operators not only for functionalities but also for customizations like state management, or pre-processing of inputs.
 
 ## CUDA custom ops
 When a model is run on a GPU, ONNX Runtime will insert a `MemcpyToHost` op before a CPU custom op and append a `MemcpyFromHost` after it to make sure tensors are accessible throughout calling.


### PR DESCRIPTION
Document the feature of "standalone ops".
By which custom ops could call directly into a native op to utilize its functions with customization.