### PR TITLE
[js/web][Fix] - updating the C API to catch non-tensor data

### DIFF
--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -328,7 +328,7 @@ export const run =
                 errorCode = wasm._OrtGetTensorData(
                     tensor, tensorDataOffset, tensorDataOffset + 4, tensorDataOffset + 8, tensorDataOffset + 12);
                 if (errorCode !== 0) {
-                  throw new Error(`Can't access tensor data - recieved unexpected data type. error code = ${errorCode}`);
+                  throw new Error(`Can't access output tensor data. error code = ${errorCode}`);
                 }
                 let tensorDataIndex = tensorDataOffset / 4;
                 const dataType = wasm.HEAPU32[tensorDataIndex++];

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -328,7 +328,7 @@ export const run =
                 errorCode = wasm._OrtGetTensorData(
                     tensor, tensorDataOffset, tensorDataOffset + 4, tensorDataOffset + 8, tensorDataOffset + 12);
                 if (errorCode !== 0) {
-                  throw new Error(`Can't get a tensor data. error code = ${errorCode}`);
+                  throw new Error(`Can't access tensor data - recieved unexpected data type. error code = ${errorCode}`);
                 }
                 let tensorDataIndex = tensorDataOffset / 4;
                 const dataType = wasm.HEAPU32[tensorDataIndex++];

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -246,9 +246,9 @@ int OrtGetTensorData(OrtValue* tensor, int* data_type, void** data, size_t** dim
   size_t* p_dims = nullptr;
   void* p_string_data = nullptr;
 
-  ONNXType* TensorType;
-  RETURN_ERROR_CODE_IF_ERROR(GetValueType, tensor, TensorType);
-  if(*TensorType!=ONNX_TYPE_TENSOR) {
+  ONNXType tensor_type;
+  RETURN_ERROR_CODE_IF_ERROR(GetValueType, tensor, &tensor_type);
+  if(tensor_type!=ONNX_TYPE_TENSOR) {
     return ORT_FAIL;
   }
 

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -248,7 +248,7 @@ int OrtGetTensorData(OrtValue* tensor, int* data_type, void** data, size_t** dim
 
   ONNXType tensor_type;
   RETURN_ERROR_CODE_IF_ERROR(GetValueType, tensor, &tensor_type);
-  if(tensor_type!=ONNX_TYPE_TENSOR) {
+  if( tensor_type != ONNX_TYPE_TENSOR ) {
     return ORT_FAIL;
   }
 

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -113,7 +113,7 @@ OrtSessionOptions* OrtCreateSessionOptions(size_t graph_optimization_level,
   RETURN_NULLPTR_IF_ERROR(EnableOrtCustomOps, session_options);
 #endif
 #if defined(USE_XNNPACK)
-  
+
   RETURN_NULLPTR_IF_ERROR(SessionOptionsAppendExecutionProvider, session_options, "XNNPACK", nullptr, nullptr, 0);
 #endif
   return session_options;
@@ -245,6 +245,12 @@ int OrtGetTensorData(OrtValue* tensor, int* data_type, void** data, size_t** dim
   OrtAllocator* allocator = nullptr;
   size_t* p_dims = nullptr;
   void* p_string_data = nullptr;
+
+  ONNXType* TensorType;
+  RETURN_ERROR_CODE_IF_ERROR(GetValueType, tensor, TensorType);
+  if(*TensorType!=ONNX_TYPE_TENSOR) {
+    return ORT_FAIL;
+  }
 
   RETURN_ERROR_CODE_IF_ERROR(GetTensorTypeAndShape, tensor, &info);
 

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -248,7 +248,7 @@ int OrtGetTensorData(OrtValue* tensor, int* data_type, void** data, size_t** dim
 
   ONNXType tensor_type;
   RETURN_ERROR_CODE_IF_ERROR(GetValueType, tensor, &tensor_type);
-  if( tensor_type != ONNX_TYPE_TENSOR ) {
+  if ( tensor_type != ONNX_TYPE_TENSOR ) {
     return ORT_FAIL;
   }
 


### PR DESCRIPTION
Added a check for tensor validation on  the input - this change fixes the quiet abort WASM takes when processing a non tensor data in "OrtGetTensorData"

**Motivation and Context**
At the current status when we try to process non-tensor data through OrtGetTensorData and exception is thrown which results in a quiet abort from WASM (assuming WASM was built without exception handling).

I added a check in the C API to catch this case and output a meaningful message to the user
[example_error_github_12622.zip](https://github.com/microsoft/onnxruntime/files/9464328/example_error_github_12622.zip)
