### PR TITLE
Remove preview keyword from DirectML pacakge

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -208,7 +208,7 @@ def generate_dependencies(xml_text, package_name, version, dependency_id, depend
 
         xml_text.append("</dependencies>")
     else:
-        include_dml = package_name == "Microsoft.ML.OnnxRuntime.DirectML.Preview"
+        include_dml = package_name == "Microsoft.ML.OnnxRuntime.DirectML"
 
         xml_text.append("<dependencies>")
         # Support .Net Core


### PR DESCRIPTION
**Description**: There is a bug which adds DirectML as a dependency only when Preview keyword is present. So removing that keyword.