### PR TITLE
Use alignas instead of naive padding to avoid false cache sharing

### DIFF
--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -1311,7 +1311,13 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
   // threads in the pool, and their lifetime is managed along with the
   // pool.
 
-  struct PerThread {
+#ifdef _MSC_VER
+#pragma warning(push)
+// C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
+#endif // _MSC_VER
+
+  struct ORT_ALIGN_TO_AVOID_FALSE_SHARING PerThread {
     constexpr PerThread() : pool(nullptr) {
     }
     ThreadPoolTempl* pool;            // Parent pool, or null for normal threads.
@@ -1327,8 +1333,12 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
     // of times that the work-stealing code paths are used for
     // rebalancing.
     InlinedVector<int> preferred_workers;
-    PaddingToAvoidFalseSharing padding_2;
   };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
 
   struct WorkerData {
     constexpr WorkerData() : thread(), queue() {

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -268,13 +268,20 @@ class ThreadPoolProfiler {
   bool enabled_ = false;
   MainThreadStat& GetMainThreadStat();  //return thread local stat
   int num_threads_;
-  struct ChildThreadStat {
+#ifdef _MSC_VER
+#pragma warning(push)
+// C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
+#endif  // _MSC_VER
+  struct ORT_ALIGN_TO_AVOID_FALSE_SHARING ChildThreadStat {
     std::thread::id thread_id_;
     uint64_t num_run_ = 0;
     onnxruntime::TimePoint last_logged_point_ = Clock::now();
     int32_t core_ = -1;                   //core that the child thread is running on
-    PaddingToAvoidFalseSharing padding_;  //to prevent false sharing
   };
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
   std::vector<ChildThreadStat> child_thread_stats_;
   std::string thread_pool_name_;
 };
@@ -308,9 +315,9 @@ class ExtendedThreadPoolInterface : public Eigen::ThreadPoolInterface {
 
   // Special case alternative to RunInParallelSection for use without
   // an existing parallel section.  Ideally we would use a single
-  // iplemenation and a stack-allocated ThreadPoolParallelSection.
+  // implementation and a stack-allocated ThreadPoolParallelSection.
   //
-  // However, on the BM_ThreadPoolParallelFor microbenchmark I saw
+  // However, on the BM_ThreadPoolParallelFor micro-benchmark I saw
   // ~20% overhead on the resulting single-loop parallel sections.
   // There are some additional costs (~5%) for additional invocations
   // through lambda functions on loop entry.  Most significantly, on

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -175,11 +175,6 @@ enum class PushResult {
 // - The __x86_64__ value is twice the line size (64 bytes).  This
 //   accounts for 2-line prefetch behavior on some cores.
 //
-// - Ideally, ORT_ALIGN_TO_AVOID_FALSE_SHARING is used.  However, the
-//   definition of ThreadPoolParallelSection uses naive padding
-//   because C++11 does not support alignment constraints on
-//   allocation or expose stdlib.h aligned_alloc.  C++17 introduces
-//   support for aligned allocation which we could use here.
 
 #if defined(__x86_64__)
 #define ORT_FALSE_SHARING_BYTES 128
@@ -188,10 +183,6 @@ enum class PushResult {
 #endif
 
 #define ORT_ALIGN_TO_AVOID_FALSE_SHARING alignas(ORT_FALSE_SHARING_BYTES)
-
-struct PaddingToAvoidFalseSharing {
-  char padding[ORT_FALSE_SHARING_BYTES];
-};
 
 /* Usage:
 1. In executor, call Start() before profiling and Stop() to get profiled numbers;
@@ -226,6 +217,7 @@ class ThreadPoolProfiler {
   std::string DumpChildThreadStat() { return {}; }
 };
 #else
+
 class ThreadPoolProfiler {
  public:
   enum ThreadPoolEvent {
@@ -268,16 +260,24 @@ class ThreadPoolProfiler {
   bool enabled_ = false;
   MainThreadStat& GetMainThreadStat();  //return thread local stat
   int num_threads_;
-  struct ChildThreadStat {
+#ifdef _MSC_VER
+#pragma warning(push)
+// C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
+#endif  // _MSC_VER
+  struct ORT_ALIGN_TO_AVOID_FALSE_SHARING ChildThreadStat {
     std::thread::id thread_id_;
     uint64_t num_run_ = 0;
     onnxruntime::TimePoint last_logged_point_ = Clock::now();
     int32_t core_ = -1;                   //core that the child thread is running on
-    PaddingToAvoidFalseSharing padding_;  //to prevent false sharing
   };
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
   std::vector<ChildThreadStat> child_thread_stats_;
   std::string thread_pool_name_;
 };
+
 #endif
 
 // Extended Eigen thread pool interface, avoiding the need to modify
@@ -308,7 +308,7 @@ class ExtendedThreadPoolInterface : public Eigen::ThreadPoolInterface {
 
   // Special case alternative to RunInParallelSection for use without
   // an existing parallel section.  Ideally we would use a single
-  // iplemenation and a stack-allocated ThreadPoolParallelSection.
+  // implementation and a stack-allocated ThreadPoolParallelSection.
   //
   // However, on the BM_ThreadPoolParallelFor microbenchmark I saw
   // ~20% overhead on the resulting single-loop parallel sections.
@@ -326,6 +326,11 @@ class ExtendedThreadPoolInterface : public Eigen::ThreadPoolInterface {
   virtual std::string StopProfiling() = 0;
 };
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
+#endif  // _MSC_VER
 class ThreadPoolParallelSection {
  public:
   // State accessed only by the main thread
@@ -354,9 +359,7 @@ class ThreadPoolParallelSection {
   // tasks may be running currently, or may be present in work queues,
   // or may have been removed from the queues by
   // RunQueue::RevokeWithTag.
-  PaddingToAvoidFalseSharing padding_1;
-  std::atomic<unsigned> tasks_finished{0};
-  PaddingToAvoidFalseSharing padding_2;
+  std::atomic<unsigned> ORT_ALIGN_TO_AVOID_FALSE_SHARING tasks_finished{0};
 
   // If non-null, the current loop that tasks should be executing.  We
   // need to be careful on access to the contents of current_loop
@@ -367,16 +370,20 @@ class ThreadPoolParallelSection {
   //
   // - Writers wishing to deallocate *current_loop must first clear
   //   current_loop and then wait for workers_in_loop==0
-  std::atomic<ThreadPoolLoop*> current_loop{nullptr};
-  std::atomic<unsigned> workers_in_loop{0};
+  std::atomic<ThreadPoolLoop*> ORT_ALIGN_TO_AVOID_FALSE_SHARING current_loop{nullptr};
+  std::atomic<unsigned> ORT_ALIGN_TO_AVOID_FALSE_SHARING workers_in_loop{0};
 
   // Members to track asynchronous dispatching
   int dispatch_q_idx = -1;      // index of thread that dispatch work to all other threads
   unsigned dispatch_w_idx = 0;  // index of enqueued work
-  std::atomic<bool> dispatch_started{false};
-  std::atomic<bool> dispatch_done{false};
-  std::atomic<bool> work_done{false};
+  std::atomic<bool> ORT_ALIGN_TO_AVOID_FALSE_SHARING dispatch_started{false};
+  std::atomic<bool> ORT_ALIGN_TO_AVOID_FALSE_SHARING dispatch_done{false};
+  std::atomic<bool> ORT_ALIGN_TO_AVOID_FALSE_SHARING work_done{false};
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 class ThreadPoolLoop {
  public:

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -490,7 +490,15 @@ std::string ThreadPool::StopProfiling() {
 }
 
 namespace {
+#ifdef _MSC_VER
+#pragma warning(push)
+// C4324: structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
+#endif  // _MSC_VER
 thread_local std::optional<ThreadPoolParallelSection> current_parallel_section;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 }
 
 ThreadPool::ParallelSection::ParallelSection(ThreadPool* tp) {

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -490,15 +490,7 @@ std::string ThreadPool::StopProfiling() {
 }
 
 namespace {
-#ifdef _MSC_VER
-#pragma warning(push)
-// C4324: structure was padded due to alignment specifier
-#pragma warning(disable : 4324)
-#endif  // _MSC_VER
 thread_local std::optional<ThreadPoolParallelSection> current_parallel_section;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // _MSC_VER
 }
 
 ThreadPool::ParallelSection::ParallelSection(ThreadPool* tp) {


### PR DESCRIPTION
**Description**:

Since we are at C++17, struct alignment is supported. Replace use of naive padding with `aligas`.

**Motivation and Context**

This produces measurable (in usec) improvements.
[BaseLine.txt](https://github.com/microsoft/onnxruntime/files/9285653/BaseLine.txt)
[NaivePadding.txt](https://github.com/microsoft/onnxruntime/files/9285651/7.-.NaivePadding.txt)


