### PR TITLE
Cosmetic fix to AttentionFusion

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -345,7 +345,7 @@ class FusionAttention(Fusion):
         )
         einsum_node = None
         if qkv_nodes is not None:
-            (_, matmul_qkv, reshape_qkv, transpose_qkv, matmul_qkv) = qkv_nodes
+            (_, _, reshape_qkv, transpose_qkv, matmul_qkv) = qkv_nodes
         else:
             # Match Albert
             qkv_nodes = self.model.match_parent_path(


### PR DESCRIPTION
`matmul_qkv` is double assigned. (If my understanding is right) The first `matmul_qkv`  is actually the MatMul AFTER Attention and BEFORE the normalization node and the last one is the actual `matmul_qkv`. Python will correctly assign the right node to `matmul_qkv` (the last one in the list) but it is good to fix this as it is confusing for a new reader of the code.