### PR TITLE
DML EP fix training build error

### DIFF
--- a/cmake/onnxruntime_training.cmake
+++ b/cmake/onnxruntime_training.cmake
@@ -120,6 +120,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
       onnxruntime_session
       ${onnxruntime_libs}
       ${PROVIDERS_MKLDNN}
+      ${PROVIDERS_DML}
       onnxruntime_optimizer
       onnxruntime_providers
       onnxruntime_util


### PR DESCRIPTION
**Description**: The combo of `--use_dml` with `--enable_training` fails to build with missing linkage errors in {onnxruntime_training_bert.exe, onnxruntime_training_mnist.exe} from onnxruntime_providers_dml.lib not being found (it actually builds fine, but it's not linked to the test apps).

`.\build.bat --config Debug --build_shared_lib --parallel --use_dml --skip_tests --skip_submodule_sync --enable_training`

**Motivation and Context**
- *Why is this change required? What problem does it solve?* ORT should be buildable with both training and DML. (this alone does not enable training with DML - there is more work elsewhere).
- *If it fixes an open issue, please link to the issue here.* NA