### PR TITLE
Fix log id issue in inference session

### DIFF
--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -243,6 +243,12 @@ class Logger {
   void SetVerbosity(int vlog_level) noexcept { max_vlog_level_ = vlog_level; }
 
   /**
+     Get the log id for log messages to be output.
+     @returns The log id.
+  */
+  std::string GetLogID() const noexcept { return id_; }
+
+  /**
      Check if output is enabled for the provided LogSeverity and DataType values.
      @param severity The severity.
      @param data_type Type of the data.

--- a/include/onnxruntime/core/common/logging/logging.h
+++ b/include/onnxruntime/core/common/logging/logging.h
@@ -246,7 +246,7 @@ class Logger {
      Get the log id for log messages to be output.
      @returns The log id.
   */
-  std::string GetLogID() const noexcept { return id_; }
+  const std::string& GetLogID() const noexcept { return id_; }
 
   /**
      Check if output is enabled for the provided LogSeverity and DataType values.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2372,9 +2372,9 @@ void InferenceSession::InitLogger(logging::LoggingManager* logging_manager) {
       severity = static_cast<logging::Severity>(session_options_.session_log_severity_level);
     }
 
-    // There's log_id in both the Env and session_option,
-    // inference session will use the one from Env if nothing set on session_option
-    // session_option can always overwrite the log id, in case the Env can be shared across sessions,
+    // There's log_id in both the Env and session_option.
+    // Inference session will use the one from Env if nothing set on session_option.
+    // Session_option can always overwrite the log id, in case the Env can be shared across sessions.
     std::string log_id = session_options_.session_logid;    
     std::string log_id_from_logger = logging_manager->DefaultLogger().GetLogID();
     if (log_id.empty() && !log_id_from_logger.empty()) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2372,7 +2372,16 @@ void InferenceSession::InitLogger(logging::LoggingManager* logging_manager) {
       severity = static_cast<logging::Severity>(session_options_.session_log_severity_level);
     }
 
-    owned_session_logger_ = logging_manager_->CreateLogger(session_options_.session_logid, severity, false,
+    // There's log_id in both the Env and session_option,
+    // inference session will use the one from Env if nothing set on session_option
+    // session_option can always overwrite the log id, in case the Env can be shared across sessions,
+    std::string log_id = session_options_.session_logid;    
+    std::string log_id_from_logger = logging_manager->DefaultLogger().GetLogID();
+    if (log_id.empty() && !log_id_from_logger.empty()) {
+      log_id = log_id_from_logger;
+    }
+    
+    owned_session_logger_ = logging_manager_->CreateLogger(log_id, severity, false,
                                                            session_options_.session_log_verbosity_level);
     session_logger_ = owned_session_logger_.get();
   } else {

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -388,13 +388,13 @@ TEST(InferenceSessionTests, LogIdTest) {
   SessionOptions so_without_log_id;
   InferenceSession session_object1{so_without_log_id, GetEnvironment()};
   // test_main has log_id set in ortenv_setup()
-  ASSERT_TRUE(session_object1.GetLogger()->GetLogID() == "Default");
+  ASSERT_EQ(session_object1.GetLogger()->GetLogID(), "Default");
 
   std::string so_log_id = "LogIdFromSessionOption";
   SessionOptions so_with_log_id;
   so_with_log_id.session_logid = so_log_id;
   InferenceSession session_object2{so_with_log_id, GetEnvironment()};
-  ASSERT_TRUE(session_object2.GetLogger()->GetLogID() == so_log_id);
+  ASSERT_EQ(session_object2.GetLogger()->GetLogID(), so_log_id);
 }
 
 TEST(InferenceSessionTests, NoTimeout) {

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -384,6 +384,19 @@ void RunModelWithBindingMatMul(InferenceSession& session_object,
   }
 }
 
+TEST(InferenceSessionTests, LogIdTest) {
+  SessionOptions so_without_log_id;
+  InferenceSession session_object1{so_without_log_id, GetEnvironment()};
+  // test_main has log_id set in ortenv_setup()
+  ASSERT_TRUE(session_object1.GetLogger()->GetLogID() == "Default");
+
+  std::string so_log_id = "LogIdFromSessionOption";
+  SessionOptions so_with_log_id;
+  so_with_log_id.session_logid = so_log_id;
+  InferenceSession session_object2{so_with_log_id, GetEnvironment()};
+  ASSERT_TRUE(session_object2.GetLogger()->GetLogID() == so_log_id);
+}
+
 TEST(InferenceSessionTests, NoTimeout) {
   SessionOptions so;
 


### PR DESCRIPTION
Fix issue: https://github.com/microsoft/onnxruntime/issues/12414
User may set log_id in the Env, but the inference session always uses the log_id from session option even it's empty.

Adjust the logic:
The inference session will use the log_id from Env if no log_id set on the session option. And session option can always overwrite the log_id if they want, in case that the Env can be shared across sessions.

**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
