### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,15 +1,15 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 5
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 5
 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - status:contributions-welcome 
-  - status:more-info-needed 
-  - status:duplicate
-  - type:enhancement
+  - contributions welcome
+  - feature request
+  - more info needed
+  - regression
   
 # Label to use when marking an issue as stale
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,14 +1,13 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 5
+daysUntilStale: 30
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 5
+daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
   - contributions welcome
   - feature request
-  - more info needed
   - regression
   
 # Label to use when marking an issue as stale


### PR DESCRIPTION
**Description**: Change the number of days of inactivity before an issue becomes stale from 60 to 30. Update the exempt labels based on the redefined set of GH labels.

**Motivation and Context**
- Why is this change required? What problem does it solve?
This change is required to fix current issues with the stale bot, which hasn't been working correctly since mid-April. Updating the stale bot will help DRIs and the engineering team follow up on issues in a more timely manner.
