### PR TITLE
[Java] JNI refactor for OrtJniUtil

### DIFF
--- a/java/src/main/java/ai/onnxruntime/MapInfo.java
+++ b/java/src/main/java/ai/onnxruntime/MapInfo.java
@@ -46,8 +46,9 @@ public class MapInfo implements ValueInfo {
 
   /**
    * Construct a MapInfo with the specified size, key type and value type.
-   * <p>
-   * Called from JNI.
+   *
+   * <p>Called from JNI.
+   *
    * @param size The size.
    * @param keyTypeInt The int representing the {@link OnnxTensorType} of the keys.
    * @param valueTypeInt The int representing the {@link OnnxTensorType} of the values.

--- a/java/src/main/java/ai/onnxruntime/MapInfo.java
+++ b/java/src/main/java/ai/onnxruntime/MapInfo.java
@@ -4,6 +4,8 @@
  */
 package ai.onnxruntime;
 
+import ai.onnxruntime.TensorInfo.OnnxTensorType;
+
 /** Describes an {@link OnnxMap} object or output node. */
 public class MapInfo implements ValueInfo {
 
@@ -40,6 +42,20 @@ public class MapInfo implements ValueInfo {
     this.size = size;
     this.keyType = keyType;
     this.valueType = valueType;
+  }
+
+  /**
+   * Construct a MapInfo with the specified size, key type and value type.
+   * <p>
+   * Called from JNI.
+   * @param size The size.
+   * @param keyTypeInt The int representing the {@link OnnxTensorType} of the keys.
+   * @param valueTypeInt The int representing the {@link OnnxTensorType} of the values.
+   */
+  MapInfo(int size, int keyTypeInt, int valueTypeInt) {
+    this.size = size;
+    this.keyType = OnnxJavaType.mapFromOnnxTensorType(OnnxTensorType.mapFromInt(keyTypeInt));
+    this.valueType = OnnxJavaType.mapFromOnnxTensorType(OnnxTensorType.mapFromInt(valueTypeInt));
   }
 
   @Override

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -90,14 +90,14 @@ public class OnnxTensor implements OnnxValue {
         case BOOL:
           return getBool(OnnxRuntime.ortApiHandle, nativeHandle);
         case STRING:
-          return getString(OnnxRuntime.ortApiHandle, nativeHandle, allocatorHandle);
+          return getString(OnnxRuntime.ortApiHandle, nativeHandle);
         case UNKNOWN:
         default:
           throw new OrtException("Extracting the value of an invalid Tensor.");
       }
     } else {
       Object carrier = info.makeCarrier();
-      getArray(OnnxRuntime.ortApiHandle, nativeHandle, allocatorHandle, carrier);
+      getArray(OnnxRuntime.ortApiHandle, nativeHandle, carrier);
       if ((info.type == OnnxJavaType.STRING) && (info.shape.length != 1)) {
         // We read the strings out from native code in a flat array and then reshape
         // to the desired output shape.
@@ -284,13 +284,12 @@ public class OnnxTensor implements OnnxValue {
 
   private native long getLong(long apiHandle, long nativeHandle, int onnxType) throws OrtException;
 
-  private native String getString(long apiHandle, long nativeHandle, long allocatorHandle)
-      throws OrtException;
+  private native String getString(long apiHandle, long nativeHandle) throws OrtException;
 
   private native boolean getBool(long apiHandle, long nativeHandle) throws OrtException;
 
-  private native void getArray(
-      long apiHandle, long nativeHandle, long allocatorHandle, Object carrier) throws OrtException;
+  private native void getArray(long apiHandle, long nativeHandle, Object carrier)
+      throws OrtException;
 
   private native void close(long apiHandle, long nativeHandle);
 

--- a/java/src/main/java/ai/onnxruntime/SequenceInfo.java
+++ b/java/src/main/java/ai/onnxruntime/SequenceInfo.java
@@ -63,6 +63,13 @@ public class SequenceInfo implements ValueInfo {
   }
 
   /**
+   * Constructs an empty sequence info. Called from JNI.
+   */
+  SequenceInfo() {
+    this(-1,OnnxJavaType.UNKNOWN);
+  }
+
+  /**
    * Is this a sequence of maps?
    *
    * @return True if it's a sequence of maps.

--- a/java/src/main/java/ai/onnxruntime/SequenceInfo.java
+++ b/java/src/main/java/ai/onnxruntime/SequenceInfo.java
@@ -4,6 +4,8 @@
  */
 package ai.onnxruntime;
 
+import ai.onnxruntime.TensorInfo.OnnxTensorType;
+
 /** Describes an {@link OnnxSequence}, including it's element type if known. */
 public class SequenceInfo implements ValueInfo {
 
@@ -36,6 +38,22 @@ public class SequenceInfo implements ValueInfo {
   }
 
   /**
+   * Construct a sequence of known length, with the specified type. This sequence does not contain
+   * maps.
+   *
+   * <p>
+   * Called from JNI.
+   * @param length The length of the sequence.
+   * @param sequenceTypeInt The element type int of the sequence mapped from {@link OnnxTensorType}.
+   */
+  SequenceInfo(int length, int sequenceTypeInt) {
+    this.length = length;
+    this.sequenceType = OnnxJavaType.mapFromOnnxTensorType(OnnxTensorType.mapFromInt(sequenceTypeInt));
+    this.sequenceOfMaps = false;
+    this.mapInfo = null;
+  }
+
+  /**
    * Construct a sequence of known length containing maps.
    *
    * @param length The length of the sequence.
@@ -60,13 +78,6 @@ public class SequenceInfo implements ValueInfo {
     this.sequenceType = OnnxJavaType.UNKNOWN;
     this.sequenceOfMaps = true;
     this.mapInfo = new MapInfo(keyType, valueType);
-  }
-
-  /**
-   * Constructs an empty sequence info. Called from JNI.
-   */
-  SequenceInfo() {
-    this(-1,OnnxJavaType.UNKNOWN);
   }
 
   /**

--- a/java/src/main/java/ai/onnxruntime/SequenceInfo.java
+++ b/java/src/main/java/ai/onnxruntime/SequenceInfo.java
@@ -41,14 +41,15 @@ public class SequenceInfo implements ValueInfo {
    * Construct a sequence of known length, with the specified type. This sequence does not contain
    * maps.
    *
-   * <p>
-   * Called from JNI.
+   * <p>Called from JNI.
+   *
    * @param length The length of the sequence.
    * @param sequenceTypeInt The element type int of the sequence mapped from {@link OnnxTensorType}.
    */
   SequenceInfo(int length, int sequenceTypeInt) {
     this.length = length;
-    this.sequenceType = OnnxJavaType.mapFromOnnxTensorType(OnnxTensorType.mapFromInt(sequenceTypeInt));
+    this.sequenceType =
+        OnnxJavaType.mapFromOnnxTensorType(OnnxTensorType.mapFromInt(sequenceTypeInt));
     this.sequenceOfMaps = false;
     this.mapInfo = null;
   }

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -121,6 +121,19 @@ public class TensorInfo implements ValueInfo {
   }
 
   /**
+   * Constructs a TensorInfo with the specified shape and native type int.
+   * <p>
+   * Called from JNI.
+   * @param shape The tensor shape.
+   * @param typeInt The native type int.
+   */
+  TensorInfo(long[] shape, int typeInt) {
+    this.shape = shape;
+    this.onnxType = OnnxTensorType.mapFromInt(typeInt);
+    this.type = OnnxJavaType.mapFromOnnxTensorType(this.onnxType);
+  }
+
+  /**
    * Get a copy of the tensor's shape.
    *
    * @return A copy of the tensor's shape.

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -122,8 +122,9 @@ public class TensorInfo implements ValueInfo {
 
   /**
    * Constructs a TensorInfo with the specified shape and native type int.
-   * <p>
-   * Called from JNI.
+   *
+   * <p>Called from JNI.
+   *
    * @param shape The tensor shape.
    * @param typeInt The native type int.
    */

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -293,7 +293,7 @@ jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorT
   dimensions = NULL;
 
   // Create the TensorInfo object
-  char *tensorInfoClassName = "ai/onnxruntime/TensorInfo";
+  static const char *tensorInfoClassName = "ai/onnxruntime/TensorInfo";
   jclass clazz = (*jniEnv)->FindClass(jniEnv, tensorInfoClassName);
   jmethodID tensorInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,clazz, "<init>", "([JI)V");
   //printf("TensorInfo class %p, methodID %p\n",clazz,tensorInfoConstructor);
@@ -338,7 +338,7 @@ jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInf
   jint onnxTypeValue = convertFromONNXDataFormat(valueType);
 
   // Get the map info class
-  char *mapInfoClassName = "ai/onnxruntime/MapInfo";
+  static const char *mapInfoClassName = "ai/onnxruntime/MapInfo";
   jclass mapInfoClazz = (*jniEnv)->FindClass(jniEnv, mapInfoClassName);
   jmethodID mapInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, mapInfoClazz, "<init>", "(III)V");
 
@@ -350,7 +350,7 @@ jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInf
 
 jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info) {
   // Get the sequence info class
-  char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
+  static const char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
   jclass sequenceInfoClazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
 
   // according to include/onnxruntime/core/framework/data_types.h the following values are supported.
@@ -863,7 +863,7 @@ jobject createJavaTensorFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAllocato
   api->ReleaseTensorTypeAndShapeInfo(info);
 
   // Construct the ONNXTensor object
-  char *tensorClassName = "ai/onnxruntime/OnnxTensor";
+  static const char *tensorClassName = "ai/onnxruntime/OnnxTensor";
   jclass clazz = (*jniEnv)->FindClass(jniEnv, tensorClassName);
   jmethodID tensorConstructor = (*jniEnv)->GetMethodID(jniEnv,clazz, "<init>", "(JJLai/onnxruntime/TensorInfo;)V");
   jobject javaTensor = (*jniEnv)->NewObject(jniEnv, clazz, tensorConstructor, (jlong) tensor, (jlong) allocator, tensorInfo);
@@ -873,7 +873,7 @@ jobject createJavaTensorFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAllocato
 
 jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* sequence) {
   // Get the sequence info class
-  char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
+  static const char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
   jclass sequenceInfoClazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
 
   // setup return value
@@ -942,7 +942,7 @@ jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
   jobject javaSequence = NULL;
   if (sequenceInfo != NULL) {
     // Construct the ONNXSequence object
-    char *sequenceClassName = "ai/onnxruntime/OnnxSequence";
+    static const char *sequenceClassName = "ai/onnxruntime/OnnxSequence";
     jclass sequenceClazz = (*jniEnv)->FindClass(jniEnv, sequenceClassName);
     jmethodID sequenceConstructor = (*jniEnv)->GetMethodID(jniEnv, sequenceClazz, "<init>", "(JJLai/onnxruntime/SequenceInfo;)V");
     javaSequence = (*jniEnv)->NewObject(jniEnv, sequenceClazz, sequenceConstructor, (jlong)sequence, (jlong)allocator, sequenceInfo);
@@ -958,7 +958,7 @@ jobject createJavaMapFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* 
   }
 
   // Get the map class & constructor
-  char *mapClassName = "ai/onnxruntime/OnnxMap";
+  static const char *mapClassName = "ai/onnxruntime/OnnxMap";
   jclass mapClazz = (*jniEnv)->FindClass(jniEnv, mapClassName);
   jmethodID mapConstructor = (*jniEnv)->GetMethodID(jniEnv, mapClazz, "<init>", "(JJLai/onnxruntime/MapInfo;)V");
 
@@ -1010,7 +1010,7 @@ jobject createMapInfoFromValue(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator 
   jint onnxTypeValue = convertFromONNXDataFormat(valueInfo.onnxTypeEnum);
 
   // Get the map info class & constructor
-  char *mapInfoClassName = "ai/onnxruntime/MapInfo";
+  static const char *mapInfoClassName = "ai/onnxruntime/MapInfo";
   jclass mapInfoClazz = (*jniEnv)->FindClass(jniEnv, mapInfoClassName);
   jmethodID mapInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, mapInfoClazz, "<init>", "(III)V");
 
@@ -1049,7 +1049,7 @@ jobject convertOrtValueToONNXValue(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
 jint throwOrtException(JNIEnv *jniEnv, int messageId, const char *message) {
   jstring messageStr = (*jniEnv)->NewStringUTF(jniEnv, message);
 
-  char *className = "ai/onnxruntime/OrtException";
+  static const char *className = "ai/onnxruntime/OrtException";
   jclass exClazz = (*jniEnv)->FindClass(jniEnv, className);
   jmethodID exConstructor = (*jniEnv)->GetMethodID(jniEnv, exClazz, "<init>", "(ILjava/lang/String;)V");
   jobject javaException = (*jniEnv)->NewObject(jniEnv, exClazz, exConstructor, messageId, messageStr);

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -8,7 +8,8 @@
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // To silence unused-parameter error.
-    // This function must exist according to the JNI spec, but the arguments aren't necessary for the library to request a specific version.
+    // This function must exist according to the JNI spec, but the arguments aren't necessary for the library
+    // to request a specific version.
     (void)vm; (void) reserved;
     // Requesting 1.6 to support Android. Will need to be bumped to a later version to call interface default methods
     // from native code, or to access other new Java features.
@@ -301,128 +302,121 @@ jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorT
 }
 
 jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInfo * info) {
-    // Create the java methods we need to call.
-    // Get the ONNXTensorType enum static method
-    char *onnxTensorTypeClassName = "ai/onnxruntime/TensorInfo$OnnxTensorType";
-    jclass onnxTensorTypeClazz = (*jniEnv)->FindClass(jniEnv, onnxTensorTypeClassName);
-    jmethodID onnxTensorTypeMapFromInt = (*jniEnv)->GetStaticMethodID(jniEnv,onnxTensorTypeClazz, "mapFromInt", "(I)Lai/onnxruntime/TensorInfo$OnnxTensorType;");
+  // Extract the key type
+  ONNXTensorElementDataType keyType;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetMapKeyType(info, &keyType));
+  if (code != ORT_OK) {
+    return NULL;
+  }
 
-    // Get the ONNXJavaType enum static method
-    char *javaDataTypeClassName = "ai/onnxruntime/OnnxJavaType";
-    jclass onnxJavaTypeClazz = (*jniEnv)->FindClass(jniEnv, javaDataTypeClassName);
-    jmethodID onnxJavaTypeMapFromONNXTensorType = (*jniEnv)->GetStaticMethodID(jniEnv,onnxJavaTypeClazz, "mapFromOnnxTensorType", "(Lai/onnxruntime/TensorInfo$OnnxTensorType;)Lai/onnxruntime/OnnxJavaType;");
-
-    // Get the map info class
-    char *mapInfoClassName = "ai/onnxruntime/MapInfo";
-    jclass mapInfoClazz = (*jniEnv)->FindClass(jniEnv, mapInfoClassName);
-    jmethodID mapInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,mapInfoClazz,"<init>","(ILai/onnxruntime/OnnxJavaType;Lai/onnxruntime/OnnxJavaType;)V");
-
-    // Extract the key type
-    ONNXTensorElementDataType keyType;
-    checkOrtStatus(jniEnv,api,api->GetMapKeyType(info,&keyType));
-
-    // Convert key type to java
-    jint onnxTypeKey = convertFromONNXDataFormat(keyType);
-    jobject onnxTensorTypeJavaKey = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeKey);
-    jobject onnxJavaTypeKey = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJavaKey);
-
-    // according to include/onnxruntime/core/framework/data_types.h only the following values are supported.
-    // string, int64, float, double
-    // So extract the value type, then convert it to a tensor type so we can get it's element type.
-    OrtTypeInfo* valueTypeInfo;
-    checkOrtStatus(jniEnv,api,api->GetMapValueType(info,&valueTypeInfo));
-    const OrtTensorTypeAndShapeInfo* tensorValueInfo;
-    checkOrtStatus(jniEnv,api,api->CastTypeInfoToTensorInfo(valueTypeInfo,&tensorValueInfo));
-    ONNXTensorElementDataType valueType;
-    checkOrtStatus(jniEnv,api,api->GetTensorElementType(tensorValueInfo,&valueType));
+  // according to include/onnxruntime/core/framework/data_types.h only the following values are supported.
+  // string, int64, float, double
+  // So extract the value type, then convert it to a tensor type so we can get it's element type.
+  OrtTypeInfo* valueTypeInfo = NULL;
+  code = checkOrtStatus(jniEnv, api, api->GetMapValueType(info, &valueTypeInfo));
+  if (code != ORT_OK) {
+    return NULL;
+  }
+  const OrtTensorTypeAndShapeInfo* tensorValueInfo = NULL;
+  code = checkOrtStatus(jniEnv, api, api->CastTypeInfoToTensorInfo(valueTypeInfo, &tensorValueInfo));
+  if (code != ORT_OK) {
     api->ReleaseTypeInfo(valueTypeInfo);
-    tensorValueInfo = NULL;
-    valueTypeInfo = NULL;
+    return NULL;
+  }
+  ONNXTensorElementDataType valueType = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  code = checkOrtStatus(jniEnv, api, api->GetTensorElementType(tensorValueInfo, &valueType));
+  api->ReleaseTypeInfo(valueTypeInfo);
+  tensorValueInfo = NULL;
+  valueTypeInfo = NULL;
+  if (code != ORT_OK) {
+    return NULL;
+  }
 
