### PR TITLE
fixed packaging of onnxruntime java module for Mac OSX with Apple M1 Chip

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -108,8 +108,11 @@ final class OnnxRuntime {
     } else if (arch.startsWith("x86")) {
       // 32-bit x86 is not supported by the Java API
       detectedArch = "x86";
-    } else if (arch.startsWith("aarch64")) {
+    } else if (arch.startsWith("aarch64") && !detectedOS.equals("osx")) {
       detectedArch = "aarch64";
+    } else if(arch.startsWith("aarch64") && detectedOS.equals("osx")) {
+      // support for Apple M1 Chip
+      detectedArch = "arm64";
     } else if (arch.startsWith("ppc64")) {
       detectedArch = "ppc64";
     } else if (isAndroid()) {


### PR DESCRIPTION
**Description**: Fixed packaging of onnxruntime java module for Mac OSX with Apple M1 Chip

**Motivation and Context**
- Since release 1.12.0 onnxruntime supports Mac OSX with Apple M1 chip, but java artifact is packaged with a wrong name, so it cannot be used on the mentioned operating system out of the box
- In order to use it in the current version of onnxruntime I have to copy jar file and prepare two application variants (for Mac OSX and other operating systems) and it should not be necessary 
- This issue was addressed by me in #11054
- It's probably related to the issue #12324 as well
- Changes in my PR were suggested by @lanking520 in the discussion under #11054  
