### PR TITLE
Add dev container / codespace configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# --------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------
+# Dockerfile to Develop inside Dev Container
+
+ARG VARIANT=ubuntu-20.04
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install common packages
+RUN apt-get update \
+    && apt-get -y install build-essential cppcheck valgrind clang lldb llvm gdb \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install additional OS packages.
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+    python3-dev \
+    python3 \
+    ca-certificates \
+    python3-numpy \
+    python3-setuptools \
+    python3-wheel \
+    python3-pip \
+    g++ \
+    gcc \
+    ninja-build \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install newer CMake version
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends aria2 aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install python dependencies
+RUN pip install torch==1.11.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install packaging "wheel>=0.35.1" parameterized

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,49 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/docker-existing-dockerfile
+{
+	"name": "Onnx Runtime - Eager Mode",
+
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"python.languageServer": "Default",
+				"cmake.ignoreCMakeListsMissing": true,
+				"python.defaultInterpreterPath": "/usr/bin/python3",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true
+			},
+
+		    // Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.vscode-pylance",
+				"ms-python.python",
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.cmake-tools"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+
+	"features": {
+		"git": "os-provided",
+		"python": "os-provided",
+		"powershell": "7.1"
+	}
+}


### PR DESCRIPTION
As a developer who has recently started contributing to this project I have found leveraging dev containers / GitHub codespaces useful. I think this would be useful for other developers as well, and I wanted to see if the project would be interested in including a dev container configuration. In particular, I think this would address some of the main pain points new developers encounter when onboarding (getting build environment and dev tooling configured), and make it easy for all developers to leverage the cloud hosted development environment via GitHub codespaces. 

As I have been mainly focusing on eager mode support, this configuration is tailored to developing in that area, but I think it is generally applicable. I would be open to any suggestions on to make it applicable more generally (we could set up different configuration files if we needed different environments), or improvements to the existing configuration.


[Dev containers](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers) provide a self-contained development environment that can be tailored for a project. [GitHub Codespaces](https://docs.github.com/en/codespaces/overview) provide a cloud hosted environment to run these containers in. This makes it easy to provision a consistent development environment with developer tooling already installed and configured that provide the following benefits:

1. Developer onboarding is simplified.
    1. Easy to get environment setup and running
    2. Reference environment is available, if developer is having issues with local environment
2. Developer tooling is provided and automatically configured.
    1. Python / C++ build tooling
    2. Python / C++ code formatters / linters
3. Easy to provision cloud hosted environment via GitHub Codespace.
4. Easy to create ephemeral development environments to test new changes.
     1. Can be used to provision environments to test changes and Pull Requests

This can ease several pain points that developers on-boarding to the project can encounter. One of the problems I have seen with developers new to the project (I am one of these) is having the baseline development environment (Python / C++) and recommended tools (e.g. VS Code Python / C++ extensions, linters, and autoformatters) installed and configured to efficiently get started in the repository. For all developers, this makes it easy to leverage ephemeral cloud hosted development environments via GitHub Codespaces.

The dev container configuration and associated docker files are based on the Ubuntu, Python, and C++ container images from the vscode-dev-container repository.

**Notes:**

  - Compiling the eager mode component can run into trouble if the codespace has < 32 GB of RAM

**Instructions to try out codespace:**

Entry point to create a new codespace: https://github.com/codespaces