### PR TITLE
Update ONNX submodule to support opset 18

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -253,7 +253,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "5a5f8a5935762397aa68429b5493084ff970f774",
+          "commitHash": "de2459972d3f834dba24a586982d1ffce5532e0b",
           "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-onnx==1.12.0
+git+http://github.com/onnx/onnx.git@de2459972d3f834dba24a586982d1ffce5532e0b#egg=onnx
 protobuf==3.18.3
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel>=0.35.1
-onnx==1.12.0
+git+http://github.com/onnx/onnx.git@de2459972d3f834dba24a586982d1ffce5532e0b#egg=onnx
 argparse
 sympy==1.10.1
 flatbuffers


### PR DESCRIPTION
This PR has the goal of updating ONNX to a particular commit and allow ORT to execute ONNX graphs with opset 18

PyTorch is about to [merge the same change](https://github.com/pytorch/pytorch/pull/83201). However, because PyTorch depends on ORT for unit testing, ORT also must update its ONNX submodule for their pipelines to succeed. Otherwise, ORT will not recognize the new ops PyTorch ONNX converter adds, such as [Col2Im](https://github.com/pytorch/pytorch/pull/84594)