### PR TITLE
Splitting quantize_tensor and quantize_input

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -590,7 +590,7 @@ class ONNXQuantizer:
             data_found, scale_name, zp_name, _, _ = self._get_quantization_params(input_name)
 
         nodes = []
-        if data_found == True:
+        if data_found:
             qlinear_node = onnx.helper.make_node(
                 "QuantizeLinear",
                 [input_name, scale_name, zp_name],
@@ -715,7 +715,7 @@ class ONNXQuantizer:
 
     def contains_tensor(self, tensor_name):
         """
-        only check for value info and newly generated tensor names, initializers are checked seperately
+        only check for value info and newly generated tensor names, initializers are checked separately
         """
         return (
             (tensor_name in self.value_infos)
@@ -734,6 +734,8 @@ class ONNXQuantizer:
             from_subgraph=from_subgraph,
         )
 
+    # In some circumstances a weight is not an initializer, for example of MatMul, if both A and B are not
+    # initializer, B can still be considered as Weight
     def quantize_weight(
         self,
         node,

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -724,7 +724,15 @@ class ONNXQuantizer:
         )
 
     def quantize_activation(self, node, indices, from_subgraph=False):
-        return self.__quantize_inputs(node, indices, False, False, False, -1, from_subgraph)
+        return self.__quantize_inputs(
+            node=node,
+            indices=indices,
+            initializer_use_weight_qType=False,
+            reduce_range=False,
+            op_level_per_channel=False,
+            axis=-1,
+            from_subgraph=from_subgraph,
+        )
 
     def quantize_weight(
         self,
@@ -735,7 +743,15 @@ class ONNXQuantizer:
         axis=-1,
         from_subgraph=False,
     ):
-        return self.__quantize_inputs(node, indices, True, reduce_range, op_level_per_channel, axis, from_subgraph)
+        return self.__quantize_inputs(
+            node=node,
+            indices=indices,
+            initializer_use_weight_qType=True,
+            reduce_range=reduce_range,
+            op_level_per_channel=op_level_per_channel,
+            axis=axis,
+            from_subgraph=from_subgraph,
+        )
 
     def __quantize_inputs(
         self,

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -289,7 +289,7 @@ class ONNXQuantizer:
 
         return self.model.model
 
-    def is_input_a_weight(self, input_name):
+    def is_input_a_initializer(self, input_name):
         initializer = find_by_name(input_name, self.model.initializer())
         return initializer is not None
 
@@ -305,7 +305,7 @@ class ONNXQuantizer:
         return self.parent.is_valid_quantize_weight(weight_name)
 
     def is_float_tensor(self, tensor_name):
-        if self.is_input_a_weight(tensor_name):
+        if self.is_input_a_initializer(tensor_name):
             return self.is_valid_quantize_weight(tensor_name)
 
         if tensor_name in self.value_infos.keys():

--- a/onnxruntime/python/tools/quantization/operators/activation.py
+++ b/onnxruntime/python/tools/quantization/operators/activation.py
@@ -53,7 +53,7 @@ class QLinearActivation(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0])
+        ) = self.quantizer.quantize_activation(node, [0])
         if not data_found or quantized_input_names is None:
             return super().quantize()
 
@@ -112,7 +112,7 @@ class QDQRemovableActivation(QDQOperatorBase):
         ):
             self.quantizer.remove_node(self.node)
         else:
-            self.quantizer.quantize_tensor(node.input[0])
+            self.quantizer.quantize_activation_tensor(node.input[0])
 
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_tensor(node.output[0])
+            self.quantizer.quantize_activation_tensor(node.output[0])

--- a/onnxruntime/python/tools/quantization/operators/attention.py
+++ b/onnxruntime/python/tools/quantization/operators/attention.py
@@ -37,7 +37,19 @@ class AttentionQuant(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0, 1], reduce_range=True, op_level_per_channel=True)
+        ) = self.quantizer.quantize_activation(node, [0])
+
+        (
+            quantized_input_names_weight,
+            zero_point_names_weight,
+            scale_names_weight,
+            nodes_weight,
+        ) = self.quantizer.quantize_weight(node, [1], reduce_range=True, op_level_per_channel=True)
+        quantized_input_names.extend(quantized_input_names_weight)
+        zero_point_names.extend(zero_point_names_weight)
+        scale_names.extend(scale_names_weight)
+        nodes.extend(nodes_weight)
+
         if quantized_input_names is None:
             return super().quantize()
 

