### PR TITLE
[TVM EP] Build on Windows with ipp-crypto support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -110,7 +110,7 @@ option(onnxruntime_USE_ROCM "Build with AMD GPU support" OFF)
 option(onnxruntime_USE_TVM "Build with TVM support" OFF)
 option(onnxruntime_TVM_CUDA_RUNTIME "Build TVM with CUDA support" OFF)
 option(onnxruntime_TVM_USE_LLVM "Build TVM with LLVM. Set customized path to llvm-config.exe here if need" OFF)
-option(onnxruntime_TVM_USE_HASH "Build ipp-crypto library for support has algorithm. It is defined for TVM only")
+option(onnxruntime_TVM_USE_HASH "Build ipp-crypto library for support hash algorithm. It is defined for TVM only")
 option(onnxruntime_USE_XNNPACK "Build with XNNPACK support. Provides an alternative math library on ARM, WebAssembly and x86." OFF)
 
 # Options related to reducing the binary size produced by the build
@@ -1491,17 +1491,12 @@ if (onnxruntime_USE_TVM)
   if (NOT TARGET tvm)
     message(STATUS "Include TVM(*).")
     include(tvm)
-    if (onnxruntime_TVM_USE_HASH)
-      message(STATUS "Include ipp-crypto(*).")
-      include(ipp-crypto)
-    endif()
   endif()
 
   # ipp-crypto
   if (onnxruntime_TVM_USE_HASH)
-    add_subdirectory(${ipp_crypto_SOURCE_DIR} ${ipp_crypto_BINARY_DIR} EXCLUDE_FROM_ALL)
-    set_target_properties(ippcp_s PROPERTIES FOLDER ${ipp_crypto_SOURCE_DIR})
-    set(IPP_CRYPTO_INCLUDES ${ipp_crypto_INCLUDE_DIRS})
+    message(STATUS "Include ipp-crypto(*).")
+    include(ipp-crypto)
   endif()
 
   # TVM
@@ -1540,10 +1535,6 @@ if (onnxruntime_USE_TVM)
   endif()
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES tvm ${FS_STDLIB})
   list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES tvm)
-  if (onnxruntime_TVM_USE_HASH)
-    list(APPEND onnxruntime_EXTERNAL_LIBRARIES ippcp_s)
-    list(APPEND onnxruntime_EXTERNAL_DEPENDENCIES ippcp_s)
-  endif()
 endif()
 
 # XNNPACK EP

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1499,7 +1499,6 @@ if (onnxruntime_USE_TVM)
 
   # ipp-crypto
   if (onnxruntime_TVM_USE_HASH)
-    set(ARCH intel64 CACHE STRING "Only defined for TVM")
     add_subdirectory(${ipp_crypto_SOURCE_DIR} ${ipp_crypto_BINARY_DIR} EXCLUDE_FROM_ALL)
     set_target_properties(ippcp_s PROPERTIES FOLDER ${ipp_crypto_SOURCE_DIR})
     set(IPP_CRYPTO_INCLUDES ${ipp_crypto_INCLUDE_DIRS})

--- a/cmake/external/ipp-crypto.cmake
+++ b/cmake/external/ipp-crypto.cmake
@@ -1,17 +1,59 @@
-if (onnxruntime_USE_TVM)
-    message(STATUS "onnxruntime_USE_TVM: Fetch ipp-crypto for TVM EP")
+message(STATUS "Build external project ipp-crypto")
 
