### PR TITLE
[CUDA] Fuse add bias and transpose into one kernel in Attention

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
@@ -109,7 +109,7 @@ bool QkvToContext(
       return false;
     }
   } else {
-    const int format = 1; // BxSxMxNxH
+    const int format = 1;  // BxSxMxNxH
     const bool enable_half4 = true;
     LaunchAddBiasTranspose(stream, 3, format, max_threads_per_block, batch_size,
                            sequence_length, num_heads, head_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
@@ -28,6 +28,7 @@ limitations under the License.
 #include "contrib_ops/cuda/bert/attention_impl.h"
 #include "contrib_ops/cuda/bert/attention_softmax.h"
 #include "contrib_ops/cuda/bert/transformer_common.h"
+#include "contrib_ops/cuda/bert/add_bias_transpose.h"
 
 using namespace onnxruntime::cuda;
 using namespace cub;
@@ -81,6 +82,7 @@ bool QkvToContext(
     const int head_size,
     const size_t element_size,
     const T* input,
+    const T* bias,
     T* output,
     T* workspace,
     const int* mask_index,
@@ -101,9 +103,21 @@ bool QkvToContext(
   const int max_threads_per_block = prop.maxThreadsPerBlock;
 
   // input should be BxSx3xNxH => scratch3: 3xBxNxSxH
-  if (!LaunchTransQkv(stream, 3, sequence_length, batch_size, head_size, num_heads,
-                      max_threads_per_block, false, input, scratch3)) {
-    return false;
+  if (bias == nullptr) {
+    if (!LaunchTransQkv(stream, 3, sequence_length, batch_size, head_size, num_heads,
+                        max_threads_per_block, false, input, scratch3)) {
+      return false;
+    }
+  } else {
+    const int format = 1; // BxSxMxNxH
+    const bool enable_half4 = true;
+    LaunchAddBiasTranspose(stream, 3, format, max_threads_per_block, batch_size,
+                           sequence_length, num_heads, head_size,
+                           input, bias, scratch3,
+                           enable_half4);
+    if (!CUDA_CALL(cudaPeekAtLastError())) {
+      return false;
+    }
   }
 
   // now scratch3 has Q, K, V: each has size BxNxSxH
@@ -142,7 +156,7 @@ bool QkvToContext(
   float one = 1.0f;
   float zero = 0.f;
 
-  // For raw attention mask, the scalar if 1/sqrt(H) is moved to softmax computation.
+  // For raw attention mask, the scalar 1/sqrt(H) is moved to combine with softmax computation.
   float alpha = use_raw_attention_mask ? one : rsqrt_head_size;
 
   if (!CUBLAS_CALL(cublasGemmStridedBatchedHelper(
@@ -208,6 +222,7 @@ bool LaunchAttentionKernel(
     int past_sequence_length,
     bool is_unidirectional,
     const void* input,
+    const void* bias,
     const int* mask_index,
     gsl::span<const int64_t> mask_index_dims,
     const void* past,
@@ -222,6 +237,7 @@ bool LaunchAttentionKernel(
   if (element_size == 2) {
     return QkvToContext(prop, cublas, stream, batch_size, sequence_length, num_heads, head_size, element_size,
                         reinterpret_cast<const half*>(input),
+                        reinterpret_cast<const half*>(bias),
                         reinterpret_cast<half*>(output),
                         reinterpret_cast<half*>(workspace),
                         mask_index,
@@ -235,6 +251,7 @@ bool LaunchAttentionKernel(
   } else {
     return QkvToContext(prop, cublas, stream, batch_size, sequence_length, num_heads, head_size, element_size,
                         reinterpret_cast<const float*>(input),
+                        reinterpret_cast<const float*>(bias),
                         reinterpret_cast<float*>(output),
                         reinterpret_cast<float*>(workspace),
                         mask_index,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
@@ -37,6 +37,7 @@ bool LaunchAttentionKernel(
     int past_sequence_length,                  // Sequence length in past state
     bool is_unidirectional,                    // Whether there is unidirecitonal mask.
     const void* input,                         // Input tensor
+    const void* bias,                          // Bias tensor
     const int* mask_index,                     // Attention mask raw data or index. NULL means no mask.
     gsl::span<const int64_t> mask_index_dims,  // Mask index shape
     const void* past,                          // Past state input

--- a/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
@@ -259,11 +259,13 @@ Status DecoderAttention<T>::ComputeInternal(OpKernelContext* context) const {
                 has_key_padding_mask_)
   );
 
-  // calcualte q
+  // calculate q
   gemm_query_buffer_p = GetScratchBuffer<T>(batch_size * sequence_length * hidden_size * element_size);
   m = sequence_length * batch_size;
   n = hidden_size;
   k = hidden_size;
+
+  // TODO(tianleiwu): fuse bias and transpose
   // broadcast bias for query: (h2, S*B)
   CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
       cublas, CUBLAS_OP_N, CUBLAS_OP_N, n, m, 1, &one,

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -151,7 +151,9 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   } else {
     dequant_scale = input_scale * weight_scale;
   }
+
   // scale back and bias
+  // TODO(tianleiwu): fuse Dequantize with Add bias and Transpose.
   ORT_RETURN_IF_ERROR(CudaDequantizeWithBias(Stream(),
                                              gemm_buffer_quantized.get(),
                                              reinterpret_cast<const CudaT*>(bias->Data<T>()),
@@ -178,6 +180,7 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
           past_sequence_length,
           is_unidirectional_,
           reinterpret_cast<const void*>(gemm_buffer.get()),
+          nullptr,  // bias has been added
           nullptr == mask_index ? nullptr : mask_index->Data<int>(),
           nullptr == mask_index ? gsl::span<const int64_t>() : mask_index->Shape().GetDims(),
           nullptr == past_tensor ? nullptr : past_tensor->Data<T>(),


### PR DESCRIPTION
**Description**: In Attention, there is MatMul-->Add-->Transpose for Q/K/V. In previous implementation, Add bias and Transpose are in different kernels. This merges them into one cuda kernel to improve performance.

**Performance on T4**
Result on `Standard_NC4as_T4_v3` virtual machine (4 vcpus, 28 GiB memory), ubuntu 18.04, CUDA 11.0:
```
python -m onnxruntime.transformers.benchmark -m bert-base-cased -b 1 8 32 -s 8 32 128 -t 1000 -f fusion.csv -r result.csv -d detail.csv -c ./cache_models --onnx_dir ./onnx_models -o by_script -g -p fp16 -i 1
```

Latency (ms) | b1_s8 | b1_s32 | b1_s128 | b8_s8 | b8_s32 | b8_s128 | b32_s8 | b32_s32 | b32_s128
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before | 1.48 | 1.51 | 2.28 | 1.69 | 3.22 | 10.77 | 3.22 | 10.62 | 43.75
After | 1.44 | 1.47 | 2.19 | 1.65 | 3.10 | 10.23 | 3.10 | 10.11 | 41.96
Gain | 2.8% | 2.7% | 4.1% | 2.4% | 3.9% | 5.3% | 3.9% | 5.0% | 4.3%

**Performance on A100**
Result on `Standard_ND96asr_v4` virtual machine with NVIDIA A100-SXM4-40GB GPU.

Latency(ms) | b1_s8 | b1_s32 | b1_s128 | b8_s8 | b8_s32 | b8_s128 | b32_s8 | b32_s32 | b32_s128
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before | 1.15 | 1.22 | 1.31 | 1.16 | 1.28 | 2.41 | 1.27 | 2.26 | 6.70
After | 1.06 | 1.06 | 1.17 | 1.11 | 1.2 | 2.26 | 1.23 | 2.13 | 6.38
Gain | 8.5% | 15.1% | 12.0% | 4.5% | 6.7% | 6.6% | 3.3% | 6.1% | 5.0%
