### PR TITLE
fix qdq relu input bug

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -399,8 +399,8 @@ class ONNXModel:
         return False
 
     def is_graph_input(self, tensor_name: str) -> bool:
-        for output in self.model.graph.output:
-            if output.name == tensor_name:
+        for input in self.model.graph.input:
+            if input.name == tensor_name:
                 return True
         return False
 

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -398,6 +398,12 @@ class ONNXModel:
                 return True
         return False
 
+    def is_graph_input(self, tensor_name: str) -> bool:
+        for output in self.model.graph.output:
+            if output.name == tensor_name:
+                return True
+        return False
+
     # TODO:use OnnxModel.graph_topological_sort(self.model.graph) from transformers.onnx_model
     # Currently it breaks Openvino/Linux training gpu pipeline so hold off for 1.8 release
     def topological_sort(self):

--- a/onnxruntime/python/tools/quantization/qdq_quantizer.py
+++ b/onnxruntime/python/tools/quantization/qdq_quantizer.py
@@ -201,6 +201,7 @@ class QDQQuantizer(ONNXQuantizer):
             output_name in self.quantization_params.keys()
             and len(self.model.input_name_to_nodes()[upstream_output_name]) == 1
             and not self.model.is_graph_output(upstream_output_name)
+            and not self.model.is_graph_input(upstream_output_name)
         ):
             self.model.replace_output_of_all_nodes(upstream_output_name, output_name)
             if upstream_output_name in self.tensors_to_quantize:


### PR DESCRIPTION
**Description**: Fix minor bug in qdq quantization tool

**Motivation and Context**
Relu node is removed in qdq quantization tool if it can be merged to its input node. When performing the removal, we forgot to check whether the input is actually the graph input