### PR TITLE
Exclude implicit inputs from dump of encoder feeds in beam search

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -143,7 +143,7 @@ Status BeamSearchT5<T>::Execute(const FeedsFetchesManager& encoder_feeds_fetches
 
 #ifdef DEBUG_BEAM_SEARCH
   const IConsoleDumper* dumper = this->GetConsoleDumper();
-  for (size_t i = 0; i < encoder_feeds.size(); i++) {
+  for (int i = 0; i < this->encoder_subgraph_.num_subgraph_inputs; i++) {
     dumper->Print("encoder_feeds", static_cast<int>(i), true);
     dumper->Print("", encoder_feeds[i]);
   }

--- a/onnxruntime/python/tools/transformers/convert_beam_search.py
+++ b/onnxruntime/python/tools/transformers/convert_beam_search.py
@@ -677,7 +677,7 @@ def remove_shared_initializers(
         if value_info.name in mapping_initializers_2:
             value_info.name = mapping_initializers_2[value_info.name]
 
-    # Rename nodes inputs in graph 1:
+    # Rename nodes inputs in graph 2:
     for node in graph2.node:
         for j in range(len(node.input)):
             if node.input[j] in mapping_initializers_2:
@@ -853,8 +853,6 @@ def convert_model(args: argparse.Namespace):
         )
     else:
         node.attribute.append(onnx.helper.make_attribute("decoder", decoder_model.graph))
-
-    from onnx import TensorProto
 
     # graph inputs
     input_ids = onnx.helper.make_tensor_value_info("input_ids", TensorProto.INT32, ["batch_size", "sequence_length"])


### PR DESCRIPTION
**Description**: 

Feeds might include implicit inputs. Sometime, implicit inputs might not be tensor, which will cause failure in getting tensor. Here we only dump feeds based on number of graph inputs of encoder. That could ensure those feeds are all tensors.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.

Dump failure when an implicit input is not tensor.
