### PR TITLE
[Java] JNI refactor for ONNX Tensor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: warning
-          flags: --linelength=120
+          flags: --linelength=120 --exclude=java/src/main/native/*.c
           filter: "-runtime/references"
 
   lint-js:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,6 @@ jobs:
           reporter: github-pr-check
           level: warning
           flags: --linelength=120
-          exclude: java/src/main/native/*.c
           filter: "-runtime/references"
 
   lint-js:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,6 +87,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           flags: --linelength=120
+          exclude: java/src/main/native/*.c
           filter: "-runtime/references"
 
   lint-js:

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -12,10 +12,12 @@ extern "C" {
 #endif
 
 typedef struct {
+  /* The number of dimensions in the Tensor */
   size_t dimensions;
-  size_t arrSize;
+  /* The number of elements in the Tensor */
+  size_t elementCount;
+  /* The type of the Tensor */
   ONNXTensorElementDataType onnxTypeEnum;
-  jbyte valid;
 } JavaTensorTypeShape;
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved);
@@ -32,7 +34,7 @@ ONNXTensorElementDataType convertToONNXDataFormat(jint type);
 
 size_t onnxTypeSize(ONNXTensorElementDataType type);
 
-JavaTensorTypeShape getTensorTypeShape(JNIEnv * jniEnv, const OrtApi * api, const OrtValue * value);
+OrtErrorCode getTensorTypeShape(JNIEnv * jniEnv, JavaTensorTypeShape * output, const OrtApi * api, const OrtValue * value);
 
 jfloat convertHalfToFloat(uint16_t half);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -11,9 +11,12 @@
 extern "C" {
 #endif
 
-jsize safecast_size_t_to_jsize(size_t v);
-
-jsize safecast_int64_to_jsize(int64_t v);
+typedef struct {
+  size_t dimensions;
+  size_t arrSize;
+  ONNXTensorElementDataType onnxTypeEnum;
+  jbyte valid;
+} JavaTensorTypeShape;
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved);
 
@@ -28,6 +31,8 @@ jint convertFromONNXDataFormat(ONNXTensorElementDataType type);
 ONNXTensorElementDataType convertToONNXDataFormat(jint type);
 
 size_t onnxTypeSize(ONNXTensorElementDataType type);
+
+JavaTensorTypeShape getTensorTypeShape(JNIEnv * jniEnv, const OrtApi * api, const OrtValue * value);
 
 jfloat convertHalfToFloat(uint16_t half);
 
@@ -74,6 +79,10 @@ jint throwOrtException(JNIEnv *env, int messageId, const char *message);
 jint convertErrorCode(OrtErrorCode code);
 
 OrtErrorCode checkOrtStatus(JNIEnv * env, const OrtApi * api, OrtStatus * status);
+
+jsize safecast_size_t_to_jsize(size_t v);
+
+jsize safecast_int64_to_jsize(int64_t v);
 
 #ifdef __cplusplus
 }

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -242,17 +242,18 @@ JNIEXPORT jobject JNICALL Java_ai_onnxruntime_OnnxTensor_getBuffer
  * Signature: (JI)F
  */
 JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OnnxTensor_getFloat
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxTypeInt) {
   (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
   const OrtApi* api = (const OrtApi*) apiHandle;
-  if (onnxType == 9) {
+  ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
+  if (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
     uint16_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       jfloat floatVal = convertHalfToFloat(*arr);
       return floatVal;
     }
-  } else if (onnxType == 10) {
+  } else if (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
     jfloat* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
@@ -286,17 +287,12 @@ JNIEXPORT jdouble JNICALL Java_ai_onnxruntime_OnnxTensor_getDouble
  * Signature: (JI)B
  */
 JNIEXPORT jbyte JNICALL Java_ai_onnxruntime_OnnxTensor_getByte
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxTypeInt) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
-  if (onnxType == 1) {
+  ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8)) {
     uint8_t* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
-    if (code == ORT_OK) {
-      return (jbyte) *arr;
-    }
-  } else if (onnxType == 2) {
-    int8_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       return (jbyte) *arr;
@@ -311,17 +307,12 @@ JNIEXPORT jbyte JNICALL Java_ai_onnxruntime_OnnxTensor_getByte
  * Signature: (JI)S
  */
 JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxTypeInt) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
-  if (onnxType == 3) {
-    uint16_t* arr;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
-    if (code == ORT_OK) {
-      return (jshort) *arr;
-    }
-  } else if (onnxType == 4) {
-    int16_t* arr;
+  ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16)) {
+    uint16_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       return (jshort) *arr;
@@ -336,17 +327,12 @@ JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
  * Signature: (JI)I
  */
 JNIEXPORT jint JNICALL Java_ai_onnxruntime_OnnxTensor_getInt
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxTypeInt) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
-  if (onnxType == 5) {
+  ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32)) {
     uint32_t* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
-    if (code == ORT_OK) {
-      return (jint) *arr;
-    }
-  } else if (onnxType == 6) {
-    int32_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       return (jint) *arr;
@@ -361,17 +347,12 @@ JNIEXPORT jint JNICALL Java_ai_onnxruntime_OnnxTensor_getInt
  * Signature: (JI)J
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_getLong
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxTypeInt) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
-  if (onnxType == 7) {
+  ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64)) {
     uint64_t* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
-    if (code == ORT_OK) {
-      return (jlong) *arr;
-    }
-  } else if (onnxType == 8) {
-    int64_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       return (jlong) *arr;

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -196,10 +196,10 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createStringTensor
         }
 
         // Release the buffers
