### PR TITLE
python lint

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -48,6 +48,7 @@ def _pytorch_type_to_onnx(scalar_type: str) -> torch.onnx.TensorProtoDataType:
     except AttributeError:
         return _CAST_PYTORCH_TO_ONNX[scalar_type]
 
+
 # For pointer needed for PythonOp execution, we firstly append it into a global store to hold a
 # reference (in case it is released after module exported).
 NONTENSOR_OBJECT_POINTER_STORE = {}


### PR DESCRIPTION
**Description**: Describe your changes.

Fix the format error
```
--- orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py	2022-09-01 09:10:02.081774 +0000
+++ orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py	2022-09-01 09:10:21.114949 +0000
@@ -45,10 +45,11 @@
would reformat orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
 def _pytorch_type_to_onnx(scalar_type: str) -> torch.onnx.TensorProtoDataType:
     try:
         return torch.onnx.JitScalarType.from_name(scalar_type).onnx_type()
     except AttributeError:
         return _CAST_PYTORCH_TO_ONNX[scalar_type]
+
 
 # For pointer needed for PythonOp execution, we firstly append it into a global store to hold a
 # reference (in case it is released after module exported).
 NONTENSOR_OBJECT_POINTER_STORE = {}
```
**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
