### PR TITLE
Update inferencing.md

### DIFF
--- a/docs/build/inferencing.md
+++ b/docs/build/inferencing.md
@@ -480,7 +480,7 @@ pip3 install numpy
 # Build the latest cmake
 mkdir /code
 cd /code
-wget https://cmake.org/files/v3.13/cmake-3.16.1.tar.gz;
+wget https://cmake.org/files/v3.16/cmake-3.16.1.tar.gz;
 tar zxf cmake-3.16.1.tar.gz
 
 cd /code/cmake-3.16.1


### PR DESCRIPTION
Fix wrong version number for downloading cmake.

**Description**: The documentation contains conflicting version numbers that will lead to a "404 Not Found" error during the build process.  

**Motivation and Context**
- This change is required for the build process to work correctly.