-        checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, (void*)strings));
+        OrtErrorCode freeCode = checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, (void*)strings));
 
         // Assignment failed, return null
-        if (code != ORT_OK) {
+        if ((code != ORT_OK) || (freeCode != ORT_OK))  {
           api->ReleaseValue(ortValue);
           return (jlong) NULL;
         }

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -14,7 +14,8 @@
  * Signature: (JJLjava/lang/Object;[JI)J
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
-        (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject dataObj, jlongArray shape, jint onnxTypeJava) {
+        (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject dataObj,
+         jlongArray shape, jint onnxTypeJava) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
@@ -27,8 +28,11 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
 
     // Create the OrtValue
     OrtValue* ortValue = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator, (int64_t*)shapeArr, shapeLen,
-                                         onnxType, &ortValue));
+    OrtErrorCode code = checkOrtStatus(jniEnv, api,
+                                       api->CreateTensorAsOrtValue(
+                                           allocator, (int64_t*)shapeArr, shapeLen, onnxType, &ortValue
+                                           )
+                                       );
     (*jniEnv)->ReleaseLongArrayElements(jniEnv, shape, shapeArr, JNI_ABORT);
 
     if (code == ORT_OK) {
@@ -52,7 +56,8 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
 
           if (code == ORT_OK) {
             // Copy the java array into the tensor
-            size_t copied = copyJavaToTensor(jniEnv, onnxType, tensorData, typeShape.elementCount, typeShape.dimensions, dataObj);
+            size_t copied = copyJavaToTensor(jniEnv, onnxType, tensorData, typeShape.elementCount,
+                                             typeShape.dimensions, dataObj);
             if (copied == 0) {
               // Copy failed, release value
               api->ReleaseValue(ortValue);
@@ -79,7 +84,8 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
  * Signature: (JJLjava/nio/Buffer;IJ[JI)J
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensorFromBuffer
-        (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject buffer, jint bufferPos, jlong bufferSize, jlongArray shape, jint onnxTypeJava) {
+        (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject buffer, jint bufferPos, jlong bufferSize,
+         jlongArray shape, jint onnxTypeJava) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
@@ -105,7 +111,7 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensorFromBuffer
     OrtValue* ortValue = NULL;
     checkOrtStatus(jniEnv, api, api->CreateTensorWithDataAsOrtValue(allocatorInfo, bufferArr, bufferSize,
                     (int64_t*)shapeArr, shapeLen, onnxType, &ortValue));
-    (*jniEnv)->ReleaseLongArrayElements(jniEnv,shape,shapeArr,JNI_ABORT);
+    (*jniEnv)->ReleaseLongArrayElements(jniEnv, shape, shapeArr, JNI_ABORT);
 
     // Return the pointer to the OrtValue
     return (jlong) ortValue;
@@ -133,10 +139,10 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createString
     const char* stringBuffer = (*jniEnv)->GetStringUTFChars(jniEnv,input,NULL);
 
     // Assign the strings into the Tensor
-    code = checkOrtStatus(jniEnv, api, api->FillStringTensor(ortValue,&stringBuffer,1));
+    code = checkOrtStatus(jniEnv, api, api->FillStringTensor(ortValue, &stringBuffer, 1));
 
     // Release the Java string whether the call succeeded or failed
-    (*jniEnv)->ReleaseStringUTFChars(jniEnv,input,stringBuffer);
+    (*jniEnv)->ReleaseStringUTFChars(jniEnv, input, stringBuffer);
 
     // Assignment failed, return null
     if (code != ORT_OK) {
@@ -248,14 +254,14 @@ JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OnnxTensor_getFloat
   const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 9) {
     uint16_t* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       jfloat floatVal = convertHalfToFloat(*arr);
       return floatVal;
     }
   } else if (onnxType == 10) {
     jfloat* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
       return *arr;
     }
@@ -443,7 +449,8 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OnnxTensor_getArray
         uint8_t* arr = NULL;
         code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData(value, (void**)&arr));
         if (code == ORT_OK) {
-          copyTensorToJava(jniEnv, typeShape.onnxTypeEnum, arr, typeShape.elementCount, typeShape.dimensions, (jarray)carrier);
+          copyTensorToJava(jniEnv, typeShape.onnxTypeEnum, arr, typeShape.elementCount,
+                           typeShape.dimensions, (jarray)carrier);
         }
       }
     }

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -15,7 +15,7 @@
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
         (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject dataObj, jlongArray shape, jint onnxTypeJava) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     // Convert type to ONNX C enum
@@ -64,11 +64,11 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensorFromBuffer
         (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobject buffer, jint bufferPos, jlong bufferSize, jlongArray shape, jint onnxTypeJava) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
     const OrtMemoryInfo* allocatorInfo;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->AllocatorGetInfo(allocator,&allocatorInfo));
+    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->AllocatorGetInfo(allocator, &allocatorInfo));
     if (code != ORT_OK) {
       return (jlong) NULL;
     }
