### PR TITLE
Partition convolution utilities for parallel processing

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -109,7 +109,8 @@ Status Conv<T>::Compute(OpKernelContext* context) const {
               pads[3],
               strides[0],
               strides[1],
-              col_buffer_data);
+              col_buffer_data,
+              thread_pool);
         } else {
           math::Im2col<T, StorageOrder::NCHW>()(
               Xdata + group_id * X_offset,
@@ -121,7 +122,8 @@ Status Conv<T>::Compute(OpKernelContext* context) const {
               dilations.data(),
               pads.data(),
               static_cast<int>(kernel_shape.size()),
-              col_buffer_data);
+              col_buffer_data,
+              thread_pool);
         }
       }
 
@@ -269,7 +271,8 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
             dilations.data(),
             pads.data(),
             static_cast<int>(kernel_shape.size()),
-            col_buffer_data);
+            col_buffer_data,
+            thread_pool);
 
         math::Gemm<float>(
             CblasNoTrans,

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
@@ -256,8 +256,6 @@ Status ConvTranspose<float>::DoConvTranspose(OpKernelContext* context, bool dyna
   float* Ydata = p.Y->MutableData<float>();
   TensorShape output_shape = p.Y->Shape().Slice(2);
 
-  // std::cout << "ConvT<float>. Images: " << p.N << " groups: " << conv_transpose_attrs_.group;
-
   for (auto image_id = 0; image_id < p.N; ++image_id) {
     for (int group_id = 0; group_id < conv_transpose_attrs_.group; ++group_id) {
       // Weight term

--- a/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv_transpose.cc
@@ -171,7 +171,7 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
           thread_pool);
 
       if (p.X->Shape().NumDimensions() == 4) {
-        math::Col2im<T, CPUMathUtil, StorageOrder::NCHW>(
+        math::Col2imPar<T, StorageOrder::NCHW>(
             col_buffer_data,
             p.num_output_channels / conv_transpose_attrs_.group,
             p.Y->Shape()[2],
@@ -187,9 +187,10 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
             p.strides[0],
             p.strides[1],
             Ydata + group_id * Y_offset,
-            &CPUMathUtil::Instance());
+            &CPUMathUtil::Instance(),
+            thread_pool);
       } else {
-        math::Col2imNd<T, CPUMathUtil, StorageOrder::NCHW>(
+        math::Col2imNdPar<T, StorageOrder::NCHW>(
             col_buffer_data,
             output_shape.GetDims().data(),
             p.input_shape.GetDims().data(),
@@ -201,7 +202,8 @@ Status ConvTranspose<T>::DoConvTranspose(OpKernelContext* context, bool dynamic_
             p.pads.data(),
             static_cast<int>(p.kernel_shape.size()),
             Ydata + group_id * Y_offset,
-            &CPUMathUtil::Instance());
+            &CPUMathUtil::Instance(),
+            thread_pool);
       }
     }
 
@@ -254,6 +256,8 @@ Status ConvTranspose<float>::DoConvTranspose(OpKernelContext* context, bool dyna
   float* Ydata = p.Y->MutableData<float>();
   TensorShape output_shape = p.Y->Shape().Slice(2);
 
+  // std::cout << "ConvT<float>. Images: " << p.N << " groups: " << conv_transpose_attrs_.group;
+
   for (auto image_id = 0; image_id < p.N; ++image_id) {
     for (int group_id = 0; group_id < conv_transpose_attrs_.group; ++group_id) {
       // Weight term
@@ -271,7 +275,7 @@ Status ConvTranspose<float>::DoConvTranspose(OpKernelContext* context, bool dyna
           thread_pool);
 
       if (p.X->Shape().NumDimensions() == 4) {
-        math::Col2im<float, CPUMathUtil, StorageOrder::NCHW>(
+        math::Col2imPar<float, StorageOrder::NCHW>(
             col_buffer_data,
             p.num_output_channels / conv_transpose_attrs_.group,
             p.Y->Shape()[2],
@@ -287,9 +291,11 @@ Status ConvTranspose<float>::DoConvTranspose(OpKernelContext* context, bool dyna
             p.strides[0],
             p.strides[1],
             Ydata + group_id * Y_offset,
-            &CPUMathUtil::Instance());
+            &CPUMathUtil::Instance(),
+            thread_pool);
+
       } else {
-        math::Col2imNd<float, CPUMathUtil, StorageOrder::NCHW>(
+        math::Col2imNdPar<float, StorageOrder::NCHW>(
             col_buffer_data,
             output_shape.GetDims().data(),
             p.input_shape.GetDims().data(),
@@ -301,7 +307,8 @@ Status ConvTranspose<float>::DoConvTranspose(OpKernelContext* context, bool dyna
             p.pads.data(),
             static_cast<int>(p.kernel_shape.size()),
             Ydata + group_id * Y_offset,
-            &CPUMathUtil::Instance());
+            &CPUMathUtil::Instance(),
+            thread_pool);
       }
     }
 

--- a/onnxruntime/core/providers/cpu/quantization/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/quantization/conv_integer.cc
@@ -133,6 +133,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
               strides[0],
               strides[1],
               col_buffer_data,
+              thread_pool,
               input_offset);
         } else {
           math::Im2col<uint8_t, StorageOrder::NCHW>()(
@@ -146,6 +147,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
               pads.data(),
               static_cast<int>(kernel_rank),
               col_buffer_data,
+              thread_pool,
               false,
               input_offset);
         }

--- a/onnxruntime/core/util/math.h
+++ b/onnxruntime/core/util/math.h
@@ -40,6 +40,7 @@ enum CBLAS_SIDE { CblasLeft = 141,
 #endif
 
 namespace onnxruntime {
+class CPUMathUtil;
 namespace concurrency {
 class ThreadPool;
 }
@@ -198,8 +199,9 @@ struct Im2col<T, StorageOrder::NCHW> {
       int64_t stride_h,
       int64_t stride_w,
       T* data_col,
+      concurrency::ThreadPool* tp,
       T padding_value = 0);
-  void operator()(
+  void operator() (
       const T* data_im,
       const int64_t* input_shape,
       const int64_t* output_shape,
@@ -210,6 +212,7 @@ struct Im2col<T, StorageOrder::NCHW> {
       const int64_t* pad,
       ptrdiff_t rank,
       T* data_col,
+      concurrency::ThreadPool* tp,
       bool accumulate_output = false,
       T padding_value = 0);
 };
@@ -233,8 +236,10 @@ struct Im2col<T, StorageOrder::NHWC> {
       int64_t output_w,
       int64_t output_start,
       int64_t output_count,
+      concurrency::ThreadPool* tp,
       T* data_col,
       T padding_value = 0);
+
   void operator()(
       const T* data_im,
       int64_t group_channels,
@@ -246,6 +251,7 @@ struct Im2col<T, StorageOrder::NHWC> {
       const int64_t* dilation,
       const int64_t* pad,
       ptrdiff_t rank,
+      concurrency::ThreadPool* tp,
       T* data_col,
       T padding_value = 0);
   void operator()(
@@ -260,12 +266,13 @@ struct Im2col<T, StorageOrder::NHWC> {
       ptrdiff_t rank,
       int64_t output_start,
       int64_t output_count,
+      concurrency::ThreadPool* tp,
       T const** data_indirection,
       const T* padding_ptr);
 };
 
-template <typename T, class Provider, int order>
-void Col2imNd(
+template <typename T, int order>
+void Col2imNdPar(
     const T* data_col,
     const int64_t* img_shape,
     const int64_t* output_shape,
@@ -277,7 +284,8 @@ void Col2imNd(
     const int64_t* pad,
     ptrdiff_t N,
     T* data_img,
-    Provider* provider);
+    CPUMathUtil* context,
+    concurrency::ThreadPool*);
 
 template <typename T, class Provider, int order>
 void Col2im(
@@ -297,6 +305,27 @@ void Col2im(
     int64_t stride_w,
     T* data_im,
     Provider* provider);
+
+template <typename T, int order>
+void Col2imPar(
+    const T* data_col,
+    int64_t channels,
+    int64_t height,
+    int64_t width,
+    int64_t patch_h,
+    int64_t patch_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t pad_t,
+    int64_t pad_l,
+    int64_t pad_b,
+    int64_t pad_r,
+    int64_t stride_h,
+    int64_t stride_w,
+    T* data_im,
+    CPUMathUtil* context,
+    concurrency::ThreadPool* tp);
+
 
 template <typename T, typename TypedCopy>
 void CopyMatrix(

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -380,7 +380,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
       }
     }
   };
-  ThreadPool::TryBatchParallelFor(tp, channels, channel_proc, batches);
+  ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(channels), channel_proc, gsl::narrow<ptrdiff_t>(batches));
 }
 
 template <typename T>
@@ -455,7 +455,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
     tp = nullptr;
   }
 
-  ThreadPool::TryBatchParallelFor(tp, channels_col, channel_proc, batches);
+  ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(channels_col), channel_proc, gsl::narrow<ptrdiff_t>(batches));
 }
 
 template struct Im2col<float, StorageOrder::NCHW>;
@@ -537,7 +537,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
       }
     }
   };
-  ThreadPool::TryBatchParallelFor(tp, output_count, im2col_proc, batches);
+  ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(output_count), im2col_proc, gsl::narrow<ptrdiff_t>(batches));
 }
 
 template <typename T>
