### PR TITLE
[CoreML EP] Remove batch=1 restriction in depthtospace op support

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/depthtospace_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/depthtospace_op_builder.cc
@@ -67,9 +67,9 @@ bool DepthToSpaceOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderI
     return false;
   }
 
-  const auto input_size = input_shape.size();
-  if (input_size != 4) {
-    LOGS(logger, VERBOSE) << "DepthToSpace only supports 4d shape, input is " << input_size << "d shape.";
+  const auto input_rank = input_shape.size();
+  if (input_rank < 4) {
+    LOGS(logger, VERBOSE) << "DepthToSpace does not support input shape of " << input_rank << "d shape.";
   }
 
   NodeAttrHelper helper(node);

--- a/onnxruntime/core/providers/coreml/builders/impl/depthtospace_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/depthtospace_op_builder.cc
@@ -72,12 +72,6 @@ bool DepthToSpaceOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderI
     LOGS(logger, VERBOSE) << "DepthToSpace only supports 4d shape, input is " << input_size << "d shape.";
   }
 
-  // CoreML spec ReorganizeDataLayer DEPTH_TO_SPACE mode only accepts input with one batch ([C, H, W]).
-  if (input_shape[0] != 1) {
-    LOGS(logger, VERBOSE) << "The batch size of DepthToSpace [" << input_shape[0] << "] is not supported.";
-    return false;
-  }
-
   NodeAttrHelper helper(node);
   if (node.SinceVersion() >= 11) {
     // For now, only DCR mode DepthToSpace is supported


### PR DESCRIPTION
**Description**: Describe your changes.

While updating coreml_op _support.md, found out an unnecessary batch = 1 condition set in DepthToSpace op support checker for CoreML EP support caused by misunderstanding.

Removed this restriction.

FYI: from coreml spec: https://github.com/microsoft/onnxruntime/blob/c72bb8aaa9759954e35d394ee39b0f578ca56c86/onnxruntime/core/providers/coreml/mlmodel_format/NeuralNetwork.proto#L2982

**Motivation and Context**

Fix.
