### PR TITLE
Increase component detection timeout

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -1,7 +1,7 @@
 # Known Limits
 # 1. Anchors are not supported in GHA
 # https://github.community/t/support-for-yaml-anchors/16128/90
-# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM, 
+# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM,
 # which is the no.1 blocker for running tests on modern Android Emulators (especially on recent API levels) on CI.
 
 jobs:
@@ -10,6 +10,8 @@ jobs:
   workspace:
     clean: all
   timeoutInMinutes: 30
+  variables:
+    ComponentDetection.Timeout: 600
   steps:
   # Onnx has no 3.9 python package available yet, need to use python 3.8
   # to avoid build onnx package
@@ -75,7 +77,7 @@ jobs:
       overWrite: true
 
   - task: CopyFiles@2
-    displayName: Copy test data 
+    displayName: Copy test data
     inputs:
       contents: 'build/**/testdata/**'
       targetFolder: $(Build.ArtifactStagingDirectory)
@@ -227,7 +229,7 @@ jobs:
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: NNAPIBuildOutput
-      
+
   - template: templates/clean-agent-build-directory-step.yml
 
 - job: Test_NNAPI_EP
@@ -262,7 +264,7 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android emulator
-      
+
     - script: |
         python3 tools/ci_build/build.py \
         --android \
@@ -310,7 +312,7 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-      
+
     - template: templates/clean-agent-build-directory-step.yml
 
 # The below jobs only run on master build
@@ -346,7 +348,7 @@ jobs:
           $(Build.BinariesDirectory)/protobuf \
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
- 
+
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -380,7 +382,7 @@ jobs:
         --build_java \
         --code_coverage
       displayName: NNAPI EP, Build, Test, CodeCoverage on Android Emulator
-      
+
     - script: |
         python3 -m pip install gcovr && \
         python3 tools/ci_build/coverage.py \
@@ -408,9 +410,9 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-      
+
     - template: templates/clean-agent-build-directory-step.yml
-      
+
 - job: Update_Dashboard
   workspace:
     clean: all
@@ -419,7 +421,7 @@ jobs:
     value: true
   pool: 'Linux-CPU-2019'
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-  dependsOn: 
+  dependsOn:
   - Test_CPU_EP
   - NNAPI_EP_MASTER
   steps:
@@ -437,5 +439,5 @@ jobs:
         scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
         arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
         workingDirectory: '$(Build.BinariesDirectory)'
-      
+
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
@@ -13,8 +13,8 @@ parameters:
   ArtifactName: 'drop-linux'
   TimeoutInMinutes: 120
   # Controls whether unreleased onnx opsets are allowed. Default is set to 1
-  AllowReleasedOpsetOnly: '1' 
-  # to inject strategy, you need to pass in the whole yaml structure - 
+  AllowReleasedOpsetOnly: '1'
+  # to inject strategy, you need to pass in the whole yaml structure -
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#strategies
   # see example in orttraining-linux-gpu-ci-pipeline.yml
   Strategy: ''
@@ -26,6 +26,7 @@ jobs:
   timeoutInMinutes:  ${{ parameters.TimeoutInMinutes }}
   variables:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
+    ComponentDetection.Timeout: 600
   pool: ${{ parameters.AgentPool }}
   ${{ if ne(parameters.Strategy, '') }}:
     strategy:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -20,6 +20,7 @@ jobs:
     BuildCommand: ${{ parameters.BuildCommand }}
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
     MACOSX_DEPLOYMENT_TARGET: '10.14'
+    ComponentDetection.Timeout: 600
   steps:
     - checkout: self
       ${{ if ne(parameters.SubmoduleCheckoutMode, '') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-arm.yml
@@ -27,6 +27,7 @@ jobs:
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DotNetExe: 'dotnet.exe'
     CUDA_VERSION: ${{ parameters.CudaVersion }}
+    ComponentDetection.Timeout: 600
 
   steps:
     - powershell: |

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -57,15 +57,16 @@ jobs:
   workspace:
     clean: all
   pool: ${{ parameters.ort_build_pool_name }}
-  timeoutInMinutes:  300  
-
+  timeoutInMinutes:  300
+  variables:
+    ComponentDetection.Timeout: 600
   steps:
     - template: telemetry-steps.yml
-    
+
     - task: UsePythonVersion@0
-      inputs: 
-        versionSpec: '3.7' 
-        addToPath: true 
+      inputs:
+        versionSpec: '3.7'
+        addToPath: true
         architecture: ${{ parameters.buildArch }}
 
     - task: NodeTool@0
@@ -83,16 +84,16 @@ jobs:
     - script: |
        python -m pip install -q setuptools wheel numpy
       workingDirectory: '$(Build.BinariesDirectory)'
-      displayName: 'Install python modules' 
+      displayName: 'Install python modules'
     - powershell: |
        $Env:USE_MSVC_STATIC_RUNTIME=1
        $Env:ONNX_ML=1
        $Env:CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.buildArch }}-windows-static"
        python setup.py bdist_wheel
        python -m pip uninstall -y onnx -qq