@@ -103,14 +103,15 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensorFromBuffer
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createString
         (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jstring input) {
-  (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+  (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
   const OrtApi* api = (const OrtApi*) apiHandle;
   OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
 
   // Create the OrtValue
   int64_t shapeArr = 1;
   OrtValue* ortValue;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator,&shapeArr,0,ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING,&ortValue));
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator, &shapeArr, 0,
+                                                                              ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, &ortValue));
 
   if (code == ORT_OK) {
     // Create the buffer for the Java string
@@ -133,7 +134,7 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createString
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createStringTensor
         (JNIEnv * jniEnv, jclass jobj, jlong apiHandle, jlong allocatorHandle, jobjectArray stringArr, jlongArray shape) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
 
@@ -187,7 +188,7 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createStringTensor
  */
 JNIEXPORT jobject JNICALL Java_ai_onnxruntime_OnnxTensor_getBuffer
         (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* ortValue = (OrtValue *) handle;
     JavaTensorTypeShape typeShape = getTensorTypeShape(jniEnv, api, ortValue);
@@ -212,7 +213,7 @@ JNIEXPORT jobject JNICALL Java_ai_onnxruntime_OnnxTensor_getBuffer
  */
 JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OnnxTensor_getFloat
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     if (onnxType == 9) {
         uint16_t* arr = NULL;
@@ -235,7 +236,7 @@ JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OnnxTensor_getFloat
  */
 JNIEXPORT jdouble JNICALL Java_ai_onnxruntime_OnnxTensor_getDouble
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     jdouble* arr = NULL;
     checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
@@ -249,7 +250,7 @@ JNIEXPORT jdouble JNICALL Java_ai_onnxruntime_OnnxTensor_getDouble
  */
 JNIEXPORT jbyte JNICALL Java_ai_onnxruntime_OnnxTensor_getByte
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 1) {
     uint8_t* arr;
@@ -271,7 +272,7 @@ JNIEXPORT jbyte JNICALL Java_ai_onnxruntime_OnnxTensor_getByte
  */
 JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 3) {
     uint16_t* arr;
@@ -293,7 +294,7 @@ JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
  */
 JNIEXPORT jint JNICALL Java_ai_onnxruntime_OnnxTensor_getInt
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 5) {
     uint32_t* arr;
@@ -315,7 +316,7 @@ JNIEXPORT jint JNICALL Java_ai_onnxruntime_OnnxTensor_getInt
  */
 JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_getLong
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jint onnxType) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 7) {
     uint64_t* arr;
@@ -337,16 +338,17 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_getLong
  */
 JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxTensor_getString
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong allocatorHandle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     // Extract a String array - if this becomes a performance issue we'll refactor later.
-    jobjectArray outputArray = createStringArrayFromTensor(jniEnv, api, (OrtAllocator*) allocatorHandle, (OrtValue*) handle);
+    jobjectArray outputArray = createStringArrayFromTensor(jniEnv, api, (OrtAllocator*) allocatorHandle,
+                                                           (OrtValue*) handle);
     if (outputArray != NULL) {
       // Get reference to the string
       jobject output = (*jniEnv)->GetObjectArrayElement(jniEnv, outputArray, 0);
 
       // Free array
-      (*jniEnv)->DeleteLocalRef(jniEnv,outputArray);
+      (*jniEnv)->DeleteLocalRef(jniEnv, outputArray);
 
       return output;
     } else {
@@ -361,7 +363,7 @@ JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxTensor_getString
  */
 JNIEXPORT jboolean JNICALL Java_ai_onnxruntime_OnnxTensor_getBool
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     jboolean* arr;
     checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
@@ -375,7 +377,7 @@ JNIEXPORT jboolean JNICALL Java_ai_onnxruntime_OnnxTensor_getBool
  */
 JNIEXPORT void JNICALL Java_ai_onnxruntime_OnnxTensor_getArray
   (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong allocatorHandle, jobject carrier) {
-    (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
+    (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* value = (OrtValue*) handle;
     JavaTensorTypeShape typeShape = getTensorTypeShape(jniEnv, api, value);

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -23,12 +23,13 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
 
     // Extract the shape information
     jboolean mkCopy;
-    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv,shape,&mkCopy);
-    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv,shape);
+    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv, shape, &mkCopy);
+    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv, shape);
 
     // Create the OrtValue
     OrtValue* ortValue = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator, (int64_t*)shapeArr, shapeLen, onnxType, &ortValue));
