### PR TITLE
[js] loosen test timeout

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1985,7 +1985,7 @@ def tvm_run_python_tests(build_dir, configs):
 
 
 def run_nodejs_tests(nodejs_binding_dir):
-    args = ["npm", "test", "--", "--timeout=30000"]
+    args = ["npm", "test", "--", "--timeout=90000"]
     if is_windows():
         args = ["cmd", "/c"] + args
     run_subprocess(args, cwd=nodejs_binding_dir)

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-multi-browsers.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-multi-browsers.yml
@@ -7,7 +7,7 @@ jobs:
 - job: build_onnxruntime_web_windows
   pool:
     vmImage: windows-2019
-  timeoutInMinutes: 30
+  timeoutInMinutes: 60
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
loosen the following test timeout:
- "Test Web Multi-Browsers" stage in "ONNX Runtime Web CI Pipeline": 30min -> 60min
- Node.js binding default per-case timeout: 30 sec -> 90 sec

Why doing this change?
Recently the CI pipeline is unstable so there are couples of test failures caused by timeout exceeded. Usually the time spent on the 2 tasks mentioned above are ~12min (current timeout 30min) and ~1sec (current timeout 30sec). However sometimes it always exceed the timeout specified. to reduce the build failure we further loosen the timeout settings.