### PR TITLE
CAPI for ort-training checkpoint property

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3494,7 +3494,7 @@ struct OrtApi {
   *
   * \since Version 1.13
   */
-  const OrtTrainingApi*(ORT_API_CALL* GetTrainingApi)(uint32_t version)NO_EXCEPTION ORT_ALL_ARGS_NONNULL;
+  const OrtTrainingApi*(ORT_API_CALL* GetTrainingApi)(uint32_t version) NO_EXCEPTION;
 
 #ifdef __cplusplus
   OrtApi(const OrtApi&)=delete; // Prevent users from accidentally copying the API structure, it should always be passed as a pointer

--- a/orttraining/orttraining/test/training_api/trainer/trainer.cc
+++ b/orttraining/orttraining/test/training_api/trainer/trainer.cc
@@ -275,7 +275,7 @@ int RunTraining(const TestRunnerParameters& params) {
   lr_scheduler_parameters->total_step_count = params.num_train_epochs * num_of_batches_per_epoch;
   lr_scheduler_parameters->warmup_step_count = lr_scheduler_parameters->total_step_count / 3;
   ORT_RETURN_ON_ERROR(g_ort_training_api->RegisterLRScheduler(
-    session, reinterpret_cast<void*>(lr_scheduler_parameters), OrtLRSchedulerType::LinearLRScheduler, nullptr));
+      session, reinterpret_cast<void*>(lr_scheduler_parameters), OrtLRSchedulerType::LinearLRScheduler, nullptr));
 
   std::cout << "Initialization completed. Now starting training loop." << std::endl;
   const int64_t stabilized_perf_start_step = 0;
@@ -355,8 +355,14 @@ int RunTraining(const TestRunnerParameters& params) {
         PathString ckpt_file = ConcatPathComponent<PathChar>(params.output_dir, ToPathString(oss.str()));
         ORT_RETURN_ON_ERROR(g_ort_training_api->SaveCheckpoint(ckpt_file.c_str(), session, true));
 
-        // TODO(baiju): enable adding more properties to checkpoint
-        // state_to_save.property_bag.AddProperty<int64_t>(std::string("epoch"), epoch);
+        ORT_RETURN_ON_ERROR(g_ort_training_api->SetCheckpointProperty(
+            checkpoint_state, "epoch", OrtCheckpointPropertyType::IntProperty, &epoch));
+
+        // Fetch the epoch for illustration
+        int64_t saved_epoch;
+        ORT_RETURN_ON_ERROR(g_ort_training_api->GetCheckpointProperty(
+            checkpoint_state, "epoch", OrtCheckpointPropertyType::IntProperty, &saved_epoch));
+        std::cout << "The saved epoch is " << saved_epoch << std::endl;
       }
       batch_idx++;
 

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -18,6 +18,12 @@ typedef struct OrtLinearLRSchedulerParameters {
   int64_t total_step_count;
 } OrtLinearLRSchedulerParameters;
 
