### PR TITLE
Fix: Android workflow fails due to ndk-bundle deprecated

### DIFF
--- a/tools/ci_build/github/android/fix_ndkbundle.sh
+++ b/tools/ci_build/github/android/fix_ndkbundle.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# according to https://github.com/actions/virtual-environments/issues/5879
+set -ex
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    function get_full_ndk_version {
+        majorVersion=$1
+        ndkVersion=$(${SDKMANAGER} --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+        echo "$ndkVersion"
+    }
+    ANDROID_HOME=$HOME/Library/Android/sdk
+    SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+    ndkDefault=$(get_full_ndk_version "23")
+    ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
+fi
+
+if [[ "$(uname -s)" == 'Linux' ]]; then
+    function get_full_ndk_version {
+        majorVersion=$1
+        ndkFullVersion=$($SDKMANAGER --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+        echo "$ndkFullVersion"
+    }
+    ANDROID_ROOT=/usr/local/lib/android
+    ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+    ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+    SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+    ndkDefaultFullVersion=$(get_full_ndk_version "23")
+    ln -sf $ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion $ANDROID_NDK_ROOT
+fi

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -304,14 +304,15 @@ jobs:
     - script: |
         function get_full_ndk_version {
             majorVersion=$1
-            ndkVersion=$(${SDKMANAGER} --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
-            echo "$ndkVersion"
+            ndkFullVersion=$($SDKMANAGER --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+            echo "$ndkFullVersion"
         }
-        ANDROID_HOME=$HOME/Library/Android/sdk
-        SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
-        ndkDefault=$(get_full_ndk_version "23")
-        ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
-        python3 tools/ci_build/build.py \
+        ANDROID_ROOT=/usr/local/lib/android
+        ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+        ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+        SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+        ndkDefaultFullVersion=$(get_full_ndk_version "23")
+        ln -sf $ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion $ANDROID_NDK_ROOT
         --android \
         --build_dir build_nnapi \
         --android_sdk_path $ANDROID_HOME \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -35,6 +35,15 @@ jobs:
     displayName: Build Host Protoc
 
   - script: |
+      function get_full_ndk_version {
+          majorVersion=$1
+          ndkVersion=$(${SDKMANAGER} --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+          echo "$ndkVersion"
+      }
+      ANDROID_HOME=$HOME/Library/Android/sdk
+      SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+      ndkDefault=$(get_full_ndk_version "23")
+      ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
       export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
       export ANDROID_HOME=/usr/local/lib/android/sdk
       export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
@@ -293,6 +302,15 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        function get_full_ndk_version {
+            majorVersion=$1
+            ndkVersion=$(${SDKMANAGER} --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+            echo "$ndkVersion"
+        }
+        ANDROID_HOME=$HOME/Library/Android/sdk
+        SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+        ndkDefault=$(get_full_ndk_version "23")
+        ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -35,15 +35,6 @@ jobs:
     displayName: Build Host Protoc
 
   - script: |
-      function get_full_ndk_version {
-          majorVersion=$1
-          ndkVersion=$(${SDKMANAGER} --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
-          echo "$ndkVersion"
-      }
-      ANDROID_HOME=$HOME/Library/Android/sdk
-      SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
-      ndkDefault=$(get_full_ndk_version "23")
-      ln -s $ANDROID_HOME/ndk/$ndkDefault $ANDROID_HOME/ndk-bundle
       export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
       export ANDROID_HOME=/usr/local/lib/android/sdk
       export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
@@ -61,6 +52,7 @@ jobs:
       jdkSourceOption: 'PreInstalled'
 
   - script: |
+      source $(Build.SourcesDirectory)/tools/ci_build/github/android/fix_ndkbundle.sh
       python3 tools/ci_build/build.py \
         --android \
         --build_dir build \
@@ -146,6 +138,7 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        source $(Build.SourcesDirectory)/tools/ci_build/github/android/fix_ndkbundle.sh
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build \
@@ -210,6 +203,7 @@ jobs:
       jdkSourceOption: 'PreInstalled'
 
   - script: |
+      source $(Build.SourcesDirectory)/tools/ci_build/github/android/fix_ndkbundle.sh
       python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \
@@ -302,17 +296,8 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
-        function get_full_ndk_version {
-            majorVersion=$1
-            ndkFullVersion=$($SDKMANAGER --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
-            echo "$ndkFullVersion"
-        }
-        ANDROID_ROOT=/usr/local/lib/android
-        ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-        ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-        SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-        ndkDefaultFullVersion=$(get_full_ndk_version "23")
-        ln -sf $ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion $ANDROID_NDK_ROOT
+        source $(Build.SourcesDirectory)/tools/ci_build/github/android/fix_ndkbundle.sh
+        python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \
         --android_sdk_path $ANDROID_HOME \
@@ -401,6 +386,7 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        source $(Build.SourcesDirectory)/tools/ci_build/github/android/fix_ndkbundle.sh
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \


### PR DESCRIPTION
**Description**: 
recreated ndk-bundle symbol link

**Motivation and Context**
ndk-bundle is deprecated, which breaks the Android workflow.
https://github.com/actions/virtual-environments/issues/5879
