### PR TITLE
Fix type mismatch in CUDA Trilu op.

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/trilu.cc
+++ b/onnxruntime/core/providers/cuda/tensor/trilu.cc
@@ -34,12 +34,12 @@ Status Trilu::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor& input = *input_ptr;
   const auto& shape = input.Shape();
   const auto& input_dims = shape.GetDims();
-  auto rank = gsl::narrow_cast<int32_t>(input_dims.size());
+  auto rank = input_dims.size();
   if (rank < 2) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Input tensor should have a rank of at least 2");
   }
   Tensor* output = ctx->Output(0, shape);
-  auto matrix_size = input_dims[static_cast<int64_t>(rank) - 1] * input_dims[static_cast<int64_t>(rank) - 2];
+  auto matrix_size = input_dims[rank - 1] * input_dims[rank - 2];
   if (matrix_size == 0) {
     return Status::OK();
   }

--- a/onnxruntime/core/providers/cuda/tensor/trilu.cc
+++ b/onnxruntime/core/providers/cuda/tensor/trilu.cc
@@ -34,12 +34,12 @@ Status Trilu::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor& input = *input_ptr;
   const auto& shape = input.Shape();
   const auto& input_dims = shape.GetDims();
-  int32_t rank = gsl::narrow_cast<int32_t>(input_dims.size());
+  auto rank = gsl::narrow_cast<int32_t>(input_dims.size());
   if (rank < 2) {
     return Status(ONNXRUNTIME, INVALID_ARGUMENT, "Input tensor should have a rank of at least 2");
   }
   Tensor* output = ctx->Output(0, shape);
-  int64_t matrix_size = input_dims[rank - 1] * input_dims[rank - 2];
+  auto matrix_size = input_dims[static_cast<int64_t>(rank) - 1] * input_dims[static_cast<int64_t>(rank) - 2];
   if (matrix_size == 0) {
     return Status::OK();
   }


### PR DESCRIPTION
**Description**: Describe your changes.
Added type cast to int64_t to avoid overflow errors/alerts.
**Motivation and Context**

- Why is this change required? What problem does it solve?
Prevent integer arithmetic overflow.
- If it fixes an open issue, please link to the issue here.
https://dev.azure.com/aiinfra/ONNX%20Runtime/_workitems/edit/9002/