### PR TITLE
Changes for AIX compilation to get CPU of running thread. hz is inter…

### DIFF
--- a/onnxruntime/core/common/logging/logging.cc
+++ b/onnxruntime/core/common/logging/logging.cc
@@ -14,7 +14,7 @@
 #include <Windows.h>
 #else
 #include <unistd.h>
-#if defined(__MACH__) || defined(__wasm__)
+#if defined(__MACH__) || defined(__wasm__) || defined(_AIX)
 #include <pthread.h>
 #else
 #include <sys/syscall.h>
@@ -218,7 +218,7 @@ unsigned int GetThreadId() {
   long tid;
   thr_self(&tid);
   return static_cast<unsigned int>(tid);
-#elif defined(__wasm__)
+#elif defined(__wasm__) || defined(_AIX)
   return static_cast<unsigned int>(pthread_self());
 #else
   return static_cast<unsigned int>(syscall(SYS_gettid));
@@ -231,7 +231,7 @@ unsigned int GetThreadId() {
 unsigned int GetProcessId() {
 #ifdef _WIN32
   return static_cast<unsigned int>(GetCurrentProcessId());
-#elif defined(__MACH__) || defined(__wasm__)
+#elif defined(__MACH__) || defined(__wasm__) || defined(_AIX)
   return static_cast<unsigned int>(getpid());
 #else
   return static_cast<unsigned int>(syscall(SYS_getpid));

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -136,6 +136,8 @@ void ThreadPoolProfiler::MainThreadStat::LogCore() {
 #endif
 #elif defined(__wasm__)
   core_ = emscripten_num_logical_cores();
+#elif defined(_AIX)
+  core_ = mycpu();
 #else
   core_ = sched_getcpu();
 #endif
@@ -218,6 +220,8 @@ void ThreadPoolProfiler::LogRun(int thread_idx) {
 #endif
 #elif defined(__wasm__)
       child_thread_stats_[thread_idx].core_ = emscripten_num_logical_cores();
+#elif defined(_AIX)
+      child_thread_stats_[thread_idx].core_ = mycpu();
 #else
       child_thread_stats_[thread_idx].core_ = sched_getcpu();
 #endif

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -227,22 +227,22 @@ inline std::basic_string<PATH_CHAR_TYPE> GetLastComponent(const std::basic_strin
 #elif defined(_AIX)
 inline OrtFileType DTToFileTypeAIX(struct stat st) {
     switch (st.st_mode & _S_IFMT) {
-	case S_IFBLK:
-		return OrtFileType::TYPE_BLK;
-	case S_IFCHR:
-		return OrtFileType::TYPE_CHR;
-	case S_IFDIR:
-		return OrtFileType::TYPE_DIR;
-	case S_IFIFO:
-		return OrtFileType::TYPE_FIFO;
-	case S_IFLNK:
-		return OrtFileType::TYPE_LNK;
-	case S_IFREG:
-		return OrtFileType::TYPE_REG;
-	/* No Socket type */
-	default:
-		return OrtFileType::TYPE_UNKNOWN;
-	}
+    case S_IFBLK:
+        return OrtFileType::TYPE_BLK;
+    case S_IFCHR:
+        return OrtFileType::TYPE_CHR;
+    case S_IFDIR:
+        return OrtFileType::TYPE_DIR;
+    case S_IFIFO:
+        return OrtFileType::TYPE_FIFO;
+    case S_IFLNK:
+        return OrtFileType::TYPE_LNK;
+    case S_IFREG:
+        return OrtFileType::TYPE_REG;
+    /* No Socket type */
+    default:
+        return OrtFileType::TYPE_UNKNOWN;
+    }
 }
 
 template <typename T>

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -253,7 +253,7 @@ void LoopDir(const std::string& dir_name, T func) {
     auto e = errno;
     char buf[1024];
     char* msg;
-#if defined(__GLIBC__) && defined(_GNU_SOURCE) && !defined(__ANDROID__)
+#if defined(__GLIBC__) && defined(_GNU_SOURCE) 
     msg = strerror_r(e, buf, sizeof(buf));
 #else
     if (strerror_r(e, buf, sizeof(buf)) != 0) {

--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -7,6 +7,10 @@
 #include <sstream>
 #include <assert.h>
 #include <stdexcept>
+#if defined(_AIX)
+#include <sys/stat.h>
+#include <iostream>
+#endif
 #ifdef _WIN32
 #include <Windows.h>
 #include <time.h>  //strftime
@@ -169,7 +173,7 @@ std::basic_string<PATH_CHAR_TYPE> ConcatPathComponent(const std::basic_string<PA
   return ret;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32)
 inline OrtFileType DTToFileType(DWORD dwFileAttributes) {
   if (dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
     return OrtFileType::TYPE_DIR;
@@ -220,6 +224,66 @@ inline std::basic_string<PATH_CHAR_TYPE> GetLastComponent(const std::basic_strin
   return input.substr(pos);
 }
 
+#elif defined(_AIX)
+inline OrtFileType DTToFileTypeAIX(struct stat st) {
+    switch (st.st_mode & _S_IFMT) {
+	case S_IFBLK:
+		return OrtFileType::TYPE_BLK;
+	case S_IFCHR:
+		return OrtFileType::TYPE_CHR;
+	case S_IFDIR:
+		return OrtFileType::TYPE_DIR;
+	case S_IFIFO:
+		return OrtFileType::TYPE_FIFO;
+	case S_IFLNK:
+		return OrtFileType::TYPE_LNK;
+	case S_IFREG:
+		return OrtFileType::TYPE_REG;
+	/* No Socket type */
+	default:
+		return OrtFileType::TYPE_UNKNOWN;
+	}
+}
+
+template <typename T>
+void LoopDir(const std::string& dir_name, T func) {
+  DIR* dir = opendir(dir_name.c_str());
+  struct stat stats; 
+  if (dir == nullptr) {
+    auto e = errno;
+    char buf[1024];
+    char* msg;
+#if defined(__GLIBC__) && defined(_GNU_SOURCE) && !defined(__ANDROID__)
+    msg = strerror_r(e, buf, sizeof(buf));
+#else
+    if (strerror_r(e, buf, sizeof(buf)) != 0) {
+      buf[0] = '\0';
+    }
+    msg = buf;
+#endif
+    std::ostringstream oss;
+    oss << "couldn't open '" << dir_name << "':" << msg;
+    std::string s = oss.str();
+    ORT_THROW(s);
+  }
+  ORT_TRY {
+    struct dirent* dp;
+    while ((dp = readdir(dir)) != nullptr) {
+    std::basic_string<PATH_CHAR_TYPE> filename  = ConcatPathComponent<PATH_CHAR_TYPE>(dir_name, dp->d_name);
+	if (stat(filename.c_str(), &stats) != 0) {
+		continue;
+	}	
+      if (!func(dp->d_name, DTToFileTypeAIX(stats))) {
+        break;
+      }
+    }
+  }
+  ORT_CATCH(const std::exception& ex) {
+    closedir(dir);
+    ORT_RETHROW;
+  }
+  closedir(dir);
+}
 #else
 inline OrtFileType DTToFileType(unsigned char t) {
   switch (t) {

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -172,7 +172,7 @@ class PosixThread : public EnvThread {
         auto [err_no, err_msg] = GetSystemError();
         ORT_THROW("pthread_create failed, error code: ", err_no, " error msg: ", err_msg);
       }
-#if !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__)
+#if !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
       if (!thread_options.affinity.empty()) {
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);

--- a/onnxruntime/core/platform/posix/stacktrace.cc
+++ b/onnxruntime/core/platform/posix/stacktrace.cc
@@ -3,7 +3,7 @@
 
 #include "core/common/common.h"
 
-#if !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_)
+#if !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
 #include <execinfo.h>
 #endif
 #include <vector>

--- a/onnxruntime/core/providers/cpu/signal/window_functions.cc
+++ b/onnxruntime/core/providers/cpu/signal/window_functions.cc
@@ -110,6 +110,7 @@ Status BlackmanWindow::Compute(OpKernelContext* ctx) const {
   return create_cosine_sum_window(ctx, data_type_, a0, a1, a2, is_periodic_);
 }
 
+// 'hz' is a #define in AIX, hence using hz1
 static inline double hz_to_mel_scale(double hz1) { return 2595 * std::log10(1 + hz1 / 700); }
 
 static inline double mel_scale_to_hz(double mels) { return 700 * (pow(10, (mels / 2595)) - 1); }
@@ -161,6 +162,7 @@ struct CreateMelWeightMatrix {
 
     // Convert each point from mel scale back to hertz, and then compute the corresponding index in the fft
     for (size_t i = 0; i < frequency_bins.size(); i++) {
+      // 'hz' is a #define in AIX, hence using hz1
       auto hz1 = mel_scale_to_hz(low_frequency_mel + mel_step * i);
       frequency_bins[i] = static_cast<size_t>(std::floor(((dft_length + 1) * hz1) / sample_rate));
     }

--- a/onnxruntime/core/providers/cpu/signal/window_functions.cc
+++ b/onnxruntime/core/providers/cpu/signal/window_functions.cc
@@ -110,7 +110,7 @@ Status BlackmanWindow::Compute(OpKernelContext* ctx) const {
   return create_cosine_sum_window(ctx, data_type_, a0, a1, a2, is_periodic_);
 }
 
-static inline double hz_to_mel_scale(double hz) { return 2595 * std::log10(1 + hz / 700); }
+static inline double hz_to_mel_scale(double hz1) { return 2595 * std::log10(1 + hz1 / 700); }
 
 static inline double mel_scale_to_hz(double mels) { return 700 * (pow(10, (mels / 2595)) - 1); }
 
@@ -161,8 +161,8 @@ struct CreateMelWeightMatrix {
 
     // Convert each point from mel scale back to hertz, and then compute the corresponding index in the fft
     for (size_t i = 0; i < frequency_bins.size(); i++) {
-      auto hz = mel_scale_to_hz(low_frequency_mel + mel_step * i);
-      frequency_bins[i] = static_cast<size_t>(std::floor(((dft_length + 1) * hz) / sample_rate));
+      auto hz1 = mel_scale_to_hz(low_frequency_mel + mel_step * i);
+      frequency_bins[i] = static_cast<size_t>(std::floor(((dft_length + 1) * hz1) / sample_rate));
     }
 
     for (size_t i = 0; i < static_cast<size_t>(num_mel_bins); i++) {


### PR DESCRIPTION
…nal variable in AIX, hence changing to hz1 in window_functions.cc so that all OS shall work

**Description**: Describe your changes.
6 files are changed. 
1. onnxruntime/core/common/logging/logging.cc 
In this file we have added code to include pthread.h for AIX with defined(_AIX)
2. onnxruntime/core/common/threadpool.cc
In this file changes to get the current CPU using mycpu() in AIX. 
3. onnxruntime/core/providers/cpu/signal/window_functions.cc
In AIX hz is an inbuilt variable. Hence changing the variable hz in the code to hz1. I have not checked the OS using defined(_AIX), as hz1 works for all OSes. 
4. onnxruntime/core/platform/posix/stacktrace.cc
In this file we added !defined(_AIX) in the below code:
#if !defined(__ANDROID__) && !defined(__wasm__) && !defined(_OPSCHEMA_LIB_) && !defined(_AIX)
#include <execinfo.h>
#endif
#include <vector>
5. onnxruntime/core/platform/path_lib.h
This file changed to enable to find file type in AIX with AIX system calls. 
6. onnxruntime/core/platform/posix/env.cc
Enable AIX similar to other platforms like _ANDROID_, __APPLE__, __wasm__

Please review and let me know if I miss something. Thanks. 

**Motivation and Context**
- Why is this change required? What problem does it solve?
      The current changes are for enabling compilation of the code in AIX Operating system. 
- If it fixes an open issue, please link to the issue here.
