### PR TITLE
Using ORTModule to wrap a evaluation model should not change the mode

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -98,6 +98,7 @@ class ORTModule(torch.nn.Module):
                 override_policy=_FallbackPolicy.FALLBACK_FORCE_TORCH_FORWARD,
             )
 
+        self.train(module.training)
         # Finally, ORTModule initialization is complete.
         # Assign self._is_initialized to True after all the ORTModule class attributes have been assigned
         # else, they will be assigned to self._torch_module.original_module instead.


### PR DESCRIPTION
To fix the bug:
When using ORTModule wrap model and do evaluation, the mode of model will become training after ORT wrapping. 