-    FetchContent_Declare(
-            ipp_crypto
-            GIT_REPOSITORY https://github.com/intel/ipp-crypto.git
-            GIT_TAG        ippcp_2021.5
-    )
+set(IPP_CRYPTO_URL https://github.com/intel/ipp-crypto.git)
+set(IPP_CRYPTO_TAG "ippcp_2021.5")
+set(IPP_CRYPTO_PREFIX ipp_crypto)
+set(IPP_CRYPTO_ARCH intel64)
+set(IPP_CRYPTO_CONFIG_TYPE RELEASE)
+set(IPP_CRYPTO_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/${IPP_CRYPTO_PREFIX}-src)
+set(IPP_CRYPTO_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/${IPP_CRYPTO_PREFIX}-build)
+set(IPP_CRYPTO_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/${IPP_CRYPTO_PREFIX}-src/include)
 
-    FetchContent_GetProperties(ipp_crypto)
-    if(NOT ipp_crypto_POPULATED)
-        FetchContent_Populate(ipp_crypto)
-    endif()
-
-    set(ipp_crypto_INCLUDE_DIRS ${ipp_crypto_SOURCE_DIR}/include)
-
+set(IPP_CRYPTO_CONFIGURE_ARGS -DCMAKE_BUILD_TYPE=${IPP_CRYPTO_CONFIG_TYPE} -DCMAKE_INSTALL_PREFIX=${IPP_CRYPTO_BIN_DIR}/bin)
+if (WIN32)
+  set(IPP_CRYPTO_ARCH ${CMAKE_GENERATOR_PLATFORM})
+  list(APPEND IPP_CRYPTO_CONFIGURE_ARGS -A${CMAKE_GENERATOR_PLATFORM} -G${CMAKE_GENERATOR_INSTANCE})
+else()
+  list(APPEND IPP_CRYPTO_CONFIGURE_ARGS -DARCH=${IPP_CRYPTO_ARCH})
 endif()
+
+set(IPP_CRYPTO_BUILD_COMMAND)
+if (WIN32)
+  set(IPP_CRYPTO_BUILD_COMMAND ${CMAKE_COMMAND} --build . --parallel 4 --target ALL_BUILD --config ${IPP_CRYPTO_CONFIG_TYPE})
+else()
+  set(IPP_CRYPTO_BUILD_COMMAND make all)
+endif()
+
+include(ExternalProject)
+ExternalProject_Add(ippcp
+  PREFIX ${IPP_CRYPTO_PREFIX}
+  GIT_REPOSITORY ${IPP_CRYPTO_URL}
+  GIT_TAG ${IPP_CRYPTO_TAG}
+  SOURCE_DIR ${IPP_CRYPTO_SOURCE_DIR}
+  BINARY_DIR ${IPP_CRYPTO_BIN_DIR}
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} ${IPP_CRYPTO_CONFIGURE_ARGS} ${IPP_CRYPTO_SOURCE_DIR}
+  BUILD_COMMAND ${IPP_CRYPTO_BUILD_COMMAND}
+  INSTALL_COMMAND ""
+)
+
+set(IPP_CRYPTO_LIB_DIR ${IPP_CRYPTO_BIN_DIR}/.build/${IPP_CRYPTO_CONFIG_TYPE}/lib)
+add_library(ippcp_s SHARED IMPORTED)
+set_target_properties(ippcp_s PROPERTIES
+     MAP_IMPORTED_CONFIG_RELEASE ${IPP_CRYPTO_CONFIG_TYPE}
+     MAP_IMPORTED_CONFIG_DEBUG ${IPP_CRYPTO_CONFIG_TYPE}
+     MAP_IMPORTED_CONFIG_RELWITHDEBUGINFO ${IPP_CRYPTO_CONFIG_TYPE}
+     MAP_IMPORTED_CONFIG_MINSIZEREL ${IPP_CRYPTO_CONFIG_TYPE}
+)
+if (WIN32)
+  set_target_properties(ippcp_s PROPERTIES
+    IMPORTED_IMPLIB_${IPP_CRYPTO_CONFIG_TYPE} "${IPP_CRYPTO_LIB_DIR}/ippcp.lib"
+    IMPORTED_LOCATION_${IPP_CRYPTO_CONFIG_TYPE} "${IPP_CRYPTO_LIB_DIR}/ippcp.dll"
+  )
+else()
+  set(IPP_CRYPTO_LIB_PATH "${IPP_CRYPTO_LIB_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}ippcp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set_target_properties(ippcp_s PROPERTIES
+    IMPORTED_LOCATION ${IPP_CRYPTO_LIB_PATH}
+    IMPORTED_LOCATION_${IPP_CRYPTO_CONFIG_TYPE} ${IPP_CRYPTO_LIB_PATH}
+  )
+endif()
+add_dependencies(ippcp_s ippcp)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1482,12 +1482,8 @@ if (onnxruntime_USE_TVM)
 
   target_include_directories(onnxruntime_providers_tvm PRIVATE
           ${TVM_INCLUDES}
-          ${IPP_CRYPTO_INCLUDES}
           ${PYTHON_INLCUDE_DIRS})
   onnxruntime_add_include_to_target(onnxruntime_providers_tvm onnxruntime_common onnx tvm)