--- a/onnxruntime/python/tools/quantization/operators/binary_op.py
+++ b/onnxruntime/python/tools/quantization/operators/binary_op.py
@@ -24,7 +24,7 @@ class QLinearBinaryOp(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0, 1], initializer_use_weight_qType=False)
+        ) = self.quantizer.quantize_activation(node, [0, 1])
         if not data_found or quantized_input_names is None:
             return super().quantize()
 

--- a/onnxruntime/python/tools/quantization/operators/concat.py
+++ b/onnxruntime/python/tools/quantization/operators/concat.py
@@ -24,7 +24,7 @@ class QLinearConcat(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [*range(0, len(node.input))], initializer_use_weight_qType=False)
+        ) = self.quantizer.quantize_activation(node, [*range(0, len(node.input))])
         if not data_found or q_input_names is None:
             return super().quantize()
 

--- a/onnxruntime/python/tools/quantization/operators/conv.py
+++ b/onnxruntime/python/tools/quantization/operators/conv.py
@@ -59,13 +59,24 @@ class ConvInteger(QuantOperatorBase):
     def quantize(self):
         node = self.node
         assert node.op_type == "Conv"
-
+        #  Get Quantized from both activation(input[0]) and weight(input[1])
         (
             quantized_input_names,
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0, 1], reduce_range=self.quantizer.reduce_range)
+        ) = self.quantizer.quantize_activation(node, [0])
+
+        (
+            quantized_input_names_weight,
+            zero_point_names_weight,
+            scale_names_weight,
+            nodes_weight,
+        ) = self.quantizer.quantize_weight(node, [1], reduce_range=self.quantizer.reduce_range)
+        quantized_input_names.extend(quantized_input_names_weight)
+        zero_point_names.extend(zero_point_names_weight)
+        scale_names.extend(scale_names_weight)
+        nodes.extend(nodes_weight)
 
         conv_integer_output = node.output[0] + "_output_quantized"
         conv_integer_name = node.name + "_quant" if node.name != "" else ""
@@ -145,7 +156,7 @@ class QLinearConv(QuantOperatorBase):
                 zero_point_names,
                 scale_names,
                 nodes,
-            ) = self.quantizer.quantize_inputs(node, [0], reduce_range=self.quantizer.reduce_range)
+            ) = self.quantizer.quantize_activation(node, [0])
             quant_weight_tuple = self.quantizer.quantize_weight_per_channel(
                 node.input[1], onnx_proto.TensorProto.INT8, 0
             )
@@ -158,7 +169,18 @@ class QLinearConv(QuantOperatorBase):
                 zero_point_names,
                 scale_names,
                 nodes,
-            ) = self.quantizer.quantize_inputs(node, [0, 1], reduce_range=self.quantizer.reduce_range)
+            ) = self.quantizer.quantize_activation(node, [0])
+
+            (
+                quantized_input_names_weight,
+                zero_point_names_weight,
+                scale_names_weight,
+                nodes_weight,
+            ) = self.quantizer.quantize_weight(node, [1], reduce_range=self.quantizer.reduce_range)
+            quantized_input_names.extend(quantized_input_names_weight)
+            zero_point_names.extend(zero_point_names_weight)
+            scale_names.extend(scale_names_weight)
+            nodes.extend(nodes_weight)
 
         if not data_found or quantized_input_names is None:
             return super().quantize()
@@ -218,14 +240,14 @@ class QDQConv(QDQOperatorBase):
         node = self.node
         assert node.op_type == "Conv"
 
-        self.quantizer.quantize_tensor(node.input[0])
+        self.quantizer.quantize_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_tensor(node.output[0])
+            self.quantizer.quantize_activation_tensor(node.output[0])
 
         if self.quantizer.is_per_channel():
-            self.quantizer.quantize_tensor_per_channel(node.input[1], 0)
+            self.quantizer.quantize_weight_tensor_per_channel(node.input[1], 0)
         else:
-            self.quantizer.quantize_tensor(node.input[1])
+            self.quantizer.quantize_weight_tensor(node.input[1])
 
         if len(node.input) == 3:
             self.quantizer.quantize_bias_tensor(node.input[2], node.input[0], node.input[1])

--- a/onnxruntime/python/tools/quantization/operators/conv.py
+++ b/onnxruntime/python/tools/quantization/operators/conv.py
@@ -150,7 +150,7 @@ class QLinearConv(QuantOperatorBase):
             _,
         ) = self.quantizer._get_quantization_params(node.output[0])
 