-    // Convert value type to java
-    jint onnxTypeValue = convertFromONNXDataFormat(valueType);
-    jobject onnxTensorTypeJavaValue = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeValue);
-    jobject onnxJavaTypeValue = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJavaValue);
+  // Convert key type to java
+  jint onnxTypeKey = convertFromONNXDataFormat(keyType);
+  // Convert value type to java
+  jint onnxTypeValue = convertFromONNXDataFormat(valueType);
 
-    // Construct map info
-    jobject mapInfo = (*jniEnv)->NewObject(jniEnv,mapInfoClazz,mapInfoConstructor,(jint)-1,onnxJavaTypeKey,onnxJavaTypeValue);
+  // Get the map info class
+  char *mapInfoClassName = "ai/onnxruntime/MapInfo";
+  jclass mapInfoClazz = (*jniEnv)->FindClass(jniEnv, mapInfoClassName);
+  jmethodID mapInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, mapInfoClazz, "<init>", "(III)V");
 
-    return mapInfo;
+  // Construct map info
+  jobject mapInfo = (*jniEnv)->NewObject(jniEnv, mapInfoClazz, mapInfoConstructor, (jint)-1, onnxTypeKey, onnxTypeValue);
+
+  return mapInfo;
 }
 
 jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info) {
-    // Get the sequence info class
-    char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
-    jclass sequenceInfoClazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
+  // Get the sequence info class
+  char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
+  jclass sequenceInfoClazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
 
-    // according to include/onnxruntime/core/framework/data_types.h the following values are supported.
-    // tensor types, map<string,float> and map<long,float>
-    OrtTypeInfo* elementTypeInfo;
-    checkOrtStatus(jniEnv,api,api->GetSequenceElementType(info,&elementTypeInfo));
-    ONNXType type;
-    checkOrtStatus(jniEnv,api,api->GetOnnxTypeFromTypeInfo(elementTypeInfo,&type));
+  // according to include/onnxruntime/core/framework/data_types.h the following values are supported.
+  // tensor types, map<string,float> and map<long,float>
+  OrtTypeInfo* elementTypeInfo = NULL;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetSequenceElementType(info, &elementTypeInfo));
+  if (code != ORT_OK) {
+    return NULL;
+  }
+  ONNXType type;
+  code = checkOrtStatus(jniEnv, api, api->GetOnnxTypeFromTypeInfo(elementTypeInfo, &type));
+  if (code != ORT_OK) {
+    return NULL;
+  }
 
