### PR TITLE
Fix arithmetic overflow warning.

### DIFF
--- a/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/cuda/math/binary_elementwise_ops.h
@@ -57,7 +57,7 @@ struct BinaryElementwisePreparation {
                              [&C](int64_t dim) { if (dim != 1) C = dim; return (dim != 1); })) {
         int32_t dim_C = gsl::narrow_cast<int32_t>(std::find(rhs_dims.begin(), rhs_dims.end(), C) - rhs_dims.begin() + output_shape.NumDimensions() - rhs_shape.NumDimensions());
         int64_t N = output_shape.SizeToDimension(dim_C);
-        int64_t H = (dim_C < out_rank - 1 ? output_shape.SizeFromDimension(dim_C + 1) : 1);
+        int64_t H = (dim_C < out_rank - 1 ? output_shape.SizeFromDimension(static_cast<size_t>(dim_C) + 1) : 1);
 
         std::vector<int64_t> new_output_dims;
         if (N == 1) {


### PR DESCRIPTION
**Description**: Fix arithmetic overflow warning. Suggested fix by static analysis tool Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).

**Motivation and Context**
Results from running the static analysis tool. Fixes #1944997.