### PR TITLE
Update Supporting DS Version to 0.7.1 for ORTModule

### DIFF
--- a/orttraining/orttraining/python/training/optim/_ds_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_ds_modifier.py
@@ -31,7 +31,7 @@ class DeepSpeedZeROModifier(FP16OptimizerModifier):
         import deepspeed
 
         ds_version = LooseVersion(deepspeed.__version__)
-        if ds_version > LooseVersion("0.7.0") or ds_version < LooseVersion("0.4.0"):
+        if ds_version > LooseVersion("0.7.1") or ds_version < LooseVersion("0.4.0"):
             warnings.warn("Skip modifying optimizer because of unsupported DeepSpeed version.", UserWarning)
             return False
 


### PR DESCRIPTION
Update supporting deepspeed version to 0.7.1 for ORTModule's FP16_Optimizer.