-    jobject sequenceInfo;
+  jobject sequenceInfo = NULL;
 
-    switch (type) {
-        case ONNX_TYPE_TENSOR: {
-            // Figure out element type
-            const OrtTensorTypeAndShapeInfo* elementTensorInfo;
-            checkOrtStatus(jniEnv,api,api->CastTypeInfoToTensorInfo(elementTypeInfo,&elementTensorInfo));
-            ONNXTensorElementDataType element;
-            checkOrtStatus(jniEnv,api,api->GetTensorElementType(elementTensorInfo,&element));
+  switch (type) {
+    case ONNX_TYPE_TENSOR: {
+      // Figure out element type
+      const OrtTensorTypeAndShapeInfo* elementTensorInfo;
+      code = checkOrtStatus(jniEnv, api, api->CastTypeInfoToTensorInfo(elementTypeInfo, &elementTensorInfo));
+      if (code != ORT_OK) {
+        goto sequence_cleanup;
+      }
+      ONNXTensorElementDataType element;
+      code = checkOrtStatus(jniEnv, api, api->GetTensorElementType(elementTensorInfo, &element));
+      if (code != ORT_OK) {
+        goto sequence_cleanup;
+      }
 
-            // Convert element type into ONNXTensorType
-            jint onnxTypeInt = convertFromONNXDataFormat(element);
-            // Get the ONNXTensorType enum static method
-            char *onnxTensorTypeClassName = "ai/onnxruntime/TensorInfo$OnnxTensorType";
-            jclass onnxTensorTypeClazz = (*jniEnv)->FindClass(jniEnv, onnxTensorTypeClassName);
-            jmethodID onnxTensorTypeMapFromInt = (*jniEnv)->GetStaticMethodID(jniEnv,onnxTensorTypeClazz, "mapFromInt", "(I)Lai/onnxruntime/TensorInfo$OnnxTensorType;");
-            jobject onnxTensorTypeJava = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxTensorTypeClazz,onnxTensorTypeMapFromInt,onnxTypeInt);
+      // Convert element type into ONNXTensorType
+      jint onnxTypeInt = convertFromONNXDataFormat(element);
 
-            // Get the ONNXJavaType enum static method
-            char *javaDataTypeClassName = "ai/onnxruntime/OnnxJavaType";
-            jclass onnxJavaTypeClazz = (*jniEnv)->FindClass(jniEnv, javaDataTypeClassName);
-            jmethodID onnxJavaTypeMapFromONNXTensorType = (*jniEnv)->GetStaticMethodID(jniEnv,onnxJavaTypeClazz, "mapFromOnnxTensorType", "(Lai/onnxruntime/TensorInfo$OnnxTensorType;)Lai/onnxruntime/OnnxJavaType;");
-            jobject onnxJavaType = (*jniEnv)->CallStaticObjectMethod(jniEnv,onnxJavaTypeClazz,onnxJavaTypeMapFromONNXTensorType,onnxTensorTypeJava);
-
-            // Construct sequence info
-            jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,sequenceInfoClazz,"<init>","(ILai/onnxruntime/OnnxJavaType;)V");
-            sequenceInfo = (*jniEnv)->NewObject(jniEnv,sequenceInfoClazz,sequenceInfoConstructor,(jint)-1,onnxJavaType);
-            break;
-        }
-        case ONNX_TYPE_MAP: {
-            // Extract the map info
-            const OrtMapTypeInfo* mapInfo;
-            checkOrtStatus(jniEnv,api,api->CastTypeInfoToMapTypeInfo(elementTypeInfo,&mapInfo));
-
-            // Convert it using the existing convert function
-            jobject javaMapInfo = convertToMapInfo(jniEnv,api,mapInfo);
-
-            // Construct sequence info
-            jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv,sequenceInfoClazz,"<init>","(ILai/onnxruntime/MapInfo;)V");
-            sequenceInfo = (*jniEnv)->NewObject(jniEnv,sequenceInfoClazz,sequenceInfoConstructor,(jint)-1,javaMapInfo);
-            break;
-        }
-        default: {
-            sequenceInfo = createEmptySequenceInfo(jniEnv);
-            throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"Invalid element type found in sequence");
-            break;
-        }
+      // Construct sequence info
+      jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, sequenceInfoClazz, "<init>", "(II)V");
+      sequenceInfo = (*jniEnv)->NewObject(jniEnv, sequenceInfoClazz, sequenceInfoConstructor, (jint)-1, onnxTypeInt);
+      break;
     }