@@ -695,7 +695,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
         output_indir += kernel_w;
       }
     };
-    ThreadPool::TryBatchParallelFor(tp, output_count, im2col_proc, batches);
+    ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(output_count), im2col_proc, gsl::narrow<ptrdiff_t>(batches));
   } else {
     const auto kernel_size = std::accumulate(kernel_shape, kernel_shape + rank, 1LL, std::multiplies<int64_t>());
 
@@ -731,7 +731,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
         *data_output++ = is_padding ? padding_ptr : data_ptr;
       } while (NextPosition(rank, kernel_shape, d_kernel.data()));
     };
-    ThreadPool::TryBatchParallelFor(tp, output_count, im2col_proc, batches);
+    ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(output_count), im2col_proc, gsl::narrow<ptrdiff_t>(batches));
   }
 }
 template struct Im2col<int8_t, StorageOrder::NHWC>;
@@ -756,7 +756,7 @@ void Col2imPar<float, StorageOrder::NCHW>(const float* data_col, int64_t channel
   constexpr int64_t cost_per_batch = 6144;
   const auto data_per_channel = kernel_h * kernel_w * output_hw;  // Input. From the loops below
   const auto total_cost = data_per_channel * channels;
-  const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);
+  const auto batches = gsl::narrow<ptrdiff_t>(std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop));
 
   Set<float, CPUMathUtil>(gsl::narrow<ptrdiff_t>(hwc), 0, data_im, context);
 
