### PR TITLE
Adding w_zero_point to conv_integer_test.cc

### DIFF
--- a/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
@@ -6,7 +6,7 @@
 
 namespace onnxruntime {
 namespace test {
-TEST(ConvIntegerTest, WithoutPadding_2D) {
+TEST(ConvIntegerTest, WithoutPadding_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -15,9 +15,10 @@ TEST(ConvIntegerTest, WithoutPadding_2D) {
 						  8, 9, 10});
   std::vector<int64_t> w_dims{1, 1, 2, 2};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 1,
-					      1, 1});
+                         {2, 2,
+					      2, 2});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddInput<uint8_t>("w_zero_point", {}, {1});
   std::vector<int64_t> y_dims{1, 1, 2, 2};
   test.AddOutput<int32_t>("y", y_dims,
                           {12, 16,
@@ -25,7 +26,7 @@ TEST(ConvIntegerTest, WithoutPadding_2D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, WithPadding_2D) {
+TEST(ConvIntegerTest, WithPadding_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -34,9 +35,10 @@ TEST(ConvIntegerTest, WithPadding_2D) {
                           8, 9, 10});
   std::vector<int64_t> w_dims{1, 1, 2, 2};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 1,
-                          1, 1});
+                         {2, 2,
+                          2, 2});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddInput<uint8_t>("w_zero_point", {}, {1});
   test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
   std::vector<int64_t> y_dims{1, 1, 4, 4};
   test.AddOutput<int32_t>("y", y_dims,
@@ -47,7 +49,7 @@ TEST(ConvIntegerTest, WithPadding_2D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, WithGroup_2D) {
+TEST(ConvIntegerTest, WithGroup_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 3, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -62,13 +64,14 @@ TEST(ConvIntegerTest, WithGroup_2D) {
                           26, 27, 28});
   std::vector<int64_t> w_dims{3, 1, 2, 2};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 2,
-                          2, 1,
-                          3, 4,
-                          4, 3,
-                          5, 6,
-                          6, 5});
+                         {11, 12,
+                          12, 11,
+                          13, 14,
+                          14, 13,
+                          15, 16,
+                          16, 15});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+    test.AddInput<uint8_t>("w_zero_point", {}, {10});
   test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
   test.AddAttribute("group", static_cast<int64_t>(3));
   std::vector<int64_t> y_dims{1, 3, 4, 4};
@@ -88,7 +91,7 @@ TEST(ConvIntegerTest, WithGroup_2D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, WithPadding_3D) {
+TEST(ConvIntegerTest, WithPadding_3D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -103,11 +106,12 @@ TEST(ConvIntegerTest, WithPadding_3D) {
                           26, 27, 28});
   std::vector<int64_t> w_dims{1, 1, 2, 2, 2};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
+                         {11, 11,
+                          11, 11,
+                          11, 11,
+                          11, 11});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddInput<uint8_t>("w_zero_point", {}, {10});
   test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1, 1, 1});
   std::vector<int64_t> y_dims{1, 1, 4, 4, 4};
   test.AddOutput<int32_t>("y", y_dims,
@@ -130,7 +134,7 @@ TEST(ConvIntegerTest, WithPadding_3D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, Pointwise_2D) {
+TEST(ConvIntegerTest, Pointwise_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -138,8 +142,9 @@ TEST(ConvIntegerTest, Pointwise_2D) {
                           5, 6, 7,
                           8, 9, 10});
   std::vector<int64_t> w_dims{1, 1, 1, 1};
-  test.AddInput<uint8_t>("w", w_dims, {4});
+  test.AddInput<uint8_t>("w", w_dims, {5});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddInput<uint8_t>("w_zero_point", {}, {1});
   std::vector<int64_t> y_dims{1, 1, 3, 3};
   test.AddOutput<int32_t>("y", y_dims,
                           {4, 8, 12,
@@ -148,7 +153,7 @@ TEST(ConvIntegerTest, Pointwise_2D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, Pointwise_3D) {
+TEST(ConvIntegerTest, Pointwise_3D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 3, 3, 3};
   test.AddInput<uint8_t>("x", x_dims,
@@ -162,8 +167,9 @@ TEST(ConvIntegerTest, Pointwise_3D) {
                           23, 24, 25,
                           26, 27, 28});
   std::vector<int64_t> w_dims{1, 1, 1, 1, 1};
-  test.AddInput<uint8_t>("w", w_dims, {4});
+  test.AddInput<uint8_t>("w", w_dims, {5});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
+  test.AddInput<uint8_t>("w_zero_point", {}, {1});
   std::vector<int64_t> y_dims{1, 1, 3, 3, 3};
   test.AddOutput<int32_t>("y", y_dims,
                           {4, 8, 12,
@@ -178,7 +184,7 @@ TEST(ConvIntegerTest, Pointwise_3D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, WithStride2_2D) {
+TEST(ConvIntegerTest, WithStride2_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 7, 7};
   test.AddInput<uint8_t>("x", x_dims,
@@ -191,10 +197,11 @@ TEST(ConvIntegerTest, WithStride2_2D) {
                           70, 71, 72, 73, 74, 75, 76});
   std::vector<int64_t> w_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 2, 1,
-                          2, 3, 2,
-                          1, 2, 1});
+                         {11, 12, 11,
+                          12, 13, 12,
+                          11, 12, 11});
   test.AddInput<uint8_t>("x_zero_point", {}, {10});
+  test.AddInput<uint8_t>("w_zero_point", {}, {10});
   test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
   test.AddAttribute<std::vector<int64_t>>("strides", {2, 2});
   std::vector<int64_t> y_dims{1, 1, 4, 4};
@@ -207,7 +214,7 @@ TEST(ConvIntegerTest, WithStride2_2D) {
   test.Run();
 }
 
-TEST(ConvIntegerTest, WithStride3_2D) {
+TEST(ConvIntegerTest, WithStride3_2D_u8u8) {
   OpTester test("ConvInteger", 10);
   std::vector<int64_t> x_dims{1, 1, 7, 7};
   test.AddInput<uint8_t>("x", x_dims,
@@ -220,10 +227,11 @@ TEST(ConvIntegerTest, WithStride3_2D) {
                           70, 71, 72, 73, 74, 75, 76});
   std::vector<int64_t> w_dims{1, 1, 3, 3};
   test.AddInput<uint8_t>("w", w_dims,
-                         {1, 2, 1,
-                          2, 3, 2,
-                          1, 2, 1});
+                         {11, 12, 11,
+                          12, 13, 12,
+                          11, 12, 11});
   test.AddInput<uint8_t>("x_zero_point", {}, {10});
+  test.AddInput<uint8_t>("w_zero_point", {}, {10});
   test.AddAttribute<std::vector<int64_t>>("pads", {2, 2, 1, 1});
   test.AddAttribute<std::vector<int64_t>>("strides", {3, 3});
   std::vector<int64_t> y_dims{1, 1, 3, 3};

--- a/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_integer_test.cc
@@ -12,17 +12,17 @@ TEST(ConvIntegerTest, WithoutPadding_2D_u8u8) {
   test.AddInput<uint8_t>("x", x_dims,
                          {2, 3, 4,
                           5, 6, 7,
-						  8, 9, 10});
+                          8, 9, 10});
   std::vector<int64_t> w_dims{1, 1, 2, 2};
   test.AddInput<uint8_t>("w", w_dims,
                          {2, 2,
-					      2, 2});
+                          2, 2});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
   test.AddInput<uint8_t>("w_zero_point", {}, {1});
   std::vector<int64_t> y_dims{1, 1, 2, 2};
   test.AddOutput<int32_t>("y", y_dims,
                           {12, 16,
-						   24, 28});
+                           24, 28});
   test.Run();
 }
 
