### PR TITLE
Fix: Test coverage is undercounting and profiling errors

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1504,9 +1504,9 @@ def run_android_tests(args, source_dir, build_dir, config, cwd):
                 )
 
             if args.use_nnapi:
-                adb_shell("cd {0} && {0}/onnx_test_runner -e nnapi {0}/test".format(device_dir))
+                run_adb_shell("{0}/onnx_test_runner -e nnapi {0}/test".format(device_dir))
             else:
-                adb_shell("cd {0} && {0}/onnx_test_runner {0}/test".format(device_dir))
+                run_adb_shell("{0}/onnx_test_runner {0}/test".format(device_dir))
             # run shared_lib_test if necessary
             if args.build_shared_lib:
                 adb_push("libonnxruntime.so", device_dir, cwd=cwd)


### PR DESCRIPTION
**Description**: Describe your changes.
Adding data relocation flag for onnx_test_runner if coverage is required.

**Motivation and Context**
test coverage didn't include onnx_test_runner results and there was many profiling errors in [NNAPI EP, Build, Test step](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=697686&view=logs&j=564a194a-2673-5e3e-8702-06ec97c72802&t=8bf6d427-7470-5eb3-39dd-3634c99284a5).
```
profiling: /Users/runner/work/1/s/build_nnapi/Debug/CMakeFiles/onnx_test_runner.dir/Users/runner/work/1/s/onnxruntime/test/onnx/main.cc.gcda: cannot open: No such file or directory
profiling: /Users/runner/work/1/s/build_nnapi/Debug/CMakeFiles/onnx_test_runner_common.dir/Users/runner/work/1/s/onnxruntime/test/onnx/TestCase.cc.gcda: cannot open: No such file or directory
profiling: /Users/runner/work/1/s/build_nnapi/Debug/CMakeFiles/onnx_test_runner_common.dir/Users/runner/work/1/s/onnxruntime/test/onnx/TestResultStat.cc.gcda: cannot open: No such file or directory
profiling: /Users/runner/work/1/s/build_nnapi/Debug/CMakeFiles/onnx_test_runner_common.dir/Users/runner/work/1/s/onnxruntime/test/onnx/heap_buffer.cc.gcda: cannot open: No such file or directory
```

Comparing the below 2 test workflows, coverage increased 1 more percent. (84.9% to 86.2%)
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=696978&view=results
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=695139&view=results

