### PR TITLE
[ROCm] add SkipLayerNorm vectorize Regular case

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/layer_norm.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/layer_norm.cuh
@@ -110,6 +110,49 @@ __device__ inline void LayerNorm(
 }
 
 template <typename T, int TPB, int ILP>
+__device__ inline void LayerNormVec(
+    const hipcub::KeyValuePair<T, T>& thread_data, const int ld, const int offset, const T* beta,
+    const T* gamma, const T epsilon, T* output) {
+  // Assuming thread_data is already divided by ld
+  using VecT = aligned_vector<T, ILP>;
+  using BlockReduce = hipcub::BlockReduce<hipcub::KeyValuePair<T, T>, TPB>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ T mu;      // mean
+  __shared__ T rsigma;  // 1 / std.dev.
+
+  KeyValuePairSum pair_sum;
+  const auto sum_kv = BlockReduce(temp_storage).Reduce(thread_data, pair_sum);
+
+  if (threadIdx.x == 0) {
+    mu = sum_kv.key;
+    rsigma = Rsqrt(sum_kv.value - mu * mu + epsilon);
+  }
+  __syncthreads();
+
+  if (ILP * threadIdx.x < ld) {
+    T beta_v[ILP], gamma_v[ILP], output_v[ILP];
+    VecT* gamma_val = reinterpret_cast<VecT*>(&gamma_v);
+    VecT* output_val = reinterpret_cast<VecT*>(&output_v);
+
+    for (int i = threadIdx.x * ILP; i < ld; i += TPB * ILP) {
+      int idx = offset + i;
+      if (beta != nullptr) {
+        VecT* beta_val = reinterpret_cast<VecT*>(&beta_v);
+        *beta_val = *reinterpret_cast<const VecT*>(&beta[i]);
+      }
+      *gamma_val = *reinterpret_cast<const VecT*>(&gamma[i]);
+      *output_val = *reinterpret_cast<const VecT*>(&output[idx]);
+      #pragma unroll
+      for (int k = 0; k < ILP; k++) {
+        output_v[k] = (beta != nullptr) ? gamma_v[k] * (output_v[k] - mu) * rsigma + beta_v[k] :
+                                          gamma_v[k] * (output_v[k] - mu) * rsigma;
+      }
+      *(reinterpret_cast<VecT*>(&output[idx])) = *reinterpret_cast<VecT*>(&output_v[0]);
+    }
+  }
+}
+
+template <typename T, int TPB, int ILP>
 __device__ inline void LayerNormSmall(const T* input_v, const hipcub::KeyValuePair<T, T>& thread_data,
                                       const int ld, const int idx, const T* beta, const T* gamma,
                                       const T epsilon, T* output) {

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
@@ -47,6 +47,49 @@ __global__ void SkipLayerNormKernel(
 
 // Vectorized kernel
 template <typename T, unsigned TPB, int ILP>
+__global__ void SkipLayerNormKernelVec(
+    const int ld, const T* input, const T* skip, const T* beta, const T* gamma,
+    const T* bias, const T epsilon, T* output, bool hasBias) {
+  const T reverse_ld = T(1.f / ld);
+  const int offset = blockIdx.x * ld;
+
+  KeyValuePairSum pair_sum;
+  // reduce x and x^2
+  hipcub::KeyValuePair<T, T> thread_data(0, 0);
+
+  using VecT = aligned_vector<T, ILP>;
+  T input_v[ILP], skip_v[ILP], bias_v[ILP], output_v[ILP];
+  if (threadIdx.x * ILP < ld) {
+    VecT* input_val = reinterpret_cast<VecT*>(&input_v);
+    VecT* skip_val = reinterpret_cast<VecT*>(&skip_v);
+
+    for (int i = threadIdx.x * ILP; i < ld; i += TPB * ILP) {
+      int idx = offset + i;
+
+      *input_val = *reinterpret_cast<const VecT*>(&input[idx]);
+      *skip_val = *reinterpret_cast<const VecT*>(&skip[idx]);
+      if (hasBias) {
+        VecT* bias_val = reinterpret_cast<VecT*>(&bias_v);
+        *bias_val = *reinterpret_cast<const VecT*>(&bias[i]);
+      }
+
+      T rldval_sum = T(0.f);
+      T rldvalsq_sum = T(0.f);
+      #pragma unroll
+      for (int k = 0; k < ILP; k++) {
+        input_v[k] += hasBias ? skip_v[k] + bias_v[k] : skip_v[k];
+        const T rldval = reverse_ld * input_v[k];
+        thread_data = pair_sum(thread_data, hipcub::KeyValuePair<T, T>(rldval, rldval * input_v[k]));
+      }
+      *(reinterpret_cast<VecT*>(&output[idx])) = *reinterpret_cast<VecT*>(&input_v[0]);
+    }
+  }
+
+  LayerNormVec<T, TPB, ILP>(thread_data, ld, offset, beta, gamma, epsilon, output);
+}
+
+// Vectorized kernel
+template <typename T, unsigned TPB, int ILP>
 __global__ void SkipLayerNormKernelSmall(
     const int ld, const T* input, const T* skip, const T* beta, const T* gamma,
     const T* bias, const T epsilon, T* output, bool hasBias) {

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -45,7 +45,8 @@ struct SkipLayerNormParams : onnxruntime::rocm::tunable::OpParams {
 template <typename T, int ThreadsPerBlock, int VecSize>
 Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
   TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(
-      !((params->ld <= 1024 && params->ld % VecSize == 0 && params->ld == ThreadsPerBlock * VecSize)));
+      !((params->ld <= 1024 && params->ld % VecSize == 0 &&
+         params->ld <= ThreadsPerBlock * VecSize && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)));
   SkipLayerNormKernelSmall<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
                                                           dim3(ThreadsPerBlock),
                                                           0, params->stream>>>(

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -58,7 +58,7 @@ Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
 template <typename T, int ThreadsPerBlock, int VecSize>
 Status SkipLayerNormRegularOp(const SkipLayerNormParams<T>* params) {
   TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(
-      !((params->ld > 0 && params->ld % VecSize == 0 && params->ld >= ThreadsPerBlock * VecSize)));
+      !((params->ld > 0 && params->ld % VecSize == 0 && (params->ld >= ThreadsPerBlock * VecSize || params->ld < 64))));
   SkipLayerNormKernelVec<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
                                                         dim3(ThreadsPerBlock),
                                                         0, params->stream>>>(

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -59,7 +59,9 @@ Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
 template <typename T, int ThreadsPerBlock, int VecSize>
 Status SkipLayerNormRegularOp(const SkipLayerNormParams<T>* params) {
   TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(
-      !((params->ld > 0 && params->ld % VecSize == 0 && (params->ld >= ThreadsPerBlock * VecSize || params->ld < 64))));
+      !((params->ld > 0 && params->ld % VecSize == 0 &&
+       (params->ld >= ThreadsPerBlock * VecSize ||
+       (params->ld < 64 && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)))));
   SkipLayerNormKernelVec<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
                                                         dim3(ThreadsPerBlock),
                                                         0, params->stream>>>(

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -12,6 +12,8 @@
 #include "core/providers/rocm/cu_inc/common.cuh"
 #include "core/providers/rocm/tunable/tunable.h"
 
+using onnxruntime::rocm::CeilDiv;
+
 namespace onnxruntime {
 namespace contrib {
 namespace rocm {
@@ -42,7 +44,6 @@ struct SkipLayerNormParams : onnxruntime::rocm::tunable::OpParams {
 
 template <typename T, int ThreadsPerBlock, int VecSize>
 Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
-  using onnxruntime::rocm::CeilDiv;
   TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(
       !((params->ld <= 1024 && params->ld % VecSize == 0 && params->ld == ThreadsPerBlock * VecSize)));
   SkipLayerNormKernelSmall<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
@@ -54,30 +55,48 @@ Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
   return HIP_CALL(hipGetLastError());
 }
 
-#define ADD_OP(threads_per_block)                                         \
-  this->ops_.emplace_back(SkipLayerNormSmallOp<T, threads_per_block, 1>); \
-  this->ops_.emplace_back(SkipLayerNormSmallOp<T, threads_per_block, 2>); \
-  this->ops_.emplace_back(SkipLayerNormSmallOp<T, threads_per_block, 4>); \
-  this->ops_.emplace_back(SkipLayerNormSmallOp<T, threads_per_block, 8>); \
-  this->ops_.emplace_back(SkipLayerNormSmallOp<T, threads_per_block, 16>);
+template <typename T, int ThreadsPerBlock, int VecSize>
+Status SkipLayerNormRegularOp(const SkipLayerNormParams<T>* params) {
+  TUNABLE_OP_RETURN_UNSUPPOTED_ARGUMENT_IF(
+      !((params->ld > 0 && params->ld % VecSize == 0 && params->ld >= ThreadsPerBlock * VecSize)));
+  SkipLayerNormKernelVec<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
+                                                        dim3(ThreadsPerBlock),
+                                                        0, params->stream>>>(
+      params->ld, params->input, params->skip,
+      params->beta, params->gamma, params->bias, maybe2half<T>(params->epsilon), params->output,
+      (params->bias == nullptr) ? false : true);
+  return HIP_CALL(hipGetLastError());
+}
+
+#define ADD_OP_FOR_ALL_VEC_SIZE(name, threads_per_block)  \
+  this->ops_.emplace_back(name<T, threads_per_block, 1>); \
+  this->ops_.emplace_back(name<T, threads_per_block, 2>); \
+  this->ops_.emplace_back(name<T, threads_per_block, 4>); \
+  this->ops_.emplace_back(name<T, threads_per_block, 8>); \
+  this->ops_.emplace_back(name<T, threads_per_block, 16>);
+
+#define ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(name) \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 64)                         \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 128)                        \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 192)                        \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 256)                        \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 320)                        \
+  ADD_OP_FOR_ALL_VEC_SIZE(name, 384)
 
 template <typename T>
 class SkipLayerNormTunableOp : public onnxruntime::rocm::tunable::TunableOp<SkipLayerNormParams<T>> {
  public:
   SkipLayerNormTunableOp() {
-    ADD_OP(64)
-    ADD_OP(128)
-    ADD_OP(192)
-    ADD_OP(256)
-    ADD_OP(320)
-    ADD_OP(384)
+    ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmallOp)
+    ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegularOp)
 
-    // NOTE: the 3-th kernel seems to be better in gerenal case, so set it as default one
-    this->SetDefaultId(3);
+    // NOTE: the 30-th kernel is SkipLayerNormRegularOp ThreadsPerBlock=64 VecSize=1
+    this->SetDefaultId(30);
   }
 };
 
-#undef ADD_OP
+#undef ADD_OP_FOR_ALL_VEC_SIZE
+#undef ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE
 
 }  // namespace rocm
 }  // namespace contrib

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm.cc
@@ -38,6 +38,30 @@ class SkipLayerNormSmall : public IKernelExplorer {
   ParamsT params_{};
 };
 
+template <typename T, int ThreadsPerBlock, int VecSize>
+class SkipLayerNormRegular : public IKernelExplorer {
+ public:
+  SkipLayerNormRegular(DeviceArray& output, DeviceArray& input, DeviceArray& skip,
+                       DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
+                       float epsilon, int hidden_size, int element_count)
+      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+                static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), static_cast<T*>(beta.ptr()),
+                static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
+
+  void Run() override {
+    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize>(&params_)));
+  }
+
+  bool IsSupported() {
+    Status status = contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize>(&params_);
+    return status.IsOK();
+  }
+
+ private:
+  using ParamsT = contrib::rocm::SkipLayerNormParams<T>;
+  ParamsT params_{};
+};
+
 template <typename T>
 class SkipLayerNormTunable : public IKernelExplorer {
  public:
@@ -102,6 +126,8 @@ class SkipLayerNormTunable : public IKernelExplorer {
 void InitSkipLayerNorm(py::module m) {
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, half);
   REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, float);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, half);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, float);
 
   REGISTER_TUNABLE_OP(half);
   REGISTER_TUNABLE_OP(float);

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -14,7 +14,7 @@ import pytest
 def get_bert_sizes():
     batch_sizes = [1, 8, 64, 128]
     seq_lens = [64, 128, 256, 384, 512]
-    hidden_sizes = [768, 1024]
+    hidden_sizes = [768, 1024, 2048]
     return product(batch_sizes, seq_lens, hidden_sizes)
 
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -14,7 +14,7 @@ import pytest
 def get_bert_sizes():
     batch_sizes = [1, 8, 64, 128]
     seq_lens = [64, 128, 256, 384, 512]
-    hidden_sizes = [768, 1024, 2048]
+    hidden_sizes = [2, 3, 7, 9, 13, 63, 65, 127, 129, 177, 768, 1024, 2048, 2049]
     return product(batch_sizes, seq_lens, hidden_sizes)
 
 
@@ -72,7 +72,6 @@ dtypes = ["float32", "float16"]
 @pytest.mark.parametrize("dtype", dtypes)
 def test_skip_layer_norm(bert_sizes, dtype):
     for func in dtype_to_funcs(dtype):
-        print(func)
         run_skip_layer_norm(*bert_sizes, dtype, func)
 
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -12,9 +12,9 @@ import pytest
 
 
 def get_bert_sizes():
-    batch_sizes = [1, 8, 64, 128]
-    seq_lens = [64, 128, 256, 384, 512]
-    hidden_sizes = [2, 3, 7, 9, 13, 63, 65, 127, 129, 177, 768, 1024, 2048, 2049]
+    batch_sizes = [1, 8, 128]
+    seq_lens = [64, 256, 384]
+    hidden_sizes = [13, 32, 63, 64, 65, 127, 128, 129, 177, 768, 1024, 2049]
     return product(batch_sizes, seq_lens, hidden_sizes)
 
 


### PR DESCRIPTION
**Description**: Describe your changes.
Related PR: https://github.com/microsoft/onnxruntime/pull/12803 https://github.com/microsoft/onnxruntime/pull/12816 https://github.com/microsoft/onnxruntime/pull/12817 
add SkipLayerNorm vectorize regular case
1. when hidden size <= 1024, SkipLayerNormTunable op can use both small case and regular case
2. when hidden size > 1024, SkipLayerNormTunable op can only use regular case.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
