### PR TITLE
Update mac-ci.yml to increase macOS build jobs' timeout value to 3 hours

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -13,7 +13,7 @@ jobs:
 - job: ${{ parameters.JobName }}
   workspace:
     clean: all
-  timeoutInMinutes:  300
+  timeoutInMinutes:  180
   pool:
     vmImage: 'macOS-11'
   variables:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -13,7 +13,7 @@ jobs:
 - job: ${{ parameters.JobName }}
   workspace:
     clean: all
-  timeoutInMinutes:  150
+  timeoutInMinutes:  300
   pool:
     vmImage: 'macOS-11'
   variables:


### PR DESCRIPTION
**Description**: 

Update mac-ci.yml to increase macOS build jobs' timeout value to 5 hours

**Motivation and Context**
- Why is this change required? What problem does it solve?

The current value is 150 minutes. But sometimes our build jobs run longer than that.  For example:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=727794&view=results

- If it fixes an open issue, please link to the issue here.