-    api->ReleaseTypeInfo(elementTypeInfo);
-    elementTypeInfo = NULL;
+    case ONNX_TYPE_MAP: {
+      // Extract the map info
+      const OrtMapTypeInfo* mapInfo;
+      code = checkOrtStatus(jniEnv, api, api->CastTypeInfoToMapTypeInfo(elementTypeInfo, &mapInfo));
+      if (code != ORT_OK) {
+        goto sequence_cleanup;
+      }
 
-    return sequenceInfo;
-}
+      // Convert it using the existing convert function
+      jobject javaMapInfo = convertToMapInfo(jniEnv, api, mapInfo);
 
-jobject createEmptySequenceInfo(JNIEnv *jniEnv) {
-    char *sequenceInfoClassName = "ai/onnxruntime/SequenceInfo";
-    jclass clazz = (*jniEnv)->FindClass(jniEnv, sequenceInfoClassName);
-    jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, clazz, "<init>", "()V");
-    jobject sequenceInfo = (*jniEnv)->NewObject(jniEnv, clazz, sequenceInfoConstructor);
+      // Construct sequence info
+      jmethodID sequenceInfoConstructor = (*jniEnv)->GetMethodID(jniEnv, sequenceInfoClazz, "<init>", "(ILai/onnxruntime/MapInfo;)V");
+      sequenceInfo = (*jniEnv)->NewObject(jniEnv, sequenceInfoClazz, sequenceInfoConstructor, (jint)-1, javaMapInfo);
+      break;
+    }
+    default: {
+      throwOrtException(jniEnv, convertErrorCode(ORT_INVALID_ARGUMENT), "Invalid element type found in sequence");
+      break;
+    }
+  }
 
