### PR TITLE
remove redundant publish unit test results

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -47,13 +47,7 @@ jobs:
         sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
         ${{ parameters.BuildCommand }}
       displayName: 'Build and Test OnnxRuntime lib for MacOS'
-    - task: PublishTestResults@2
-      displayName: 'Publish unit test results'
-      inputs:
-        testResultsFiles: '**/*.results.xml'
-        searchFolder: '$(Build.BinariesDirectory)'
-        testRunTitle: 'Unit Test Run'
-      condition: succeededOrFailed()
+
     - ${{ if eq(parameters['DoNugetPack'], 'true') }}:
       - script: |
          ${{ parameters.NuPackScript }}


### PR DESCRIPTION
**Description**: 
remove the `publish unit test results `step in mac-ci.yml

**Motivation and Context**
 There's `publish unit test results` step in clean-agent-build-directory-step.yml.
![image](https://user-images.githubusercontent.com/16190118/186384784-c8c46233-e5de-463e-827d-85f4d69e9f29.png)
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=730011&view=logs&j=c2247f00-e206-5037-f302-3b9d68cbf95f

