### PR TITLE
[CUDA] Use dim3.z to Handle Large Input For GatherGrad

### DIFF
--- a/orttraining/orttraining/test/training_ops/cpu/tensor/gather_grad_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/gather_grad_op_test.cc
@@ -236,6 +236,10 @@ TEST(GatherGradOpTest, ConsistentOutput) {
 TEST(GatherGradOpTest, ConsistentOutputFewDistinctIndices) {
   RunGatherGradConsistentOutputTest(0, {2}, {1024 * 1024});
 }
+
+TEST(GatherGradOpTest, LargeGatherElementsPerIndex) {
+  RunGatherGradConsistentOutputTest(0, {8, 256, 196, 192}, {4});
+}
 #endif
 
 }  // namespace test

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.cu
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.cu
@@ -122,7 +122,8 @@ __global__ void DirectSumKernel(
       auto target_row = dX_indices_sorted[idx];
       if (target_row < 0) target_row += gather_dimension_size;
       for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
-        const auto gathered_element_idx_start = threadIdx.x + blockIdx.y * blockDim.x * NumElementsPerThread;
+        const auto gathered_element_idx_start =
+            threadIdx.x + (blockIdx.y + gridDim.y * blockIdx.z) * blockDim.x * NumElementsPerThread;
         const auto dX_row_offset =
             (batch_idx * gather_dimension_size + target_row) * num_gathered_per_index;
         const auto dY_row_offset =
@@ -162,6 +163,7 @@ __global__ void DirectSumKernel(
 template <typename T, typename TIndex>
 void DirectSumImpl(
     cudaStream_t stream,
+    const cudaDeviceProp& prop,
     const TIndex* dX_indices_sorted,
     const TIndex* dY_indices_sorted,
     const T* dY_data,
@@ -171,7 +173,15 @@ void DirectSumImpl(
     int64_t gather_dimension_size,
     int64_t num_batches) {
   dim3 block(GPU_WARP_SIZE_HOST, 4);
-  dim3 grid(CeilDiv(num_gathered_indices, 4), CeilDiv(num_gathered_per_index, GridDim::maxElementsPerThread * GPU_WARP_SIZE_HOST));
+  uint32_t grid_y =
+      static_cast<uint32_t>(CeilDiv(num_gathered_per_index, GridDim::maxElementsPerThread * GPU_WARP_SIZE_HOST));
+  uint32_t grid_z = 1;
+  const uint32_t max_grid_y = static_cast<uint32_t>(prop.maxGridSize[1]);
+  if (grid_y > max_grid_y) {
+    grid_z = CeilDiv(grid_y, max_grid_y);
+    grid_y = max_grid_y;
+  }
+  dim3 grid(CeilDiv(num_gathered_indices, 4), grid_y, grid_z);
 
   DirectSumKernel<T, TIndex, GridDim::maxElementsPerThread><<<grid, block, 0, stream>>>(
       dX_indices_sorted,
@@ -412,6 +422,7 @@ void PartialSumsImpl(
 template <typename T, typename TIndex>
 void Impl(
     cudaStream_t stream,
+    const cudaDeviceProp& prop,
     const CudaScratchBufferAllocator& allocator,
     const T* dY_data,
     const TIndex* dX_indices,
@@ -474,7 +485,7 @@ void Impl(
   constexpr GatheredIndexIndex_t kMaxSegmentSizeThreshold = 32;
   if (host_max_segment_count <= kMaxSegmentSizeThreshold) {
     DirectSumImpl(
-        stream, dX_indices_sorted.get(), dY_indices_sorted.get(),
+        stream, prop, dX_indices_sorted.get(), dY_indices_sorted.get(),
         dY_data, dX_data,
         num_gathered_indices, num_gathered_per_index, gather_dimension_size, num_batches);
   } else {
@@ -531,6 +542,7 @@ void Impl_Simplified(
 template <typename T, typename TIndex>
 void GatherGradImpl(
     cudaStream_t stream,
+    const cudaDeviceProp& prop,
     const CudaScratchBufferAllocator& allocator,
     const T* dY_data,
     const TIndex* dX_indices,
@@ -541,6 +553,7 @@ void GatherGradImpl(
     T* dX_data) {
   gather_grad_internal::Impl(
       stream,
+      prop,
       allocator,
       dY_data, dX_indices,
       num_gathered_indices, gather_dimension_size, num_gathered_per_index, num_batches,
@@ -550,6 +563,7 @@ void GatherGradImpl(
 #define SPECIALIZED(T, TIndex)                         \
   template void GatherGradImpl<T, TIndex>(             \
       cudaStream_t stream,                             \
+      const cudaDeviceProp& prop,                      \
       const CudaScratchBufferAllocator& allocator,     \
       const T* dY_data,                                \
       const TIndex* dX_indices,                        \

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_grad_impl.h
@@ -29,6 +29,7 @@ using GatheredIndexIndex_t = int32_t;
 template <typename T, typename TIndex>
 void GatherGradImpl(
     cudaStream_t stream,
+    const cudaDeviceProp& prop,
     const CudaScratchBufferAllocator& allocator,
     const T* dY_data,
     const TIndex* dX_indices,


### PR DESCRIPTION
The DirectSumImpl for GatherGrad kernel uses dim3.y to handle num_gathers_per_index, while max_grid_dim.y for devices is not big enough (65535 in V100) to handle when num_gathers_per_index is very large. In such case, use dim3.z to cover this case.