### PR TITLE
replace 'master' branch ref to 'main' for onnx repo

### DIFF
--- a/docs/Reduced_Operator_Kernel_build.md
+++ b/docs/Reduced_Operator_Kernel_build.md
@@ -60,7 +60,7 @@ The opset can match either the opset import for each model, or the initial ONNX 
 e.g. if a model imports opset 12 of ONNX, all ONNX operators in that model can be listed under opset 12 for the 'ai.onnx' domain.
 
 [Netron](https://netron.app/) can be used to view an ONNX model properties to discover the opset imports.
-Additionally, the ONNX operator specs for [DNN](https://github.com/onnx/onnx/blob/master/docs/Operators.md) and [traditional ML](https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md) operators list the individual operator versions.
+Additionally, the ONNX operator specs for [DNN](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [traditional ML](https://github.com/onnx/onnx/blob/main/docs/Operators-ml.md) operators list the individual operator versions.
 
 ### Type reduction format
 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -22,7 +22,7 @@ models that are stamped with ONNX opset versions in the range [7-9].
 ### Version matrix
 The [table](https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support) summarizes the relationship between the ONNX Runtime version and the ONNX opset version implemented in that release.
 Please note the backward compatibility notes above.
-For more details on ONNX Release versions, see [this page](https://github.com/onnx/onnx/blob/master/docs/Versioning.md).
+For more details on ONNX Release versions, see [this page](https://github.com/onnx/onnx/blob/main/docs/Versioning.md).
 
 ## Tool Compatibility
 A variety of tools can be used to create ONNX models. Unless otherwise noted, please use the latest released version of the tools to convert/export the ONNX model. Most tools are backwards compatible and support multiple ONNX versions. Join this with the table above to evaluate ONNX Runtime compatibility.
@@ -40,4 +40,3 @@ A variety of tools can be used to create ONNX models. Unless otherwise noted, pl
 |[Paddle2ONNX](https://pypi.org/project/paddle2onnx/)| [Latest stable](https://github.com/PaddlePaddle/Paddle2ONNX/releases) | 1.6-1.9 |
 |[AutoML](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-automated-ml)|[1.0.39+](https://pypi.org/project/azureml-automl-core)|1.5|
 | |[1.0.33](https://pypi.org/project/azureml-automl-core/1.0.33/)|1.4|
-

--- a/docs/onnxruntime_extensions.md
+++ b/docs/onnxruntime_extensions.md
@@ -79,7 +79,7 @@ e2e_graph = helper.make_graph(
 )
 # ...
 ```
-For more usage of ONNX helper, please visit the document [Python API Overview](https://github.com/onnx/onnx/blob/master/docs/PythonAPIOverview.md).
+For more usage of ONNX helper, please visit the document [Python API Overview](https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md).
 
 ### Run E2E Model in Python
 ```python

--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -17,7 +17,7 @@ Load and run a model
 --------------------
 
 InferenceSession is the main class of ONNX Runtime. It is used to load and run an ONNX model,
-as well as specify environment and application configuration options. 
+as well as specify environment and application configuration options.
 
 .. code-block:: python
 
@@ -65,7 +65,7 @@ Data on CPU
 ^^^^^^^^^^^
 
 On CPU (the default), OrtValues can be mapped to and from native Python data structures: numpy arrays, dictionaries and lists of
-numpy arrays. 
+numpy arrays.
 
 .. code-block:: python
 
@@ -95,15 +95,15 @@ this called `IOBinding`.
 
 To use the `IOBinding` feature, replace `InferenceSession.run()` with `InferenceSession.run_with_iobinding()`.
 
-A graph is executed on a device other than CPU, for instance CUDA. Users can 
+A graph is executed on a device other than CPU, for instance CUDA. Users can
 use IOBinding to copy the data onto the GPU.
 
 .. code-block:: python
 
-	# X is numpy array on cpu 
+	# X is numpy array on cpu
 	session = onnxruntime.InferenceSession('model.onnx', providers=['CUDAExecutionProvider', 'CPUExecutionProvider']))
 	io_binding = session.io_binding()
-	# OnnxRuntime will copy the data over to the CUDA device if 'input' is consumed by nodes on the CUDA device 
+	# OnnxRuntime will copy the data over to the CUDA device if 'input' is consumed by nodes on the CUDA device
 	io_binding.bind_cpu_input('input', X)
 	io_binding.bind_output('output')
 	session.run_with_iobinding(io_binding)
@@ -122,7 +122,7 @@ The input data is on a device, users directly use the input. The output data is 
 	session.run_with_iobinding(io_binding)
 	Y = io_binding.copy_outputs_to_cpu()[0]
 
-The input data and output data are both on a device, users directly use the input and also place output on the device.	
+The input data and output data are both on a device, users directly use the input and also place output on the device.
 
 .. code-block:: python
 
@@ -284,7 +284,7 @@ Backend
 
 In addition to the regular API which is optimized for performance and usability, 
 *ONNX Runtime* also implements the
-`ONNX backend API <https://github.com/onnx/onnx/blob/master/docs/ImplementingAnOnnxBackend.md>`_
+`ONNX backend API <https://github.com/onnx/onnx/blob/main/docs/ImplementingAnOnnxBackend.md>`_
 for verification of *ONNX* specification conformance.
 The following functions are supported:
 

--- a/docs/python/inference/examples/plot_backend.py
+++ b/docs/python/inference/examples/plot_backend.py
@@ -8,8 +8,8 @@
 ONNX Runtime Backend for ONNX
 =============================
 
-*ONNX Runtime* extends the 
-`onnx backend API <https://github.com/onnx/onnx/blob/master/docs/ImplementingAnOnnxBackend.md>`_
+*ONNX Runtime* extends the
+`onnx backend API <https://github.com/onnx/onnx/blob/main/docs/ImplementingAnOnnxBackend.md>`_
 to run predictions using this runtime.
 Let's use the API to compute the prediction
 of a simple logistic regression model.

--- a/docs/python/inference/examples/plot_load_and_predict.py
+++ b/docs/python/inference/examples/plot_load_and_predict.py
@@ -19,7 +19,7 @@ from onnxruntime.datasets import get_example
 
 #########################
 # Let's load a very simple model.
-# The model is available on github `onnx...test_sigmoid <https://github.com/onnx/onnx/tree/master/onnx/backend/test/data/node/test_sigmoid>`_.
+# The model is available on github `onnx...test_sigmoid <https://github.com/onnx/onnx/blob/main/onnx/backend/test/data/node/test_sigmoid>`_.
 
 example1 = get_example("sigmoid.onnx")
 sess = rt.InferenceSession(example1, providers=rt.get_available_providers())

--- a/docs/python/inference/examples/plot_pipeline.py
+++ b/docs/python/inference/examples/plot_pipeline.py
@@ -6,7 +6,7 @@ Draw a pipeline
 ===============
 
 There is no other way to look into one model stored
-in ONNX format than looking into its node with 
+in ONNX format than looking into its node with
 *onnx*. This example demonstrates
 how to draw a model and to retrieve it in *json*
 format.
@@ -34,7 +34,7 @@ print(model)
 #################################
 # Draw a model with ONNX
 # ++++++++++++++++++++++
-# We use `net_drawer.py <https://github.com/onnx/onnx/blob/master/onnx/tools/net_drawer.py>`_
+# We use `net_drawer.py <https://github.com/onnx/onnx/blob/main/onnx/tools/net_drawer.py>`_
 # included in *onnx* package.
 # We use *onnx* to load the model
 # in a different way than before.

--- a/java/src/test/java/ai/onnxruntime/OnnxMl.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxMl.java
@@ -24951,7 +24951,7 @@ public final class OnnxMl {
        * Standard denotation can optionally be used to denote tensor
        * dimensions with standard semantic descriptions to ensure
        * that operations are applied to the correct axis of a tensor.
-       * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+       * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
        * for pre-defined dimension denotations.
        * </pre>
        *
@@ -24965,7 +24965,7 @@ public final class OnnxMl {
        * Standard denotation can optionally be used to denote tensor
        * dimensions with standard semantic descriptions to ensure
        * that operations are applied to the correct axis of a tensor.
-       * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+       * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
        * for pre-defined dimension denotations.
        * </pre>
        *
@@ -25177,7 +25177,7 @@ public final class OnnxMl {
        * Standard denotation can optionally be used to denote tensor
        * dimensions with standard semantic descriptions to ensure
        * that operations are applied to the correct axis of a tensor.
-       * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+       * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
        * for pre-defined dimension denotations.
        * </pre>
        *
@@ -25201,7 +25201,7 @@ public final class OnnxMl {
        * Standard denotation can optionally be used to denote tensor
        * dimensions with standard semantic descriptions to ensure
        * that operations are applied to the correct axis of a tensor.
-       * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+       * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
        * for pre-defined dimension denotations.
        * </pre>
        *
@@ -25742,7 +25742,7 @@ public final class OnnxMl {
          * Standard denotation can optionally be used to denote tensor
          * dimensions with standard semantic descriptions to ensure
          * that operations are applied to the correct axis of a tensor.
-         * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+         * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
          * for pre-defined dimension denotations.
          * </pre>
          *
@@ -25766,7 +25766,7 @@ public final class OnnxMl {
          * Standard denotation can optionally be used to denote tensor
          * dimensions with standard semantic descriptions to ensure
          * that operations are applied to the correct axis of a tensor.
-         * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+         * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
          * for pre-defined dimension denotations.
          * </pre>
          *
@@ -25790,7 +25790,7 @@ public final class OnnxMl {
          * Standard denotation can optionally be used to denote tensor
          * dimensions with standard semantic descriptions to ensure
          * that operations are applied to the correct axis of a tensor.
-         * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+         * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
          * for pre-defined dimension denotations.
          * </pre>
          *
@@ -25812,7 +25812,7 @@ public final class OnnxMl {
          * Standard denotation can optionally be used to denote tensor
          * dimensions with standard semantic descriptions to ensure
          * that operations are applied to the correct axis of a tensor.
-         * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+         * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
          * for pre-defined dimension denotations.
          * </pre>
          *
@@ -25831,7 +25831,7 @@ public final class OnnxMl {
          * Standard denotation can optionally be used to denote tensor
          * dimensions with standard semantic descriptions to ensure
          * that operations are applied to the correct axis of a tensor.
-         * Refer to https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+         * Refer to https://github.com/onnx/onnx/blob/main/docs/DimensionDenotation.md#denotation-definition
          * for pre-defined dimension denotations.
          * </pre>
          *
@@ -26657,7 +26657,7 @@ public final class OnnxMl {
      * <pre>
      * An optional denotation can be used to denote the whole
      * type with a standard semantic description as to what is
-     * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+     * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
      * for pre-defined type denotations.
      * </pre>
      *
@@ -26670,7 +26670,7 @@ public final class OnnxMl {
      * <pre>
      * An optional denotation can be used to denote the whole
      * type with a standard semantic description as to what is
-     * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+     * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
      * for pre-defined type denotations.
      * </pre>
      *
@@ -30755,7 +30755,7 @@ public final class OnnxMl {
      * <pre>
      * An optional denotation can be used to denote the whole
      * type with a standard semantic description as to what is
-     * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+     * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
      * for pre-defined type denotations.
      * </pre>
      *
@@ -30778,7 +30778,7 @@ public final class OnnxMl {
      * <pre>
      * An optional denotation can be used to denote the whole
      * type with a standard semantic description as to what is
-     * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+     * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
      * for pre-defined type denotations.
      * </pre>
      *
@@ -32122,7 +32122,7 @@ public final class OnnxMl {
        * <pre>
        * An optional denotation can be used to denote the whole
        * type with a standard semantic description as to what is
-       * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+       * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
        * for pre-defined type denotations.
        * </pre>
        *
@@ -32145,7 +32145,7 @@ public final class OnnxMl {
        * <pre>
        * An optional denotation can be used to denote the whole
        * type with a standard semantic description as to what is
-       * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+       * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
        * for pre-defined type denotations.
        * </pre>
        *
@@ -32168,7 +32168,7 @@ public final class OnnxMl {
        * <pre>
        * An optional denotation can be used to denote the whole
        * type with a standard semantic description as to what is
-       * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+       * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
        * for pre-defined type denotations.
        * </pre>
        *
@@ -32189,7 +32189,7 @@ public final class OnnxMl {
        * <pre>
        * An optional denotation can be used to denote the whole
        * type with a standard semantic description as to what is
-       * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+       * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
        * for pre-defined type denotations.
        * </pre>
        *
@@ -32207,7 +32207,7 @@ public final class OnnxMl {
        * <pre>
        * An optional denotation can be used to denote the whole
        * type with a standard semantic description as to what is
-       * stored inside. Refer to https://github.com/onnx/onnx/blob/master/docs/TypeDenotation.md#type-denotation-definition
+       * stored inside. Refer to https://github.com/onnx/onnx/blob/main/docs/TypeDenotation.md#type-denotation-definition
        * for pre-defined type denotations.
        * </pre>
        *

--- a/js/web/README.md
+++ b/js/web/README.md
@@ -46,11 +46,11 @@ Refer to the following links for development information:
 
 #### WebAssembly backend
 
-ONNX Runtime Web currently support all operators in [ai.onnx](https://github.com/onnx/onnx/blob/master/docs/Operators.md) and [ai.onnx.ml](https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md).
+ONNX Runtime Web currently support all operators in [ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md) and [ai.onnx.ml](https://github.com/onnx/onnx/blob/main/docs/Operators-ml.md).
 
 #### WebGL backend
 
-ONNX Runtime Web currently supports a subset of operators in [ai.onnx](https://github.com/onnx/onnx/blob/master/docs/Operators.md) operator set. See [operators.md](./docs/operators.md) for a complete, detailed list of which ONNX operators are supported by WebGL backend.
+ONNX Runtime Web currently supports a subset of operators in [ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md) operator set. See [operators.md](./docs/operators.md) for a complete, detailed list of which ONNX operators are supported by WebGL backend.
 
 ## License
 

--- a/js/web/docs/operators.md
+++ b/js/web/docs/operators.md
@@ -1,6 +1,6 @@
 ## Operators Support Table
 
-The following table shows [ai.onnx](https://github.com/onnx/onnx/blob/master/docs/Operators.md)  operators from which onnx opset version are currently supported by ONNX Runtime Web. For example, `4-6, 8+` means  ONNX Runtime Web currently support opset version 4 to 6, 8 and above.
+The following table shows [ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md)  operators from which onnx opset version are currently supported by ONNX Runtime Web. For example, `4-6, 8+` means  ONNX Runtime Web currently support opset version 4 to 6, 8 and above.
 
 See [Compatibility](../README.md#Compatibility) for a list of the supported platforms.
 
@@ -8,181 +8,181 @@ See [Compatibility](../README.md#Compatibility) for a list of the supported plat
 
 | Operator | WebGl Backend |
 |:--------:|:-------------:|
-| [Abs](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Abs) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Abs-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Abs-13) |
-| [Acos](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Acos) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Acos-7) |
-| [Acosh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Acosh) |  |
-| [Add](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Add) | [7-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Add-7), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Add-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Add-14) |
-| [And](https://github.com/onnx/onnx/blob/master/docs/Operators.md#And) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#And-7) |
-| [ArgMax](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ArgMax) |  |
-| [ArgMin](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ArgMin) |  |
-| [Asin](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Asin) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Asin-7) |
-| [Asinh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Asinh) |  |
-| [Atan](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Atan) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Atan-7) |
-| [Atanh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Atanh) |  |
-| [AveragePool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#AveragePool) | [7-9](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#AveragePool-7), [10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#AveragePool-10), [11+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#AveragePool-11) |
-| [BatchNormalization](https://github.com/onnx/onnx/blob/master/docs/Operators.md#BatchNormalization) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-7), [9-13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-9), [14](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-14), [15+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-15) |
-| [Bernoulli](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Bernoulli) |  |
-| [BitShift](https://github.com/onnx/onnx/blob/master/docs/Operators.md#BitShift) |  |
-| [BlackmanWindow](https://github.com/onnx/onnx/blob/master/docs/Operators.md#BlackmanWindow) |  |
-| [Cast](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cast) | [6-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Cast-6), [9-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Cast-9), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Cast-13) |
-| [CastLike](https://github.com/onnx/onnx/blob/master/docs/Operators.md#CastLike) |  |
-| [Ceil](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Ceil) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Ceil-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Ceil-13) |
-| [Celu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Celu) |  |
-| [Clip](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Clip) | [6-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Clip-6), [11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Clip-11), [12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Clip-12), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Clip-13) |
-| [Compress](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Compress) |  |
-| [Concat](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Concat) | [4-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Concat-4), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Concat-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Concat-13) |
-| [ConcatFromSequence](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConcatFromSequence) |  |
-| [Constant](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Constant) |  |
-| [ConstantOfShape](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConstantOfShape) |  |
-| [Conv](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Conv-1), [11+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Conv-11) |
-| [ConvInteger](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConvInteger) |  |
-| [ConvTranspose](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConvTranspose) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ConvTranspose-1), [11+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ConvTranspose-11) |
-| [Cos](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cos) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Cos-7) |
-| [Cosh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Cosh) |  |
-| [CumSum](https://github.com/onnx/onnx/blob/master/docs/Operators.md#CumSum) |  |
-| [DFT](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DFT) |  |
-| [DepthToSpace](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DepthToSpace) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#DepthToSpace-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#DepthToSpace-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#DepthToSpace-13) |
-| [DequantizeLinear](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DequantizeLinear) |  |
-| [Det](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Det) |  |
-| [Div](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Div) | [7-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Div-7), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Div-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Div-14) |
-| [Dropout](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Dropout) | [7-9](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Dropout-7), [10-11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Dropout-10), [12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Dropout-12), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Dropout-13) |
-| [DynamicQuantizeLinear](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DynamicQuantizeLinear) |  |
-| [Einsum](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Einsum) |  |
-| [Elu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Elu) | [6+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Elu-6) |
-| [Equal](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Equal) | [7-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Equal-7), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Equal-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Equal-13) |
-| [Erf](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Erf) |  |
-| [Exp](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Exp) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Exp-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Exp-13) |
-| [Expand](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Expand) |  |
-| [EyeLike](https://github.com/onnx/onnx/blob/master/docs/Operators.md#EyeLike) |  |
-| [Flatten](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Flatten) | [1-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Flatten-1), [9-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Flatten-9), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Flatten-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Flatten-13) |
-| [Floor](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Floor) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Floor-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Floor-13) |
-| [GRU](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GRU) |  |
-| [Gather](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Gather) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gather-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gather-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gather-13) |
-| [GatherElements](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GatherElements) |  |
-| [GatherND](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GatherND) |  |
-| [Gemm](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Gemm) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gemm-7), [9-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gemm-9), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gemm-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gemm-13) |
-| [GlobalAveragePool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GlobalAveragePool) | [1+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#GlobalAveragePool-1) |
-| [GlobalLpPool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GlobalLpPool) |  |
-| [GlobalMaxPool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GlobalMaxPool) | [1+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#GlobalMaxPool-1) |
-| [Greater](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Greater) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Greater-7), [9-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Greater-9), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Greater-13) |
-| [GreaterOrEqual](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GreaterOrEqual) |  |
-| [GridSample](https://github.com/onnx/onnx/blob/master/docs/Operators.md#GridSample) |  |
-| [HammingWindow](https://github.com/onnx/onnx/blob/master/docs/Operators.md#HammingWindow) |  |
-| [HannWindow](https://github.com/onnx/onnx/blob/master/docs/Operators.md#HannWindow) |  |
-| [HardSigmoid](https://github.com/onnx/onnx/blob/master/docs/Operators.md#HardSigmoid) |  |
-| [HardSwish](https://github.com/onnx/onnx/blob/master/docs/Operators.md#HardSwish) |  |
-| [Hardmax](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Hardmax) |  |
-| [Identity](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Identity) | [1-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Identity-1), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Identity-13), [14-15](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Identity-14), [16+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Identity-16) |
-| [If](https://github.com/onnx/onnx/blob/master/docs/Operators.md#If) |  |
-| [InstanceNormalization](https://github.com/onnx/onnx/blob/master/docs/Operators.md#InstanceNormalization) | [6+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#InstanceNormalization-6) |
-| [IsInf](https://github.com/onnx/onnx/blob/master/docs/Operators.md#IsInf) |  |
-| [IsNaN](https://github.com/onnx/onnx/blob/master/docs/Operators.md#IsNaN) |  |
-| [LRN](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LRN) |  |
-| [LSTM](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LSTM) |  |
-| [LayerNormalization](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LayerNormalization) |  |
-| [LeakyRelu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LeakyRelu) | [6-15](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#LeakyRelu-6), [16+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#LeakyRelu-16) |
-| [Less](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Less) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Less-7), [9-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Less-9), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Less-13) |
-| [LessOrEqual](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LessOrEqual) |  |
-| [Log](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Log) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Log-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Log-13) |
-| [LogSoftmax](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LogSoftmax) |  |
-| [Loop](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Loop) |  |
-| [LpNormalization](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LpNormalization) |  |
-| [LpPool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#LpPool) |  |
-| [MatMul](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MatMul) | [1-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MatMul-1), [9-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MatMul-9), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MatMul-13) |
-| [MatMulInteger](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MatMulInteger) |  |
-| [Max](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Max) |  |
-| [MaxPool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MaxPool) | [1-7](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MaxPool-1), [8-9](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MaxPool-8), [10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MaxPool-10), [11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MaxPool-11), [12+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#MaxPool-12) |
-| [MaxRoiPool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MaxRoiPool) |  |
-| [MaxUnpool](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MaxUnpool) |  |
-| [Mean](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Mean) |  |
-| [MeanVarianceNormalization](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MeanVarianceNormalization) |  |
-| [MelWeightMatrix](https://github.com/onnx/onnx/blob/master/docs/Operators.md#MelWeightMatrix) |  |
-| [Min](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Min) |  |
-| [Mod](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Mod) |  |
-| [Mul](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Mul) | [7-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Mul-7), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Mul-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Mul-14) |
-| [Multinomial](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Multinomial) |  |
-| [Neg](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Neg) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Neg-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Neg-13) |
-| [NegativeLogLikelihoodLoss](https://github.com/onnx/onnx/blob/master/docs/Operators.md#NegativeLogLikelihoodLoss) |  |
-| [NonMaxSuppression](https://github.com/onnx/onnx/blob/master/docs/Operators.md#NonMaxSuppression) |  |
-| [NonZero](https://github.com/onnx/onnx/blob/master/docs/Operators.md#NonZero) |  |
-| [Not](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Not) | [1+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Not-1) |
-| [OneHot](https://github.com/onnx/onnx/blob/master/docs/Operators.md#OneHot) |  |
-| [Optional](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Optional) |  |
-| [OptionalGetElement](https://github.com/onnx/onnx/blob/master/docs/Operators.md#OptionalGetElement) |  |
-| [OptionalHasElement](https://github.com/onnx/onnx/blob/master/docs/Operators.md#OptionalHasElement) |  |
-| [Or](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Or) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Or-7) |
-| [PRelu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#PRelu) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#PRelu-7), [9-15](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#PRelu-9), [16+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#PRelu-16) |
-| [Pad](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Pad) | [2-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pad-2), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pad-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pad-13) |
-| [Pow](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Pow) | [7-11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pow-7), [12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pow-12), [13-14](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pow-13), [15+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Pow-15) |
-| [QLinearConv](https://github.com/onnx/onnx/blob/master/docs/Operators.md#QLinearConv) |  |
-| [QLinearMatMul](https://github.com/onnx/onnx/blob/master/docs/Operators.md#QLinearMatMul) |  |
-| [QuantizeLinear](https://github.com/onnx/onnx/blob/master/docs/Operators.md#QuantizeLinear) |  |
-| [RNN](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RNN) |  |
-| [RandomNormal](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RandomNormal) |  |
-| [RandomNormalLike](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RandomNormalLike) |  |
-| [RandomUniform](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RandomUniform) |  |
-| [RandomUniformLike](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RandomUniformLike) |  |
-| [Range](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Range) |  |
-| [Reciprocal](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Reciprocal) |  |
-| [ReduceL1](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceL1) |  |
-| [ReduceL2](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceL2) |  |
-| [ReduceLogSum](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceLogSum) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceLogSum-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceLogSum-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceLogSum-13) |
-| [ReduceLogSumExp](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceLogSumExp) |  |
-| [ReduceMax](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceMax) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMax-1), [11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMax-11), [12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMax-12), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMax-13) |
-| [ReduceMean](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceMean) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMean-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMean-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMean-13) |
-| [ReduceMin](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceMin) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMin-1), [11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMin-11), [12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMin-12), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceMin-13) |
-| [ReduceProd](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceProd) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceProd-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceProd-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceProd-13) |
-| [ReduceSum](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceSum) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceSum-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceSum-11) |
-| [ReduceSumSquare](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReduceSumSquare) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceSumSquare-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceSumSquare-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ReduceSumSquare-13) |
-| [Relu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Relu) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Relu-6), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Relu-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Relu-14) |
-| [Reshape](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Reshape) | [5-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Reshape-5), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Reshape-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Reshape-14) |
-| [Resize](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Resize) | [10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Resize-10), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Resize-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Resize-13) |
-| [ReverseSequence](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ReverseSequence) |  |
-| [RoiAlign](https://github.com/onnx/onnx/blob/master/docs/Operators.md#RoiAlign) |  |
-| [Round](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Round) |  |
-| [STFT](https://github.com/onnx/onnx/blob/master/docs/Operators.md#STFT) |  |
-| [Scan](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Scan) |  |
-| [Scatter](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Scatter) |  |
-| [ScatterElements](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ScatterElements) |  |
-| [ScatterND](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ScatterND) |  |
-| [Selu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Selu) |  |
-| [SequenceAt](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceAt) |  |
-| [SequenceConstruct](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceConstruct) |  |
-| [SequenceEmpty](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceEmpty) |  |
-| [SequenceErase](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceErase) |  |
-| [SequenceInsert](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceInsert) |  |
-| [SequenceLength](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceLength) |  |
-| [SequenceMap](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SequenceMap) |  |
-| [Shape](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shape) | [1-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Shape-1), [13-14](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Shape-13), [15+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Shape-15) |
-| [Shrink](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shrink) |  |
-| [Sigmoid](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sigmoid) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sigmoid-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sigmoid-13) |
-| [Sign](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sign) |  |
-| [Sin](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sin) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sin-7) |
-| [Sinh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sinh) |  |
-| [Size](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Size) |  |
-| [Slice](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Slice) | [1-9](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Slice-1), [10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Slice-10), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Slice-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Slice-13) |
-| [Softmax](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-13) |
-| [SoftmaxCrossEntropyLoss](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SoftmaxCrossEntropyLoss) |  |
-| [Softplus](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softplus) |  |
-| [Softsign](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softsign) |  |
-| [SpaceToDepth](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SpaceToDepth) |  |
-| [Split](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Split) | [2-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Split-2), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Split-11) |
-| [SplitToSequence](https://github.com/onnx/onnx/blob/master/docs/Operators.md#SplitToSequence) |  |
-| [Sqrt](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sqrt) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sqrt-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sqrt-13) |
-| [Squeeze](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Squeeze) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Squeeze-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Squeeze-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Squeeze-13) |
-| [StringNormalizer](https://github.com/onnx/onnx/blob/master/docs/Operators.md#StringNormalizer) |  |
-| [Sub](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sub) | [7-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sub-7), [13](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sub-13), [14+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sub-14) |
-| [Sum](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Sum) | [6-7](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sum-6), [8-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sum-8), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Sum-13) |
-| [Tan](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Tan) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Tan-7) |
-| [Tanh](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Tanh) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Tanh-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Tanh-13) |
-| [TfIdfVectorizer](https://github.com/onnx/onnx/blob/master/docs/Operators.md#TfIdfVectorizer) |  |
-| [ThresholdedRelu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ThresholdedRelu) |  |
-| [Tile](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Tile) | [6-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Tile-6), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Tile-13) |
-| [TopK](https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK) |  |
-| [Transpose](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Transpose) | [1-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Transpose-1), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Transpose-13) |
-| [Trilu](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Trilu) |  |
-| [Unique](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Unique) |  |
-| [Unsqueeze](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Unsqueeze) | [1-10](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Unsqueeze-1), [11-12](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Unsqueeze-11), [13+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Unsqueeze-13) |
-| [Upsample](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Upsample) | [7-8](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Upsample-7), [9](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Upsample-9) |
-| [Where](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where) |  |
-| [Xor](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Xor) | [7+](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Xor-7) |
+| [Abs](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Abs) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Abs-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Abs-13) |
+| [Acos](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Acos) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Acos-7) |
+| [Acosh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Acosh) |  |
+| [Add](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Add) | [7-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Add-7), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Add-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Add-14) |
+| [And](https://github.com/onnx/onnx/blob/main/docs/Operators.md#And) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#And-7) |
+| [ArgMax](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ArgMax) |  |
+| [ArgMin](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ArgMin) |  |
+| [Asin](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Asin) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Asin-7) |
+| [Asinh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Asinh) |  |
+| [Atan](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Atan) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Atan-7) |
+| [Atanh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Atanh) |  |
+| [AveragePool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#AveragePool) | [7-9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-7), [10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-10), [11+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#AveragePool-11) |
+| [BatchNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BatchNormalization) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-7), [9-13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-9), [14](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-14), [15+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#BatchNormalization-15) |
+| [Bernoulli](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Bernoulli) |  |
+| [BitShift](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BitShift) |  |
+| [BlackmanWindow](https://github.com/onnx/onnx/blob/main/docs/Operators.md#BlackmanWindow) |  |
+| [Cast](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Cast) | [6-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cast-6), [9-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cast-9), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cast-13) |
+| [CastLike](https://github.com/onnx/onnx/blob/main/docs/Operators.md#CastLike) |  |
+| [Ceil](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Ceil) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Ceil-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Ceil-13) |
+| [Celu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Celu) |  |
+| [Clip](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Clip) | [6-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Clip-6), [11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Clip-11), [12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Clip-12), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Clip-13) |
+| [Compress](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Compress) |  |
+| [Concat](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Concat) | [4-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Concat-4), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Concat-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Concat-13) |
+| [ConcatFromSequence](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConcatFromSequence) |  |
+| [Constant](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Constant) |  |
+| [ConstantOfShape](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConstantOfShape) |  |
+| [Conv](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Conv) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Conv-1), [11+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Conv-11) |
+| [ConvInteger](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvInteger) |  |
+| [ConvTranspose](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConvTranspose-1), [11+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConvTranspose-11) |
+| [Cos](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Cos) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Cos-7) |
+| [Cosh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Cosh) |  |
+| [CumSum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#CumSum) |  |
+| [DFT](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DFT) |  |
+| [DepthToSpace](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DepthToSpace) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#DepthToSpace-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#DepthToSpace-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#DepthToSpace-13) |
+| [DequantizeLinear](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DequantizeLinear) |  |
+| [Det](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Det) |  |
+| [Div](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Div) | [7-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Div-7), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Div-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Div-14) |
+| [Dropout](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Dropout) | [7-9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Dropout-7), [10-11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Dropout-10), [12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Dropout-12), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Dropout-13) |
+| [DynamicQuantizeLinear](https://github.com/onnx/onnx/blob/main/docs/Operators.md#DynamicQuantizeLinear) |  |
+| [Einsum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Einsum) |  |
+| [Elu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Elu) | [6+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Elu-6) |
+| [Equal](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Equal) | [7-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Equal-7), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Equal-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Equal-13) |
+| [Erf](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Erf) |  |
+| [Exp](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Exp) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Exp-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Exp-13) |
+| [Expand](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Expand) |  |
+| [EyeLike](https://github.com/onnx/onnx/blob/main/docs/Operators.md#EyeLike) |  |
+| [Flatten](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Flatten) | [1-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Flatten-1), [9-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Flatten-9), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Flatten-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Flatten-13) |
+| [Floor](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Floor) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Floor-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Floor-13) |
+| [GRU](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GRU) |  |
+| [Gather](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gather) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gather-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gather-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gather-13) |
+| [GatherElements](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GatherElements) |  |
+| [GatherND](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GatherND) |  |
+| [Gemm](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gemm) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gemm-7), [9-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gemm-9), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gemm-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Gemm-13) |
+| [GlobalAveragePool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GlobalAveragePool) | [1+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#GlobalAveragePool-1) |
+| [GlobalLpPool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GlobalLpPool) |  |
+| [GlobalMaxPool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GlobalMaxPool) | [1+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#GlobalMaxPool-1) |
+| [Greater](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Greater) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Greater-7), [9-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Greater-9), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Greater-13) |
+| [GreaterOrEqual](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GreaterOrEqual) |  |
+| [GridSample](https://github.com/onnx/onnx/blob/main/docs/Operators.md#GridSample) |  |
+| [HammingWindow](https://github.com/onnx/onnx/blob/main/docs/Operators.md#HammingWindow) |  |
+| [HannWindow](https://github.com/onnx/onnx/blob/main/docs/Operators.md#HannWindow) |  |
+| [HardSigmoid](https://github.com/onnx/onnx/blob/main/docs/Operators.md#HardSigmoid) |  |
+| [HardSwish](https://github.com/onnx/onnx/blob/main/docs/Operators.md#HardSwish) |  |
+| [Hardmax](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Hardmax) |  |
+| [Identity](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Identity) | [1-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Identity-1), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Identity-13), [14-15](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Identity-14), [16+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Identity-16) |
+| [If](https://github.com/onnx/onnx/blob/main/docs/Operators.md#If) |  |
+| [InstanceNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#InstanceNormalization) | [6+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#InstanceNormalization-6) |
+| [IsInf](https://github.com/onnx/onnx/blob/main/docs/Operators.md#IsInf) |  |
+| [IsNaN](https://github.com/onnx/onnx/blob/main/docs/Operators.md#IsNaN) |  |
+| [LRN](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LRN) |  |
+| [LSTM](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LSTM) |  |
+| [LayerNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LayerNormalization) |  |
+| [LeakyRelu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LeakyRelu) | [6-15](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#LeakyRelu-6), [16+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#LeakyRelu-16) |
+| [Less](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Less) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Less-7), [9-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Less-9), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Less-13) |
+| [LessOrEqual](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LessOrEqual) |  |
+| [Log](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Log) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Log-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Log-13) |
+| [LogSoftmax](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LogSoftmax) |  |
+| [Loop](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Loop) |  |
+| [LpNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LpNormalization) |  |
+| [LpPool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#LpPool) |  |
+| [MatMul](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MatMul) | [1-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MatMul-1), [9-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MatMul-9), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MatMul-13) |
+| [MatMulInteger](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MatMulInteger) |  |
+| [Max](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Max) |  |
+| [MaxPool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MaxPool) | [1-7](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MaxPool-1), [8-9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MaxPool-8), [10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MaxPool-10), [11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MaxPool-11), [12+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#MaxPool-12) |
+| [MaxRoiPool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MaxRoiPool) |  |
+| [MaxUnpool](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MaxUnpool) |  |
+| [Mean](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Mean) |  |
+| [MeanVarianceNormalization](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MeanVarianceNormalization) |  |
+| [MelWeightMatrix](https://github.com/onnx/onnx/blob/main/docs/Operators.md#MelWeightMatrix) |  |
+| [Min](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Min) |  |
+| [Mod](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Mod) |  |
+| [Mul](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Mul) | [7-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Mul-7), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Mul-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Mul-14) |
+| [Multinomial](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Multinomial) |  |
+| [Neg](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Neg) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Neg-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Neg-13) |
+| [NegativeLogLikelihoodLoss](https://github.com/onnx/onnx/blob/main/docs/Operators.md#NegativeLogLikelihoodLoss) |  |
+| [NonMaxSuppression](https://github.com/onnx/onnx/blob/main/docs/Operators.md#NonMaxSuppression) |  |
+| [NonZero](https://github.com/onnx/onnx/blob/main/docs/Operators.md#NonZero) |  |
+| [Not](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Not) | [1+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Not-1) |
+| [OneHot](https://github.com/onnx/onnx/blob/main/docs/Operators.md#OneHot) |  |
+| [Optional](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Optional) |  |
+| [OptionalGetElement](https://github.com/onnx/onnx/blob/main/docs/Operators.md#OptionalGetElement) |  |
+| [OptionalHasElement](https://github.com/onnx/onnx/blob/main/docs/Operators.md#OptionalHasElement) |  |
+| [Or](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Or) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Or-7) |
+| [PRelu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#PRelu) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#PRelu-7), [9-15](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#PRelu-9), [16+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#PRelu-16) |
+| [Pad](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Pad) | [2-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pad-2), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pad-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pad-13) |
+| [Pow](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Pow) | [7-11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pow-7), [12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pow-12), [13-14](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pow-13), [15+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Pow-15) |
+| [QLinearConv](https://github.com/onnx/onnx/blob/main/docs/Operators.md#QLinearConv) |  |
+| [QLinearMatMul](https://github.com/onnx/onnx/blob/main/docs/Operators.md#QLinearMatMul) |  |
+| [QuantizeLinear](https://github.com/onnx/onnx/blob/main/docs/Operators.md#QuantizeLinear) |  |
+| [RNN](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RNN) |  |
+| [RandomNormal](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RandomNormal) |  |
+| [RandomNormalLike](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RandomNormalLike) |  |
+| [RandomUniform](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RandomUniform) |  |
+| [RandomUniformLike](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RandomUniformLike) |  |
+| [Range](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Range) |  |
+| [Reciprocal](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Reciprocal) |  |
+| [ReduceL1](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceL1) |  |
+| [ReduceL2](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceL2) |  |
+| [ReduceLogSum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceLogSum) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceLogSum-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceLogSum-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceLogSum-13) |
+| [ReduceLogSumExp](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceLogSumExp) |  |
+| [ReduceMax](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceMax) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMax-1), [11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMax-11), [12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMax-12), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMax-13) |
+| [ReduceMean](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceMean) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMean-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMean-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMean-13) |
+| [ReduceMin](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceMin) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMin-1), [11](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMin-11), [12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMin-12), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceMin-13) |
+| [ReduceProd](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceProd) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceProd-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceProd-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceProd-13) |
+| [ReduceSum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceSum) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceSum-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceSum-11) |
+| [ReduceSumSquare](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReduceSumSquare) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceSumSquare-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceSumSquare-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ReduceSumSquare-13) |
+| [Relu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Relu) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Relu-6), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Relu-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Relu-14) |
+| [Reshape](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Reshape) | [5-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Reshape-5), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Reshape-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Reshape-14) |
+| [Resize](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Resize) | [10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Resize-10), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Resize-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Resize-13) |
+| [ReverseSequence](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ReverseSequence) |  |
+| [RoiAlign](https://github.com/onnx/onnx/blob/main/docs/Operators.md#RoiAlign) |  |
+| [Round](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Round) |  |
+| [STFT](https://github.com/onnx/onnx/blob/main/docs/Operators.md#STFT) |  |
+| [Scan](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Scan) |  |
+| [Scatter](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Scatter) |  |
+| [ScatterElements](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ScatterElements) |  |
+| [ScatterND](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ScatterND) |  |
+| [Selu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Selu) |  |
+| [SequenceAt](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceAt) |  |
+| [SequenceConstruct](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceConstruct) |  |
+| [SequenceEmpty](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceEmpty) |  |
+| [SequenceErase](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceErase) |  |
+| [SequenceInsert](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceInsert) |  |
+| [SequenceLength](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceLength) |  |
+| [SequenceMap](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SequenceMap) |  |
+| [Shape](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Shape) | [1-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Shape-1), [13-14](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Shape-13), [15+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Shape-15) |
+| [Shrink](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Shrink) |  |
+| [Sigmoid](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sigmoid) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sigmoid-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sigmoid-13) |
+| [Sign](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sign) |  |
+| [Sin](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sin) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sin-7) |
+| [Sinh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sinh) |  |
+| [Size](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Size) |  |
+| [Slice](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Slice) | [1-9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Slice-1), [10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Slice-10), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Slice-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Slice-13) |
+| [Softmax](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-13) |
+| [SoftmaxCrossEntropyLoss](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SoftmaxCrossEntropyLoss) |  |
+| [Softplus](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softplus) |  |
+| [Softsign](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softsign) |  |
+| [SpaceToDepth](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SpaceToDepth) |  |
+| [Split](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Split) | [2-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Split-2), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Split-11) |
+| [SplitToSequence](https://github.com/onnx/onnx/blob/main/docs/Operators.md#SplitToSequence) |  |
+| [Sqrt](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sqrt) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sqrt-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sqrt-13) |
+| [Squeeze](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Squeeze) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Squeeze-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Squeeze-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Squeeze-13) |
+| [StringNormalizer](https://github.com/onnx/onnx/blob/main/docs/Operators.md#StringNormalizer) |  |
+| [Sub](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sub) | [7-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sub-7), [13](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sub-13), [14+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sub-14) |
+| [Sum](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Sum) | [6-7](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sum-6), [8-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sum-8), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Sum-13) |
+| [Tan](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Tan) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Tan-7) |
+| [Tanh](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Tanh) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Tanh-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Tanh-13) |
+| [TfIdfVectorizer](https://github.com/onnx/onnx/blob/main/docs/Operators.md#TfIdfVectorizer) |  |
+| [ThresholdedRelu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#ThresholdedRelu) |  |
+| [Tile](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Tile) | [6-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Tile-6), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Tile-13) |
+| [TopK](https://github.com/onnx/onnx/blob/main/docs/Operators.md#TopK) |  |
+| [Transpose](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Transpose) | [1-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Transpose-1), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Transpose-13) |
+| [Trilu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Trilu) |  |
+| [Unique](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Unique) |  |
+| [Unsqueeze](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Unsqueeze) | [1-10](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Unsqueeze-1), [11-12](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Unsqueeze-11), [13+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Unsqueeze-13) |
+| [Upsample](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Upsample) | [7-8](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Upsample-7), [9](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Upsample-9) |
+| [Where](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Where) |  |
+| [Xor](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Xor) | [7+](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Xor-7) |

--- a/js/web/lib/onnxjs/backends/webgl/ops/conv-transpose.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/conv-transpose.ts
@@ -91,7 +91,7 @@ const createUnpackedConvTransposeProgramInfo =
     ivec4 coords = getOutputCoords();
     int batch = coords.x;
     int output_channel = coords.y;
-    
+
     ivec2 loc = coords.zw + pads;
 
     int group_id = output_channel / ${outputChannelsPerGroup};
@@ -192,7 +192,7 @@ export const parseConvTransposeAttributes: OperatorInitialization<ConvTransposeA
 
 const validateInputs = (inputs: Tensor[], attributes: ConvTransposeAttributes): void => {
   // Refer to the below link for all input checks
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Conv
   if (!inputs || (inputs.length !== 2 && inputs.length !== 3)) {
     throw new Error('Conv requires 2 or 3 inputs');
   }

--- a/js/web/lib/onnxjs/backends/webgl/ops/conv.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/conv.ts
@@ -129,7 +129,7 @@ export const parseConvAttributes: OperatorInitialization<ConvAttributes> = (node
 
 const validateInputs = (inputs: Tensor[], attributes: ConvAttributes): void => {
   // Refer to the below link for all input checks
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Conv
   if (!inputs || (inputs.length !== 2 && inputs.length !== 3)) {
     throw new Error('Conv requires 2 or 3 inputs');
   }

--- a/js/web/lib/onnxjs/backends/webgl/ops/softmax.ts
+++ b/js/web/lib/onnxjs/backends/webgl/ops/softmax.ts
@@ -54,8 +54,8 @@ export const parseSoftmaxAttributesV13: OperatorInitialization<SoftmaxAttributes
     (node: Graph.Node): SoftmaxAttributes => createAttributeWithCacheKey({axis: node.attributes.getInt('axis', -1)});
 
 // The "semantic" meaning of axis has changed in opset-13.
-// Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-// with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11 for detailed explanations
+// Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
+// with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11 for detailed explanations
 // To account for the opset-13 behavior, our plan will be to transpose the "axis" dim to the innermost dim
 // and perform softmax and then reverse the transpose. We can skip the transposing aspect if the axis is already
 // the innermost dim

--- a/js/web/lib/onnxjs/util.ts
+++ b/js/web/lib/onnxjs/util.ts
@@ -624,7 +624,7 @@ export class ShapeUtil {
    * originalDims = [2,2] and shapeHints = [0,-1] will return [2,2]
    * originalDims = [2,2] and shapeHints = [4] will return [4]
    * originalDims = [2,2] and shapeHints = [5] will throw an exception
-   * https://github.com/onnx/onnx/blob/master/docs/Operators.md#Reshape
+   * https://github.com/onnx/onnx/blob/main/docs/Operators.md#Reshape
    */
 
   static calculateReshapedDims(originalDims: readonly number[], shapeHints: ArrayLike<number>): number[] {

--- a/js/web/script/generate-operator-md.ts
+++ b/js/web/script/generate-operator-md.ts
@@ -27,7 +27,7 @@ function formatDesc(opType: string, range: [number, number], support: boolean, l
   let versionDesc = '';
   if (support) {
     versionDesc = last ? `${range[0]}+` : range[0] === range[1] ? `${range[0]}` : `${range[0]}-${range[1]}`;
-    versionDesc = `[${versionDesc}](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#${opType}-${range[0]})`;
+    versionDesc = `[${versionDesc}](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#${opType}-${range[0]})`;
   }
   return versionDesc;
 }
@@ -73,7 +73,7 @@ const opTypes = Array.from(onnxOpset.keys()).sort();
 
 const doc = fs.createWriteStream(path.join(__dirname, '../docs/operators.md'));
 doc.write(`## Operators Support Table${EOL}${EOL}`);
-doc.write(`The following table shows [ai.onnx](https://github.com/onnx/onnx/blob/master/docs/Operators.md)\
+doc.write(`The following table shows [ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md)\
   operators from which onnx opset version are currently supported by ONNX Runtime Web. For example, \`4-6, 8+\` means\
   ONNX Runtime Web currently support opset version 4 to 6, 8 and above.${EOL}${EOL}`);
 doc.write(`See [Compatibility](../README.md#Compatibility) for a list of the supported platforms.${EOL}${EOL}`);
@@ -99,7 +99,7 @@ for (const type of opTypes) {
     webgl.push(formatDesc(type, versionRange, checkSupport(type, versionRange, webglCheckOnlyRules), last));
   }
 
-  doc.write(`| [${type}](https://github.com/onnx/onnx/blob/master/docs/Operators.md#${type}) | ${
+  doc.write(`| [${type}](https://github.com/onnx/onnx/blob/main/docs/Operators.md#${type}) | ${
       webgl.filter(d => d.length > 0).join(', ')} |${EOL}`);
 }
 doc.end();

--- a/onnxruntime/contrib_ops/cuda/math/complex_mul_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/math/complex_mul_impl.cu
@@ -50,7 +50,7 @@ __global__ void _ElementWiseWithStrideTwo(
     if (id < N / 2) {
       CUDA_LONG lhs_index = (lhs_need_compute ? 0 : id);
       CUDA_LONG rhs_index = (rhs_need_compute ? 0 : id);
-      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
       CUDA_LONG offset = id;
 #pragma unroll
       for (auto dim = 0; dim < fdm_output_strides.Capacity(); dim++) {

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -791,7 +791,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 17, ST
  opset.
 
  To double-check what versions an operator should have registrations for see
- https://github.com/onnx/onnx/blob/master/docs/Operators.md
+ https://github.com/onnx/onnx/blob/main/docs/Operators.md
 *****/
 
 template <>

--- a/onnxruntime/core/providers/cpu/generator/random.cc
+++ b/onnxruntime/core/providers/cpu/generator/random.cc
@@ -132,7 +132,7 @@ ONNX_CPU_OPERATOR_KERNEL(
                         BuildKernelDefConstraintsFromTypeList<EnabledRandomUniformLikeOutputTypes>()),
     RandomUniformLike);
 
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#multinomial
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#multinomial
 ONNX_CPU_OPERATOR_KERNEL(
     Multinomial,
     7,

--- a/onnxruntime/core/providers/cpu/math/hardmax.cc
+++ b/onnxruntime/core/providers/cpu/math/hardmax.cc
@@ -30,8 +30,8 @@ Status Hardmax<float>::Compute(OpKernelContext* ctx) const {
   std::vector<size_t> permutation(rank);
 
   // The "semantic" meaning of axis has changed in opset-13.
-  // Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Hardmax
-  // with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Hardmax-11 for detailed explanations
+  // Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Hardmax
+  // with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Hardmax-11 for detailed explanations
   // To account for the opset-13 behavior, our plan will be to transpose the "axis" dim to the innermost dim
   // and perform softmax and then reverse the transpose. We can skip the transposing aspect if the axis is already
   // the innermost dim

--- a/onnxruntime/core/providers/cpu/math/softmax.cc
+++ b/onnxruntime/core/providers/cpu/math/softmax.cc
@@ -133,8 +133,8 @@ Status Softmax<T>::ComputeImplOpset13(const Tensor& input, Tensor& output, size_
   std::vector<size_t> permutation(rank);
 
   // The "semantic" meaning of axis has changed in opset-13.
-  // Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-  // with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11 for detailed explanations
+  // Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
+  // with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11 for detailed explanations
   // To account for the opset-13 behavior, our plan will be to transpose the "axis" dim to the innermost dim
   // and perform softmax and then reverse the transpose. We can skip the transposing aspect if the axis is already
   // the innermost dim

--- a/onnxruntime/core/providers/cpu/math/top_k.cc
+++ b/onnxruntime/core/providers/cpu/math/top_k.cc
@@ -572,7 +572,7 @@ Status TopK<11, int64_t>::Compute(OpKernelContext* p_op_kernel_context) const {
 }
 
 // Register necessary kernels
-// spec https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK
+// spec https://github.com/onnx/onnx/blob/main/docs/Operators.md#TopK
 
 #define REGISTER_TOPK_VERSIONED_TYPED_KERNEL(OPSET1, OPSET2, TYPE)                                           \
   ONNX_CPU_OPERATOR_VERSIONED_TYPED_KERNEL(TopK, OPSET1, OPSET2, TYPE,                                       \

--- a/onnxruntime/core/providers/cpu/ml/array_feature_extractor.cc
+++ b/onnxruntime/core/providers/cpu/ml/array_feature_extractor.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/ml/array_feature_extractor.h"
 
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 ONNX_OPERATOR_SCHEMA(ArrayFeatureExtractor)
     .SetDomain("ai.onnx.ml")
     .SetDoc(R"DOC(

--- a/onnxruntime/core/providers/cpu/ml/binarizer.cc
+++ b/onnxruntime/core/providers/cpu/ml/binarizer.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/ml/binarizer.h"
 #include <cmath>
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 
 ONNX_OPERATOR_SCHEMA(Binarizer)
 .SetDomain("ai.onnx.ml")

--- a/onnxruntime/core/providers/cpu/ml/feature_vectorizer.h
+++ b/onnxruntime/core/providers/cpu/ml/feature_vectorizer.h
@@ -10,7 +10,7 @@
 namespace onnxruntime {
 namespace ml {
 
-// https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md#ai.onnx.ml.FeatureVectorizer
+// https://github.com/onnx/onnx/blob/main/docs/Operators-ml.md#ai.onnx.ml.FeatureVectorizer
 class FeatureVectorizer final : public OpKernel {
  public:
   FeatureVectorizer(const OpKernelInfo& info) : OpKernel(info) {

--- a/onnxruntime/core/providers/cpu/ml/imputer.cc
+++ b/onnxruntime/core/providers/cpu/ml/imputer.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/ml/imputer.h"
 #include <cmath>
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 ONNX_OPERATOR_SCHEMA(Imputer)
 .SetDomain("ai.onnx.ml")
 .SetDoc(R"DOC(

--- a/onnxruntime/core/providers/cpu/ml/linearclassifier.cc
+++ b/onnxruntime/core/providers/cpu/ml/linearclassifier.cc
@@ -38,7 +38,7 @@ LinearClassifier::LinearClassifier(const OpKernelInfo& info)
 }
 
 // Use GEMM for the calculations, with broadcasting of intercepts
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#Gemm
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gemm
 //
 // X: [num_batches, num_features]
 // coefficients_: [num_targets, num_features]

--- a/onnxruntime/core/providers/cpu/ml/linearregressor.cc
+++ b/onnxruntime/core/providers/cpu/ml/linearregressor.cc
@@ -28,7 +28,7 @@ LinearRegressor::LinearRegressor(const OpKernelInfo& info)
 }
 
 // Use GEMM for the calculations, with broadcasting of intercepts
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#Gemm
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gemm
 //
 // X: [num_batches, num_features]
 // coefficients_: [num_targets, num_features]

--- a/onnxruntime/core/providers/cpu/ml/onehotencoder.cc
+++ b/onnxruntime/core/providers/cpu/ml/onehotencoder.cc
@@ -3,7 +3,7 @@
 
 #include "core/providers/cpu/ml/onehotencoder.h"
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 ONNX_OPERATOR_SCHEMA(OneHotEncoder)
 .SetDomain("ai.onnx.ml")
 .SetDoc(R"DOC(

--- a/onnxruntime/core/providers/cpu/ml/scaler.cc
+++ b/onnxruntime/core/providers/cpu/ml/scaler.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/ml/scaler.h"
 
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 ONNX_OPERATOR_SCHEMA(Scaler)
 .SetDomain("ai.onnx.ml")
 .SetDoc(R"DOC(

--- a/onnxruntime/core/providers/cpu/ml/zipmap.cc
+++ b/onnxruntime/core/providers/cpu/ml/zipmap.cc
@@ -4,7 +4,7 @@
 #include "core/providers/cpu/ml/zipmap.h"
 #include "core/util/math_cpuonly.h"
 /**
-https://github.com/onnx/onnx/blob/master/onnx/defs/traditionalml/defs.cc
+https://github.com/onnx/onnx/blob/main/onnx/defs/traditionalml/defs.cc
 ONNX_OPERATOR_SCHEMA(ZipMap)
 .SetDomain("ai.onnx.ml")
 .SetDoc(R"DOC(

--- a/onnxruntime/core/providers/cpu/nn/batch_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/batch_norm.cc
@@ -19,7 +19,7 @@
 #include "core/providers/cpu/nn/batch_norm_helper.h"
 
 namespace onnxruntime {
-// spec: https://github.com/onnx/onnx/blob/master/docs/Operators.md#BatchNormalization
+// spec: https://github.com/onnx/onnx/blob/main/docs/Operators.md#BatchNormalization
 
 ONNX_CPU_OPERATOR_VERSIONED_TYPED_KERNEL(BatchNormalization, 7, 8, float,
                                          KernelDefBuilder().TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),

--- a/onnxruntime/core/providers/cpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//https://github.com/onnx/onnx/blob/master/docs/Operators.md#Gather
+//https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gather
 #include "core/providers/cpu/tensor/gather.h"
 #include "core/common/common.h"
 #include "core/framework/op_kernel_type_control_utils.h"

--- a/onnxruntime/core/providers/cpu/tensor/isinf.cc
+++ b/onnxruntime/core/providers/cpu/tensor/isinf.cc
@@ -11,7 +11,7 @@
 #include "core/providers/op_kernel_type_control.h"
 
 namespace onnxruntime {
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#IsInf
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#IsInf
 
 namespace op_kernel_type_control {
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES_ALL_OPSETS(

--- a/onnxruntime/core/providers/cpu/tensor/isnan.cc
+++ b/onnxruntime/core/providers/cpu/tensor/isnan.cc
@@ -9,7 +9,7 @@
 #include "Eigen/src/Core/arch/Default/Half.h"
 
 namespace onnxruntime {
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#IsNaN
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#IsNaN
 #define ADD_TYPED_ISNAN_OP_9(data_type)                                   \
   ONNX_CPU_OPERATOR_VERSIONED_TYPED_KERNEL(                               \
       IsNaN,                                                              \

--- a/onnxruntime/core/providers/cpu/tensor/onehot.cc
+++ b/onnxruntime/core/providers/cpu/tensor/onehot.cc
@@ -26,7 +26,7 @@ using namespace ::onnxruntime::common;
 using namespace std;
 
 namespace onnxruntime {
-// spec: https://github.com/onnx/onnx/blob/master/docs/Operators.md#OneHot
+// spec: https://github.com/onnx/onnx/blob/main/docs/Operators.md#OneHot
 
 // T1: indices, T2: depth, T3: values
 #define REG_TYPED_ONE_HOT_OP_V9_10(types_str, in_type, out_type, depth_type) \

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//https://github.com/onnx/onnx/blob/master/docs/Operators.md#Scatter
+//https://github.com/onnx/onnx/blob/main/docs/Operators.md#Scatter
 #include <type_traits>
 
 #include "gsl/gsl"

--- a/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/binary_elementwise_impl.cuh
@@ -32,7 +32,7 @@ __global__ void _BinaryElementWise(
     if (id < N) {
       CUDA_LONG lhs_index = (lhs_need_compute ? 0 : id);
       CUDA_LONG rhs_index = (rhs_need_compute ? 0 : id);
-      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
       CUDA_LONG offset = id;
 #pragma unroll
       for (auto dim = 0; dim < fdm_output_strides.Capacity(); dim++) {
@@ -188,7 +188,7 @@ void BinaryElementWiseNoBroadcastImpl(
     size_t count) {
   if (count == 0)  // special case where there's a dim value of 0 in the output shape
     return;
-  
+
   #ifdef USE_ROCM
   const int num_elements_per_thread = 2;
   const int num_threads_per_block = 512;

--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -116,8 +116,8 @@ Status Softmax<T>::ComputeInternal(OpKernelContext* ctx) const {
   std::vector<size_t> permutation(rank);
 
   // The "semantic" meaning of axis has changed in opset-13.
-  // Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-  // with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11 for detailed explanations
+  // Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
+  // with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11 for detailed explanations
   // To account for the opset-13 behavior, our plan will be to transpose the "axis" dim to the innermost dim
   // and perform softmax and then reverse the transpose. We can skip the transposing aspect if the axis is already
   // the innermost dim

--- a/onnxruntime/core/providers/cuda/tensor/expand_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/expand_impl.cu
@@ -59,7 +59,7 @@ __global__ void ExpandKernel(
 #pragma unroll
   for (int i = 0; i < NumElementsPerThread; i++) {
     if (id < N) {
-      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
       CUDA_LONG index = 0;
       CUDA_LONG offset = id;
 #pragma unroll

--- a/onnxruntime/core/providers/cuda/tensor/where_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/where_impl.cu
@@ -35,7 +35,7 @@ __global__ void _TenaryElementWise(
 #pragma unroll
   for (int i = 0; i < NumElementsPerThread; i++) {
     if (id < N) {
-      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+      // compute indexes with broadcasting rules: https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
       CUDA_LONG cond_index = (CondIndexType == BroadcastIndexType::NoBroadcast ? id : 0);
       CUDA_LONG x_index = (XIndexType == BroadcastIndexType::NoBroadcast ? id : 0);
       CUDA_LONG y_index = (YIndexType == BroadcastIndexType::NoBroadcast ? id : 0);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorValueScale2D.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorValueScale2D.cpp
@@ -6,7 +6,7 @@
 namespace Dml
 {
 
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#experimental-imagescaler
+// https://github.com/onnx/onnx/blob/main/docs/Operators.md#experimental-imagescaler
 class DmlOperatorValueScale2d : public DmlOperator
 {
 public:

--- a/onnxruntime/core/providers/nuphar/scripts/model_editor.py
+++ b/onnxruntime/core/providers/nuphar/scripts/model_editor.py
@@ -182,7 +182,7 @@ def handle_final_scan_outputs(node, nf, scan_outputs, state_outputs, num_directi
 def convert_loop_to_scan(node, out_main_graph, keep_unconvertible_loop_ops):
     assert node.op_type == "Loop"
 
-    # https://github.com/onnx/onnx/blob/master/docs/Operators.md#inputs-2---
+    # https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-2---
     initial_state_names = node.input[2:]  # exclude M and cond.
 
     loop_subgraph_input_i = node.attribute[0].g.input[0]

--- a/onnxruntime/core/providers/rocm/math/softmax.cc
+++ b/onnxruntime/core/providers/rocm/math/softmax.cc
@@ -117,8 +117,8 @@ Status Softmax<T>::ComputeInternal(OpKernelContext* ctx) const {
   std::vector<size_t> permutation(rank);
 
   // The "semantic" meaning of axis has changed in opset-13.
-  // Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-  // with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11 for detailed explanations
+  // Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
+  // with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11 for detailed explanations
   // To account for the opset-13 behavior, our plan will be to transpose the "axis" dim to the innermost dim
   // and perform softmax and then reverse the transpose. We can skip the transposing aspect if the axis is already
   // the innermost dim

--- a/onnxruntime/core/providers/xnnpack/nn/softmax.cc
+++ b/onnxruntime/core/providers/xnnpack/nn/softmax.cc
@@ -138,8 +138,8 @@ Softmax::Softmax(const OpKernelInfo& info) : OpKernel{info} {
   Status status = info.GetAttr<int64_t>("axis", &axis);
   // our op checker function has ensured that axis must be the last dim
   // The "semantic" meaning of axis has changed in opset-13.
-  // Please compare: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-  // with https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11 for detailed explanations
+  // Please compare: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
+  // with https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-11 for detailed explanations
   if (status.IsOK()) {
     axis_ = gsl::narrow_cast<int>(axis);
   } else {

--- a/onnxruntime/python/backend/backend.py
+++ b/onnxruntime/python/backend/backend.py
@@ -20,7 +20,7 @@ from onnxruntime.backend.backend_rep import OnnxRuntimeBackendRep
 class OnnxRuntimeBackend(Backend):
     """
     Implements
-    `ONNX's backend API <https://github.com/onnx/onnx/blob/master/docs/ImplementingAnOnnxBackend.md>`_
+    `ONNX's backend API <https://github.com/onnx/onnx/blob/main/docs/ImplementingAnOnnxBackend.md>`_
     with *ONNX Runtime*.
     The backend is mostly used when you need to switch between
     multiple runtimes with the same API.

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -306,7 +306,7 @@ def attribute_to_kwarg(attribute):
         raise ValueError("attribute {} does not have type specified.".format(attribute.name))
 
     # Based on attribute type definitions from AttributeProto
-    # definition in https://github.com/onnx/onnx/blob/master/onnx/onnx.proto
+    # definition in https://github.com/onnx/onnx/blob/main/onnx/onnx.proto
     if attribute.type == 1:
         value = attribute.f
     elif attribute.type == 2:

--- a/onnxruntime/test/providers/cpu/math/hardmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/hardmax_test.cc
@@ -33,7 +33,7 @@ static void RunTest(const std::vector<float>& x_vals,
 }
 
 TEST(HardmaxOperator, Simple) {
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Hardmax
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Hardmax
   std::vector<float> x_vals = {-1.0f, 0.0f, 1.0f};
   std::vector<float> expected_vals = {0.0f, 0.0f, 1.0f};
   std::vector<int64_t> dimensions = {1, 3};

--- a/onnxruntime/test/providers/cpu/math/logsoftmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/logsoftmax_test.cc
@@ -39,7 +39,7 @@ static void RunTest(const std::vector<float>& x_vals,
 }
 
 TEST(LogSoftmaxOperator, Simple) {
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#LogSoftmax
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#LogSoftmax
   // x = np.array([[-1, 0, 1]]).astype(np.float32)
   // # expected output[[-2.40760589, -1.40760589, -0.40760589]]
 

--- a/onnxruntime/test/providers/cpu/math/softmax_test.cc
+++ b/onnxruntime/test/providers/cpu/math/softmax_test.cc
@@ -35,7 +35,7 @@ static void RunTest(const std::vector<float>& x_vals,
 }
 
 TEST(SoftmaxOperator, Simple) {
-  // https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
+  // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Softmax
   //    x = np.array([[-1, 0, 1]]).astype(np.float32)
   //    y = np.exp(x) / np.sum(np.exp(x), axis = 1) #expected output[[0.09003058, 0.24472848, 0.66524094]]
 
@@ -71,7 +71,7 @@ TEST(SoftmaxOperator, Simple_fp16) {
 
   test.AddInput<MLFloat16>("X", dimensions, f_X);
   test.AddOutput<MLFloat16>("Y", dimensions, f_Y);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});  
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 #endif
 
@@ -96,7 +96,7 @@ TEST(SoftmaxOperator, Simple_bfloat16) {
   execution_providers.push_back(DefaultCudaExecutionProvider());
 #elif USE_ROCM
   execution_providers.push_back(DefaultRocmExecutionProvider());
-#endif 
+#endif
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 #endif

--- a/orttraining/orttraining/python/training/_utils.py
+++ b/orttraining/orttraining/python/training/_utils.py
@@ -113,7 +113,7 @@ def dtype_torch_to_numpy(torch_dtype):
 def dtype_onnx_to_torch(onnx_type):
     """Converts ONNX types to PyTorch types
 
-    Reference: https://github.com/onnx/onnx/blob/master/onnx/onnx.in.proto (enum DataType)
+    Reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.in.proto (enum DataType)
                https://pytorch.org/docs/stable/tensors.html
     """
     onnx_types = [

--- a/orttraining/orttraining/training_ops/cuda/math/div_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/math/div_grad.cc
@@ -30,7 +30,7 @@ TensorShapeVector prepended_dimension_1(const TensorShape& shape, size_t total_r
 
   TensorShapeVector dims(total_rank, 1);
 
-  // https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+  // https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
   // for property 3 of Multidirectional Broadcasting, we need to prepended with a dimension of length 1.
   if (input_rank > 0)
     std::copy(shape.GetDims().begin(), shape.GetDims().end(), &dims[total_rank - input_rank]);

--- a/orttraining/orttraining/training_ops/rocm/math/div_grad.cc
+++ b/orttraining/orttraining/training_ops/rocm/math/div_grad.cc
@@ -30,7 +30,7 @@ TensorShapeVector prepended_dimension_1(const TensorShape& shape, size_t total_r
 
   TensorShapeVector dims(total_rank, 1);
 
-  // https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md
+  // https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md
   // for property 3 of Multidirectional Broadcasting, we need to prepended with a dimension of length 1.
   if (input_rank > 0)
     std::copy(shape.GetDims().cbegin(), shape.GetDims().cend(), &dims[total_rank - input_rank]);

--- a/winml/lib/Api/impl/FeatureCompatibility.h
+++ b/winml/lib/Api/impl/FeatureCompatibility.h
@@ -349,7 +349,7 @@ void verify<K::Tensor, K::Image>(
         1. Image metadata does not exist: We should be tolerant to the models that does not have Image Metadata.
             In this case, user can still pass in ImageFeatureValue as long as it meets the requirement for image tensorization
         2. Model may have Image metadata that values that we do not support. In this case we should reject binding ImageFeatureValue
-           https://github.com/onnx/onnx/blob/master/docs/MetadataProps.md
+           https://github.com/onnx/onnx/blob/main/docs/MetadataProps.md
            Supported metadata values in RS5
                - Image.BitmapPixelFormat: Gray8, RGB8, BGR8
                - Image.ColorSpaceGamma: SRGB

--- a/winml/test/image/README.md
+++ b/winml/test/image/README.md
@@ -46,7 +46,7 @@ To make image related tests data driven and increase test code coverage.
 ### 4. Models
 > Des: Currently, we are using four models, FNS-candy_Bgr8_freeDimInput, FNS-candy_Bgr8, FNS-candy_Rgb8, and FNS-candy_Tensor. We would try to get more models to cover the following listed cases.
 
-a. [Input Image Metadata](https://github.com/onnx/onnx/blob/master/docs/MetadataProps.md)
+a. [Input Image Metadata](https://github.com/onnx/onnx/blob/main/docs/MetadataProps.md)
 
 1.  No metadata provided (**TODO**)
 2. BitmapPixelFormat


### PR DESCRIPTION
**Description**: Replace all occurences of the following:

https://github.com/onnx/onnx/blob/master/
https://github.com/onnx/onnx/tree/master/

into:

https://github.com/onnx/onnx/blob/main/

in the whole code base.