@@ -791,9 +791,8 @@ void Col2imPar<float, StorageOrder::NCHW>(const float* data_col, int64_t channel
           }
         }
       }
-      //}
     };
-    ThreadPool::TryBatchParallelFor(tp, channels, basic_channel_proc, batches);
+    ThreadPool::TryBatchParallelFor(tp, gsl::narrow<ptrdiff_t>(channels), basic_channel_proc, batches);
     return;
   }
 

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -293,9 +293,10 @@ static inline bool NextPosition(int64_t N, const int64_t* shape, int64_t* dims) 
 
 static inline void NumToDims(int64_t num, gsl::span<const int64_t> shape, gsl::span<int64_t> dims) {
   ORT_ENFORCE(shape.size(), dims.size());
-  for (size_t d_i = dims.size() - 1; d_i >= 0 && num > 0; --d_i) {
-    const auto carry = num / shape[d_i];
-    dims[d_i] = num - carry * shape[d_i];
+  for (size_t d_i = dims.size(); d_i > 0 && num > 0; --d_i) {
+    const auto idx = d_i - 1;
+    const auto carry = num / shape[idx];
+    dims[idx] = num - carry * shape[idx];
     num = carry;
   }
 }

--- a/onnxruntime/core/util/math_cpu.cc
+++ b/onnxruntime/core/util/math_cpu.cc
@@ -18,9 +18,7 @@
 #include "core/util/math_cpuonly.h"
 #include "core/util/math.h"
 
-#include <windows.h>
 #include <algorithm>
-#include <iostream>
 #include <gsl/gsl>
 #include "core/common/inlined_containers_fwd.h"
 #include "core/mlas/inc/mlas.h"
@@ -325,7 +323,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
   const int64_t output_w = (width + pad_l + pad_r - (dilation_w * (kernel_w - 1) + 1)) / stride_w + 1;
 
   const auto dop = ThreadPool::DegreeOfParallelism(tp);
-  constexpr int64_t cost_per_batch = 8192;
+  constexpr int64_t cost_per_batch = 6144;
   const auto cost_per_channel = kernel_h * kernel_w * output_h * output_w;
   const auto total_cost = cost_per_channel * channels;
   const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);
@@ -403,7 +401,7 @@ void Im2col<T, StorageOrder::NCHW>::operator()(
   const auto output_size = std::accumulate(output_shape, output_shape + rank, 1LL, std::multiplies<int64_t>());
 
   const auto dop = ThreadPool::DegreeOfParallelism(tp);
-  constexpr int64_t cost_per_batch = 8129;
+  constexpr int64_t cost_per_batch = 6144;
   const auto total_cost = output_size * (rank + 1) * channels_col;
   const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);
 
@@ -485,7 +483,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
     T padding_value) {
 
   const auto dop = ThreadPool::DegreeOfParallelism(tp);
-  constexpr int64_t cost_per_batch = 8192;  // Tunable
+  constexpr int64_t cost_per_batch = 6144;  // Tunable
   const auto cost_per_output = kernel_h * kernel_w * group_channels;
   const auto total_cost = output_count * cost_per_output;
   const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);
@@ -562,7 +560,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
   const auto kernel_size = std::accumulate(kernel_shape, kernel_shape + rank, 1LL, std::multiplies<int64_t>());
   const auto output_count = std::accumulate(output_shape, output_shape + rank, 1LL, std::multiplies<int64_t>());
 
