### PR TITLE
Check GCC version

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,6 +40,10 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose build type: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+  message(FATAL_ERROR  "GCC Version Must Not Less than 8.0")
+else()
+
 # Options
 option(onnxruntime_RUN_ONNX_TESTS "Enable ONNX Compatibility Testing" OFF)
 option(onnxruntime_GENERATE_TEST_REPORTS "Enable test report generation" OFF)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
   message(FATAL_ERROR  "GCC Version Must Not Less than 8.0")
-else()
+endif()
 
 # Options
 option(onnxruntime_RUN_ONNX_TESTS "Enable ONNX Compatibility Testing" OFF)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -41,7 +41,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8)
-  message(FATAL_ERROR  "GCC Version Must Not Less than 8")
+  message(FATAL_ERROR  "GCC version must not less than 8")
 endif()
 
 # Options

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,8 +40,8 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose build type: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
-  message(FATAL_ERROR  "GCC Version Must Not Less than 8.0")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8)
+  message(FATAL_ERROR  "GCC Version Must Not Less than 8")
 endif()
 
 # Options


### PR DESCRIPTION
**Description**: 
check gcc version, if it's less than 8, stop compiling.

**Motivation and Context**
Fixes #12650
Make the error message more friendly to users.


**verfication link**
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=728544&view=logs&j=7536d2cd-87d4-54fe-4891-bfbbf2741d83&t=32a004b5-6abc-5719-dbf1-16350e4ba258
