### PR TITLE
Add Tunable GEMM composed from rocblas and composable kernels

### DIFF
--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm.cc
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 #include "python/tools/kernel_explorer/kernels/gemm.h"
-#include "python/tools/kernel_explorer/kernels/gemm_rocblas.h"
 #include "python/tools/kernel_explorer/kernels/gemm_ck.h"
+#include "python/tools/kernel_explorer/kernels/gemm_rocblas.h"
+#include "python/tools/kernel_explorer/kernels/gemm_tunable.h"
 
 #include <type_traits>
 #include <pybind11/pybind11.h>
@@ -22,6 +23,7 @@ void InitGemm(py::module mod) {
 
   InitRocBlasGemm(mod);
   InitComposableKernelGemm(mod);
+  InitTunableGemm(mod);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.cc
@@ -5,73 +5,15 @@
 
 #include <pybind11/stl.h>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#include "ck/ck.hpp"
-#include "ck/library/tensor_operation_instance/gpu/gemm.hpp"
-#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
-#include "ck/tensor_operation/gpu/device/device_gemm.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-
-#include "python/tools/kernel_explorer/kernels/gemm.h"
-
 namespace py = pybind11;
 
 namespace onnxruntime {
-
-namespace {
-
-template <typename T>
-struct DataTypeAdaptor {
-  using type = T;
-};
-
-template <>
-struct DataTypeAdaptor<half> {
-  using type = ck::half_t;
-};
-
-}  // namespace
-
-using Row = ck::tensor_layout::gemm::RowMajor;
-using Col = ck::tensor_layout::gemm::ColumnMajor;
-
-using Nop = ck::tensor_operation::element_wise::PassThrough;
-
-// to be moved to onnxruntime once we have a monolithicly tunable gemm wrapper and it is enabled for onnxruntime
-template <typename T, typename ALayout, typename BLayout>
-auto GetCKGemmTypeStringAndOps() {
-  using CKDataType = typename DataTypeAdaptor<T>::type;
-  using DeviceGemm = ck::tensor_operation::device::DeviceGemm<
-      ALayout, BLayout, Row,
-      CKDataType, CKDataType, CKDataType,
-      Nop, Nop, Nop>;
-  using InstanceFactory = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<DeviceGemm>;
-
-  std::vector<std::pair<std::string, contrib::rocm::Op<GemmParams<T>>>> ret;
-  for (auto&& impl : InstanceFactory::GetInstances()) {
-    auto type_string = impl->GetTypeString();
-    auto invoker = impl->MakeInvokerPointer();
-    auto ck_gemm_op = [impl = std::move(impl), invoker = std::move(invoker)](const GemmParams<T>* params) -> Status {
-      auto nop = Nop{};
-      auto arg = impl->MakeArgumentPointer(params->a, params->b, params->c,
-                                           params->m, params->n, params->k,
-                                           params->lda, params->ldb, params->ldc,
-                                           nop, nop, nop);
-      TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
-                                               impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
-      return Status::OK();
-    };
-    ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemm_op)));
-  }
-  return ret;
-}
 
 template <typename T, typename ALayout, typename BLayout>
 class CKGemm : public IKernelExplorer {

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.h
@@ -5,6 +5,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "ck/ck.hpp"

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_ck.h
@@ -5,10 +5,65 @@
 
 #include <pybind11/pybind11.h>
 
+#include <vector>
+
+#include "ck/ck.hpp"
+#include "ck/library/tensor_operation_instance/gpu/gemm.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/device/device_gemm.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+#include "python/tools/kernel_explorer/kernels/gemm.h"
+
 namespace py = pybind11;
 
 namespace onnxruntime {
 
+template <typename T>
+struct DataTypeAdaptor {
+  using type = T;
+};
+
+template <>
+struct DataTypeAdaptor<half> {
+  using type = ck::half_t;
+};
+
+using Row = ck::tensor_layout::gemm::RowMajor;
+using Col = ck::tensor_layout::gemm::ColumnMajor;
+
+using Nop = ck::tensor_operation::element_wise::PassThrough;
+
+// to be moved to onnxruntime once we have a monolithicly tunable gemm wrapper and it is enabled for onnxruntime
+template <typename T, typename ALayout, typename BLayout>
+auto GetCKGemmTypeStringAndOps() {
+  using CKDataType = typename DataTypeAdaptor<T>::type;
+  using DeviceGemm = ck::tensor_operation::device::DeviceGemm<
+      ALayout, BLayout, Row,
+      CKDataType, CKDataType, CKDataType,
+      Nop, Nop, Nop>;
+  using InstanceFactory = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<DeviceGemm>;
+
+  std::vector<std::pair<std::string, contrib::rocm::Op<GemmParams<T>>>> ret;
+  for (auto&& impl : InstanceFactory::GetInstances()) {
+    auto type_string = impl->GetTypeString();
+    auto invoker = impl->MakeInvokerPointer();
+    auto ck_gemm_op = [impl = std::move(impl), invoker = std::move(invoker)](const GemmParams<T>* params) -> Status {
+      auto nop = Nop{};
+      auto arg = impl->MakeArgumentPointer(params->a, params->b, params->c,
+                                           params->m, params->n, params->k,
+                                           params->lda, params->ldb, params->ldc,
+                                           nop, nop, nop);
+      TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
+                                               impl->GetTypeString(), " does not support ", params->Signature());
+      invoker->Run(arg.get(), StreamConfig{params->stream});
+      return Status::OK();
+    };
+    ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemm_op)));
+  }
+  return ret;
+}
+
 void InitComposableKernelGemm(py::module mod);
 
