### PR TITLE
Remove dynamic allocation for ThreadPool ParallelSection

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -27,7 +27,9 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(abseil_cpp)
-FetchContent_GetProperties(abseil_cpp SOURCE_DIR)
+FetchContent_GetProperties(abseil_cpp)
+set(ABSEIL_SOURCE_DIR ${abseil_cpp_SOURCE_DIR})
+message(STATUS "Abseil source dir:" ${ABSEIL_SOURCE_DIR})
 
 if (GDK_PLATFORM)
   # Abseil considers any partition that is NOT in the WINAPI_PARTITION_APP a viable platform

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -110,6 +110,7 @@ endif()
 
 if(NOT onnxruntime_DISABLE_ABSEIL)
   include(external/abseil-cpp.cmake)
+  target_include_directories(onnxruntime_common PRIVATE ${ABSEIL_SOURCE_DIR})
   if (MSVC)
     set(ABSEIL_NATVIS_FILE "abseil-cpp.natvis")
     target_sources(

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -41,6 +41,7 @@
 #pragma warning(pop)
 #endif
 #include "core/common/denormal.h"
+#include "core/common/inlined_containers_fwd.h"
 #include "core/common/spin_pause.h"
 #include "core/platform/ort_mutex.h"
 #include "core/platform/Barrier.h"
@@ -333,7 +334,7 @@ class ThreadPoolParallelSection {
 
   // Tasks successfully submitted to the work queues.  This sets the
   // maximum degree of parallelism that the section will support.
-  std::vector<std::pair<int, unsigned>> tasks;
+  InlinedVector<std::pair<int, unsigned>> tasks;
 
   // Number of tasks revoked (i.e., removed from the queues prior to
   // execution).  We count this at various points, and omit waiting
@@ -1014,7 +1015,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
   //   From that point onwards, the two main threads will dispatch tasks
   //   to separate workers, avoiding the need for further work stealing.
 
-  void InitializePreferredWorkers(std::vector<int>& preferred_workers) {
+  void InitializePreferredWorkers(InlinedVector<int>& preferred_workers) {
     static std::atomic<unsigned> next_worker{0};
 
     // preferred_workers[0] isn't supposed to be used, so initializing it with -1 to:
@@ -1033,7 +1034,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
   // Update the preferred worker for par_idx to be the calling thread
 
-  void UpdatePreferredWorker(std::vector<int>& preferred_workers,
+  void UpdatePreferredWorker(InlinedVector<int>& preferred_workers,
                              unsigned par_idx) {
     unsigned ran_on_idx = GetPerThread()->thread_id;
     assert(ran_on_idx < num_threads_);
@@ -1045,7 +1046,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
   void ScheduleOnPreferredWorkers(PerThread& pt,
                                   ThreadPoolParallelSection& ps,
-                                  std::vector<int>& preferred_workers,
+                                  InlinedVector<int>& preferred_workers,
                                   unsigned par_idx_start,
                                   unsigned par_idx_end,
                                   std::function<void(unsigned)> worker_fn) {
@@ -1124,7 +1125,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
     // the size of the vector and recording the locations that tasks run
     // in as they complete.
     assert(new_dop <= (unsigned)(num_threads_ + 1));
-    std::vector<int>& preferred_workers = pt.preferred_workers;
+    auto& preferred_workers = pt.preferred_workers;
     InitializePreferredWorkers(preferred_workers);
 
     // current_dop is the degree of parallelism via any workers already
@@ -1337,7 +1338,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
     // retain cache state within the workers, and to reduce the number
     // of times that the work-stealing code paths are used for
     // rebalancing.
-    std::vector<int> preferred_workers;
+    InlinedVector<int> preferred_workers;
     PaddingToAvoidFalseSharing padding_2;
   };
 

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -289,7 +289,6 @@ class ExtendedThreadPoolInterface : public Eigen::ThreadPoolInterface {
   // Start/end a parallel section, within which calls to
   // RunInParallelSection may be made.  Parallel sections are
   // non-nesting.
-  virtual std::unique_ptr<ThreadPoolParallelSection, void (*)(ThreadPoolParallelSection*)> AllocateParallelSection() = 0;
   virtual void StartParallelSection(ThreadPoolParallelSection& ps) = 0;
   virtual void EndParallelSection(ThreadPoolParallelSection& ps) = 0;
 
@@ -787,17 +786,6 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
   // Parallel sections
   // -----------------
   //
-  // Allocate a new ThreadPoolParallelSection, owned by the returned
-  // unique_ptr.  The explicit deleter avoids the Eigen-specific
-  // definition of ThreadPoolParallelSection needing to be avilable in
-  // threadpool.h where the user-facing parallel section API is defined.
-  GSL_SUPPRESS(r .11)
-  std::unique_ptr<ThreadPoolParallelSection, void (*)(ThreadPoolParallelSection*)> AllocateParallelSection() override {
-    return std::unique_ptr<ThreadPoolParallelSection, void (*)(ThreadPoolParallelSection*)>(new ThreadPoolParallelSection,
-                                                                                            [](ThreadPoolParallelSection* tps) {
-                                                                                              delete tps;
-                                                                                            });
-  }
 
   // Start a parallel section, using a caller-provided
   // ThreadPoolParallelSection for maintaining the per-section state.

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -209,16 +209,9 @@ class ThreadPool {
     // deleter here so that the definition of
     // ThreadPoolParallelSection does not need to be available at this
     // point to avoid a dependence on the Eigen headers.
-    std::unique_ptr<ThreadPoolParallelSection, void(*)(ThreadPoolParallelSection*)>
-      ps_{nullptr, [](ThreadPoolParallelSection*){}};
+    ThreadPoolParallelSection* ps_{nullptr};
     ThreadPool *tp_;
     ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ParallelSection);
-
-    // Non-owning reference to the current thread's paralel section
-    // (or nullptr outside parallel sections).
-    static thread_local ParallelSection *current_parallel_section;
-    static_assert(std::is_trivially_destructible<decltype(current_parallel_section)>::value,
-                  "Per-thread state should be trivially destructible");
   };
 
   // The below API allows to disable spinning

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <memory>
+#include <optional>
 
 #include "core/platform/threadpool.h"
 #include "core/common/common.h"
@@ -488,31 +489,32 @@ std::string ThreadPool::StopProfiling() {
   }
 }
 
-thread_local ThreadPool::ParallelSection* ThreadPool::ParallelSection::current_parallel_section{nullptr};
+namespace {
+thread_local std::optional<ThreadPoolParallelSection> current_parallel_section;
+}
 
 ThreadPool::ParallelSection::ParallelSection(ThreadPool* tp) {
-  ORT_ENFORCE(!current_parallel_section, "Nested parallelism not supported");
-  ORT_ENFORCE(!ps_.get());
+  ORT_ENFORCE(!current_parallel_section.has_value(), "Nested parallelism not supported");
+  ORT_ENFORCE(!ps_);
   tp_ = tp;
   if (tp && tp->underlying_threadpool_) {
-    ps_ = tp->underlying_threadpool_->AllocateParallelSection();
-    tp_->underlying_threadpool_->StartParallelSection(*ps_.get());
-    current_parallel_section = this;
+    current_parallel_section.emplace();
+    ps_ = &*current_parallel_section;
+    tp_->underlying_threadpool_->StartParallelSection(*ps_);
   }
 }
 
 ThreadPool::ParallelSection::~ParallelSection() {
   if (current_parallel_section) {
-    tp_->underlying_threadpool_->EndParallelSection(*ps_.get());
-    ps_.reset();
-    current_parallel_section = nullptr;
+    tp_->underlying_threadpool_->EndParallelSection(*ps_);
+    current_parallel_section.reset();
   }
 }
 
 void ThreadPool::RunInParallel(std::function<void(unsigned idx)> fn, unsigned n, std::ptrdiff_t block_size) {
   if (underlying_threadpool_) {
-    if (ThreadPool::ParallelSection::current_parallel_section) {
-      underlying_threadpool_->RunInParallelSection(*(ThreadPool::ParallelSection::current_parallel_section->ps_.get()),
+    if (current_parallel_section.has_value()) {
+      underlying_threadpool_->RunInParallelSection(*current_parallel_section,
                                                    std::move(fn),
                                                    n, block_size);
     } else {


### PR DESCRIPTION
**Description**:

Construct ThreadPool Paralel section in a thread local `std::optional`. This allows to avoid repeated dynamic memory allocation.

Empty `std::optional` would construct on the first reference and destructed on thread exit.

**Motivation and Context**
Improve latency variance when running parallel section in a thread pool.