### PR TITLE
Remove reference to the deprecated variable in `torch.onnx.symbolic_helper`

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -25,6 +25,7 @@ from ._fallback import ORTModuleONNXModelException, wrap_exception
 BANNED_AUTOGRAD_FUNCTION_NAMES = frozenset([torch.utils.checkpoint.CheckpointFunction.__name__])
 
 
+# pylint: disable=protected-access
 # Mapping from pytorch scalar type to onnx scalar type.
 _CAST_PYTORCH_TO_ONNX = {
     "Byte": torch._C._onnx.TensorProtoDataType.UINT8,
@@ -41,6 +42,7 @@ _CAST_PYTORCH_TO_ONNX = {
     "BFloat16": torch._C._onnx.TensorProtoDataType.BFLOAT16,
     "Undefined": torch._C._onnx.TensorProtoDataType.UNDEFINED,
 }
+# pylint: enable=protected-access
 
 
 def _export_pt_1_10(g, n, *args, **kwargs):

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -41,6 +41,7 @@ _CAST_PYTORCH_TO_ONNX = {
     "Undefined": torch.onnx.TensorProtoDataType.UNDEFINED,
 }
 
+
 def _pytorch_type_to_onnx(scalar_type: str) -> torch.onnx.TensorProtoDataType:
     try:
         return torch.onnx.JitScalarType.from_name(scalar_type).onnx_type()


### PR DESCRIPTION
**Description**: Remove reference to the deprecated variable in `torch.onnx.symbolic_helper` pytorch/pytorch#81953

- Removed unused imports
- Changed BANNED_AUTOGRAD_FUNCTION_NAMES to a frozenset

**Motivation and Context**

The cast_pytorch_to_onnx variable is deprecated and removed in `torch.onnx.symbolic_helper`. Since there is still a need for converting scalar types to onnx type, I copied the mapping to `_CAST_PYTORCH_TO_ONNX` in the module.