### PR TITLE
Fix C header to stop people accidentally copying the OrtApi by value

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3495,6 +3495,10 @@ struct OrtApi {
   * \since Version 1.13
   */
   const OrtTrainingApi*(ORT_API_CALL* GetTrainingApi)(uint32_t version)NO_EXCEPTION ORT_ALL_ARGS_NONNULL;
+
+#ifdef __cplusplus
+  OrtApi(const OrtApi&)=delete; // Prevent users from accidentally copying the API structure, it should always be passed as a pointer
+#endif
 };
 
 /*
@@ -3503,7 +3507,6 @@ struct OrtApi {
  *   2 Create an OrtCustomOp structure for each op and add them to the domain
  *   3 Call OrtAddCustomOpDomain to add the custom domain of ops to the session options
 */
-#define OrtCustomOpApi OrtApi
 
 // Specifies some characteristics of inputs/outputs of custom ops:
 // Specify if the inputs/outputs are one of:

--- a/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
+++ b/onnxruntime/core/providers/coreml/coreml_execution_provider.cc
@@ -139,7 +139,7 @@ common::Status CoreMLExecutionProvider::Compile(const std::vector<FusedNodeAndGr
       ORT_UNUSED_PARAMETER(state);
     };
 
-    compute_info.compute_func = [](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       coreml::Model* model = reinterpret_cast<coreml::Model*>(state);
       const size_t num_inputs = ort.KernelContext_GetInputCount(context);
@@ -243,7 +243,7 @@ common::Status CoreMLExecutionProvider::Compile(const std::vector<FusedNodeAndGr
     NodeComputeInfo compute_info;
     compute_info.create_state_func = [](ComputeContext* /*context*/, FunctionState* /*state*/) { return 0; };
     compute_info.release_state_func = [](FunctionState /*state*/) {};
-    compute_info.compute_func = [](FunctionState /* state */, const OrtCustomOpApi* /* api */,
+    compute_info.compute_func = [](FunctionState /* state */, const OrtApi* /* api */,
                                    OrtKernelContext* /* context */) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "Compute is not supported in this build.");
     };

--- a/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_execution_provider.cc
@@ -309,7 +309,7 @@ Status DNNLExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fuse
       ORT_UNUSED_PARAMETER(state);
     };
 
-    compute_info.compute_func = [](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       ort_dnnl::DnnlSubgraphPrimitive* subgraph_primitive = reinterpret_cast<ort_dnnl::DnnlSubgraphPrimitive*>(state);
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1038,7 +1038,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         delete static_cast<MIGraphXFuncState*>(state);
     };
 
