### PR TITLE
Add CANN EP

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -105,6 +105,7 @@ option(onnxruntime_ARMNN_BN_USE_CPU "Use the CPU implementation for the Batch No
 option(onnxruntime_ENABLE_INSTRUMENT "Enable Instrument with Event Tracing for Windows (ETW)" OFF)
 option(onnxruntime_USE_TELEMETRY "Build with Telemetry" OFF)
 option(onnxruntime_USE_MIMALLOC "Override new/delete and arena allocator with mimalloc" OFF)
+option(onnxruntime_USE_CANN "Build with CANN support" OFF)
 #The onnxruntime_PREFER_SYSTEM_LIB is mainly designed for package managers like apt/yum/vcpkg.
 #Please note, by default Protobuf_USE_STATIC_LIBS is OFF but it's recommended to turn it ON on Windows. You should set it properly when onnxruntime_PREFER_SYSTEM_LIB is ON otherwise you'll hit linkage errors.
 #If you have already installed protobuf(or the others) in your system at the default system paths(like /usr/include), then it's better to set onnxruntime_PREFER_SYSTEM_LIB ON. Otherwise onnxruntime may see two different protobuf versions and we won't know which one will be used, the worst case could be onnxruntime picked up header files from one of them but the binaries from the other one.
@@ -1258,6 +1259,11 @@ if (onnxruntime_USE_XNNPACK)
   list(APPEND ORT_PROVIDER_FLAGS -DUSE_XNNPACK=1)
   list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_XNNPACK=1)
   list(APPEND ONNXRUNTIME_PROVIDER_NAMES xnnpack)
+endif()
+if (onnxruntime_USE_CANN)
+    list(APPEND ORT_PROVIDER_FLAGS  -DUSE_CANN=1)
+    list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_CANN=1)
+    list(APPEND ONNXRUNTIME_PROVIDER_NAMES cann)
 endif()
 
 function(onnxruntime_set_compile_flags target_name)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -154,6 +154,9 @@ endif()
 if(onnxruntime_USE_SNPE)
     include(onnxruntime_snpe_provider.cmake)
 endif()
+if (onnxruntime_USE_CANN)
+  set(PROVIDERS_CANN onnxruntime_providers_cann)
+endif()
 
 source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_common_srcs} ${onnxruntime_providers_srcs})
 
@@ -1533,6 +1536,38 @@ if (onnxruntime_USE_XNNPACK)
             RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
             FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif()
