### PR TITLE
Fix broken onnxruntime.ai/docs links

### DIFF
--- a/docs/onnxruntime_extensions.md
+++ b/docs/onnxruntime_extensions.md
@@ -24,7 +24,7 @@ ai.onnx.contrib;1;GPT2Tokenizer,
 In above operators config, `ai.onnx.contrib` is the domain name of operators in onnxruntime-extensions. We would parse this line to generate required operators in onnxruntime-extensions for build.
 
 ### Generate Operators Config
-To generate the **required_operators.config** file from model, please follow the guidance [Converting ONNX models to ORT format](https://onnxruntime.ai/docs/how-to/mobile/model-conversion.html).
+To generate the **required_operators.config** file from model, please follow the guidance [Converting ONNX models to ORT format](https://onnxruntime.ai/docs/reference/ort-format-models.html#convert-onnx-models-to-ort-format).
 
 If your model contains operators from onnxruntime-extensions, please add argument `--custom_op_library` and pass the path to **ortcustomops** shared library built following guidance [share library](https://github.com/microsoft/onnxruntime-extensions#the-share-library-for-non-python).
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -2287,7 +2287,7 @@ struct OrtApi {
   * Lifetime of the created allocator will be valid for the duration of the environment.
   * Returns an error if an allocator with the same ::OrtMemoryInfo is already registered.
   *
-  * See https://onnxruntime.ai/docs/reference/api/c-api.html for details.
+  * See https://onnxruntime.ai/docs/api/c/struct_ort_api.html for details.
   *
   * \param[in] env ::OrtEnv instance
   * \param[in] mem_info
@@ -2614,7 +2614,7 @@ struct OrtApi {
   *
   * Create the configuration of an arena that can eventually be used to define an arena based allocator's behavior.
   *
-  * Supported keys are (See https://onnxruntime.ai/docs/reference/api/c-api.html for details on what the
+  * Supported keys are (See https://onnxruntime.ai/docs/api/c/struct_ort_api.html for details on what the
   * following parameters mean and how to choose these values.):
   * "max_mem": Maximum memory that can be allocated by the arena based allocator.
   *  Use 0 for ORT to pick the best value. Default is 0.
@@ -2831,7 +2831,7 @@ struct OrtApi {
   * The behavior of this is exactly the same as OrtApi::CreateAndRegisterAllocator except
   * instead of ORT creating an allocator based on provided info, in this case
   * ORT uses the user-provided custom allocator.
-  * See https://onnxruntime.ai/docs/reference/api/c-api.html for details.
+  * See https://onnxruntime.ai/docs/api/c/struct_ort_api.html for details.
   *
   * \param[in] env
   * \param[in] allocator User provided allocator

--- a/java/build-android.gradle
+++ b/java/build-android.gradle
@@ -32,7 +32,7 @@ def mobileDescription = 'The ONNX Runtime Mobile package is a size optimized inf
 	'but with reduced disk footprint targeting mobile platforms. To minimize binary size this library supports a ' +
 	'reduced set of operators and types aligned to typical mobile applications. The ONNX model must be converted to ' +
 	'ORT format in order to use it with this package. ' +
-	'See https://onnxruntime.ai/docs/reference/ort-model-format.html for more details.'
+	'See https://onnxruntime.ai/docs/reference/ort-format-models.html for more details.'
 def defaultDescription = 'ONNX Runtime is a performance-focused inference engine for ONNX (Open Neural Network ' +
 	'Exchange) models. This package contains the Android (aar) build of ONNX Runtime. It includes support for all ' +
 	'types and operators, for ONNX format models. All standard ONNX models can be executed with this package. ' +

--- a/js/README.md
+++ b/js/README.md
@@ -300,7 +300,7 @@ It should be able to consumed by both from projects that uses NPM packages (thro
 
 #### Reduced WebAssembly artifacts
 
-By default, the WebAssembly artifacts from onnxruntime-web package allows use of both standard ONNX models (.onnx) and ORT format models (.ort). There is an option to use a minimal build of ONNX Runtime to reduce the binary size, which only supports ORT format models. See also [ORT format model](https://onnxruntime.ai/docs/tutorials/mobile/overview.html) for more information.
+By default, the WebAssembly artifacts from onnxruntime-web package allows use of both standard ONNX models (.onnx) and ORT format models (.ort). There is an option to use a minimal build of ONNX Runtime to reduce the binary size, which only supports ORT format models. See also [ORT format model](https://onnxruntime.ai/docs/tutorials/mobile/) for more information.
 
 #### Reduced JavaScript bundle file fize
 
@@ -339,7 +339,7 @@ This project provides an ONNX Runtime React Native JavaScript library to run ONN
 
 ### Models with ORT format
 
-By default, ONNX Runtime React Native leverages ONNX Runtime Mobile package with ORT format. Follow the [instruciton](https://onnxruntime.ai/docs/tutorials/mobile/model-conversion.html) to covert ONNX model to ORT format.
+By default, ONNX Runtime React Native leverages ONNX Runtime Mobile package with ORT format. Follow the [instructions](https://onnxruntime.ai/docs/reference/ort-format-models.html) to convert ONNX model to ORT format.
 
 ### Build
 

--- a/js/README.md
+++ b/js/README.md
@@ -300,7 +300,7 @@ It should be able to consumed by both from projects that uses NPM packages (thro
 
 #### Reduced WebAssembly artifacts
 
-By default, the WebAssembly artifacts from onnxruntime-web package allows use of both standard ONNX models (.onnx) and ORT format models (.ort). There is an option to use a minimal build of ONNX Runtime to reduce the binary size, which only supports ORT format models. See also [ORT format model](https://onnxruntime.ai/docs/tutorials/mobile/) for more information.
+By default, the WebAssembly artifacts from onnxruntime-web package allows use of both standard ONNX models (.onnx) and ORT format models (.ort). There is an option to use a minimal build of ONNX Runtime to reduce the binary size, which only supports ORT format models. See also [ORT format model](https://onnxruntime.ai/docs/reference/ort-format-models.html) for more information.
 
 #### Reduced JavaScript bundle file fize
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -175,7 +175,7 @@ def optimize_model(
 ):
     """Optimize Model by OnnxRuntime and/or python fusion logic.
 
-    ONNX Runtime has graph optimizations (https://onnxruntime.ai/docs/resources/graph-optimizations.html).
+    ONNX Runtime has graph optimizations (https://onnxruntime.ai/docs/performance/graph-optimizations.html).
     However, the coverage is limited. We also have graph fusions that implemented in Python to improve the coverage.
     They can combined: ONNX Runtime will run first when opt_level > 0, then graph fusions in Python will be applied.
 

--- a/onnxruntime/test/platform/ios/ios_package_test/README.md
+++ b/onnxruntime/test/platform/ios/ios_package_test/README.md
@@ -21,4 +21,4 @@ The iOS End-to-End Test App will use CocoaPods to install the Onnx Runtime C/C++
 
 ## Build and Test iOS Framework using [build.py](../../../../../tools/ci_build/build.py)
 
-Use the [build for iOS simulator]https://onnxruntime.ai/docs/build/ios.html#cross-compile-for-ios-simulator) with `--build_apple_framework`
+Use the [build for iOS simulator](https://onnxruntime.ai/docs/build/ios.html#cross-compile-for-ios-simulator) with `--build_apple_framework`

--- a/onnxruntime/test/platform/ios/ios_package_test/README.md
+++ b/onnxruntime/test/platform/ios/ios_package_test/README.md
@@ -4,7 +4,7 @@ This End-to-End test app for iOS will test ORT Mobile C/C++ API framework using 
 
 ## Requirements
 
-- [Prerequisites for building ORT-Mobile for iOS](https://onnxruntime.ai/docs/build/android-ios.html#prerequisites-1)
+- [Prerequisites for building ORT-Mobile for iOS](https://onnxruntime.ai/docs/build/ios.html#prerequisites)
 - [CocoaPods](https://cocoapods.org/)
 
 ## iOS End-to-End Test App Overview
@@ -14,11 +14,11 @@ The iOS End-to-End Test App will use CocoaPods to install the Onnx Runtime C/C++
 ### Model used
 - [sigmoid ONNX model](https://github.com/onnx/onnx/blob/f9b0cc99344869c246b8f4011b8586a39841284c/onnx/backend/test/data/node/test_sigmoid/model.onnx) converted to ORT format
 
-    Here's the [document](https://onnxruntime.ai/docs/tutorials/mobile/model-conversion.html) about how you can convert an ONNX model into ORT format.
+    Here's the [document](https://onnxruntime.ai/docs/reference/ort-format-models.html) about how you can convert an ONNX model into ORT format.
 
 ### Tests
 - [Tests for C++ API ](./ios_package_testUITests/ios_package_uitest_cpp_api.mm)
 
 ## Build and Test iOS Framework using [build.py](../../../../../tools/ci_build/build.py)
 
-Use the [build for iOS simulator](https://onnxruntime.ai/docs/build/android-ios.html#cross-build-for-ios-simulator) with `--build_apple_framework`
+Use the [build for iOS simulator]https://onnxruntime.ai/docs/build/ios.html#cross-compile-for-ios-simulator) with `--build_apple_framework`

--- a/tools/ci_build/reduce_op_kernels.py
+++ b/tools/ci_build/reduce_op_kernels.py
@@ -314,7 +314,7 @@ if __name__ == "__main__":
         type=str,
         help="Path to configuration file. "
         "Create with <ORT root>/tools/python/create_reduced_build_config.py and edit if needed. "
-        "See https://onnxruntime.ai/docs/reference/reduced-operator-config-file.html for more "
+        "See https://onnxruntime.ai/docs/reference/operators/reduced-operator-config-file.html for more "
         "information.",
     )
 


### PR DESCRIPTION
**Description**: Noticed some deprecated links across codebase that led to 404 errors in the onnxruntime.ai docs - went through and replaced broken links with working pages.

Links & Replacements: ([Old] => [New])
-  [Old] https://onnxruntime.ai/docs/how-to/mobile/model-conversion.html 
   [New] https://onnxruntime.ai/docs/reference/ort-format-models.html#convert-onnx-models-to-ort-format

-  [Old] https://onnxruntime.ai/docs/reference/api/c-api.html
    [New] https://onnxruntime.ai/docs/api/c/struct_ort_api.html

-  [Old] https://onnxruntime.ai/docs/resources/graph-optimizations.html
   [New] https://onnxruntime.ai/docs/performance/graph-optimizations.html

-  [Old] https://onnxruntime.ai/docs/build/android-ios.html#prerequisites
   [New] https://onnxruntime.ai/docs/build/ios.html#prerequisites

-  [Old] https://onnxruntime.ai/docs/build/android-ios.html#cross-build-for-ios-simulator
   [New] https://onnxruntime.ai/docs/build/ios.html#cross-compile-for-ios-simulator

-  [Old] https://onnxruntime.ai/docs/reference/reduced-operator-config-file.html 
   [New] https://onnxruntime.ai/docs/reference/operators/reduced-operator-config-file.html

**Motivation and Context**
- Why is this change required? What problem does it solve?
  - Users can now be correctly redirected to relevant documentation pages and avoid manually crawling
- If it fixes an open issue, please link to the issue here.
