### PR TITLE
Update android-x86_64-crosscompile-ci-pipeline.yml for Azure Pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -141,7 +141,7 @@ jobs:
         --android \
         --build_dir build \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=30 \
         --build_java \


### PR DESCRIPTION
Because the var ANDROID_NDK_HOME has been removed.

To verify, compare:
1. https://github.com/actions/virtual-environments/blob/macOS-11/20220724.1/images/macos/macos-11-Readme.md
2. https://github.com/actions/virtual-environments/blob/macOS-11/20220719.1/images/macos/macos-11-Readme.md
3. 