### PR TITLE
Fix a build error

### DIFF
--- a/include/onnxruntime/core/framework/ortmemoryinfo.h
+++ b/include/onnxruntime/core/framework/ortmemoryinfo.h
@@ -48,7 +48,7 @@ struct OrtMemoryInfo {
     auto h = std::hash<int>()(alloc_type);
     HashCombine(std::hash<int>()(mem_type), h);
     HashCombine(std::hash<int>()(id), h);
-    HashCombine(std::hash<const char*>()(name), h);
+    HashCombine(std::hash<std::string>()(name), h);
     return h;
   }
 


### PR DESCRIPTION
LLVM compiler complains the std::hash<const char*> and suggests std::hash<const void*>. But the intention is to hash the name string instead of the pointer. So use std::hash\<std::string\> to be explicit.

Fix #12598
