### PR TITLE
Enabling softmax grad and logsoftmax grad on ORT

### DIFF
--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -47,7 +47,7 @@ class SoftmaxGrad(ONNXOp):
 
     def __init__(self, dY, Y, axis=None):
         super().__init__(
-            "SoftmaxGrad",
+            "SoftmaxGrad_13",
             1,
             [
                 {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
@@ -67,7 +67,7 @@ class LogSoftmaxGrad(ONNXOp):
 
     def __init__(self, dY, Y, axis=None):
         super().__init__(
-            "LogSoftmaxGrad",
+            "LogSoftmaxGrad_13",
             1,
             [
                 {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -49,8 +49,10 @@ class SoftmaxGrad(ONNXOp):
         super().__init__(
             "SoftmaxGrad",
             1,
-            [{"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
-             {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"}],
+            [
+                {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+                {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+            ],
             dY,
             Y,
             axis=ONNXAttr(axis, AttrType.INT),
@@ -67,8 +69,10 @@ class LogSoftmaxGrad(ONNXOp):
         super().__init__(
             "LogSoftmaxGrad",
             1,
-            [{"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
-             {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"}],
+            [
+                {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+                {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+            ],
             dY,
             Y,
             axis=ONNXAttr(axis, AttrType.INT),

--- a/orttraining/orttraining/eager/opgen/opgen/atenops.py
+++ b/orttraining/orttraining/eager/opgen/opgen/atenops.py
@@ -40,6 +40,42 @@ class GeluGrad(ONNXOp):
         self.domain = kMSDomain
 
 
+class SoftmaxGrad(ONNXOp):
+    """
+    The operator computes the grad of softmax values:
+    """
+
+    def __init__(self, dY, Y, axis=None):
+        super().__init__(
+            "SoftmaxGrad",
+            1,
+            [{"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+             {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"}],
+            dY,
+            Y,
+            axis=ONNXAttr(axis, AttrType.INT),
+        )
+        self.domain = kMSDomain
+
+
+class LogSoftmaxGrad(ONNXOp):
+    """
+    The operator computes the grad of log of softmax values:
+    """
+
+    def __init__(self, dY, Y, axis=None):
+        super().__init__(
+            "LogSoftmaxGrad",
+            1,
+            [{"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"},
+             {"at::kDouble", "at::kBFloat16", "at::kHalf", "at::kFloat"}],
+            dY,
+            Y,
+            axis=ONNXAttr(axis, AttrType.INT),
+        )
+        self.domain = kMSDomain
+
+
 ops = {}
 type_promotion_ops = []
 aten_output_type = {}
@@ -163,7 +199,8 @@ hand_implemented = {
     # Leaving nll_loss_forward.output set to fallback. https://github.com/microsoft/onnxruntime/blob/master/docs/OperatorKernels.md.
     "aten::nll_loss_forward.output": MakeTorchFallback(),
     "aten::nll_loss_backward.grad_input": MakeTorchFallback(),
-    "aten::_log_softmax_backward_data.out": MakeTorchFallback(),
+    "aten::_softmax_backward_data": SoftmaxGrad("grad_output", "output", axis="dim"),
+    "aten::_log_softmax_backward_data": LogSoftmaxGrad("grad_output", "output", axis="dim"),
     "aten::squeeze.dim": Squeeze("self", "dim"),
     "aten::squeeze": SignatureOnly(),
     "aten::unsqueeze": Unsqueeze(data="self", axes="dim"),

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -211,9 +211,15 @@ class OrtOpTests(unittest.TestCase):
         assert torch.allclose(cpu_result_c, ort_result_c.cpu())
         assert torch.allclose(ort_result_a.cpu(), ort_result_c.cpu())
 
-    @parameterized.expand([param((2, 64, 256), 0), param((2, 64, 256), 1),
-                           param((2, 64, 256), -1), ((4096, 1024), 0),
-                           param((512, 8192), 1)])
+    @parameterized.expand(
+        [
+            param((2, 64, 256), 0),
+            param((2, 64, 256), 1),
+            param((2, 64, 256), -1),
+            param((4096, 1024), 0),
+            param((512, 8192), 1),
+        ]
+    )
     def test_softmax_grad(self, input_shape, dim):
         device = self.get_device()
         cpu_tensor = torch.nn.Parameter(torch.rand(input_shape))
@@ -227,9 +233,15 @@ class OrtOpTests(unittest.TestCase):
         assert torch.allclose(ort_result.cpu(), cpu_result)
         assert torch.allclose(ort_tensor.grad.cpu(), cpu_tensor.grad, rtol=0.01)
 
-    @parameterized.expand([param((2, 64, 256), 0), param((2, 32, 128), 1),
-                           param((2, 64, 128), -1), ((1024, 8), 0),
-                           param((2, 2048), 1)])
+    @parameterized.expand(
+        [
+            param((2, 64, 256), 0),
+            param((2, 32, 128), 1),
+            param((2, 64, 128), -1),
+            param((1024, 8), 0),
+            param((2, 2048), 1),
+        ]
+    )
     def test_logsoftmax_grad(self, input_shape, dim):
         device = self.get_device()
         cpu_tensor = torch.nn.Parameter(torch.rand(input_shape))

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 import onnxruntime_pybind11_state as torch_ort
 import torch
-from parameterized import parameterized
+from parameterized import parameterized, param
 
 
 class OrtOpTests(unittest.TestCase):
@@ -210,6 +210,38 @@ class OrtOpTests(unittest.TestCase):
         ort_result_c = torch.log_softmax(ort_tensor, dim=-1)
         assert torch.allclose(cpu_result_c, ort_result_c.cpu())
         assert torch.allclose(ort_result_a.cpu(), ort_result_c.cpu())
+
+    @parameterized.expand([param((2, 64, 256), 0), param((2, 64, 256), 1),
+                           param((2, 64, 256), -1), ((4096, 1024), 0),
+                           param((512, 8192), 1)])
+    def test_softmax_grad(self, input_shape, dim):
+        device = self.get_device()
+        cpu_tensor = torch.nn.Parameter(torch.rand(input_shape))
+        ort_tensor = torch.nn.Parameter(cpu_tensor.detach().clone().to(device))
+        cpu_result = torch.softmax(cpu_tensor, dim=dim)
+        ort_result = torch.softmax(ort_tensor, dim=dim)
+        cpu_loss = cpu_result.pow(2).sum()
+        ort_loss = ort_result.cpu().pow(2).sum()
+        cpu_loss.backward()
+        ort_loss.backward()
+        assert torch.allclose(ort_result.cpu(), cpu_result)
+        assert torch.allclose(ort_tensor.grad.cpu(), cpu_tensor.grad, rtol=0.01)
+
+    @parameterized.expand([param((2, 64, 256), 0), param((2, 32, 128), 1),
+                           param((2, 64, 128), -1), ((1024, 8), 0),
+                           param((2, 2048), 1)])
+    def test_logsoftmax_grad(self, input_shape, dim):
+        device = self.get_device()
+        cpu_tensor = torch.nn.Parameter(torch.rand(input_shape))
+        ort_tensor = torch.nn.Parameter(cpu_tensor.detach().clone().to(device))
+        cpu_result = torch.log_softmax(cpu_tensor, dim=dim)
+        ort_result = torch.log_softmax(ort_tensor, dim=dim)
+        cpu_loss = cpu_result.pow(2).sum()
+        ort_loss = ort_result.cpu().pow(2).sum()
+        cpu_loss.backward()
+        ort_loss.backward()
+        assert torch.allclose(ort_result.cpu(), cpu_result)
+        assert torch.allclose(ort_tensor.grad.cpu(), cpu_tensor.grad, rtol=0.05)
 
     def test_addmm(self):
         device = self.get_device()

--- a/orttraining/orttraining/training_ops/cpu/op_gradients.cc
+++ b/orttraining/orttraining/training_ops/cpu/op_gradients.cc
@@ -84,7 +84,7 @@ Status SoftmaxGrad<T>::Compute(OpKernelContext* context) const {
     return Status::OK();
   }
 
-  bool is_transpose_required = (axis != (rank - 1));
+  bool is_transpose_required = opset_ >= 13 && axis != (rank - 1);
 
   Tensor transposed_dY;
   Tensor transposed_Y;

--- a/orttraining/orttraining/training_ops/cpu/op_gradients.cc
+++ b/orttraining/orttraining/training_ops/cpu/op_gradients.cc
@@ -84,7 +84,7 @@ Status SoftmaxGrad<T>::Compute(OpKernelContext* context) const {
     return Status::OK();
   }
 
-  bool is_transpose_required = opset_ >= 13 && axis != (rank - 1);
+  bool is_transpose_required = (axis != (rank - 1));
 
   Tensor transposed_dY;
   Tensor transposed_Y;


### PR DESCRIPTION
**Description**: Softmax backward and log softmax backward were falling back to Torch implementation. This PR enables running softmax backward and log softmax backward on ORT backend. Parametrized tests were added for softmax and log softmax backward when running on ort backend. 