### PR TITLE
Second attempt to fix Java api docs broken link

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
  *
  * <p>There can be at most one OrtEnvironment object created in a JVM lifetime. This class
  * implements {@link AutoCloseable} as before for backwards compatibility with 1.10 and earlier, but
- * the {@link #close} method is a no-op. The environment is closed by a JVM shutdown hook registered
+ * the close method is a no-op. The environment is closed by a JVM shutdown hook registered
  * on construction.
  */
 public final class OrtEnvironment implements AutoCloseable {

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -15,8 +15,8 @@ import java.util.logging.Logger;
  *
  * <p>There can be at most one OrtEnvironment object created in a JVM lifetime. This class
  * implements {@link AutoCloseable} as before for backwards compatibility with 1.10 and earlier, but
- * the close method is a no-op. The environment is closed by a JVM shutdown hook registered
- * on construction.
+ * the close method is a no-op. The environment is closed by a JVM shutdown hook registered on
+ * construction.
  */
 public final class OrtEnvironment implements AutoCloseable {
 


### PR DESCRIPTION
The {link #close} was generating a link to a method with a signature that does not exist. I removed the link. The resulting documentation is still clear IMO