-        if self.quantizer.is_input_a_weight(node.input[1]) and self.quantizer.is_per_channel():
+        if self.quantizer.is_input_a_initializer(node.input[1]) and self.quantizer.is_per_channel():
             (
                 quantized_input_names,
                 zero_point_names,

--- a/onnxruntime/python/tools/quantization/operators/direct_q8.py
+++ b/onnxruntime/python/tools/quantization/operators/direct_q8.py
@@ -44,7 +44,7 @@ class Direct8BitOp(QuantOperatorBase):
                 zero_point_names,
                 scale_names,
                 nodes,
-            ) = self.quantizer.quantize_inputs(node, [0])
+            ) = self.quantizer.quantize_activation(node, [0])
             if quantized_input_names is None:
                 return super().quantize()
 
@@ -71,8 +71,8 @@ class QDQDirect8BitOp(QDQOperatorBase):
 
     def quantize(self):
         if self.quantizer.force_quantize_no_input_check:
-            self.quantizer.quantize_tensor(self.node.input[0])
+            self.quantizer.quantize_activation_tensor(self.node.input[0])
             if not self.disable_qdq_for_node_output:
-                self.quantizer.quantize_tensor(self.node.output[0], self.node.input[0])
+                self.quantizer.quantize_activation_tensor(self.node.output[0], self.node.input[0])
         elif self.quantizer.is_tensor_quantized(self.node.input[0]) and not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_tensor(self.node.output[0], self.node.input[0])
+            self.quantizer.quantize_activation_tensor(self.node.output[0], self.node.input[0])

--- a/onnxruntime/python/tools/quantization/operators/embed_layernorm.py
+++ b/onnxruntime/python/tools/quantization/operators/embed_layernorm.py
@@ -45,7 +45,7 @@ class EmbedLayerNormalizationQuant(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [2, 3, 4, 5, 6])
+        ) = self.quantizer.quantize_activation(node, [2, 3, 4, 5, 6])
         if quantized_input_names is None:
             return super().quantize()
 

--- a/onnxruntime/python/tools/quantization/operators/gather.py
+++ b/onnxruntime/python/tools/quantization/operators/gather.py
@@ -26,7 +26,7 @@ class GatherQuant(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0])
+        ) = self.quantizer.quantize_activation(node, [0])
         if quantized_input_names is None:
             return super().quantize()
 
@@ -58,7 +58,7 @@ class QDQGather(QDQOperatorBase):
         assert node.op_type == "Gather"
 
         if self.quantizer.is_valid_quantize_weight(node.input[0]) or self.quantizer.force_quantize_no_input_check:
-            self.quantizer.quantize_tensor(node.input[0])
-            self.quantizer.quantize_tensor(node.output[0], node.input[0])
+            self.quantizer.quantize_activation_tensor(node.input[0])
+            self.quantizer.quantize_activation_tensor(node.output[0], node.input[0])
         elif self.quantizer.is_tensor_quantized(node.input[0]):
-            self.quantizer.quantize_tensor(node.output[0], node.input[0])
+            self.quantizer.quantize_activation_tensor(node.output[0], node.input[0])

--- a/onnxruntime/python/tools/quantization/operators/gemm.py
+++ b/onnxruntime/python/tools/quantization/operators/gemm.py
@@ -64,7 +64,7 @@ class QLinearGemm(QOpMatMul):
                 zero_point_names,
                 scale_names,
                 nodes,
-            ) = self.quantizer.quantize_inputs(node, [0], reduce_range=self.quantizer.reduce_range)
+            ) = self.quantizer.quantize_activation(node, [0])
             quant_weight_tuple = self.quantizer.quantize_weight_per_channel(
                 node.input[1],
                 onnx_proto.TensorProto.INT8,
@@ -74,12 +74,24 @@ class QLinearGemm(QOpMatMul):
             zero_point_names.append(quant_weight_tuple[1])
             scale_names.append(quant_weight_tuple[2])
         else:
+            #  Get Quantized from both activation(input[0]) and weight(input[1])
             (
                 quantized_input_names,
                 zero_point_names,
                 scale_names,
                 nodes,
-            ) = self.quantizer.quantize_inputs(node, [0, 1], reduce_range=self.quantizer.reduce_range)
+            ) = self.quantizer.quantize_activation(node, [0])
+
+            (
+                quantized_input_names_weight,
+                zero_point_names_weight,
+                scale_names_weight,
+                nodes_weight,
+            ) = self.quantizer.quantize_weight(node, [1], reduce_range=self.quantizer.reduce_range)
+            quantized_input_names.extend(quantized_input_names_weight)
+            zero_point_names.extend(zero_point_names_weight)
+            scale_names.extend(scale_names_weight)
+            nodes.extend(nodes_weight)
 
         if not data_found or quantized_input_names is None:
             return super().quantize()