+    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator, (int64_t*)shapeArr, shapeLen,
+                                         onnxType, &ortValue));
     (*jniEnv)->ReleaseLongArrayElements(jniEnv, shape, shapeArr, JNI_ABORT);
 
     if (code == ORT_OK) {
@@ -76,18 +77,19 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensorFromBuffer
     ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeJava);
 
     // Extract the buffer
-    char* bufferArr = (char*)(*jniEnv)->GetDirectBufferAddress(jniEnv,buffer);
+    char* bufferArr = (char*)(*jniEnv)->GetDirectBufferAddress(jniEnv, buffer);
     // Increment by bufferPos bytes
     bufferArr = bufferArr + bufferPos;
 
     // Extract the shape information
     jboolean mkCopy;
-    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv,shape,&mkCopy);
-    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv,shape);
+    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv, shape, &mkCopy);
+    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv, shape);
 
     // Create the OrtValue
     OrtValue* ortValue = NULL;
-    checkOrtStatus(jniEnv, api, api->CreateTensorWithDataAsOrtValue(allocatorInfo,bufferArr,bufferSize,(int64_t*)shapeArr,shapeLen,onnxType,&ortValue));
+    checkOrtStatus(jniEnv, api, api->CreateTensorWithDataAsOrtValue(allocatorInfo, bufferArr, bufferSize,
+                    (int64_t*)shapeArr, shapeLen, onnxType, &ortValue));
     (*jniEnv)->ReleaseLongArrayElements(jniEnv,shape,shapeArr,JNI_ABORT);
 
     // Return the pointer to the OrtValue
@@ -137,40 +139,43 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createStringTensor
 
     // Extract the shape information
     jboolean mkCopy;
-    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv,shape,&mkCopy);
-    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv,shape);
+    jlong* shapeArr = (*jniEnv)->GetLongArrayElements(jniEnv, shape, &mkCopy);
+    jsize shapeLen = (*jniEnv)->GetArrayLength(jniEnv, shape);
 
     // Array length
     jsize length = (*jniEnv)->GetArrayLength(jniEnv, stringArr);
 
     // Create the OrtValue
-    OrtValue* ortValue;
-    checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator,(int64_t*)shapeArr,shapeLen,ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING,&ortValue));
-    (*jniEnv)->ReleaseLongArrayElements(jniEnv,shape,shapeArr,JNI_ABORT);
+    OrtValue* ortValue = NULL;
+    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->CreateTensorAsOrtValue(allocator, (int64_t*)shapeArr, shapeLen,
+                                        ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, &ortValue));
+    (*jniEnv)->ReleaseLongArrayElements(jniEnv, shape, shapeArr, JNI_ABORT);
 
