### PR TITLE
Update Sdl.ruleset to remove C26812 from the rules

### DIFF
--- a/cmake/Sdl.ruleset
+++ b/cmake/Sdl.ruleset
@@ -36,7 +36,6 @@
     <Rule Id="C26498" Action="Error" />
     <Rule Id="C26810" Action="Error" />
     <Rule Id="C26811" Action="Error" />
-    <Rule Id="C26812" Action="Error" />
     <Rule Id="C26814" Action="Error" />
     <Rule Id="C26815" Action="Error" />
     <Rule Id="C26816" Action="Error" />


### PR DESCRIPTION
**Description**: 
C26812 is for warnings like:

onnxruntime\core\mlas\inc\mlas.h(239): warning C26812: The enum type 'CBLAS_TRANSPOSE' is unscoped. Prefer 'enum class' over 'enum' (Enum.3). 

But sometimes it doesn't make sense for us as we have C code and C doesn't have enum class. The static analyzer doesn't know which file needs to support pure C.  As there were too many false positives, we have disabled it in our CMakeLists.txt

https://github.com/microsoft/onnxruntime/blob/main/cmake/CMakeLists.txt#L590

But, we should not include it in our SDL ruleset file. This PR is to remove it. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
