### PR TITLE
Use Big Windows Pool to accelerate web-ci pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -83,7 +83,7 @@ stages:
         CommitOverride: true
         BuildConfig: 'Release'
         ExtraBuildArgs: '$(ExtraBuildArgs)'
-        PoolName: ${{ parameters.PoolName }}
+        PoolName: Big-Win-CPU-2019
         SkipPublish: true
         TimeoutInMinutes: 150
 

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -85,7 +85,7 @@ stages:
         ExtraBuildArgs: '$(ExtraBuildArgs)'
         PoolName: Big-Win-CPU-2019
         SkipPublish: true
-        TimeoutInMinutes: 150
+        TimeoutInMinutes: 120
 
 - stage: Build_web_Release
   dependsOn: Build_wasm_Release

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -51,7 +51,7 @@ stages:
       CommitOverride: true
       BuildConfig: 'Debug'
       ExtraBuildArgs: '$(ExtraBuildArgs)'
-      PoolName: ${{ parameters.PoolName }}
+      PoolName: Big-Win-CPU-2019
 
 - stage: Build_web_Debug
   dependsOn: Build_wasm_Debug


### PR DESCRIPTION
**Description**: 
Allocate the Build_wasm_Release_static_library and Build_wasm_Debug  to the big windows(D16) pool 

**Motivation and Context**
Build_wasm_Release_static_library and Build_wasm_Debug are very timeconsuming.
This change can reduce the duration from 120 minutes to 90minutes

