### PR TITLE
Update max opset for NNAPI and CoreML. 

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
+++ b/onnxruntime/core/providers/coreml/builders/impl/base_op_builder.h
@@ -46,7 +46,7 @@ class BaseOpBuilder : public IOpBuilder {
   virtual bool HasSupportedInputsImpl(const Node& node, const logging::Logger& logger) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
-  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 15; }
+  virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 17; }
 
  private:
   bool HasSupportedOpSet(const Node& node, const logging::Logger& logger) const;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_support_checker.cc
@@ -346,7 +346,7 @@ class BaseOpSupportChecker : public IOpSupportChecker {
       const OpSupportCheckParams& params) const;
 
   virtual int GetMinSupportedOpSet(const NodeUnit& /* node_unit */) const { return 1; }
-  virtual int GetMaxSupportedOpSet(const NodeUnit& /* node_unit */) const { return 15; }
+  virtual int GetMaxSupportedOpSet(const NodeUnit& /* node_unit */) const { return 17; }
 
   // Check if this node_unit's type is supported
   // SingleNode type NodeUnit is supported


### PR DESCRIPTION
**Description**: 
Changes in opsets 16 and 17 don't require any updates to currently supported NNAPI/Coreml operator+type combinations.

**Motivation and Context**
#12793  involved an opset 16 model with PRelu. There were other issues, but the PRelu should at least have been able to be handled.