### PR TITLE
Update aarch64 building pool to aiinfra-linux-ARM64-CPU-2019

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -52,6 +52,7 @@ jobs:
     OnnxruntimeCFlags: '-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all'
     OnnxruntimeCXXFlags: '-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all'
     OnnxruntimeNodejsBindingArch: 'x64'
+    PoolName: 'Linux-CPU'
 
 - template: c-api-linux-cpu.yml
   parameters:        
@@ -61,6 +62,7 @@ jobs:
     OnnxruntimeCFlags: '-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -O3 -Wl,--strip-all'
     OnnxruntimeCXXFlags: '-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -O3 -Wl,--strip-all'
     OnnxruntimeNodejsBindingArch: 'arm64'
+    PoolName: 'aiinfra-linux-ARM64-CPU-2019'
 
 - job: MacOS_C_API_Packaging_CPU_x64
   workspace:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -55,9 +55,6 @@ jobs:
     PoolName: 'Linux-CPU'
 
 - template: c-api-linux-cpu.yml
-  variables:
-    - name: skipComponentGovernanceDetection
-      value: true
   parameters:        
     AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
     BaseImage: 'arm64v8/centos:7'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -55,7 +55,7 @@ jobs:
     PoolName: 'Linux-CPU'
 
 - template: c-api-linux-cpu.yml
-  variable:
+  variables:
     skipComponentGovernanceDetection: true
   parameters:        
     AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -56,7 +56,8 @@ jobs:
 
 - template: c-api-linux-cpu.yml
   variables:
-    skipComponentGovernanceDetection: true
+    - name: skipComponentGovernanceDetection
+      value: true
   parameters:        
     AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
     BaseImage: 'arm64v8/centos:7'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -55,6 +55,8 @@ jobs:
     PoolName: 'Linux-CPU'
 
 - template: c-api-linux-cpu.yml
+  variable:
+    skipComponentGovernanceDetection: true
   parameters:        
     AdditionalBuildFlags: ${{ parameters.AdditionalBuildFlags }}
     BaseImage: 'arm64v8/centos:7'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -1,7 +1,4 @@
 # This file contains the ADO job that build libonnxruntime.so on Linux
-variables:
-  - name: skipComponentGovernanceDetection
-    value: true
 parameters:
 - name: AdditionalBuildFlags
   displayName: Additional build flags for build.py
@@ -31,6 +28,9 @@ jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
   workspace:
     clean: all
+  variables:
+  - name: skipComponentGovernanceDetection
+    value: true
   timeoutInMinutes:  210
   pool: ${{parameters.PoolName}}
   steps:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -103,11 +103,6 @@ jobs:
           arch: '${{parameters.OnnxruntimeNodejsBindingArch}}'
           os: 'linux'
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
-          
-  ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
-    - template: component-governance-component-detection-steps.yml
-      parameters :
-        condition : 'succeeded'
         
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -28,7 +28,7 @@ jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
   variables:
     - name: skipComponentGovernanceDetection
-      value: ${{ eq(parameters.OnnxruntimeNodejsBindingArch, 'arm64') }}
+      value: true
       
   workspace:
     clean: all

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -31,7 +31,16 @@ jobs:
   timeoutInMinutes:  210
   pool: ${{parameters.PoolName}}
   steps:
-    - task: DockerInstaller@0
+    - bash: |
+        set -euo pipefail
+        if ! which docker; then
+          sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+        fi
+      displayName: Setup Docker Engine
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -41,11 +41,20 @@ jobs:
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
           sudo chmod 666 /var/run/docker.sock
         fi
-      displayName: Setup Docker Engine
-    - task: UseDotNet@2
+      displayName: Install Docker Engine
+    - bass: |
+        set -euo pipefail
+        if ! which dotnet; then
+          sudo apt-get install -y wget
+          wget  https://dot.net/v1/dotnet-install.sh
+          chmod 755 dotnet-install.sh
+          ./dotnet-install.sh -c Current
+          rm dotnet-install.sh
+        fi
+      displayName: Install Dotnet
       inputs:
         packageType: sdk
