### PR TITLE
Enable way to extract all parameters to and from a contiguous buffer.

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -48,6 +48,7 @@ def _pytorch_type_to_onnx(scalar_type: str) -> torch.onnx.TensorProtoDataType:
     except AttributeError:
         return _CAST_PYTORCH_TO_ONNX[scalar_type]
 
+
 # For pointer needed for PythonOp execution, we firstly append it into a global store to hold a
 # reference (in case it is released after module exported).
 NONTENSOR_OBJECT_POINTER_STORE = {}

--- a/orttraining/orttraining/test/training_api/core/training_api_tests.cc
+++ b/orttraining/orttraining/test/training_api/core/training_api_tests.cc
@@ -29,18 +29,83 @@ namespace {
 
 #define MODEL_FOLDER ORT_TSTR("testdata/training_api/")
 
-void GenerateRandomInput(gsl::span<const int64_t> dims, OrtValue& input) {
+void GenerateRandomData(std::vector<float>& data) {
   float scale = 1.f;
   float mean = 0.f;
   float seed = 123.f;
 
-  TensorShape shape(dims);
   std::default_random_engine generator_float{gsl::narrow_cast<uint32_t>(seed)};
   std::normal_distribution<float> distribution_float{mean, scale};
-  std::vector<float> data(shape.Size());
   std::for_each(data.begin(), data.end(),
                 [&generator_float, &distribution_float](float& value) { value = distribution_float(generator_float); });
+}
+
+void GenerateRandomInput(gsl::span<const int64_t> dims, OrtValue& input) {
+  TensorShape shape(dims);
+  std::vector<float> data(shape.Size());
+  GenerateRandomData(data);
   onnxruntime::training::api::utils::CreateInputOrtValue<float>(dims, data, &input);
+}
+
+TEST(TrainingApiTest, ModuleParametersSize) {
+  auto model_uri = MODEL_FOLDER "training_model.onnx";
+
+  onnxruntime::training::api::CheckpointState state;
+  auto checkpoint_to_load_path = MODEL_FOLDER "checkpoint.ckpt";
+  ASSERT_STATUS_OK(onnxruntime::training::api::LoadCheckpoint(checkpoint_to_load_path, state));
+
+  onnxruntime::SessionOptions session_option;
+  std::unique_ptr<Environment> env;
+  ASSERT_STATUS_OK(Environment::Create(nullptr, env));
+  auto model = std::make_unique<onnxruntime::training::api::Module>(ToUTF8String(model_uri),
+                                                                    state.module_checkpoint_state.named_parameters, session_option,
+                                                                    *env, std::vector<std::shared_ptr<IExecutionProvider>>());
+  size_t params_size;
+  for (auto& param : model->Parameters()) {
+    params_size += param->Data().Get<Tensor>().Shape().Size();
+  }
+
+  // ((500*784) + 500 + (10*500) + 10) = 397510
+  ASSERT_EQ(params_size, 397510);
+  ASSERT_EQ(model->GetParametersSize(), 397510);
+}
+
+TEST(TrainingApiTest, ModuleCopyBufferToParameters) {
+  auto model_uri = MODEL_FOLDER "training_model.onnx";
+
+  onnxruntime::training::api::CheckpointState state;
+  auto checkpoint_to_load_path = MODEL_FOLDER "checkpoint.ckpt";
+  ASSERT_STATUS_OK(onnxruntime::training::api::LoadCheckpoint(checkpoint_to_load_path, state));
+
+  onnxruntime::SessionOptions session_option;
+  std::unique_ptr<Environment> env;
+  ASSERT_STATUS_OK(Environment::Create(nullptr, env));
+  auto model = std::make_unique<onnxruntime::training::api::Module>(ToUTF8String(model_uri),
+                                                                    state.module_checkpoint_state.named_parameters, session_option,
+                                                                    *env, std::vector<std::shared_ptr<IExecutionProvider>>());
+  int64_t params_size = static_cast<int64_t>(model->GetParametersSize());
+  std::vector<float> expected_param_buffer(params_size);
+  GenerateRandomData(expected_param_buffer);
+
+  OrtValue input_params;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(),
+                       {params_size},
+                       reinterpret_cast<void*>(expected_param_buffer.data()),
+                       onnxruntime::test::TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault)->Info(),
+                       input_params, 0);
+  ASSERT_STATUS_OK(model->CopyBufferToParameters(input_params));
+
+  OrtValue output_params;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), {params_size},
+                       onnxruntime::test::TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault), 
+                       output_params);
+  ASSERT_STATUS_OK(model->CopyParametersToBuffer(output_params));
+
+  const float* buffer = output_params.Get<Tensor>().Data<float>();
+  ASSERT_TRUE(nullptr != buffer);
+  for (int64_t i = 0; i < params_size; i++) {
+    ASSERT_TRUE(*(buffer + i) == expected_param_buffer[i]);
+  }
 }
 
 TEST(TrainingApiTest, ModuleTrainStep) {

--- a/orttraining/orttraining/test/training_api/core/training_api_tests.cc
+++ b/orttraining/orttraining/test/training_api/core/training_api_tests.cc
@@ -60,7 +60,7 @@ TEST(TrainingApiTest, ModuleParametersSize) {
   auto model = std::make_unique<onnxruntime::training::api::Module>(ToUTF8String(model_uri),
                                                                     state.module_checkpoint_state.named_parameters, session_option,
                                                                     *env, std::vector<std::shared_ptr<IExecutionProvider>>());
-  size_t params_size;
+  size_t params_size=0;
   for (auto& param : model->Parameters()) {
     params_size += param->Data().Get<Tensor>().Shape().Size();
   }

--- a/orttraining/orttraining/training_api/include/module.h
+++ b/orttraining/orttraining/training_api/include/module.h
@@ -92,7 +92,7 @@ struct Module {
   size_t GetEvalModeOutputCount() const noexcept;
 
   // Return size of all parameters
-  size_t GetParametersSize(const bool trainable_only=true) const noexcept;
+  size_t GetParametersSize(const bool trainable_only=true) const;
 
   // Copy parameters onto contiguous buffer held by parameters_buffer
   Status CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only=true);

--- a/orttraining/orttraining/training_api/include/module.h
+++ b/orttraining/orttraining/training_api/include/module.h
@@ -91,6 +91,15 @@ struct Module {
   // Returns the output count for eval graph
   size_t GetEvalModeOutputCount() const noexcept;
 
+  // Return size of all parameters
+  size_t GetParametersSize(const bool trainable_only=true) const noexcept;
+
+  // Copy parameters onto contiguous buffer held by parameters_buffer
+  Status CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only=true);
+  
+  // Copy parameter values from contiguous buffer held by parameters_buffer onto parameters
+  Status CopyBufferToParameters(OrtValue& parameters_buffer, const bool trainable_only=true);
+
  private:
   std::unique_ptr<onnxruntime::InferenceSession> train_sess_{nullptr};
   std::unique_ptr<onnxruntime::InferenceSession> eval_sess_{nullptr};
@@ -98,6 +107,7 @@ struct Module {
   std::vector<std::string> train_output_names_;
   std::vector<std::string> eval_input_names_;
   std::vector<std::string> eval_output_names_;
+  std::vector<std::string> weight_names_;
   std::vector<OrtValue> weights_;
   std::vector<OrtValue> gradients_;
   bool accumulate_gradient_ = false;

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -252,7 +252,7 @@ struct OrtTrainingApi {
   *
   */
   ORT_API2_STATUS(CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only);
 
   /** \brief Copy parameter values from contiguous buffer held by parameters_buffer onto parameters
   *
@@ -271,7 +271,7 @@ struct OrtTrainingApi {
   *
   */
   ORT_API2_STATUS(CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only);
 
   /** \brief Frees up the memory used up by the training session.
   *

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -221,6 +221,54 @@ struct OrtTrainingApi {
   */
   ORT_API2_STATUS(SchedulerStep, _Inout_ OrtTrainingSession* sess);
 
+  /** \brief Retrieves the size of all the parameters.
+  *
+  * Calculates the size of all the parameters for the training session.
+  * When 'trainable_only' is true, the size is calculated for trainable params only.
+  *
+  * \param[in] sess The training session.
+  * \param[in] trainable_only Whether to skip non-trainable parameters
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(GetParametersSize, _Inout_ OrtTrainingSession* sess,
+                  _Out_ size_t* out, bool trainable_only);
+
+  /** \brief Copy parameters onto contiguous buffer held by parameters_buffer
+  *
+  * The parameters_buffer has to be of the size given by GetParametersSize api call,
+  * with matching setting for 'trainable_only'. The OrtValue must be pre-allocated onto
+  * the desired device. This is a complementary function to 'CopyBufferToParameters'.
+  * Parameter ordering is preserved.
+  *
+  * \param[in] sess The training session.
+  * \param[in] trainable_only Whether to skip non-trainable parameters
+  * \param[out] parameters_buffer The pre-allocated OrtValue buffer to copy onto.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+
+  /** \brief Copy parameter values from contiguous buffer held by parameters_buffer onto parameters
+  *
+  * The parameters_buffer has to be of the size given by GetParametersSize api call,
+  * with matching setting for 'trainable_only'. This is a complementary function to 'CopyBufferToParameters'
+  * and can be used to load updated buffer values onto the parameters. 
+  * Parameter ordering is preserved.
+  *
+  * \param[in] sess The training session.
+  * \param[in] trainable_only Whether to skip non-trainable parameters
+  * \param[out] parameters_buffer The pre-allocated OrtValue buffer to copy from.
+  *
+  * \snippet{doc} snippets.dox OrtStatus Return Value
+  *
+  */
+  ORT_API2_STATUS(CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+
   /** \brief Frees up the memory used up by the training session.
   *
   * This function frees up any memory that was allocated in the training session. The training

--- a/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
+++ b/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h
@@ -238,9 +238,11 @@ struct OrtTrainingApi {
   /** \brief Copy parameters onto contiguous buffer held by parameters_buffer
   *
   * The parameters_buffer has to be of the size given by GetParametersSize api call,
-  * with matching setting for 'trainable_only'. The OrtValue must be pre-allocated onto
+  * with matching setting for 'trainable_only'. All the target parameters must be of the same
+  * datatype. The OrtValue must be pre-allocated onto
   * the desired device. This is a complementary function to 'CopyBufferToParameters'.
   * Parameter ordering is preserved.
+  * User is responsible for allocating/freeing the 'parameters_buffer'.
   *
   * \param[in] sess The training session.
   * \param[in] trainable_only Whether to skip non-trainable parameters
@@ -255,9 +257,11 @@ struct OrtTrainingApi {
   /** \brief Copy parameter values from contiguous buffer held by parameters_buffer onto parameters
   *
   * The parameters_buffer has to be of the size given by GetParametersSize api call,
-  * with matching setting for 'trainable_only'. This is a complementary function to 'CopyBufferToParameters'
+  * with matching setting for 'trainable_only'. All the target parameters must be of the same
+  * datatype. This is a complementary function to 'CopyBufferToParameters'
   * and can be used to load updated buffer values onto the parameters. 
   * Parameter ordering is preserved.
+  * User is responsible for allocating/freeing the 'parameters_buffer'.
   *
   * \param[in] sess The training session.
   * \param[in] trainable_only Whether to skip non-trainable parameters

--- a/orttraining/orttraining/training_api/include/ort_training_apis.h
+++ b/orttraining/orttraining/training_api/include/ort_training_apis.h
@@ -43,10 +43,10 @@ ORT_API_STATUS_IMPL(GetParametersSize, _Inout_ OrtTrainingSession* sess,
                     _Out_ size_t* out, bool trainable_only);
 
 ORT_API_STATUS_IMPL(CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only);
 
 ORT_API_STATUS_IMPL(CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only);
 
 ORT_API(void, ReleaseCheckpointState, _Frees_ptr_opt_ OrtCheckpointState* session);
 

--- a/orttraining/orttraining/training_api/include/ort_training_apis.h
+++ b/orttraining/orttraining/training_api/include/ort_training_apis.h
@@ -9,7 +9,6 @@ ORT_API_STATUS_IMPL(CreateTrainingSession, _In_ const OrtEnv* env, _In_ const Or
                     _Inout_ OrtCheckpointState* checkpoint_state, _In_ const ORTCHAR_T* train_model_path,
                     _In_ const ORTCHAR_T* eval_model_path, _In_ const ORTCHAR_T* optimizer_model_path,
                     _Outptr_ OrtTrainingSession** out);
-ORT_API(void, ReleaseTrainingSession, _Frees_ptr_opt_ OrtTrainingSession* session);
 
 ORT_API_STATUS_IMPL(TrainingSessionGetTrainModeOutputCount, _In_ const OrtTrainingSession* sess, _Out_ size_t* out);
 
@@ -40,6 +39,17 @@ ORT_API_STATUS_IMPL(LoadCheckpoint, _In_ const ORTCHAR_T* checkpoint_path,
 ORT_API_STATUS_IMPL(SaveCheckpoint, _In_ const ORTCHAR_T* checkpoint_path, _In_ const OrtTrainingSession* session,
                     bool save_optimizer_state);
 
+ORT_API_STATUS_IMPL(GetParametersSize, _Inout_ OrtTrainingSession* sess,
+                    _Out_ size_t* out, bool trainable_only);
+
+ORT_API_STATUS_IMPL(CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+
+ORT_API_STATUS_IMPL(CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only);
+
 ORT_API(void, ReleaseCheckpointState, _Frees_ptr_opt_ OrtCheckpointState* session);
+
+ORT_API(void, ReleaseTrainingSession, _Frees_ptr_opt_ OrtTrainingSession* session);
 
 }  // namespace OrtTrainingApis

--- a/orttraining/orttraining/training_api/include/training_session.h
+++ b/orttraining/orttraining/training_api/include/training_session.h
@@ -57,7 +57,7 @@ class TrainingSession {
 
   Status CreateCheckpointState(CheckpointState& chkpt_state, bool save_optimizer_state) const;
 
-  size_t GetParametersSize(const bool trainable_only=true) const noexcept;
+  size_t GetParametersSize(const bool trainable_only=true) const;
 
   Status CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only=true);
   

--- a/orttraining/orttraining/training_api/include/training_session.h
+++ b/orttraining/orttraining/training_api/include/training_session.h
@@ -57,6 +57,12 @@ class TrainingSession {
 
   Status CreateCheckpointState(CheckpointState& chkpt_state, bool save_optimizer_state) const;
 
+  size_t GetParametersSize(const bool trainable_only=true) const noexcept;
+
+  Status CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only=true);
+  
+  Status CopyBufferToParameters(OrtValue& parameters_buffer, const bool trainable_only=true);
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(TrainingSession);
 

--- a/orttraining/orttraining/training_api/module.cc
+++ b/orttraining/orttraining/training_api/module.cc
@@ -138,6 +138,7 @@ Module::Module(const std::string& train_model_path_or_bytes,
     }
 
     weights_.push_back(param_data);
+    weight_names_.push_back(param_name);
 
     // Create gradient buffer when parameter requires gradient.
     if (params_iter->second->RequiresGrad()) {
@@ -194,12 +195,105 @@ size_t Module::GetEvalModeOutputCount() const noexcept {
   return eval_output_names_.size();
 }
 
+size_t Module::GetParametersSize(const bool trainable_only) const noexcept {
+  size_t parameters_size = 0;
+  for (auto& it : named_parameters_) {
+    if (trainable_only && !it.second->RequiresGrad()) {
+      continue;
+    }
+    parameters_size += it.second->Data().Get<Tensor>().Shape().Size();
+  }
+  return parameters_size;
+}
+
 std::vector<std::shared_ptr<Parameter>> Module::Parameters() const {
   std::vector<std::shared_ptr<Parameter>> params;
   for (auto& it : named_parameters_) {
     params.push_back(it.second);
   }
   return params;
+}
+
+Status Module::CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only) {
+  ORT_ENFORCE(parameters_buffer.IsAllocated(), "Parameters buffer should be pre-allocated.");
+  ORT_ENFORCE(parameters_buffer.IsTensor(), "Parameters buffer should of tensor type.");
+  auto* init_tensor = parameters_buffer.GetMutable<Tensor>();
+  ORT_ENFORCE(nullptr != init_tensor);
+  ORT_ENFORCE(init_tensor->Shape().Size() == static_cast<int64_t>(GetParametersSize(trainable_only)),
+              "Parameters buffer size incorrect.");
+
+  const DataTransferManager& sess_data_transfer_manager = train_sess_->GetDataTransferManager();
+
+  size_t offset = 0;
+  for (auto& param_name : weight_names_) {
+    auto& param = named_parameters_.at(param_name);
+    if (trainable_only && !param->RequiresGrad()) {
+      continue;
+    }
+    OrtValue& weight = param->Data();
+    auto* weight_tensor = weight.GetMutable<Tensor>();
+
+    const TensorShape& shape = weight_tensor->Shape();
+    auto element_type = init_tensor->DataType();
+    ORT_ENFORCE(weight_tensor->DataType() == element_type, "Data types must match.");
+
+    const OrtMemoryInfo& info = init_tensor->Location();
+    std::unique_ptr<Tensor> p_tensor;
+
+    if (onnxruntime::utils::IsPrimitiveDataType<float>(element_type)) {
+      float* data_buffer = init_tensor->MutableData<float>();
+      p_tensor = std::make_unique<Tensor>(element_type,
+                                          shape,
+                                          data_buffer + offset,
+                                          info);
+    } else {
+      ORT_THROW("Unsupported type: ", element_type);
+    }
+    ORT_THROW_IF_ERROR(sess_data_transfer_manager.CopyTensor(*weight_tensor, *p_tensor.get()));
+    offset += shape.Size();
+  }
+  return Status::OK();
+}
+
+Status Module::CopyBufferToParameters(OrtValue& parameters_buffer, const bool trainable_only) {
+  ORT_ENFORCE(parameters_buffer.IsAllocated(), "Parameters buffer should be pre-allocated.");
+  ORT_ENFORCE(parameters_buffer.IsTensor(), "Parameters buffer should of tensor type.");
+  auto* init_tensor = parameters_buffer.GetMutable<Tensor>();
+  ORT_ENFORCE(nullptr != init_tensor);
+  ORT_ENFORCE(init_tensor->Shape().Size() == static_cast<int64_t>(GetParametersSize(trainable_only)),
+              "Parameters buffer size incorrect.");
+
+  const DataTransferManager& sess_data_transfer_manager = train_sess_->GetDataTransferManager();
+
+  size_t offset = 0;
+  for (auto& param_name : weight_names_) {
+    auto& param = named_parameters_.at(param_name);
+    if (trainable_only && !param->RequiresGrad()) {
+      continue;
+    }
+    OrtValue& weight = param->Data();
+    auto* weight_tensor = weight.GetMutable<Tensor>();
+
+    const TensorShape& shape = weight_tensor->Shape();
+    auto element_type = init_tensor->DataType();
+    ORT_ENFORCE(weight_tensor->DataType() == element_type, "Data types must match.");
+
+    const OrtMemoryInfo& info = init_tensor->Location();
+    std::unique_ptr<Tensor> p_tensor;
+
+    if (onnxruntime::utils::IsPrimitiveDataType<float>(element_type)) {
+      float* data_buffer = init_tensor->MutableData<float>();
+      p_tensor = std::make_unique<Tensor>(element_type,
+                                          shape,
+                                          data_buffer + offset,
+                                          info);
+    } else {
+      ORT_THROW("Unsupported type: ", element_type);
+    }
+    ORT_THROW_IF_ERROR(sess_data_transfer_manager.CopyTensor(*p_tensor.get(), *weight_tensor));
+    offset += shape.Size();
+  }
+  return Status::OK();
 }
 
 Status Module::ResetGrad() {

--- a/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
+++ b/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
@@ -288,20 +288,26 @@ ORT_API_STATUS_IMPL(OrtTrainingApis::GetParametersSize, _Inout_ OrtTrainingSessi
 }
 
 ORT_API_STATUS_IMPL(OrtTrainingApis::CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only) {
   API_IMPL_BEGIN
+  if (parameters_buffer == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "parameters_buffer is null.");
+  }
   auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
-  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyParametersToBuffer(parameters_buffer, trainable_only));
+  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyParametersToBuffer(*parameters_buffer, trainable_only));
   
   return nullptr;
   API_IMPL_END
 }
 
 ORT_API_STATUS_IMPL(OrtTrainingApis::CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
-                    _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
+                    _Inout_ OrtValue* parameters_buffer, bool trainable_only) {
   API_IMPL_BEGIN
+  if (parameters_buffer == nullptr) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "parameters_buffer is null.");
+  }
   auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
-  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyBufferToParameters(parameters_buffer, trainable_only));
+  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyBufferToParameters(*parameters_buffer, trainable_only));
 
   return nullptr;
   API_IMPL_END

--- a/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
+++ b/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
@@ -278,6 +278,39 @@ ORT_API_STATUS_IMPL(OrtTrainingApis::SaveCheckpoint, _In_ const ORTCHAR_T* check
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtTrainingApis::GetParametersSize, _Inout_ OrtTrainingSession* sess,
+                    _Out_ size_t* out, bool trainable_only) {
+  API_IMPL_BEGIN
+  auto session = reinterpret_cast<const onnxruntime::training::api::TrainingSession*>(sess);
+  *out = session->GetParametersSize(trainable_only);
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtTrainingApis::CopyParametersToBuffer, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
+  API_IMPL_BEGIN
+  auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
+  Status status = session->CopyParametersToBuffer(parameters_buffer, trainable_only);
+
+  if (!status.IsOK())
+    return onnxruntime::ToOrtStatus(status);
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtTrainingApis::CopyBufferToParameters, _Inout_ OrtTrainingSession* sess,
+                    _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
+  API_IMPL_BEGIN
+  auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
+  Status status = session->CopyBufferToParameters(parameters_buffer, trainable_only);
+
+  if (!status.IsOK())
+    return onnxruntime::ToOrtStatus(status);
+  return nullptr;
+  API_IMPL_END
+}
+
 ORT_API(void, OrtTrainingApis::ReleaseTrainingSession, _Frees_ptr_opt_ OrtTrainingSession* session) {
   delete reinterpret_cast<onnxruntime::training::api::TrainingSession*>(session);
 }
@@ -299,6 +332,9 @@ static constexpr OrtTrainingApi ort_training_api = {
     &OrtTrainingApis::OptimizerStep,
     &OrtTrainingApis::RegisterLRScheduler,
     &OrtTrainingApis::SchedulerStep,
+    &OrtTrainingApis::GetParametersSize,
+    &OrtTrainingApis::CopyParametersToBuffer,
+    &OrtTrainingApis::CopyBufferToParameters,
     &OrtTrainingApis::ReleaseTrainingSession,
     &OrtTrainingApis::ReleaseCheckpointState,
 };

--- a/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
+++ b/orttraining/orttraining/training_api/onnxruntime_training_c_api.cc
@@ -291,10 +291,8 @@ ORT_API_STATUS_IMPL(OrtTrainingApis::CopyParametersToBuffer, _Inout_ OrtTraining
                     _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
-  Status status = session->CopyParametersToBuffer(parameters_buffer, trainable_only);
-
-  if (!status.IsOK())
-    return onnxruntime::ToOrtStatus(status);
+  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyParametersToBuffer(parameters_buffer, trainable_only));
+  
   return nullptr;
   API_IMPL_END
 }
@@ -303,10 +301,8 @@ ORT_API_STATUS_IMPL(OrtTrainingApis::CopyBufferToParameters, _Inout_ OrtTraining
                     _Inout_ OrtValue& parameters_buffer, bool trainable_only) {
   API_IMPL_BEGIN
   auto session = reinterpret_cast<onnxruntime::training::api::TrainingSession*>(sess);
-  Status status = session->CopyBufferToParameters(parameters_buffer, trainable_only);
+  ORT_API_RETURN_IF_STATUS_NOT_OK(session->CopyBufferToParameters(parameters_buffer, trainable_only));
 
-  if (!status.IsOK())
-    return onnxruntime::ToOrtStatus(status);
   return nullptr;
   API_IMPL_END
 }

--- a/orttraining/orttraining/training_api/training_session.cc
+++ b/orttraining/orttraining/training_api/training_session.cc
@@ -82,7 +82,7 @@ Status TrainingSession::SchedulerStep() noexcept {
   return scheduler_->Step();
 }
 
-size_t TrainingSession::GetParametersSize(const bool trainable_only) const noexcept {
+size_t TrainingSession::GetParametersSize(const bool trainable_only) const {
   return module_->GetParametersSize(trainable_only);
 }
 

--- a/orttraining/orttraining/training_api/training_session.cc
+++ b/orttraining/orttraining/training_api/training_session.cc
@@ -82,6 +82,18 @@ Status TrainingSession::SchedulerStep() noexcept {
   return scheduler_->Step();
 }
 
+size_t TrainingSession::GetParametersSize(const bool trainable_only) const noexcept {
+  return module_->GetParametersSize(trainable_only);
+}
+
+Status TrainingSession::CopyParametersToBuffer(OrtValue& parameters_buffer, const bool trainable_only) {
+  return module_->CopyParametersToBuffer(parameters_buffer, trainable_only);
+}
+
+Status TrainingSession::CopyBufferToParameters(OrtValue& parameters_buffer, const bool trainable_only) {
+  return module_->CopyBufferToParameters(parameters_buffer, trainable_only);
+}
+
 }  // namespace api
 }  // namespace training
 }  // namespace onnxruntime


### PR DESCRIPTION
Some scenarios like Federated Learning require extraction of parameters to and from a contiguous buffer. This PR adds the implementation and C APIs for the functions:
GetParametersSize
CopyParametersToBuffer
CopyBufferToParameters