### PR TITLE
Change cuda and rocm error checking helpers to return Status

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -98,7 +98,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                                                    past_sequence_length);
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize);
-  if (!LaunchAttentionKernel(
+  ORT_RETURN_IF_ERROR(LaunchAttentionKernel(
           device_prop,
           Stream(),
           cublas,
@@ -117,11 +117,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
           nullptr == extra_add_qk ? nullptr : extra_add_qk->Data<T>(),
           work_space.get(),
           output->MutableData<T>(),
-          nullptr == present ? nullptr : present->MutableData<T>())) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
+          nullptr == present ? nullptr : present->MutableData<T>()));
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/bert/attention_concat.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_concat.cu
@@ -92,7 +92,7 @@ __global__ void ConcatTensorToTensorLarge(const int tensor_add_sequence_length,
   }
 }
 
-bool LaunchConcatTensorToTensor(cudaStream_t stream,
+Status LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const int all_sequence_length,
                                 const int sequence_length,
                                 const int batch_size,
@@ -133,10 +133,10 @@ bool LaunchConcatTensorToTensor(cudaStream_t stream,
                                                                    tensor_out);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-bool LaunchConcatTensorToTensor(cudaStream_t stream,
+Status LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const int all_sequence_length,
                                 const int sequence_length,
                                 const int batch_size,
@@ -193,10 +193,10 @@ bool LaunchConcatTensorToTensor(cudaStream_t stream,
                                                                   tensor_out);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-bool LaunchConcatPastToPresent(cudaStream_t stream,
+Status LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,
@@ -220,7 +220,7 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
       present);
 }
 
-bool LaunchConcatPastToPresent(cudaStream_t stream,
+Status LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
@@ -25,7 +25,7 @@ size_t GetAttentionWorkspaceSize(
     size_t sequence_length,
     size_t past_sequence_length);
 
-bool LaunchAttentionKernel(
+Status LaunchAttentionKernel(
     const cudaDeviceProp& prop,                // Device Properties
     cudaStream_t stream,                       // cuda stream
     cublasHandle_t& cublas,                    // Cublas handle
@@ -47,7 +47,7 @@ bool LaunchAttentionKernel(
     void* present                              // Present state output
 );
 
-bool LaunchDecoderAttentionKernel(
+Status LaunchDecoderAttentionKernel(
     const cudaDeviceProp& prop,       // Device Properties
     cudaStream_t stream,              // Cuda stream
     cublasHandle_t& cublas,           // Cublas handle
@@ -73,23 +73,23 @@ bool LaunchDecoderAttentionKernel(
     void* new_value_cache             // New_value_cache tensor
 );
 
-bool LaunchTransCtx(cudaStream_t stream,
+Status LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
 
-bool LaunchTransCtx(cudaStream_t stream,
+Status LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
 
-bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
+Status LaunchTransQkv(cudaStream_t stream, const int matrix_num,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
 
-bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
+Status LaunchTransQkv(cudaStream_t stream, const int matrix_num,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
 
-bool LaunchConcatTensorToTensor(cudaStream_t stream,
+Status LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const int all_sequence_length,
                                 const int sequence_length,
                                 const int batch_size,
@@ -101,7 +101,7 @@ bool LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const float* tensor_add,
                                 float* tensor_out);
 
-bool LaunchConcatTensorToTensor(cudaStream_t stream,
+Status LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const int all_sequence_length,
                                 const int sequence_length,
                                 const int batch_size,
@@ -113,7 +113,7 @@ bool LaunchConcatTensorToTensor(cudaStream_t stream,
                                 const half* tensor_add,
                                 half* tensor_out);
 
-bool LaunchConcatPastToPresent(cudaStream_t stream,
+Status LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,
@@ -124,7 +124,7 @@ bool LaunchConcatPastToPresent(cudaStream_t stream,
                                const float* k_v,
                                float* present);
 
-bool LaunchConcatPastToPresent(cudaStream_t stream,
+Status LaunchConcatPastToPresent(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
@@ -281,7 +281,7 @@ __global__ void SoftmaxKernel(const int all_sequence_length,
 }
 
 template <typename T>
-bool ComputeSoftmax(cudaStream_t stream, const int all_sequence_length, const int sequence_length,
+Status ComputeSoftmax(cudaStream_t stream, const int all_sequence_length, const int sequence_length,
                     const int batch_size, const int num_heads,
                     const T* add_before_softmax, const T* input, T* output, bool is_unidirectional) {
   const dim3 grid(sequence_length * num_heads, batch_size, 1);
@@ -314,10 +314,10 @@ bool ComputeSoftmax(cudaStream_t stream, const int all_sequence_length, const in
     SoftmaxKernel<T, blockSize><<<grid, blockSize, 0, stream>>>(
         all_sequence_length, sequence_length, add_before_softmax, input, output);
   } else {
-    ORT_THROW("Attention CUDA operator does not support total sequence length > 1024.");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Attention CUDA operator does not support total sequence length > 1024.");
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <typename T, unsigned TPB>
@@ -397,7 +397,7 @@ __global__ void SoftmaxWithRawMaskSmallKernel(const int all_sequence_length,
 }
 
 template <typename T>
-bool ComputeSoftmaxWithMask1D(cudaStream_t stream,
+Status ComputeSoftmaxWithMask1D(cudaStream_t stream,
                               const int all_sequence_length,
                               const int sequence_length,
                               const int batch_size,
@@ -446,14 +446,14 @@ bool ComputeSoftmaxWithMask1D(cudaStream_t stream,
         <<<grid, blockSize, 0, stream>>>(all_sequence_length, sequence_length, mask_index, mask_start,
                                          add_before_softmax, input, output);
   } else {
-    ORT_THROW("Attention CUDA operator does not support total sequence length > 1024.");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Attention CUDA operator does not support total sequence length > 1024.");
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <typename T>
-bool ComputeSoftmaxWithRawMask(cudaStream_t stream,
+Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,
@@ -515,7 +515,7 @@ bool ComputeSoftmaxWithRawMask(cudaStream_t stream,
                                          is_unidirectional, rsqrt_head_size, mask_dimension, max_sequence_length,
                                          use_persistent_softmax);
   } else {
-    ORT_THROW("Attention CUDA operator does not support total sequence length > 1024.");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Attention CUDA operator does not support total sequence length > 1024.");
   }
 
   if (use_persistent_softmax) {
@@ -527,7 +527,7 @@ bool ComputeSoftmaxWithRawMask(cudaStream_t stream,
                                                           batch_size * num_heads * sequence_length);
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_transpose.cu
@@ -92,7 +92,7 @@ __global__ void TransposeCtxLarge(const int H, const bool reversed_bs, const T* 
   }
 }
 
-bool LaunchTransCtx(cudaStream_t stream,
+Status LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const float* input, float* output) {
   const dim3 grid(sequence_length, batch_size, 1);
@@ -116,10 +116,10 @@ bool LaunchTransCtx(cudaStream_t stream,
       TransposeCtxLarge<float><<<grid, block, 0, stream>>>(head_size, reversed_bs, input, output);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-bool LaunchTransCtx(cudaStream_t stream,
+Status LaunchTransCtx(cudaStream_t stream,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const half* input, half* output) {
   const dim3 grid(sequence_length, batch_size, 1);
@@ -155,7 +155,7 @@ bool LaunchTransCtx(cudaStream_t stream,
     }
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <typename T>
@@ -229,7 +229,7 @@ __global__ void TransposeQKVLarge(const int H, const bool reversed_bs, const T* 
   }
 }
 
-bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
+Status LaunchTransQkv(cudaStream_t stream, const int matrix_num,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const float* input, float* output) {
   const dim3 grid(sequence_length, batch_size, matrix_num);
@@ -253,10 +253,10 @@ bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
       TransposeQKVLarge<float><<<grid, block, 0, stream>>>(head_size, reversed_bs, input, output);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
+Status LaunchTransQkv(cudaStream_t stream, const int matrix_num,
                     const int sequence_length, const int batch_size, const int head_size, const int num_heads,
                     const int max_threads_per_block, const bool reversed_bs, const half* input, half* output) {
   const dim3 grid(sequence_length, batch_size, matrix_num);
@@ -291,7 +291,7 @@ bool LaunchTransQkv(cudaStream_t stream, const int matrix_num,
       TransposeQKVLarge<half><<<grid, block, 0, stream>>>(head_size, reversed_bs, input, output);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
@@ -361,7 +361,7 @@ Status DecoderAttention<T>::ComputeInternal(OpKernelContext* context) const {
   Tensor* new_key_cache(context->Output(1, new_cache_shape));
   Tensor* new_value_cache(context->Output(2, new_cache_shape));
 
-  if (!LaunchDecoderAttentionKernel(
+  return LaunchDecoderAttentionKernel(
           device_prop,
           stream,
           cublas,
@@ -384,13 +384,7 @@ Status DecoderAttention<T>::ComputeInternal(OpKernelContext* context) const {
           workspace_p.get(),
           output->MutableData<T>(),
           nullptr == new_key_cache ? nullptr : new_key_cache->MutableData<T>(),
-          nullptr == new_value_cache ? nullptr : new_value_cache->MutableData<T>())) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          nullptr == new_value_cache ? nullptr : new_value_cache->MutableData<T>());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm.cc
@@ -61,7 +61,7 @@ Status EmbedLayerNorm<T>::ComputeInternal(OpKernelContext* context) const {
   int sequence_length = static_cast<int>(input_dims[1]);
   size_t element_size = sizeof(T);
 
-  if (!LaunchEmbedLayerNormKernel(
+  return LaunchEmbedLayerNormKernel(
           Stream(),
           output->MutableData<T>(),
           mask_index->MutableData<int32_t>(),
@@ -79,13 +79,7 @@ Status EmbedLayerNorm<T>::ComputeInternal(OpKernelContext* context) const {
           sequence_length,
           element_size,
           embedding_sum == nullptr ? nullptr : embedding_sum->MutableData<T>(),
-          position_ids == nullptr ? nullptr : position_ids->Data<int32_t>())) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          position_ids == nullptr ? nullptr : position_ids->Data<int32_t>());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.cu
@@ -85,7 +85,7 @@ __global__ void MaskIndexKernel(int sequence_length, const int* mask, int* mask_
   }
 }
 
-inline bool ComputeMaskIndex(cudaStream_t stream,
+inline Status ComputeMaskIndex(cudaStream_t stream,
                              const int sequence_length,
                              const int batch_size,
                              const int* mask,
@@ -104,7 +104,7 @@ inline bool ComputeMaskIndex(cudaStream_t stream,
     MaskIndexKernel<256><<<batch_size, 256, 0, stream>>>(sequence_length, mask, mask_index);
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <typename T, unsigned TPB>
@@ -172,7 +172,7 @@ __global__ void EmbedLayerNormKernel(
 }
 
 template <typename T>
-bool EmbedSkipLayerNorm(
+Status EmbedSkipLayerNorm(
     cudaStream_t stream, int hidden_size, int batch_size, int sequence_length,
     const int* input_ids, const int* segment_ids, const T* beta, const T* gamma,
     const T* word_embedding, const T* position_embedding, const T* segment_embedding,
@@ -186,10 +186,10 @@ bool EmbedSkipLayerNorm(
                                    word_embedding, position_embedding, segment_embedding,
                                    epsilon, output, embedding_sum, position_ids);
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-bool LaunchEmbedLayerNormKernel(
+Status LaunchEmbedLayerNormKernel(
     cudaStream_t stream,
     void* output,
     void* mask_index,
@@ -209,10 +209,10 @@ bool LaunchEmbedLayerNormKernel(
     void* embedding_sum,
     const int* position_ids) {
   if (nullptr == input_mask) {
-    if (!CUDA_CALL(cudaMemsetAsync(mask_index, 0, sizeof(int) * batch_size, stream)))
-      return false;
-  } else if (!ComputeMaskIndex(stream, sequence_length, batch_size, input_mask, static_cast<int*>(mask_index))) {
-    return false;
+    CUDA_RETURN_IF_ERROR(cudaMemsetAsync(mask_index, 0, sizeof(int) * batch_size, stream));
+  } else {
+    ORT_RETURN_IF_ERROR(
+      ComputeMaskIndex(stream, sequence_length, batch_size, input_mask, static_cast<int*>(mask_index)));
   }
 
   if (element_size == 2) {

--- a/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/embed_layer_norm_impl.h
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
-bool LaunchEmbedLayerNormKernel(cudaStream_t stream,
+Status LaunchEmbedLayerNormKernel(cudaStream_t stream,
                                 void* output,                    // output tensor
                                 void* mask_index,                // output mask index
                                 const int* input_ids,            // input word IDs

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu.cc
@@ -50,19 +50,14 @@ Status FastGelu<T>::ComputeInternal(OpKernelContext* context) const {
   int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
   typedef typename ToCudaType<T>::MappedType CudaT;
 
-  if (!LaunchFastGeluKernel<CudaT>(GetDeviceProp(),
+  return LaunchFastGeluKernel<CudaT>(GetDeviceProp(),
                                    Stream(),
                                    static_cast<int>(input_length),
                                    static_cast<int>(bias_length),
                                    reinterpret_cast<const CudaT*>(input->Data<T>()),
                                    (nullptr != bias) ? reinterpret_cast<const CudaT*>(bias->Data<T>()) : nullptr,
                                    reinterpret_cast<CudaT*>(output->MutableData<T>()),
-                                   use_half2_)) {
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+                                   use_half2_);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.cu
@@ -65,18 +65,18 @@ __global__ void FastGeluKernel2(const half2 a, const half2 b, const half2 c, int
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
                           const float* input, const float* bias, float* output, bool /*use_half2*/) {
   constexpr int blockSize = 256;
   const int gridSize = (input_length + blockSize - 1) / blockSize;
   FastGeluKernel<float, blockSize><<<gridSize, blockSize, 0, stream>>>(A, B, C, input_length, bias_length,
                                                                        input, bias, output);
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
                           const half* input, const half* bias, half* output, bool use_half2) {
   constexpr int blockSize = 256;
   if (use_half2 && 0 == (bias_length & 1) && prop.major >= 7) {
@@ -96,11 +96,11 @@ bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int i
                                                                         input, bias, output);
   }
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
                           const BFloat16* input, const BFloat16* bias, BFloat16* output, bool /*use_half2*/) {
   constexpr int blockSize = 256;
 
@@ -110,7 +110,7 @@ bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int i
   FastGeluKernel<BFloat16, blockSize>
       <<<gridSize, blockSize, 0, stream>>>(A, B, C, input_length, bias_length, input, bias, output);
 
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/fast_gelu_impl.h
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
 template <typename T>
-bool LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(const cudaDeviceProp& prop, cudaStream_t stream, int input_length, int bias_length,
                           const T* input, const T* bias, T* output, bool use_half2);
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention.cc
@@ -258,7 +258,7 @@ Status LongformerAttention<T>::ComputeInternal(OpKernelContext* context) const {
                                                              window_,
                                                              disable_compact_memory);
   auto workspace_buffer = GetScratchBuffer<void>(workSpaceSize);
-  if (!LaunchLongformerAttentionKernel(
+  ORT_RETURN_IF_ERROR(LaunchLongformerAttentionKernel(
           device_prop,
           cublas,
           stream,
@@ -282,11 +282,7 @@ Status LongformerAttention<T>::ComputeInternal(OpKernelContext* context) const {
           element_size,
           disable_compact_memory,
           use_merged_qkv_weights,
-          use_half4_)) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
+          use_half4_));
 
   // Defer release of pinned memory since cudaStreamSynchronize is not used here and kernel need access the buffer.
   this->AddDeferredReleaseCPUPtr(pinned_buffer.release());

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.cu
@@ -34,15 +34,8 @@ limitations under the License.
 using namespace onnxruntime::cuda;
 using namespace cub;
 
-#define CHECK(expr)         \
-  if (!CUBLAS_CALL(expr)) { \
-    return false;           \
-  }
-
-#define CHECK_CUDA(expr)  \
-  if (!CUDA_CALL(expr)) { \
-    return false;         \
-  }
+#define CHECK(expr) CUBLAS_RETURN_IF_ERROR(expr)
+#define CHECK_CUDA(expr) CUDA_RETURN_IF_ERROR(expr)
 
 namespace onnxruntime {
 namespace contrib {
@@ -368,7 +361,7 @@ __launch_bounds__(blockSize)
   }
 }
 
-bool LaunchLongformerSoftmaxKernel(
+Status LaunchLongformerSoftmaxKernel(
     cudaStream_t stream,
     cublasHandle_t cublas,
     void* workspace,
@@ -833,11 +826,11 @@ bool LaunchLongformerSoftmaxKernel(
     }
   }
 
-  return true;
+  return Status::OK();
 }
 
 template <typename T>
-bool LongformerQkvToContext(
+Status LongformerQkvToContext(
     const cudaDeviceProp& device_prop,
     cublasHandle_t cublas,
     cudaStream_t stream,
@@ -899,9 +892,7 @@ bool LongformerQkvToContext(
                            global_input + 2 * elements, global_bias, qkv + 5 * elements,
                            use_half4);
   }
-  if (!CUDA_CALL(cudaPeekAtLastError())) {
-    return false;
-  }
+  CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
   // Transposed Q, K, V with shape (B, N, S, H)
   const T* q = qkv;
@@ -921,7 +912,7 @@ bool LongformerQkvToContext(
   T* temp_output = qkv;  // Q will be overwritten
 
   if (disable_compact_memory) {
-    if (!LaunchLongformerSoftmaxSimpleKernel(
+    ORT_RETURN_IF_ERROR(LaunchLongformerSoftmaxSimpleKernel(
             stream,
             cublas,
             workspace,
@@ -943,13 +934,10 @@ bool LongformerQkvToContext(
             num_heads,
             head_size,
             window,
-            element_size)) {
-      return false;
-    }
+            element_size));
   } else {
     ORT_ENFORCE(max_num_global <= window);
-
-    if (!LaunchLongformerSoftmaxKernel(
+    ORT_RETURN_IF_ERROR(LaunchLongformerSoftmaxKernel(
             stream,
             cublas,
             workspace,
@@ -973,9 +961,7 @@ bool LongformerQkvToContext(
             num_heads,
             head_size,
             window,
-            element_size)) {
-      return false;
-    }
+            element_size));
   }
 
   // The temp_output is BxNxSxH, transpose it to final output BxSxNxH
@@ -983,7 +969,7 @@ bool LongformerQkvToContext(
                         num_heads, max_threads_per_block, false, temp_output, output);
 }
 
-bool LaunchLongformerAttentionKernel(
+Status LaunchLongformerAttentionKernel(
     const cudaDeviceProp& device_prop,
     cublasHandle_t cublas,
     cudaStream_t stream,

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.h
@@ -17,11 +17,12 @@ size_t GetLongformerAttentionWorkspaceSize(
     size_t num_heads,
     size_t head_size,
     size_t sequence_length,
+
     size_t max_num_global,
     size_t window,
     bool disable_compact_memory);
 
-bool LaunchLongformerAttentionKernel(
+Status LaunchLongformerAttentionKernel(
     const cudaDeviceProp& device_prop,  // Device Properties
     cublasHandle_t cublas,              // Cublas handle
     cudaStream_t stream,                // CUDA stream

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.cu
@@ -31,10 +31,7 @@ limitations under the License.
 using namespace onnxruntime::cuda;
 using namespace cub;
 
-#define CHECK(expr)         \
-  if (!CUBLAS_CALL(expr)) { \
-    return false;           \
-  }
+#define CHECK(expr) CUBLAS_RETURN_IF_ERROR(expr)
 
 namespace onnxruntime {
 namespace contrib {
@@ -191,7 +188,7 @@ __launch_bounds__(blockSize)
 }
 
 // Launch the softmax kernel for non compact memory.
-bool LaunchLongformerSoftmaxSimpleKernel(
+Status LaunchLongformerSoftmaxSimpleKernel(
     cudaStream_t stream,
     cublasHandle_t cublas,
     void* workspace,              // softmax space
@@ -669,7 +666,7 @@ bool LaunchLongformerSoftmaxSimpleKernel(
     }
   }
 
-  return true;
+  return Status::OK();
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_softmax.h
@@ -13,13 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
 // Launch the softmax kernels that does not use compact memory.
-bool LaunchLongformerSoftmaxSimpleKernel(
+Status LaunchLongformerSoftmaxSimpleKernel(
     cudaStream_t stream,
     cublasHandle_t cublas,
     void* workspace,              // softmax space

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
@@ -96,7 +96,7 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
   size_t element_size = sizeof(T);
   typedef typename ToCudaType<T>::MappedType CudaT;
 
-  if (!LaunchSkipLayerNormKernel<CudaT>(
+  return LaunchSkipLayerNormKernel<CudaT>(
           Stream(),
           reinterpret_cast<CudaT*>(output->MutableData<T>()),
           reinterpret_cast<const CudaT*>(input->Data<T>()),
@@ -107,13 +107,7 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
           epsilon_,
           hidden_size,
           static_cast<int>(element_count),
-          element_size)) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          element_size);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
@@ -111,7 +111,7 @@ __global__ void SkipLayerNormKernelSmall(
 }
 
 template <typename T>
-bool LaunchSkipLayerNormKernel(
+Status LaunchSkipLayerNormKernel(
     cudaStream_t stream, T* output, const T* input, const T* skip, const T* gamma,
     const T* beta, const T* bias, float epsilon, const int ld, const int element_count,
     size_t element_size) {
@@ -185,15 +185,15 @@ bool LaunchSkipLayerNormKernel(
                                                  maybe2half<T>(epsilon), output);
     }
   }
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
-template bool LaunchSkipLayerNormKernel<float>(cudaStream_t stream, float* output, const float* input,
+template Status LaunchSkipLayerNormKernel<float>(cudaStream_t stream, float* output, const float* input,
                                                const float* skip, const float* gamma, const float* beta,
                                                const float* bias, float epsilon, const int ld,
                                                const int element_count, size_t element_size);
 
-template bool LaunchSkipLayerNormKernel<half>(cudaStream_t stream, half* output, const half* input,
+template Status LaunchSkipLayerNormKernel<half>(cudaStream_t stream, half* output, const half* input,
                                               const half* skip, const half* gamma, const half* beta,
                                               const half* bias, float epsilon, const int ld,
                                               const int element_count, size_t element_size);

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
 template <typename T>
-bool LaunchSkipLayerNormKernel(
+Status LaunchSkipLayerNormKernel(
     cudaStream_t stream,
     T* output,          // output tensor
     const T* input,     // input tensor

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -168,7 +168,7 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   size_t workSpaceSize = GetAttentionWorkspaceSize(element_size, batch_size, num_heads_, head_size, sequence_length, past_sequence_length);
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize);
-  if (!LaunchAttentionKernel(
+  return LaunchAttentionKernel(
           GetDeviceProp(),
           Stream(),
           cublas,
@@ -187,13 +187,7 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
           nullptr,  // TODO: support add_qk in quantized attention
           work_space.get(),
           output->MutableData<T>(),
-          nullptr == present_tensor ? nullptr : present_tensor->MutableData<T>())) {
-    // Get last error to reset it to cudaSuccess.
-    CUDA_CALL(cudaGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          nullptr == present_tensor ? nullptr : present_tensor->MutableData<T>());
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/rocm/bert/attention.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/attention.cc
@@ -97,7 +97,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                                                    sequence_length, past_sequence_length);
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize);
-  if (!LaunchAttentionKernel(
+  return LaunchAttentionKernel(
           device_prop,
           Stream(),
           rocblas,
@@ -115,13 +115,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
           nullptr == extra_add_qk ? nullptr : extra_add_qk->Data<T>(),
           work_space.get(),
           output->MutableData<T>(),
-          nullptr == present ? nullptr : present->MutableData<T>())) {
-    // Get last error to reset it to hipSuccess.
-    HIP_CALL(hipGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          nullptr == present ? nullptr : present->MutableData<T>());
 }
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention_impl.h
@@ -25,7 +25,7 @@ size_t GetAttentionWorkspaceSize(
     int sequence_length,
     int past_sequence_length);
 
-bool LaunchAttentionKernel(
+Status LaunchAttentionKernel(
     const hipDeviceProp_t& prop,               // Device Properties
     hipStream_t stream,                        // cuda stream
     rocblas_handle& rocblas,                   // Rocblas handle
@@ -46,7 +46,7 @@ bool LaunchAttentionKernel(
     void* present                              // Present state output
 );
 
-bool LaunchDecoderAttentionKernel(
+Status LaunchDecoderAttentionKernel(
     const hipDeviceProp_t& prop,      // Device Properties
     hipStream_t stream,               // Cuda stream
     rocblas_handle& rocblas,          // Rocblas handle
@@ -72,67 +72,67 @@ bool LaunchDecoderAttentionKernel(
     void* new_value_cache             // New_value_cache tensor
 );
 
-bool LaunchTransCtx(hipStream_t stream,
-                    const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
+Status LaunchTransCtx(hipStream_t stream,
+                      const int sequence_length, const int batch_size, const int head_size, const int num_heads,
+                      const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
 
-bool LaunchTransCtx(hipStream_t stream,
-                    const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
+Status LaunchTransCtx(hipStream_t stream,
+                      const int sequence_length, const int batch_size, const int head_size, const int num_heads,
+                      const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
 
-bool LaunchTransQkv(hipStream_t stream, const int matrix_num,
-                    const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
+Status LaunchTransQkv(hipStream_t stream, const int matrix_num,
+                      const int sequence_length, const int batch_size, const int head_size, const int num_heads,
+                      const int max_threads_per_block, const bool reversed_bs, const float* input, float* output);
 
-bool LaunchTransQkv(hipStream_t stream, const int matrix_num,
-                    const int sequence_length, const int batch_size, const int head_size, const int num_heads,
-                    const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
+Status LaunchTransQkv(hipStream_t stream, const int matrix_num,
+                      const int sequence_length, const int batch_size, const int head_size, const int num_heads,
+                      const int max_threads_per_block, const bool reversed_bs, const half* input, half* output);
 
-bool LaunchConcatTensorToTensor(hipStream_t stream,
-                                const int all_sequence_length,
-                                const int sequence_length,
-                                const int batch_size,
-                                const int head_size,
-                                const int num_heads,
-                                const int max_threads_per_block,
-                                const int matrix_num,
-                                const float* tensor_in,
-                                const float* tensor_add,
-                                float* tensor_out);
+Status LaunchConcatTensorToTensor(hipStream_t stream,
+                                  const int all_sequence_length,
+                                  const int sequence_length,
+                                  const int batch_size,
+                                  const int head_size,
+                                  const int num_heads,
+                                  const int max_threads_per_block,
+                                  const int matrix_num,
+                                  const float* tensor_in,
+                                  const float* tensor_add,
+                                  float* tensor_out);
 
-bool LaunchConcatTensorToTensor(hipStream_t stream,
-                                const int all_sequence_length,
-                                const int sequence_length,
-                                const int batch_size,
-                                const int head_size,
-                                const int num_heads,
-                                const int max_threads_per_block,
-                                const int matrix_num,
-                                const half* tensor_in,
-                                const half* tensor_add,
-                                half* tensor_out);
+Status LaunchConcatTensorToTensor(hipStream_t stream,
+                                  const int all_sequence_length,
+                                  const int sequence_length,
+                                  const int batch_size,
+                                  const int head_size,
+                                  const int num_heads,
+                                  const int max_threads_per_block,
+                                  const int matrix_num,
+                                  const half* tensor_in,
+                                  const half* tensor_add,
+                                  half* tensor_out);
 
-bool LaunchConcatPastToPresent(hipStream_t stream,
-                               const int all_sequence_length,
-                               const int sequence_length,
-                               const int batch_size,
-                               const int head_size,
-                               const int num_heads,
-                               const int max_threads_per_block,
-                               const float* past,
-                               const float* k_v,
-                               float* present);
+Status LaunchConcatPastToPresent(hipStream_t stream,
+                                 const int all_sequence_length,
+                                 const int sequence_length,
+                                 const int batch_size,
+                                 const int head_size,
+                                 const int num_heads,
+                                 const int max_threads_per_block,
+                                 const float* past,
+                                 const float* k_v,
+                                 float* present);
 
-bool LaunchConcatPastToPresent(hipStream_t stream,
-                               const int all_sequence_length,
-                               const int sequence_length,
-                               const int batch_size,
-                               const int head_size,
-                               const int num_heads,
-                               const int max_threads_per_block,
-                               const half* past,
-                               const half* k_v,
-                               half* present);
+Status LaunchConcatPastToPresent(hipStream_t stream,
+                                 const int all_sequence_length,
+                                 const int sequence_length,
+                                 const int batch_size,
+                                 const int head_size,
+                                 const int num_heads,
+                                 const int max_threads_per_block,
+                                 const half* past,
+                                 const half* k_v,
+                                 half* present);
 
 inline rocblas_status _compat_rocblas_gemm_strided_batched_ex(rocblas_handle handle,
                                                               rocblas_operation transa,

--- a/onnxruntime/contrib_ops/rocm/bert/attention_softmax.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention_softmax.h
@@ -279,7 +279,7 @@ __global__ void SoftmaxKernel(const int all_sequence_length, const int sequence_
 }
 
 template <typename T>
-bool ComputeSoftmax(
+Status ComputeSoftmax(
     hipStream_t stream,
     const int all_sequence_length, const int sequence_length, const int batch_size, const int num_heads,
     const T* add_before_softmax, const T* input, T* output, bool is_unidirectional) {
@@ -388,7 +388,7 @@ __global__ void SoftmaxWithRawMaskSmallKernel(const int all_sequence_length,
 }
 
 template <typename T>
-bool ComputeSoftmaxWithMask1D(
+Status ComputeSoftmaxWithMask1D(
     hipStream_t stream,
     const int all_sequence_length, const int sequence_length, const int batch_size, const int num_heads,
     const int* mask_index, const int* mask_start,
@@ -438,7 +438,7 @@ bool ComputeSoftmaxWithMask1D(
 }
 
 template <typename T>
-bool ComputeSoftmaxWithRawMask(hipStream_t stream,
+Status ComputeSoftmaxWithRawMask(hipStream_t stream,
                                const int all_sequence_length,
                                const int sequence_length,
                                const int batch_size,

--- a/onnxruntime/contrib_ops/rocm/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/fast_gelu.cc
@@ -54,18 +54,13 @@ Status FastGelu<T>::ComputeInternal(OpKernelContext* context) const {
   int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
   typedef typename ToHipType<T>::MappedType HipT;
 
-  if (!LaunchFastGeluKernel<HipT>(Stream(),
+  return LaunchFastGeluKernel<HipT>(Stream(),
                                   static_cast<int>(input_length),
                                   static_cast<int>(bias_length),
                                   reinterpret_cast<const HipT*>(input->Data<T>()),
                                   (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->Data<T>()) : nullptr,
                                   reinterpret_cast<HipT*>(output->MutableData<T>()),
-                                  tuning_)) {
-    HIP_CALL(hipGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+                                  tuning_);
 }
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.cu
@@ -40,7 +40,7 @@ namespace contrib {
 namespace rocm {
 
 template <typename T>
-bool LaunchFastGeluKernel(hipStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(hipStream_t stream, int input_length, int bias_length,
                           const T* input, const T* bias, T* output, bool tuning) {
   static FastGeluTunableOp<T> op;
   if (tuning) {
@@ -51,13 +51,13 @@ bool LaunchFastGeluKernel(hipStream_t stream, int input_length, int bias_length,
   return HIP_CALL(hipPeekAtLastError());
 }
 
-template bool LaunchFastGeluKernel<float>(hipStream_t stream, int input_length, int bias_length,
+template Status LaunchFastGeluKernel<float>(hipStream_t stream, int input_length, int bias_length,
                                           const float* input, const float* bias, float* output, bool tuning);
 
-template bool LaunchFastGeluKernel<BFloat16>(hipStream_t stream, int input_length, int bias_length,
+template Status LaunchFastGeluKernel<BFloat16>(hipStream_t stream, int input_length, int bias_length,
                                              const BFloat16* input, const BFloat16* bias, BFloat16* output, bool tuning);
 
-template bool LaunchFastGeluKernel<half>(hipStream_t stream, int input_length, int bias_length,
+template Status LaunchFastGeluKernel<half>(hipStream_t stream, int input_length, int bias_length,
                                          const half* input, const half* bias, half* output, bool tuning);
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/fast_gelu_impl.h
@@ -6,13 +6,14 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
 template <typename T>
-bool LaunchFastGeluKernel(hipStream_t stream, int input_length, int bias_length,
+Status LaunchFastGeluKernel(hipStream_t stream, int input_length, int bias_length,
                           const T* input, const T* bias, T* output, bool use_half2);
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -69,17 +69,13 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   int64_t fast_gelu_input_length = Y->Shape().Size();
   int64_t bias_length = (nullptr == bias) ? 0 : bias->Shape().Size();
 
-  if (!LaunchFastGeluKernel<HipT>(Stream(),
+  return LaunchFastGeluKernel<HipT>(Stream(),
                                   static_cast<int>(fast_gelu_input_length),
                                   static_cast<int>(bias_length),
                                   reinterpret_cast<HipT*>(gemm_buffer.get()),
                                   (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->Data<T>()) : nullptr,
                                   reinterpret_cast<HipT*>(Y->MutableData<T>()),
-                                  false)) {
-    HIP_CALL(hipGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-  return Status::OK();
+                                  false);
 }
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
@@ -96,7 +96,7 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
   size_t element_size = sizeof(T);
   typedef typename ToHipType<T>::MappedType HipT;
 
-  if (!LaunchSkipLayerNormKernel<HipT>(
+  return LaunchSkipLayerNormKernel<HipT>(
           Stream(),
           reinterpret_cast<HipT*>(output->MutableData<T>()),
           reinterpret_cast<const HipT*>(input->Data<T>()),
@@ -107,13 +107,7 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
           epsilon_,
           hidden_size,
           static_cast<int>(element_count),
-          element_size)) {
-    // Get last error to reset it to hipSuccess.
-    HIP_CALL(hipGetLastError());
-    return Status(common::ONNXRUNTIME, common::FAIL);
-  }
-
-  return Status::OK();
+          element_size);
 }
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
@@ -112,7 +112,7 @@ __global__ void SkipLayerNormKernelSmall(
 }
 
 template <typename T>
-bool LaunchSkipLayerNormKernel(
+Status LaunchSkipLayerNormKernel(
     hipStream_t stream, T* output, const T* input, const T* skip, const T* gamma,
     const T* beta, const T* bias, float epsilon, const int ld, const int element_count,
     size_t element_size) {
@@ -178,15 +178,15 @@ bool LaunchSkipLayerNormKernel(
   return HIP_CALL(hipPeekAtLastError());
 }
 
-template bool LaunchSkipLayerNormKernel<float>(hipStream_t stream, float* output, const float* input,
-                                               const float* skip, const float* gamma, const float* beta,
-                                               const float* bias, float epsilon, const int ld,
-                                               const int element_count, size_t element_size);
+template Status LaunchSkipLayerNormKernel<float>(hipStream_t stream, float* output, const float* input,
+                                                 const float* skip, const float* gamma, const float* beta,
+                                                 const float* bias, float epsilon, const int ld,
+                                                 const int element_count, size_t element_size);
 
-template bool LaunchSkipLayerNormKernel<half>(hipStream_t stream, half* output, const half* input,
-                                               const half* skip, const half* gamma, const half* beta,
-                                               const half* bias, float epsilon, const int ld,
-                                               const int element_count, size_t element_size);
+template Status LaunchSkipLayerNormKernel<half>(hipStream_t stream, half* output, const half* input,
+                                                const half* skip, const half* gamma, const half* beta,
+                                                const half* bias, float epsilon, const int ld,
+                                                const int element_count, size_t element_size);
 
 }  // namespace rocm
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 
 namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
 template <typename T>
-bool LaunchSkipLayerNormKernel(
+Status LaunchSkipLayerNormKernel(
     hipStream_t stream,
     T* output,        // output tensor
     const T* input,   // input tensor
@@ -25,4 +26,3 @@ bool LaunchSkipLayerNormKernel(
 }  // namespace rocm
 }  // namespace contrib
 }  // namespace onnxruntime
-

--- a/onnxruntime/core/providers/cuda/cuda_call.cc
+++ b/onnxruntime/core/providers/cuda/cuda_call.cc
@@ -85,7 +85,8 @@ const char* CudaErrString<ncclResult_t>(ncclResult_t e) {
 #endif
 
 template <typename ERRTYPE, bool THRW>
-bool CudaCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg) {
+std::conditional_t<THRW, void, Status> CudaCall(
+  ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg) {
   if (retCode != successCode) {
     try {
 #ifdef _WIN32
@@ -111,36 +112,40 @@ bool CudaCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRT
                libName, (int)retCode, CudaErrString(retCode), currentCudaDevice,
                hostname,
                exprString, msg);
-      if (THRW) {
+      if constexpr (THRW) {
         // throw an exception with the error info
         ORT_THROW(str);
       } else {
         LOGS_DEFAULT(ERROR) << str;
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, str);
       }
     } catch (const std::exception& e) {  // catch, log, and rethrow since CUDA code sometimes hangs in destruction, so we'd never get to see the error
-      if (THRW) {
+      if constexpr (THRW) {
         ORT_THROW(e.what());
       } else {
         LOGS_DEFAULT(ERROR) << e.what();
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
       }
     }
-    return false;
   }
-  return true;
+  if constexpr (!THRW) {
+    return Status::OK();
+  }
 }
 
-template bool CudaCall<cudaError, false>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg);
-template bool CudaCall<cudaError, true>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg);
-template bool CudaCall<cublasStatus_t, false>(cublasStatus_t retCode, const char* exprString, const char* libName, cublasStatus_t successCode, const char* msg);
-template bool CudaCall<cublasStatus_t, true>(cublasStatus_t retCode, const char* exprString, const char* libName, cublasStatus_t successCode, const char* msg);
-template bool CudaCall<cudnnStatus_t, false>(cudnnStatus_t retCode, const char* exprString, const char* libName, cudnnStatus_t successCode, const char* msg);
-template bool CudaCall<cudnnStatus_t, true>(cudnnStatus_t retCode, const char* exprString, const char* libName, cudnnStatus_t successCode, const char* msg);
-template bool CudaCall<curandStatus_t, false>(curandStatus_t retCode, const char* exprString, const char* libName, curandStatus_t successCode, const char* msg);
-template bool CudaCall<curandStatus_t, true>(curandStatus_t retCode, const char* exprString, const char* libName, curandStatus_t successCode, const char* msg);
-template bool CudaCall<cufftResult, false>(cufftResult retCode, const char* exprString, const char* libName, cufftResult successCode, const char* msg);
-template bool CudaCall<cufftResult, true>(cufftResult retCode, const char* exprString, const char* libName, cufftResult successCode, const char* msg);
+template Status CudaCall<cudaError, false>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg);
+template void CudaCall<cudaError, true>(cudaError retCode, const char* exprString, const char* libName, cudaError successCode, const char* msg);
+template Status CudaCall<cublasStatus_t, false>(cublasStatus_t retCode, const char* exprString, const char* libName, cublasStatus_t successCode, const char* msg);
+template void CudaCall<cublasStatus_t, true>(cublasStatus_t retCode, const char* exprString, const char* libName, cublasStatus_t successCode, const char* msg);
+template Status CudaCall<cudnnStatus_t, false>(cudnnStatus_t retCode, const char* exprString, const char* libName, cudnnStatus_t successCode, const char* msg);
+template void CudaCall<cudnnStatus_t, true>(cudnnStatus_t retCode, const char* exprString, const char* libName, cudnnStatus_t successCode, const char* msg);
+template Status CudaCall<curandStatus_t, false>(curandStatus_t retCode, const char* exprString, const char* libName, curandStatus_t successCode, const char* msg);
+template void CudaCall<curandStatus_t, true>(curandStatus_t retCode, const char* exprString, const char* libName, curandStatus_t successCode, const char* msg);
+template Status CudaCall<cufftResult, false>(cufftResult retCode, const char* exprString, const char* libName, cufftResult successCode, const char* msg);
+template void CudaCall<cufftResult, true>(cufftResult retCode, const char* exprString, const char* libName, cufftResult successCode, const char* msg);
 
 #ifdef ORT_USE_NCCL
-template bool CudaCall<ncclResult_t, false>(ncclResult_t retCode, const char* exprString, const char* libName, ncclResult_t successCode, const char* msg);
+template Status CudaCall<ncclResult_t, false>(ncclResult_t retCode, const char* exprString, const char* libName, ncclResult_t successCode, const char* msg);
+template void CudaCall<ncclResult_t, true>(ncclResult_t retCode, const char* exprString, const char* libName, ncclResult_t successCode, const char* msg);
 #endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_check_memory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_check_memory.cc
@@ -7,9 +7,9 @@
 namespace onnxruntime {
 void CheckIfMemoryOnCurrentGpuDevice(const void* ptr) {
   cudaPointerAttributes attrs;
-  CUDA_CALL(cudaPointerGetAttributes(&attrs, ptr));
+  CUDA_CALL_THROW(cudaPointerGetAttributes(&attrs, ptr));
   int current_device;
-  CUDA_CALL(cudaGetDevice(&current_device));
+  CUDA_CALL_THROW(cudaGetDevice(&current_device));
   ORT_ENFORCE(attrs.device == current_device,
               "Current CUDA device is ", current_device,
               " but the memory of pointer ", ptr,

--- a/onnxruntime/core/providers/cuda/cuda_common.h
+++ b/onnxruntime/core/providers/cuda/cuda_common.h
@@ -14,40 +14,13 @@
 namespace onnxruntime {
 namespace cuda {
 
-#define CUDA_RETURN_IF_ERROR(expr)               \
-  ORT_RETURN_IF_ERROR(CUDA_CALL(expr)            \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDA error executing ", #expr))
-
-#define CUBLAS_RETURN_IF_ERROR(expr)             \
-  ORT_RETURN_IF_ERROR(CUBLAS_CALL(expr)          \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUBLAS error executing ", #expr))
-
-#define CUSPARSE_RETURN_IF_ERROR(expr)           \
-  ORT_RETURN_IF_ERROR(CUSPARSE_CALL(expr)        \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUSPARSE error executing ", #expr))
-
-#define CURAND_RETURN_IF_ERROR(expr)             \
-  ORT_RETURN_IF_ERROR(CURAND_CALL(expr)          \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CURAND error executing ", #expr))
-
-#define CUDNN_RETURN_IF_ERROR(expr)              \
-  ORT_RETURN_IF_ERROR(CUDNN_CALL(expr)           \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDNN error executing ", #expr))
-
-#define CUDNN2_RETURN_IF_ERROR(expr, m)          \
-  ORT_RETURN_IF_ERROR(CUDNN_CALL2(expr, m)       \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUDNN2 error executing ", #expr))
-
-#define CUFFT_RETURN_IF_ERROR(expr)              \
-  ORT_RETURN_IF_ERROR(CUFFT_CALL(expr)           \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CUFFT error executing ", #expr))
+#define CUDA_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUDA_CALL(expr))
+#define CUBLAS_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUBLAS_CALL(expr))
+#define CUSPARSE_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUSPARSE_CALL(expr))
+#define CURAND_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CURAND_CALL(expr))
+#define CUDNN_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUDNN_CALL(expr))
+#define CUDNN2_RETURN_IF_ERROR(expr, m) ORT_RETURN_IF_ERROR(CUDNN_CALL2(expr, m))
+#define CUFFT_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(CUFFT_CALL(expr))
 
 // Type mapping for MLFloat16 to half
 template <typename T>

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -163,20 +163,8 @@ CUDAExecutionProvider::PerThreadContext::PerThreadContext(OrtDevice::DeviceId de
 }
 
 CUDAExecutionProvider::PerThreadContext::~PerThreadContext() {
-  // dtor shouldn't throw. if something went wrong earlier (e.g. out of CUDA memory) the handles
-  // here may be bad, and the destroy calls can throw.
-  // https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-noexcept
-  try {
-    CUBLAS_CALL(cublasDestroy(cublas_handle_));
-  } catch (const std::exception& ex) {
-    LOGS_DEFAULT(ERROR) << "cublasDestroy threw:" << ex.what();
-  }
-
-  try {
-    CUDNN_CALL(cudnnDestroy(cudnn_handle_));
-  } catch (const std::exception& ex) {
-    LOGS_DEFAULT(ERROR) << "cudnnDestroy threw:" << ex.what();
-  }
+  ORT_IGNORE_RETURN_VALUE(CUBLAS_CALL(cublasDestroy(cublas_handle_)));
+  ORT_IGNORE_RETURN_VALUE(CUDNN_CALL(cudnnDestroy(cudnn_handle_)));
 }
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 10000
@@ -265,7 +253,7 @@ CUDAExecutionProvider::~CUDAExecutionProvider() {
   }
 
   if (!external_stream_ && stream_) {
-    CUDA_CALL(cudaStreamDestroy(stream_));
+    ORT_IGNORE_RETURN_VALUE(CUDA_CALL(cudaStreamDestroy(stream_)));
   }
 }
 

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider_info.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider_info.cc
@@ -52,9 +52,7 @@ CUDAExecutionProviderInfo CUDAExecutionProviderInfo::FromProviderOptions(const P
               [&info](const std::string& value_str) -> Status {
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
                 int num_devices{};
-                ORT_RETURN_IF_NOT(
-                    CUDA_CALL(cudaGetDeviceCount(&num_devices)),
-                    "cudaGetDeviceCount() failed.");
+                CUDA_RETURN_IF_ERROR(cudaGetDeviceCount(&num_devices));
                 ORT_RETURN_IF_NOT(
                     0 <= info.device_id && info.device_id < num_devices,
                     "Invalid device ID: ", info.device_id,

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -106,26 +106,26 @@ struct ProviderInfo_CUDA_Impl : ProviderInfo_CUDA {
     return cuda::Impl_Cast(static_cast<cudaStream_t>(stream), input_data, output_data, count);
   }
 
-  bool CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return CudaCall<cudaError, false>(cudaError(retCode), exprString, libName, cudaError(successCode), msg); }
-  bool CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return CudaCall<cudaError, true>(cudaError(retCode), exprString, libName, cudaError(successCode), msg); }
+  Status CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return CudaCall<cudaError, false>(cudaError(retCode), exprString, libName, cudaError(successCode), msg); }
+  void CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { CudaCall<cudaError, true>(cudaError(retCode), exprString, libName, cudaError(successCode), msg); }
 
   void CopyGpuToCpu(void* dst_ptr, const void* src_ptr, const size_t size, const OrtMemoryInfo& dst_location, const OrtMemoryInfo& src_location) override {
     ORT_ENFORCE(dst_location.device.Type() == OrtDevice::CPU);
 
     // Current CUDA device.
     int device;
-    CUDA_CALL(cudaGetDevice(&device));
+    CUDA_CALL_THROW(cudaGetDevice(&device));
 
     if (device != src_location.id) {
       // Need to switch to the allocating device.
-      CUDA_CALL(cudaSetDevice(src_location.id));
+      CUDA_CALL_THROW(cudaSetDevice(src_location.id));
       // Copy from GPU to CPU.
-      CUDA_CALL(cudaMemcpy(dst_ptr, src_ptr, size, cudaMemcpyDeviceToHost));
+      CUDA_CALL_THROW(cudaMemcpy(dst_ptr, src_ptr, size, cudaMemcpyDeviceToHost));
       // Switch back to current device.
-      CUDA_CALL(cudaSetDevice(device));
+      CUDA_CALL_THROW(cudaSetDevice(device));
     } else {
       // Copy from GPU to CPU.
-      CUDA_CALL(cudaMemcpy(dst_ptr, src_ptr, size, cudaMemcpyDeviceToHost));
+      CUDA_CALL_THROW(cudaMemcpy(dst_ptr, src_ptr, size, cudaMemcpyDeviceToHost));
     }
   }
 

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.h
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.h
@@ -32,8 +32,8 @@ struct ProviderInfo_CUDA {
   virtual void cuda__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) = 0;
   virtual void cuda__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) = 0;
 
-  virtual bool CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
-  virtual bool CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual Status CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual void CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
 
   virtual void CopyGpuToCpu(void* dst_ptr, const void* src_ptr, const size_t size, const OrtMemoryInfo& dst_location, const OrtMemoryInfo& src_location) = 0;
   virtual void cudaMemcpy_HostToDevice(void* dst, const void* src, size_t count) = 0;

--- a/onnxruntime/core/providers/cuda/generator/range.cc
+++ b/onnxruntime/core/providers/cuda/generator/range.cc
@@ -71,10 +71,7 @@ static Status ComputeRange(cudaStream_t stream, OpKernelContext* ctx) {
   T* y = ctx->Output(0, shape)->MutableData<T>();
 
   if (count > 0) {
-    if (!RangeImpl(stream, start, delta, count, y)) {
-      CUDA_CALL(cudaGetLastError());
-      return Status(common::ONNXRUNTIME, common::FAIL);
-    }
+    ORT_RETURN_IF_ERROR(RangeImpl(stream, start, delta, count, y));
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/cuda/generator/range_impl.cu
+++ b/onnxruntime/core/providers/cuda/generator/range_impl.cu
@@ -22,15 +22,15 @@ __global__ void RangeKernel(const T start, const T delta, const int count, T* ou
 }
 
 template <typename T>
-bool RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output) {
+Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output) {
   constexpr int block_size = 256;
   int grid_size = (count + block_size - 1) / block_size;
   RangeKernel<T><<<grid_size, block_size, 0, stream>>>(start, delta, count, output);
-  return CUDA_CALL(cudaPeekAtLastError());
+  return CUDA_CALL(cudaGetLastError());
 }
 
 #define SPECIALIZED_IMPL(T) \
-  template bool RangeImpl<T>(cudaStream_t stream, const T start, const T delta, const int count, T* output);
+  template Status RangeImpl<T>(cudaStream_t stream, const T start, const T delta, const int count, T* output);
 
 SPECIALIZED_IMPL(int16_t)
 SPECIALIZED_IMPL(int32_t)

--- a/onnxruntime/core/providers/cuda/generator/range_impl.h
+++ b/onnxruntime/core/providers/cuda/generator/range_impl.h
@@ -9,7 +9,7 @@ namespace cuda {
 
 
 template <typename T>
-bool RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output);
+Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
@@ -25,10 +25,10 @@ GPUDataTransfer::GPUDataTransfer(cudaStream_t stream, bool do_copy_in_default_st
 
 GPUDataTransfer::~GPUDataTransfer() {
   if (!do_copy_in_default_stream_ && streams_[kCudaStreamCopyIn] != nullptr) {
-    CUDA_CALL(cudaStreamDestroy(streams_[kCudaStreamCopyIn]));
+    ORT_IGNORE_RETURN_VALUE(CUDA_CALL(cudaStreamDestroy(streams_[kCudaStreamCopyIn])));
   }
   if (!do_copy_in_default_stream_ && streams_[kCudaStreamCopyOut] != nullptr) {
-    CUDA_CALL(cudaStreamDestroy(streams_[kCudaStreamCopyOut]));
+    ORT_IGNORE_RETURN_VALUE(CUDA_CALL(cudaStreamDestroy(streams_[kCudaStreamCopyOut])));
   }
 }
 

--- a/onnxruntime/core/providers/cuda/math/matmul_integer.cu
+++ b/onnxruntime/core/providers/cuda/math/matmul_integer.cu
@@ -34,7 +34,7 @@ Status ReduceRowSumOnMatrixA(cudaStream_t stream, const int8_t* matrix, int32_t*
                                                                                                                                                  static_cast<int>(helper.K()));
   }
 
-  return CUDA_CALL(cudaPeekAtLastError()) ? Status::OK() : Status(common::ONNXRUNTIME, common::FAIL);
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template <int TPB>
@@ -63,7 +63,7 @@ Status ReduceColSumOnMatrixB(cudaStream_t stream, const int8_t* matrix, int32_t*
                                                                                                                                                  static_cast<int32_t>(helper.N()));
   }
 
-  return CUDA_CALL(cudaPeekAtLastError()) ? Status::OK() : Status(common::ONNXRUNTIME, common::FAIL);
+  return CUDA_CALL(cudaGetLastError());
 }
 
 __global__ void ComputeOffsetOfMatrixAB(const int32_t* row_sum,
@@ -124,7 +124,7 @@ Status OffsetOutput(cudaStream_t stream,
     }
   }
 
-  return CUDA_CALL(cudaPeekAtLastError()) ? Status::OK() : Status(common::ONNXRUNTIME, common::FAIL);
+  return CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/shared_inc/cuda_call.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/cuda_call.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 #include "core/providers/cuda/cuda_pch.h"
 
 namespace onnxruntime {
@@ -11,7 +12,8 @@ namespace onnxruntime {
 // -----------------------------------------------------------------------
 
 template <typename ERRTYPE, bool THRW>
-bool CudaCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
+std::conditional_t<THRW, void, Status> CudaCall(
+  ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
 
 #define CUDA_CALL(expr) (CudaCall<cudaError, false>((expr), #expr, "CUDA", cudaSuccess))
 #define CUBLAS_CALL(expr) (CudaCall<cublasStatus_t, false>((expr), #expr, "CUBLAS", CUBLAS_STATUS_SUCCESS))

--- a/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/resize_impl.cu
@@ -694,7 +694,7 @@ void ResizeImpl(
   bool isSame = std::all_of(scales_vals.Data(), scales_vals.Data() + rank, [](float v) { return v == 1.0f; }) &&
                 (coordinate_transform_mode != ResizeCoordinateTransformationMode::TF_CROP_AND_RESIZE);
   if (isSame) {
-    CUDA_CALL(cudaMemcpyAsync(output_data, input_data, N * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+    CUDA_CALL_THROW(cudaMemcpyAsync(output_data, input_data, N * sizeof(T), cudaMemcpyDeviceToDevice, stream));
     return;
   }
 

--- a/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_nd.cc
@@ -48,7 +48,8 @@ Status ScatterND::ComputeInternal(OpKernelContext* context) const {
 
   if (input_data != output_data) {
     // TODO: Run benchmarks to determine if a dedicated kernel doing data copy will be faster than invoking cudaMemcpy ?
-    CUDA_CALL(cudaMemcpyAsync(output_data, input_data, input_tensor->SizeInBytes(), cudaMemcpyDeviceToDevice, Stream()));
+    CUDA_RETURN_IF_ERROR(
+      cudaMemcpyAsync(output_data, input_data, input_tensor->SizeInBytes(), cudaMemcpyDeviceToDevice, Stream()));
   }
 
   // Bail out early

--- a/onnxruntime/core/providers/cuda/tensor/tile.cc
+++ b/onnxruntime/core/providers/cuda/tensor/tile.cc
@@ -95,8 +95,7 @@ Status Tile::ComputeInternal(OpKernelContext* ctx) const {
 
   // Repeat tensor has all 1s in it
   if (output_shape == input_shape) {
-    CUDA_CALL(cudaMemcpyAsync(output_tensor.MutableDataRaw(), input_tensor.DataRaw(), input_tensor.SizeInBytes(), cudaMemcpyDeviceToDevice, Stream()));
-    return Status::OK();
+    return CUDA_CALL(cudaMemcpyAsync(output_tensor.MutableDataRaw(), input_tensor.DataRaw(), input_tensor.SizeInBytes(), cudaMemcpyDeviceToDevice, Stream()));
   }
 
   bool is_batched_memcpy = false;

--- a/onnxruntime/core/providers/migraphx/migraphx_call.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_call.h
@@ -13,7 +13,8 @@ namespace onnxruntime {
 // -----------------------------------------------------------------------
 
 template <typename ERRTYPE, bool THRW>
-bool RocmCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
+std::conditional_t<THRW, void, Status> RocmCall(
+  ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
 
 #define HIP_CALL(expr) (RocmCall<hipError_t, false>((expr), #expr, "HIP", hipSuccess))
 #define HIP_CALL_THROW(expr) (RocmCall<hipError_t, true>((expr), #expr, "HIP", hipSuccess))

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -27,9 +27,7 @@ MIGraphXExecutionProviderInfo MIGraphXExecutionProviderInfo::FromProviderOptions
               [&info](const std::string& value_str) -> Status {
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
                 int num_devices{};
-                ORT_RETURN_IF_NOT(
-                    HIP_CALL(hipGetDeviceCount(&num_devices)),
-                    "hipGetDeviceCount() failed.");
+                ORT_RETURN_IF_ERROR(HIP_CALL(hipGetDeviceCount(&num_devices)));
                 ORT_RETURN_IF_NOT(
                     0 <= info.device_id && info.device_id < num_devices,
                     "Invalid device ID: ", info.device_id,

--- a/onnxruntime/core/providers/rocm/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/rocm/gpu_data_transfer.cc
@@ -25,10 +25,10 @@ GPUDataTransfer::GPUDataTransfer(hipStream_t stream, bool do_copy_in_default_str
 
 GPUDataTransfer::~GPUDataTransfer() {
   if (!do_copy_in_default_stream_ && streams_[kHipStreamCopyIn] != nullptr) {
-    HIP_CALL(hipStreamDestroy(streams_[kHipStreamCopyIn]));
+    ORT_IGNORE_RETURN_VALUE(HIP_CALL(hipStreamDestroy(streams_[kHipStreamCopyIn])));
   }
   if (!do_copy_in_default_stream_ && streams_[kHipStreamCopyOut] != nullptr) {
-    HIP_CALL(hipStreamDestroy(streams_[kHipStreamCopyOut]));
+    ORT_IGNORE_RETURN_VALUE(HIP_CALL(hipStreamDestroy(streams_[kHipStreamCopyOut])));
   }
 }
 

--- a/onnxruntime/core/providers/rocm/rocm_common.h
+++ b/onnxruntime/core/providers/rocm/rocm_common.h
@@ -15,40 +15,13 @@
 namespace onnxruntime {
 namespace rocm {
 
-#define HIP_RETURN_IF_ERROR(expr)               \
-  ORT_RETURN_IF_ERROR(HIP_CALL(expr)            \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIP error executing ", #expr))
-
-#define ROCBLAS_RETURN_IF_ERROR(expr)             \
-  ORT_RETURN_IF_ERROR(ROCBLAS_CALL(expr)          \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "ROCBLAS error executing ", #expr))
-
-#define HIPSPARSE_RETURN_IF_ERROR(expr)           \
-  ORT_RETURN_IF_ERROR(HIPSPARSE_CALL(expr)        \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIPSPARSE error executing ", #expr))
-
-#define HIPRAND_RETURN_IF_ERROR(expr)             \
-  ORT_RETURN_IF_ERROR(HIPRAND_CALL(expr)          \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIPRAND error executing ", #expr))
-
-#define MIOPEN_RETURN_IF_ERROR(expr)              \
-  ORT_RETURN_IF_ERROR(MIOPEN_CALL(expr)           \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "MIOPEN error executing ", #expr))
-
-#define MIOPEN2_RETURN_IF_ERROR(expr, m)          \
-  ORT_RETURN_IF_ERROR(MIOPEN_CALL2(expr, m)       \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "MIOPEN2 error executing ", #expr))
-
-#define HIPFFT_RETURN_IF_ERROR(expr)              \
-  ORT_RETURN_IF_ERROR(HIPFFT_CALL(expr)           \
-                          ? common::Status::OK() \
-                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "HIPFFT error executing ", #expr))
+#define HIP_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(HIP_CALL(expr))
+#define ROCBLAS_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(ROCBLAS_CALL(expr))
+#define HIPSPARSE_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(HIPSPARSE_CALL(expr))
+#define HIPRAND_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(HIPRAND_CALL(expr))
+#define MIOPEN_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(MIOPEN_CALL(expr))
+#define MIOPEN2_RETURN_IF_ERROR(expr, m) ORT_RETURN_IF_ERROR(MIOPEN_CALL2(expr, m))
+#define HIPFFT_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(HIPFFT_CALL(expr))
 
 // Type mapping for MLFloat16 to half
 template <typename T>

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -141,13 +141,13 @@ ROCMExecutionProvider::PerThreadContext::~PerThreadContext() {
   // here may be bad, and the destroy calls can throw.
   // https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-noexcept
   try {
-    ROCBLAS_CALL(rocblas_destroy_handle(rocblas_handle_));
+    ROCBLAS_CALL_THROW(rocblas_destroy_handle(rocblas_handle_));
   } catch (const std::exception& ex) {
     LOGS_DEFAULT(ERROR) << "rocblas_destroy_handle threw:" << ex.what();
   }
 
   try {
-    MIOPEN_CALL(miopenDestroy(miopen_handle_));
+    MIOPEN_CALL_THROW(miopenDestroy(miopen_handle_));
   } catch (const std::exception& ex) {
     LOGS_DEFAULT(ERROR) << "miopenDestroy threw:" << ex.what();
   }
@@ -210,7 +210,7 @@ ROCMExecutionProvider::~ROCMExecutionProvider() {
   }
 
   if (!external_stream_ && stream_) {
-    HIP_CALL(hipStreamDestroy(stream_));
+    HIP_CALL_THROW(hipStreamDestroy(stream_));
   }
 }
 

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider_info.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider_info.cc
@@ -43,9 +43,7 @@ ROCMExecutionProviderInfo ROCMExecutionProviderInfo::FromProviderOptions(const P
               [&info](const std::string& value_str) -> Status {
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
                 int num_devices{};
-                ORT_RETURN_IF_NOT(
-                    HIP_CALL(hipGetDeviceCount(&num_devices)),
-                    "hipGetDeviceCount() failed.");
+                HIP_RETURN_IF_ERROR(hipGetDeviceCount(&num_devices));
                 ORT_RETURN_IF_NOT(
                     0 <= info.device_id && info.device_id < num_devices,
                     "Invalid device ID: ", info.device_id,

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
@@ -104,26 +104,26 @@ struct ProviderInfo_ROCM_Impl : ProviderInfo_ROCM {
     return rocm::Impl_Cast(static_cast<hipStream_t>(stream), input_data, output_data, count);
   }
 
-  bool RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return RocmCall<hipError_t, false>(hipError_t(retCode), exprString, libName, hipError_t(successCode), msg); }
-  bool RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return RocmCall<hipError_t, true>(hipError_t(retCode), exprString, libName, hipError_t(successCode), msg); }
+  Status RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return RocmCall<hipError_t, false>(hipError_t(retCode), exprString, libName, hipError_t(successCode), msg); }
+  void RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { RocmCall<hipError_t, true>(hipError_t(retCode), exprString, libName, hipError_t(successCode), msg); }
 
   void CopyGpuToCpu(void* dst_ptr, const void* src_ptr, const size_t size, const OrtMemoryInfo& dst_location, const OrtMemoryInfo& src_location) override {
     ORT_ENFORCE(dst_location.device.Type() == OrtDevice::CPU);
 
     // Current ROCM device.
     int device;
-    HIP_CALL(hipGetDevice(&device));
+    HIP_CALL_THROW(hipGetDevice(&device));
 
     if (device != src_location.id) {
       // Need to switch to the allocating device.
-      HIP_CALL(hipSetDevice(src_location.id));
+      HIP_CALL_THROW(hipSetDevice(src_location.id));
       // Copy from GPU to CPU.
-      HIP_CALL(hipMemcpy(dst_ptr, src_ptr, size, hipMemcpyDeviceToHost));
+      HIP_CALL_THROW(hipMemcpy(dst_ptr, src_ptr, size, hipMemcpyDeviceToHost));
       // Switch back to current device.
-      HIP_CALL(hipSetDevice(device));
+      HIP_CALL_THROW(hipSetDevice(device));
     } else {
       // Copy from GPU to CPU.
-      HIP_CALL(hipMemcpy(dst_ptr, src_ptr, size, hipMemcpyDeviceToHost));
+      HIP_CALL_THROW(hipMemcpy(dst_ptr, src_ptr, size, hipMemcpyDeviceToHost));
     }
   }
 

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.h
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.h
@@ -29,8 +29,8 @@ struct ProviderInfo_ROCM {
   virtual void rocm__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) = 0;
   virtual void rocm__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) = 0;
 
-  virtual bool RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
-  virtual bool RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual Status RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual void RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
 
   virtual void CopyGpuToCpu(void* dst_ptr, const void* src_ptr, const size_t size, const OrtMemoryInfo& dst_location, const OrtMemoryInfo& src_location) = 0;
   virtual void rocmMemcpy_HostToDevice(void* dst, const void* src, size_t count) = 0;

--- a/onnxruntime/core/providers/rocm/shared_inc/rocm_call.h
+++ b/onnxruntime/core/providers/rocm/shared_inc/rocm_call.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "core/common/common.h"
 #include "core/providers/rocm/rocm_pch.h"
 
 namespace onnxruntime {
@@ -11,7 +12,8 @@ namespace onnxruntime {
 // -----------------------------------------------------------------------
 
 template <typename ERRTYPE, bool THRW>
-bool RocmCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
+std::conditional_t<THRW, void, Status> RocmCall(
+  ERRTYPE retCode, const char* exprString, const char* libName, ERRTYPE successCode, const char* msg = "");
 
 #define HIP_CALL(expr) (RocmCall<hipError_t, false>((expr), #expr, "HIP", hipSuccess))
 #define ROCBLAS_CALL(expr) (RocmCall<rocblas_status, false>((expr), #expr, "ROCBLAS", rocblas_status_success))

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -157,8 +157,8 @@ struct ProviderHost {
   virtual void cuda__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) = 0;
   virtual void cuda__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) = 0;
 
-  virtual bool CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
-  virtual bool CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual Status CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual void CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
 #endif
 
 #ifdef USE_ROCM

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -171,8 +171,8 @@ struct ProviderHost {
   virtual void rocm__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) = 0;
   virtual void rocm__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) = 0;
 
-  virtual bool RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
-  virtual bool RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual Status RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
+  virtual void RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) = 0;
 #endif
 
   virtual std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewer& graph,

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_info.cc
@@ -41,9 +41,7 @@ TensorrtExecutionProviderInfo TensorrtExecutionProviderInfo::FromProviderOptions
               [&info](const std::string& value_str) -> Status {
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, info.device_id));
                 int num_devices{};
-                ORT_RETURN_IF_NOT(
-                    CUDA_CALL(cudaGetDeviceCount(&num_devices)),
-                    "cudaGetDeviceCount() failed.");
+                CUDA_RETURN_IF_ERROR(cudaGetDeviceCount(&num_devices));
                 ORT_RETURN_IF_NOT(
                     0 <= info.device_id && info.device_id < num_devices,
                     "Invalid device ID: ", info.device_id,

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -194,8 +194,8 @@ struct ProviderHostImpl : ProviderHost {
   void cuda__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) override { return GetProviderInfo_CUDA().cuda__Impl_Cast(stream, input_data, output_data, count); }
   void cuda__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) override { return GetProviderInfo_CUDA().cuda__Impl_Cast(stream, input_data, output_data, count); }
 
-  bool CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_CUDA().CudaCall_false(retCode, exprString, libName, successCode, msg); }
-  bool CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_CUDA().CudaCall_true(retCode, exprString, libName, successCode, msg); }
+  Status CudaCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_CUDA().CudaCall_false(retCode, exprString, libName, successCode, msg); }
+  void CudaCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { GetProviderInfo_CUDA().CudaCall_true(retCode, exprString, libName, successCode, msg); }
 #endif
 
 #ifdef USE_ROCM

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -209,8 +209,8 @@ struct ProviderHostImpl : ProviderHost {
   void rocm__Impl_Cast(void* stream, const double* input_data, float* output_data, size_t count) override { return GetProviderInfo_ROCM().rocm__Impl_Cast(stream, input_data, output_data, count); }
   void rocm__Impl_Cast(void* stream, const float* input_data, double* output_data, size_t count) override { return GetProviderInfo_ROCM().rocm__Impl_Cast(stream, input_data, output_data, count); }
 
-  bool RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_ROCM().RocmCall_false(retCode, exprString, libName, successCode, msg); }
-  bool RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_ROCM().RocmCall_true(retCode, exprString, libName, successCode, msg); }
+  Status RocmCall_false(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { return GetProviderInfo_ROCM().RocmCall_false(retCode, exprString, libName, successCode, msg); }
+  void RocmCall_true(int retCode, const char* exprString, const char* libName, int successCode, const char* msg) override { GetProviderInfo_ROCM().RocmCall_true(retCode, exprString, libName, successCode, msg); }
 #endif
 
   std::string GetEnvironmentVar(const std::string& var_name) override { return Env::Default().GetEnvironmentVar(var_name); }

--- a/orttraining/orttraining/training_ops/cuda/collective/adasum_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/collective/adasum_kernels.cc
@@ -36,7 +36,7 @@ Status AdasumAllReduce::ComputeInternal(OpKernelContext* context) const {
 
   for (int i = 0; i < num_tensors; ++i) {
     const Tensor* x_tensor = context->Input<Tensor>(i);
-    CUDA_CALL(cudaMemcpyAsync((uint8_t*)data_buffer_ptr.get() + tensor_offsets[i], x_tensor->DataRaw(),
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync((uint8_t*)data_buffer_ptr.get() + tensor_offsets[i], x_tensor->DataRaw(),
                               tensor_sizes[i], cudaMemcpyDeviceToHost, Stream()));
   }
 
@@ -52,7 +52,7 @@ Status AdasumAllReduce::ComputeInternal(OpKernelContext* context) const {
 
   for (int i = 0; i < num_tensors; i++) {
     Tensor* y_tensor = context->Output(i, context->Input<Tensor>(i)->Shape());
-    CUDA_CALL(cudaMemcpyAsync(y_tensor->MutableDataRaw(), (uint8_t*)data_buffer + tensor_offsets[i],
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(y_tensor->MutableDataRaw(), (uint8_t*)data_buffer + tensor_offsets[i],
                               tensor_sizes[i], cudaMemcpyHostToDevice, Stream()));
   }
   return Status::OK();

--- a/orttraining/orttraining/training_ops/cuda/collective/nccl_common.h
+++ b/orttraining/orttraining/training_ops/cuda/collective/nccl_common.h
@@ -14,7 +14,7 @@ namespace onnxruntime {
 namespace cuda {
 
 #if defined(ORT_USE_NCCL)
-#define NCCL_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(NCCL_CALL(expr) ? common::Status::OK() : common::Status(common::ONNXRUNTIME, common::FAIL))
+#define NCCL_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR(NCCL_CALL(expr))
 #endif
 class NcclContext final {
  public:

--- a/orttraining/orttraining/training_ops/cuda/communication/recv.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/recv.cc
@@ -89,10 +89,10 @@ void Recv::ReceiveData(
     assert(tensor_offset_in_bytes + tensor->SizeInBytes() <= aggregated_aligned_tensor_bytes);
     // Copy data out from buffer.
 #if defined(ORT_USE_NCCL) && defined(USE_NCCL_P2P)
-    CUDA_CALL(cudaMemcpyAsync(tensor->MutableDataRaw(), buffer.get() + tensor_offset_in_bytes,
+    CUDA_CALL_THROW(cudaMemcpyAsync(tensor->MutableDataRaw(), buffer.get() + tensor_offset_in_bytes,
                               tensor->SizeInBytes(), cudaMemcpyDeviceToDevice, Stream()));
 #else
-    CUDA_CALL(cudaMemcpyAsync(tensor->MutableDataRaw(), buffer.get() + tensor_offset_in_bytes,
+    CUDA_CALL_THROW(cudaMemcpyAsync(tensor->MutableDataRaw(), buffer.get() + tensor_offset_in_bytes,
                               tensor->SizeInBytes(), cudaMemcpyHostToDevice, Stream()));
 #endif
 

--- a/orttraining/orttraining/training_ops/cuda/communication/send.cc
+++ b/orttraining/orttraining/training_ops/cuda/communication/send.cc
@@ -66,10 +66,10 @@ void Send::SendData(
 #endif
 
 #if defined(ORT_USE_NCCL) && defined(USE_NCCL_P2P)
-    CUDA_CALL(cudaMemcpyAsync(buffer.get() + tensor_offsets_in_bytes[i], tensor->DataRaw(),
+    CUDA_CALL_THROW(cudaMemcpyAsync(buffer.get() + tensor_offsets_in_bytes[i], tensor->DataRaw(),
                               tensor_sizes_in_bytes[i], cudaMemcpyDeviceToDevice, Stream()));
 #else
-    CUDA_CALL(cudaMemcpyAsync(buffer.get() + tensor_offsets_in_bytes[i], tensor->DataRaw(),
+    CUDA_CALL_THROW(cudaMemcpyAsync(buffer.get() + tensor_offsets_in_bytes[i], tensor->DataRaw(),
                               tensor_sizes_in_bytes[i], cudaMemcpyDeviceToHost, Stream()));
 #endif
   }


### PR DESCRIPTION
**Description**: Currently, some helper returns `bool` to indicate an error, which is not ideal and is not consistent with existing kernels that return `Status`. This unify them to return `Status` in non-throw path and return void in throw path.

**Motivation and Context**
- Why is this change required? What problem does it solve?
   This fixes/imporve various problem.
   1. avoid **unchecked status**, for example https://github.com/microsoft/onnxruntime/blob/53ecb9e6355dec171ed61d6daae13d89d53407bd/onnxruntime/core/providers/rocm/rocm_provider_factory.cc#L115-L126
   2. avoid anti-pattern error checking code, for example https://github.com/microsoft/onnxruntime/blob/cb2601c5ea54f491bc8934d401fe041f498bf132/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu#L177-L182
   3. avoid discard true error message, for example https://github.com/microsoft/onnxruntime/blob/bc3e123b0977b82336a0417626cf654d0a41570f/onnxruntime/core/providers/rocm/rocm_common.h#L18-L26

