### PR TITLE
Run IOS pipeline concurrently

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -1,10 +1,10 @@
 jobs:
-- job: iOS_CI_on_Mac
+- job: iOS_CI_CPU_on_Mac
   pool:
     vmImage: 'macOS-11'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
-  timeoutInMinutes: 150
+  timeoutInMinutes: 100
   steps:
     - script: |
         /bin/bash $(Build.SourcesDirectory)/tools/ci_build/github/apple/build_host_protoc.sh \
@@ -27,6 +27,21 @@ jobs:
           --path_to_protoc_exe $(Build.BinariesDirectory)/protobuf_install/bin/protoc \
           --parallel
       displayName: (CPU EP) Build onnxruntime for iOS x86_64 and run tests using simulator
+
+
+- job: iOS_CI_CoreML_on_Mac
+  pool:
+    vmImage: 'macOS-11'
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.14'
+  timeoutInMinutes: 100
+  steps:
+    - script: |
+        /bin/bash $(Build.SourcesDirectory)/tools/ci_build/github/apple/build_host_protoc.sh \
+          $(Build.SourcesDirectory) \
+          $(Build.BinariesDirectory)/protobuf \
+          $(Build.BinariesDirectory)/protobuf_install
+      displayName: Build Host Protoc
 
     - script: |
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \


### PR DESCRIPTION
**Description**:
Split IOS pipelines to 2 jobs to shorten pipeline duration

**Motivation and Context**
1. nearly 15% master build failed due to time out.
![image](https://user-images.githubusercontent.com/16190118/182090338-8a9f5fbb-8148-41df-a025-d83121ce3610.png)
(https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=134&_a=summary&view=branches)

2. The average succeeded runs duration is 2h28m
![image](https://user-images.githubusercontent.com/16190118/182090893-ade7ad47-9808-4cbd-a0f7-4aa1b98dc50e.png)
(https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=134&_a=summary&view=ms.vss-pipelineanalytics-web.new-build-definition-pipeline-analytics-view-cardmetrics)

**Mac Quota has been doubled. We could assign every build to individual machines rather than extend the time out limit**

related PR: #12399