### PR TITLE
[oneDNN] Improve DequantizeLinear operator performance.

### DIFF
--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_dequantizelinear.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_dequantizelinear.h
@@ -24,6 +24,7 @@ class DnnlDequantizeLinear {
   void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
 
  private:
+  bool isZeroPointNonZero(dnnl::memory* zp_mem);
   int64_t GetAxis(DnnlNode& node, size_t x_dims);
   void Padd(dnnl::memory::desc* target, size_t front_pad, size_t back_pad);
   void ValidateDims(DnnlSubgraphPrimitive& sp, DnnlNode& node);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph.h
@@ -36,16 +36,18 @@ class DnnlNodeArg {
 
 class DnnlTensor {
  public:
-  DnnlTensor(const NodeArg* arg);
+  DnnlTensor(const NodeArg* arg, bool isConstantInitializer = false);
   DnnlTensor(std::string name);
   DnnlTensor() = default;
   std::string Name() const;
   dnnl::memory::dims Dim() const;
   dnnl::memory::data_type Type() const;
   dnnl::memory::format_tag Format();
-  //check whether the tensor is dynamic, e.g. contains unspecified dimension
+  // Check whether the tensor is dynamic, e.g. contains unspecified dimension
   bool IsDynamic();
-  //check whether the tensor exsits for optional input output
+  // Check whether the tensor is constant initializer
+  bool IsConstant();
+  // Check whether the tensor exsits for optional input output
   bool Exists();
   std::vector<DnnlNodeArg>& GetConsumers() { return consumers_; };
   DnnlNodeArg& GetProducer() { return producer_; };
@@ -64,6 +66,7 @@ class DnnlTensor {
   //a tensor can have no producer (input.initializer) or no consumer (output for subgraph)
   DnnlNodeArg producer_;
   std::vector<DnnlNodeArg> consumers_;
+  bool isConstant_;
 };
 
 class DnnlNode {

--- a/onnxruntime/test/providers/dnnl/math/quantize_linear_ops_test.cc
+++ b/onnxruntime/test/providers/dnnl/math/quantize_linear_ops_test.cc
@@ -1,0 +1,63 @@
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+
+namespace onnxruntime {
+namespace test {
+
+#ifdef USE_DNNL
+// The same as the default provider, but in this case with constant initializers to test optimization
+
+TEST(DequantizeLinearOpTest, DNNL_Uint8_ConstantInitializer) {
+  OpTester test("DequantizeLinear", 10);
+  std::vector<int64_t> dims{4};
+  test.AddInput<uint8_t>("x", dims, {0, 3, 128, 255});
+  test.AddInput<float>("x_scale", {}, {2.0f});
+  test.AddInput<uint8_t>("x_zero_point", {}, {128}, true);
+  test.AddOutput<float>("y", dims, {-256.0f, -250.0f, 0.0f, 254.0f});
+  test.Run();
+}
+
+// scalar zero & scale with int8
+TEST(DequantizeLinearOpTest, DNNL_Int8_ConstantInitializer) {
+  OpTester test("DequantizeLinear", 10);
+  std::vector<int64_t> dims{4};
+  test.AddInput<int8_t>("x", dims, {-30, -3, 100, 127});
+  test.AddInput<float>("x_scale", {}, {2.0f});
+  test.AddInput<int8_t>("x_zero_point", {}, {-10}, true);
+  test.AddOutput<float>("y", dims, {-40.0f, 14.0f, 220.0f, 274.0f});
+  // Disable Tensorrt EP due to error:node1_quantize_scale_node: out of bounds channel axis 1. Number of input dimensions is 1.
+  test.Run();
+}
+
+// scalar zero & scale with int8
+TEST(DequantizeLinearOpTest, DNNL_Int32_ConstantInitializer) {
+  OpTester test("DequantizeLinear", 10);
+  std::vector<int64_t> dims{4};
+  test.AddInput<int32_t>("x", dims, {-30, -3, 100, 127});
+  test.AddInput<float>("x_scale", {}, {2.0f}, true);
+  test.AddOutput<float>("y", dims, {-60.f, -6.f, 200.f, 254.f});
+  test.Run();
+}
+
+// 2d inputs
+TEST(DequantizeLinearOpTest, DNNL_2D_ConstantInitializer) {
+  OpTester test("DequantizeLinear", 10);
+  std::vector<int64_t> dims{3, 4};
+  test.AddInput<uint8_t>("X", dims,
+                         {0, 1, 2, 3,
+                          0, 1, 2, 3,
+                          0, 10, 20, 30});
+  test.AddInput<float>("scale", {}, {1.0f});
+  test.AddInput<uint8_t>("zero_point", {}, {0}, true);
+  test.AddOutput<float>("Y", dims,
+                        {0, 1, 2, 3,
+                         0, 1, 2, 3,
+                         0, 10, 20, 30});
+  test.Run();
+}
+
+#endif  // USE_DNNL
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Improved DequantizeLinear operator performance

**Motivation and Context**
- Why is this change required? What problem does it solve?
R/ Multiple models use the DequantizeLinear operator so it's performance is critical for multiple tasks
- If it fixes an open issue, please link to the issue here.