+endif()
+
+if (onnxruntime_USE_CANN)
+  add_definitions(-DUSE_CANN=1)
+  file(GLOB_RECURSE onnxruntime_providers_cann_cc_srcs CONFIGURE_DEPENDS
+    "${ONNXRUNTIME_ROOT}/core/providers/cann/*.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/cann/*.cc"
+  )
+
+  # The shared_library files are in a separate list since they use precompiled headers, and the above files have them disabled.
+  file(GLOB_RECURSE onnxruntime_providers_cann_shared_srcs CONFIGURE_DEPENDS
+    "${ONNXRUNTIME_ROOT}/core/providers/shared_library/*.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/shared_library/*.cc"
+  )
+
+  source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_cann_cc_srcs} ${onnxruntime_providers_cann_shared_srcs})
+  set(onnxruntime_providers_cann_src ${onnxruntime_providers_cann_cc_srcs} ${onnxruntime_providers_cann_shared_srcs})
+
+  onnxruntime_add_shared_library_module(onnxruntime_providers_cann ${onnxruntime_providers_cann_src})
+  onnxruntime_add_include_to_target(onnxruntime_providers_cann onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
+
+  add_dependencies(onnxruntime_providers_cann onnxruntime_providers_shared ${onnxruntime_EXTERNAL_DEPENDENCIES})
+  target_link_libraries(onnxruntime_providers_cann PRIVATE ascendcl acl_op_compiler nsync_cpp ${ABSEIL_LIBS} onnxruntime_providers_shared)
+  target_link_directories(onnxruntime_providers_cann PRIVATE ${onnxruntime_CANN_HOME}/lib64)
+  target_include_directories(onnxruntime_providers_cann PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} ${eigen_INCLUDE_DIRS} ${onnxruntime_CANN_HOME} ${onnxruntime_CANN_HOME}/include)
+  set_target_properties(onnxruntime_providers_cann PROPERTIES LINKER_LANGUAGE CXX)
+  set_target_properties(onnxruntime_providers_cann PROPERTIES FOLDER "ONNXRuntime")
+
+  install(TARGETS onnxruntime_providers_cann
+          ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if (NOT onnxruntime_BUILD_SHARED_LIB)

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -113,6 +113,9 @@ target_include_directories(onnxruntime_pybind11_state PRIVATE ${ONNXRUNTIME_ROOT
 if(onnxruntime_USE_CUDA AND onnxruntime_CUDNN_HOME)
     target_include_directories(onnxruntime_pybind11_state PRIVATE ${onnxruntime_CUDNN_HOME}/include)
 endif()
+if(onnxruntime_USE_CANN)
+    target_include_directories(onnxruntime_pybind11_state PRIVATE ${onnxruntime_CANN_HOME}/include)
+endif()
 if(onnxruntime_USE_ROCM)
   target_compile_options(onnxruntime_pybind11_state PUBLIC -D__HIP_PLATFORM_HCC__=1)
   target_include_directories(onnxruntime_pybind11_state PRIVATE ${onnxruntime_ROCM_HOME}/hipfft/include ${onnxruntime_ROCM_HOME}/include ${onnxruntime_ROCM_HOME}/hiprand/include ${onnxruntime_ROCM_HOME}/rocrand/include ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/onnxruntime ${CMAKE_CURRENT_BINARY_DIR}/amdgpu/orttraining)
@@ -807,6 +810,16 @@ if (onnxruntime_USE_CUDA)
       TARGET onnxruntime_pybind11_state POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy
           $<TARGET_FILE:onnxruntime_providers_cuda>
+          $<TARGET_FILE:onnxruntime_providers_shared>
+          $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
+    )
+endif()
+
+if (onnxruntime_USE_CANN)
+    add_custom_command(
+      TARGET onnxruntime_pybind11_state POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy
+          $<TARGET_FILE:onnxruntime_providers_cann>
           $<TARGET_FILE:onnxruntime_providers_shared>
           $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/capi/
     )

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -320,6 +320,13 @@ if (onnxruntime_USE_CUDA AND NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_R
   list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_cuda_src})
 endif()
 
+if (onnxruntime_USE_CANN)
+  file(GLOB_RECURSE onnxruntime_test_providers_cann_src CONFIGURE_DEPENDS
+    "${TEST_SRC_DIR}/providers/cann/*"
+    )
+  list(APPEND onnxruntime_test_providers_src ${onnxruntime_test_providers_cann_src})
+endif()
+
 if (onnxruntime_ENABLE_TRAINING)
   file(GLOB_RECURSE orttraining_test_trainingops_cpu_src CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/test/training_ops/compare_provider_test_utils.cc"
@@ -441,6 +448,10 @@ set (onnxruntime_test_providers_dependencies ${onnxruntime_EXTERNAL_DEPENDENCIES
 
 if(onnxruntime_USE_CUDA)
   list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_cuda)
+endif()
+
+if(onnxruntime_USE_CANN)
+  list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_cann)
 endif()
 
 if(onnxruntime_USE_NNAPI_BUILTIN)

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -37,6 +37,8 @@ namespace onnxruntime {
 constexpr const char* CPU = "Cpu";
 constexpr const char* CUDA = "Cuda";
 constexpr const char* CUDA_PINNED = "CudaPinned";
+constexpr const char* CANN = "Cann";
+constexpr const char* CANN_PINNED = "CannPinned";
 constexpr const char* DML = "DML";
 constexpr const char* OpenVINO_CPU = "OpenVINO_CPU";
 constexpr const char* OpenVINO_GPU = "OpenVINO_GPU";

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -15,12 +15,14 @@ struct OrtDevice {
   static const DeviceType CPU = 0;
   static const DeviceType GPU = 1;  // Nvidia or AMD
   static const DeviceType FPGA = 2;
+  static const DeviceType NPU = 3;  // Ascend
 
   struct MemType {
     // Pre-defined memory types.
     static const MemoryType DEFAULT = 0;
     static const MemoryType CUDA_PINNED = 1;
     static const MemoryType HIP_PINNED = 2;
+    static const MemoryType CANN_PINNED = 3;
   };
 
   constexpr OrtDevice(DeviceType device_type_, MemoryType memory_type_, DeviceId device_id_)

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -41,6 +41,7 @@ constexpr const char* kCoreMLExecutionProvider = "CoreMLExecutionProvider";
 constexpr const char* kSnpeExecutionProvider = "SNPEExecutionProvider";
 constexpr const char* kTvmExecutionProvider = "TvmExecutionProvider";
 constexpr const char* kXnnpackExecutionProvider = "XnnpackExecutionProvider";
+constexpr const char* kCannExecutionProvider = "CANNExecutionProvider";
 
 constexpr const char* kExecutionProviderSharedLibraryPath = "shared_lib_path";
 constexpr const char* kExecutionProviderSharedLibraryEntry = "provider_factory_entry_point";

--- a/include/onnxruntime/core/providers/cann/cann_provider_options.h
+++ b/include/onnxruntime/core/providers/cann/cann_provider_options.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "onnxruntime_c_api.h"
+#include "core/framework/arena_extend_strategy.h"
+
+struct OrtCANNProviderOptions {
+  int device_id;                                           // CANN device id
+  int max_opqueue_num;                                     // CANN operator cache information aging configuration
+  size_t npu_mem_limit;                                    // BFC Arena memory limit for CANN
+  onnxruntime::ArenaExtendStrategy arena_extend_strategy;  // Strategy used to grow the memory arena
+  int do_copy_in_default_stream;                           // Flag indicating if copying needs to take place on the
+                                                           // same stream as the compute stream in the CANN EP
+  OrtArenaCfg* default_memory_arena_cfg;                   // CANN memory arena configuration parameters
+};

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -413,6 +413,53 @@ typedef struct OrtCUDAProviderOptions {
 
 } OrtCUDAProviderOptions;
 
+/** \brief CANN Provider Options
+*
+* \see OrtApi::SessionOptionsAppendExecutionProvider_CANN
+*/
+typedef struct OrtCANNProviderOptions {
+#ifdef __cplusplus
+  OrtCANNProviderOptions() : device_id{}, npu_mem_limit{SIZE_MAX}, arena_extend_strategy{},
+                             do_copy_in_default_stream{1}, max_opqueue_num{10000},
+                             default_memory_arena_cfg{} {}
+#endif
+
+  /** \brief CANN device Id
+  *   Defaults to 0.
+  */
+  int device_id;
+
+  /** \brief CANN memory limit (To use all possible memory pass in maximum size_t)
+  *   Defaults to SIZE_MAX.
+  *   \note If a ::OrtArenaCfg has been applied, it will override this field
+  */
+  size_t npu_mem_limit;
+
+  /** \brief Strategy used to grow the memory arena
+  *   0 = kNextPowerOfTwo<br>
+  *   1 = kSameAsRequested<br>
+  *   Defaults to 0.
+  *   \note If a ::OrtArenaCfg has been applied, it will override this field
+  */
+  int arena_extend_strategy;
+
+  /** \brief Flag indicating if copying needs to take place on the same stream as the compute stream in the CANN EP
+  *   0 = Use separate streams for copying and compute.
+  *   1 = Use the same stream for copying and compute.
+  *   Defaults to 1.
+  */
+  int do_copy_in_default_stream;
+
+  /** \brief CANN operator cache information aging configuration
+  *   Defaults to 10000
+  */
+  int max_opqueue_num;
+
+  /** \brief CANN memory arena configuration parameters
+  */
+  OrtArenaCfg* default_memory_arena_cfg;
+} OrtCANNProviderOptions;
+
 /** \brief ROCM Provider Options
 *
 * \see OrtApi::SessionOptionsAppendExecutionProvider_ROCM
@@ -3495,6 +3542,18 @@ struct OrtApi {
   * \since Version 1.13
   */
   const OrtTrainingApi*(ORT_API_CALL* GetTrainingApi)(uint32_t version) NO_EXCEPTION;
+
+  /** \brief Append CANN provider to session options
+  *
+  * If CANN is not available (due to a non CANN enabled build, or if CANN is not installed on the system), this function will return failure.
+  *
+  * \param[in] options
+  * \param[in] cann_options
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  */
+  ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_CANN,
+                  _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* cann_options);
 
 #ifdef __cplusplus
   OrtApi(const OrtApi&)=delete; // Prevent users from accidentally copying the API structure, it should always be passed as a pointer

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -387,6 +387,8 @@ struct SessionOptions : Base<OrtSessionOptions> {
   SessionOptions& AppendExecutionProvider_TensorRT(const OrtTensorRTProviderOptions& provider_options);       ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_TensorRT
   SessionOptions& AppendExecutionProvider_TensorRT_V2(const OrtTensorRTProviderOptionsV2& provider_options);  ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_TensorRT
   SessionOptions& AppendExecutionProvider_MIGraphX(const OrtMIGraphXProviderOptions& provider_options);       ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_MIGraphX
+  ///< Wraps OrtApi::SessionOptionsAppendExecutionProvider_CANN
+  SessionOptions& AppendExecutionProvider_CANN(const OrtCANNProviderOptions& provider_options);
   /// Wraps OrtApi::SessionOptionsAppendExecutionProvider. Currently supports SNPE and XNNPACK.
   SessionOptions& AppendExecutionProvider(const std::string& provider_name,
                                           const std::unordered_map<std::string, std::string>& provider_options = {});

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -551,6 +551,11 @@ inline SessionOptions& SessionOptions::AppendExecutionProvider_MIGraphX(const Or
   return *this;
 }
 
+inline SessionOptions& SessionOptions::AppendExecutionProvider_CANN(const OrtCANNProviderOptions& provider_options) {
+  ThrowOnError(GetApi().SessionOptionsAppendExecutionProvider_CANN(p_, &provider_options));
+  return *this;
+}
+
 inline SessionOptions& SessionOptions::AppendExecutionProvider(
     const std::string& provider_name,
     const std::unordered_map<std::string, std::string>& provider_options) {

--- a/onnxruntime/core/providers/cann/activation/activations.cc
+++ b/onnxruntime/core/providers/cann/activation/activations.cc
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/activation/activations.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status Activations::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  const Tensor* X = ctx->Input<Tensor>(0);
+  Tensor* Y = ctx->Output(0, X->Shape());
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_ACTIVATION_TYPED_COMPUTE(x, T)                                \
+  template <>                                                                  \
+  Status x<T>::ComputeInternal(OpKernelContext* context) const {               \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare<T>(context, prepare));                         \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute(#x,                            \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_ACTIVATION_TYPED_KERNEL(x, class_name, ver, T)                            \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      class_name<T>);
+
+#define REGISTER_ACTIVATION_VERSIONED_TYPED_KERNEL(x, startver, endver, T)                 \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      x<T>);
+
+#define REGISTER_ACTIVATION_VERSIONED_TYPED(name, startver, endver, T) \
+  REGISTER_ACTIVATION_VERSIONED_TYPED_KERNEL(name, startver, endver, T)
+
+#define REGISTER_ACTIVATION_TYPED(name, ver, T)        \
+  REGISTER_ACTIVATION_TYPED_KERNEL(name, name, ver, T) \
+  REGISTER_ACTIVATION_TYPED_COMPUTE(name, T)
+
+#define REGISTER_ACTIVATION_VERSIONED_HFD(name, startver, endver)        \
+  REGISTER_ACTIVATION_VERSIONED_TYPED(name, startver, endver, MLFloat16) \
+  REGISTER_ACTIVATION_VERSIONED_TYPED(name, startver, endver, float)     \
+  REGISTER_ACTIVATION_VERSIONED_TYPED(name, startver, endver, double)
+
+#define REGISTER_ACTIVATION_CSIHFD(name, ver)     \
+  REGISTER_ACTIVATION_TYPED(name, ver, int8_t)    \
+  REGISTER_ACTIVATION_TYPED(name, ver, int16_t)   \
+  REGISTER_ACTIVATION_TYPED(name, ver, int32_t)   \
+  REGISTER_ACTIVATION_TYPED(name, ver, MLFloat16) \
+  REGISTER_ACTIVATION_TYPED(name, ver, float)     \
+  REGISTER_ACTIVATION_TYPED(name, ver, double)
+
+REGISTER_ACTIVATION_VERSIONED_HFD(Relu, 6, 12)
+
+REGISTER_ACTIVATION_VERSIONED_HFD(Relu, 13, 13)
+
+REGISTER_ACTIVATION_CSIHFD(Relu, 14)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/activation/activations.h
+++ b/onnxruntime/core/providers/cann/activation/activations.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+class Activations : public CannKernel {
+ protected:
+  explicit Activations(const OpKernelInfo& info) : CannKernel(info) {}
+  Status ComputeInternal(OpKernelContext*) const override {
+    return Status(common::ONNXRUNTIME, common::FAIL);  // should not reach here
+  }
+  template <typename T>
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+};
+
+template <typename T>
+class Relu final : public Activations {
+ public:
+  Relu(const OpKernelInfo& info) : Activations(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_allocator.cc
+++ b/onnxruntime/core/providers/cann/cann_allocator.cc
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <memory>
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_call.h"
+#include "core/providers/cann/cann_allocator.h"
+#include "core/framework/allocatormgr.h"
+#include "core/providers/cann/cann_fence.h"
+#include "core/providers/cann/npu_data_transfer.h"
+
+namespace onnxruntime {
+
+static const NPUDataTransfer* GetNPUDataTransfer(const SessionState* session_state) {
+  OrtDevice npu_device(OrtDevice::NPU, OrtDevice::MemType::DEFAULT, 0);
+  OrtDevice cpu_device;
+  return static_cast<const NPUDataTransfer*>(
+      session_state->GetDataTransferMgr().GetDataTransfer(npu_device, cpu_device));
+}
+
+void* CANNAllocator::Alloc(size_t size) {
+  void* p = nullptr;
+  aclrtMemMallocPolicy policy = ACL_MEM_MALLOC_HUGE_FIRST;
+  if (size > 0) {
+    CANN_CALL_THROW(aclrtMalloc(reinterpret_cast<void**>(&p), size, policy));
+  }
+  return p;
+}
+
+void CANNAllocator::Free(void* p) {
+  aclrtFree(p);
+}
+
+FencePtr CANNAllocator::CreateFence(const SessionState* session_state) {
+  return std::make_shared<CANNFence>(GetNPUDataTransfer(session_state));
+}
+
+void* CANNPinnedAllocator::Alloc(size_t size) {
+  void* p = nullptr;
+  if (size > 0) {
+    CANN_CALL_THROW(aclrtMallocHost(reinterpret_cast<void**>(&p), size));
+  }
+  return p;
+}
+
+void CANNPinnedAllocator::Free(void* p) {
+  CANN_CALL_THROW(aclrtFreeHost(p));
+}
+
+FencePtr CANNPinnedAllocator::CreateFence(const SessionState* session_state) {
+  return std::make_shared<CANNFence>(GetNPUDataTransfer(session_state));
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_allocator.h
+++ b/onnxruntime/core/providers/cann/cann_allocator.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/inlined_containers.h"
+#include "core/framework/allocator.h"
+#include "core/platform/ort_mutex.h"
+
+namespace onnxruntime {
+
+class CANNAllocator : public IAllocator {
+ public:
+  CANNAllocator(OrtDevice::DeviceId device_id, const char* name)
+      : IAllocator(
+            OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                          OrtDevice(OrtDevice::NPU, OrtDevice::MemType::DEFAULT, device_id),
+                          device_id, OrtMemTypeDefault)) {}
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+  FencePtr CreateFence(const SessionState* session_state) override;
+};
+
+class CANNPinnedAllocator : public IAllocator {
+ public:
+  CANNPinnedAllocator(OrtDevice::DeviceId device_id, const char* name)
+      : IAllocator(
+            OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+                          OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CANN_PINNED, device_id),
+                          device_id, OrtMemTypeCPUOutput)) {}
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+  FencePtr CreateFence(const SessionState* session_state) override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_call.cc
+++ b/onnxruntime/core/providers/cann/cann_call.cc
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string.h>
+#include "core/providers/shared_library/provider_api.h"
+#include "cann_call.h"
+
+namespace onnxruntime {
+
+template <typename ERRTYPE>
+const char* CannErrString(ERRTYPE x) {
+  ORT_NOT_IMPLEMENTED();
+}
+
+#define CASE_ENUM_TO_STR(x) \
+  case x:                   \
+    return #x
+
+template <>
+const char* CannErrString<aclError>(aclError e) {
+  aclrtSynchronizeDevice();
+
+  switch (e) {
+    CASE_ENUM_TO_STR(ACL_SUCCESS);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_PARAM);
+    CASE_ENUM_TO_STR(ACL_ERROR_UNINITIALIZE);
+    CASE_ENUM_TO_STR(ACL_ERROR_REPEAT_INITIALIZE);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_FILE);
+    CASE_ENUM_TO_STR(ACL_ERROR_WRITE_FILE);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_FILE_SIZE);
+    CASE_ENUM_TO_STR(ACL_ERROR_PARSE_FILE);
+    CASE_ENUM_TO_STR(ACL_ERROR_FILE_MISSING_ATTR);
+    CASE_ENUM_TO_STR(ACL_ERROR_FILE_ATTR_INVALID);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_DUMP_CONFIG);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_PROFILING_CONFIG);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_MODEL_ID);
+    CASE_ENUM_TO_STR(ACL_ERROR_DESERIALIZE_MODEL);
+    CASE_ENUM_TO_STR(ACL_ERROR_PARSE_MODEL);
+    CASE_ENUM_TO_STR(ACL_ERROR_READ_MODEL_FAILURE);
+    CASE_ENUM_TO_STR(ACL_ERROR_MODEL_SIZE_INVALID);
+    CASE_ENUM_TO_STR(ACL_ERROR_MODEL_MISSING_ATTR);
+    CASE_ENUM_TO_STR(ACL_ERROR_MODEL_INPUT_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_MODEL_OUTPUT_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_MODEL_NOT_DYNAMIC);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_TYPE_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_INPUT_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_OUTPUT_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_ATTR_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_NOT_FOUND);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_LOAD_FAILED);
+    CASE_ENUM_TO_STR(ACL_ERROR_UNSUPPORTED_DATA_TYPE);
+    CASE_ENUM_TO_STR(ACL_ERROR_FORMAT_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_BIN_SELECTOR_NOT_REGISTERED);
+    CASE_ENUM_TO_STR(ACL_ERROR_KERNEL_NOT_FOUND);
+    CASE_ENUM_TO_STR(ACL_ERROR_BIN_SELECTOR_ALREADY_REGISTERED);
+    CASE_ENUM_TO_STR(ACL_ERROR_KERNEL_ALREADY_REGISTERED);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_QUEUE_ID);
+    CASE_ENUM_TO_STR(ACL_ERROR_REPEAT_SUBSCRIBE);
+    CASE_ENUM_TO_STR(ACL_ERROR_STREAM_NOT_SUBSCRIBE);
+    CASE_ENUM_TO_STR(ACL_ERROR_THREAD_NOT_SUBSCRIBE);
+    CASE_ENUM_TO_STR(ACL_ERROR_WAIT_CALLBACK_TIMEOUT);
+    CASE_ENUM_TO_STR(ACL_ERROR_REPEAT_FINALIZE);
+    CASE_ENUM_TO_STR(ACL_ERROR_NOT_STATIC_AIPP);
+    CASE_ENUM_TO_STR(ACL_ERROR_COMPILING_STUB_MODE);
+    CASE_ENUM_TO_STR(ACL_ERROR_GROUP_NOT_SET);
+    CASE_ENUM_TO_STR(ACL_ERROR_GROUP_NOT_CREATE);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROF_ALREADY_RUN);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROF_NOT_RUN);
+    CASE_ENUM_TO_STR(ACL_ERROR_DUMP_ALREADY_RUN);
+    CASE_ENUM_TO_STR(ACL_ERROR_DUMP_NOT_RUN);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROF_REPEAT_SUBSCRIBE);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROF_API_CONFLICT);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_MAX_OPQUEUE_NUM_CONFIG);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_OPP_PATH);
+    CASE_ENUM_TO_STR(ACL_ERROR_OP_UNSUPPORTED_DYNAMIC);
+    CASE_ENUM_TO_STR(ACL_ERROR_RELATIVE_RESOURCE_NOT_CLEARED);
+    CASE_ENUM_TO_STR(ACL_ERROR_UNSUPPORTED_JPEG);
+    CASE_ENUM_TO_STR(ACL_ERROR_BAD_ALLOC);
+    CASE_ENUM_TO_STR(ACL_ERROR_API_NOT_SUPPORT);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_DEVICE);
+    CASE_ENUM_TO_STR(ACL_ERROR_MEMORY_ADDRESS_UNALIGNED);
+    CASE_ENUM_TO_STR(ACL_ERROR_RESOURCE_NOT_MATCH);
+    CASE_ENUM_TO_STR(ACL_ERROR_INVALID_RESOURCE_HANDLE);
+    CASE_ENUM_TO_STR(ACL_ERROR_FEATURE_UNSUPPORTED);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROF_MODULES_UNSUPPORTED);
+    CASE_ENUM_TO_STR(ACL_ERROR_STORAGE_OVER_LIMIT);
+    CASE_ENUM_TO_STR(ACL_ERROR_INTERNAL_ERROR);
+    CASE_ENUM_TO_STR(ACL_ERROR_FAILURE);
+    CASE_ENUM_TO_STR(ACL_ERROR_GE_FAILURE);
+    CASE_ENUM_TO_STR(ACL_ERROR_RT_FAILURE);
+    CASE_ENUM_TO_STR(ACL_ERROR_DRV_FAILURE);
+    CASE_ENUM_TO_STR(ACL_ERROR_PROFILING_FAILURE);
+    default:
+      return "(look for ACL_ERROR_xxx in acl.h)";
+  }
+}
+
+template <typename ERRTYPE, bool THRW>
+bool CannCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg) {
+  if (retCode != successCode) {
+    try {
+      char hostname[HOST_NAME_MAX];
+      if (gethostname(hostname, HOST_NAME_MAX) != 0)
+        snprintf(hostname, HOST_NAME_MAX, "%s", "?");
+      int currentCannDevice;
+      (void)aclrtGetDevice(&currentCannDevice);
+      (void)aclGetRecentErrMsg();
+      static char str[1024];
+      snprintf(str, sizeof(str), "%s failure %d: %s ; NPU=%d ; hostname=%s ; expr=%s; %s",
+               libName, static_cast<int>(retCode), CannErrString(retCode), currentCannDevice,
+               hostname,
+               exprString, msg);
+      if (THRW) {
+        ORT_THROW(str);
+      } else {
+        LOGS_DEFAULT(ERROR) << str;
+      }
+    } catch (const std::exception& e) {
+      if (THRW) {
+        ORT_THROW(e.what());
+      } else {
+        LOGS_DEFAULT(ERROR) << e.what();
+      }
+    }
+    return false;
+  }
+  return true;
+}
+
+template bool CannCall<aclError, false>(aclError retCode, const char* exprString, const char* libName,
+                                        aclError successCode, const char* msg);
+template bool CannCall<aclError, true>(aclError retCode, const char* exprString, const char* libName,
+                                       aclError successCode, const char* msg);
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_call.h
+++ b/onnxruntime/core/providers/cann/cann_call.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cann_inc.h"
+#include "core/common/status.h"
+
+namespace onnxruntime {
+
+template <typename ERRTYPE, bool THRW>
+bool CannCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
+
+#define CANN_CALL(expr) (CannCall<aclError, false>((expr), #expr, "CANN", ACL_SUCCESS))
+#define CANN_CALL_THROW(expr) (CannCall<aclError, true>((expr), #expr, "CANN", ACL_SUCCESS))
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -1,0 +1,748 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <utility>
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_execution_provider.h"
+#include "core/providers/cann/cann_inc.h"
+#include "core/providers/cann/cann_call.h"
+#include "core/providers/cann/cann_allocator.h"
+#include "core/providers/cann/cann_fence.h"
+#include "core/providers/cann/cann_fwd.h"
+#include "core/providers/cann/npu_data_transfer.h"
+
+using onnxruntime::common::Status;
+
+namespace onnxruntime {
+
+class Memcpy final : public OpKernel {
+ public:
+  Memcpy(const OpKernelInfo& info) : OpKernel{info} {}
+
+  Status Compute(OpKernelContext* ctx) const override {
+    auto X_type = ctx->InputType(0);
+    if (X_type->IsTensorType()) {
+      const auto* X = ctx->Input<Tensor>(0);
+      ORT_ENFORCE(X != nullptr, "Memcpy: Input tensor is nullptr.");
+      Tensor* Y = ctx->Output(0, X->Shape());
+      ORT_ENFORCE(Y != nullptr, "Memcpy: Failed to allocate output tensor.");
+      return Info().GetDataTransferManager().CopyTensor(*X, *Y, Info().GetKernelDef().ExecQueueId());
+    } else if (X_type->IsSparseTensorType()) {
+      const auto* X = ctx->Input<SparseTensor>(0);
+      ORT_ENFORCE(X != nullptr, "Memcpy: Input tensor is nullptr.");
+      SparseTensor* Y = ctx->OutputSparse(0, X->DenseShape());
+      ORT_ENFORCE(Y != nullptr, "Memcpy: Failed to allocate output sparse tensor.");
+      return X->Copy(Info().GetDataTransferManager(), Info().GetKernelDef().ExecQueueId(), *Y);
+    } else if (X_type->IsTensorSequenceType()) {
+      const TensorSeq* X = ctx->Input<TensorSeq>(0);
+      ORT_ENFORCE(X != nullptr, "Memcpy: Input tensor sequence is nullptr.");
+      TensorSeq* Y = ctx->Output<TensorSeq>(0);
+      ORT_ENFORCE(Y != nullptr, "Memcpy: Failed to allocate output tensor sequence.");
+      auto X_dtype = X->DataType();
+      Y->SetType(X_dtype);
+      AllocatorPtr alloc;
+
+      if (Node().OpType() == "MemcpyFromHost") {
+        auto status = ctx->GetTempSpaceAllocator(&alloc);
+        if (!status.IsOK()) {
+          return Status(common::ONNXRUNTIME, common::FAIL,
+                        "Memcpy cann: unable to get an allocator.");
+        }
+      } else {
+        auto status = ctx->GetTempSpaceCPUAllocator(&alloc);
+        if (!status.IsOK()) {
+          return Status(common::ONNXRUNTIME, common::FAIL,
+                        "Memcpy cann: unable to get the CPU allocator.");
+        }
+      }
+      auto X_size = X->Size();
+      for (size_t i = 0; i < X_size; ++i) {
+        const Tensor& source_tensor = X->Get(i);
+        std::unique_ptr<Tensor> target_tensor = Tensor::Create(source_tensor.DataType(), source_tensor.Shape(), alloc);
+        Status retval = Info().GetDataTransferManager().CopyTensor(source_tensor, *target_tensor,
+                                                                   Info().GetKernelDef().ExecQueueId());
+        if (!retval.IsOK()) {
+          return retval;
+        }
+        Y->Add(std::move(*target_tensor));
+      }
+      return Status::OK();
+    }
+    return Status(common::ONNXRUNTIME, common::FAIL, "Memcpy: Unsupported input type.");
+  }
+};
+
+namespace cann {
+
+ONNX_OPERATOR_KERNEL_EX(
+    MemcpyFromHost,
+    kOnnxDomain,
+    1,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .InputMemoryType(OrtMemTypeCPUInput, 0)
+        .ExecQueueId(kCannStreamCopyIn)
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorAndSequenceTensorTypes()),
+    Memcpy);
+
+ONNX_OPERATOR_KERNEL_EX(
+    MemcpyToHost,
+    kOnnxDomain,
+    1,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .OutputMemoryType(OrtMemTypeCPUOutput, 0)
+        .ExecQueueId(kCannStreamCopyOut)
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorAndSequenceTensorTypes()),
+    Memcpy);
+
+}  // namespace cann
+
+namespace cann {
+
+// op 1-9
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MemcpyFromHost);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MemcpyToHost);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int64_t, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, double, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int64_t, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, double, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, double, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 8, MLFloat16, Gemm);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, MLFloat16, Gemm);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 8, MLFloat16, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 8, float, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, uint8_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, uint16_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, uint32_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, uint64_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, int8_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, int16_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, int32_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, int64_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, MLFloat16, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, float, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      7, 8, MLFloat16, BatchNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      7, 8, float, BatchNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      9, 13, MLFloat16, BatchNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      9, 13, float, BatchNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MLFloat16, GlobalAveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, float, GlobalAveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      7, 9, MLFloat16, AveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 9, float, AveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 7, MLFloat16, MaxPool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MLFloat16, GlobalMaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, float, GlobalMaxPool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, double, GlobalMaxPool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, Conv);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, float, Conv);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, double, Conv);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 9, Dropout);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 12, Identity);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 8, MLFloat16, MatMul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 8, float, MatMul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, MLFloat16, MatMul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, float, MatMul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int32_t, MatMul);
+
+// op 10
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      10, 10, MLFloat16, AveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 10, 10, float, AveragePool);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 10, 11, Dropout);
+
+// op 11
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, Gemm);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, uint8_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, uint16_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, uint32_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, uint64_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, int8_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, int16_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, int32_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, int64_t, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, Flatten);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, float, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, MLFloat16, AveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, float, AveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, MLFloat16, Conv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, float, Conv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, double, Conv);
+
+// op 12
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 12, 12, Dropout);
+
+// op 13
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int64_t, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Add);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int64_t, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Div);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Gemm);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint8_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint16_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint32_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint64_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int8_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int16_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int64_t, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Flatten);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Flatten);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, Dropout);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, Identity);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, MatMul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, MatMul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, MatMul);
+
+// op 14
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Relu);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      14, 14, MLFloat16, BatchNormalization);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      14, 14, float, BatchNormalization);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Identity);
+
+// op 15
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 15, MLFloat16, BatchNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 15, float, BatchNormalization);
+
+Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
+  static const BuildKernelCreateInfoFn function_table[] = {
+      // op 1-9
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MemcpyFromHost)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MemcpyToHost)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int32_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int64_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, MLFloat16, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, float, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, double, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int32_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, MLFloat16, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, float, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int32_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, MLFloat16, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int32_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int64_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, MLFloat16, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, float, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, double, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, double, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 8, MLFloat16, Gemm)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, MLFloat16, Gemm)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 8, MLFloat16, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 8, float, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, uint8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, uint16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, uint32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, uint64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, int8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, int16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, int32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, int64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, MLFloat16, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 10, float, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 8, MLFloat16, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 8, float, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 13, MLFloat16, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 13, float, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, MLFloat16, GlobalAveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, float, GlobalAveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 9, MLFloat16, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 9, float, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 7, MLFloat16, MaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 7, float, MaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, MLFloat16, GlobalMaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, float, GlobalMaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, double, GlobalMaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 10, MLFloat16, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 10, float, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 10, double, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      7, 9, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      1, 12, Identity)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 8, MLFloat16, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 8, float, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, MLFloat16, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, float, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, int32_t, MatMul)>,
+
+      // op 10
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            10, 10, MLFloat16, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            10, 10, float, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      10, 11, Dropout)>,
+
+      // op 11
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, MLFloat16, Gemm)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, uint8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, uint16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, uint32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, uint64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, int8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, int16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, int32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, int64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, MLFloat16, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            11, 12, float, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, MLFloat16, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, float, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, MLFloat16, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, float, Conv)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, double, Conv)>,
+
+      // op 12
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      12, 12, Dropout)>,
+
+      // op 13
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int32_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int64_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, MLFloat16, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, float, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, double, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int32_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, MLFloat16, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, float, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int32_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, MLFloat16, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int32_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int64_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, MLFloat16, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, float, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, double, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, MLFloat16, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, float, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, double, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Gemm)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int8_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int16_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int32_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int64_t, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Flatten)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      13, 13, Identity)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int32_t, MatMul)>,
+
+      // op 14
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint8_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int8_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int16_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int32_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int64_t, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, MLFloat16, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, float, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, double, Add)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int32_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, MLFloat16, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, float, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint8_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int8_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int16_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int32_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, MLFloat16, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int32_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int64_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, MLFloat16, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, float, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, double, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int8_t, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int16_t, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int32_t, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, MLFloat16, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, float, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, double, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            14, 14, MLFloat16, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            14, 14, float, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Identity)>,
+
+      // op 15
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  15, MLFloat16, BatchNormalization)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  15, float, BatchNormalization)>,
+  };
+
+  for (auto& function_table_entry : function_table) {
+    KernelCreateInfo info = function_table_entry();
+    if (info.kernel_def != nullptr) {
+      ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
+    }
+  }
+  return Status::OK();
+}
+
+}  // namespace cann
+
+CANNExecutionProvider::CANNExecutionProvider(const CANNExecutionProviderInfo& info)
+    : IExecutionProvider{onnxruntime::kCannExecutionProvider}, info_{info} {
+  CANN_CALL_THROW(aclrtSetDevice(info_.device_id));
+  CANN_CALL_THROW(aclrtCreateStream(&stream_));
+}
+
+CANNExecutionProvider::~CANNExecutionProvider() {
+  CANN_CALL_THROW(aclrtDestroyStream(stream_));
+}
+
+// All threads share the same context and stream
+Status CANNExecutionProvider::OnRunStart() {
+  CANN_CALL_THROW(aclrtSetDevice(info_.device_id));
+
+  return Status::OK();
+}
+
+Status CANNExecutionProvider::OnRunEnd(bool sync_stream) {
+  if (sync_stream) {
+    CANN_CALL_THROW(aclrtSynchronizeStream(stream_));
+  }
+
+  return Status::OK();
+}
+
+static std::shared_ptr<KernelRegistry> s_kernel_registry;
+
+void InitializeRegistry() {
+  s_kernel_registry = KernelRegistry::Create();
+  ORT_THROW_IF_ERROR(cann::RegisterCANNKernels(*s_kernel_registry));
+
+  CANN_CALL_THROW(aclInit(nullptr));
+}
+
+void DeleteRegistry() {
+  s_kernel_registry.reset();
+
+  CANN_CALL_THROW(aclFinalize());
+}
+
+std::shared_ptr<KernelRegistry> CANNExecutionProvider::GetKernelRegistry() const {
+  return s_kernel_registry;
+}
+
+std::unique_ptr<onnxruntime::IDataTransfer> CANNExecutionProvider::GetDataTransfer() const {
+  return std::make_unique<onnxruntime::NPUDataTransfer>(static_cast<aclrtStream>(GetComputeStream()),
+                                                        info_.do_copy_in_default_stream);
+}
+
+std::vector<std::unique_ptr<ComputeCapability>>
+CANNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
+                                     const std::vector<const KernelRegistry*>& kernel_registries) const {
+  InlinedVector<NodeIndex> candidates;
+  for (auto& node_index : graph.GetNodesInTopologicalOrder()) {
+    const auto* p_node = graph.GetNode(node_index);
+    if (p_node == nullptr)
+      continue;
+
+    const auto& node = *p_node;
+    const KernelCreateInfo* cann_kernel_def = nullptr;
+    if (!node.GetExecutionProviderType().empty()) {
+      continue;
+    }
+
+    for (auto registry : kernel_registries) {
+      auto st = registry->TryFindKernel(node, Type(), &cann_kernel_def);
+
+      if (st.IsOK())
+        break;
+    }
+
+    if (cann_kernel_def == nullptr) {
+      LOGS_DEFAULT(INFO) << "CANN kernel not found in registries for Op type: " << node.OpType()
+                         << " node name: " << node.Name();
+      continue;
+    }
+
+    candidates.push_back(node.Index());
+  }
+
+  auto cpu_nodes = GetCpuPreferredNodes(graph, Type(), kernel_registries, candidates);
+  std::vector<std::unique_ptr<ComputeCapability>> result;
+  for (auto& node_index : candidates) {
+    if (cpu_nodes.count(node_index) > 0)
+      continue;
+
+    auto sub_graph = IndexedSubGraph::Create();
+    sub_graph->Nodes().push_back(node_index);
+    result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+  }
+
+  return result;
+}
+
+void CANNExecutionProvider::RegisterAllocator(AllocatorManager& allocator_manager) {
+  OrtDevice cann_device{OrtDevice::NPU, OrtDevice::MemType::DEFAULT, info_.device_id};
+  OrtDevice pinned_device{OrtDevice::CPU, OrtDevice::MemType::CANN_PINNED, DEFAULT_CPU_ALLOCATOR_DEVICE_ID};
+  OrtDevice cpu_device{OrtDevice::CPU, OrtDevice::MemType::DEFAULT, DEFAULT_CPU_ALLOCATOR_DEVICE_ID};
+
+  auto cann_alloc = IExecutionProvider::GetAllocator(cann_device.Id(), OrtMemTypeDefault);
+  if (!cann_alloc) {
+    cann_alloc = allocator_manager.GetAllocator(OrtMemTypeDefault, cann_device);
+
+    if (!cann_alloc) {
+      AllocatorCreationInfo default_memory_info(
+          [](OrtDevice::DeviceId id) {
+            return std::make_unique<CANNAllocator>(id, CANN);
+          },
+          cann_device.Id(),
+          true,
+          {info_.default_memory_arena_cfg ? *info_.default_memory_arena_cfg
+                                          : OrtArenaCfg(info_.npu_mem_limit,
+                                                        static_cast<int>(info_.arena_extend_strategy), -1, -1, -1)});
+
+      cann_alloc = CreateAllocator(default_memory_info);
+      allocator_manager.InsertAllocator(cann_alloc);
+    }
+
+    InsertAllocator(cann_alloc);
+  }
+
+  auto cann_pinned_alloc = IExecutionProvider::GetAllocator(pinned_device.Id(), OrtMemTypeCPUOutput);
+  if (!cann_pinned_alloc) {
+    cann_pinned_alloc = allocator_manager.GetAllocator(OrtMemTypeCPUOutput, pinned_device);
+
+    if (!cann_pinned_alloc) {
+      AllocatorCreationInfo pinned_memory_info(
+          [](OrtDevice::DeviceId device_id) {
+            return std::make_unique<CANNPinnedAllocator>(device_id, CANN_PINNED);
+          },
+          pinned_device.Id());
+
+      cann_pinned_alloc = CreateAllocator(pinned_memory_info);
+      allocator_manager.InsertAllocator(cann_pinned_alloc);
+    }
+
+    InsertAllocator(cann_pinned_alloc);
+  }
+
+  auto cann_cpu_alloc = IExecutionProvider::GetAllocator(cpu_device.Id(), OrtMemTypeCPUInput);
+  if (!cann_cpu_alloc) {
+    cann_cpu_alloc = allocator_manager.GetAllocator(OrtMemTypeCPUInput, cpu_device);
+
+    if (!cann_cpu_alloc) {
+      AllocatorCreationInfo cpu_memory_info(
+          [](int device_id) {
+            return std::make_unique<CPUAllocator>(
+                OrtMemoryInfo("CANN_CPU", OrtAllocatorType::OrtDeviceAllocator, OrtDevice(), device_id,
+                              OrtMemTypeCPUInput));
+          },
+          cpu_device.Id());
+
+      cann_cpu_alloc = CreateAllocator(cpu_memory_info);
+      allocator_manager.InsertAllocator(cann_cpu_alloc);
+    }
+
+    InsertAllocator(cann_cpu_alloc);
+  }
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/framework/allocatormgr.h"
+#include "core/framework/arena_extend_strategy.h"
+#include "core/framework/execution_provider.h"
+#include "core/platform/ort_mutex.h"
+#include "core/providers/cann/cann_execution_provider_info.h"
+#include "core/providers/cann/cann_inc.h"
+
+namespace onnxruntime {
+
+class CANNExecutionProvider : public IExecutionProvider {
+ public:
+  explicit CANNExecutionProvider(const CANNExecutionProviderInfo& info);
+  virtual ~CANNExecutionProvider();
+
+  Status OnRunStart() override;
+
+  Status OnRunEnd(bool sync_stream) override;
+
+  void* GetComputeStream() const override { return static_cast<void*>(stream_); }
+
+  template <typename T>
+  IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
+    if (count_or_bytes == 0)
+      return nullptr;
+
+    return IAllocator::MakeUniquePtr<T>(GetAllocator(info_.device_id, OrtMemTypeDefault), count_or_bytes);
+  }
+
+  std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
+  std::unique_ptr<onnxruntime::IDataTransfer> GetDataTransfer() const override;
+
+  std::vector<std::unique_ptr<ComputeCapability>> GetCapability(
+      const onnxruntime::GraphViewer& graph,
+      const std::vector<const KernelRegistry*>& kernel_registries) const override;
+
+  ProviderOptions GetProviderOptions() const override {
+    return CANNExecutionProviderInfo::ToProviderOptions(info_);
+  }
+
+  void RegisterAllocator(AllocatorManager& allocator_manager) override;
+
+ private:
+  CANNExecutionProviderInfo info_;
+  aclrtStream stream_ = nullptr;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.h
@@ -42,12 +42,13 @@ class CANNExecutionProvider : public IExecutionProvider {
 
   std::vector<std::unique_ptr<ComputeCapability>> GetCapability(
       const onnxruntime::GraphViewer& graph,
-      const std::vector<const KernelRegistry*>& kernel_registries) const override;
+      const IKernelLookup& kernel_lookup) const override;
 
   ProviderOptions GetProviderOptions() const override {
     return CANNExecutionProviderInfo::ToProviderOptions(info_);
   }
 
+  AllocatorPtr GetAllocator(int id, OrtMemType mem_type) const override;
   void RegisterAllocator(AllocatorManager& allocator_manager) override;
 
  private:

--- a/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string>
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_execution_provider_info.h"
+
+#include "core/common/make_string.h"
+#include "core/common/parse_string.h"
+#include "core/framework/provider_options_utils.h"
+#include "core/providers/cann/cann_inc.h"
+#include "core/providers/cann/cann_call.h"
+
+namespace onnxruntime {
+namespace cann {
+namespace provider_option_names {
+constexpr const char* kDeviceId = "device_id";
+constexpr const char* kMemLimit = "npu_mem_limit";
+constexpr const char* kArenaExtendStrategy = "arena_extend_strategy";
+constexpr const char* kMaxOpqueueNum = "max_opqueue_num";
+constexpr const char* kDoCopyInDefaultStream = "do_copy_in_default_stream";
+}  // namespace provider_option_names
+}  // namespace cann
+
+namespace {
+const DeleteOnUnloadPtr<EnumNameMapping<ArenaExtendStrategy>> arena_extend_strategy_mapping =
+    new EnumNameMapping<ArenaExtendStrategy>{
+        {ArenaExtendStrategy::kNextPowerOfTwo, "kNextPowerOfTwo"},
+        {ArenaExtendStrategy::kSameAsRequested, "kSameAsRequested"},
+    };
+}  // namespace
+
+CANNExecutionProviderInfo CANNExecutionProviderInfo::FromProviderOptions(const ProviderOptions& options) {
+  CANNExecutionProviderInfo info{};
+  ORT_THROW_IF_ERROR(
+      ProviderOptionsParser{}
+          .AddValueParser(
+              cann::provider_option_names::kDeviceId,
+              [&info](const std::string& value_str) -> Status {
+                ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
+                uint32_t num_devices{};
+                ORT_RETURN_IF_NOT(
+                    CANN_CALL(aclrtGetDeviceCount(&num_devices)),
+                    "aclrtGetDeviceCount() failed.");
+                ORT_RETURN_IF_NOT(
+                    0 <= info.device_id && (unsigned)info.device_id < num_devices,
+                    "Invalid device ID: ", info.device_id,
+                    ", must be between 0 (inclusive) and ", num_devices, " (exclusive).");
+                return Status::OK();
+              })
+          .AddAssignmentToReference(cann::provider_option_names::kMaxOpqueueNum, info.max_opqueue_num)
+          .AddAssignmentToReference(cann::provider_option_names::kMemLimit, info.npu_mem_limit)
+          .AddAssignmentToEnumReference(
+              cann::provider_option_names::kArenaExtendStrategy,
+              *arena_extend_strategy_mapping, info.arena_extend_strategy)
+          .AddAssignmentToReference(cann::provider_option_names::kDoCopyInDefaultStream, info.do_copy_in_default_stream)
+          .Parse(options));
+  return info;
+}
+
+ProviderOptions CANNExecutionProviderInfo::ToProviderOptions(const CANNExecutionProviderInfo& info) {
+  const ProviderOptions options{
+      {cann::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
+      {cann::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.npu_mem_limit)},
+      {cann::provider_option_names::kArenaExtendStrategy,
+       EnumToName(*arena_extend_strategy_mapping, info.arena_extend_strategy)},
+      {cann::provider_option_names::kDoCopyInDefaultStream,
+       MakeStringWithClassicLocale(info.do_copy_in_default_stream)},
+      {cann::provider_option_names::kMaxOpqueueNum, MakeStringWithClassicLocale(info.max_opqueue_num)}};
+  return options;
+}
+
+ProviderOptions CANNExecutionProviderInfo::ToProviderOptions(const OrtCANNProviderOptions& info) {
+  const ProviderOptions options{
+      {cann::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
+      {cann::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.npu_mem_limit)},
+      {cann::provider_option_names::kArenaExtendStrategy,
+       EnumToName(*arena_extend_strategy_mapping, ArenaExtendStrategy(info.arena_extend_strategy))},
+      {cann::provider_option_names::kDoCopyInDefaultStream,
+       MakeStringWithClassicLocale(info.do_copy_in_default_stream)},
+      {cann::provider_option_names::kMaxOpqueueNum, MakeStringWithClassicLocale(info.max_opqueue_num)}};
+  return options;
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cann/cann_execution_provider_info.h"
+#include "core/providers/cann/cann_provider_options.h"
 
 #include "core/common/make_string.h"
 #include "core/common/parse_string.h"

--- a/onnxruntime/core/providers/cann/cann_execution_provider_info.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider_info.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <limits>
+
+#include "core/framework/arena_extend_strategy.h"
+#include "core/framework/ortdevice.h"
+#include "core/framework/provider_options.h"
+#include "core/session/onnxruntime_c_api.h"
+
+namespace onnxruntime {
+struct CANNExecutionProviderInfo {
+  OrtDevice::DeviceId device_id{0};
+  int max_opqueue_num{10000};
+  size_t npu_mem_limit{std::numeric_limits<size_t>::max()};
+  ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
+  bool do_copy_in_default_stream{true};
+  OrtArenaCfg* default_memory_arena_cfg{nullptr};
+
+  static CANNExecutionProviderInfo FromProviderOptions(const ProviderOptions& options);
+  static ProviderOptions ToProviderOptions(const CANNExecutionProviderInfo& info);
+  static ProviderOptions ToProviderOptions(const OrtCANNProviderOptions& info);
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_fence.cc
+++ b/onnxruntime/core/providers/cann/cann_fence.cc
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_call.h"
+#include "core/providers/cann/npu_data_transfer.h"
+#include "core/providers/cann/cann_fence.h"
+
+namespace onnxruntime {
+
+CANNFence::CANNFence(const NPUDataTransfer* data_transfer) : data_transfer_(data_transfer) {
+  CANN_CALL_THROW(aclrtCreateEvent(&read_event_));
+  CANN_CALL_THROW(aclrtCreateEvent(&write_event_));
+}
+
+CANNFence::~CANNFence() {
+  CANN_CALL_THROW(aclrtDestroyEvent(read_event_));
+  CANN_CALL_THROW(aclrtDestroyEvent(write_event_));
+}
+
+void CANNFence::BeforeUsingAsInput(onnxruntime::ProviderType provider_type, int async_queue_id) {
+  if (provider_type == onnxruntime::kCannExecutionProvider) {
+    CANN_CALL_THROW(aclrtStreamWaitEvent(data_transfer_->GetStream(async_queue_id), write_event_));
+    CANN_CALL_THROW(aclrtResetEvent(write_event_, data_transfer_->GetStream(async_queue_id)));
+  } else {
+    CANN_CALL_THROW(aclrtSynchronizeEvent(write_event_));
+  }
+}
+
+void CANNFence::BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int queue_id) {
+  if (provider_type == onnxruntime::kCannExecutionProvider) {
+    aclrtStream stream = data_transfer_->GetStream(queue_id);
+    CANN_CALL_THROW(aclrtStreamWaitEvent(stream, read_event_));
+    CANN_CALL_THROW(aclrtResetEvent(read_event_, stream));
+    CANN_CALL_THROW(aclrtStreamWaitEvent(stream, write_event_));
+    CANN_CALL_THROW(aclrtResetEvent(write_event_, stream));
+  } else {
+    CANN_CALL_THROW(aclrtSynchronizeEvent(read_event_));
+    CANN_CALL_THROW(aclrtSynchronizeEvent(write_event_));
+  }
+}
+
+bool CANNFence::CanRelease() {
+  aclrtEventRecordedStatus read_status;
+  aclrtEventRecordedStatus write_status;
+
+  return aclrtQueryEventStatus(read_event_, &read_status) == ACL_SUCCESS &&
+         aclrtQueryEventStatus(write_event_, &write_status) == ACL_SUCCESS &&
+         read_status == ACL_EVENT_RECORDED_STATUS_COMPLETE &&
+         write_status == ACL_EVENT_RECORDED_STATUS_COMPLETE;
+}
+
+void CANNFence::AfterUsedAsInput(int queue_id) {
+  aclrtStream stream = data_transfer_->GetStream(queue_id);
+  CANN_CALL_THROW(aclrtRecordEvent(read_event_, stream));
+}
+
+void CANNFence::AfterUsedAsOutput(int queue_id) {
+  aclrtStream stream = data_transfer_->GetStream(queue_id);
+  CANN_CALL_THROW(aclrtRecordEvent(write_event_, stream));
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_fence.h
+++ b/onnxruntime/core/providers/cann/cann_fence.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/fence.h"
+#include "core/providers/cann/cann_inc.h"
+
+namespace onnxruntime {
+class NPUDataTransfer;
+
+class CANNFence : public IFence {
+ public:
+  explicit CANNFence(const NPUDataTransfer* data_transfer);
+  virtual ~CANNFence();
+  void BeforeUsingAsInput(onnxruntime::ProviderType provider_type, int queue_id) override;
+  void BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int queue_id) override;
+  void AfterUsedAsInput(int queue_id) override;
+  void AfterUsedAsOutput(int queue_id) override;
+  bool CanRelease() override;
+
+ private:
+  aclrtEvent read_event_;
+  aclrtEvent write_event_;
+  const NPUDataTransfer* data_transfer_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_fwd.h
+++ b/onnxruntime/core/providers/cann/cann_fwd.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime {
+namespace cann {
+template <typename T>
+KernelCreateInfo BuildKernelCreateInfo();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_inc.h
+++ b/onnxruntime/core/providers/cann/cann_inc.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License
+
+#pragma once
+
+#include <acl/acl.h>
+#include <acl/acl_op_compiler.h>

--- a/onnxruntime/core/providers/cann/cann_kernel.h
+++ b/onnxruntime/core/providers/cann/cann_kernel.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_inc.h"
+#include "core/providers/cann/cann_call.h"
+#include "core/providers/cann/cann_execution_provider.h"
+#include "core/providers/cann/cann_fwd.h"
+#include "core/providers/cann/cann_utils.h"
+
+namespace onnxruntime {
+namespace cann {
+
+class CannKernel : public OpKernel {
+ public:
+  explicit CannKernel(const OpKernelInfo& info)
+      : OpKernel(info),
+        provider_(const_cast<CANNExecutionProvider*>(
+            static_cast<const CANNExecutionProvider*>(info.GetExecutionProvider()))) {}
+
+  Status Compute(OpKernelContext* p_op_kernel_context) const override {
+    auto s = ComputeInternal(p_op_kernel_context);
+
+    if (s.IsOK()) {
+      auto err = aclGetRecentErrMsg();
+      if (err != nullptr) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CANN error", err);
+      }
+    }
+
+    return s;
+  }
+
+  virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
+    return provider_->GetScratchBuffer<T>(count_or_bytes);
+  }
+
+  inline aclrtStream Stream() const { return static_cast<aclrtStream>(provider_->GetComputeStream()); }
+
+ private:
+  CANNExecutionProvider* provider_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_provider_factory.cc
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.cc
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_provider_factory.h"
+#include "core/providers/cann/cann_execution_provider_info.h"
+#include "core/providers/cann/cann_execution_provider.h"
+#include "core/providers/cann/cann_allocator.h"
+#include "core/providers/cann/npu_data_transfer.h"
+#include "core/providers/cann/cann_call.h"
+
+namespace onnxruntime {
+
+void InitializeRegistry();
+void DeleteRegistry();
+
+struct CANNProviderFactory : IExecutionProviderFactory {
+  explicit CANNProviderFactory(const CANNExecutionProviderInfo& info) : info_(info) {}
+  ~CANNProviderFactory() override {}
+
+  std::unique_ptr<IExecutionProvider> CreateProvider() override;
+
+ private:
+  CANNExecutionProviderInfo info_;
+};
+
+std::unique_ptr<IExecutionProvider> CANNProviderFactory::CreateProvider() {
+  return std::make_unique<CANNExecutionProvider>(info_);
+}
+
+struct ProviderInfo_CANN_Impl : ProviderInfo_CANN {
+  void CANNExecutionProviderInfo__FromProviderOptions(const ProviderOptions& options,
+                                                      CANNExecutionProviderInfo& info) override {
+    info = CANNExecutionProviderInfo::FromProviderOptions(options);
+  }
+
+  std::shared_ptr<IExecutionProviderFactory>
+  CreateExecutionProviderFactory(const CANNExecutionProviderInfo& info) override {
+    return std::make_shared<CANNProviderFactory>(info);
+  }
+} g_info;
+
+struct CANN_Provider : Provider {
+  void* GetInfo() override { return &g_info; }
+
+  std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(const void* void_params) override {
+    auto params = reinterpret_cast<const OrtCANNProviderOptions*>(void_params);
+
+    CANNExecutionProviderInfo info{};
+    info.device_id = static_cast<OrtDevice::DeviceId>(params->device_id);
+    info.max_opqueue_num = params->max_opqueue_num;
+    info.npu_mem_limit = params->npu_mem_limit;
+    info.arena_extend_strategy = ArenaExtendStrategy(params->arena_extend_strategy);
+    info.do_copy_in_default_stream = params->do_copy_in_default_stream != 0;
+    info.default_memory_arena_cfg = params->default_memory_arena_cfg;
+
+    return std::make_shared<CANNProviderFactory>(info);
+  }
+
+  void UpdateProviderOptions(void* provider_options, const ProviderOptions& options) override {
+    auto internal_options = onnxruntime::CANNExecutionProviderInfo::FromProviderOptions(options);
+    auto& cann_options = *reinterpret_cast<OrtCANNProviderOptions*>(provider_options);
+
+    cann_options.device_id = internal_options.device_id;
+    cann_options.max_opqueue_num = internal_options.max_opqueue_num;
+    cann_options.npu_mem_limit = internal_options.npu_mem_limit;
+    cann_options.arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
+    cann_options.do_copy_in_default_stream = internal_options.do_copy_in_default_stream;
+    cann_options.default_memory_arena_cfg = internal_options.default_memory_arena_cfg;
+  }
+
+  ProviderOptions GetProviderOptions(const void* provider_options) override {
+    auto& options = *reinterpret_cast<const OrtCANNProviderOptions*>(provider_options);
+    return onnxruntime::CANNExecutionProviderInfo::ToProviderOptions(options);
+  }
+
+  void Initialize() override {
+    InitializeRegistry();
+  }
+
+  void Shutdown() override {
+    DeleteRegistry();
+  }
+} g_provider;
+
+}  // namespace onnxruntime
+
+extern "C" {
+
+ORT_API(onnxruntime::Provider*, GetProvider) {
+  return &onnxruntime::g_provider;
+}
+}

--- a/onnxruntime/core/providers/cann/cann_provider_factory.cc
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.cc
@@ -4,6 +4,8 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cann/cann_provider_factory.h"
+#include "core/providers/cann/cann_provider_factory_creator.h"
+#include "core/providers/cann/cann_provider_options.h"
 #include "core/providers/cann/cann_execution_provider_info.h"
 #include "core/providers/cann/cann_execution_provider.h"
 #include "core/providers/cann/cann_allocator.h"
@@ -51,7 +53,7 @@ struct CANN_Provider : Provider {
     info.device_id = static_cast<OrtDevice::DeviceId>(params->device_id);
     info.max_opqueue_num = params->max_opqueue_num;
     info.npu_mem_limit = params->npu_mem_limit;
-    info.arena_extend_strategy = ArenaExtendStrategy(params->arena_extend_strategy);
+    info.arena_extend_strategy = params->arena_extend_strategy;
     info.do_copy_in_default_stream = params->do_copy_in_default_stream != 0;
     info.default_memory_arena_cfg = params->default_memory_arena_cfg;
 
@@ -65,7 +67,7 @@ struct CANN_Provider : Provider {
     cann_options.device_id = internal_options.device_id;
     cann_options.max_opqueue_num = internal_options.max_opqueue_num;
     cann_options.npu_mem_limit = internal_options.npu_mem_limit;
-    cann_options.arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
+    cann_options.arena_extend_strategy = internal_options.arena_extend_strategy;
     cann_options.do_copy_in_default_stream = internal_options.do_copy_in_default_stream;
     cann_options.default_memory_arena_cfg = internal_options.default_memory_arena_cfg;
   }

--- a/onnxruntime/core/providers/cann/cann_provider_factory.h
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include "onnxruntime_c_api.h"
+#include "core/framework/provider_options.h"
+
+namespace onnxruntime {
+struct IExecutionProviderFactory;
+struct CANNExecutionProviderInfo;
+
+struct ProviderInfo_CANN {
+  virtual void CANNExecutionProviderInfo__FromProviderOptions(const onnxruntime::ProviderOptions& options,
+                                                              onnxruntime::CANNExecutionProviderInfo& info) = 0;
+  virtual std::shared_ptr<onnxruntime::IExecutionProviderFactory>
+  CreateExecutionProviderFactory(const onnxruntime::CANNExecutionProviderInfo& info) = 0;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_provider_factory.h
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include "onnxruntime_c_api.h"
 #include "core/framework/provider_options.h"
+#include "core/providers/cann/cann_provider_options.h"
 
 namespace onnxruntime {
 struct IExecutionProviderFactory;

--- a/onnxruntime/core/providers/cann/cann_provider_factory_creator.h
+++ b/onnxruntime/core/providers/cann/cann_provider_factory_creator.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+
+#include "core/providers/providers.h"
+
+struct OrtCANNProviderOptions;
+
+namespace onnxruntime {
+struct CannProviderFactoryCreator {
+  static std::shared_ptr<IExecutionProviderFactory> Create(const OrtCANNProviderOptions* provider_options);
+};
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_utils.cc
+++ b/onnxruntime/core/providers/cann/cann_utils.cc
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/cann_utils.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+aclDataType getACLType() {
+  return ACL_DT_UNDEFINED;
+}
+
+#define GET_ACL_TYPE(onnx_type, cann_type) \
+  template <>                              \
+  aclDataType getACLType<onnx_type>() {    \
+    return cann_type;                      \
+  }
+
+GET_ACL_TYPE(int8_t, ACL_INT8);
+GET_ACL_TYPE(int16_t, ACL_INT16);
+GET_ACL_TYPE(int32_t, ACL_INT32);
+GET_ACL_TYPE(int64_t, ACL_INT64);
+GET_ACL_TYPE(uint8_t, ACL_UINT8);
+GET_ACL_TYPE(uint16_t, ACL_UINT16);
+GET_ACL_TYPE(uint32_t, ACL_UINT32);
+GET_ACL_TYPE(uint64_t, ACL_UINT64);
+GET_ACL_TYPE(float, ACL_FLOAT);
+GET_ACL_TYPE(MLFloat16, ACL_FLOAT16);
+GET_ACL_TYPE(BFloat16, ACL_BF16);
+GET_ACL_TYPE(double, ACL_DOUBLE);
+GET_ACL_TYPE(bool, ACL_BOOL);
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_utils.h
+++ b/onnxruntime/core/providers/cann/cann_utils.h
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <vector>
+#include <iomanip>
+#include "core/providers/cann/cann_call.h"
+#include "core/providers/cann/cann_inc.h"
+#include "core/framework/float16.h"
+
+namespace onnxruntime {
+namespace cann {
+
+struct CannPreparation {
+  CannPreparation() {
+    opAttr_ = aclopCreateAttr();
+  }
+
+  virtual ~CannPreparation() {
+    for (auto desc : inputDesc_) {
+      aclDestroyTensorDesc(desc);
+    }
+
+    for (auto desc : outputDesc_) {
+      aclDestroyTensorDesc(desc);
+    }
+
+    for (auto buf : inputBuffers_) {
+      aclDestroyDataBuffer(buf);
+    }
+
+    for (auto buf : outputBuffers_) {
+      aclDestroyDataBuffer(buf);
+    }
+
+    aclopDestroyAttr(opAttr_);
+  }
+
+  std::vector<aclDataBuffer*> inputBuffers_;
+  std::vector<aclDataBuffer*> outputBuffers_;
+  std::vector<aclTensorDesc*> inputDesc_;
+  std::vector<aclTensorDesc*> outputDesc_;
+  aclopAttr* opAttr_;
+};
+
+template <typename T>
+aclDataType getACLType();
+
+#define CANN_PREPARE_INPUTDESC(var, ...)           \
+  do {                                             \
+    auto _rPtr = aclCreateTensorDesc(__VA_ARGS__); \
+    if (_rPtr == nullptr)                          \
+      ORT_THROW("aclCreateTensorDesc run failed"); \
+    else                                           \
+      var.inputDesc_.push_back(_rPtr);             \
+  } while (0)
+
+#define CANN_PREPARE_OUTPUTDESC(var, ...)          \
+  do {                                             \
+    auto _rPtr = aclCreateTensorDesc(__VA_ARGS__); \
+    if (_rPtr == nullptr)                          \
+      ORT_THROW("aclCreateTensorDesc run failed"); \
+    else                                           \
+      var.outputDesc_.push_back(_rPtr);            \
+  } while (0)
+
+#define CANN_PREPARE_INPUTBUFFER(var, ...)         \
+  do {                                             \
+    auto _rPtr = aclCreateDataBuffer(__VA_ARGS__); \
+    if (_rPtr == nullptr)                          \
+      ORT_THROW("aclCreateDataBuffer run failed"); \
+    else                                           \
+      var.inputBuffers_.push_back(_rPtr);          \
+  } while (0)
+
+#define CANN_PREPARE_OUTPUTBUFFER(var, ...)        \
+  do {                                             \
+    auto _rPtr = aclCreateDataBuffer(__VA_ARGS__); \
+    if (_rPtr == nullptr)                          \
+      ORT_THROW("aclCreateDataBuffer run failed"); \
+    else                                           \
+      var.outputBuffers_.push_back(_rPtr);         \
+  } while (0)
+
+#define CANN_RETURN_IF_ERROR(expr)               \
+  ORT_RETURN_IF_ERROR(CANN_CALL(expr)            \
+                          ? common::Status::OK() \
+                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CANN error executing ", #expr))
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cann/math/binary_elementwise_ops.cc
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/math/binary_elementwise_ops.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  const Tensor* A = ctx->Input<Tensor>(0);
+  const Tensor* B = ctx->Input<Tensor>(1);
+  Tensor* C = ctx->Output(0, A->Shape());
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(A->template Data<T>()), A->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, C->template MutableData<T>(), C->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_ELEMENTWISE_TYPED_COMPUTE(x, T)                               \
+  template <>                                                                  \
+  Status x<T>::ComputeInternal(OpKernelContext* context) const {               \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare<T>(context, prepare));                         \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute(#x,                            \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_ELEMENTWISE_TYPED_KERNEL(x, class_name, ver, T)                           \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      class_name<T>);
+
+#define REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(x, startver, endver, T)                \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      x<T>);
+
+#define REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, T) \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(name, startver, endver, T)
+
+#define REGISTER_ELEMENTWISE_TYPED(name, ver, T)        \
+  REGISTER_ELEMENTWISE_TYPED_KERNEL(name, name, ver, T) \
+  REGISTER_ELEMENTWISE_TYPED_COMPUTE(name, T)
+
+#define REGISTER_ELEMENTWISE_VERSIONED_ILHFD(name, startver, endver)      \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int32_t)   \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int64_t)   \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, MLFloat16) \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, float)     \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, double)
+
+#define REGISTER_ELEMENTWISE_VERSIONED_IHF(name, startver, endver)        \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int32_t)   \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, MLFloat16) \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, float)
+
+#define REGISTER_ELEMENTWISE_BCSILHFD(name, ver)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, uint8_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int8_t)    \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int16_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int64_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, float)     \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, double)
+
+#define REGISTER_ELEMENTWISE_IHF(name, ver)        \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, float)
+
+#define REGISTER_ELEMENTWISE_BCSIHF(name, ver)     \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, uint8_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int8_t)    \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int16_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, float)
+
+#define REGISTER_ELEMENTWISE_ILHFD(name, ver)      \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int64_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, float)     \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, double)
+
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Add, 7, 12)
+REGISTER_ELEMENTWISE_VERSIONED_IHF(Sub, 7, 12)
+REGISTER_ELEMENTWISE_VERSIONED_IHF(Mul, 7, 12)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Div, 7, 12)
+
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Add, 13, 13)
+REGISTER_ELEMENTWISE_VERSIONED_IHF(Sub, 13, 13)
+REGISTER_ELEMENTWISE_VERSIONED_IHF(Mul, 13, 13)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Div, 13, 13)
+
+REGISTER_ELEMENTWISE_BCSILHFD(Add, 14)
+REGISTER_ELEMENTWISE_IHF(Sub, 14)
+REGISTER_ELEMENTWISE_BCSIHF(Mul, 14)
+REGISTER_ELEMENTWISE_ILHFD(Div, 14)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/cann/math/binary_elementwise_ops.h
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+#include "core/providers/cpu/tensor/utils.h"
+
+namespace onnxruntime {
+namespace cann {
+
+class BinaryElementwise : public CannKernel {
+ protected:
+  explicit BinaryElementwise(const OpKernelInfo& info) : CannKernel(info) {}
+  Status ComputeInternal(OpKernelContext*) const override {
+    return Status(common::ONNXRUNTIME, common::FAIL);  // should not reach here
+  }
+  template <typename T>
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+};
+
+template <typename T>
+class Add final : public BinaryElementwise {
+ public:
+  Add(const OpKernelInfo& info) : BinaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Sub final : public BinaryElementwise {
+ public:
+  Sub(const OpKernelInfo& info) : BinaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Mul final : public BinaryElementwise {
+ public:
+  Mul(const OpKernelInfo& info) : BinaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Div final : public BinaryElementwise {
+ public:
+  Div(const OpKernelInfo& info) : BinaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/gemm.cc
+++ b/onnxruntime/core/providers/cann/math/gemm.cc
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/math/gemm.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status Gemm<T>::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const auto* A = ctx->Input<Tensor>(0);
+  const auto* B = ctx->Input<Tensor>(1);
+  const auto* C = ctx->Input<Tensor>(2);
+
+  GemmHelper helper(A->Shape(), trans_A_, B->Shape(), trans_B_, C != nullptr ? C->Shape() : TensorShape({}));
+  if (!helper.State().IsOK())
+    return helper.State();
+
+  int M = gsl::narrow_cast<int>(helper.M());
+  int N = gsl::narrow_cast<int>(helper.N());
+  auto* Y = ctx->Output(0, {M, N});
+
+  TensorShape shape{1};
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_a", trans_A_));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_b", trans_B_));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, B->Shape().NumDimensions(), B->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, C->Shape().NumDimensions(), C->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(A->template Data<T>()), A->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(C->template Data<T>()), C->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<float*>(&alpha_), sizeof(float));
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<float*>(&beta_), sizeof(float));
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_GEMM_TYPED_COMPUTE(T)                                         \
+  template <>                                                                  \
+  Status Gemm<T>::ComputeInternal(OpKernelContext* context) const {            \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare(context, prepare));                            \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute("GEMM",                        \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_GEMM_TYPED_KERNEL(ver, T)                                                 \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      Gemm,                                                                                \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Gemm<T>);
+
+#define REGISTER_GEMM_VERSIONED_TYPED_KERNEL(startver, endver, T)                          \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      Gemm,                                                                                \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Gemm<T>);
+
+#define REGISTER_GEMM_VERSIONED_TYPED(startver, endver, T) \
+  REGISTER_GEMM_VERSIONED_TYPED_KERNEL(startver, endver, T)
+
+#define REGISTER_GEMM_TYPED(ver, T)  \
+  REGISTER_GEMM_TYPED_KERNEL(ver, T) \
+  REGISTER_GEMM_TYPED_COMPUTE(T)
+
+REGISTER_GEMM_VERSIONED_TYPED(7, 8, MLFloat16)
+REGISTER_GEMM_VERSIONED_TYPED(9, 10, MLFloat16)
+REGISTER_GEMM_VERSIONED_TYPED(11, 12, MLFloat16)
+REGISTER_GEMM_TYPED(13, MLFloat16)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/gemm.h
+++ b/onnxruntime/core/providers/cann/math/gemm.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+#include "core/providers/cpu/math/gemm_helper.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class Gemm final : public CannKernel {
+ public:
+  Gemm(const OpKernelInfo& info) : CannKernel(info) {
+    int64_t temp;
+    ORT_ENFORCE(info.GetAttr<int64_t>("transA", &temp).IsOK());
+    trans_A_ = (temp != 0);
+
+    ORT_ENFORCE(info.GetAttr<int64_t>("transB", &temp).IsOK());
+    trans_B_ = (temp != 0);
+
+    ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
+    ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+
+ private:
+  bool trans_A_;
+  bool trans_B_;
+  float alpha_;
+  float beta_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/matmul.cc
+++ b/onnxruntime/core/providers/cann/math/matmul.cc
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/math/matmul.h"
+#include "core/providers/cpu/math/matmul_helper.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
+  const Tensor* A = ctx->Input<Tensor>(0);
+  const Tensor* B = ctx->Input<Tensor>(1);
+
+  bool transa = trans_A_;
+  bool transb = trans_B_;
+  if (A->Shape().NumDimensions() == 1) {
+    transa = false;
+  }
+  if (B->Shape().NumDimensions() == 1) {
+    transb = false;
+  }
+
+  MatMulComputeHelper helper;
+  ORT_RETURN_IF_ERROR(helper.Compute(A->Shape(), B->Shape(), transa, transb, trans_batch_a_, trans_batch_b_, false));
+
+  Tensor* Y = ctx->Output(0, helper.OutputShape());
+  if (Y->Shape().Size() == 0)
+    return Status::OK();
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_x1", transa));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_x2", transb));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, B->Shape().NumDimensions(), B->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(A->template Data<T>()), A->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, nullptr, 0);
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("MatMul",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+#define REGISTER_MATMUL_TYPED_KERNEL(T, startver)                                          \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      MatMul,                                                                              \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      MatMul<T>);
+
+#define REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(T, startver, endver) \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                          \
+      MatMul,                                                       \
+      kOnnxDomain,                                                  \
+      startver,                                                     \
+      endver,                                                       \
+      T,                                                            \
+      kCannExecutionProvider,                                       \
+      (*KernelDefBuilder::Create())                                 \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),   \
+      MatMul<T>);
+
+REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(MLFloat16, 1, 8)
+REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(float, 1, 8)
+
+REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(MLFloat16, 9, 12)
+REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(float, 9, 12)
+REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(int32_t, 9, 12)
+
+REGISTER_MATMUL_TYPED_KERNEL(MLFloat16, 13)
+REGISTER_MATMUL_TYPED_KERNEL(float, 13)
+REGISTER_MATMUL_TYPED_KERNEL(int32_t, 13)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/matmul.h
+++ b/onnxruntime/core/providers/cann/math/matmul.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class MatMul final : public CannKernel {
+ public:
+  MatMul(const OpKernelInfo& info)
+      : CannKernel(info),
+        alpha_{info.GetAttrOrDefault<float>("alpha", 1.0f)},
+        trans_A_{info.GetAttrOrDefault<int64_t>("transA", 0) != 0},
+        trans_B_{info.GetAttrOrDefault<int64_t>("transB", 0) != 0},
+        trans_batch_a_{info.GetAttrOrDefault<int64_t>("transBatchA", 0) != 0},
+        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0} {}
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  const float alpha_;
+  const bool trans_A_;
+  const bool trans_B_;
+  const bool trans_batch_a_;
+  const bool trans_batch_b_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cann/nn/batch_norm.cc
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/nn/batch_norm.h"
+#include "core/providers/cpu/nn/batch_norm_helper.h"
+
+using namespace onnxruntime::common;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status BatchNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
+  const Tensor* X = ctx->Input<Tensor>(0);
+  const Tensor* scale = ctx->Input<Tensor>(1);
+  const Tensor* B = ctx->Input<Tensor>(2);
+  const Tensor* mean = ctx->Input<Tensor>(3);
+  const Tensor* var = ctx->Input<Tensor>(4);
+
+  ORT_RETURN_IF_ERROR(BatchNormHelper::ValidateInputs(X, scale, B, mean, var, spatial_ == 1));
+
+  const TensorShape& x_shape = X->Shape();
+  const TensorShape& channel_shape = mean->Shape();
+
+  Tensor* Y = ctx->Output(0, x_shape);
+  Tensor* running_mean = ctx->Output(1, channel_shape);
+  Tensor* running_var = ctx->Output(2, channel_shape);
+  Tensor* saved_mean = ctx->Output(3, channel_shape);
+  Tensor* saved_var = ctx->Output(4, channel_shape);
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "epsilon", epsilon_));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, scale->Shape().NumDimensions(), scale->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, B->Shape().NumDimensions(), B->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, mean->Shape().NumDimensions(), mean->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, var->Shape().NumDimensions(), var->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+    if (running_mean && running_var && saved_mean && saved_var) {
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_FLOAT, running_mean->Shape().NumDimensions(),
+                              running_mean->Shape().GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_FLOAT, running_var->Shape().NumDimensions(),
+                              running_var->Shape().GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_FLOAT, saved_mean->Shape().NumDimensions(),
+                              saved_mean->Shape().GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_FLOAT, saved_var->Shape().NumDimensions(),
+                              saved_var->Shape().GetDims().data(), format);
+    } else {
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+    }
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(scale->template Data<T>()), scale->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(mean->template Data<T>()), mean->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(var->template Data<T>()), var->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    if (running_mean && running_var && saved_mean && saved_var) {
+      CANN_PREPARE_OUTPUTBUFFER(prepare, running_mean->template MutableData<T>(), running_mean->SizeInBytes());
+      CANN_PREPARE_OUTPUTBUFFER(prepare, running_var->template MutableData<T>(), running_var->SizeInBytes());
+      CANN_PREPARE_OUTPUTBUFFER(prepare, saved_mean->template MutableData<T>(), saved_mean->SizeInBytes());
+      CANN_PREPARE_OUTPUTBUFFER(prepare, saved_var->template MutableData<T>(), saved_var->SizeInBytes());
+    } else {
+      CANN_PREPARE_OUTPUTBUFFER(prepare, nullptr, 0);
+      CANN_PREPARE_OUTPUTBUFFER(prepare, nullptr, 0);
+      CANN_PREPARE_OUTPUTBUFFER(prepare, nullptr, 0);
+      CANN_PREPARE_OUTPUTBUFFER(prepare, nullptr, 0);
+    }
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("BatchNormalization",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+#define REGISTER_KERNEL_TYPED(T)                                   \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                         \
+      BatchNormalization,                                          \
+      kOnnxDomain,                                                 \
+      7, 8,                                                        \
+      T,                                                           \
+      kCannExecutionProvider,                                      \
+      (*KernelDefBuilder::Create())                                \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),  \
+      BatchNorm<T>);                                               \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                         \
+      BatchNormalization,                                          \
+      kOnnxDomain,                                                 \
+      9, 13,                                                       \
+      T,                                                           \
+      kCannExecutionProvider,                                      \
+      (*KernelDefBuilder::Create())                                \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),  \
+      BatchNorm<T>);                                               \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                         \
+      BatchNormalization,                                          \
+      kOnnxDomain,                                                 \
+      14, 14,                                                      \
+      T,                                                           \
+      kCannExecutionProvider,                                      \
+      (*KernelDefBuilder::Create())                                \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())   \
+          .TypeConstraint("U", DataTypeImpl::GetTensorType<T>()),  \
+      BatchNorm<T>);                                               \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                   \
+      BatchNormalization,                                          \
+      kOnnxDomain,                                                 \
+      15,                                                          \
+      T,                                                           \
+      kCannExecutionProvider,                                      \
+      (*KernelDefBuilder::Create())                                \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())   \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>())  \
+          .TypeConstraint("T2", DataTypeImpl::GetTensorType<T>()), \
+      BatchNorm<T>);
+
+REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(float)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/batch_norm.h
+++ b/onnxruntime/core/providers/cann/nn/batch_norm.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class BatchNorm final : public CannKernel {
+ public:
+  BatchNorm(const OpKernelInfo& info)
+      : CannKernel(info),
+        momentum_(0.9) {
+    float tmp_epsilon;
+    ORT_ENFORCE(info.GetAttr<float>("epsilon", &tmp_epsilon).IsOK());
+    epsilon_ = static_cast<float>(tmp_epsilon);
+
+    // spatial or not
+    int64_t tmp_spatial;
+    if (info.GetAttr<int64_t>("spatial", &tmp_spatial).IsOK()) {
+      spatial_ = tmp_spatial;
+    }
+
+    float tmp_momentum;
+    if (info.GetAttr<float>("momentum", &tmp_momentum).IsOK()) {
+      momentum_ = static_cast<double>(tmp_momentum);
+    }
+
+    is_training_mode_ = (info.GetAttrOrDefault<int64_t>("training_mode", 0) == 1);
+    const auto& node = info.node();
+    auto opset = node.SinceVersion();
+
+    ORT_ENFORCE(!(is_training_mode_ && opset >= 14), "Training mode does not support BN opset 14 (or higher) yet.");
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  float epsilon_;
+  int64_t spatial_ = 1;
+  float momentum_;
+  bool is_training_mode_ = 0;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/conv.cc
+++ b/onnxruntime/core/providers/cann/nn/conv.cc
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/nn/conv.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+using ConvPadVector = ConvAttributes::ConvPadVector;
+
+template <typename T>
+Status Conv<T>::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const auto* X = ctx->Input<Tensor>(0);
+  const auto* W = ctx->Input<Tensor>(1);
+  const Tensor* B = ctx->Input<Tensor>(2);
+  const int64_t N = X->Shape()[0];
+  const int64_t M = W->Shape()[0];
+
+  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
+
+  TensorShapeVector kernel_shape;
+  ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));
+
+  ConvPadVector pads(conv_attrs_.pads);
+  if (pads.empty()) {
+    pads.resize(kernel_shape.size() * 2, 0);
+  }
+  TensorShapeVector dilations(conv_attrs_.dilations);
+  if (dilations.empty()) {
+    dilations.resize(kernel_shape.size(), 1);
+  }
+  TensorShapeVector strides(conv_attrs_.strides);
+  if (strides.empty()) {
+    strides.resize(kernel_shape.size(), 1);
+  }
+
+  TensorShapeVector Y_dims({N, M});
+  TensorShape input_shape = X->Shape().Slice(2);
+  ORT_RETURN_IF_ERROR(conv_attrs_.InferPadsAndOutputShape(input_shape, kernel_shape, strides, dilations, pads, Y_dims));
+  Tensor* Y = ctx->Output(0, TensorShape(Y_dims));
+
+  if (strides.size() < 4) {
+    strides.insert(strides.begin(), {1, 1});
+  }
+  if (dilations.size() < 4) {
+    dilations.insert(dilations.begin(), {1, 1});
+  }
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_NCHW;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "auto_pad", static_cast<int64_t>(conv_attrs_.auto_pad)));
+  CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "group", conv_attrs_.group));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "dilations", dilations.size(), dilations.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "strides", strides.size(), strides.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "pads", pads.size(), pads.data()));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, W->Shape().NumDimensions(), W->Shape().GetDims().data(), format);
+    if (ctx->InputCount() >= 3) {
+      CANN_PREPARE_INPUTDESC(prepare, aclType, B->Shape().NumDimensions(), B->Shape().GetDims().data(), format);
+    } else {
+      CANN_PREPARE_INPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
+    }
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(W->template Data<T>()), W->SizeInBytes());
+    if (ctx->InputCount() >= 3) {
+      CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
+    } else {
+      CANN_PREPARE_INPUTBUFFER(prepare, nullptr, 0);
+    }
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_CONV_TYPED_COMPUTE(T)                                         \
+  template <>                                                                  \
+  Status Conv<T>::ComputeInternal(OpKernelContext* context) const {            \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare(context, prepare));                            \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute("Conv2D",                      \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_CONV_TYPED_KERNEL(ver, T)                                                 \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      Conv,                                                                                \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Conv<T>);
+
+#define REGISTER_CONV_VERSIONED_TYPED_KERNEL(startver, endver, T)                          \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      Conv,                                                                                \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Conv<T>);
+
+#define REGISTER_CONV_VERSIONED_TYPED(startver, endver, T) \
+  REGISTER_CONV_VERSIONED_TYPED_KERNEL(startver, endver, T)
+
+#define REGISTER_CONV_TYPED(ver, T)  \
+  REGISTER_CONV_TYPED_KERNEL(ver, T) \
+  REGISTER_CONV_TYPED_COMPUTE(T)
+
+REGISTER_CONV_VERSIONED_TYPED(1, 10, MLFloat16)
+REGISTER_CONV_VERSIONED_TYPED(1, 10, float)
+REGISTER_CONV_VERSIONED_TYPED(1, 10, double)
+REGISTER_CONV_TYPED(11, MLFloat16)
+REGISTER_CONV_TYPED(11, float)
+REGISTER_CONV_TYPED(11, double)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/conv.h
+++ b/onnxruntime/core/providers/cann/nn/conv.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+#include "core/providers/cpu/nn/conv_attributes.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class Conv final : public CannKernel {
+ public:
+  Conv(const OpKernelInfo& info) : CannKernel(info), conv_attrs_(info) {
+    auto pads_size = conv_attrs_.pads.size();
+    ORT_ENFORCE(pads_size % 2 == 0);
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+
+ private:
+  ConvAttributes conv_attrs_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/dropout.cc
+++ b/onnxruntime/core/providers/cann/nn/dropout.cc
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/nn/dropout.h"
+
+namespace onnxruntime {
+namespace cann {
+
+namespace {
+
+template <typename T>
+struct GetRatioDataImpl {
+  void operator()(const Tensor* ratio, float& ratio_data) const {
+    ratio_data = static_cast<float>(*(ratio->Data<T>()));
+    ORT_ENFORCE(ratio_data >= 0.0f && ratio_data < 1.0f, "ratio_data is outside range [0, 1)");
+  }
+};
+
+template <typename T>
+struct DropoutComputeImpl {
+  void operator()(const Tensor* X, Tensor* Y, float ratio_data, void* mask_data, aclrtStream stream) const {
+    const aclDataType aclType = getACLType<T>();
+    aclFormat format = ACL_FORMAT_ND;
+
+    TensorShape shape{1};
+    bool train_mode = true;
+
+    CannPreparation prepare;
+
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, ACL_BOOL, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, ACL_BOOL, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, &ratio_data, sizeof(float));
+    CANN_PREPARE_INPUTBUFFER(prepare, &train_mode, sizeof(bool));
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, mask_data, X->Shape().Size());
+
+    CANN_CALL_THROW(aclopCompileAndExecute("Dropout",
+                                           prepare.inputDesc_.size(),
+                                           prepare.inputDesc_.data(),
+                                           prepare.inputBuffers_.data(),
+                                           prepare.outputDesc_.size(),
+                                           prepare.outputDesc_.data(),
+                                           prepare.outputBuffers_.data(),
+                                           prepare.opAttr_,
+                                           ACL_ENGINE_SYS,
+                                           ACL_COMPILE_SYS,
+                                           NULL,
+                                           stream));
+  }
+};
+
+}  // namespace
+
+Status Dropout::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* X = context->Input<Tensor>(0);
+  if (!X) return Status(common::ONNXRUNTIME, common::FAIL, "X Input is not available.");
+  const TensorShape& shape = X->Shape();
+  const int64_t N = shape.Size();
+
+  auto Y = context->Output(0, shape);
+
+  Tensor* mask = context->Output(1, shape);
+  ORT_ENFORCE(!mask || mask->Shape().Size() == N);
+
+  float ratio_data = default_ratio_;
+  auto ratio = context->Input<Tensor>(1);
+  if (ratio) {
+    utils::MLTypeCallDispatcher<float, MLFloat16, double, BFloat16> t_disp(ratio->GetElementType());
+    t_disp.Invoke<GetRatioDataImpl>(ratio, ratio_data);
+  }
+
+  const Tensor* training_mode = context->Input<Tensor>(2);
+  if (ratio_data == 0.f || !training_mode || !(*(training_mode->Data<bool>()))) {
+    const void* X_data = X->DataRaw();
+    void* Y_data = Y->MutableDataRaw();
+
+    if (Y_data != X_data) {
+      CANN_RETURN_IF_ERROR(aclrtMemcpyAsync(Y_data, Y->SizeInBytes(), X_data, X->SizeInBytes(),
+                                            ACL_MEMCPY_DEVICE_TO_DEVICE, Stream()));
+    }
+
+    if (mask) {
+      CANN_RETURN_IF_ERROR(aclrtMemsetAsync(mask->MutableData<bool>(), mask->SizeInBytes(), true,
+                                            N * sizeof(bool), Stream()));
+    }
+
+    return Status::OK();
+  }
+
+  IAllocatorUniquePtr<void> temp_mask_buffer{};  // buffer to use if mask is not provided
+  void* const mask_data = [this, N, mask, &temp_mask_buffer]() {
+    if (mask) return mask->MutableDataRaw();
+    temp_mask_buffer =
+        GetScratchBuffer<void>(N * sizeof(bool));
+    return temp_mask_buffer.get();
+  }();
+
+  ORT_TRY {
+    utils::MLTypeCallDispatcher<float, MLFloat16, double, BFloat16> t_disp(X->GetElementType());
+    t_disp.Invoke<DropoutComputeImpl>(X, Y, ratio_data, mask_data, Stream());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(Dropout, kOnnxDomain, 12, 12, kCannExecutionProvider,
+                                  (*KernelDefBuilder::Create())
+                                      .TypeConstraint("T", DataTypeImpl::AllIEEEFloatTensorTypes())
+                                      .TypeConstraint("T1", DataTypeImpl::AllIEEEFloatTensorTypes())
+                                      .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>())
+                                      .InputMemoryType(OrtMemTypeCPUInput, 1)
+                                      .InputMemoryType(OrtMemTypeCPUInput, 2),
+                                  Dropout);
+
+ONNX_OPERATOR_KERNEL_EX(Dropout, kOnnxDomain, 13, kCannExecutionProvider,
+                        (*KernelDefBuilder::Create())
+                            .TypeConstraint("T", BuildKernelDefConstraints<MLFloat16, float, double, BFloat16>())
+                            .TypeConstraint("T1", BuildKernelDefConstraints<MLFloat16, float, double>())
+                            .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>())
+                            .InputMemoryType(OrtMemTypeCPUInput, 1)
+                            .InputMemoryType(OrtMemTypeCPUInput, 2),
+                        Dropout);
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/dropout.h
+++ b/onnxruntime/core/providers/cann/nn/dropout.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+class Dropout final : public CannKernel {
+ public:
+  Dropout(const OpKernelInfo& info) : CannKernel(info) {
+    int64_t seed = 0;
+    if (info.GetAttr<int64_t>("seed", &seed).IsOK()) {
+      seed_ = seed;
+    }
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  int64_t seed_;
+  static constexpr float default_ratio_ = 0.5f;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/pool.cc
+++ b/onnxruntime/core/providers/cann/nn/pool.cc
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/nn/pool.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status Pool<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* X = context->Input<Tensor>(0);
+  const TensorShape& x_shape = X->Shape();
+  const auto x_dims = x_shape.GetDims();
+
+  if (x_shape.NumDimensions() < 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input dimension cannot be less than 3.");
+  }
+
+  auto kernel_shape = pool_attrs_.kernel_shape;
+  auto pads = pool_attrs_.pads;
+  auto strides = pool_attrs_.strides;
+
+  if (pool_attrs_.global_pooling) {
+    kernel_shape.assign(x_dims.begin() + 2, x_dims.end());
+    pads.assign(kernel_shape.size(), 0);
+    strides.assign(kernel_shape.size(), 1);
+  }
+
+  auto y_dims = pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
+  TensorShape y_shape(y_dims);
+  Tensor* Y = context->Output(0, y_shape);
+  if (y_shape.Size() == 0)
+    return Status::OK();
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  if (!pool_attrs_.global_pooling) {
+    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "auto_pad", static_cast<int64_t>(pool_attrs_.auto_pad)));
+    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "kernel_shape", pool_attrs_.kernel_shape.size(),
+                                             pool_attrs_.kernel_shape.data()));
+    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "strides", pool_attrs_.strides.size(),
+                                             pool_attrs_.strides.data()));
+    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "pads", pool_attrs_.pads.size(),
+                                             pool_attrs_.pads.data()));
+    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "ceil_mode", pool_attrs_.ceil_mode));
+  }
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute(op_name_.c_str(),
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+#define REGISTER_POOL_TYPED_KERNEL(x, T, startver)                                         \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Pool<T>);
+
+#define REGISTER_POOL_VERSIONED_TYPED_KERNEL(x, T, startver, endver) \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                           \
+      x,                                                             \
+      kOnnxDomain,                                                   \
+      startver,                                                      \
+      endver,                                                        \
+      T,                                                             \
+      kCannExecutionProvider,                                        \
+      (*KernelDefBuilder::Create())                                  \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
+      Pool<T>);
+
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 7, 9)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, MLFloat16, 7, 9)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 10, 10)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, MLFloat16, 10, 10)
+REGISTER_POOL_TYPED_KERNEL(AveragePool, float, 11)
+REGISTER_POOL_TYPED_KERNEL(AveragePool, MLFloat16, 11)
+
+REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, float, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, MLFloat16, 1)
+
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, float, 1, 7)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, MLFloat16, 1, 7)
+
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, float, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, double, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, MLFloat16, 1)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/pool.h
+++ b/onnxruntime/core/providers/cann/nn/pool.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cann/cann_kernel.h"
+#include "core/providers/cpu/nn/pool_base.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class Pool : public CannKernel, public PoolBase {
+ public:
+  explicit Pool(const OpKernelInfo& info) : CannKernel(info), PoolBase(info) {}
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/npu_data_transfer.cc
+++ b/onnxruntime/core/providers/cann/npu_data_transfer.cc
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/npu_data_transfer.h"
+#include "core/providers/cann/cann_call.h"
+
+namespace onnxruntime {
+NPUDataTransfer::NPUDataTransfer(aclrtStream stream, bool do_copy_in_default_stream) {
+  do_copy_in_default_stream_ = do_copy_in_default_stream;
+  streams_[kCannStreamDefault] = stream;
+  if (do_copy_in_default_stream) {
+    streams_[kCannStreamCopyIn] = stream;
+    streams_[kCannStreamCopyOut] = stream;
+  } else {
+    CANN_CALL_THROW(aclrtCreateStream(&streams_[kCannStreamCopyIn]));
+    CANN_CALL_THROW(aclrtCreateStream(&streams_[kCannStreamCopyOut]));
+  }
+}
+
+NPUDataTransfer::~NPUDataTransfer() {
+  if (!do_copy_in_default_stream_ && streams_[kCannStreamCopyIn] != nullptr) {
+    CANN_CALL_THROW(aclrtDestroyStream(streams_[kCannStreamCopyIn]));
+  }
+  if (!do_copy_in_default_stream_ && streams_[kCannStreamCopyOut] != nullptr) {
+    CANN_CALL_THROW(aclrtDestroyStream(streams_[kCannStreamCopyOut]));
+  }
+}
+
+bool NPUDataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
+  return src_device.Type() == OrtDevice::NPU || dst_device.Type() == OrtDevice::NPU;
+}
+
+common::Status NPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int exec_queue_id) const {
+  size_t bytes = src.SizeInBytes();
+  const void* src_data = src.DataRaw();
+  void* dst_data = dst.MutableDataRaw();
+
+  auto& src_device = src.Location().device;
+  auto& dst_device = dst.Location().device;
+
+  if (dst_device.Type() == OrtDevice::NPU) {
+    if (src_device.Type() == OrtDevice::CPU && src_device.MemType() == OrtDevice::MemType::CANN_PINNED) {
+      CANN_CALL_THROW(aclrtMemcpyAsync(dst_data, bytes, src_data, bytes,
+                                       ACL_MEMCPY_HOST_TO_DEVICE, GetStream(exec_queue_id)));
+    } else if (src_device.Type() == OrtDevice::NPU) {
+      if (dst_data != src_data) {
+        CANN_CALL_THROW(aclrtMemcpyAsync(dst_data, bytes, src_data, bytes,
+                                         ACL_MEMCPY_DEVICE_TO_DEVICE, GetStream(kCannStreamDefault)));
+      }
+    } else {
+      CANN_CALL_THROW(aclrtMemcpyAsync(dst_data, bytes, src_data, bytes,
+                                       ACL_MEMCPY_HOST_TO_DEVICE, GetStream(kCannStreamDefault)));
+      CANN_CALL_THROW(aclrtSynchronizeStream(GetStream(kCannStreamDefault)));
+    }
+  } else {
+    if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::CANN_PINNED) {
+      CANN_CALL_THROW(aclrtMemcpyAsync(dst_data, bytes, src_data, bytes,
+                                       ACL_MEMCPY_DEVICE_TO_HOST, GetStream(exec_queue_id)));
+    } else {
+      CANN_CALL_THROW(aclrtMemcpyAsync(dst_data, bytes, src_data, bytes,
+                                       ACL_MEMCPY_DEVICE_TO_HOST, GetStream(kCannStreamDefault)));
+      CANN_CALL_THROW(aclrtSynchronizeStream(GetStream(kCannStreamDefault)));
+    }
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/npu_data_transfer.h
+++ b/onnxruntime/core/providers/cann/npu_data_transfer.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cann_inc.h"
+#include "core/framework/data_transfer.h"
+
+namespace onnxruntime {
+
+enum CANNStreamType : int {
+  kCannStreamDefault = 0,
+  kCannStreamCopyIn,
+  kCannStreamCopyOut,
+  kTotalCannStreams,
+};
+
+class NPUDataTransfer : public IDataTransfer {
+ public:
+  explicit NPUDataTransfer(aclrtStream stream, bool do_copy_in_default_stream = true);
+  ~NPUDataTransfer();
+
+  bool CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const override;
+
+  common::Status CopyTensor(const Tensor& src, Tensor& dst, int exec_queue_id) const override;
+
+  aclrtStream GetStream(int queue_id) const {
+    ORT_ENFORCE(queue_id >= 0 && queue_id < kTotalCannStreams);
+    return streams_[queue_id];
+  }
+
+ private:
+  bool do_copy_in_default_stream_;
+  aclrtStream streams_[kTotalCannStreams];
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/symbols.def
+++ b/onnxruntime/core/providers/cann/symbols.def
@@ -1,0 +1,2 @@
+EXPORTS
+   GetProvider

--- a/onnxruntime/core/providers/cann/tensor/flatten.cc
+++ b/onnxruntime/core/providers/cann/tensor/flatten.cc
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/tensor/flatten.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status Flatten<T>::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const Tensor* X = ctx->Input<Tensor>(0);
+  const TensorShape& X_shape = X->Shape();
+
+  auto axis = axis_;
+  if (axis < 0) {
+    axis = HandleNegativeAxis(axis, X_shape.NumDimensions());  // handle negative and enforce axis is valid
+  }
+  ORT_ENFORCE(gsl::narrow_cast<int64_t>(X_shape.NumDimensions()) >= axis, "The rank of input tensor must be >= axis");
+
+  Tensor* Y = ctx->Output(0, {X_shape.SizeToDimension(axis), X_shape.SizeFromDimension(axis)});
+
+  const void* source = X->DataRaw();
+  void* target = Y->MutableDataRaw();
+  if (target != source) {
+    const aclDataType aclType = getACLType<T>();
+    aclFormat format = ACL_FORMAT_ND;
+
+    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "axis", axis_));
+
+    ORT_TRY {
+      CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+      CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
+      CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    }
+    ORT_CATCH(const std::exception& e) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+    }
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_FLATTEN_TYPED_COMPUTE(T)                                      \
+  template <>                                                                  \
+  Status Flatten<T>::ComputeInternal(OpKernelContext* context) const {         \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare(context, prepare));                            \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute("Flatten",                     \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_FLATTEN_TYPED_KERNEL(ver, T)                                              \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      Flatten,                                                                             \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Flatten<T>);
+
+#define REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, T)                       \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      Flatten,                                                                             \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Flatten<T>);
+
+#define REGISTER_FLATTEN_VERSIONED_TYPED(startver, endver, T) \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, T)
+
+#define REGISTER_FLATTEN_TYPED(ver, T)  \
+  REGISTER_FLATTEN_TYPED_KERNEL(ver, T) \
+  REGISTER_FLATTEN_TYPED_COMPUTE(T)
+
+#define REGISTER_FLATTEN_VERSIONED_HF(startver, endver)                \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, MLFloat16) \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, float)
+
+#define REGISTER_FLATTEN_VERSIONED_BWUZCSILHF(startver, endver)        \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, uint8_t)   \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, uint16_t)  \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, uint32_t)  \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, uint64_t)  \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, int8_t)    \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, int16_t)   \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, int32_t)   \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, int64_t)   \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, MLFloat16) \
+  REGISTER_FLATTEN_VERSIONED_TYPED_KERNEL(startver, endver, float)
+
+#define REGISTER_FLATTEN_BWUZCSILHF(ver) \
+  REGISTER_FLATTEN_TYPED(ver, uint8_t)   \
+  REGISTER_FLATTEN_TYPED(ver, uint16_t)  \
+  REGISTER_FLATTEN_TYPED(ver, uint32_t)  \
+  REGISTER_FLATTEN_TYPED(ver, uint64_t)  \
+  REGISTER_FLATTEN_TYPED(ver, int8_t)    \
+  REGISTER_FLATTEN_TYPED(ver, int16_t)   \
+  REGISTER_FLATTEN_TYPED(ver, int32_t)   \
+  REGISTER_FLATTEN_TYPED(ver, int64_t)   \
+  REGISTER_FLATTEN_TYPED(ver, MLFloat16) \
+  REGISTER_FLATTEN_TYPED(ver, float)
+
+REGISTER_FLATTEN_VERSIONED_HF(1, 8)
+REGISTER_FLATTEN_VERSIONED_BWUZCSILHF(9, 10)
+REGISTER_FLATTEN_VERSIONED_BWUZCSILHF(11, 12)
+REGISTER_FLATTEN_BWUZCSILHF(13)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/flatten.h
+++ b/onnxruntime/core/providers/cann/tensor/flatten.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+class Flatten final : public CannKernel {
+ public:
+  Flatten(const OpKernelInfo& info) : CannKernel(info) {
+    ORT_ENFORCE(info.GetAttr<int64_t>("axis", &axis_).IsOK());
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+
+ private:
+  int64_t axis_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/identity_op.cc
+++ b/onnxruntime/core/providers/cann/tensor/identity_op.cc
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/tensor/identity_op.h"
+
+namespace onnxruntime {
+namespace cann {
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Dropout,
+    kOnnxDomain,
+    7, 9,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>(),
+                              DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()})
+        .Alias(0, 0),
+    IdentityOp<true>);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Dropout,
+    kOnnxDomain,
+    10,
+    11,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<MLFloat16>(),
+                              DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>()})
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<bool>())
+        .Alias(0, 0),
+    IdentityOp<true>);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Identity,
+    kOnnxDomain,
+    1, 12,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .Alias(0, 0),
+    IdentityOp<false>);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Identity,
+    kOnnxDomain,
+    13, 13,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .Alias(0, 0),
+    IdentityOp<false>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    Identity,
+    kOnnxDomain,
+    14,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("V", DataTypeImpl::AllFixedSizeTensorAndSequenceTensorTypes())
+        .Alias(0, 0),
+    IdentityOp<false>);
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/identity_op.h
+++ b/onnxruntime/core/providers/cann/tensor/identity_op.h
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <bool is_dropout>
+class IdentityOp final : public CannKernel {
+ public:
+  IdentityOp(const OpKernelInfo& info) : CannKernel(info) {
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override {
+    auto X_ml_type = context->InputType(0);
+    if (X_ml_type->IsTensorType()) {
+      const Tensor* X = context->Input<Tensor>(0);
+      if (nullptr == X) {
+        return Status(common::ONNXRUNTIME, common::FAIL,
+                      "IdentityOp cann: input count mismatch.");
+      }
+      const TensorShape& shape = X->Shape();
+      Tensor* Y = context->Output(0, shape);
+      if (nullptr == Y) {
+        return Status(common::ONNXRUNTIME, common::FAIL,
+                      "IdentityOp cann: failed to allocate output tensor.");
+      }
+      auto X_type = X->DataType();
+
+      const void* source = X->DataRaw(X_type);
+      void* target = Y->MutableDataRaw(X_type);
+      if (target != source) {
+        CANN_RETURN_IF_ERROR(aclrtMemcpyAsync(target, Y->SizeInBytes(), source,
+                                              X->Shape().Size() * X->DataType()->Size(),
+                                              ACL_MEMCPY_DEVICE_TO_DEVICE, Stream()));
+      }
+
+      if (is_dropout) {
+        Tensor* mask = context->Output(1, shape);
+        if (mask != nullptr) {
+          void* mask_data = mask->MutableDataRaw();
+          CANN_RETURN_IF_ERROR(aclrtMemsetAsync(mask_data, mask->SizeInBytes(), 0, mask->SizeInBytes(), Stream()));
+        }
+      }
+    } else if (X_ml_type->IsTensorSequenceType()) {
+      const TensorSeq* X = context->Input<TensorSeq>(0);
+      ORT_ENFORCE(X != nullptr, "IdentityOp cann: input tensor is missing.");
+      TensorSeq* Y = context->Output<TensorSeq>(0);
+      ORT_ENFORCE(Y != nullptr, "IdentityOp cann: failed to allocate output tensor sequence.");
+      if (X == Y) {
+        return Status::OK();
+      }
+      auto X_type = X->DataType();
+      Y->SetType(X_type);
+      AllocatorPtr alloc;
+      auto status = context->GetTempSpaceAllocator(&alloc);
+      if (!status.IsOK()) {
+        return Status(common::ONNXRUNTIME, common::FAIL,
+                      "IdentityOp cann: unable to get an allocator.");
+      }
+      auto X_size = X->Size();
+      for (size_t i = 0; i < X_size; ++i) {
+        const Tensor& source_tensor = X->Get(i);
+        std::unique_ptr<Tensor> target_tensor = Tensor::Create(source_tensor.DataType(),
+                                                               source_tensor.Shape(), alloc);
+        CANN_RETURN_IF_ERROR(aclrtMemcpyAsync(target_tensor->MutableDataRaw(),
+                                              target_tensor->SizeInBytes(),
+                                              source_tensor.DataRaw(),
+                                              source_tensor.SizeInBytes(),
+                                              ACL_MEMCPY_DEVICE_TO_DEVICE, Stream()));
+        Y->Add(std::move(*target_tensor));
+      }
+    } else {
+      return Status(common::ONNXRUNTIME, common::FAIL,
+                    "IdentityOp cann: unsupported input type.");
+    }
+    return Status::OK();
+  }
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/get_execution_providers.cc
+++ b/onnxruntime/core/providers/get_execution_providers.cc
@@ -137,6 +137,14 @@ constexpr ProviderInfo kProvidersInPriorityOrder[] =
             false,
 #endif
         },
+        {
+            kCannExecutionProvider,
+#ifdef USE_CANN
+            true,
+#else
+            false,
+#endif
+        },
         {kCpuExecutionProvider, true},  // kCpuExecutionProvider is always last
 };
 }  // namespace

