### PR TITLE
Remove debug build/test in Mac CPU training

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
@@ -1,19 +1,41 @@
 trigger: none
 
-jobs:
-- template: templates/mac-ci.yml
-  parameters:
-    JobName: 'Mac_CPU_Training'
-    SubmoduleCheckoutMode: 'recursive'
-    BuildCommand: >
-      python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
-      --build_dir $(Build.BinariesDirectory)
-      --skip_submodule_sync
-      --parallel
-      --build_shared_lib
-      --config Debug RelWithDebInfo
-      --enable_training
-    DoNugetPack: 'false'
-    # Enable unreleased onnx opsets in CI builds
-    # This facilitates testing the implementation for the new opsets
-    AllowReleasedOpsetOnly: '0'
+stages:
+- stage: Mac_CPU_Debug_Traing
+  jobs:
+  - template: templates/mac-ci.yml
+    parameters:
+      JobName: 'Mac_CPU_Training'
+      SubmoduleCheckoutMode: 'recursive'
+      BuildCommand: >
+        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
+        --build_dir $(Build.BinariesDirectory)
+        --skip_submodule_sync
+        --parallel
+        --build_shared_lib
+        --config Debug
+        --enable_training
+      DoNugetPack: 'false'
+      # Enable unreleased onnx opsets in CI builds
+      # This facilitates testing the implementation for the new opsets
+      AllowReleasedOpsetOnly: '0'
+
+- stage: Mac_CPU_RelWithDebInfo_Traing
+  dependsOn: []
+  jobs:
+  - template: templates/mac-ci.yml
+    parameters:
+      JobName: 'Mac_CPU_Training'
+      SubmoduleCheckoutMode: 'recursive'
+      BuildCommand: >
+        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
+        --build_dir $(Build.BinariesDirectory)
+        --skip_submodule_sync
+        --parallel
+        --build_shared_lib
+        --config RelWithDebInfo
+        --enable_training
+      DoNugetPack: 'false'
+      # Enable unreleased onnx opsets in CI builds
+      # This facilitates testing the implementation for the new opsets
+      AllowReleasedOpsetOnly: '0'

--- a/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
@@ -1,41 +1,17 @@
-trigger: none
-
-stages:
-- stage: Mac_CPU_Debug_Traing
-  jobs:
-  - template: templates/mac-ci.yml
-    parameters:
-      JobName: 'Mac_CPU_Training_Debug'
-      SubmoduleCheckoutMode: 'recursive'
-      BuildCommand: >
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
-        --build_dir $(Build.BinariesDirectory)
-        --skip_submodule_sync
-        --parallel
-        --build_shared_lib
-        --config Debug
-        --enable_training
-      DoNugetPack: 'false'
-      # Enable unreleased onnx opsets in CI builds
-      # This facilitates testing the implementation for the new opsets
-      AllowReleasedOpsetOnly: '0'
-
-- stage: Mac_CPU_RelWithDebInfo_Traing
-  dependsOn: []
-  jobs:
-  - template: templates/mac-ci.yml
-    parameters:
-      JobName: 'Mac_CPU_Training_RelWithDebInfo'
-      SubmoduleCheckoutMode: 'recursive'
-      BuildCommand: >
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
-        --build_dir $(Build.BinariesDirectory)
-        --skip_submodule_sync
-        --parallel
-        --build_shared_lib
-        --config RelWithDebInfo
-        --enable_training
-      DoNugetPack: 'false'
-      # Enable unreleased onnx opsets in CI builds
-      # This facilitates testing the implementation for the new opsets
-      AllowReleasedOpsetOnly: '0'
+jobs:
+- template: templates/mac-ci.yml
+  parameters:
+    JobName: 'Mac_CPU_Training'
+    SubmoduleCheckoutMode: 'recursive'
+    BuildCommand: >
+      python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
+      --build_dir $(Build.BinariesDirectory)
+      --skip_submodule_sync
+      --parallel
+      --build_shared_lib
+      --config RelWithDebInfo
+      --enable_training
+    DoNugetPack: 'false'
+    # Enable unreleased onnx opsets in CI builds
+    # This facilitates testing the implementation for the new opsets
+    AllowReleasedOpsetOnly: '0'

--- a/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
@@ -5,7 +5,7 @@ stages:
   jobs:
   - template: templates/mac-ci.yml
     parameters:
-      JobName: 'Mac_CPU_Training'
+      JobName: 'Mac_CPU_Training_Debug'
       SubmoduleCheckoutMode: 'recursive'
       BuildCommand: >
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py
@@ -25,7 +25,7 @@ stages:
   jobs:
   - template: templates/mac-ci.yml
     parameters:
-      JobName: 'Mac_CPU_Training'
+      JobName: 'Mac_CPU_Training_RelWithDebInfo'
       SubmoduleCheckoutMode: 'recursive'
       BuildCommand: >
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py


### PR DESCRIPTION
**Description**: 
Remove debug build/test in Mac CPU training.

**Motivation and Context**
Currently, Mac CPU training is the most time-consuming (2h19m, 80th percentile) pipeline in PR CI.
the debug config isn't necessary.
