### PR TITLE
WIP: Implement native_dropout operator

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -178,6 +178,7 @@ hand_implemented = {
     "aten::nll_loss_forward.output": MakeTorchFallback(),
     "aten::nll_loss_backward.grad_input": MakeTorchFallback(),
     "aten::_log_softmax_backward_data.out": MakeTorchFallback(),
+    "aten::native_dropout": SignatureOnly(),
 }
 
 # If the aten op expects a specific output type that differs from self

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 import onnxruntime_pybind11_state as torch_ort
 import torch
+import torch._ops
 from parameterized import parameterized
 
 
@@ -443,6 +444,21 @@ class OrtOpTests(unittest.TestCase):
             torch.mm(ort_mat1, ort_wrong_type)
         with self.assertRaises(RuntimeError):
             torch.mm(ort_mat1, ort_not_matrix)
+
+    def test_native_dropout(self):
+        device = self.get_device()
+
+        # out version test
+        cpu_tensor = torch.rand(3, 2)
+        ort_tensor = cpu_tensor.to(device)
+
+        cpu_result = torch.ops.aten.native_dropout(cpu_tensor, 0.5, True)
+        ort_result = torch.ops.aten.native_dropout(ort_tensor, 0.5, True)
+
+        # The result is random - we could look at setting specific random seed...
+        # For now, just check tensor shape
+        # self.assertEqual(cpu_result[0].size(), ort_result[0].size())
+        # self.assertEqual(cpu_result[1].size(), ort_result[1].size())
 
     ################################ parameterized test follow #######################################
     # OPS - is a list of [test_operator, tested_tensor=torch.rand (6)].


### PR DESCRIPTION
Implementing `native_dropout` operator enables PyTorch `dropout` operation to be
dispatched to be dispatched to backend that supports "fused_kernel" for
dropout.

However, PyTorch does not currently list the ORT backend as supporting
"fused_kernel" for dropout, and so it will not actually dispatch to ORT
backend. The following change updates PyTorch to forward `dropout`
calls to `native_dropout` kernel for ORT backend:

https://github.com/pytorch/pytorch/pull/82816


## TODO:
- Add tests
- Implement `native_dropout_backward`?