### PR TITLE
DirectML GEMM broken in opset 11 and 13 when optional tensor C not provided

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorGemm.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorGemm.cpp
@@ -10,12 +10,13 @@ class DmlOperatorGemm : public DmlOperator, public GemmHelper
 {
 public:
     DmlOperatorGemm(const MLOperatorKernelCreationContext& kernelInfo)
-        :   DmlOperator(kernelInfo), 
+        :   DmlOperator(kernelInfo),
             GemmHelper(kernelInfo, kernelInfo.GetTensorShapeDescription())
     {
         ML_CHECK_VALID_ARGUMENT(kernelInfo.GetInputCount() >= 2);
         ML_CHECK_VALID_ARGUMENT(kernelInfo.GetOutputCount() == 1);
-        DmlOperator::Initialize(kernelInfo);
+        auto kernelInputIndices = std::vector<std::optional<uint32_t>> { 0, 1, 2 };
+        DmlOperator::Initialize(kernelInfo, kernelInputIndices);
 
         bool containsBiasTensor = kernelInfo.IsInputValid(2);
 


### PR DESCRIPTION
DirectML GEMM broken in opset 11 and 13 when optional tensor C not provided

In opset 11, GEMM's input C became optional. This was not accounted for in DML.