### PR TITLE
Add example of specific image to website link previews

### DIFF
--- a/docs/tutorials/azureml.md
+++ b/docs/tutorials/azureml.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy on AzureML
 descriptions: Deploy high performance question-answer model on AzureML with ONNX Runtime
+image: /images/azureml-deployment.png
 parent: Tutorials
 nav_order: 5
 ---


### PR DESCRIPTION
Add `image: /images/azureml-deployment.png` to the article front matter.

![image](https://user-images.githubusercontent.com/3302433/192908399-d9234328-e658-4cab-a304-c4391d21f5e6.png)