-}
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.cc
@@ -10,33 +10,11 @@
 #include <vector>
 
 #include "core/providers/rocm/rocm_common.h"
-#include "core/providers/rocm/shared_inc/fpgeneric.h"
 #include "python/tools/kernel_explorer/device_array.h"
-#include "python/tools/kernel_explorer/kernels/gemm.h"
 
 namespace py = pybind11;
 
 namespace onnxruntime {
-
-// to be moved to onnxruntime once we have a monolithicly tunable gemm wrapper and it is enabled for onnxruntime
-template <typename T>
-Status RocBlasGemmOp(const GemmParams<T>* params) {
-  // NOTE: rocblas assumes the storage is column-majored, swapping A and B makes it have the same interface
-  // as those with row-majored convention. That is, if you treat the storage as row-majored but view the matrices as
-  // transposed, then by using the property Transpose(A*B) = Tranpose(B)*Transpose(A), the correctness is obvious.
-  auto status = rocblasGemmHelper(
-      params->handle,
-      params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->n, params->m, params->k,
-      &(params->alpha),
-      params->b, params->ldb,
-      params->a, params->lda,
-      &(params->beta),
-      params->c, params->ldc);
-  ORT_RETURN_IF(status != rocblas_status_success, rocblas_status_to_string(status));
-  return Status::OK();
-}
 
 template <typename T>
 class RocBlasGemm : public IKernelExplorer {

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.h
@@ -5,9 +5,33 @@
 
 #include <pybind11/pybind11.h>
 
+#include "core/common/common.h"
+#include "core/providers/rocm/shared_inc/fpgeneric.h"
+#include "python/tools/kernel_explorer/kernels/gemm.h"
+
 namespace py = pybind11;
 
 namespace onnxruntime {
+
+// to be moved to onnxruntime once we have a monolithicly tunable gemm wrapper and it is enabled for onnxruntime
+template <typename T>
+Status RocBlasGemmOp(const GemmParams<T>* params) {
+  // NOTE: rocblas assumes the storage is column-majored, swapping A and B makes it have the same interface
+  // as those with row-majored convention. That is, if you treat the storage as row-majored but view the matrices as
+  // transposed, then by using the property Transpose(A*B) = Tranpose(B)*Transpose(A), the correctness is obvious.
+  auto status = rocblasGemmHelper(
+      params->handle,
+      params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+      params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+      params->n, params->m, params->k,
+      &(params->alpha),
+      params->b, params->ldb,
+      params->a, params->lda,
+      &(params->beta),
+      params->c, params->ldc);
+  ORT_RETURN_IF(status != rocblas_status_success, rocblas_status_to_string(status));
+  return Status::OK();
+}
 
 void InitRocBlasGemm(py::module mod);
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_rocblas.h
@@ -35,4 +35,4 @@ Status RocBlasGemmOp(const GemmParams<T>* params) {
 
 void InitRocBlasGemm(py::module mod);
 
-}
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -135,6 +135,15 @@ def test_ck_gemm_bert_cases(dtype, size, transab):
     _test_gemm(getattr(ke, wrapper_name), dtype, *size, *transab)
 
 
+# Tunable is basically wrapped around of rocblas and ck gemm, so no need for full tests
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("size", reduced_basic_sizes + get_bert_sizes(full=False))
+@pytest.mark.parametrize("transab", no_transabs)
+def test_gemm_tunable_bert_cases(dtype, size, transab):
+    wrapper_name = "GemmTunable_{}_{}".format(dtype_to_suffix(dtype), transab_to_suffix(transab))
+    _test_gemm(getattr(ke, wrapper_name), dtype, *size, *transab)
+
+
 def profile_gemm_func(f, dtype, m, n, k):
     a_shape = (m, k)
     b_shape = (k, n)
@@ -172,6 +181,8 @@ def profile():
             profile_gemm_func(getattr(ke, "RocblasGemm" + dtype_suffix), dtype, m, n, k)
             transab_suffix = "_" + transab_to_suffix((False, False))
             profile_gemm_func(getattr(ke, "CKGemm" + dtype_suffix + transab_suffix), dtype, m, n, k)
+            profile_gemm_func(getattr(ke, "GemmTunable" + dtype_suffix + transab_suffix), dtype, m, n, k)
+
             print()
         print()
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
@@ -5,6 +5,10 @@
 
 #include <pybind11/stl.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "core/providers/rocm/rocm_common.h"
 #include "contrib_ops/rocm/bert/tunable_op.h"
 #include "python/tools/kernel_explorer/kernels/gemm.h"

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "contrib_ops/rocm/bert/tunable_op.h"
+#include "python/tools/kernel_explorer/kernels/gemm_tunable.h"
 
 #include <pybind11/stl.h>
 
 #include "core/providers/rocm/rocm_common.h"
+#include "contrib_ops/rocm/bert/tunable_op.h"
 #include "python/tools/kernel_explorer/kernels/gemm.h"
 #include "python/tools/kernel_explorer/kernels/gemm_ck.h"
 #include "python/tools/kernel_explorer/kernels/gemm_rocblas.h"

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/rocm/bert/tunable_op.h"
+
+#include <pybind11/stl.h>
+
+#include "core/providers/rocm/rocm_common.h"
+#include "python/tools/kernel_explorer/kernels/gemm.h"
+#include "python/tools/kernel_explorer/kernels/gemm_ck.h"
+#include "python/tools/kernel_explorer/kernels/gemm_rocblas.h"
+
+namespace onnxruntime {
+
+template <typename T, typename ALayout, typename BLayout>
+class GemmTunableOp : public contrib::rocm::TunableOp<GemmParams<T>> {
+ public:
+  GemmTunableOp() {
+    this->ops_.emplace_back(RocBlasGemmOp<T>);
+    for (auto&& [_, op] : GetCKGemmTypeStringAndOps<T, ALayout, BLayout>()) {
+      ORT_UNUSED_PARAMETER(_);
+      this->ops_.emplace_back(std::move(op));
+    }
+  }
+};
+
+template <typename T, typename ALayout, typename BLayout>
+class GemmTunable : public IKernelExplorer {
+ public:
+  GemmTunable(BlasOp opa, BlasOp opb,
+              int64_t m, int64_t n, int64_t k,
+              double alpha,
+              DeviceArray& a, int64_t lda,
+              DeviceArray& b, int64_t ldb,
+              double beta,
+              DeviceArray& c, int64_t ldc) {
+    ROCBLAS_CALL_THROW(rocblas_create_handle(&rocblas_handle_));
+    params_.handle = rocblas_handle_;
+    params_.opa = opa;
+    params_.opb = opb;
+    params_.m = m;
+    params_.n = n;
+    params_.k = k;
+    params_.alpha = alpha;
+    params_.a = static_cast<T*>(a.ptr());
+    params_.lda = lda;
+    params_.b = static_cast<T*>(b.ptr());
+    params_.ldb = ldb;
+    params_.beta = beta;
+    params_.c = static_cast<T*>(c.ptr());
+    params_.ldc = ldc;
+
+    impl_.EnableTuning();
+  }
+
+  ~GemmTunable() {
+    ROCBLAS_CALL_THROW(rocblas_destroy_handle(rocblas_handle_));
+    rocblas_handle_ = nullptr;
+  }
+
+  void Run() override {
+    ORT_THROW_IF_ERROR(impl_(&params_));
+  }
+
+  std::vector<std::string> ListOps() const {
+    return {"Tunable"};
+  }
+
+  bool SelectOp(const std::string& name) {
+    return name == "Tunable";
+  }
+
+ private:
+  using ParamsT = GemmParams<T>;
+  ParamsT params_;
+
+  // tunable is stateful, store it as an instance
+  GemmTunableOp<T, ALayout, BLayout> impl_{};
+  rocblas_handle rocblas_handle_;
+};
+
+#define REGISTER_OP(type, alayout, blayout, layout_string)                                   \
+  py::class_<GemmTunable<type, alayout, blayout>>(m, "GemmTunable_" #type "_" layout_string) \
+      .def(py::init<BlasOp, BlasOp, int64_t, int64_t, int64_t,                               \
+                    double,                                                                  \
+                    DeviceArray&, int64_t,                                                   \
+                    DeviceArray&, int64_t,                                                   \
+                    double,                                                                  \
+                    DeviceArray&, int64_t>())                                                \
+      .def("SetRepeats", &GemmTunable<type, alayout, blayout>::SetRepeats)                   \
+      .def("Profile", &GemmTunable<type, alayout, blayout>::Profile)                         \
+      .def("Run", &GemmTunable<type, alayout, blayout>::Run)                                 \
+      .def("ListOps", &GemmTunable<type, alayout, blayout>::ListOps)                         \
+      .def("SelectOp", &GemmTunable<type, alayout, blayout>::SelectOp);
+
+#define REGISTER_OP_FOR_ALL_TRANSAB(type) \
+  REGISTER_OP(type, Row, Row, "NN");      \
+  REGISTER_OP(type, Row, Col, "NT");      \
+  REGISTER_OP(type, Col, Row, "TN");      \
+  REGISTER_OP(type, Col, Col, "TT");
+
+void InitTunableGemm(py::module m) {
+  REGISTER_OP_FOR_ALL_TRANSAB(float);
+  REGISTER_OP_FOR_ALL_TRANSAB(half);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.cc
@@ -55,7 +55,7 @@ class GemmTunable : public IKernelExplorer {
     params_.c = static_cast<T*>(c.ptr());
     params_.ldc = ldc;
 
-    impl_.EnableTuning();
+    op_.EnableTuning();
   }
 
   ~GemmTunable() {
@@ -64,7 +64,7 @@ class GemmTunable : public IKernelExplorer {
   }
 
   void Run() override {
-    ORT_THROW_IF_ERROR(impl_(&params_));
+    ORT_THROW_IF_ERROR(op_(&params_));
   }
 
   std::vector<std::string> ListOps() const {
@@ -80,7 +80,7 @@ class GemmTunable : public IKernelExplorer {
   ParamsT params_;
 
   // tunable is stateful, store it as an instance
-  GemmTunableOp<T, ALayout, BLayout> impl_{};
+  GemmTunableOp<T, ALayout, BLayout> op_{};
   rocblas_handle rocblas_handle_;
 };
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_tunable.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace onnxruntime {
+
+void InitTunableGemm(py::module mod);
+
+}


### PR DESCRIPTION
Based on #12597

**Description**: Introduce Tunable GEMM, which is composed from rocblas and composable kernels

**Motivation and Context**
- Why is this change required? What problem does it solve?
   composable kernels' implementations sometimes can outperform rocblas.
