### PR TITLE
Fix attribute renaming bug in function inliner

### DIFF
--- a/onnxruntime/core/graph/function_utils.cc
+++ b/onnxruntime/core/graph/function_utils.cc
@@ -359,7 +359,10 @@ private:
         // if the call-node contains the attribute. Otherwise, this attribute must be removed.
         auto entry = attr_map.find(attr.ref_attr_name());
         if (entry != attr_map.cend()) {
+          // Copy value of attribute, but retain original name:
+          std::string name = attr.name();
           attr = entry->second;
+          attr.set_name(name);
         } else {
           attr_iter = attributes.erase(attr_iter);
           continue;

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -306,7 +306,7 @@ TEST(FunctionTest, AttrName) {
         opset_import: [ "" : 16 ],
         domain: "local"
         >
-        myfun <const> (lx) => (ly) {
+        myfun <s> (lx) => (ly) {
             d = Shape <start : int = @s> (lx)
             df = Cast <to = 1> (d)
             ly = Mul (lx, df)


### PR DESCRIPTION
**Description**: 

Fixes a bug in the function-inliner that does not handle attribute-references where source and target attribute names are different. A node in a function-body may contain attribute-references of the form `target = @source` where `target` is the name of attribute for the op called by the node, and its value is given by the value of the attribute named `source` in the call to the containing-function. The existing implementation simply replaces that target AttributeProto by a copy of the source AttributeProto. This works fine where the target/source have the same names (a common use-case), but fails otherwise, since it ends up replacing the target attribute's name with the source-name (we want to replace only the value).

Add a test-case to cover this scenario.

