### PR TITLE
Use specific Android NDK version in CI builds.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -4,9 +4,6 @@
 # 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM,
 # which is the no.1 blocker for running tests on modern Android Emulators (especially on recent API levels) on CI.
 
-variables:
-  AndroidNdkVersion: "25.0.8775105"  # LTS version
-
 jobs:
 - job: Build_CPU_EP
   pool: Linux-CPU-2019
@@ -26,9 +23,7 @@ jobs:
   - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
     displayName: Install coreutils and ninja
 
-  - template: "templates/get-android-ndk.yml"
-    parameters:
-      AndroidNdkVersion: $(AndroidNdkVersion)
+  - template: "templates/use-android-ndk.yml"
 
   - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
     displayName: Setup gradle wrapper to use gradle 6.8.3
@@ -124,9 +119,7 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
-    - template: "templates/get-android-ndk.yml"
-      parameters:
-        AndroidNdkVersion: $(AndroidNdkVersion)
+    - template: "templates/use-android-ndk.yml"
 
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3
@@ -185,9 +178,7 @@ jobs:
   - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
     displayName: Install coreutils and ninja
 
-  - template: "templates/get-android-ndk.yml"
-    parameters:
-      AndroidNdkVersion: $(AndroidNdkVersion)
+  - template: "templates/use-android-ndk.yml"
 
   - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
     displayName: Setup gradle wrapper to use gradle 6.8.3
@@ -284,9 +275,7 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
-    - template: "templates/get-android-ndk.yml"
-      parameters:
-        AndroidNdkVersion: $(AndroidNdkVersion)
+    - template: "templates/use-android-ndk.yml"
 
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3
@@ -366,9 +355,7 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
-    - template: "templates/get-android-ndk.yml"
-      parameters:
-        AndroidNdkVersion: $(AndroidNdkVersion)
+    - template: "templates/use-android-ndk.yml"
 
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -4,6 +4,9 @@
 # 2. today most cloud-based CI services are still lacking hardware acceleration support from the host VM,
 # which is the no.1 blocker for running tests on modern Android Emulators (especially on recent API levels) on CI.
 
+variables:
+  AndroidNdkVersion: "25.0.8775105"  # LTS version
+
 jobs:
 - job: Build_CPU_EP
   pool: Linux-CPU-2019
@@ -23,6 +26,10 @@ jobs:
   - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
     displayName: Install coreutils and ninja
 
+  - template: "templates/get-android-ndk.yml"
+    parameters:
+      AndroidNdkVersion: $(AndroidNdkVersion)
+
   - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
     displayName: Setup gradle wrapper to use gradle 6.8.3
 
@@ -35,12 +42,8 @@ jobs:
     displayName: Build Host Protoc
 
   - script: |
-      export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
-      export ANDROID_HOME=/usr/local/lib/android/sdk
-      export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-      export ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk-bundle
       env | grep ANDROID
-    displayName: Set Android ENVs
+    displayName: View Android ENVs
 
   # Start switching to jdk 11 after the Android Emulator is started
   # since Android SDK manager requires java 8
@@ -116,6 +119,15 @@ jobs:
         artifact: 'CPUBuildOutput'
         path: $(Build.SourcesDirectory)
 
+    - task: UsePythonVersion@0
+      displayName: Use Python $(pythonVersion)
+      inputs:
+        versionSpec: $(pythonVersion)
+
+    - template: "templates/get-android-ndk.yml"
+      parameters:
+        AndroidNdkVersion: $(AndroidNdkVersion)
+
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3
 
@@ -173,6 +185,10 @@ jobs:
   - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
     displayName: Install coreutils and ninja
 
+  - template: "templates/get-android-ndk.yml"
+    parameters:
+      AndroidNdkVersion: $(AndroidNdkVersion)
+
   - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
     displayName: Setup gradle wrapper to use gradle 6.8.3
 
@@ -185,12 +201,8 @@ jobs:
     displayName: Build Host Protoc
 
   - script: |
-      export ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
-      export ANDROID_HOME=/usr/local/lib/android/sdk
-      export ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
-      export ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk-bundle
       env | grep ANDROID
