### PR TITLE
[WIP ]Remove std::function internal usage from the TP 

### DIFF
--- a/include/onnxruntime/core/common/callables.h
+++ b/include/onnxruntime/core/common/callables.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <functional>
+#include <type_traits>
 
 namespace onnxruntime {
 /// <summary>

--- a/include/onnxruntime/core/common/callables.h
+++ b/include/onnxruntime/core/common/callables.h
@@ -7,8 +7,6 @@
 #include <tuple>
 
 namespace onnxruntime {
-namespace test {
-
 /// <summary>
 /// This class serves as a callable entity that can be used
 /// either in a threadpool or as a callback for async operations. It supports both
@@ -146,5 +144,4 @@ private:
   ObjectType* obj_;
 };
 
-} // test
 } // onnxruntime

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -186,7 +186,7 @@ class FunctorCallback {
 
   Callable_t GetCallable() noexcept {
     CallableFactory<FunctorCallback, void, Args...> f(this);
-    return f.GetCallable<&FunctorCallback::Func>();
+    return f.template GetCallable<&FunctorCallback::Func>();
   }
 
  private:
@@ -1122,7 +1122,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
     Callable_t GetCallable() noexcept {
       CallableFactory<ScheduleOnPreferredFunc, void> f(this);
-      return f.GetCallable<&ScheduleOnPreferredFunc::Func>();
+      return f.template GetCallable<&ScheduleOnPreferredFunc::Func>();
     }
 
    private:
@@ -1238,7 +1238,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
     Callable_t GetCallable() noexcept {
       CallableFactory<DispatcherTask, void> f(this);
-      return f.GetCallable<&DispatcherTask::Func>();
+      return f.template GetCallable<&DispatcherTask::Func>();
     }
 
    private:
@@ -1349,7 +1349,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
 
     Callable_t GetCallable() noexcept {
       CallableFactory<ConsistencyLoop, void, unsigned> f(this);
-      return f.GetCallable<&ConsistencyLoop::Func>();
+      return f.template GetCallable<&ConsistencyLoop::Func>();
     }
 
    private:

--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -139,10 +139,6 @@ class ExtendedThreadPoolInterface;
 class LoopCounter;
 class ThreadPoolParallelSection;
 
-namespace threadpool_details {
-
-}
-
 class ThreadPool {
  public:
 #ifdef _WIN32

--- a/onnxruntime/test/onnx/dataitem_request.h
+++ b/onnxruntime/test/onnx/dataitem_request.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "callables.h"
+#include "core/common/callables.h"
 #include "TestCaseResult.h"
 #include "core/common/common.h"
 #include "core/platform/env_time.h"

--- a/onnxruntime/test/onnx/testcase_request.h
+++ b/onnxruntime/test/onnx/testcase_request.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "callables.h"
+#include "core/common/callables.h"
 #include "TestCaseResult.h"
 #include "test_allocator.h"
 #include <core/platform/env_time.h>


### PR DESCRIPTION
**Description**:
Eliminate chain usage of `std::function` as it dynamically allocates memory and affects latency/varieance.

**Motivation and Context**
This is an experimental DRAFT.