-       Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}   
-      workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'      
-      displayName: 'Install ONNX'    
+       Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
+      workingDirectory: '$(Build.SourcesDirectory)\cmake\external\onnx'
+      displayName: 'Install ONNX'
 
     - template: set-version-number-variables-step.yml
 
@@ -102,7 +103,7 @@ jobs:
         scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
         arguments: '--config RelWithDebInfo --enable_lto --disable_rtti --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 16 2019" --enable_onnx_tests $(TelemetryOption) ${{ parameters.buildparameter }}'
         workingDirectory: '$(Build.BinariesDirectory)'
- 
+
     - task: VSBuild@1
       displayName: 'Build'
       inputs:
@@ -127,7 +128,7 @@ jobs:
        dir *.dll
        mkdir $(Build.ArtifactStagingDirectory)\testdata
       workingDirectory: '$(Build.BinariesDirectory)/RelWithDebInfo/RelWithDebInfo'
-      displayName: 'List built DLLs' 
+      displayName: 'List built DLLs'
 
     - template: c-api-artifacts-package-and-publish-steps-windows.yml
       parameters:
@@ -148,8 +149,8 @@ jobs:
     - task: PublishPipelineArtifact@1
       condition: and(succeeded(), eq('${{ parameters.packageName}}', 'x64'))
       inputs:
-        targetPath: '$(Build.BinariesDirectory)\RelWithDebInfo\external\protobuf\cmake\RelWithDebInfo\protoc.exe' 
-        artifactName: 'drop-extra' 
+        targetPath: '$(Build.BinariesDirectory)\RelWithDebInfo\external\protobuf\cmake\RelWithDebInfo\protoc.exe'
+        artifactName: 'drop-extra'
 
 
     - task: CopyFiles@2
@@ -164,7 +165,7 @@ jobs:
     - task: PublishPipelineArtifact@1
       condition: and(succeeded(), eq('${{ parameters.packageName}}', 'x64'))
       inputs:
-        targetPath: '$(Build.BinariesDirectory)\RelWithDebInfo\external\protobuf\cmake\RelWithDebInfo\protoc.exe' 
+        targetPath: '$(Build.BinariesDirectory)\RelWithDebInfo\external\protobuf\cmake\RelWithDebInfo\protoc.exe'
         artifactName: 'drop-nuget'
 
 
@@ -209,13 +210,13 @@ jobs:
           rd /s /q $(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}\stage
           dir /s /b $(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}
         workingDirectory: '$(Build.BinariesDirectory)\RelWithDebInfo'
-        displayName: 'Add symbols and notices to Java'    
-      
+        displayName: 'Add symbols and notices to Java'
+
     - task: PublishBuildArtifacts@1
       condition: and(succeeded(), eq('${{ parameters.buildJava}}', true))
       displayName: 'Publish Java temp binaries'
       inputs:
-        pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}' 
+        pathtoPublish: '$(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}'
         artifactName: 'drop-onnxruntime-java-win-${{ parameters.packageName }}'
 
     - ${{ if eq(parameters['DoCompliance'], 'true') }}:
