### PR TITLE
Update numpy version from 1.21.0 to 1.21.6 to avoid building it from source

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-selectable-stage.yml
@@ -153,7 +153,7 @@ stages:
           modifyEnvironment: true
 
       - script: |
-          python -m pip install -q setuptools wheel numpy==1.21.0
+          python -m pip install -q setuptools wheel numpy==1.21.6
         workingDirectory: '$(Build.BinariesDirectory)'
         displayName: 'Install python modules'
 
@@ -415,7 +415,7 @@ stages:
           workingFolder: '$(Build.BinariesDirectory)'
 
       - script: |
-          python -m pip install -q setuptools wheel numpy==1.21.0
+          python -m pip install -q setuptools wheel numpy==1.21.6
         workingDirectory: '$(Build.BinariesDirectory)'
         displayName: 'Install python modules'
 

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-stage.yml
@@ -465,7 +465,7 @@ stages:
           workingFolder: '$(Build.BinariesDirectory)'
 
       - script: |
-          python -m pip install -q setuptools wheel numpy==1.21.0
+          python -m pip install -q setuptools wheel numpy==1.21.6
         workingDirectory: '$(Build.BinariesDirectory)'
         displayName: 'Install python modules'
 
@@ -670,7 +670,7 @@ stages:
           workingFolder: '$(Build.BinariesDirectory)'
 
       - script: |
-          python -m pip install -q setuptools wheel numpy==1.21.0
+          python -m pip install -q setuptools wheel numpy==1.21.6
         workingDirectory: '$(Build.BinariesDirectory)'
         displayName: 'Install python modules'
 
@@ -992,7 +992,7 @@ stages:
               --volume $(Build.BinariesDirectory):/build \
               -w /tmp/a \
               quay.io/pypa/$(Image) \
-                /usr/bin/bash -c  "$(PYTHON_EXE) -m pip install numpy==1.21.0 && $(PYTHON_EXE) /onnxruntime_src/tools/ci_build/build.py \
+                /usr/bin/bash -c  "$(PYTHON_EXE) -m pip install numpy==1.21.6 && $(PYTHON_EXE) /onnxruntime_src/tools/ci_build/build.py \
                   --build_dir /build \
                   --config Release \
                   --skip_submodule_sync \

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.0
+numpy==1.21.6
 mypy
 pytest
 setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -1,5 +1,5 @@
 cerberus
-numpy==1.21.0
+numpy==1.21.6
 mypy
 pytest
 setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.11.0_rocm5.1.1/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.11.0_rocm5.1.1/requirements.txt
@@ -4,7 +4,7 @@
 torch==1.11.0
 pandas
 sklearn
-numpy==1.21.0
+numpy==1.21.6
 transformers==v4.3.2
 tensorboard>=2.2.0,<2.5.0
 h5py

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.11.0_rocm5.2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch1.11.0_rocm5.2/requirements.txt
@@ -4,7 +4,7 @@
 torch==1.11.0
 pandas
 sklearn
-numpy==1.21.0
+numpy==1.21.6
 transformers==v4.3.2
 tensorboard>=2.2.0,<2.5.0
 h5py

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -1,6 +1,6 @@
 pandas
 sklearn
-numpy==1.21.0
+numpy==1.21.6
 transformers==v4.4.2
 tensorboard>=2.2.0,<2.5.0
 h5py

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -2,7 +2,7 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 sklearn
-numpy==1.21.0
+numpy==1.21.6
 transformers==v2.10.0
 torch==1.10.0+cu113
 torchvision==0.11.1+cu113

--- a/tools/ci_build/requirements.txt
+++ b/tools/ci_build/requirements.txt
@@ -1,6 +1,6 @@
 # packages used by transformers tool test
 protobuf==3.17.0
-numpy==1.21.0
+numpy==1.21.6
 coloredlogs==15.0
 transformers==4.6.1
 onnxconverter-common==1.8.1


### PR DESCRIPTION
**Description**: 

Update numpy version from 1.21.0 to 1.21.6 to avoid building it from source for python 3.10


**Motivation and Context**
- Why is this change required? What problem does it solve?

To fix the numpy python 3.10 build failures in https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=224016&view=results . The build error I saw was:
"  TypeError: CCompiler_spawn() got an unexpected keyword argument 'env' "

It seems to be a compatibility issue between older numpy versions and newer setuptools versions.  See: https://github.com/pypa/distutils/issues/15 . Most likely it was triggered because I updated the build machines. In the update python 3.10 version was changed from 3.10.5 to 3.10.6.  The python installation has bundled setuptools package which was updated from 50.x to 63.2.0. And the new version somehow doesn't work with numpy 1.21.0 anymore.  

We can avoid the problem by only using prebuilt numpy packages. 

- If it fixes an open issue, please link to the issue here.
