### PR TITLE
replace ANDROID_NDK_HOME as ANDROID_NDK_LATEST_HOME

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -112,6 +112,11 @@ jobs:
       displayName: Setup gradle wrapper to use gradle 6.8.3
 
     - script: |
+      set -ex
+      ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
+      displayName: install ndk 21.0
+
+    - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
         --create-avd --system-image "system-images;android-30;google_apis;x86_64" \
@@ -129,7 +134,6 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
-        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build \
@@ -262,6 +266,11 @@ jobs:
       displayName: Setup gradle wrapper to use gradle 6.8.3
 
     - script: |
+        set -ex
+        ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
+      displayName: install ndk 21.0
+
+    - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
         --create-avd --system-image "system-images;android-30;google_apis;x86_64" \
@@ -279,7 +288,6 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
-        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \
@@ -352,6 +360,9 @@ jobs:
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
 
+    - script: ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
+      displayName: install ndk 21.0
+
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -369,7 +380,6 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
-        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -1,7 +1,7 @@
 # Known Limits
 # 1. Anchors are not supported in GHA
 # https://github.community/t/support-for-yaml-anchors/16128/90
-# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM, 
+# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM,
 # which is the no.1 blocker for running tests on modern Android Emulators (especially on recent API levels) on CI.
 
 jobs:
@@ -75,7 +75,7 @@ jobs:
       overWrite: true
 
   - task: CopyFiles@2
-    displayName: Copy test data 
+    displayName: Copy test data
     inputs:
       contents: 'build/**/testdata/**'
       targetFolder: $(Build.ArtifactStagingDirectory)
@@ -84,7 +84,9 @@ jobs:
   - task: CopyFiles@2
     displayName: Copy test executables
     inputs:
