### PR TITLE
DML EP squeeze all axes when empty

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1852,8 +1852,14 @@ namespace OperatorHelper
             m_axes = kernelInformation.GetAttributes().GetOptionalAttributeVectorInt32(AttrName::Axes);
         }
         std::vector<DimensionType> inputDimensions = shapeInformation.GetInputTensorShape(0);
+
         HandleNegativeAxes(/*inout*/ m_axes, gsl::narrow_cast<uint32_t>(inputDimensions.size()));
         std::sort(m_axes.begin(), m_axes.end());
+        if (m_axes.empty())
+        {
+            m_axes.resize(inputDimensions.size());
+            std::iota(m_axes.begin(), m_axes.end(), 0u);
+        }
     }
 
     std::vector<EdgeShapes> SqueezeHelper::GetOutputShapes(const MLShapeInferenceContext& shapeInfo) const


### PR DESCRIPTION
**Description**: [ONNX Squeeze](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Squeeze) operator says to treat empty `axes` as if all axes had been given (e.g. for 3D, axes=[] means axes=[0,1,2]). The DML EP shape inference code instead treated 0 axes as, well, 0 axes. This affects a customer model<!-- ADO OS 40979563-->.

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Makes ORT DML EP consistent with spec.
- *If it fixes an open issue, please link to the issue here.* NA
