### PR TITLE
Fix TRT custom op issue

### DIFF
--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -187,6 +187,8 @@ class GraphViewer {
   */
   const IndexedSubGraph* GetFilterInfo() const { return filter_info_; }
 
+  IOnnxRuntimeOpSchemaCollectionPtr GetSchemaRegistry() const { return graph_->GetSchemaRegistry(); }
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphViewer);
   GraphViewer(const Graph& graph, const IndexedSubGraph* filter_info);

--- a/include/onnxruntime/core/graph/graph_viewer.h
+++ b/include/onnxruntime/core/graph/graph_viewer.h
@@ -187,7 +187,9 @@ class GraphViewer {
   */
   const IndexedSubGraph* GetFilterInfo() const { return filter_info_; }
 
+#if !defined(ORT_MINIMAL_BUILD)
   IOnnxRuntimeOpSchemaCollectionPtr GetSchemaRegistry() const { return graph_->GetSchemaRegistry(); }
+#endif
 
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GraphViewer);

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -743,7 +743,7 @@ struct ProviderHostImpl : ProviderHost {
   void GraphViewer__operator_delete(GraphViewer* p) override { delete p; }
   std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* graph_viewer, const logging::Logger& logger) override {
     return std::make_unique<Model>(graph_viewer->Name(), true, ModelMetaData(), PathString(),
-                                   IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
+                                   IOnnxRuntimeOpSchemaRegistryList({graph_viewer->GetSchemaRegistry()}), graph_viewer->DomainToVersionMap(),
                                    std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
   }
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -743,7 +743,11 @@ struct ProviderHostImpl : ProviderHost {
   void GraphViewer__operator_delete(GraphViewer* p) override { delete p; }
   std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* graph_viewer, const logging::Logger& logger) override {
     return std::make_unique<Model>(graph_viewer->Name(), true, ModelMetaData(), PathString(),
+#if !defined(ORT_MINIMAL_BUILD)
                                    IOnnxRuntimeOpSchemaRegistryList({graph_viewer->GetSchemaRegistry()}), graph_viewer->DomainToVersionMap(),
+#else
+                                   IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
+#end
                                    std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
   }
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -747,7 +747,7 @@ struct ProviderHostImpl : ProviderHost {
                                    IOnnxRuntimeOpSchemaRegistryList({graph_viewer->GetSchemaRegistry()}), graph_viewer->DomainToVersionMap(),
 #else
                                    IOnnxRuntimeOpSchemaRegistryList(), graph_viewer->DomainToVersionMap(),
-#end
+#endif // ORT_MINIMAL_BUILD
                                    std::vector<ONNX_NAMESPACE::FunctionProto>(), logger);
   }
 


### PR DESCRIPTION
**Description**:
Fix issue #12282 : TRT EP failed to create model session with CUDA custom op.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  When executing a model with customop, ORT crashes at TRT EP's `GetSupportedList`. Inside this function, it will create a graph builder first, then construct subgraphs.
https://github.com/microsoft/onnxruntime/blob/f2533d3084b6af933f60575a32d31e0ecf3f7174/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L721-L722

  However, during graph viewer model creation, it lost the schema registries information for custom ops. Thus, causing exceptions in the line below:  
https://github.com/microsoft/onnxruntime/blob/f2533d3084b6af933f60575a32d31e0ecf3f7174/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc#L763

  The fix is to pass schema registries inside `GraphViewer__CreateModel`.

- If it fixes an open issue, please link to the issue here.
  #12282 