-    return sequenceInfo;
+sequence_cleanup:
+  api->ReleaseTypeInfo(elementTypeInfo);
+  elementTypeInfo = NULL;
+
+  return sequenceInfo;
 }
 
 int64_t copyJavaToPrimitiveArray(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray input) {
@@ -915,7 +909,7 @@ jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
             break;
         }
         default: {
-            sequenceInfo = createEmptySequenceInfo(jniEnv);
+            sequenceInfo = NULL;
             throwOrtException(jniEnv,convertErrorCode(ORT_INVALID_ARGUMENT),"Invalid element type found in sequence");
             break;
         }

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -581,13 +581,25 @@ int64_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxT
             (*jniEnv)->SetBooleanArrayRegion(jniEnv, typedArr, 0, outputLength, (jboolean *)inputTensor);
             return consumedSize;
         }
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:   // complex with float32 real and imaginary components
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:  // complex with float64 real and imaginary components
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64: {
+          // complex with float32 real and imaginary components
+          throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "Invalid inputTensor element type ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64.");
+          return -1;
+        }
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128: {
+          // complex with float64 real and imaginary components
+          throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "Invalid inputTensor element type ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128.");
+          return -1;
+        }
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: {
+          // Non-IEEE floating-point format based on IEEE754 single-precision
+          throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "Invalid inputTensor element type ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16.");
+          return -1;
+        }
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:
         default: {
-            throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "Invalid inputTensor element type.");
-            return -1;
+          throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "Invalid inputTensor element type ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED.");
+          return -1;
         }
     }
 }
