### PR TITLE
Add pybind support for all memory config options in OrtArenaCfg

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1083,7 +1083,7 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
       .def_static("default_memory", []() { return OrtDevice::MemType::DEFAULT; });
 
   py::class_<OrtArenaCfg> ort_arena_cfg_binding(m, "OrtArenaCfg");
-  // Note: Doesn't expose initial_growth_chunk_sizes_bytes option. This constructor kept for 
+  // Note: Doesn't expose initial_growth_chunk_sizes_bytes option. This constructor kept for
   // backwards compatibility, key-value pair constructor overload exposes all options
   // There is a global var: arena_extend_strategy, which means we can't use that var name here
   // See docs/C_API.md for details on what the following parameters mean and how to choose these values
@@ -1103,7 +1103,7 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
       if (key == "max_mem") {
         ort_arena_cfg->max_mem = kvp.second.cast<size_t>();
       } else if (key == "arena_extend_strategy") {
-        ort_arena_cfg->arena_extend_strategy = kvp.second.cast<int>(); 
+        ort_arena_cfg->arena_extend_strategy = kvp.second.cast<int>();
       } else if (key == "initial_chunk_size_bytes") {
         ort_arena_cfg->initial_chunk_size_bytes = kvp.second.cast<int>();
       } else if (key == "max_dead_bytes_per_chunk") {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1086,12 +1086,14 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
   // There is a global var: arena_extend_strategy, which means we can't use that var name here
   // See docs/C_API.md for details on what the following parameters mean and how to choose these values
   ort_arena_cfg_binding.def(py::init([](size_t max_mem, int arena_extend_strategy_local,
-                                        int initial_chunk_size_bytes, int max_dead_bytes_per_chunk) {
+                                        int initial_chunk_size_bytes, int max_dead_bytes_per_chunk,
+                                        int initial_growth_chunk_size_bytes) {
     auto ort_arena_cfg = std::make_unique<OrtArenaCfg>();
     ort_arena_cfg->max_mem = max_mem;
     ort_arena_cfg->arena_extend_strategy = arena_extend_strategy_local;
     ort_arena_cfg->initial_chunk_size_bytes = initial_chunk_size_bytes;
     ort_arena_cfg->max_dead_bytes_per_chunk = max_dead_bytes_per_chunk;
+    ort_arena_cfg->initial_growth_chunk_size_bytes = initial_growth_chunk_size_bytes;
     return ort_arena_cfg;
   }));
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1086,14 +1086,33 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
   // There is a global var: arena_extend_strategy, which means we can't use that var name here
   // See docs/C_API.md for details on what the following parameters mean and how to choose these values
   ort_arena_cfg_binding.def(py::init([](size_t max_mem, int arena_extend_strategy_local,
-                                        int initial_chunk_size_bytes, int max_dead_bytes_per_chunk,
-                                        int initial_growth_chunk_size_bytes) {
+                                        int initial_chunk_size_bytes, int max_dead_bytes_per_chunk) {
     auto ort_arena_cfg = std::make_unique<OrtArenaCfg>();
     ort_arena_cfg->max_mem = max_mem;
     ort_arena_cfg->arena_extend_strategy = arena_extend_strategy_local;
     ort_arena_cfg->initial_chunk_size_bytes = initial_chunk_size_bytes;
     ort_arena_cfg->max_dead_bytes_per_chunk = max_dead_bytes_per_chunk;
-    ort_arena_cfg->initial_growth_chunk_size_bytes = initial_growth_chunk_size_bytes;
+    return ort_arena_cfg;
+  }));
+
+  ort_arena_cfg_binding.def(py::init([](const py::dict& feeds) {
+    auto ort_arena_cfg = std::make_unique<OrtArenaCfg>();
+    for (const auto kvp : feeds) {
+      auto key = kvp.first.cast<std::string>();
+      if (strcmp(key, "max_mem") == 0) {
+        ort_arena_cfg->max_mem = static_cast<size_t>(kvp.second);
+      } else if (strcmp(key, "arena_extend_strategy") == 0) {
+        ort_arena_cfg->arena_extend_strategy = static_cast<int>(kvp.second);
+      } else if (strcmp(key, "initial_chunk_size_bytes") == 0) {
+        ort_arena_cfg->initial_chunk_size_bytes = static_cast<int>(kvp.second);
+      } else if (strcmp(key, "max_dead_bytes_per_chunk") == 0) {
+        ort_arena_cfg->max_dead_bytes_per_chunk = static_cast<int>(kvp.second);
+      } else if (strcmp(key, "initial_growth_chunk_size_bytes") == 0) {
+        ort_arena_cfg->initial_growth_chunk_size_bytes = static_cast<int>(kvp.second);
+        } else {
+        ORT_THROW("Invalid OrtArenaCfg option: ", key);
+      }
+    }
     return ort_arena_cfg;
   }));
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1083,6 +1083,8 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
       .def_static("default_memory", []() { return OrtDevice::MemType::DEFAULT; });
 
   py::class_<OrtArenaCfg> ort_arena_cfg_binding(m, "OrtArenaCfg");
+  // Note: Doesn't expose initial_growth_chunk_sizes_bytes option. This constructor kept for 
+  // backwards compatibility, key-value pair constructor overload exposes all options
   // There is a global var: arena_extend_strategy, which means we can't use that var name here
   // See docs/C_API.md for details on what the following parameters mean and how to choose these values
   ort_arena_cfg_binding.def(py::init([](size_t max_mem, int arena_extend_strategy_local,
@@ -1093,28 +1095,32 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
     ort_arena_cfg->initial_chunk_size_bytes = initial_chunk_size_bytes;
     ort_arena_cfg->max_dead_bytes_per_chunk = max_dead_bytes_per_chunk;
     return ort_arena_cfg;
-  }));
-
-  ort_arena_cfg_binding.def(py::init([](const py::dict& feeds) {
+  }))
+      .def(py::init([](const py::dict& feeds) {
     auto ort_arena_cfg = std::make_unique<OrtArenaCfg>();
     for (const auto kvp : feeds) {
-      auto key = kvp.first.cast<std::string>();
-      if (strcmp(key, "max_mem") == 0) {
-        ort_arena_cfg->max_mem = static_cast<size_t>(kvp.second);
-      } else if (strcmp(key, "arena_extend_strategy") == 0) {
-        ort_arena_cfg->arena_extend_strategy = static_cast<int>(kvp.second);
-      } else if (strcmp(key, "initial_chunk_size_bytes") == 0) {
-        ort_arena_cfg->initial_chunk_size_bytes = static_cast<int>(kvp.second);
-      } else if (strcmp(key, "max_dead_bytes_per_chunk") == 0) {
-        ort_arena_cfg->max_dead_bytes_per_chunk = static_cast<int>(kvp.second);
-      } else if (strcmp(key, "initial_growth_chunk_size_bytes") == 0) {
-        ort_arena_cfg->initial_growth_chunk_size_bytes = static_cast<int>(kvp.second);
+      std::string key = kvp.first.cast<std::string>();
+      if (key == "max_mem") {
+        ort_arena_cfg->max_mem = kvp.second.cast<size_t>();
+      } else if (key == "arena_extend_strategy") {
+        ort_arena_cfg->arena_extend_strategy = kvp.second.cast<int>(); 
+      } else if (key == "initial_chunk_size_bytes") {
+        ort_arena_cfg->initial_chunk_size_bytes = kvp.second.cast<int>();
+      } else if (key == "max_dead_bytes_per_chunk") {
+        ort_arena_cfg->max_dead_bytes_per_chunk = kvp.second.cast<int>();
+      } else if (key == "initial_growth_chunk_size_bytes") {
+        ort_arena_cfg->initial_growth_chunk_size_bytes = kvp.second.cast<int>();
         } else {
         ORT_THROW("Invalid OrtArenaCfg option: ", key);
       }
     }
     return ort_arena_cfg;
-  }));
+  }))
+      .def_readwrite("max_mem", &OrtArenaCfg::max_mem)
+      .def_readwrite("arena_extend_strategy", &OrtArenaCfg::arena_extend_strategy)
+      .def_readwrite("initial_chunk_size_bytes", &OrtArenaCfg::initial_chunk_size_bytes)
+      .def_readwrite("max_dead_bytes_per_chunk", &OrtArenaCfg::max_dead_bytes_per_chunk)
+      .def_readwrite("initial_growth_chunk_size_bytes", &OrtArenaCfg::initial_growth_chunk_size_bytes);
 
   py::class_<OrtMemoryInfo> ort_memory_info_binding(m, "OrtMemoryInfo");
   ort_memory_info_binding.def(py::init([](const char* name, OrtAllocatorType type, int id, OrtMemType mem_type) {

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1313,33 +1313,18 @@ class TestInferenceSession(unittest.TestCase):
     def testCreateAllocator(self):
         def verify_allocator(allocator, expected_config):
             for key, val in expected_config.items():
-                if (key == "max_mem"):
-                    self.assertEqual(
-                        allocator.max_mem,
-                        val
-                    )
-                elif (key == "arena_extend_strategy"):
-                    self.assertEqual(
-                        allocator.arena_extend_strategy,
-                        val
-                    )
-                elif (key == "initial_chunk_size_bytes"):
-                    self.assertEqual(
-                        allocator.initial_chunk_size_bytes,
-                        val
-                    )
-                elif (key == "max_dead_bytes_per_chunk"):
-                    self.assertEqual(
-                        allocator.max_dead_bytes_per_chunk,
-                        val
-                    )
-                elif (key == "initial_growth_chunk_size_bytes"):
-                    self.assertEqual(
-                        allocator.initial_growth_chunk_size_bytes,
-                        val
-                    )
+                if key == "max_mem":
+                    self.assertEqual(allocator.max_mem, val)
+                elif key == "arena_extend_strategy":
+                    self.assertEqual(allocator.arena_extend_strategy, val)
+                elif key == "initial_chunk_size_bytes":
+                    self.assertEqual(allocator.initial_chunk_size_bytes, val)
+                elif key == "max_dead_bytes_per_chunk":
+                    self.assertEqual(allocator.max_dead_bytes_per_chunk, val)
+                elif key == "initial_growth_chunk_size_bytes":
+                    self.assertEqual(allocator.initial_growth_chunk_size_bytes, val)
                 else:
-                    raise ValueError('Invalid OrtArenaCfg option: ' + key)
+                    raise ValueError("Invalid OrtArenaCfg option: " + key)
 
         # Verify ordered parameter initialization
         ort_arena_cfg = onnxrt.OrtArenaCfg(8, 0, 4, 2)
@@ -1347,8 +1332,8 @@ class TestInferenceSession(unittest.TestCase):
             "max_mem": 8,
             "arena_extend_strategy": 0,
             "initial_chunk_size_bytes": 4,
-            "max_dead_bytes_per_chunk": 2
-            }
+            "max_dead_bytes_per_chunk": 2,
+        }
         verify_allocator(ort_arena_cfg, expected_allocator)
 
         # Verify key-value pair initialization
@@ -1357,10 +1342,11 @@ class TestInferenceSession(unittest.TestCase):
             "arena_extend_strategy": 1,
             "initial_chunk_size_bytes": 8,
             "max_dead_bytes_per_chunk": 4,
-            "initial_growth_chunk_size_bytes": 2
-            }
+            "initial_growth_chunk_size_bytes": 2,
+        }
         ort_arena_cfg_kvp = onnxrt.OrtArenaCfg(expected_kvp_allocator)
         verify_allocator(ort_arena_cfg_kvp, expected_kvp_allocator)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1311,9 +1311,9 @@ class TestInferenceSession(unittest.TestCase):
         print("Create session with customize execution provider successfully!")
 
     def testCreateAllocator(self):
