### PR TITLE
fix CalculateHash for Big Endian platforms.

### DIFF
--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -55,7 +55,6 @@ void KernelDef::CalculateHash() {
            (uint32_t)c[2] << 16 |
            (uint32_t)c[3] << 24);
   }
- 
 
   // If we include op_since_version_end_ the hash of an existing op changes when it's superseded.
   // e.g. Unsqueeze 11 had no end version until Unsqueeze 13, at which point the existing op is changed to have

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -45,7 +45,17 @@ void KernelDef::CalculateHash() {
   // kernel definition)
 
   hash_str(op_name_);
-  hash_int(op_since_version_start_);
+
+  if constexpr (onnxruntime::endian::native == onnxruntime::endian::little) {
+    hash_int(op_since_version_start_);
+  } else {
+    const uint8_t* c = (const uint8_t*)&op_since_version_start_;
+    hash_int((uint32_t)c[0] |
+           (uint32_t)c[1] << 8 |
+           (uint32_t)c[2] << 16 |
+           (uint32_t)c[3] << 24);
+  }
+ 
 
   // If we include op_since_version_end_ the hash of an existing op changes when it's superseded.
   // e.g. Unsqueeze 11 had no end version until Unsqueeze 13, at which point the existing op is changed to have


### PR DESCRIPTION
**Description**: Describe your changes.

This fixes the CalculateHash() function for big endian platforms like AIX. 

Following file is the modification:
onnxruntime/core/framework/kernel_def_builder.cc

Basically the CalculateHash() is calling hash_int() which is passing address of an int to  MurmurHash3::x86_128() , this is causing overall hash generation different causing kernel lookups failing on AIX. Change is to pass on the 
LE representation of the int on Big Endian platform like AIX so that hash generation will be common.



**Motivation and Context**
- Why is this change required? What problem does it solve?
-Explained above. Kernel lookups would fail on AIX.

- If it fixes an open issue, please link to the issue here.
https://github.com/microsoft/onnxruntime/issues/12728