@@ -618,7 +630,7 @@ int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, con
   }
 }
 
-jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor) {
+jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor) {
   jobject tempString = NULL;
   // Get the buffer size needed
   size_t totalStringLength = 0;
@@ -651,7 +663,7 @@ jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllo
   return tempString;
 }
 
-OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor, size_t length, jobjectArray outputArray) {
+OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor, size_t length, jobjectArray outputArray) {
   char * tempBuffer = NULL;
   // Get the buffer size needed
   size_t totalStringLength = 0;
@@ -711,7 +723,7 @@ string_tensor_cleanup:
   return code;
 }
 
-jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor) {
+jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor) {
     // Extract tensor info
     OrtTensorTypeAndShapeInfo* tensorInfo = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorTypeAndShape(tensor, &tensorInfo));
@@ -731,7 +743,7 @@ jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, Ort
     jclass stringClazz = (*jniEnv)->FindClass(jniEnv, "java/lang/String");
     jobjectArray outputArray = (*jniEnv)->NewObjectArray(jniEnv, safecast_size_t_to_jsize(length), stringClazz, NULL);
 
-    code = copyStringTensorToArray(jniEnv, api, allocator, tensor, length, outputArray);
+    code = copyStringTensorToArray(jniEnv, api, tensor, length, outputArray);
     if (code != ORT_OK) {
         outputArray = NULL;
     }
