### PR TITLE
Increase timeout for clean-build-docker-image-cache-pipeline.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/clean-build-docker-image-cache-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/clean-build-docker-image-cache-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-20.04'
 
-  timeoutInMinutes: 10
+  timeoutInMinutes: 30
 
   steps:
   - checkout: self


### PR DESCRIPTION
**Description**
Increase timeout for clean-build-docker-image-cache-pipeline.

**Motivation and Context**
It has been timing out sometimes.