### PR TITLE
Spike: create onnxruntime + PyTorch dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,3 +37,6 @@ RUN apt-get update \
 # Install non-PyTorch Python dependencies for OnnxRuntime
 RUN pip install packaging "wheel>=0.35.1" parameterized
 
+# Dependencies required to build PyTorch
+RUN pip3 install astunparse pyyaml setuptools cffi typing_extensions future six requests dataclasses
+RUN pip3 install mkl mkl-devel

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,4 +34,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends aria2 aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
+# Install non-PyTorch Python dependencies for OnnxRuntime
+RUN pip install packaging "wheel>=0.35.1" parameterized
 

--- a/.devcontainer/clone-pytorch.sh
+++ b/.devcontainer/clone-pytorch.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Script is meant to be called from /workspaces/onnxruntime directory.
+
+# Change into /workspaces directory
+cd ..
+
+# Check if the PyTorch repository exists
+if [ ! -d "pytorch" ]
+then
+    echo "Cloning pytorch repository"
+    git clone https://github.com/pytorch/pytorch
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
 	// "forwardPorts": [],
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	"postCreateCommand": "bash .devcontainer/clone-pytorch.sh",
 
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],

--- a/orttraining/orttraining/eager/README.md
+++ b/orttraining/orttraining/eager/README.md
@@ -58,6 +58,31 @@ start in `orttraining/orttraining/eager/opgen/opgen/custom_ops.py`, which will g
 
 Please add tests for all ops. Tests are defined in `orttraining/orttraining/eager/test/ort_ops.py`
 
+## Setting up dev container with combined onnxruntime + PyTorch
+
+Open this branch in a code space / dev container. This will clone PyTorch at `/workspaces/pytorch`. To have PyTorch source readily available in VS Code, you can add the the PyTorch directory to your workspace (File -> Add Folder to Workspace - /workspaces/pytorch)
+
+From the `/workspaces/pytorch` directory, run the following commands to checkout PyTorch v1.12.0, build it, and and install in local environment:
+
+
+```
+git checkout v1.12.0
+
+export CMAKE_PREFIX_PATH=/usr/lib/python3/dist-packages
+
+DEBUG=1 USE_CUDA=0 USE_KINETO=0 BUILD_CAFFE2=0 USE_DISTRIBUTED=0 USE_NCCL=0 BUILD_TEST=0 USE_XNNPACK=0 USE_FBGEMM=0 USE_QNNPACK=0 USE_MKLDNN=0 USE_MIOPEN=0 USE_NNPACK=0 BUILD_CAFFE2_OPS=0 USE_TENSORPIPE=0 python3 setup.py develop --user
+```
+
+- Review: better undersrtand the `CMAKE_PREFIX_PATH` setting
+
+After this you can build / test onnx runtime as normal.
+
+From `workspaces/onnxruntime` directory, run the following commands:
+
+```
+./build.sh --cmake_generator Ninja --config Debug --build_shared_lib --parallel --build_eager_mode --enable_training --enable_pybind  --build_wheel --skip_tests
+```
+
 ## Decisions worth noting
 - Resizing the output tensor: Aten supports resizing any out tensor but prints a warning this is depracated and support
 will end. With that in mind, we have decided to error in `resize_output` if the output tensor is not empty or already


### PR DESCRIPTION
Example changes to explore dev container to easily build PyTorch from source and consume this in onnxruntime.

There are some other options to consider here:

- Multiple Dev Container definitions (if we want to support different environments for different onnxruntime workstreams)
- Move PyTorch environment setup into a self contained script. This would let developer decide whether they want PyTorch source (as opposed to PyTorch installed from PIP)
