### PR TITLE
[TVM EP] fix issue #12625 for TVM EP by allocator priority

### DIFF
--- a/include/onnxruntime/core/framework/ortmemoryinfo.h
+++ b/include/onnxruntime/core/framework/ortmemoryinfo.h
@@ -12,9 +12,11 @@ struct OrtMemoryInfo {
   OrtMemType mem_type = OrtMemTypeDefault;
   OrtAllocatorType alloc_type = OrtInvalidAllocator;
   OrtDevice device;
+  OrtAllocatorPriority alloc_prior = OrtAllocatorPriorityDefault;
 
   constexpr OrtMemoryInfo(const char* name_, OrtAllocatorType type_, OrtDevice device_ = OrtDevice(), int id_ = 0,
-                          OrtMemType mem_type_ = OrtMemTypeDefault)
+                          OrtMemType mem_type_ = OrtMemTypeDefault,
+                          OrtAllocatorPriority alloc_prior_ = OrtAllocatorPriorityDefault)
 #if ((defined(__GNUC__) && __GNUC__ > 4) || defined(__clang__))
       // this causes a spurious error in CentOS gcc 4.8 build so disable if GCC version < 5
       __attribute__((nonnull))
@@ -23,7 +25,8 @@ struct OrtMemoryInfo {
         id(id_),
         mem_type(mem_type_),
         alloc_type(type_),
-        device(device_) {
+        device(device_),
+        alloc_prior(alloc_prior_) {
   }
 
   // To make OrtMemoryInfo become a valid key in std map
@@ -59,6 +62,7 @@ struct OrtMemoryInfo {
          << " id:" << id
          << " OrtMemType:" << mem_type
          << " OrtAllocatorType:" << alloc_type
+         << " OrtAllocatorPriority:" << alloc_prior
          << " " << device.ToString()
          << "]";
     return ostr.str();

--- a/include/onnxruntime/core/framework/ortmemoryinfo.h
+++ b/include/onnxruntime/core/framework/ortmemoryinfo.h
@@ -12,11 +12,11 @@ struct OrtMemoryInfo {
   OrtMemType mem_type = OrtMemTypeDefault;
   OrtAllocatorType alloc_type = OrtInvalidAllocator;
   OrtDevice device;
-  OrtAllocatorPriority alloc_prior = OrtAllocatorPriorityDefault;
+  int alloc_prior = OrtAllocatorPriorityDefault;
 
   constexpr OrtMemoryInfo(const char* name_, OrtAllocatorType type_, OrtDevice device_ = OrtDevice(), int id_ = 0,
                           OrtMemType mem_type_ = OrtMemTypeDefault,
-                          OrtAllocatorPriority alloc_prior_ = OrtAllocatorPriorityDefault)
+                          int alloc_prior_ = OrtAllocatorPriorityDefault)
 #if ((defined(__GNUC__) && __GNUC__ > 4) || defined(__clang__))
       // this causes a spurious error in CentOS gcc 4.8 build so disable if GCC version < 5
       __attribute__((nonnull))

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -336,6 +336,12 @@ typedef enum OrtAllocatorType {
   OrtArenaAllocator = 1
 } OrtAllocatorType;
 
+typedef enum OrtAllocatorPriority {
+  OrtAllocatorPriorityLow = 0,
+  OrtAllocatorPriorityDefault = 1,
+  OrtAllocatorPriorityHigh = 2
+} OrtAllocatorPriority;
+
 /** \brief Memory types for allocated memory, execution provider specific types should be extended in each provider.
 */
 // Whenever this struct is updated, please also update the MakeKey function in onnxruntime / core / framework / execution_provider.cc

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -353,6 +353,7 @@ class SessionState {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SessionState);
 
   void SetupAllocators();
+  void SetupAllocator(IExecutionProvider& provider, const OrtMemoryInfo& mem_info);
 
   // Populate OrtValueNameIdxMap and create the graph viewer.
   void CreateGraphInfo();

--- a/onnxruntime/core/providers/tvm/tvm_allocator.h
+++ b/onnxruntime/core/providers/tvm/tvm_allocator.h
@@ -21,6 +21,13 @@ class TVMAllocator : public IAllocator {
                                                0,
                                                OrtMemTypeDefault,
                                                OrtAllocatorPriorityHigh)) {}
+    TVMAllocator(int alloc_prior) : TVMAllocator(OrtMemoryInfo("TVM",
+                                                               OrtAllocatorType::OrtDeviceAllocator,
+                                                               OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, 0),
+                                                               0,
+                                                               OrtMemTypeDefault,
+                                                               alloc_prior)) {}
+
   explicit TVMAllocator(const OrtMemoryInfo& info)
     : IAllocator(info) {
       switch (info.device.Type()) {

--- a/onnxruntime/core/providers/tvm/tvm_allocator.h
+++ b/onnxruntime/core/providers/tvm/tvm_allocator.h
@@ -19,7 +19,8 @@ class TVMAllocator : public IAllocator {
                                                OrtAllocatorType::OrtDeviceAllocator,
                                                OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, 0),
                                                0,
-                                               OrtMemTypeDefault)) {}
+                                               OrtMemTypeDefault,
+                                               OrtAllocatorPriorityHigh)) {}
   explicit TVMAllocator(const OrtMemoryInfo& info)
     : IAllocator(info) {
       switch (info.device.Type()) {

--- a/onnxruntime/core/providers/tvm/tvm_ep_options.cc
+++ b/onnxruntime/core/providers/tvm/tvm_ep_options.cc
@@ -16,6 +16,7 @@ namespace tvm {
 
 namespace provider_option_names {
 constexpr const char* kExecutor = "executor";
+constexpr const char* kAllocatorPriority = "allocator_priority";
 constexpr const char* kSoFolder = "so_folder";
 constexpr const char* kCheckHash = "check_hash";
 constexpr const char* kHashFilePath = "hash_file_path";
@@ -31,6 +32,7 @@ constexpr const char* kInputShapes = "input_shapes";
 
 static const std::unordered_set<std::string> valid_keys {
   std::string{kExecutor},
+  std::string{kAllocatorPriority},
   std::string{kTarget},
   std::string{kTargetHost},
   std::string{kOptLevel},
@@ -114,6 +116,7 @@ TvmEPOptions TvmEPOptionsHelper::FromProviderOptions(const ProviderOptions& pr_o
   ORT_THROW_IF_ERROR(
     ProviderOptionsParser{}
       .AddAssignmentToReference(tvm::provider_option_names::kExecutor, options.executor)
+      .AddAssignmentToReference(tvm::provider_option_names::kAllocatorPriority, options.allocator_priority)
       .AddAssignmentToReference(tvm::provider_option_names::kSoFolder, options.so_folder)
       .AddAssignmentToReference(tvm::provider_option_names::kCheckHash, options.check_hash)
       .AddAssignmentToReference(tvm::provider_option_names::kHashFilePath, options.hash_file_path)
@@ -251,6 +254,7 @@ void TvmEPOptionsHelper::optLevelPostprocess(unsigned int& opt_level) {
 std::ostream& operator<<(std::ostream& out, const TvmEPOptions& options) {
   out << "TVM EP options:\n" <<
   "executor type: " << options.executor << "\n" <<
+  "allocator priority: " << options.allocator_priority << "\n" <<
   "so_folder: " << options.so_folder << "\n" <<
   "check_hash: " << options.check_hash << "\n" <<
   "hash_file_path: " << options.hash_file_path << "\n" <<

--- a/onnxruntime/core/providers/tvm/tvm_ep_options.h
+++ b/onnxruntime/core/providers/tvm/tvm_ep_options.h
@@ -11,9 +11,9 @@
 
 #include "core/framework/provider_options.h"
 #include "core/framework/tensor_shape.h"
+#include "core/session/onnxruntime_c_api.h"
 
 #include "tvm_defaults.h"
-
 
 namespace onnxruntime {
 
@@ -33,6 +33,7 @@ using InputsInfoMap = std::unordered_map<size_t, TensorShapeVector>;
 // Information needed to construct an TVM execution provider.
 struct TvmEPOptions {
   std::string executor{tvm::default_executor_type};
+  int allocator_priority{OrtAllocatorPriorityHigh};
   std::string so_folder{""};
   bool check_hash = false;
   std::string hash_file_path{""};

--- a/onnxruntime/core/providers/tvm/tvm_execution_provider.cc
+++ b/onnxruntime/core/providers/tvm/tvm_execution_provider.cc
@@ -37,8 +37,9 @@ struct TVMFuncState {
 TvmExecutionProvider::TvmExecutionProvider(const TvmEPOptions& options)
     : IExecutionProvider{kTvmExecutionProvider},
       options_{options} {
-  AllocatorCreationInfo default_memory_info = {[](int) {
-                                                 return std::make_unique<TVMAllocator>();
+  int alloc_prior = options_.allocator_priority;
+  AllocatorCreationInfo default_memory_info = {[alloc_prior](int) {
+                                                 return std::make_unique<TVMAllocator>(alloc_prior);
                                                },
                                                0, false};
   allocator_ = CreateAllocator(default_memory_info);

--- a/onnxruntime/core/providers/tvm/tvm_so_execution_provider.cc
+++ b/onnxruntime/core/providers/tvm/tvm_so_execution_provider.cc
@@ -38,8 +38,9 @@ struct TVMFuncState {
 TvmSoExecutionProvider::TvmSoExecutionProvider(const TvmEPOptions& options)
     : IExecutionProvider{kTvmExecutionProvider},
       options_{options} {
-  AllocatorCreationInfo default_memory_info = {[](int) {
-                                                 return std::make_unique<TVMAllocator>();
+  int alloc_prior = options_.allocator_priority;
+  AllocatorCreationInfo default_memory_info = {[alloc_prior](int) {
+                                                 return std::make_unique<TVMAllocator>(alloc_prior);
                                                },
                                                0, false};
   allocator_ = CreateAllocator(default_memory_info);


### PR DESCRIPTION
**Description**:
- Add allocator priority field to OrtMemoryInfo
- Update conditions in SessionState::SetupAllocators()
- Update TVM EP options

**Motivation and Context**
Customized TVM EP Allocator is overwritten by default Allocator from CPU EP on high-level which leads to problem with memory allocation. The general problem of Allocator selection with the same memory info from different EPs is described in  https://github.com/microsoft/onnxruntime/issues/12625. The first solution for TVM EP was implemented in [12627](https://github.com/microsoft/onnxruntime/pull/12627), but it was reasonably rejected by reviewers.
Skott McKay suggested two other ways, in the same time they both have disadvantages. Nevertheless the first one gives me idea to add new field to allocator which defines priority when allocator is choosen for the same memory info and different EPs. Just now it solves problems for TVM EP, for other EPs it works as before.

Possibly I partly resolve this [TODO](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/session_state.cc#L31)