@@ -1025,7 +1037,8 @@ jobject convertOrtValueToONNXValue(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
     case ONNX_TYPE_UNKNOWN:
     case ONNX_TYPE_OPAQUE:
     case ONNX_TYPE_OPTIONAL:
-    case ONNX_TYPE_SPARSETENSOR: {
+    case ONNX_TYPE_SPARSETENSOR:
+    default: {
       throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "These types are unsupported - ONNX_TYPE_UNKNOWN, ONNX_TYPE_OPAQUE, ONNX_TYPE_SPARSETENSOR.");
       return NULL;
     }

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -894,7 +894,7 @@ jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
     if (code != ORT_OK) {
       return NULL;
     }
-    ONNXType elementType;
+    ONNXType elementType = ONNX_TYPE_UNKNOWN;
     code = checkOrtStatus(jniEnv, api, api->GetValueType(firstElement, &elementType));
     if (code == ORT_OK) {
       switch (elementType) {
@@ -903,7 +903,7 @@ jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
           OrtTensorTypeAndShapeInfo* firstElementInfo = NULL;
           code = checkOrtStatus(jniEnv, api, api->GetTensorTypeAndShape(firstElement, &firstElementInfo));
           if (code == ORT_OK) {
-            ONNXTensorElementDataType element;
+            ONNXTensorElementDataType element = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
             code = checkOrtStatus(jniEnv, api, api->GetTensorElementType(firstElementInfo, &element));
             api->ReleaseTensorTypeAndShapeInfo(firstElementInfo);
             if (code == ORT_OK) {
@@ -976,11 +976,7 @@ jobject createMapInfoFromValue(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator 
 
   JavaTensorTypeShape keyInfo;
   code = getTensorTypeShape(jniEnv, &keyInfo, api, keys);
-  if (code != ORT_OK) {
-    checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, keys));
-    return NULL;
-  }
-  code = checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, keys));
+  api->ReleaseValue(keys);
   if (code != ORT_OK) {
     return NULL;
   }
@@ -994,11 +990,7 @@ jobject createMapInfoFromValue(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator 
 
   JavaTensorTypeShape valueInfo;
   code = getTensorTypeShape(jniEnv, &valueInfo, api, values);
-  if (code != ORT_OK) {
-    checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, values));
-    return NULL;
-  }
-  code = checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, values));
+  api->ReleaseValue(values);
   if (code != ORT_OK) {
     return NULL;
   }

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -43,9 +43,8 @@ jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, OrtTypeInfo * inf
 jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorTypeAndShapeInfo * info);
 
 jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInfo * info);
-jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info);
 
-jobject createEmptySequenceInfo(JNIEnv *jniEnv);
+jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info);
 
 int64_t copyJavaToPrimitiveArray(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray input);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -38,7 +38,7 @@ OrtErrorCode getTensorTypeShape(JNIEnv * jniEnv, JavaTensorTypeShape * output, c
 
 jfloat convertHalfToFloat(uint16_t half);
 
-jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, OrtTypeInfo * info);
+jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info);
 
 jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorTypeAndShapeInfo * info);
 
@@ -46,13 +46,13 @@ jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInf
 
 jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info);
 
-int64_t copyJavaToPrimitiveArray(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray input);
+int64_t copyJavaToPrimitiveArray(JNIEnv* jniEnv, ONNXTensorElementDataType onnxType, jarray inputArray, uint8_t* outputTensor);
 
-int64_t copyJavaToTensor(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray input);
+int64_t copyJavaToTensor(JNIEnv* jniEnv, ONNXTensorElementDataType onnxType, size_t tensorSize, size_t dimensionsRemaining, jarray inputArray, uint8_t* outputTensor);
 
-int64_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray output);
+int64_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, const uint8_t* inputTensor, jarray outputArray);
 
-int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray output);
+int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, const uint8_t* inputTensor, size_t tensorSize, size_t dimensionsRemaining, jarray outputArray);
 
 jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -54,11 +54,11 @@ int64_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxT
 
 int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, const uint8_t* inputTensor, size_t tensorSize, size_t dimensionsRemaining, jarray outputArray);
 
-jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
+jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor);
 
-OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor, size_t length, jobjectArray outputArray);
+OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor, size_t length, jobjectArray outputArray);
 
-jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
+jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor);
 
 jlongArray createLongArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtValue* tensor);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -56,7 +56,7 @@ int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uin
 
 jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
 
-void copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor, size_t length, jobjectArray outputArray);
+OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor, size_t length, jobjectArray outputArray);
 
 jobjectArray createStringArrayFromTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -45,16 +45,15 @@ jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorT
 jobject convertToMapInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtMapTypeInfo * info);
 jobject convertToSequenceInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtSequenceTypeInfo * info);
 
-jobject createEmptyMapInfo(JNIEnv *jniEnv);
 jobject createEmptySequenceInfo(JNIEnv *jniEnv);
 
-size_t copyJavaToPrimitiveArray(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray input);
+int64_t copyJavaToPrimitiveArray(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray input);
 
-size_t copyJavaToTensor(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray input);
+int64_t copyJavaToTensor(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray input);
 
-size_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray output);
+int64_t copyPrimitiveArrayToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, jarray output);
 
-size_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray output);
+int64_t copyTensorToJava(JNIEnv *jniEnv, ONNXTensorElementDataType onnxType, uint8_t* tensor, size_t tensorSize, size_t dimensionsRemaining, jarray output);
 
 jobject createStringFromStringTensor(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* tensor);
 

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -72,6 +72,8 @@ jobject createJavaSequenceFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAlloca
 
 jobject createJavaMapFromONNX(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* map);
 
+jobject createMapInfoFromValue(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator * allocator, const OrtValue * map);
+
 jobject convertOrtValueToONNXValue(JNIEnv *jniEnv, const OrtApi * api, OrtAllocator* allocator, OrtValue* onnxValue);
 
 jint throwOrtException(JNIEnv *env, int messageId, const char *message);