-  if (onnxruntime_TVM_USE_HASH)
-    onnxruntime_add_include_to_target(onnxruntime_providers_tvm ippcp_s)
-  endif()
 
   add_dependencies(onnxruntime_providers_tvm ${onnxruntime_EXTERNAL_DEPENDENCIES})
 
@@ -1498,9 +1494,9 @@ if (onnxruntime_USE_TVM)
       onnxruntime_framework
   )
   if (onnxruntime_TVM_USE_HASH)
-    target_link_libraries(onnxruntime_providers_tvm PRIVATE
-      ippcp_s
-    )
+    add_dependencies(onnxruntime_providers_tvm ippcp_s)
+    target_include_directories(onnxruntime_providers_tvm PRIVATE ${IPP_CRYPTO_INCLUDE_DIR})
+    target_link_libraries(onnxruntime_providers_tvm PRIVATE ippcp_s)
   endif()
 
   set_target_properties(onnxruntime_providers_tvm PROPERTIES FOLDER "ONNXRuntime")

--- a/docs/TVM_EP.md
+++ b/docs/TVM_EP.md
@@ -110,8 +110,13 @@ winget install nasm -i
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Add it to PATH (instruction for Windows GUI can be seen [here](https://www.computerhope.com/issues/ch000549.htm#dospath)) or by cmd:
-```
+```cmd
 set PATH="%PATH%;C:\Program Files\NASM"
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+or
+```cmd
+setx PATH "%PATH%;C:\Program Files\NASM"
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 Check by `nasm --version` in prompt command line.<br>
@@ -119,7 +124,14 @@ Check by `nasm --version` in prompt command line.<br>
 2. install openssl on windows by msi-file from [here](https://slproweb.com/products/Win32OpenSSL.html)
 Add path to directory (e.g. "C:\Program Files\OpenSSL-Win64\bin") with executable file to PATH (see instructions above).<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-Check by `openssl version` in prompt command line.
+Check by `openssl version` in prompt command line.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+3. Correct build of ipp-crytpo requires specific environment variables for supported MSVC compiler. Long way to adjust the environment is to follow to instructions [here](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170&viewFallbackFrom=vs-2017). Quick way is to use VS Developer command prompt where the environment have been already adjusted or add some paths to standard Windows command prompt:
+```cmd
+set INCLUDE=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\include;C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt
+```
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Take into account that MSVC and Kit versions are specific for Visual Studio built on the machine, specified values here are used as example.
 <br>
 <br>
 
@@ -148,7 +160,7 @@ build.bat --config Release --enable_pybind --build_wheel --skip_tests --parallel
 ```
 build.bat --config Release --enable_pybind --build_wheel --skip_tests --parallel --use_tvm --skip_onnx_tests --cmake_generator "Visual Studio 17 2022" --llvm_config <path_to_llvm_root>/build/Release/bin/llvm-config.exe --use_cuda --cudnn_home “C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.*” --cuda_home “C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.*”
 ```
-In both cases (CPU, GPU) there are the following options for cmake generator: "Visual Studio 15 2017", "Visual Studio 16 2019", "Visual Studio 17 2022" and "Ninja"
+In both cases (CPU, GPU) there are the following options for cmake generator: "Visual Studio 15 2017", "Visual Studio 16 2019", "Visual Studio 17 2022" and "Ninja". Also handshake mechanism can be switched on by `--use_tvm_hash` flag. At the latter case ipp-crypto library is built with dependencies, see details above.
 - Install python wheel package for ONNX Runtime:<br>
 Default path to the package is `<path_to_onnxruntime_root>/build/Windows/Release/Release/dist`. Note that it is different in comparison with path to the package on Linux. Before installation check names of wheel packages and use corresponding one. It can be looked like the following:
 ```cmd


### PR DESCRIPTION
**Description**:
- CMake files was updated for build external project ipp-crypto on Windows.
- TVM_EP.md was updated.

**Motivation and Context**
- Intel ipp-crypto is used by TVM EP for supporting of handshake mechanism which allows to match onnx model and performance library obtained for it.
- Intel ipp-crypto has some specifics for build on Windows which does not allow to build it together with ORT project. Particularly it strongly uses NASM compiler for .asm files, the compiler conflicts with default one used for ORT.