-        def verifyAllocator(allocator, expectedConfig):
-            for key in expectedConfig:
-                val = expectedConfig[key]
+        def verifyAllocator(allocator, expected_config):
+            for key in expected_config:
+                val = expected_config[key]
                 if (key == "max_mem"):
                     self.assertEqual(
                         allocator.max_mem,

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1308,6 +1308,34 @@ class TestInferenceSession(unittest.TestCase):
         )
         print("Create session with customize execution provider successfully!")
 
+    def testCreateAllocator(self):
+        def verifyAllocator(allocator, expectedConfig):
+            for key in expectedConfig:
+                self.assertEqual(
+                    allocator.getattr(key),
+                    expectedConfig[key]
+                )
+
+        # Verify ordered parameter initialization
+        ort_memory_info = onnxrt.OrtArenaCfg(8, 0, 4, 2)
+        expected_allocator = {
+            "max_mem": 8,
+            "arena_extend_strategy": 0,
+            "initial_chunk_size_bytes": 4,
+            "max_dead_bytes_per_chunk": 2
+            }
+        verifyAllocator(ort_memory_info, expected_allocator)
+
+        # Verify key-value pair initialization
+        expected_kvp_allocator = {
+            "max_mem": 16,
+            "arena_extend_strategy": 1,
+            "initial_chunk_size_bytes": 8,
+            "max_dead_bytes_per_chunk": 4,
+            "initial_growth_chunk_size_bytes": 2
+            }
+        ort_kvp_memory_info = onnxrt.OrtArenaCfg(expected_kvp_allocator)
+        verifyAllocator(ort_kvp_memory_info, expected_kvp_allocator)
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1154,7 +1154,9 @@ class TestInferenceSession(unittest.TestCase):
     def testSharedAllocatorUsingCreateAndRegisterAllocator(self):
         # Create and register an arena based allocator
 