-        version: 3.1.x
+        version: 3.1x
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -31,6 +31,7 @@ jobs:
   timeoutInMinutes:  210
   pool: ${{parameters.PoolName}}
   steps:
+    - task: DockerInstaller@0
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -36,7 +36,7 @@ jobs:
         if ! which docker; then
           sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+          sudo add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
         fi

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -39,6 +39,7 @@ jobs:
           sudo add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          sudo chmod 666 /var/run/docker.sock
         fi
       displayName: Setup Docker Engine
     - template: set-version-number-variables-step.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -52,9 +52,6 @@ jobs:
           rm dotnet-install.sh
         fi
       displayName: Install Dotnet
-      inputs:
-        packageType: sdk
-        version: 3.1x
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -105,7 +105,8 @@ jobs:
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
     - ${{ if not(eq(parameters.OnnxruntimeNodejsBindingArch, 'arm64')) }}:
       - template: component-governance-component-detection-steps.yml
-        condition: 'succeeded'
+        parametes:
+          condition: 'succeeded'
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -42,6 +42,9 @@ jobs:
           sudo chmod 666 /var/run/docker.sock
         fi
       displayName: Setup Docker Engine
+    - task: UseDotNet@2
+      inputs:
+        packageType: sdk
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -42,7 +42,7 @@ jobs:
           sudo chmod 666 /var/run/docker.sock
         fi
       displayName: Install Docker Engine
-    - bass: |
+    - bash: |
         set -euo pipefail
         if ! which dotnet; then
           sudo apt-get install -y wget

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -26,11 +26,12 @@ parameters:
   
 jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
+  
   workspace:
     clean: all
   variables:
   - name: skipComponentGovernanceDetection