--- a/onnxruntime/core/providers/provider_factory_creators.h
+++ b/onnxruntime/core/providers/provider_factory_creators.h
@@ -81,3 +81,7 @@
 #if defined(USE_XNNPACK)
 #include "core/providers/xnnpack/xnnpack_provider_factory_creator.h"
 #endif
+
+#if defined(USE_CANN)
+#include "core/providers/cann/cann_provider_factory_creator.h"
+#endif

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -232,6 +232,7 @@ constexpr const char* kMSDomain = "com.microsoft";
 constexpr const char* kPytorchAtenDomain = "org.pytorch.aten";
 constexpr const char* kNGraphDomain = "com.intel.ai";
 constexpr const char* kCudaExecutionProvider = "CUDAExecutionProvider";
+constexpr const char* kCannExecutionProvider = "CANNExecutionProvider";
 constexpr const char* kDnnlExecutionProvider = "DnnlExecutionProvider";
 constexpr const char* kOpenVINOExecutionProvider = "OpenVINOExecutionProvider";
 constexpr const char* kRocmExecutionProvider = "ROCMExecutionProvider";

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -519,6 +519,15 @@ common::Status InferenceSession::RegisterExecutionProvider(const std::shared_ptr
     }
   }
 
+  if (provider_type == onnxruntime::kCannExecutionProvider) {
+    if (session_options_.execution_mode != ExecutionMode::ORT_SEQUENTIAL) {
+      LOGS(*session_logger_, WARNING)
+          << "Parallel execution mode does not support the CANN Execution Provider. "
+          << "So making the execution mode sequential for this session since it uses the CANN Execution Provider.";
+      session_options_.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
+    }
+  }
+
   // if any EPs do not support concurrent calls to Run we add locking around graph execution
   if (p_exec_provider->ConcurrentRunSupported() == false) {
     is_concurrent_run_supported_ = false;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2579,6 +2579,10 @@ static constexpr OrtApi ort_api_1_to_12 = {
     // Start of Version 13 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::GetTrainingApi,
     &OrtApis::SessionOptionsAppendExecutionProvider_CANN,
+    &OrtApis::CreateCANNProviderOptions,
+    &OrtApis::UpdateCANNProviderOptions,
+    &OrtApis::GetCANNProviderOptionsAsString,
+    &OrtApis::ReleaseCANNProviderOptions,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -51,6 +51,14 @@ ProviderInfo_CUDA* TryGetProviderInfo_CUDA();
 #include "orttraining/training_api/include/ort_training_apis.h"
 #endif
 
+#ifdef USE_CANN
+#include "core/providers/cann/cann_provider_factory.h"
+#include "core/providers/cann/cann_execution_provider_info.h"
+namespace onnxruntime {
+ProviderInfo_CANN* TryGetProviderInfo_CANN();
+}
+#endif
+
 #ifdef USE_DML
 #include "core/providers/dml/dml_provider_factory.h"
 const OrtDmlApi* GetOrtDmlApi(_In_ uint32_t version) NO_EXCEPTION;
@@ -2570,6 +2578,7 @@ static constexpr OrtApi ort_api_1_to_12 = {
 
     // Start of Version 13 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::GetTrainingApi,
+    &OrtApis::SessionOptionsAppendExecutionProvider_CANN,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -250,8 +250,6 @@ ORT_API_STATUS_IMPL(AddInitializer, _Inout_ OrtSessionOptions* options, _In_z_ c
 
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CUDA,
                     _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptions* cuda_options);
-ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CANN,
-                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* cann_options);
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_ROCM,
                     _In_ OrtSessionOptions* options, _In_ const OrtROCMProviderOptions* rocm_options);
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_OpenVINO,
@@ -391,5 +389,16 @@ ORT_API_STATUS_IMPL(CopyKernelInfo, _In_ const OrtKernelInfo* info, _Outptr_ Ort
 ORT_API(void, ReleaseKernelInfo, _Frees_ptr_opt_ OrtKernelInfo* info_copy);
 
 ORT_API(const OrtTrainingApi*, GetTrainingApi, uint32_t version);
+
+ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CANN,
+                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* cann_options);
+ORT_API_STATUS_IMPL(CreateCANNProviderOptions, _Outptr_ OrtCANNProviderOptions** out);
+ORT_API_STATUS_IMPL(UpdateCANNProviderOptions, _Inout_ OrtCANNProviderOptions* cann_options,
+                    _In_reads_(num_keys) const char* const* provider_options_keys,
+                    _In_reads_(num_keys) const char* const* provider_options_values,
+                    size_t num_keys);
+ORT_API_STATUS_IMPL(GetCANNProviderOptionsAsString, _In_ const OrtCANNProviderOptions* cann_options,
+                    _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
+ORT_API(void, ReleaseCANNProviderOptions, _Frees_ptr_opt_ OrtCANNProviderOptions*);
 
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -250,6 +250,8 @@ ORT_API_STATUS_IMPL(AddInitializer, _Inout_ OrtSessionOptions* options, _In_z_ c
 
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CUDA,
                     _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptions* cuda_options);
+ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CANN,
+                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* cann_options);
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_ROCM,
                     _In_ OrtSessionOptions* options, _In_ const OrtROCMProviderOptions* rocm_options);
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_OpenVINO,

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -154,13 +154,6 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CUDA,
   return CreateNotEnabledStatus("CUDA");
 }
 
-ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CANN,
-                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* provider_options) {
-  ORT_UNUSED_PARAMETER(options);
-  ORT_UNUSED_PARAMETER(provider_options);
-  return CreateNotEnabledStatus("CANN");
-}
-
 ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CUDA_V2,
                     _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptionsV2* cuda_options) {
   ORT_UNUSED_PARAMETER(options);
@@ -271,5 +264,42 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_MIGraphX,
   ORT_UNUSED_PARAMETER(options);
   ORT_UNUSED_PARAMETER(migraphx_options);
   return CreateNotEnabledStatus("MIGraphX");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CANN,
+                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* provider_options) {
+  ORT_UNUSED_PARAMETER(options);
+  ORT_UNUSED_PARAMETER(provider_options);
+  return CreateNotEnabledStatus("CANN");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::CreateCANNProviderOptions, _Outptr_ OrtCANNProviderOptions** out) {
+  ORT_UNUSED_PARAMETER(out);
+  return CreateNotEnabledStatus("CANN");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::UpdateCANNProviderOptions,
+                    _Inout_ OrtCANNProviderOptions* cann_options,
+                    _In_reads_(num_keys) const char* const* provider_options_keys,
+                    _In_reads_(num_keys) const char* const* provider_options_values,
+                    size_t num_keys) {
+  ORT_UNUSED_PARAMETER(cann_options);
+  ORT_UNUSED_PARAMETER(provider_options_keys);
+  ORT_UNUSED_PARAMETER(provider_options_values);
+  ORT_UNUSED_PARAMETER(num_keys);
+  return CreateNotEnabledStatus("CANN");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetCANNProviderOptionsAsString,
+                    _In_ const OrtCANNProviderOptions* cann_options, _Inout_ OrtAllocator* allocator,
+                    _Outptr_ char** ptr) {
+  ORT_UNUSED_PARAMETER(cann_options);
+  ORT_UNUSED_PARAMETER(allocator);
+  ORT_UNUSED_PARAMETER(ptr);
+  return CreateStatus(ORT_FAIL, "CANN execution provider is not enabled in this build.");
+}
+
+ORT_API(void, OrtApis::ReleaseCANNProviderOptions, _Frees_ptr_opt_ OrtCANNProviderOptions* ptr) {
+  ORT_UNUSED_PARAMETER(ptr);
 }
 #endif

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -154,6 +154,13 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CUDA,
   return CreateNotEnabledStatus("CUDA");
 }
 
+ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CANN,
+                    _In_ OrtSessionOptions* options, _In_ const OrtCANNProviderOptions* provider_options) {
+  ORT_UNUSED_PARAMETER(options);
+  ORT_UNUSED_PARAMETER(provider_options);
+  return CreateNotEnabledStatus("CANN");
+}
+
 ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_CUDA_V2,
                     _In_ OrtSessionOptions* options, _In_ const OrtCUDAProviderOptionsV2* cuda_options) {
   ORT_UNUSED_PARAMETER(options);

--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
+++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
@@ -76,6 +76,12 @@ void addGlobalSchemaFunctions(pybind11::module& m) {
 #ifdef USE_XNNPACK
             onnxruntime::XnnpackProviderFactoryCreator::Create(ProviderOptions{}),
 #endif
+#ifdef USE_CANN
+            []() {
+              OrtCANNProviderOptions provider_options{};
+              return CannProviderFactoryCreator::Create(&provider_options);
+            }(),
+#endif
         };
 
       for (const auto& f : factories) {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -344,6 +344,18 @@ const CUDAExecutionProviderInfo GetCudaExecutionProviderInfo(ProviderInfo_CUDA* 
 }
 #endif
 
+#ifdef USE_CANN
+const CANNExecutionProviderInfo GetCannExecutionProviderInfo(ProviderInfo_CANN* cann_provider_info,
+                                                             const ProviderOptionsMap& provider_options_map) {
+  ORT_ENFORCE(cann_provider_info);
+  const auto it = provider_options_map.find(kCannExecutionProvider);
+  CANNExecutionProviderInfo info;
+  if (it != provider_options_map.end())
+    cann_provider_info->CANNExecutionProviderInfo__FromProviderOptions(it->second, info);
+  return info;
+}
+#endif
+
 #ifdef USE_ROCM
 const ROCMExecutionProviderInfo GetRocmExecutionProviderInfo(ProviderInfo_ROCM* rocm_provider_info,
                                                              const ProviderOptionsMap& provider_options_map) {
@@ -750,6 +762,16 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
   } else if (type == kXnnpackExecutionProvider) {
 #if defined(USE_XNNPACK)
     return onnxruntime::XnnpackProviderFactoryCreator::Create(ProviderOptions{})->CreateProvider();
+#endif
+  } else if (type == kCannExecutionProvider) {
+#ifdef USE_CANN
+    if (auto* cann_provider_info = TryGetProviderInfo_CANN()) {
+      const CANNExecutionProviderInfo info = GetCannExecutionProviderInfo(cann_provider_info,
+                                                                          provider_options_map);
+      return cann_provider_info->CreateExecutionProviderFactory(info)->CreateProvider();
+    } else {
+      ORT_THROW("create CANN ExecutionProvider fail");
+    }
 #endif
   } else {
     // check whether it is a dynamic load EP:

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -22,7 +22,7 @@ struct OrtStatus {
   char msg[1];  // a null-terminated string
 };
 
-#define BACKEND_DEVICE BACKEND_PROC BACKEND_DNNL BACKEND_OPENVINO BACKEND_TVM BACKEND_OPENBLAS BACKEND_MIGRAPHX BACKEND_ACL BACKEND_ARMNN BACKEND_DML
+#define BACKEND_DEVICE BACKEND_PROC BACKEND_DNNL BACKEND_OPENVINO BACKEND_TVM BACKEND_OPENBLAS BACKEND_MIGRAPHX BACKEND_ACL BACKEND_ARMNN BACKEND_DML BACKEND_CANN
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/providers.h"
 #include "core/providers/provider_factory_creators.h"
@@ -115,6 +115,12 @@ struct OrtStatus {
 #define BACKEND_DML ""
 #endif
 
+#if USE_CANN
+#define BACKEND_CANN "-CANN"
+#else
+#define BACKEND_CANN ""
+#endif
+
 #ifdef USE_CUDA
 #include "core/providers/cuda/cuda_provider_factory.h"
 #include "core/providers/cuda/cuda_execution_provider_info.h"
@@ -154,6 +160,10 @@ extern std::string openvino_device_type;
 #ifdef USE_DML
 #include "core/providers/dml/dml_provider_factory.h"
 #endif
+#ifdef USE_CANN
+#include "core/providers/cann/cann_provider_factory.h"
+#include "core/providers/cann/cann_execution_provider_info.h"
+#endif
 
 #ifdef USE_CUDA
 namespace onnxruntime {
@@ -167,6 +177,13 @@ extern bool do_copy_in_default_stream;
 extern onnxruntime::CUDAExecutionProviderExternalAllocatorInfo external_allocator_info;
 extern onnxruntime::ArenaExtendStrategy arena_extend_strategy;
 }  // namespace python
+}  // namespace onnxruntime
+#endif
+
+#ifdef USE_CANN
+namespace onnxruntime {
+ProviderInfo_CANN* TryGetProviderInfo_CANN();
+ProviderInfo_CANN& GetProviderInfo_CANN();
 }  // namespace onnxruntime
 #endif
 

--- a/onnxruntime/test/providers/cann/cann_basic_test.cc
+++ b/onnxruntime/test/providers/cann/cann_basic_test.cc
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/graph/onnx_protobuf.h"
+#include "core/session/inference_session.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/framework/test_utils.h"
+#include "gtest/gtest.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+void VerifyOutputs(const std::vector<OrtValue>& fetches, const std::vector<int64_t>& expected_dims,
+                   const std::vector<int64_t>& expected_values) {
+  ASSERT_EQ(1, fetches.size());
+  auto& rtensor = fetches.front().Get<Tensor>();
+  TensorShape expected_shape(expected_dims);
+  ASSERT_EQ(expected_shape, rtensor.Shape());
+  const std::vector<int64_t> found(rtensor.template Data<int64_t>(),
+                                   rtensor.template Data<int64_t>() + expected_values.size());
+  ASSERT_EQ(expected_values, found);
+}
+
+TEST(CannExecutionProviderTest, FunctionTest) {
+  onnxruntime::Model model("graph_1", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+  std::vector<onnxruntime::NodeArg*> inputs;
+  std::vector<onnxruntime::NodeArg*> outputs;
+
+  ONNX_NAMESPACE::TypeProto int64_tensor;
+  int64_tensor.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  int64_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  int64_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  int64_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+  int64_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(2);
+
+  auto& input_arg_1 = graph.GetOrCreateNodeArg("X", &int64_tensor);
+  auto& input_arg_2 = graph.GetOrCreateNodeArg("Y", &int64_tensor);
+  inputs.push_back(&input_arg_1);
+  inputs.push_back(&input_arg_2);
+  auto& output_arg = graph.GetOrCreateNodeArg("node_1_out_1", &int64_tensor);
+  outputs.push_back(&output_arg);
+  graph.AddNode("node_1", "Add", "node 1.", inputs, outputs);
+
+  auto& input_arg_3 = graph.GetOrCreateNodeArg("Z", &int64_tensor);
+  inputs.clear();
+  inputs.push_back(&output_arg);
+  inputs.push_back(&input_arg_3);
+  auto& output_arg_2 = graph.GetOrCreateNodeArg("M", &int64_tensor);
+  outputs.clear();
+  outputs.push_back(&output_arg_2);
+  graph.AddNode("node_2", "Add", "node 2.", inputs, outputs);
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK());
+  std::string model_file_name = "cann_execution_provider_test_graph.onnx";
+  status = onnxruntime::Model::Save(model, model_file_name);
+
+  SessionOptions so;
+  so.session_logid = "CannExecutionProviderTest.FunctionTest";
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+
+  InferenceSession session_object{so, GetEnvironment()};
+  auto cann_provider = DefaultCannExecutionProvider();
+  status = session_object.RegisterExecutionProvider(std::move(cann_provider));
+  ASSERT_TRUE(status.IsOK());
+  status = session_object.Load(model_file_name);
+  ASSERT_TRUE(status.IsOK());
+  status = session_object.Initialize();
+  ASSERT_TRUE(status.IsOK());
+
+  // prepare inputs
+  std::vector<int64_t> dims_mul_x = {1, 1, 3, 2};
+  std::vector<int64_t> values_mul_x = {1, 2, 3, 4, 5, 6};
+  OrtValue ml_value_x;
+  CreateMLValue<int64_t>(gsl::make_span(dims_mul_x), values_mul_x.data(), OrtMemoryInfo(), &ml_value_x);
+  OrtValue ml_value_y;
+  CreateMLValue<int64_t>(gsl::make_span(dims_mul_x), values_mul_x.data(), OrtMemoryInfo(), &ml_value_y);
+  OrtValue ml_value_z;
+  CreateMLValue<int64_t>(gsl::make_span(dims_mul_x), values_mul_x.data(), OrtMemoryInfo(), &ml_value_z);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value_x));
+  feeds.insert(std::make_pair("Y", ml_value_y));
+  feeds.insert(std::make_pair("Z", ml_value_z));
+
+  // prepare outputs
+  std::vector<std::string> output_names;
+  output_names.push_back("M");
+  std::vector<OrtValue> fetches;
+
+  // prepare expected inputs and outputs
+  std::vector<int64_t> expected_dims_mul_m = {1, 1, 3, 2};
+  std::vector<int64_t> expected_values_mul_m = {3, 6, 9, 12, 15, 18};
+
+  // Now run
+  status = session_object.Run(run_options, feeds, output_names, &fetches);
+  ASSERT_TRUE(status.IsOK());
+  VerifyOutputs(fetches, expected_dims_mul_m, expected_values_mul_m);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -204,5 +204,14 @@ std::unique_ptr<IExecutionProvider> DefaultXnnpackExecutionProvider() {
 #endif
 }
 
+std::unique_ptr<IExecutionProvider> DefaultCannExecutionProvider() {
+#ifdef USE_CANN
+  OrtCANNProviderOptions provider_options{};
+  if (auto factory = CannProviderFactoryCreator::Create(&provider_options))
+    return factory->CreateProvider();
+#endif
+  return nullptr;
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -51,6 +51,7 @@ std::unique_ptr<IExecutionProvider> DefaultRocmExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultCoreMLExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultSnpeExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultXnnpackExecutionProvider();
+std::unique_ptr<IExecutionProvider> DefaultCannExecutionProvider();
 
 std::unique_ptr<IExecutionProvider> DefaultInternalTestingExecutionProvider(
     const std::unordered_set<std::string>& supported_ops);

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -25,6 +25,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Rknpu(
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Rocm(const OrtROCMProviderOptions* provider_options);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensorrt(const OrtTensorRTProviderOptions* params);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Tensorrt(const OrtTensorRTProviderOptionsV2* params);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Cann(const OrtCANNProviderOptions* provider_options);
 
 // EP for internal testing
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_InternalTesting(

--- a/onnxruntime/test/util/include/providers.h
+++ b/onnxruntime/test/util/include/providers.h
@@ -37,3 +37,6 @@
 #ifdef USE_XNNPACK
 #include "core/providers/xnnpack/xnnpack_provider_factory_creator.h"
 #endif
+#ifdef USE_CANN
+#include "core/providers/cann/cann_provider_factory.h"
+#endif

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ elif parse_arg_remove_boolean(sys.argv, "--use_acl"):
     package_name = "onnxruntime-acl"
 elif parse_arg_remove_boolean(sys.argv, "--use_armnn"):
     package_name = "onnxruntime-armnn"
+elif parse_arg_remove_boolean(sys.argv, "--use_cann"):
+    package_name = "onnxruntime-cann"
 
 # PEP 513 defined manylinux1_x86_64 and manylinux1_i686
 # PEP 571 defined manylinux2010_x86_64 and manylinux2010_i686

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -652,6 +652,8 @@ def parse_arguments():
         help="enable cuda kernel profiling, \
         cupti library must be added to PATH beforehand.",
     )
+    parser.add_argument("--use_cann", action="store_true", help="Build with CANN")
+    parser.add_argument("--cann_home", help="Path to CANN installation dir")
 
     parser.add_argument(
         "--enable_rocm_profiling",
@@ -822,6 +824,7 @@ def generate_build_tree(
     armnn_home,
     armnn_libs,
     snpe_root,
+    cann_home,
     path_to_protoc_exe,
     configs,
     cmake_extra_defines,
@@ -928,6 +931,7 @@ def generate_build_tree(
         "-Donnxruntime_ENABLE_CUDA_PROFILING=" + ("ON" if args.enable_cuda_profiling else "OFF"),
         "-Donnxruntime_ENABLE_ROCM_PROFILING=" + ("ON" if args.enable_rocm_profiling else "OFF"),
         "-Donnxruntime_USE_XNNPACK=" + ("ON" if args.use_xnnpack else "OFF"),
+        "-Donnxruntime_USE_CANN=" + ("ON" if args.use_cann else "OFF"),
     ]
     if args.external_graph_transformer_path:
         cmake_args.append("-Donnxruntime_EXTERNAL_TRANSFORMER_SRC_PATH=" + args.external_graph_transformer_path)
@@ -1002,6 +1006,9 @@ def generate_build_tree(
 
     if snpe_root and os.path.exists(snpe_root):
         cmake_args += ["-DSNPE_ROOT=" + snpe_root]
+
+    if cann_home and os.path.exists(cann_home):
+        cmake_args += ["-Donnxruntime_CANN_HOME=" + cann_home]
 
     if args.winml_root_namespace_override:
         cmake_args += ["-Donnxruntime_WINML_NAMESPACE_OVERRIDE=" + args.winml_root_namespace_override]
@@ -1363,6 +1370,23 @@ def setup_cuda_vars(args):
             )
 
     return cuda_home, cudnn_home
+
+
+def setup_cann_vars(args):
+    cann_home = ""
+
+    if args.use_cann:
+        cann_home = args.cann_home if args.cann_home else os.getenv("ASCEND_HOME_PATH")
+
+        cann_home_valid = cann_home is not None and os.path.exists(cann_home)
+
+        if not cann_home_valid:
+            raise BuildError(
+                "cann_home paths must be specified and valid.",
+                "cann_home='{}' valid={}.".format(cann_home, cann_home_valid),
+            )
+
+    return cann_home
 
 
 def setup_tensorrt_vars(args):
@@ -2017,6 +2041,7 @@ def build_python_wheel(
     use_acl,
     use_armnn,
     use_dml,
+    use_cann,
     wheel_name_suffix,
     enable_training,
     nightly_build=False,
@@ -2070,6 +2095,8 @@ def build_python_wheel(
             args.append("--use_armnn")
         elif use_dml:
             args.append("--wheel_name_suffix=directml")
+        elif use_cann:
+            args.append("--use_cann")
 
         run_subprocess(args, cwd=cwd)
 
@@ -2474,6 +2501,9 @@ def main():
     # if using rocm, setup rocm paths
     rocm_home = setup_rocm_build(args, configs)
 
+    # if using cann, setup cann paths
+    cann_home = setup_cann_vars(args)
+
     if args.update or args.build:
         for config in configs:
             os.makedirs(get_config_build_dir(build_dir, config), exist_ok=True)
@@ -2672,6 +2702,7 @@ def main():
             armnn_home,
             armnn_libs,
             snpe_root,
+            cann_home,
             path_to_protoc_exe,
             configs,
             cmake_extra_defines,
@@ -2733,6 +2764,7 @@ def main():
                 args.use_acl,
                 args.use_armnn,
                 args.use_dml,
+                args.use_cann,
                 args.wheel_name_suffix,
                 args.enable_training,
                 nightly_build=nightly_build,

--- a/tools/ci_build/gen_def.py
+++ b/tools/ci_build/gen_def.py
@@ -67,7 +67,7 @@ with open(args.output_source, "w") as file:
 
         # external symbols are removed, xnnpack ep will be created via the standard ORT API.
         # https://github.com/microsoft/onnxruntime/pull/11798
-        if c not in ("winml", "cuda", "migraphx", "snpe", "xnnpack"):
+        if c not in ("winml", "cuda", "migraphx", "snpe", "xnnpack", "cann"):
             file.write("#include <core/providers/%s/%s_provider_factory.h>\n" % (c, c))
     file.write("void* GetFunctionEntryByName(const char* name){\n")
     for symbol in symbols:


### PR DESCRIPTION
**Description**: This PR adds Ascend CANN execution provider support.

**Motivation and Context**
- Why is this change required? What problem does it solve?
  As the info shown in the issue. CANN is the API layer for Ascend processor. Add CANN EP can allow user run onnx model on Ascend hardware via onnxruntime
  The detail change:
  1. Added CANN EP framework.
  2. Added the basic operators to support ResNet and VGG model.
  3. Added C/C++、Python API support
- If it fixes an open issue, please link to the issue here.
   https://github.com/microsoft/onnxruntime/issues/11477

Author: 
lijiawei <lijiawei19@huawei.com>
wangxiyuan <wangxiyuan1007@gmail.com>