--- a/java/src/main/native/ai_onnxruntime_OnnxMap.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxMap.c
@@ -22,7 +22,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxMap_getStringKeys(JNIEnv*
   OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, 0, allocator, &keys));
   if (code == ORT_OK) {
     // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
+    jobjectArray output = createStringArrayFromTensor(jniEnv, api, keys);
 
     api->ReleaseValue(keys);
 
@@ -72,7 +72,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxMap_getStringValues(JNIEn
   OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, 1, allocator, &values));
   if (code == ORT_OK) {
     // Convert to Java String array
-    jobjectArray output = createStringArrayFromTensor(jniEnv, api, allocator, values);
+    jobjectArray output = createStringArrayFromTensor(jniEnv, api, values);
 
     api->ReleaseValue(values);
 

--- a/java/src/main/native/ai_onnxruntime_OnnxSequence.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxSequence.c
@@ -28,7 +28,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringKeys(JN
 
     if (code == ORT_OK) {
       // Convert to Java String array
-      output = createStringArrayFromTensor(jniEnv, api, allocator, keys);
+      output = createStringArrayFromTensor(jniEnv, api, keys);
       // Release if valid
       api->ReleaseValue(element);
     }
@@ -94,7 +94,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringValues(
 
     if (code == ORT_OK) {
       // Convert to Java String array
-      output = createStringArrayFromTensor(jniEnv, api, allocator, values);
+      output = createStringArrayFromTensor(jniEnv, api, values);
       // Release if valid
       api->ReleaseValue(element);
     }
@@ -230,7 +230,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStrings(JNIEn
       OrtValue* element;
       code = checkOrtStatus(jniEnv, api, api->GetValue(sequence, (int)i, allocator, &element));
       if (code == ORT_OK) {
-        jobject str = createStringFromStringTensor(jniEnv, api, allocator, element);
+        jobject str = createStringFromStringTensor(jniEnv, api, element);
         if (str == NULL) {
           api->ReleaseValue(element);
           // bail out as exception has been thrown

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -367,12 +367,11 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_getLong
  * Signature: (JJ)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxTensor_getString
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong allocatorHandle) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     // Extract a String array - if this becomes a performance issue we'll refactor later.
-    jobjectArray outputArray = createStringArrayFromTensor(jniEnv, api, (OrtAllocator*) allocatorHandle,
-                                                           (OrtValue*) handle);
+    jobjectArray outputArray = createStringArrayFromTensor(jniEnv, api, (OrtValue*) handle);
     if (outputArray != NULL) {
       // Get reference to the string
       jobject output = (*jniEnv)->GetObjectArrayElement(jniEnv, outputArray, 0);
@@ -410,7 +409,7 @@ JNIEXPORT jboolean JNICALL Java_ai_onnxruntime_OnnxTensor_getBool
  * Signature: (JJLjava/lang/Object;)V
  */
 JNIEXPORT void JNICALL Java_ai_onnxruntime_OnnxTensor_getArray
-  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jlong allocatorHandle, jobject carrier) {
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong handle, jobject carrier) {
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
     OrtValue* value = (OrtValue*) handle;
@@ -418,7 +417,7 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OnnxTensor_getArray
     OrtErrorCode code = getTensorTypeShape(jniEnv, &typeShape, api, value);
     if (code == ORT_OK) {
       if (typeShape.onnxTypeEnum == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
-        copyStringTensorToArray(jniEnv, api, (OrtAllocator*) allocatorHandle, value, typeShape.elementCount, carrier);
+        copyStringTensorToArray(jniEnv, api, value, typeShape.elementCount, carrier);
       } else {
         uint8_t* arr = NULL;
         code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData(value, (void**)&arr));

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -44,8 +44,8 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
         // Check if we're copying a scalar or not
         if (shapeLen == 0) {
           // Scalars are passed in as a single element array
-          size_t copied = copyJavaToPrimitiveArray(jniEnv, onnxType, tensorData, dataObj);
-          failed = copied == 0 ? 1 : failed;
+          int64_t copied = copyJavaToPrimitiveArray(jniEnv, onnxType, dataObj, tensorData);
+          failed = copied == -1 ? 1 : failed;
         } else {
           // Extract the tensor shape information
           JavaTensorTypeShape typeShape;
@@ -53,9 +53,9 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxTensor_createTensor
 
           if (code == ORT_OK) {
             // Copy the java array into the tensor
-            size_t copied = copyJavaToTensor(jniEnv, onnxType, tensorData, typeShape.elementCount,
-                                             typeShape.dimensions, dataObj);
-            failed = copied == 0 ? 1 : failed;
+            int64_t copied = copyJavaToTensor(jniEnv, onnxType, typeShape.elementCount,
+                                             typeShape.dimensions, dataObj, tensorData);
+            failed = copied == -1 ? 1 : failed;
           } else {
             failed = 1;
           }


### PR DESCRIPTION
**Description**:

Following on from #12013, #12281 and #12496 this PR fixes the JNI error handling in OrtJniUtil. The refactor of all the JNI code should be complete now. I'll revise the sparse tensor PR (#10653) after this has been merged as it touches many of the same parts of the code.

This change is independent of https://github.com/microsoft/onnxruntime/pull/12496.

**Motivation and Context**
- Why is this change required? What problem does it solve? Improves error handling in the Java<->native bridge.
- If it fixes an open issue, please link to the issue here. This change and #12496 should fix #11451.
