### PR TITLE
Bugfix for BiasSoftmax Fusion

### DIFF
--- a/onnxruntime/contrib_ops/cuda/math/bias_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/math/bias_softmax.h
@@ -9,6 +9,10 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
+// BiasSoftmax follows the OpSet-11 definision of Softmax Op, that is, the input will be coerced to a 2D tensor
+// using axis attribute, all dims after axis (included) are in the same batch. This is different from definition
+// since OpSet-13. To use BiasSoftmax, during the fusion, if Softmax is OpSet-13 or newer, you can only fuse it
+// when axis attribute is the last dim, othewise, the computation result may be wrong.
 class BiasSoftmax final : public onnxruntime::cuda::CudaKernel {
  public:
   BiasSoftmax(const OpKernelInfo& info) : CudaKernel{info} {


### PR DESCRIPTION
Currently BiasSoftmax's kernel implementation follows the Softmax's definition before OpSet-11. The axis attribute is used to coerce the input to 2D tensor, i.e., all dims from axis dim to last dim will be in a same batch. But this definition is changed since OpSet-13 for Softmax, where only axis dim belongs to a batch. The computation will need to transpose the axis dim to the last dim and use new_axis=rank-1 for Softmax computation. So our BiasSoftmax fusion will generate wrong output is axis is not the last dim since OpSet-13. This PR is to disable the fusion if the axis is not the last dim in Softmax since OpSet-13. In this case, we don't need the fusion, because fusing it means we also need an extra transpose on the bias input.