### PR TITLE
cpplint & Eager mode: refactor and add comments to empty_* functions, general lint cleanup in ort_aten

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,10 @@
     "python.linting.pydocstyleArgs": [
         "--convention=google"
     ],
-    "python.linting.banditEnabled": true
+    "python.linting.banditEnabled": true,
+    "cpplint.lineLength": 120,
+    "cpplint.filters": [
+        "-build/include_subdir",
+        "-runtime/references"
+    ]
 }

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -507,9 +507,9 @@ at::Tensor empty_strided(
   at::IntArrayRef size,
   at::IntArrayRef stride,
   c10::optional<at::ScalarType> dtype_opt,
-  c10::optional<at::Layout> layout_opt, // Ignored because there's no ONNX support.
-  c10::optional<at::Device> device_opt, // Will be ORT by the time this is dispatched.
-  c10::optional<bool> pin_memory_opt) { // Ignored because there's no ONNX support.
+  c10::optional<at::Layout> layout_opt,  // Ignored because there's no ONNX support.
+  c10::optional<at::Device> device_opt,  // Will be ORT by the time this is dispatched.
+  c10::optional<bool> pin_memory_opt) {  // Ignored because there's no ONNX support.
   ORT_LOG_FN(size, stride, dtype_opt, layout_opt, device_opt, pin_memory_opt);
 
   OrtValue ot;
@@ -532,7 +532,7 @@ at::Tensor empty_memory_format(
   c10::optional<at::Layout> layout_opt,
   c10::optional<at::Device> device_opt,
   c10::optional<bool> pin_memory,
-  c10::optional<at::MemoryFormat> memory_format) { // Ignored because there's no ONNX support.
+  c10::optional<at::MemoryFormat> memory_format) {  // Ignored because there's no ONNX support.
   ORT_LOG_FN(size, dtype_opt, layout_opt, device_opt, pin_memory, memory_format);
 
   // Use the strided impl with default (no strides specified).

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -224,6 +224,13 @@ class OrtOpTests(unittest.TestCase):
         cpu_tensor_copied = ort_tensor.cpu()
         assert cpu_tensor_copied.stride() == (0, 0, 0)
 
+    def test_empty(self):
+        device = self.get_device()
+        cpu_tensor = torch.empty(size=(3, 4))
+        ort_tensor = torch.empty(size=(3, 4), device=device)
+        assert ort_tensor.is_ort
+        assert ort_tensor.size() == cpu_tensor.size()
+
     def test_softmax(self):
         device = self.get_device()
         cpu_tensor = torch.rand(3, 5)


### PR DESCRIPTION
**Description**: Minor updates to clarify and simplify implementations of empty_* eager functions.
Cleanup cpplint errors in ort_aten.cpp.
Add cpplint vscode settings.