-    displayName: set Android ENVs
+    displayName: View Android ENVs
 
   # Start switching to jdk 11 after the Android Emulator is started since Android SDK manager requires java 8
   - task: JavaToolInstaller@0
@@ -272,6 +284,10 @@ jobs:
       inputs:
         versionSpec: $(pythonVersion)
 
+    - template: "templates/get-android-ndk.yml"
+      parameters:
+        AndroidNdkVersion: $(AndroidNdkVersion)
+
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3
 
@@ -349,6 +365,10 @@ jobs:
       displayName: Use Python $(pythonVersion)
       inputs:
         versionSpec: $(pythonVersion)
+
+    - template: "templates/get-android-ndk.yml"
+      parameters:
+        AndroidNdkVersion: $(AndroidNdkVersion)
 
     - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(pwd)
       displayName: Setup gradle wrapper to use gradle 6.8.3

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -37,6 +37,8 @@ jobs:
       artifactName: '${{parameters.artifactName}}'
       targetPath: '$(Build.BinariesDirectory)/final-android-aar'
 
+  - template: use-android-ndk.yml
+
   - script: /bin/bash tools/ci_build/github/android/setup_gradle_wrapper.sh $(Build.SourcesDirectory)
     displayName: Setup gradle wrapper to use gradle 6.8.3
 

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar.yml
@@ -72,6 +72,8 @@ jobs:
       DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
       Repository: onnxruntimecpubuild
 
+  - template: use-android-ndk.yml
+
   - task: CmdLine@2
     displayName: Build Android AAR Packages
     inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/get-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/get-android-ndk.yml
@@ -1,0 +1,30 @@
+# Installs specified version of Android NDK and sets environment variables ANDROID_NDK_HOME and ANDROID_NDK_ROOT to
+# refer to it.
+
+  parameters:
+  - name: AndroidNdkVersion
+    type: string
+
+  steps:
+  - bash: |
+      set -e
+
+      "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;${{ parameters.AndroidNdkVersion }}"
+
+      NDK_PATH="${ANDROID_SDK_ROOT}/ndk/${{ parameters.AndroidNdkVersion }}"
+      if [[ ! -d "${NDK_PATH}" ]]; then
+        echo "NDK directory is not in expected location: ${NDK_PATH}"
+        exit 1
+      fi
+
+      set_var() {
+        local VAR_NAME=${1:?}
+        local VAR_VALUE=${2:?}
+        echo "##vso[task.setvariable variable=${VAR_NAME}]${VAR_VALUE}"
+        echo "${VAR_NAME}: ${VAR_VALUE}"
+      }
+
+      set_var "ANDROID_NDK_HOME" "${NDK_PATH}"
+      set_var "ANDROID_NDK_ROOT" "${NDK_PATH}"
+
+    displayName: Get Android NDK ${{ parameters.AndroidNdkVersion }}

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -1,9 +1,9 @@
-# Installs specified version of Android NDK and sets environment variables ANDROID_NDK_HOME and ANDROID_NDK_ROOT to
-# refer to it.
+# Installs the Android NDK and sets environment variables ANDROID_NDK_HOME and ANDROID_NDK_ROOT to refer to it.
 
   parameters:
   - name: AndroidNdkVersion
     type: string
+    default: "25.0.8775105"  # LTS version
 
   steps:
   - bash: |
@@ -27,4 +27,4 @@
       set_var "ANDROID_NDK_HOME" "${NDK_PATH}"
       set_var "ANDROID_NDK_ROOT" "${NDK_PATH}"
 
-    displayName: Get Android NDK ${{ parameters.AndroidNdkVersion }}
+    displayName: Use Android NDK ${{ parameters.AndroidNdkVersion }}


### PR DESCRIPTION
**Description**
Current builds use a NDK version that happens to be on the build machine. The build machine environment may change in ways that are outside of our control.
This change installs a specific version of NDK (the current LTS version 25.0.8775105) and uses it.

**Motivation and Context**
Fix Android CI build, be explicit about the NDK version.
Related PRs: #12341 and #12345