### PR TITLE
Adds a react-native test using the android API

### DIFF
--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -507,8 +507,8 @@ public class InferenceTest {
       float[] inputData = tuple.inputData;
       NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
       Map<String, OnnxTensor> container = new HashMap<>();
-      float[] wrongSizeData = Arrays.copyOf(inputData, 2*224*224);
-      Object tensor = OrtUtil.reshape(wrongSizeData, new long[]{1,2,224,224});
+      float[] wrongSizeData = Arrays.copyOf(inputData, 2 * 224 * 224);
+      Object tensor = OrtUtil.reshape(wrongSizeData, new long[] {1, 2, 224, 224});
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
@@ -530,7 +530,7 @@ public class InferenceTest {
       float[] inputData = tuple.inputData;
       NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
       Map<String, OnnxTensor> container = new HashMap<>();
-      Object tensor = OrtUtil.reshape(inputData, new long[]{1,1,3,224,224});
+      Object tensor = OrtUtil.reshape(inputData, new long[] {1, 1, 3, 224, 224});
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -500,6 +500,51 @@ public class InferenceTest {
   }
 
   @Test
+  public void throwWrongSizeInput() throws OrtException {
+    SqueezeNetTuple tuple = openSessionSqueezeNet();
+    try (OrtSession session = tuple.session) {
+
+      float[] inputData = tuple.inputData;
+      NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+      Map<String, OnnxTensor> container = new HashMap<>();
+      float[] wrongSizeData = Arrays.copyOf(inputData, 2*224*224);
+      Object tensor = OrtUtil.reshape(wrongSizeData, new long[]{1,2,224,224});
+      container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
+      try {
+        session.run(container);
+        OnnxValue.close(container.values());
+        fail("Should throw exception for incorrect size.");
+      } catch (OrtException e) {
+        OnnxValue.close(container.values());
+        String msg = e.getMessage();
+        assertTrue(msg.contains("Got invalid dimensions for input"));
+      }
+    }
+  }
+
+  @Test
+  public void throwWrongRankInput() throws OrtException {
+    SqueezeNetTuple tuple = openSessionSqueezeNet();
+    try (OrtSession session = tuple.session) {
+
+      float[] inputData = tuple.inputData;
+      NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
+      Map<String, OnnxTensor> container = new HashMap<>();
+      Object tensor = OrtUtil.reshape(inputData, new long[]{1,1,3,224,224});
+      container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
+      try {
+        session.run(container);
+        OnnxValue.close(container.values());
+        fail("Should throw exception for incorrect size.");
+      } catch (OrtException e) {
+        OnnxValue.close(container.values());
+        String msg = e.getMessage();
+        assertTrue(msg.contains("Invalid rank for input"));
+      }
+    }
+  }
+
+  @Test
   public void throwExtraInputs() throws OrtException {
     SqueezeNetTuple tuple = openSessionSqueezeNet();
     try (OrtSession session = tuple.session) {

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -462,12 +462,12 @@ public class InferenceTest {
       container.put("wrong_name", OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
-        OnnxValue.close(container.values());
         fail("Should throw exception for incorrect name.");
       } catch (OrtException e) {
-        OnnxValue.close(container.values());
         String msg = e.getMessage();
         assertTrue(msg.contains("Unknown input name"));
+      } finally {
+        OnnxValue.close(container.values());
       }
     }
   }
@@ -489,12 +489,12 @@ public class InferenceTest {
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
-        OnnxValue.close(container.values());
         fail("Should throw exception for incorrect type.");
       } catch (OrtException e) {
-        OnnxValue.close(container.values());
         String msg = e.getMessage();
         assertTrue(msg.contains("Unexpected input data type"));
+      } finally {
+        OnnxValue.close(container.values());
       }
     }
   }
@@ -512,12 +512,12 @@ public class InferenceTest {
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
-        OnnxValue.close(container.values());
         fail("Should throw exception for incorrect size.");
       } catch (OrtException e) {
-        OnnxValue.close(container.values());
         String msg = e.getMessage();
         assertTrue(msg.contains("Got invalid dimensions for input"));
+      } finally {
+        OnnxValue.close(container.values());
       }
     }
   }
@@ -534,12 +534,12 @@ public class InferenceTest {
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
-        OnnxValue.close(container.values());
         fail("Should throw exception for incorrect size.");
       } catch (OrtException e) {
-        OnnxValue.close(container.values());
         String msg = e.getMessage();
         assertTrue(msg.contains("Invalid rank for input"));
+      } finally {
+        OnnxValue.close(container.values());
       }
     }
   }
@@ -562,12 +562,12 @@ public class InferenceTest {
       container.put("extra", OnnxTensor.createTensor(env, tensor));
       try {
         session.run(container);
-        OnnxValue.close(container.values());
         fail("Should throw exception for too many inputs.");
       } catch (OrtException e) {
-        OnnxValue.close(container.values());
         String msg = e.getMessage();
         assertTrue(msg.contains("Unexpected number of inputs"));
+      } finally {
+        OnnxValue.close(container.values());
       }
     }
   }
