### PR TITLE
Convert more quantized weights to uint8

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -74,15 +74,14 @@ static bool QDQ_S8_to_U8(Graph& graph, Node& q_node, Node& dq_node) {
 }
 
 bool QDQS8ToU8Transformer::ShouldConvertWeightFromS8ToU8(Graph& graph, Node& node) const {
-  const auto consumers = graph.GetConsumerNodes(node.Name());
-
   if (weights_to_u8_) {
     return true;
   }
 
+  const auto consumers = graph.GetConsumerNodes(node.Name());
   for (const Node* c : consumers) {
-    if (exclude_next.find(c->OpType()) != exclude_next.end()) {
-      // opType is among the exclude_next, leave out this node
+    if (operators_prefer_S8.find(c->OpType()) != operators_prefer_S8.cend()) {
+      // opType is among the `operators_prefer_S8`, leave out this node
       return false;
     }
   }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -118,7 +118,6 @@ Status QDQS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_l
     }
 
     // recognize lone DQ node
-    // if (weights_to_u8_ && this->ShouldConvertWeightFromS8ToU8(graph, node)) {
     if (QDQ::MatchDQNode(node) && this->ShouldConvertWeightFromS8ToU8(graph, node)) {
       modified |= QDQ::ConvertS8WeightToU8(graph, node, 0, 2);
       continue;

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
@@ -17,14 +17,14 @@ class QDQS8ToU8Transformer : public GraphTransformer {
  public:
   QDQS8ToU8Transformer(bool weights_to_u8, const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
       : GraphTransformer("QDQS8ToU8Transformer", compatible_execution_providers), weights_to_u8_(weights_to_u8) {
-          exclude_next = {"MatMul", "Conv", "Gemm", "Gather"};
+          operators_prefer_S8 = {"MatMul", "Conv", "Gemm", "Gather"};
       }
   bool ShouldConvertWeightFromS8ToU8(Graph& graph, Node& node) const;
 
  private:
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
   bool weights_to_u8_;
-  std::set<std::string> exclude_next;
+  InlinedHashSet<std::string> operators_prefer_S8;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
@@ -17,7 +17,7 @@ class QDQS8ToU8Transformer : public GraphTransformer {
  public:
   QDQS8ToU8Transformer(bool weights_to_u8, const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
       : GraphTransformer("QDQS8ToU8Transformer", compatible_execution_providers), weights_to_u8_(weights_to_u8) {
-          exclude_next = {"MatMul", "Conv", "Gemm"};
+          exclude_next = {"MatMul", "Conv", "Gemm", "Gather"};
       }
   bool ShouldConvertWeightFromS8ToU8(Graph& graph, Node& node) const;
 

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.h
@@ -16,11 +16,15 @@ namespace onnxruntime {
 class QDQS8ToU8Transformer : public GraphTransformer {
  public:
   QDQS8ToU8Transformer(bool weights_to_u8, const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
-      : GraphTransformer("QDQS8ToU8Transformer", compatible_execution_providers), weights_to_u8_(weights_to_u8) {}
+      : GraphTransformer("QDQS8ToU8Transformer", compatible_execution_providers), weights_to_u8_(weights_to_u8) {
+          exclude_next = {"MatMul", "Conv", "Gemm"};
+      }
+  bool ShouldConvertWeightFromS8ToU8(Graph& graph, Node& node) const;
 
  private:
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
   bool weights_to_u8_;
+  std::set<std::string> exclude_next;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -25,6 +25,8 @@
 
 #include "qdq_test_utils.h"
 
+#include <iostream>
+
 #if defined(_MSC_VER)
 #pragma warning(disable : 4127)
 #endif  // #if defined(_MSC_VER)
@@ -410,6 +412,34 @@ TEST(QDQTransformerTests, Add_Have_Different_Types) {
   QDQTransformerBinaryOpTests<int8_t, int8_t, int8_t>("Add");
   QDQTransformerBinaryOpTests<int8_t, uint8_t, int8_t>("Add");
   QDQTransformerBinaryOpTests<int8_t, int8_t, uint8_t>("Add");
+  auto test_case = [&](const std::vector<int64_t>& input1_shape, const std::vector<int64_t>& weights_shape) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input1_arg = builder.MakeInput<float>(input1_shape, -1.f, 1.f);
+      auto* output_arg = builder.MakeOutput();
+
+      // add QDQ activation
+      auto* dq1_output = AddQDQNodePair<int8_t>(builder, input1_arg, .004f, 1);
+
+      // add DQ weights and Add
+      auto* weight = builder.MakeInitializer<uint8_t>(weights_shape, -128, 127);
+      auto* dq_w_output = builder.MakeIntermediate();
+      auto* add_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<uint8_t>(weight, .003f, 12, dq_w_output);
+      builder.AddNode("Add", {dq_w_output, dq1_output}, {add_output});
+
+      // add Q
+      builder.AddQuantizeLinearNode<uint8_t>(add_output, .004f, 135, output_arg);
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.QLinearAdd"], 1);
+      EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+    };
+
+    TransformerTester(build_test_case, check_graph, TransformerLevel::Level1, TransformerLevel::Level2);
+  };
+  test_case({12, 12}, {12});
 }
 
 TEST(QDQTransformerTests, Mul) {

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -25,8 +25,6 @@
 
 #include "qdq_test_utils.h"
 
-#include <iostream>
-
 #if defined(_MSC_VER)
 #pragma warning(disable : 4127)
 #endif  // #if defined(_MSC_VER)
@@ -392,7 +390,6 @@ void QDQTransformerBinaryOpTests(const std::string& op_type) {
       }
     };
 
-    const InlinedHashSet<std::string_view> cpu_ep = {onnxruntime::kCpuExecutionProvider};
     TransformerTester(BuildBinaryOpTestCase<Input1Type, Input2Type, OutputType, IsInput2Constant>(input_shape, op_type),
                       check_graph,
                       TransformerLevel::Level1,
@@ -402,17 +399,16 @@ void QDQTransformerBinaryOpTests(const std::string& op_type) {
                       0.01 /*relative_per_sample_tolerance*/,
                       std::make_unique<QDQSelectorActionTransformer>(QDQIsInt8Allowed()));
   };
+
   test_case({1, 12, 37});
   test_case({1, 23, 13, 13});
   test_case({1, 22, 11, 13, 15});
 }
 
-
 TEST(QDQTransformerTests, Add) {
   QDQTransformerBinaryOpTests<uint8_t, uint8_t, uint8_t, false>("Add");
   QDQTransformerBinaryOpTests<int8_t, int8_t, int8_t, false>("Add");
 }
-
 
 TEST(QDQTransformerTests, Add_Have_Different_Types) {
   QDQTransformerBinaryOpTests<uint8_t, int8_t, int8_t, false>("Add");
@@ -423,7 +419,6 @@ TEST(QDQTransformerTests, Add_Have_Different_Types) {
   QDQTransformerBinaryOpTests<int8_t, int8_t, uint8_t, false>("Add");
   QDQTransformerBinaryOpTests<uint8_t, int8_t, uint8_t, true>("Add");
 }
-
 
 TEST(QDQTransformerTests, Mul) {
   QDQTransformerBinaryOpTests<uint8_t, uint8_t, uint8_t, false>("Mul");
@@ -438,7 +433,6 @@ TEST(QDQTransformerTests, Mul_Have_Different_Types) {
   QDQTransformerBinaryOpTests<int8_t, uint8_t, int8_t, false>("Mul");
   QDQTransformerBinaryOpTests<int8_t, int8_t, uint8_t, false>("Mul");
 }
-
 
 template <typename Input1Type, typename Input2Type, typename OutputType>
 void QDQTransformerMatMulTests(bool has_output_q) {


### PR DESCRIPTION
**Description**: Optimization after static quantization (QDQ) with `QLinearAdd` was not possible because `QLinearAdd` expects uint8 / uint8 as input types, and the weights from a bias followed by a DequantizeLinear were in int8.

These changes should allow to convert the output from DequantizeLinear of bias weights to uint8, allowing to insert a `QLinearAdd`.

This should fix https://github.com/microsoft/onnxruntime/issues/12487

Thanks @yufenglee for your help, is my understanding correct? It's the first time I code in C++ so I hope it is not too ugly. Let me know if you would like me to add tests or change something.

**Motivation and Context**
Before:

![image](https://user-images.githubusercontent.com/9808326/185181218-c4f26122-e453-4d91-9363-b5bba7b209ff.png)

After:

![image](https://user-images.githubusercontent.com/9808326/185181321-991a7a0b-3bdf-40f1-8964-cd13400c44f8.png)

