### PR TITLE
Improve the compilation speed when compiling for multiple architectures.

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/setup.py
@@ -4,12 +4,15 @@
 # --------------------------------------------------------------------------
 
 import os
-from setuptools import setup, Extension
+
+from setuptools import Extension, setup
 from torch.utils import cpp_extension
 
 filename = os.path.join(os.path.dirname(__file__), "torch_interop_utils.cc")
+extra_compile_args={"cxx": ["-O3"]}
 setup(
     name="torch_interop_utils",
-    ext_modules=[cpp_extension.CppExtension(name="torch_interop_utils", sources=[filename])],
+    ext_modules=[cpp_extension.CppExtension(name="torch_interop_utils", sources=[filename],
+                                            extra_compile_args=extra_compile_args)],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
 )

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cpu/torch_interop_utils/setup.py
@@ -9,10 +9,13 @@ from setuptools import Extension, setup
 from torch.utils import cpp_extension
 
 filename = os.path.join(os.path.dirname(__file__), "torch_interop_utils.cc")
-extra_compile_args={"cxx": ["-O3"]}
+extra_compile_args = {"cxx": ["-O3"]}
 setup(
     name="torch_interop_utils",
-    ext_modules=[cpp_extension.CppExtension(name="torch_interop_utils", sources=[filename],
-                                            extra_compile_args=extra_compile_args)],
+    ext_modules=[
+        cpp_extension.CppExtension(
+            name="torch_interop_utils", sources=[filename], extra_compile_args=extra_compile_args
+        )
+    ],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
 )

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
@@ -21,7 +21,7 @@ filenames = [
 use_rocm = True if os.environ["ONNXRUNTIME_ROCM_VERSION"] else False
 extra_compile_args = {"cxx": ["-O3"]}
 if not use_rocm:
-    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(',')})
+    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(",")})
 
 setup(
     name="fused_ops",

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
@@ -21,7 +21,7 @@ filenames = [
 use_rocm = True if os.environ["ONNXRUNTIME_ROCM_VERSION"] else False
 extra_compile_args = {"cxx": ["-O3"]}
 if not use_rocm:
-    extra_compile_args.update({"nvcc": ["-lineinfo", "-O3", "--use_fast_math"]})
+    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(',')})
 
 setup(
     name="fused_ops",

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/setup.py
@@ -10,7 +10,6 @@ import sys
 from setuptools import setup
 from torch.utils import cpp_extension
 
-
 # TODO: Implement a cleaner way to auto-generate torch_gpu_allocator.cc
 use_rocm = True if os.environ["ONNXRUNTIME_ROCM_VERSION"] else False
 gpu_identifier = "hip" if use_rocm else "cuda"
@@ -24,8 +23,13 @@ with fileinput.FileInput(filename, inplace=True) as file:
             line = line.replace("___gpu_allocator_header___", gpu_allocator_header)
         sys.stdout.write(line)
 
+extra_compile_args = {"cxx": ["-O3"]}
+if not use_rocm:
+    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(',')})
+
 setup(
     name="torch_gpu_allocator",
-    ext_modules=[cpp_extension.CUDAExtension(name="torch_gpu_allocator", sources=[filename])],
+    ext_modules=[cpp_extension.CUDAExtension(name="torch_gpu_allocator", sources=[filename],
+                                             extra_compile_args=extra_compile_args)],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
 )

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/torch_gpu_allocator/setup.py
@@ -25,11 +25,14 @@ with fileinput.FileInput(filename, inplace=True) as file:
 
 extra_compile_args = {"cxx": ["-O3"]}
 if not use_rocm:
-    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(',')})
+    extra_compile_args.update({"nvcc": os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"].split(",")})
 
 setup(
     name="torch_gpu_allocator",
-    ext_modules=[cpp_extension.CUDAExtension(name="torch_gpu_allocator", sources=[filename],
-                                             extra_compile_args=extra_compile_args)],
+    ext_modules=[
+        cpp_extension.CUDAExtension(
+            name="torch_gpu_allocator", sources=[filename], extra_compile_args=extra_compile_args
+        )
+    ],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
 )

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
@@ -10,6 +10,7 @@ from glob import glob
 from shutil import copyfile
 
 import torch
+from packaging import version
 
 from onnxruntime.training import ortmodule
 
@@ -40,15 +41,10 @@ def _install_extension(ext_name, ext_path, cwd):
 
 def _get_cuda_extra_build_params():
     nvcc_extra_args = ["-lineinfo", "-O3", "--use_fast_math"]
-    raw_output = torch.version.cuda
-    if raw_output is not None:
-        release = raw_output.split(".")
-        bare_metal_major = release[0]
-        bare_metal_minor = release[1]
-
-        if int(bare_metal_major) >= 11 and int(bare_metal_minor) >= 2:
-            # If number is 0, the number of threads used is the number of CPUs on the machine.
-            nvcc_extra_args += ["--threads", "0"]
+    cuda_version = torch.version.cuda
+    if cuda_version is not None and version.parse(cuda_version) > version.parse("11.2"):
+        # If number is 0, the number of threads used is the number of CPUs on the machine.
+        nvcc_extra_args += ["--threads", "0"]
 
     os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"] = ",".join(nvcc_extra_args)
 

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
@@ -48,7 +48,7 @@ def _get_cuda_extra_build_params():
 
         if int(bare_metal_major) >= 11 and int(bare_metal_minor) >= 2:
             # If number is 0, the number of threads used is the number of CPUs on the machine.
-            nvcc_extra_args += ["--threads", "0"]
+            nvcc_extra_args += ["--threads", "32"]
 
     os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"] = ",".join(nvcc_extra_args)
 
@@ -69,7 +69,8 @@ def build_torch_cpp_extensions():
         ortmodule.ONNXRUNTIME_ROCM_VERSION if ortmodule.ONNXRUNTIME_ROCM_VERSION is not None else ""
     )
 
-    _get_cuda_extra_build_params()
+    if torch.version.cuda is not None and ortmodule.ONNXRUNTIME_CUDA_VERSION is not None:
+        _get_cuda_extra_build_params()
 
     ############################################################################
     # Pytorch CPP Extensions that DO require CUDA/ROCM

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
@@ -48,7 +48,7 @@ def _get_cuda_extra_build_params():
 
         if int(bare_metal_major) >= 11 and int(bare_metal_minor) >= 2:
             # If number is 0, the number of threads used is the number of CPUs on the machine.
-            nvcc_extra_args += ["--threads", "32"]
+            nvcc_extra_args += ["--threads", "0"]
 
     os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"] = ",".join(nvcc_extra_args)
 

--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/install.py
@@ -37,11 +37,12 @@ def _install_extension(ext_name, ext_path, cwd):
         print(f"There was an error compiling '{ext_name}' PyTorch CPP extension")
         sys.exit(ret_code)
 
+
 def _get_cuda_extra_build_params():
     nvcc_extra_args = ["-lineinfo", "-O3", "--use_fast_math"]
     raw_output = torch.version.cuda
     if raw_output is not None:
-        release = raw_output.split('.')
+        release = raw_output.split(".")
         bare_metal_major = release[0]
         bare_metal_minor = release[1]
 
@@ -49,7 +50,7 @@ def _get_cuda_extra_build_params():
             # If number is 0, the number of threads used is the number of CPUs on the machine.
             nvcc_extra_args += ["--threads", "0"]
 
-    os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"] = ','.join(nvcc_extra_args)
+    os.environ["ONNXRUNTIME_CUDA_NVCC_EXTRA_ARGS"] = ",".join(nvcc_extra_args)
 
 
 def build_torch_cpp_extensions():


### PR DESCRIPTION
**Description**: Improve compiling speed for multiple architectures.

Since cuda 11.2, NVCC introduce a build option '--threads':

[4.2.5.4. --threads number (-t)](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads)
Specify the maximum number of threads to be used to execute the compilation steps in parallel.

This option can be used to improve the compilation speed when compiling for multiple architectures. The compiler creates number threads to execute the compilation steps in parallel. If number is 1, this option is ignored. If number is 0, the number of threads used is the number of CPUs on the machine.

Previously, CUDA extensions built in 65.59178829193115 seconds, after enabling it, CUDA extensions built in 48.63271450996399 seconds. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