@@ -577,12 +577,11 @@ public class InferenceTest {
     int numThreads = 10;
     int loop = 10;
     SqueezeNetTuple tuple = openSessionSqueezeNet();
+    Map<String, OnnxTensor> container = new HashMap<>();
     try (OrtSession session = tuple.session) {
-
       float[] inputData = tuple.inputData;
       float[] expectedOutput = tuple.outputData;
       NodeInfo inputMeta = session.getInputInfo().values().iterator().next();
-      Map<String, OnnxTensor> container = new HashMap<>();
       long[] inputShape = ((TensorInfo) inputMeta.getInfo()).shape;
       Object tensor = OrtUtil.reshape(inputData, inputShape);
       container.put(inputMeta.getName(), OnnxTensor.createTensor(env, tensor));
@@ -604,8 +603,9 @@ public class InferenceTest {
       }
       executor.shutdown();
       executor.awaitTermination(1, TimeUnit.MINUTES);
-      OnnxValue.close(container.values());
       assertTrue(executor.isTerminated());
+    } finally {
+      OnnxValue.close(container.values());
     }
   }
 

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -211,10 +211,9 @@ public class OnnxruntimeModuleTest {
 
       OnnxruntimeModule ortModule = new OnnxruntimeModule(reactContext);
 
-      InputStream modelStream =
-          reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
-      JavaOnlyMap options = new JavaOnlyMap();
-      try {
+      try (InputStream modelStream =
+               reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)) {
+        JavaOnlyMap options = new JavaOnlyMap();
         ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
 
         int[] dims = new int[] {1, 7};
@@ -267,10 +266,9 @@ public class OnnxruntimeModuleTest {
 
       OnnxruntimeModule ortModule = new OnnxruntimeModule(reactContext);
 
-      InputStream modelStream =
-          reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
       JavaOnlyMap options = new JavaOnlyMap();
-      try {
+      try (InputStream modelStream =
+               reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)){
         ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
 
         int[] dims = new int[] {1, 1, 7};

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -203,7 +203,7 @@ public class OnnxruntimeModuleTest {
   }
 
   @Test
-  public void throwWrongSizeInput() throws OrtException {
+  public void throwWrongSizeInput() {
     MockitoSession mockSession = mockitoSession().mockStatic(Arguments.class).startMocking();
     try {
       when(Arguments.createMap()).thenAnswer(i -> new JavaOnlyMap());
@@ -215,7 +215,7 @@ public class OnnxruntimeModuleTest {
           reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
       JavaOnlyMap options = new JavaOnlyMap();
       try {
-        ReadableMap resultMap = ortModule.loadModel("test", modelStream, options);
+        ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
 
         int[] dims = new int[] {1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};
@@ -245,10 +245,10 @@ public class OnnxruntimeModuleTest {
         JavaOnlyArray outputNames = new JavaOnlyArray();
         outputNames.pushString("output");
 
-        JavaOnlyMap options = new JavaOnlyMap();
-        options.putBoolean("encodeTensorData", true);
+        JavaOnlyMap runOptions = new JavaOnlyMap();
+        runOptions.putBoolean("encodeTensorData", true);
 
-        ReadableMap resultMap = ortModule.run("test", inputDataMap, outputNames, options);
+        ReadableMap resultMap = ortModule.run("test", inputDataMap, outputNames, runOptions);
         Assert.fail("Should have thrown exception");
       } catch (Exception e) {
         Assert.assertTrue(e.getMessage().contains("Got invalid dimensions for input"));
@@ -259,7 +259,7 @@ public class OnnxruntimeModuleTest {
   }
 
   @Test
-  public void throwWrongRankInput() throws OrtException {
+  public void throwWrongRankInput() {
     MockitoSession mockSession = mockitoSession().mockStatic(Arguments.class).startMocking();
     try {
       when(Arguments.createMap()).thenAnswer(i -> new JavaOnlyMap());
@@ -271,7 +271,7 @@ public class OnnxruntimeModuleTest {
           reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
       JavaOnlyMap options = new JavaOnlyMap();
       try {
-        ReadableMap resultMap = ortModule.loadModel("test", modelStream, options);
+        ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
 
         int[] dims = new int[] {1, 1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};
@@ -301,10 +301,10 @@ public class OnnxruntimeModuleTest {
         JavaOnlyArray outputNames = new JavaOnlyArray();
         outputNames.pushString("output");
 
-        JavaOnlyMap options = new JavaOnlyMap();
-        options.putBoolean("encodeTensorData", true);
+        JavaOnlyMap runOptions = new JavaOnlyMap();
+        runOptions.putBoolean("encodeTensorData", true);
 
-        ReadableMap resultMap = ortModule.run("test", inputDataMap, outputNames, options);
+        ReadableMap resultMap = ortModule.run("test", inputDataMap, outputNames, runOptions);
         Assert.fail("Should have thrown exception");
       } catch (Exception e) {
         Assert.assertTrue(e.getMessage().contains("Invalid rank for input"));

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -274,7 +274,7 @@ public class OnnxruntimeModuleTest {
 
       JavaOnlyMap options = new JavaOnlyMap();
       try (InputStream modelStream =
-               reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)){
+               reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)) {
         byte[] modelBuffer = getInputModelBuffer(modelStream);
         ReadableMap loadMap = ortModule.loadModel(modelBuffer, options);
         sessionKey = loadMap.getString("key");

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -254,9 +254,10 @@ public class OnnxruntimeModuleTest {
         Assert.fail("Should have thrown exception");
       } catch (Exception e) {
         Assert.assertTrue(e.getMessage().contains("Got invalid dimensions for input"));
+      } finally {
+        ortModule.dispose(sessionKey);
       }
     } finally {
-      ortModule.dispose(sessionKey);
       mockSession.finishMocking();
     }
   }
@@ -313,9 +314,10 @@ public class OnnxruntimeModuleTest {
         Assert.fail("Should have thrown exception");
       } catch (Exception e) {
         Assert.assertTrue(e.getMessage().contains("Invalid rank for input"));
+      } finally {
+        ortModule.dispose(sessionKey);
       }
     } finally {
-      ortModule.dispose(sessionKey);
       mockSession.finishMocking();
     }
   }

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -210,11 +210,14 @@ public class OnnxruntimeModuleTest {
       when(Arguments.createArray()).thenAnswer(i -> new JavaOnlyArray());
 
       OnnxruntimeModule ortModule = new OnnxruntimeModule(reactContext);
+      String sessionKey = null;
 
       try (InputStream modelStream =
                reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)) {
         JavaOnlyMap options = new JavaOnlyMap();
-        ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
+        byte[] modelBuffer = getInputModelBuffer(modelStream);
+        ReadableMap loadMap = ortModule.loadModel(modelBuffer, options);
+        sessionKey = resultMap.getString("key");
 
         int[] dims = new int[] {1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};
@@ -253,6 +256,7 @@ public class OnnxruntimeModuleTest {
         Assert.assertTrue(e.getMessage().contains("Got invalid dimensions for input"));
       }
     } finally {
+      ortModule.dispose(sessionKey);
       mockSession.finishMocking();
     }
   }
@@ -265,11 +269,14 @@ public class OnnxruntimeModuleTest {
       when(Arguments.createArray()).thenAnswer(i -> new JavaOnlyArray());
 
       OnnxruntimeModule ortModule = new OnnxruntimeModule(reactContext);
+      String sessionKey = null;
 
       JavaOnlyMap options = new JavaOnlyMap();
       try (InputStream modelStream =
                reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)){
-        ReadableMap loadMap = ortModule.loadModel("test", modelStream, options);
+        byte[] modelBuffer = getInputModelBuffer(modelStream);
+        ReadableMap loadMap = ortModule.loadModel(modelBuffer, options);
+        sessionKey = resultMap.getString("key");
 
         int[] dims = new int[] {1, 1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};
@@ -308,6 +315,7 @@ public class OnnxruntimeModuleTest {
         Assert.assertTrue(e.getMessage().contains("Invalid rank for input"));
       }
     } finally {
+      ortModule.dispose(sessionKey);
       mockSession.finishMocking();
     }
   }

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -217,7 +217,7 @@ public class OnnxruntimeModuleTest {
         JavaOnlyMap options = new JavaOnlyMap();
         byte[] modelBuffer = getInputModelBuffer(modelStream);
         ReadableMap loadMap = ortModule.loadModel(modelBuffer, options);
-        sessionKey = resultMap.getString("key");
+        sessionKey = loadMap.getString("key");
 
         int[] dims = new int[] {1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};
@@ -276,7 +276,7 @@ public class OnnxruntimeModuleTest {
                reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float)){
         byte[] modelBuffer = getInputModelBuffer(modelStream);
         ReadableMap loadMap = ortModule.loadModel(modelBuffer, options);
-        sessionKey = resultMap.getString("key");
+        sessionKey = loadMap.getString("key");
 
         int[] dims = new int[] {1, 1, 7};
         float[] inputData = new float[] {1.0f, 2.0f, -3.0f, Float.MIN_VALUE, Float.MAX_VALUE, 5f, -6f};


### PR DESCRIPTION
**Description**: 

Adds a test which should trigger #11451 on Android. It also adds the same tests to Java, but those already passed.

I suspect the react tests could be cleaned up more, but I've no idea how they are actually run, or if there can be multiple modules, so someone who better understands how those tests are run should take a look. I don't have an environment setup to allow me to run them locally, though I have checked the new Java side tests.

cc @fs-eire 

**Motivation and Context**
- Why is this change required? What problem does it solve? Test for the JNI refactor when using Android & react-native.
- If it fixes an open issue, please link to the issue here.
