### PR TITLE
Change native folder name for java macos arm64

### DIFF
--- a/tools/ci_build/github/linux/java_copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/java_copy_strip_binary.sh
@@ -21,6 +21,8 @@ uname -a
 echo "Version: $VERSION_NUMBER"
 if [[ $LIB_NAME == *.dylib ]] && [[ $ARCH == 'osx-x86_64' ]]; then
 	ARCH='osx-x64'
+elif [[ $LIB_NAME == *.dylib ]] && [[ $ARCH == 'osx-arm64' ]]; then
+	ARCH='osx-aarch64'
 fi
 NATIVE_FOLDER=ai/onnxruntime/native/$ARCH
 


### PR DESCRIPTION
**Description**: 

Change native folder name for java macos arm64

**Motivation and Context**
- Why is this change required? What problem does it solve?

see : #12325  #12324 

- If it fixes an open issue, please link to the issue here.
