### PR TITLE
Add cast before copy for dissimilar scalar type

### DIFF
--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -666,10 +666,10 @@ at::Tensor& copy_(
   if (self.scalar_type() != src.scalar_type()) {
     // invoke cast first
     if(self.device().type() != src.device().type()){
-      auto src_invoker = GetORTInvoker(src.device());
-      auto val = CastToType(src_invoker, ort_src, self.scalar_type());
-      copy_(self, aten_tensor_from_ort(std::move(val), src.options()), false);
+      auto val = at::native::to(src, self.scalar_type());
+      copy_(self, val, false);
     }else{
+      //Will we ever encounter a case when Scalar type is different but device type is the same?
       std::vector<OrtValue> ort_cast_output(1);
       onnxruntime::NodeAttributes attrs(1);
       attrs["to"] = create_ort_attribute(

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -668,7 +668,7 @@ at::Tensor& copy_(
     if(self.device().type() != src.device().type()){
       auto src_invoker = GetORTInvoker(src.device());
       auto val = CastToType(src_invoker, ort_src, self.scalar_type());
-      copy_(self, aten_tensor_from_ort(std::move(val), src.options()));
+      copy_(self, aten_tensor_from_ort(std::move(val), src.options()), false);
     }else{
       std::vector<OrtValue> ort_cast_output(1);
       onnxruntime::NodeAttributes attrs(1);

--- a/orttraining/orttraining/eager/ort_aten.cpp
+++ b/orttraining/orttraining/eager/ort_aten.cpp
@@ -668,7 +668,7 @@ at::Tensor& copy_(
     if(self.device().type() != src.device().type()){
       auto src_invoker = GetORTInvoker(src.device());
       auto val = CastToType(src_invoker, ort_src, self.scalar_type());
-      copy_(aten_tensor_from_ort(std::move(val), src.options()), self);
+      copy_(self, aten_tensor_from_ort(std::move(val), src.options()));
     }else{
       std::vector<OrtValue> ort_cast_output(1);
       onnxruntime::NodeAttributes attrs(1);


### PR DESCRIPTION
For the copy_ operation, if the scalar type is different, we need to perform cast first. If self and src are of different device types, we need to ensure that the right invoker for src is called. This PR adds a potential fix for issue#12367 https://github.com/microsoft/onnxruntime/issues/12367