### PR TITLE
Address warnings and move 'using common::Status' to status.h

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -42,10 +42,6 @@ namespace onnxruntime {
 
 using TimePoint = std::chrono::high_resolution_clock::time_point;
 
-// Using statements for common classes that we refer to in ONNXRuntime very often.
-// TODO(Task:137) Remove 'using' statements from header files
-using common::Status;
-
 #ifdef _WIN32
 #define ORT_UNUSED_PARAMETER(x) (x)
 #else

--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -188,4 +188,8 @@ inline std::ostream& operator<<(std::ostream& out, const Status& status) {
 }
 
 }  // namespace common
+
+// make Status directly available in the onnxruntime namespace as it is widely used
+using common::Status;
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -273,6 +273,16 @@ std::unique_ptr<profiling::EpProfiler> CUDAExecutionProvider::GetProfiler() {
   return std::make_unique<profiling::CudaProfiler>();
 }
 
+// Suppressing warning "C26816: The pointer points to memory allocated on the stack." for
+// CUDAExecutionProvider::GetPerThreadContext().
+// While CUDAExecutionProvider::GetPerThreadContext() does return the result of dereferencing a local
+// std::shared_ptr<PerThreadContext>, the underlying PerThreadContext is owned by the CUDA EP and is not local to this
+// function.
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 26816)
+#endif
+
 CUDAExecutionProvider::PerThreadContext& CUDAExecutionProvider::GetPerThreadContext() const {
   const auto& per_thread_context_cache = PerThreadContextCache();
 
@@ -310,6 +320,10 @@ CUDAExecutionProvider::PerThreadContext& CUDAExecutionProvider::GetPerThreadCont
 
   return *context;
 }
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
 
 void CUDAExecutionProvider::ReleasePerThreadContext() const {
   const auto& per_thread_context_cache = PerThreadContextCache();

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -2506,8 +2506,8 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_BasicDQQCleanUp) {
   auto test_case = [](bool use_matching_qdq_params) {
     // input -> Q -> DQ -> Q -> DQ -> output
     auto build_test_case = [&](ModelTestBuilder& builder) {
-      const float scale_1 = 0.05f;
-      const uint8_t zp_1 = 128;
+      constexpr float scale_1 = 0.05f;
+      constexpr uint8_t zp_1 = 128;
       auto* const input = builder.MakeInput<float>({1, 2, 4}, -1.0f, 1.0f);
       auto* const dq_1_out = AddQDQNodePair<uint8_t>(builder, input, scale_1, zp_1);
 
@@ -2550,8 +2550,8 @@ TEST(QDQTransformerTests, QDQFinalCleanupTransformer_GraphInputToOutput) {
   auto test_case = [](bool is_q_dq) {
     // create model with input -> Q/DQ pair -> output
     auto build_test_case = [&](ModelTestBuilder& builder) {
-      const float scale = 0.05f;
-      const uint8_t zp = 128;
+      constexpr float scale = 0.05f;
+      constexpr uint8_t zp = 128;
       NodeArg* input = is_q_dq ? builder.MakeInput<float>({1, 2, 4}, -1.f, 1.f)
                                : builder.MakeInput<uint8_t>({1, 2, 4},
                                                             std::numeric_limits<uint8_t>::min(),

--- a/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cuda/nn/layer_norm.cc
@@ -80,10 +80,10 @@ Status LayerNormGrad<T, U, V, simplified>::ComputeInternal(OpKernelContext* p_op
   }
 
   #ifndef USE_ROCM
-  const int part_size = 16;
+  constexpr int part_size = 16;
   #else
   // Optimization for ROCm MI100
-  const int part_size = 64;
+  constexpr int part_size = 64;
   #endif
   auto part_grad_gamma = GetScratchBuffer<CudaU>(part_size * n2);
   auto part_grad_beta = GetScratchBuffer<CudaU>(part_size * n2);


### PR DESCRIPTION
**Description**
- [Move 'using common::Status;' from common.h to status.h.](https://github.com/microsoft/onnxruntime/commit/6c1c5412162ecab4851fcf2349542abc73abd660)
- [Address some static analysis warnings.](https://github.com/microsoft/onnxruntime/commit/3c475f77bc6feae25307885f9ab71772ef97e051)

**Motivation and Context**
Clean up and address warnings.
