### PR TITLE
Add image to link previews

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<meta property="og:image" content="/images/logos/onnxruntime/ORT_icon_for_light_bg.png" />


### PR DESCRIPTION
Add og:image meta tag to website page headers

Link previews will look something like: 
![image](https://user-images.githubusercontent.com/3302433/188214055-6e452dbd-118f-411d-979c-8a7772302c1f.png)

instead of

![image](https://user-images.githubusercontent.com/3302433/188214181-4e37e210-bf74-4625-9e24-92fff29d66ee.png)