@@ -251,7 +252,7 @@ jobs:
            **/*.obj
            **/*.pdb
            **/*.dll
-          
+
       #Manually set msBuildCommandline so that we can also set CAExcludePath
       - task: SDLNativeRules@3
         displayName: 'Run the PREfast SDL Native Rules for MSBuild'

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -43,10 +43,11 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
+    ComponentDetection.Timeout: 600
   workspace:
     clean: all
   pool: 'Win-CPU-2019'
-  timeoutInMinutes:  300  
+  timeoutInMinutes:  300
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -77,10 +78,10 @@ jobs:
   - script: |
      set ORT_DOXY_SRC=$(Build.SourcesDirectory)
      set ORT_DOXY_OUT=$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}
-     mkdir %ORT_DOXY_SRC% 
+     mkdir %ORT_DOXY_SRC%
      mkdir %ORT_DOXY_OUT%
      "C:\Program Files\doxygen\bin\doxygen.exe" $(Build.SourcesDirectory)\tools\ci_build\github\Doxyfile_csharp.cfg
-     
+
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'API Documentation Check and generate'
 
@@ -152,7 +153,7 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'    
+    displayName: 'Build C#'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       configuration: '${{ parameters.BuildConfig }}'
@@ -167,7 +168,7 @@ jobs:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj'
-          configuration: '${{ parameters.BuildConfig }}'          
+          configuration: '${{ parameters.BuildConfig }}'
           arguments: '--configuration ${{ parameters.BuildConfig }} -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) --blame'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
@@ -175,14 +176,14 @@ jobs:
       - powershell: |
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Install onnxruntime wheel'
 
   - ${{ if eq(parameters.RunOnnxRuntimeTests, true) }}:
       - powershell: |
          python $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019"  --build_shared_lib --enable_onnx_tests ${{ parameters.additionalBuildFlags }}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Run tests'
 
@@ -213,7 +214,7 @@ jobs:
         displayName: 'Create Security Analysis Report'
         inputs:
           SDLNativeRules: true
-          
+
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish Security Analysis Logs'
         continueOnError: true

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -20,7 +20,7 @@ parameters:
 - name: isX86
   type: boolean
   default: false
-  
+
 - name: isTraining
   type: boolean
   default: false
@@ -37,11 +37,11 @@ parameters:
 - name: RunStaticCodeAnalysis
   displayName: Run Static Code Analysis
   type: boolean
-  default: true  
-  
+  default: true
+
 - name: ORT_EP_NAME
   type: string
-  
+
 - name: MachinePool
   type: string
 
@@ -55,14 +55,15 @@ jobs:
   variables:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true    
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}    
+    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}
+    ComponentDetection.Timeout: 600
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}
-  timeoutInMinutes:  300  
+  timeoutInMinutes:  300
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -93,10 +94,10 @@ jobs:
   - script: |
      set ORT_DOXY_SRC=$(Build.SourcesDirectory)
      set ORT_DOXY_OUT=$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}
-     mkdir %ORT_DOXY_SRC% 
+     mkdir %ORT_DOXY_SRC%
      mkdir %ORT_DOXY_OUT%
      "C:\Program Files\doxygen\bin\doxygen.exe" $(Build.SourcesDirectory)\tools\ci_build\github\Doxyfile_csharp.cfg
-     
+
     workingDirectory: '$(Build.SourcesDirectory)'
     displayName: 'API Documentation Check and generate'
 
@@ -175,7 +176,7 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
   - task: MSBuild@1
-    displayName: 'Build C#'    
+    displayName: 'Build C#'
     inputs:
       solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
       configuration: '${{ parameters.BuildConfig }}'
@@ -190,7 +191,7 @@ jobs:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\csharp\test\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp\Microsoft.ML.OnnxRuntime.Tests.NetCoreApp.csproj'
-          configuration: '${{ parameters.BuildConfig }}'          
+          configuration: '${{ parameters.BuildConfig }}'
           arguments: '--configuration ${{ parameters.BuildConfig }} -p:Platform="Any CPU" -p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:DefineConstants=USE_${{ parameters.ORT_EP_NAME }} --blame'
           workingDirectory: '$(Build.SourcesDirectory)\csharp'
 
@@ -198,14 +199,14 @@ jobs:
       - powershell: |
          python3 -m pip uninstall -y ort-nightly-gpu ort-nightly onnxruntime onnxruntime-gpu onnxruntime-training onnxruntime-directml ort-nightly-directml -qq
          Get-ChildItem -Path dist/*.whl | foreach {pip --disable-pip-version-check install --upgrade $_.fullname}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Install onnxruntime wheel'
 
   - ${{ if eq(parameters.RunOnnxRuntimeTests, true) }}:
       - powershell: |
          python $(Build.SourcesDirectory)\tools\ci_build\build.py --config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "Visual Studio 16 2019"  --build_shared_lib --enable_onnx_tests ${{ parameters.additionalBuildFlags }}
-       
+
         workingDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\${{ parameters.BuildConfig }}'
         displayName: 'Run tests'
 
@@ -234,16 +235,16 @@ jobs:
           rulesetName: Custom
           customRuleset: $(Build.SourcesDirectory)\cmake\Sdl.ruleset
           publishXML: true
-          
+
       - task: SdtReport@2
         displayName: 'Create Security Analysis Report'
         inputs:
           SDLNativeRules: true
-    
+
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish Security Analysis Logs'
         continueOnError: true
-   
+
       - task: PostAnalysis@2
         displayName: 'Guardian Break v2'
         inputs:


### PR DESCRIPTION
**Description**: 
override the default component detection timeout.

**Motivation and Context**
workflows failed due to component detection timeout very frequently. 
```
[ERROR] The execution did not complete in the alotted time (360 seconds) and has been terminated prior to completion 
[ERROR] To override the default timeout, use the pipeline variable ComponentDetection.Timeout with a larger integer value (in seconds).
```

PS. 
This change might not cover all workflows.
If any other workflow came across the issue, the owner could change the timeout in job scope as well.
```
  variables:
    ComponentDetection.Timeout: 600
```