-    value: true
+    value: ${{eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')}}
   timeoutInMinutes:  210
   pool: ${{parameters.PoolName}}
   steps:
@@ -105,8 +106,10 @@ jobs:
 
     - template: component-governance-component-detection-steps.yml
       parameters :
+        ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
         condition : 'succeeded'
-
+        ${{ else }}:
+        condition : ''
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get install -y wget
           wget  https://dot.net/v1/dotnet-install.sh
           chmod 755 dotnet-install.sh
-          ./dotnet-install.sh -c Current
+          sudo ./dotnet-install.sh -c Current --install-dir /usr/bin
           rm dotnet-install.sh
         fi
       displayName: Install Dotnet

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -105,7 +105,7 @@ jobs:
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
     - ${{ if not(eq(parameters.OnnxruntimeNodejsBindingArch, 'arm64')) }}:
       - template: component-governance-component-detection-steps.yml
-        parametes:
+        parameters:
           condition: 'succeeded'
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -106,10 +106,10 @@ jobs:
 
     - template: component-governance-component-detection-steps.yml
       parameters :
-      ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
-        condition : 'succeeded'
-      ${{ else }}:
-        condition : ''
+        ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
+          condition : 'succeeded'
+        ${{ else }}:
+          condition : ''
         
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -45,6 +45,7 @@ jobs:
     - task: UseDotNet@2
       inputs:
         packageType: sdk
+        version: 3.1.x
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -1,4 +1,7 @@
 # This file contains the ADO job that build libonnxruntime.so on Linux
+variables:
+  - name: skipComponentGovernanceDetection
+    value: true
 parameters:
 - name: AdditionalBuildFlags
   displayName: Additional build flags for build.py
@@ -26,10 +29,6 @@ parameters:
   
 jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
-  variables:
-    - name: skipComponentGovernanceDetection
-      value: true
-      
   workspace:
     clean: all
   timeoutInMinutes:  210

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -26,6 +26,10 @@ parameters:
   
 jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
+  variables:
+    - name: skipComponentGovernanceDetection
+      value: ${{ eq(parameters.OnnxruntimeNodejsBindingArch, 'arm64') }}
+      
   workspace:
     clean: all
   timeoutInMinutes:  210

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -46,16 +46,6 @@ jobs:
           sudo chmod 666 /var/run/docker.sock
         fi
       displayName: Install Docker Engine
-    # - bash: |
-    #     set -euo pipefail
-    #     if ! which dotnet; then
-    #       sudo apt-get install -y wget
-    #       wget  https://dot.net/v1/dotnet-install.sh
-    #       chmod 755 dotnet-install.sh
-    #       sudo ./dotnet-install.sh -c Current --install-dir /usr/bin
-    #       rm dotnet-install.sh
-    #     fi
-    #   displayName: Install Dotnet
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -46,16 +46,16 @@ jobs:
           sudo chmod 666 /var/run/docker.sock
         fi
       displayName: Install Docker Engine
-    - bash: |
-        set -euo pipefail
-        if ! which dotnet; then
-          sudo apt-get install -y wget
-          wget  https://dot.net/v1/dotnet-install.sh
-          chmod 755 dotnet-install.sh
-          sudo ./dotnet-install.sh -c Current --install-dir /usr/bin
-          rm dotnet-install.sh
-        fi
-      displayName: Install Dotnet
+    # - bash: |
+    #     set -euo pipefail
+    #     if ! which dotnet; then
+    #       sudo apt-get install -y wget
+    #       wget  https://dot.net/v1/dotnet-install.sh
+    #       chmod 755 dotnet-install.sh
+    #       sudo ./dotnet-install.sh -c Current --install-dir /usr/bin
+    #       rm dotnet-install.sh
+    #     fi
+    #   displayName: Install Dotnet
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml
       parameters:
@@ -103,7 +103,9 @@ jobs:
           arch: '${{parameters.OnnxruntimeNodejsBindingArch}}'
           os: 'linux'
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
-        
+    - ${{ if not(eq(parameters.OnnxruntimeNodejsBindingArch, 'arm64')) }}:
+      - template: component-governance-component-detection-steps.yml
+        condition: 'succeeded'
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -19,13 +19,17 @@ parameters:
 
 - name: OnnxruntimeNodejsBindingArch  
   type: string
+
+- name: PoolName
+  type: string
+  default: 'Linux-CPU'
   
 jobs:
 - job: Linux_C_API_Packaging_CPU_${{parameters.OnnxruntimeArch}}
   workspace:
     clean: all
   timeoutInMinutes:  210
-  pool: 'Linux-CPU'
+  pool: ${{parameters.PoolName}}
   steps:
     - template: set-version-number-variables-step.yml
     - template: get-docker-image-steps.yml

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -103,13 +103,11 @@ jobs:
           arch: '${{parameters.OnnxruntimeNodejsBindingArch}}'
           os: 'linux'
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
-
-    - template: component-governance-component-detection-steps.yml
-      parameters :
-        ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
+          
+    ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
+      - template: component-governance-component-detection-steps.yml
+        parameters :
           condition : 'succeeded'
-        ${{ else }}:
-          condition : ''
         
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -104,10 +104,10 @@ jobs:
           os: 'linux'
           artifactName: 'drop-onnxruntime-nodejs-linux-${{parameters.OnnxruntimeArch}}'
           
-    ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
-      - template: component-governance-component-detection-steps.yml
-        parameters :
-          condition : 'succeeded'
+  ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
+    - template: component-governance-component-detection-steps.yml
+      parameters :
+        condition : 'succeeded'
         
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -106,10 +106,11 @@ jobs:
 
     - template: component-governance-component-detection-steps.yml
       parameters :
-        ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
+      ${{ if not(eq('${{parameters.OnnxruntimeNodejsBindingArch}}', 'arm64')) }}:
         condition : 'succeeded'
-        ${{ else }}:
+      ${{ else }}:
         condition : ''
+        
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()


### PR DESCRIPTION
**Description**: Describe your changes.
Update aarch64 building pool to aiinfra-linux-ARM64-CPU-2019
**Motivation and Context**
 This reduce our build time from 3 hours to 16 mins. 
- If it fixes an open issue, please link to the issue here.
