### PR TITLE
Use CMake EXCLUDE_FROM_ALL for composable kernels to avoid building of conv related kernels

### DIFF
--- a/cmake/external/composable_kernel.cmake
+++ b/cmake/external/composable_kernel.cmake
@@ -11,9 +11,13 @@ FetchContent_Declare(composable_kernel
   PATCH_COMMAND  git apply --reverse --check ${PATCH} || git apply --ignore-space-change --ignore-whitespace ${PATCH}
 )
 
-FetchContent_MakeAvailable(composable_kernel)
+FetchContent_GetProperties(composable_kernel)
+if(NOT composable_kernel_POPULATED)
+  FetchContent_Populate(composable_kernel)
+  add_subdirectory(${composable_kernel_SOURCE_DIR} ${composable_kernel_BINARY_DIR} EXCLUDE_FROM_ALL)
 
-add_library(onnxruntime_composable_kernel_includes INTERFACE)
-target_include_directories(onnxruntime_composable_kernel_includes INTERFACE
-  ${composable_kernel_SOURCE_DIR}/include
-  ${composable_kernel_SOURCE_DIR}/library/include)
+  add_library(onnxruntime_composable_kernel_includes INTERFACE)
+  target_include_directories(onnxruntime_composable_kernel_includes INTERFACE
+    ${composable_kernel_SOURCE_DIR}/include
+    ${composable_kernel_SOURCE_DIR}/library/include)
+endif()


### PR DESCRIPTION
**Description**: Conv related kernel building in composable kernels are extremely slow. This use `EXCLUDE_FROM_ALL` to make ort only build dependent targets in composable kernels repo.

**Motivation and Context**
- Why is this change required? What problem does it solve?
   Improve building.
