### PR TITLE
revert PreferredInlinedVectorSizeOf back to 64

### DIFF
--- a/include/onnxruntime/core/common/inlined_containers_fwd.h
+++ b/include/onnxruntime/core/common/inlined_containers_fwd.h
@@ -65,7 +65,7 @@ struct CalculateInlinedVectorDefaultInlinedElements {
   // 1. There is at least one inlined element.
   // 2. `sizeof(InlinedVector<T>) <= kPreferredInlinedVectorSizeof` unless
   // it contradicts 1.
-  static constexpr size_t kPreferredInlinedVectorSizeof = 128;
+  static constexpr size_t kPreferredInlinedVectorSizeof = 64;
 
   // static_assert that sizeof(T) is not "too big".
   //


### PR DESCRIPTION
**Description**: revert PreferredInlinedVectorSizeOf back to 64.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