+typedef enum OrtCheckpointPropertyType {
+  IntProperty,
+  FloatProperty,
+  StringProperty
+} OrtCheckpointPropertyType;
+
 struct OrtTrainingApi {
   /** \brief Load a checkpoint state from directory on disk into checkpoint_state.
   *
@@ -220,6 +226,43 @@ struct OrtTrainingApi {
   *
   */
   ORT_API2_STATUS(SchedulerStep, _Inout_ OrtTrainingSession* sess);
+
+  /** \brief Adds the given property to the checkpoint state.
+  *
+  * Runtime properties such as epoch, training step, best score, and others can be saved by
+  * the user if they desire by calling this function with the appropriate property name and
+  * value. The given property name must be unique to be able to successfully add the property.
+  *
+  * \param[in] checkpoint_state The checkpoint state which should hold the property.
+  * \param[in] property_name Unique name of the property being added.
+  * \param[in] property_type Type of the property associated with the given name.
+  * \param[in] property_value Property value associated with the given name.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(SetCheckpointProperty, _Inout_ OrtCheckpointState* checkpoint_state,
+                  _In_ const char* property_name, enum OrtCheckpointPropertyType property_type,
+                  _In_ void* property_value);
+
+  /** \brief Gets the property value associated with the given name from the checkpoint state.
+  *
+  * Gets the property value from an existing entry in the checkpoint state. The property must
+  * exist in the checkpoint state to be able to retrieve it successfully.
+  * If the property value is of string type, a char array is allocated on the heap. The user
+  * must free up the memory as needed by their application.
+  *
+  * \param[in] checkpoint_state The checkpoint state that is currently holding the property.
+  * \param[in] property_name Unique name of the property being retrieved.
+  * \param[in] property_type Type of the property associated with the given name.
+  * \param[out] property_value Property value associated with the given name.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(GetCheckpointProperty, _In_ const OrtCheckpointState* checkpoint_state,
+                  _In_ const char* property_name, enum OrtCheckpointPropertyType property_type,
+                  _Out_ void* property_value);
 
   /** \brief Frees up the memory used up by the training session.
   *

--- a/orttraining/orttraining/training_api/include/ort_training_apis.h
+++ b/orttraining/orttraining/training_api/include/ort_training_apis.h
@@ -40,6 +40,14 @@ ORT_API_STATUS_IMPL(LoadCheckpoint, _In_ const ORTCHAR_T* checkpoint_path,
 ORT_API_STATUS_IMPL(SaveCheckpoint, _In_ const ORTCHAR_T* checkpoint_path, _In_ const OrtTrainingSession* session,
                     bool save_optimizer_state);
 
+ORT_API_STATUS_IMPL(SetCheckpointProperty, _Inout_ OrtCheckpointState* checkpoint_state,
+                    _In_ const char* property_name, enum OrtCheckpointPropertyType property_type,
+                    _In_ void* property_value);
+
+ORT_API_STATUS_IMPL(GetCheckpointProperty, _In_ const OrtCheckpointState* checkpoint_state,
+                    _In_ const char* property_name, enum OrtCheckpointPropertyType property_type,
+                    _Out_ void* property_value);
+
 ORT_API(void, ReleaseCheckpointState, _Frees_ptr_opt_ OrtCheckpointState* session);
 
 }  // namespace OrtTrainingApis


### PR DESCRIPTION
This pull request
- Fixes a warning that was being emitted by the compiler: ```warning: no parameter has pointer type```
- Introduces C apis for setting and getting checkpoint properties.

To use the C apis to set and get the checkpoint properties:

```cc
// Int value
int64_t epoch = 987;
ORT_RETURN_ON_ERROR(g_ort_training_api->SetCheckpointProperty(
    checkpoint_state, "epoch", OrtCheckpointPropertyType::IntProperty, &epoch));

int64_t saved_int_value;
ORT_RETURN_ON_ERROR(g_ort_training_api->GetCheckpointProperty(
    checkpoint_state, "epoch", OrtCheckpointPropertyType::IntProperty, &saved_int_value));


// Float value
float learning_rate = 0.001f;
ORT_RETURN_ON_ERROR(g_ort_training_api->SetCheckpointProperty(
    checkpoint_state, "lr", OrtCheckpointPropertyType::FloatProperty, &learning_rate));

float saved_float_value;
ORT_RETURN_ON_ERROR(g_ort_training_api->GetCheckpointProperty(
    checkpoint_state, "lr", OrtCheckpointPropertyType::FloatProperty, &saved_float_value));


// String value
char model_name[] = "model name";
ORT_RETURN_ON_ERROR(g_ort_training_api->SetCheckpointProperty(
    checkpoint_state, "model_name", OrtCheckpointPropertyType::StringProperty, model_name));

char* saved_str_value;
ORT_RETURN_ON_ERROR(g_ort_training_api->GetCheckpointProperty(
    checkpoint_state, "model_name", OrtCheckpointPropertyType::StringProperty, &saved_str_value));
```