-    compute_info.compute_func = [](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
       std::unordered_map<std::string, std::size_t>& map_input_name_index = mgx_state->input_name_indexes;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/nnapi_execution_provider.cc
@@ -297,7 +297,7 @@ common::Status NnapiExecutionProvider::Compile(const std::vector<FusedNodeAndGra
       ORT_UNUSED_PARAMETER(state);
     };
 
-    compute_info.compute_func = [](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       nnapi::Model* model = reinterpret_cast<nnapi::Model*>(state);
       const size_t num_inputs = ort.KernelContext_GetInputCount(context);

--- a/onnxruntime/core/providers/nuphar/nuphar_execution_provider.cc
+++ b/onnxruntime/core/providers/nuphar/nuphar_execution_provider.cc
@@ -453,7 +453,7 @@ Status NupharExecutionProvider::Compile(
     // Compute function
     // This is similar to the original OpKernel's Compute()
     info.compute_func =
-        [](FunctionState state, const OrtCustomOpApi*, OrtKernelContext* op_kernel_context) {
+        [](FunctionState state, const OrtApi*, OrtKernelContext* op_kernel_context) {
           NupharKernelState* s = reinterpret_cast<NupharKernelState*>(state);
           return s->Compute(reinterpret_cast<OpKernelContext*>(op_kernel_context));
         };

--- a/onnxruntime/core/providers/rknpu/rknpu_execution_provider.cc
+++ b/onnxruntime/core/providers/rknpu/rknpu_execution_provider.cc
@@ -315,7 +315,7 @@ common::Status RknpuExecutionProvider::Compile(const std::vector<FusedNodeAndGra
     };
 
     compute_info.compute_func = [](FunctionState state,
-                                   const OrtCustomOpApi* api,
+                                   const OrtApi* api,
                                    OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       RknpuFuncState* rk_state = reinterpret_cast<RknpuFuncState*>(state);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1368,7 +1368,7 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
     };
 
     // Create compute function
-    compute_info.compute_func = [this](FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [this](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::CustomOpApi ort{*api};
       TensorrtFuncState* trt_state = reinterpret_cast<TensorrtFuncState*>(state);
       std::lock_guard<OrtMutex> lock(*(trt_state->tensorrt_mu_ptr));

--- a/onnxruntime/core/providers/tvm/tvm_runner.cc
+++ b/onnxruntime/core/providers/tvm/tvm_runner.cc
@@ -18,7 +18,7 @@ TVMRunner::TVMRunner(const TvmEPOptions& options,
   runner_ = getTVMRunnerImpl(mod, options, inputs_info, output_tensors);
 }
 
-common::Status TVMRunner::operator()(FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context) {
+common::Status TVMRunner::operator()(FunctionState state, const OrtApi* api, OrtKernelContext* context) {
   return runner_->run(api, context);
 }
 

--- a/onnxruntime/core/providers/tvm/tvm_runner.h
+++ b/onnxruntime/core/providers/tvm/tvm_runner.h
@@ -23,7 +23,7 @@ public:
             const InputsInfoMap& inputs_info,
             const std::vector<DLTensor>& output_tensor);
 
-  common::Status operator()(FunctionState state, const OrtCustomOpApi* api, OrtKernelContext* context);
+  common::Status operator()(FunctionState state, const OrtApi* api, OrtKernelContext* context);
 
 private:
   std::shared_ptr<RunnerImpl> runner_;

--- a/onnxruntime/core/providers/tvm/tvm_runner_impl.h
+++ b/onnxruntime/core/providers/tvm/tvm_runner_impl.h
@@ -27,7 +27,7 @@ public:
              const std::vector<DLTensor> tensors_outputs);
   virtual ~RunnerImpl() = default;
 
-  virtual common::Status run(const OrtCustomOpApi* api, OrtKernelContext* context) {
+  virtual common::Status run(const OrtApi* api, OrtKernelContext* context) {
     Ort::CustomOpApi ort{*api};
 
     set_input(ort, context);

--- a/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.cc
+++ b/onnxruntime/test/providers/internal_testing/internal_testing_execution_provider.cc
@@ -215,7 +215,7 @@ common::Status InternalTestingExecutionProvider::Compile(const std::vector<Fused
     compute_info.release_state_func = [](FunctionState /*state*/) {
     };
 
-    compute_info.compute_func = [&node](FunctionState /*state*/, const OrtCustomOpApi* c_api,
+    compute_info.compute_func = [&node](FunctionState /*state*/, const OrtApi* c_api,
                                         OrtKernelContext* context) -> Status {
       Ort::CustomOpApi api{*c_api};  // use C++ API for convenience
 

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -47,8 +47,7 @@ struct OrtTensorDimensions : std::vector<int64_t> {
 
 struct KernelOne {
   KernelOne(const OrtApi& api)
-      : api_(api),
-        ort_(api_) {
+      : ort_(api) {
   }
 
   void Compute(OrtKernelContext* context) {
@@ -80,7 +79,6 @@ struct KernelOne {
   }
 
  private:
-  const OrtApi& api_;  // keep a copy of the struct, whose ref is used in the ort_
   Ort::CustomOpApi ort_;
 };
 

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -46,7 +46,7 @@ struct OrtTensorDimensions : std::vector<int64_t> {
 };
 
 struct KernelOne {
-  KernelOne(OrtApi api)
+  KernelOne(const OrtApi& api)
       : api_(api),
         ort_(api_) {
   }
@@ -80,12 +80,12 @@ struct KernelOne {
   }
 
  private:
-  OrtApi api_;  // keep a copy of the struct, whose ref is used in the ort_
+  const OrtApi& api_;  // keep a copy of the struct, whose ref is used in the ort_
   Ort::CustomOpApi ort_;
 };
 
 struct KernelTwo {
-  KernelTwo(OrtApi api)
+  KernelTwo(const OrtApi& api)
       : api_(api),
         ort_(api_) {
   }
@@ -112,12 +112,12 @@ struct KernelTwo {
   }
 
  private:
-  OrtApi api_;  // keep a copy of the struct, whose ref is used in the ort_
+  const OrtApi& api_;  // keep a copy of the struct, whose ref is used in the ort_
   Ort::CustomOpApi ort_;
 };
 
 struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne> {
-  void* CreateKernel(OrtApi api, const OrtKernelInfo* /* info */) const {
+  void* CreateKernel(const OrtApi& api, const OrtKernelInfo* /* info */) const {
     return new KernelOne(api);
   };
 
@@ -136,7 +136,7 @@ struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne> {
 } c_CustomOpOne;
 
 struct CustomOpTwo : Ort::CustomOpBase<CustomOpTwo, KernelTwo> {
-  void* CreateKernel(OrtApi api, const OrtKernelInfo* /* info */) const {
+  void* CreateKernel(const OrtApi& api, const OrtKernelInfo* /* info */) const {
     return new KernelTwo(api);
   };
 

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -84,8 +84,7 @@ struct KernelOne {
 
 struct KernelTwo {
   KernelTwo(const OrtApi& api)
-      : api_(api),
-        ort_(api_) {
+      : ort_(api) {
   }
 
   void Compute(OrtKernelContext* context) {
@@ -110,7 +109,6 @@ struct KernelTwo {
   }
 
  private:
-  const OrtApi& api_;  // keep a copy of the struct, whose ref is used in the ort_
   Ort::CustomOpApi ort_;
 };
 


### PR DESCRIPTION
**Description**: 
This change adds a deleted copy constructor to generate an error if anyone accidentally does this.

**Motivation and Context**
I noticed when helping someone else using Ort that they were copying the OrtApi by value. This is not recommended, it should always be passed by pointer/reference.