### PR TITLE
Avoid false-positive dependent name lookup error by not depending on auto keyword

### DIFF
--- a/onnxruntime/core/providers/cuda/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.cc
@@ -40,7 +40,7 @@ Status RoiAlign<T>::ComputeInternal(OpKernelContext* context) const {
     return status;
   }
 
-  auto& Y = *context->Output(0, {num_rois, x_dims[1], this->output_height_, this->output_width_});
+  Tensor& Y = *context->Output(0, {num_rois, x_dims[1], this->output_height_, this->output_width_});
   int64_t output_size = Y.Shape().Size();
 
   if (output_size > 0) {

--- a/onnxruntime/core/providers/cuda/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.cc
@@ -57,7 +57,7 @@ Status RoiAlign<T>::ComputeInternal(OpKernelContext* context) const {
         this->sampling_ratio_,
         reinterpret_cast<const typename ToCudaType<T>::MappedType*>(rois_ptr->Data<T>()),
         num_roi_cols,
-        reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.MutableData<T>()),
+        reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.template MutableData<T>()),
         this->mode_ == RoiAlignMode::avg,
         this->half_pixel_,
         batch_indices_ptr->Data<int64_t>());

--- a/onnxruntime/core/providers/cuda/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cuda/object_detection/roialign.cc
@@ -57,7 +57,7 @@ Status RoiAlign<T>::ComputeInternal(OpKernelContext* context) const {
         this->sampling_ratio_,
         reinterpret_cast<const typename ToCudaType<T>::MappedType*>(rois_ptr->Data<T>()),
         num_roi_cols,
-        reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.template MutableData<T>()),
+        reinterpret_cast<typename ToCudaType<T>::MappedType*>(Y.MutableData<T>()),
         this->mode_ == RoiAlignMode::avg,
         this->half_pixel_,
         batch_indices_ptr->Data<int64_t>());

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -155,8 +155,8 @@ Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
     return BaseCompute(context, roi, scales_, output_dims);
   }
 
-  const auto* scales = context->Input<Tensor>(scales_input_idx_);
-  const auto* sizes = context->Input<Tensor>(sizes_input_idx_);
+  const Tensor* scales = context->Input<Tensor>(scales_input_idx_);
+  const Tensor* sizes = context->Input<Tensor>(sizes_input_idx_);
 
   if (scales_cached_) {
     ORT_ENFORCE(sizes == nullptr, "Only one of scales or sizes must be provided as input.");

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -176,7 +176,7 @@ Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
                 "Either scales or sizes MUST be provided as input.");
     ORT_ENFORCE(sizes->Shape().Size() == static_cast<int64_t>(output_dims.size()),
                 "Resize: input tensor's rank does not match the output tensor's rank.");
-    memcpy(output_dims.data(), sizes->template Data<int64_t>(), sizes->Shape().Size() * sizeof(int64_t));
+    memcpy(output_dims.data(), sizes->Data<int64_t>(), sizes->Shape().Size() * sizeof(int64_t));
     ParseScalesDataFromOutputSize(output_dims, X->Shape().GetDims(), scales_array);
   }
 

--- a/onnxruntime/core/providers/cuda/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cuda/tensor/upsample.cc
@@ -176,7 +176,7 @@ Status Upsample<T>::ComputeInternal(OpKernelContext* context) const {
                 "Either scales or sizes MUST be provided as input.");
     ORT_ENFORCE(sizes->Shape().Size() == static_cast<int64_t>(output_dims.size()),
                 "Resize: input tensor's rank does not match the output tensor's rank.");
-    memcpy(output_dims.data(), sizes->Data<int64_t>(), sizes->Shape().Size() * sizeof(int64_t));
+    memcpy(output_dims.data(), sizes->template Data<int64_t>(), sizes->Shape().Size() * sizeof(int64_t));
     ParseScalesDataFromOutputSize(output_dims, X->Shape().GetDims(), scales_array);
   }
 


### PR DESCRIPTION
**Description**:
Fix dependent name lookup in class template to access templated method.


**Motivation and Context**
- Why is this change required? What problem does it solve?
   C++ grammar enforcement.