-        # ort_arena_cfg = onnxrt.OrtArenaCfg(0, -1, -1, -1) (create an OrtArenaCfg like this template if you want to use non-default parameters)
+        # To create an OrtArenaCfg using non-default parameters, use one of below templates:
+        # ort_arena_cfg = onnxrt.OrtArenaCfg(0, -1, -1, -1) - Note: doesn't expose initial_growth_chunk_size_bytes option
+        # ort_arena_cfg = onnxrt.OrtArenaCfg({"max_mem": -1, ""arena_extend_strategy": 1, etc..})
         ort_memory_info = onnxrt.OrtMemoryInfo(
             "Cpu",
             onnxrt.OrtAllocatorType.ORT_ARENA_ALLOCATOR,
@@ -1311,10 +1313,34 @@ class TestInferenceSession(unittest.TestCase):
     def testCreateAllocator(self):
         def verifyAllocator(allocator, expectedConfig):
             for key in expectedConfig:
-                self.assertEqual(
-                    allocator.getattr(key),
-                    expectedConfig[key]
-                )
+                val = expectedConfig[key]
+                if (key == "max_mem"):
+                    self.assertEqual(
+                        allocator.max_mem,
+                        val
+                    )
+                elif (key == "arena_extend_strategy"):
+                    self.assertEqual(
+                        allocator.arena_extend_strategy,
+                        val
+                    )
+                elif (key == "initial_chunk_size_bytes"):
+                    self.assertEqual(
+                        allocator.initial_chunk_size_bytes,
+                        val
+                    )
+                elif (key == "max_dead_bytes_per_chunk"):
+                    self.assertEqual(
+                        allocator.max_dead_bytes_per_chunk,
+                        val
+                    )
+                elif (key == "initial_growth_chunk_size_bytes"):
+                    self.assertEqual(
+                        allocator.initial_growth_chunk_size_bytes,
+                        val
+                    )
+                else:
+                    raise ValueError('Invalid OrtArenaCfg option: ' + key)
 
         # Verify ordered parameter initialization
         ort_memory_info = onnxrt.OrtArenaCfg(8, 0, 4, 2)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1312,8 +1312,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testCreateAllocator(self):
         def verify_allocator(allocator, expected_config):
-            for key in expected_config:
-                val = expected_config[key]
+            for key, val in expected_config.items():
                 if (key == "max_mem"):
                     self.assertEqual(
                         allocator.max_mem,

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1311,7 +1311,7 @@ class TestInferenceSession(unittest.TestCase):
         print("Create session with customize execution provider successfully!")
 
     def testCreateAllocator(self):
-        def verifyAllocator(allocator, expected_config):
+        def verify_allocator(allocator, expected_config):
             for key in expected_config:
                 val = expected_config[key]
                 if (key == "max_mem"):
@@ -1343,14 +1343,14 @@ class TestInferenceSession(unittest.TestCase):
                     raise ValueError('Invalid OrtArenaCfg option: ' + key)
 
         # Verify ordered parameter initialization
-        ort_memory_info = onnxrt.OrtArenaCfg(8, 0, 4, 2)
+        ort_arena_cfg = onnxrt.OrtArenaCfg(8, 0, 4, 2)
         expected_allocator = {
             "max_mem": 8,
             "arena_extend_strategy": 0,
             "initial_chunk_size_bytes": 4,
             "max_dead_bytes_per_chunk": 2
             }
-        verifyAllocator(ort_memory_info, expected_allocator)
+        verify_allocator(ort_arena_cfg, expected_allocator)
 
         # Verify key-value pair initialization
         expected_kvp_allocator = {
@@ -1360,8 +1360,8 @@ class TestInferenceSession(unittest.TestCase):
             "max_dead_bytes_per_chunk": 4,
             "initial_growth_chunk_size_bytes": 2
             }
-        ort_kvp_memory_info = onnxrt.OrtArenaCfg(expected_kvp_allocator)
-        verifyAllocator(ort_kvp_memory_info, expected_kvp_allocator)
+        ort_arena_cfg_kvp = onnxrt.OrtArenaCfg(expected_kvp_allocator)
+        verify_allocator(ort_arena_cfg_kvp, expected_kvp_allocator)
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
**Description**: Improve the `pybind` implementation of `OrtArenaCfg` object. Currently, the `OrtArenaCfg` constructor provided through `pybind` doesn't expose all options to the user, and the public class members of `OrtArenaCfg` aren't accessible through `pybind`. This PR makes the following changes:
 - Add new `pybind` constructor for `OrtArenaCfg` that takes a collection of Key-Value pairs instead of ordered parameters. This allows users to access all memory arena options going forward without having to modify the constructor each time a new parameter is added.
 - Add `pybind` support for accessing the class members within `OrtArenaCfg`. These members are public in the C api, and should be accessible through Python as well.
 - UT for changes


**Motivation and Context** 

- There is one config value `initial_growth_chunk_size_bytes` that isn't exposed to the user through the `pybind` offering of `OrtArenaCfg`. See diff between:

   - [`OrtArenaCfg` Constructor](https://github.com/microsoft/onnxruntime/blob/ac7538b909990f89f9bfebb325cd53c3d31cf158/include/onnxruntime/core/framework/allocator.h#L33)
  - [`pybind` implementation](https://github.com/microsoft/onnxruntime/blob/aa85092b51ced97507d7fec12c4c67d6d376aac7/onnxruntime/python/onnxruntime_pybind_state.cc#L1091)

   I don't have reasoning as to why we hide the parameter from users, so this PR aims to add more flexibility to ORT going forward by adding a more flexible constructor and member access.
