### PR TITLE
Disable CG task in PR pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -11,6 +11,8 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
+  variables:
+    skipComponentGovernanceDetection: true
   pool: Linux-CPU-2019
   steps:
   - checkout: self
@@ -143,10 +145,6 @@ jobs:
       searchFolder: '$(Build.BinariesDirectory)'
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
-
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
 
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-dnnl-ci-pipeline.yml
@@ -9,6 +9,8 @@ resources:
 jobs:
 - job: Linux_py_Wheels
   timeoutInMinutes: 180
+  variables:
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: Linux-CPU-2019
@@ -56,10 +58,6 @@ jobs:
       searchFolder: '$(Build.BinariesDirectory)'
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
-
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters:
-      condition: 'succeeded'
 
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -9,6 +9,8 @@ resources:
 jobs:
 - job: Linux_Build
   timeoutInMinutes: 120
+  variables:
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: Linux-CPU-2019
@@ -78,6 +80,8 @@ jobs:
 
 - job: Linux_Test
   timeoutInMinutes: 60
+  variables:
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: Onnxruntime-Linux-GPU-NC6sv3

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-ci-pipeline.yml
@@ -11,6 +11,7 @@ jobs:
   pool: onnxruntime-tensorrt-linuxbuild
   variables:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
+    skipComponentGovernanceDetection: true
   timeoutInMinutes: 180
   steps:
     - checkout: self
@@ -56,9 +57,5 @@ jobs:
         searchFolder: '$(Build.BinariesDirectory)'
         testRunTitle: 'Unit Test Run'
       condition: succeededOrFailed()
-
-    - template: templates/component-governance-component-detection-steps.yml
-      parameters :
-        condition : 'ci_only'
 
     - template: templates/clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-ci-pipeline.yml
@@ -9,6 +9,8 @@ resources:
 jobs:
 - job: Linux_Build
   timeoutInMinutes: 120
+  variables:
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: Linux-CPU-2019

--- a/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
@@ -26,6 +26,7 @@ jobs:
   timeoutInMinutes:  ${{ parameters.TimeoutInMinutes }}
   variables:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
+    skipComponentGovernanceDetection: true
   pool: ${{ parameters.AgentPool }}
   ${{ if ne(parameters.Strategy, '') }}:
     strategy:
@@ -74,7 +75,4 @@ jobs:
         parameters:
           DockerImageTag: ${{ parameters.DockerImageTag }}
           BuildConfig: ${{ parameters.BuildConfig }}
-    - template: component-governance-component-detection-steps.yml
-      parameters :
-        condition : 'succeeded'
     - template: clean-agent-build-directory-step.yml

--- a/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-cpu-ci.yml
@@ -43,6 +43,7 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: 'Win-CPU-2019'
@@ -233,7 +234,3 @@ jobs:
           searchFolder: '$(Build.BinariesDirectory)/${{ parameters.BuildConfig }}'
           testRunTitle: 'Unit Test Run'
         condition: succeededOrFailed()
-
-  - template: component-governance-component-detection-steps.yml
-    parameters :
-      condition : 'succeeded'

--- a/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-gpu-ci.yml
@@ -58,7 +58,8 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true    
     setVcvars: true
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '0'
-    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}    
+    DocUpdateNeeded: ${{ parameters.DocUpdateNeeded }}
+    skipComponentGovernanceDetection: true
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}
@@ -275,7 +276,3 @@ jobs:
     inputs:
       pathtoPublish: '$(Build.SourcesDirectory)/docs/ContribOperators.md'
       artifactName: 'ContribOperators.md'
-
-  - template: component-governance-component-detection-steps.yml
-    parameters :
-      condition : 'succeeded'

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -11,6 +11,7 @@ jobs:
     setVcvars: true
     BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
+    skipComponentGovernanceDetection: true
   timeoutInMinutes: 150
   workspace:
     clean: all
@@ -82,7 +83,3 @@ jobs:
     workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
     displayName: 'Run tests'
 
-
-  - template: templates/component-governance-component-detection-steps.yml
-    parameters :
-      condition : 'succeeded'


### PR DESCRIPTION
**Description**: 
We have pull request pipelines, packaging pipelines and some other nightly pipelines.
This PR will disable the CG task in **some** pull request pipelines to unblock the patch release.  The task is auto-injected and recently it is very fragile. We still need to use it for the bits we releases. While we'd better to run it in every pipeline, currently nobody watches the results from pull request pipelines. Therefore I will disable the task until someone wants to look the results. 
While I should do it for all pull request pipelines instead of **some**, we have too many pipelines and I don't know what is missed. But once this is checked in,  I can watch which pipeline still sends data there then I will know.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