-    // Create the buffers for the Java strings
-    const char** strings;
-    checkOrtStatus(jniEnv, api, api->AllocatorAlloc(allocator,sizeof(char*)*length,(void**)&strings));
-    jobject* javaStrings;
-    checkOrtStatus(jniEnv, api, api->AllocatorAlloc(allocator,sizeof(jobject)*length,(void**)&javaStrings));
+    if (code == ORT_OK) {
+      // Create the buffers for the Java strings
+      const char** strings;
+      code = checkOrtStatus(jniEnv, api, api->AllocatorAlloc(allocator, sizeof(char*) * length, (void**)&strings));
 
-    // Copy the java strings into the buffers
-    for (jsize i = 0; i < length; i++) {
-        javaStrings[i] = (*jniEnv)->GetObjectArrayElement(jniEnv,stringArr,i);
-        strings[i] = (*jniEnv)->GetStringUTFChars(jniEnv,javaStrings[i],NULL);
+      if (code == ORT_OK) {
+        // Copy the java strings into the buffers
+        for (jsize i = 0; i < length; i++) {
+            jobject javaString = (*jniEnv)->GetObjectArrayElement(jniEnv, stringArr, i);
+            strings[i] = (*jniEnv)->GetStringUTFChars(jniEnv, javaString, NULL);
+        }
+
+        // Assign the strings into the Tensor
+        checkOrtStatus(jniEnv, api, api->FillStringTensor(ortValue, strings, length));
+
+        // Release the Java strings
+        for (int i = 0; i < length; i++) {
+            jobject javaString = (*jniEnv)->GetObjectArrayElement(jniEnv, stringArr, i);
+            (*jniEnv)->ReleaseStringUTFChars(jniEnv, javaString, strings[i]);
+        }
+
+        // Release the buffers
+        checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, (void*)strings));
+      }
     }
-
-    // Assign the strings into the Tensor
-    checkOrtStatus(jniEnv, api, api->FillStringTensor(ortValue,strings,length));
-
-    // Release the Java strings
-    for (int i = 0; i < length; i++) {
-        (*jniEnv)->ReleaseStringUTFChars(jniEnv,javaStrings[i],strings[i]);
-    }
-
-    // Release the buffers
-    checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, (void*)strings));
-    checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, javaStrings));
 
     return (jlong) ortValue;
 }
@@ -192,7 +197,7 @@ JNIEXPORT jobject JNICALL Java_ai_onnxruntime_OnnxTensor_getBuffer
       size_t sizeBytes = typeShape.arrSize*typeSize;
 
       uint8_t* arr = NULL;
-      checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+      checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
 
       return (*jniEnv)->NewDirectByteBuffer(jniEnv, arr, sizeBytes);
     } else {
@@ -233,7 +238,7 @@ JNIEXPORT jdouble JNICALL Java_ai_onnxruntime_OnnxTensor_getDouble
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     jdouble* arr = NULL;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return *arr;
 }
 
@@ -248,11 +253,11 @@ JNIEXPORT jbyte JNICALL Java_ai_onnxruntime_OnnxTensor_getByte
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 1) {
     uint8_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jbyte) *arr;
   } else if (onnxType == 2) {
     int8_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jbyte) *arr;
   } else {
     return (jbyte) 0;
@@ -270,11 +275,11 @@ JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 3) {
     uint16_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jshort) *arr;
   } else if (onnxType == 4) {
     int16_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jshort) *arr;
   } else {
     return (jshort) 0;
@@ -292,11 +297,11 @@ JNIEXPORT jint JNICALL Java_ai_onnxruntime_OnnxTensor_getInt
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 5) {
     uint32_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jint) *arr;
   } else if (onnxType == 6) {
     int32_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jint) *arr;
   } else {
     return (jint) 0;
@@ -314,11 +319,11 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_getLong
     const OrtApi* api = (const OrtApi*) apiHandle;
   if (onnxType == 7) {
     uint64_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jlong) *arr;
   } else if (onnxType == 8) {
     int64_t* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return (jlong) *arr;
   } else {
     return (jlong) 0;
@@ -359,7 +364,7 @@ JNIEXPORT jboolean JNICALL Java_ai_onnxruntime_OnnxTensor_getBool
     (void) jobj; // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     jboolean* arr;
-    checkOrtStatus(jniEnv,api,api->GetTensorMutableData((OrtValue*)handle,(void**)&arr));
+    checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     return *arr;
 }
 


### PR DESCRIPTION
**Description**:

Following on from #12013, this PR improves the error handling in the JNI code for OnnxTensor. OrtSession and the OrtJniUtil helper file are the remaining bits of unfixed JNI code.

**Motivation and Context**
- Why is this change required? What problem does it solve? The error handling and exception throwing in the JNI code doesn't handle repeated errors very well. See #11451.
- If it fixes an open issue, please link to the issue here. Partial fix for #11451.