@@ -133,14 +145,14 @@ class QDQGemm(QDQOperatorBase):
         node = self.node
         assert node.op_type == "Gemm"
 
-        self.quantizer.quantize_tensor(node.input[0])
+        self.quantizer.quantize_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
-            self.quantizer.quantize_tensor(node.output[0])
+            self.quantizer.quantize_activation_tensor(node.output[0])
 
         if self.quantizer.is_per_channel():
-            self.quantizer.quantize_tensor_per_channel(node.input[1], 0 if is_B_transposed(node) else 1)
+            self.quantizer.quantize_weight_tensor_per_channel(node.input[1], 0 if is_B_transposed(node) else 1)
         else:
-            self.quantizer.quantize_tensor(node.input[1])
+            self.quantizer.quantize_weight_tensor(node.input[1])
 
         if len(node.input) == 3:
             if self.quantizer.is_input_a_weight(node.input[2]):

--- a/onnxruntime/python/tools/quantization/operators/gemm.py
+++ b/onnxruntime/python/tools/quantization/operators/gemm.py
@@ -58,7 +58,7 @@ class QLinearGemm(QOpMatMul):
             _,
         ) = self.quantizer._get_quantization_params(node.output[0])
 
-        if self.quantizer.is_input_a_weight(node.input[1]) and self.quantizer.is_per_channel():
+        if self.quantizer.is_input_a_initializer(node.input[1]) and self.quantizer.is_per_channel():
             (
                 quantized_input_names,
                 zero_point_names,
@@ -98,7 +98,7 @@ class QLinearGemm(QOpMatMul):
 
         quantized_bias_name = ""
         if len(node.input) == 3:
-            if not self.quantizer.is_input_a_weight(node.input[2]):
+            if not self.quantizer.is_input_a_initializer(node.input[2]):
                 return super().quantize()
 
             quantized_bias_name = self.quantizer.quantize_bias_static(
@@ -155,7 +155,7 @@ class QDQGemm(QDQOperatorBase):
             self.quantizer.quantize_weight_tensor(node.input[1])
 
         if len(node.input) == 3:
-            if self.quantizer.is_input_a_weight(node.input[2]):
+            if self.quantizer.is_input_a_initializer(node.input[2]):
                 self.quantizer.quantize_bias_tensor(node.input[2], node.input[0], node.input[1], get_beta(self.node))
                 set_default_beta(self.node)
             else:

--- a/onnxruntime/python/tools/quantization/operators/pad.py
+++ b/onnxruntime/python/tools/quantization/operators/pad.py
@@ -47,7 +47,7 @@ class QPad(QuantOperatorBase):
                     scale_value = scale_array.item() if scale_array.ndim == 0 else scale_array[0]
                     padding_constant_array = onnx.numpy_helper.to_array(padding_constant_initializer)
                     quantized_padding_constant_array = quantize_nparray(
-                        self.quantizer.input_qType,
+                        self.quantizer.activation_qType,
                         padding_constant_array,
                         scale_value,
                         zp_value,
@@ -66,7 +66,7 @@ class QPad(QuantOperatorBase):
                     pad_value_qnodes = self.quantizer._get_quantize_input_nodes(
                         node,
                         2,
-                        self.quantizer.input_qType,
+                        self.quantizer.activation_qType,
                         quantized_input_value.scale_name,
                         quantized_input_value.zp_name,
                     )

--- a/onnxruntime/python/tools/quantization/operators/pooling.py
+++ b/onnxruntime/python/tools/quantization/operators/pooling.py
@@ -26,7 +26,7 @@ class QLinearPool(QuantOperatorBase):
             input_zero_point_names,
             input_scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0])
+        ) = self.quantizer.quantize_activation(node, [0])
 
         if not data_found or quantized_input_names is None:
             return super().quantize()

--- a/onnxruntime/python/tools/quantization/operators/qdq_base_operator.py
+++ b/onnxruntime/python/tools/quantization/operators/qdq_base_operator.py
@@ -21,4 +21,4 @@ class QDQOperatorBase:
             tensors_to_quantize = itertools.chain(node.input, node.output)
 
         for tensor_name in tensors_to_quantize:
-            self.quantizer.quantize_tensor(tensor_name)
+            self.quantizer.quantize_activation_tensor(tensor_name)

--- a/onnxruntime/python/tools/quantization/operators/softmax.py
+++ b/onnxruntime/python/tools/quantization/operators/softmax.py
@@ -9,7 +9,7 @@ class QLinearSoftmax(QuantOperatorBase):
     def quantize(self):
         node = self.node
         # set limitations for softmax output scale and zp, because the output of softmax is always 0-1
-        if self.quantizer.input_qType == onnx.onnx_pb.TensorProto.UINT8:
+        if self.quantizer.activation_qType == onnx.onnx_pb.TensorProto.UINT8:
             out_scale = 1 / 256.0
             out_zero_point = 0
         else:
@@ -30,7 +30,7 @@ class QLinearSoftmax(QuantOperatorBase):
             input_zero_point_names,
             input_scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0])
+        ) = self.quantizer.quantize_activation(node, [0])
 
         if not data_found or quantized_input_names is None:
             return super().quantize()
@@ -77,7 +77,7 @@ class QLinearSoftmax(QuantOperatorBase):
 class QDQSoftmax(QDQOperatorBase):
     def quantize(self):
         super().quantize()
-        if self.quantizer.input_qType == onnx.onnx_pb.TensorProto.UINT8:
+        if self.quantizer.activation_qType == onnx.onnx_pb.TensorProto.UINT8:
             out_scale = 1 / 256.0
             out_zero_point = 0
         else:

--- a/onnxruntime/python/tools/quantization/operators/split.py
+++ b/onnxruntime/python/tools/quantization/operators/split.py
@@ -16,7 +16,7 @@ class QSplit(QuantOperatorBase):
             zero_point_names,
             scale_names,
             nodes,
-        ) = self.quantizer.quantize_inputs(node, [0])
+        ) = self.quantizer.quantize_activation(node, [0])
         if quantized_input_names is None:
             return super().quantize()
 
@@ -57,7 +57,7 @@ class QDQSplit(QDQOperatorBase):
         assert node.op_type == "Split"
 
         if not self.quantizer.is_tensor_quantized(node.input[0]):
-            self.quantizer.quantize_tensor(node.input[0])
+            self.quantizer.quantize_activation_tensor(node.input[0])
         if not self.disable_qdq_for_node_output:
             for output in node.output:
-                self.quantizer.quantize_tensor(output, node.input[0])
+                self.quantizer.quantize_activation_tensor(output, node.input[0])

--- a/onnxruntime/python/tools/quantization/qdq_quantizer.py
+++ b/onnxruntime/python/tools/quantization/qdq_quantizer.py
@@ -30,15 +30,17 @@ from .registry import CreateQDQQuantizer
 
 
 class QDQQuantTensorType(Enum):
-    NORMAL = 0
-    SHARE_PARAM = 1
+    ACTIVATION = 0
+    WEIGHT = 1
+    BIAS = 2
 
 
 class QDQTensorQuantInfo:
-    def __init__(self, tensor_type=QDQQuantTensorType.NORMAL, quant_para_provider=None, axis=None):
+    def __init__(self, tensor_type=QDQQuantTensorType.ACTIVATION, quant_para_provider=None, axis=None):
         self.tensor_type = tensor_type
         self.quant_para_provider = quant_para_provider
         self.axis = axis
+        self.is_shared = quant_para_provider is not None
 
 
 class QDQQuantizer(ONNXQuantizer):
@@ -50,7 +52,7 @@ class QDQQuantizer(ONNXQuantizer):
         mode,
         static,
         weight_qType,
-        input_qType,
+        activation_qType,
         tensors_range,
         nodes_to_quantize,
         nodes_to_exclude,
@@ -65,7 +67,7 @@ class QDQQuantizer(ONNXQuantizer):
             mode,
             static,
             weight_qType,
-            input_qType,
+            activation_qType,
             tensors_range,
             nodes_to_quantize,
             nodes_to_exclude,
@@ -131,27 +133,50 @@ class QDQQuantizer(ONNXQuantizer):
 
         return False
 
