### PR TITLE
Compatibility patch for nlohmann/json < 3.9.0.

### DIFF
--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -75,7 +75,12 @@ static TestTolerances LoadTestTolerances(bool enable_cuda, bool enable_openvino)
   }
   const auto overrides_json = nlohmann::json::parse(
       overrides_ifstream,
-      /*cb=*/nullptr, /*allow_exceptions=*/true, /*ignore_comments=*/true);
+      /*cb=*/nullptr, /*allow_exceptions=*/true
+      // Comment support is added in 3.9.0 with breaking change to default behavior.
+      #if NLOHMANN_JSON_VERSION_MAJOR * 1000 + NLOHMANN_JSON_VERSION_MINOR >= 3009
+      , /*ignore_comments=*/true
+      #endif
+    );
   overrides_json["atol_overrides"].get_to(absolute_overrides);
   overrides_json["rtol_overrides"].get_to(relative_overrides);
   return TestTolerances(


### PR DESCRIPTION
This is required on CentOS 7 if using distro-provided json-devel 3.6.1.

Regression introduced in:
- https://github.com/microsoft/onnxruntime/pull/11775

Related upstream commit:
- https://github.com/nlohmann/json/commit/74520d8bb0aa62374e5c5465b5b0f3b43d75d956

Fixed https://github.com/microsoft/onnxruntime/issues/12393