### PR TITLE
Update Supporting Deepspeed Version of ORTModule's FP16_Optimizer

### DIFF
--- a/orttraining/orttraining/python/training/optim/_ds_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_ds_modifier.py
@@ -31,7 +31,7 @@ class DeepSpeedZeROModifier(FP16OptimizerModifier):
         import deepspeed
 
         ds_version = LooseVersion(deepspeed.__version__)
-        if ds_version > LooseVersion("0.6.5") or ds_version < LooseVersion("0.4.0"):
+        if ds_version > LooseVersion("0.7.0") or ds_version < LooseVersion("0.4.0"):
             warnings.warn("Skip modifying optimizer because of unsupported DeepSpeed version.", UserWarning)
             return False
 


### PR DESCRIPTION
Deepspeed updated its version to 0.7.0 while the zero optimizer code had no change, so our FP16_Optimizer can still support it. This PR is to update the supporting version in the code.