@@ -43,9 +43,9 @@ TEST(ConvIntegerTest, WithPadding_2D_u8u8) {
   std::vector<int64_t> y_dims{1, 1, 4, 4};
   test.AddOutput<int32_t>("y", y_dims,
                           {1, 3, 5, 3,
-	                       5, 12, 16, 9,
+                           5, 12, 16, 9,
                            11, 24, 28, 15,
-	                       7, 15, 17, 9});
+                           7, 15, 17, 9});
   test.Run();
 }
 
@@ -71,7 +71,7 @@ TEST(ConvIntegerTest, WithGroup_2D_u8u8) {
                           15, 16,
                           16, 15});
   test.AddInput<uint8_t>("x_zero_point", {}, {1});
-    test.AddInput<uint8_t>("w_zero_point", {}, {10});
+  test.AddInput<uint8_t>("w_zero_point", {}, {10});
   test.AddAttribute<std::vector<int64_t>>("pads", {1, 1, 1, 1});
   test.AddAttribute("group", static_cast<int64_t>(3));
   std::vector<int64_t> y_dims{1, 3, 4, 4};
@@ -148,8 +148,8 @@ TEST(ConvIntegerTest, Pointwise_2D_u8u8) {
   std::vector<int64_t> y_dims{1, 1, 3, 3};
   test.AddOutput<int32_t>("y", y_dims,
                           {4, 8, 12,
-	                       16, 20, 24,
-	                       28, 32, 36});
+                           16, 20, 24,
+                           28, 32, 36});
   test.Run();
 }
 
@@ -173,14 +173,14 @@ TEST(ConvIntegerTest, Pointwise_3D_u8u8) {
   std::vector<int64_t> y_dims{1, 1, 3, 3, 3};
   test.AddOutput<int32_t>("y", y_dims,
                           {4, 8, 12,
-	                       16, 20, 24,
-	                       28, 32, 36,
+                           16, 20, 24,
+                           28, 32, 36,
                            40, 44, 48,
-	                       52, 56, 60,
-	                       64, 68, 72,
+                           52, 56, 60,
+                           64, 68, 72,
                            76, 80, 84,
-	                       88, 92, 96,
-	                       100, 104, 108});
+                           88, 92, 96,
+                           100, 104, 108});
   test.Run();
 }
 
@@ -207,9 +207,9 @@ TEST(ConvIntegerTest, WithStride2_2D_u8u8) {
   std::vector<int64_t> y_dims{1, 1, 4, 4};
   test.AddOutput<int32_t>("y", y_dims,
                           {33, 62, 84, 75,
-	                       224, 330, 360, 282,
+                           224, 330, 360, 282,
                            444, 630, 660, 502,
-	                       453, 642, 664, 495});
+                           453, 642, 664, 495});
   // Exercise the (stride_w = 2) path inside Math::Im2col.
   test.Run();
 }
@@ -237,7 +237,7 @@ TEST(ConvIntegerTest, WithStride3_2D_u8u8) {
   std::vector<int64_t> y_dims{1, 1, 3, 3};
   test.AddOutput<int32_t>("y", y_dims,
                           {0, 8, 20,
-	                       80, 330, 375,
+                           80, 330, 375,
                            200, 780, 825});
   // Exercise the (stride_w > 2) path inside Math::Im2col.
   test.Run();


### PR DESCRIPTION
**Description**: Describe your changes.
Adding w_zero_point to conv_ineger_test.cc. Prepare for u8s8 unit_tests
**Motivation and Context**
Currently all unit test does cover the cases where w_zero_point is not 0. 
- Why is this change required? What problem does it solve?
-- This will help with test coverage to cover when w_zero_point isn't 0 
- If it fixes an open issue, please link to the issue here.
