### PR TITLE
Scope CreateFileMapping2 to valid API partitions

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -369,7 +369,7 @@ class WindowsEnv : public Env {
           " - ", std::system_category().message(error_code));
     }
 
-#if NTDDI_VERSION >= NTDDI_WIN10_RS5
+#if NTDDI_VERSION >= NTDDI_WIN10_RS5 && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
     wil::unique_hfile file_mapping_handle{
         CreateFileMapping2(file_handle.get(),
                            nullptr,


### PR DESCRIPTION
**Description**: 
Limits the use of `CreateFileMapping2` to API partitions that support it.

**Motivation and Context**
This change is necessary to build for WINAPI_FAMILY_GAMES, which is used with the GDK toolchain. The header that exposes the `CreateFileMapping2` API limits it to desktop and system partitions (not just NTDDI_WIN10_RS5), so compiling with WINAPI_FAMILY_GAMES will fail with an unresolved symbol. See the declaration of this API from `memoryapi.h`

```cpp
#if (NTDDI_VERSION >= NTDDI_WIN10_RS5)

#pragma region Desktop Family or OneCore Family
#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)

WINBASEAPI
_Ret_maybenull_
HANDLE
WINAPI
CreateFileMapping2(
    _In_ HANDLE File,
    _In_opt_ SECURITY_ATTRIBUTES* SecurityAttributes,
    _In_ ULONG DesiredAccess,
    _In_ ULONG PageProtection,
    _In_ ULONG AllocationAttributes,
    _In_ ULONG64 MaximumSize,
    _In_opt_ PCWSTR Name,
    _Inout_updates_opt_(ParameterCount) MEM_EXTENDED_PARAMETER* ExtendedParameters,
    _In_ ULONG ParameterCount
    );

#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM) */
#pragma endregion
```