-      contents: 'build/Debug/*'
+      contents: |
+        build/Debug/*
+        build/Debug/java/androidtest/android/**
       targetFolder: $(Build.ArtifactStagingDirectory)
       overWrite: true
 
@@ -114,6 +116,9 @@ jobs:
         artifact: 'CPUBuildOutput'
         path: $(Build.SourcesDirectory)
 
+    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
+      displayName: Setup gradle wrapper to use gradle 6.8.3
+
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -121,6 +126,15 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android emulator
+
+    # Start switching to jdk 11 after the Android Emulator is started
+    # since Android SDK manager requires java 8
+    - task: JavaToolInstaller@0
+      displayName: Use jdk 11
+      inputs:
+        versionSpec: '11'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
 
     - script: |
         python3 tools/ci_build/build.py \
@@ -130,6 +144,7 @@ jobs:
         --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=30 \
+        --build_java \
         --test
       displayName: CPU EP, Test on Android Emulator
 
@@ -219,7 +234,9 @@ jobs:
   - task: CopyFiles@2
     displayName: Copy Test Executables
     inputs:
-      contents: 'build_nnapi/Debug/*'
+      contents: |
+        build_nnapi/Debug/*
+        build_nnapi/Debug/java/androidtest/android/**
       targetFolder: $(Build.ArtifactStagingDirectory)
       overWrite: true
 
@@ -227,7 +244,7 @@ jobs:
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: NNAPIBuildOutput
-      
+
   - template: templates/clean-agent-build-directory-step.yml
 
 - job: Test_NNAPI_EP
@@ -255,6 +272,9 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
+    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
+      displayName: Setup gradle wrapper to use gradle 6.8.3
+
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -262,7 +282,16 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android emulator
-      
+
+    # Start switching to jdk 11 after the Android Emulator is started
+    # since Android SDK manager requires java 8
+    - task: JavaToolInstaller@0
+      displayName: Use jdk 11
+      inputs:
+        versionSpec: '11'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+
     - script: |
         python3 tools/ci_build/build.py \
         --android \
@@ -271,6 +300,7 @@ jobs:
         --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=29 \
+        --build_java \
         --use_nnapi \
         --test
       displayName: NNAPI EP, Test, CodeCoverage on Android Emulator
@@ -287,18 +317,6 @@ jobs:
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
 
-    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
-      displayName: Setup gradle wrapper to use gradle 6.8.3
-
-    # Start switching to jdk 11 after the Android Emulator is started
-    # since Android SDK manager requires java 8
-    - task: JavaToolInstaller@0
-      displayName: Use jdk 11
-      inputs:
-        versionSpec: '11'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
-
     - script: /bin/bash tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh $(pwd)
       # Build Minimal ORT with NNAPI and reduced Ops, run unit tests on Android Emulator
       displayName: Build Minimal ORT with NNAPI and run tests
@@ -310,7 +328,7 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-      
+
     - template: templates/clean-agent-build-directory-step.yml
 
 # The below jobs only run on master build
@@ -346,7 +364,7 @@ jobs:
           $(Build.BinariesDirectory)/protobuf \
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
- 
+
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -380,7 +398,7 @@ jobs:
         --build_java \
         --code_coverage
       displayName: NNAPI EP, Build, Test, CodeCoverage on Android Emulator
-      
+
     - script: |
         python3 -m pip install gcovr && \
         python3 tools/ci_build/coverage.py \
@@ -408,9 +426,9 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-      
+
     - template: templates/clean-agent-build-directory-step.yml
-      
+
 - job: Update_Dashboard
   workspace:
     clean: all
@@ -419,7 +437,7 @@ jobs:
     value: true
   pool: 'Linux-CPU-2019'
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-  dependsOn: 
+  dependsOn:
   - Test_CPU_EP
   - NNAPI_EP_MASTER
   steps:
@@ -437,5 +455,5 @@ jobs:
         scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
         arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
         workingDirectory: '$(Build.BinariesDirectory)'
-      
+
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -34,14 +34,6 @@ jobs:
         $(Build.SourcesDirectory)/protobuf_install
     displayName: Build Host Protoc
 
-  - script: |
-      export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
-      export ANDROID_HOME=/usr/local/lib/android/sdk
-      export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-      export ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk-bundle
-      env | grep ANDROID
-    displayName: Set Android ENVs
-
   # Start switching to jdk 11 after the Android Emulator is started
   # since Android SDK manager requires java 8
   - task: JavaToolInstaller@0
@@ -184,13 +176,6 @@ jobs:
         $(Build.SourcesDirectory)/protobuf_install
     displayName: Build Host Protoc
 
-  - script: |
-      export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
-      export ANDROID_HOME=/usr/local/lib/android/sdk
-      export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-      export ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk-bundle
-      env | grep ANDROID
-    displayName: set Android ENVs
 
   # Start switching to jdk 11 after the Android Emulator is started since Android SDK manager requires java 8
   - task: JavaToolInstaller@0

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -129,6 +129,7 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build \
@@ -278,6 +279,7 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \
@@ -367,6 +369,7 @@ jobs:
         jdkSourceOption: 'PreInstalled'
 
     - script: |
+        sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
         python3 tools/ci_build/build.py \
         --android \
         --build_dir build_nnapi \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -56,7 +56,7 @@ jobs:
         --android \
         --build_dir build \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=30 \
         --skip_submodule_sync \
@@ -141,7 +141,7 @@ jobs:
         --android \
         --build_dir build \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=30 \
         --build_java \
@@ -205,7 +205,7 @@ jobs:
         --android \
         --build_dir build_nnapi \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=29 \
         --skip_submodule_sync \
@@ -297,7 +297,7 @@ jobs:
         --android \
         --build_dir build_nnapi \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=29 \
         --build_java \
@@ -386,7 +386,7 @@ jobs:
         --android \
         --build_dir build_nnapi \
         --android_sdk_path $ANDROID_HOME \
-        --android_ndk_path $ANDROID_NDK_HOME \
+        --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=29 \
         --skip_submodule_sync \

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -1,7 +1,7 @@
 # Known Limits
 # 1. Anchors are not supported in GHA
 # https://github.community/t/support-for-yaml-anchors/16128/90
-# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM,
+# 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM, 
 # which is the no.1 blocker for running tests on modern Android Emulators (especially on recent API levels) on CI.
 
 jobs:
@@ -75,7 +75,7 @@ jobs:
       overWrite: true
 
   - task: CopyFiles@2
-    displayName: Copy test data
+    displayName: Copy test data 
     inputs:
       contents: 'build/**/testdata/**'
       targetFolder: $(Build.ArtifactStagingDirectory)
@@ -84,9 +84,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Copy test executables
     inputs:
-      contents: |
-        build/Debug/*
-        build/Debug/java/androidtest/android/**
+      contents: 'build/Debug/*'
       targetFolder: $(Build.ArtifactStagingDirectory)
       overWrite: true
 
@@ -116,9 +114,6 @@ jobs:
         artifact: 'CPUBuildOutput'
         path: $(Build.SourcesDirectory)
 
-    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
-      displayName: Setup gradle wrapper to use gradle 6.8.3
-
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -126,15 +121,6 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android emulator
-
-    # Start switching to jdk 11 after the Android Emulator is started
-    # since Android SDK manager requires java 8
-    - task: JavaToolInstaller@0
-      displayName: Use jdk 11
-      inputs:
-        versionSpec: '11'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
 
     - script: |
         python3 tools/ci_build/build.py \
@@ -144,7 +130,6 @@ jobs:
         --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=30 \
-        --build_java \
         --test
       displayName: CPU EP, Test on Android Emulator
 
@@ -234,9 +219,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Copy Test Executables
     inputs:
-      contents: |
-        build_nnapi/Debug/*
-        build_nnapi/Debug/java/androidtest/android/**
+      contents: 'build_nnapi/Debug/*'
       targetFolder: $(Build.ArtifactStagingDirectory)
       overWrite: true
 
@@ -244,7 +227,7 @@ jobs:
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
       artifactName: NNAPIBuildOutput
-
+      
   - template: templates/clean-agent-build-directory-step.yml
 
 - job: Test_NNAPI_EP
@@ -272,9 +255,6 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
-    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
-      displayName: Setup gradle wrapper to use gradle 6.8.3
-
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -282,16 +262,7 @@ jobs:
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android emulator
-
-    # Start switching to jdk 11 after the Android Emulator is started
-    # since Android SDK manager requires java 8
-    - task: JavaToolInstaller@0
-      displayName: Use jdk 11
-      inputs:
-        versionSpec: '11'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
-
+      
     - script: |
         python3 tools/ci_build/build.py \
         --android \
@@ -300,7 +271,6 @@ jobs:
         --android_ndk_path $ANDROID_NDK_LATEST_HOME \
         --android_abi=x86_64 \
         --android_api=29 \
-        --build_java \
         --use_nnapi \
         --test
       displayName: NNAPI EP, Test, CodeCoverage on Android Emulator
@@ -317,6 +287,18 @@ jobs:
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
 
+    - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
+      displayName: Setup gradle wrapper to use gradle 6.8.3
+
+    # Start switching to jdk 11 after the Android Emulator is started
+    # since Android SDK manager requires java 8
+    - task: JavaToolInstaller@0
+      displayName: Use jdk 11
+      inputs:
+        versionSpec: '11'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+
     - script: /bin/bash tools/ci_build/github/linux/ort_minimal/nnapi_minimal_build_minimal_ort_and_run_tests.sh $(pwd)
       # Build Minimal ORT with NNAPI and reduced Ops, run unit tests on Android Emulator
       displayName: Build Minimal ORT with NNAPI and run tests
@@ -328,7 +310,7 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-
+      
     - template: templates/clean-agent-build-directory-step.yml
 
 # The below jobs only run on master build
@@ -364,7 +346,7 @@ jobs:
           $(Build.BinariesDirectory)/protobuf \
           $(Build.SourcesDirectory)/protobuf_install
       displayName: Build Host Protoc
-
+ 
     - script: |
         python3 tools/python/run_android_emulator.py \
         --android-sdk-root ${ANDROID_SDK_ROOT} \
@@ -398,7 +380,7 @@ jobs:
         --build_java \
         --code_coverage
       displayName: NNAPI EP, Build, Test, CodeCoverage on Android Emulator
-
+      
     - script: |
         python3 -m pip install gcovr && \
         python3 tools/ci_build/coverage.py \
@@ -426,9 +408,9 @@ jobs:
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Stop Android emulator
       condition: always()
-
+      
     - template: templates/clean-agent-build-directory-step.yml
-
+      
 - job: Update_Dashboard
   workspace:
     clean: all
@@ -437,7 +419,7 @@ jobs:
     value: true
   pool: 'Linux-CPU-2019'
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-  dependsOn:
+  dependsOn: 
   - Test_CPU_EP
   - NNAPI_EP_MASTER
   steps:
@@ -455,5 +437,5 @@ jobs:
         scriptPath: $(Build.SourcesDirectory)/tools/ci_build/github/linux/upload_code_coverage_data.sh
         arguments: '"$(Build.BinariesDirectory)/coverage_rpt.txt" "https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=$(Build.BuildId)" arm android nnapi'
         workingDirectory: '$(Build.BinariesDirectory)'
-
+      
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -112,8 +112,8 @@ jobs:
       displayName: Setup gradle wrapper to use gradle 6.8.3
 
     - script: |
-      set -ex
-      ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
+        set -ex
+        ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669"
       displayName: install ndk 21.0
 
     - script: |


### PR DESCRIPTION
**Description**: 
replace deprecated ANDROID_NDK_HOME as ANDROID_NDK_LATEST_HOME

**Motivation and Context**
Android workflow failed due to deprecated ndk-bundle and retired ANDROID_NDK_HOME