-  constexpr int64_t cost_per_batch = 8192;
+  constexpr int64_t cost_per_batch = 6144;
   const auto cost_per_output = kernel_size * (group_channels + rank);
   const auto total_cost = output_count * cost_per_output;
   const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);
@@ -622,7 +620,7 @@ void Im2col<T, StorageOrder::NHWC>::operator()(
     const T* padding_ptr) {
 
   const auto dop = ThreadPool::DegreeOfParallelism(tp);
-  constexpr int64_t cost_per_batch = 8192;
+  constexpr int64_t cost_per_batch = 6144;
 
   if (rank == 1) {
     const int64_t stride_w = stride[0];
@@ -754,7 +752,7 @@ void Col2imPar<float, StorageOrder::NCHW>(const float* data_col, int64_t channel
   const int64_t hwc = hw * channels;  // Total output
 
   const auto dop = ThreadPool::DegreeOfParallelism(tp);
-  constexpr int64_t cost_per_batch = 8129;
+  constexpr int64_t cost_per_batch = 6144;
   const auto data_per_channel = kernel_h * kernel_w * output_hw;  // Input. From the loops below
   const auto total_cost = data_per_channel * channels;
   const auto batches = std::min<int64_t>((total_cost + cost_per_batch - 1) / cost_per_batch, dop);

--- a/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
@@ -79,7 +79,6 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
   const T* Wdata = W->template Data<T>();
   const T* dYdata = dY->template Data<T>();
 
-
   BufferUniquePtr bias_multiplier(alloc->Alloc(sizeof(T) * output_image_size), BufferDeleter(alloc));
   T* bias_multiplier_data = nullptr;
   Tensor* dB = context->Output(2, {M});
@@ -94,7 +93,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
                               bias_multiplier_data,
                               &CPUMathUtil::Instance());
   }
-  
+
   T* dWdata = nullptr;
   if (dW) {
     dWdata = dW->template MutableData<T>();
@@ -124,7 +123,8 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
                 pads[1],
                 1,
                 strides[0],
-                col_buffer_data);
+                col_buffer_data,
+                tp);
           } else if (kernel_rank == 2) {
             math::Im2col<T, StorageOrder::NCHW>()(
                 Xdata + group_id * X_offset,
@@ -141,7 +141,8 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
                 pads[3],
                 strides[0],
                 strides[1],
-                col_buffer_data);
+                col_buffer_data,
+                tp);
           } else {
             math::Im2col<T, StorageOrder::NCHW>()(
                 Xdata + group_id * X_offset,
@@ -153,7 +154,8 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
                 dilations.data(),
                 pads.data(),
                 static_cast<int>(kernel_shape.size()),
-                col_buffer_data);
+                col_buffer_data,
+                tp);
           }
         }
         // Gradient with respect to W, filter.
@@ -188,7 +190,6 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
     dYdata += Y_offset * conv_attrs_.group;
   }
 
-
   Tensor* dX = context->Output(0, X->Shape());
   if (dX) {
     T* dXdata = dX->template MutableData<T>();
@@ -210,7 +211,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
             tp);
 
         if (kernel_rank == 2) {
-          math::Col2im<T, CPUMathUtil, StorageOrder::NCHW>(
+          math::Col2imPar<T, StorageOrder::NCHW>(
               col_buffer_data,
               C / conv_attrs_.group,
               input_shape[0],
@@ -226,9 +227,10 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
               strides[0],
               strides[1],
               dXdata,
-              &CPUMathUtil::Instance());
+              &CPUMathUtil::Instance(),
+              tp);
         } else {
-          math::Col2imNd<T, CPUMathUtil, StorageOrder::NCHW>(
+          math::Col2imNdPar<T, StorageOrder::NCHW>(
               col_buffer_data,
               input_shape.GetDims().data(),
               output_shape.GetDims().data(),
@@ -240,7 +242,8 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
               pads.data(),
               static_cast<int>(kernel_shape.size()),
               dXdata,
-              &CPUMathUtil::Instance());
+              &CPUMathUtil::Instance(),
+              tp);
         }
         dXdata += X_offset;
         dYdata += Y_offset;
@@ -260,4 +263,3 @@ ONNX_OPERATOR_KERNEL_EX(
 
 }  // namespace contrib
 }  // namespace onnxruntime
-


### PR DESCRIPTION
**Description**:
This change partitions `Im2Col` and `Col2Im` utilities for multi-threaded batching.
This is done on the basis of the algo/data cost rather than on a per-channel basis.
Multiple channels are batches together for processing on a single thread when there is little data per channel to process. We aim to make sure batches are no smaller than a certain threshold so we do not blindly divide data between all available threads, but only those that are needed. In the latter case, launching threads costs add more latency variance rather than speedup. 

**Motivation and Context**
This speeds up certain customer models.