### PR TITLE
fix bug: output of Concat is quantized twice in qdq format

### DIFF
--- a/onnxruntime/python/tools/quantization/operators/concat.py
+++ b/onnxruntime/python/tools/quantization/operators/concat.py
@@ -54,12 +54,3 @@ class QLinearConcat(QuantOperatorBase):
 
         self.quantizer.new_nodes += nodes
         self.quantizer.new_nodes += [qlconcat_node]
-
-
-class QDQConcat(QDQOperatorBase):
-    def __init__(self, onnx_quantizer, onnx_node):
-        super().__init__(onnx_quantizer, onnx_node)
-
-    def quantize(self):
-        super().quantize()
-        self.quantizer.quantize_tensor(self.node.output[0])

--- a/onnxruntime/python/tools/quantization/registry.py
+++ b/onnxruntime/python/tools/quantization/registry.py
@@ -3,7 +3,7 @@ from .operators.argmax import QArgMax
 from .operators.attention import AttentionQuant
 from .operators.base_operator import QuantOperatorBase
 from .operators.binary_op import QLinearBinaryOp
-from .operators.concat import QDQConcat, QLinearConcat
+from .operators.concat import QLinearConcat
 from .operators.conv import ConvInteger, QDQConv, QLinearConv
 from .operators.direct_q8 import Direct8BitOp, QDQDirect8BitOp
 from .operators.embed_layernorm import EmbedLayerNormalizationQuant
@@ -70,7 +70,6 @@ QDQRegistry = {
     "Resize": QDQResize,
     "MaxPool": QDQMaxPool,
     "AveragePool": QDQDirect8BitOp,
-    "Concat": QDQConcat,
     "MatMul": QDQMatMul,
 }
 


### PR DESCRIPTION
As the title says, output of Concat is handled twice, which leads to the deletion Relu not clean. #12178 