-    def quantize_tensor(self, tensor_name, quant_sharing_param=None):
+    def __quantize_tensor(self, tensor_name, quant_sharing_param=None, tensor_type=QDQQuantTensorType.ACTIVATION):
         """
         Quantize tensors. If quant_param_tensor is not None, tensor with name tensor_name will be quantized with same
         quantization parameters as tensor quant_param_tensor
-        :param tensor_name: name of the tensor to quantize
-        :param quant_sharing_param: name of the tensor that provides quantization parameter
+
+        Args:
+            tensor_name: name of the tensor to quantize
+            quant_sharing_param: name of the tensor that provides quantization parameter
+            tensor_type: QDQQuantTensorType default ACTIVATION
         """
         if self._is_tensor_quantizable(tensor_name):
             if quant_sharing_param:
                 self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(
-                    tensor_type=QDQQuantTensorType.SHARE_PARAM, quant_para_provider=quant_sharing_param
+                    tensor_type=tensor_type, quant_para_provider=quant_sharing_param
                 )
             elif tensor_name not in self.tensors_to_quantize:
-                self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo()
+                self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(tensor_type=tensor_type)
 
-    def quantize_tensor_per_channel(self, tensor_name, axis):
+    def quantize_activation_tensor(self, tensor_name, quant_sharing_param=None):
+        """
+        Quantize Activation Tensor
+        Args:
+            tensor_name: name of the tensor to quantize
+            quant_sharing_param: name of the tensor that provides quantization parameter
+
+        """
+        return self.__quantize_tensor(tensor_name, quant_sharing_param, QDQQuantTensorType.ACTIVATION)
+
+    def quantize_weight_tensor(self, tensor_name, quant_sharing_param=None):
+        """
+        Quantize Weight Tensor
+        Args:
+            tensor_name: name of the tensor to quantize
+            quant_sharing_param: name of the tensor that provides quantization parameter
+
+        """
+        return self.__quantize_tensor(tensor_name, quant_sharing_param, QDQQuantTensorType.WEIGHT)
+
+    def quantize_weight_tensor_per_channel(self, tensor_name, axis):
         weight = find_by_name(tensor_name, self.model.initializer())
         if weight:
             if weight.data_type == onnx_proto.TensorProto.FLOAT:
                 self.tensors_to_quantize[tensor_name] = QDQTensorQuantInfo(
-                    tensor_type=QDQQuantTensorType.NORMAL, axis=axis
+                    tensor_type=QDQQuantTensorType.WEIGHT, axis=axis
                 )
         else:
             logging.warning(
@@ -228,7 +253,7 @@ class QDQQuantizer(ONNXQuantizer):
         )
         self.model.add_nodes([qlinear_node, dequant_node])
 
-    def _add_qdq_pair_for_weight(self, weight_proto, axis=None):
+    def _add_qdq_pair_for_initializer(self, weight_proto, tensor_type, axis=None):
         weight_name = weight_proto.name
         if axis:
             if self.opset_version < 13:
@@ -237,8 +262,10 @@ class QDQQuantizer(ONNXQuantizer):
                 weight_name, onnx_proto.TensorProto.INT8, axis, keep_float_weight=self.add_qdq_pair_to_weight
             )
         else:
-            q_weight_name, zp_name, scale_name = self.quantize_weight(
-                weight_proto, self.weight_qType, keep_float_weight=self.add_qdq_pair_to_weight
+            q_weight_name, zp_name, scale_name = self.quantize_initializer(
+                weight_proto,
+                self.weight_qType if tensor_type is QDQQuantTensorType.WEIGHT else self.activation_qType,
+                keep_float_weight=self.add_qdq_pair_to_weight,
             )
 
         weight_dequant_output = add_dequant_output_suffix(weight_name)
@@ -335,11 +362,11 @@ class QDQQuantizer(ONNXQuantizer):
             if tensor_name in self.quantized_value_map.keys():
                 continue
 
-            if tensor_info.tensor_type == QDQQuantTensorType.NORMAL:
+            if not tensor_info.is_shared:
                 # Quantize the input
                 initializer = find_by_name(tensor_name, self.model.initializer())
                 if initializer:
-                    self._add_qdq_pair_for_weight(initializer, tensor_info.axis)
+                    self._add_qdq_pair_for_initializer(initializer, tensor_info.tensor_type, tensor_info.axis)
                 else:
                     used_scale, used_zp = self.find_quant_scale_zp(tensor_name)
                     data_found, scale_name, zp_name, _, _ = self._get_quantization_params(


### PR DESCRIPTION
**Description**: Describe your changes.
Splitting quantize_tensor and quantize_input into quantize_activation_tensor, quantize_weight_tensor, quantize_activation and quantize_weight
**Motivation and Context**
This will reduce the naming confusion