### PR TITLE
Fix unused variable warning from reduced ops build

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -174,7 +174,6 @@ static constexpr PATH_TYPE VARIED_INPUT_CUSTOM_OP_MODEL_URI_2 = TSTR("testdata/f
 static constexpr PATH_TYPE OPTIONAL_INPUT_OUTPUT_CUSTOM_OP_MODEL_URI = TSTR("testdata/foo_bar_1.onnx");
 static constexpr PATH_TYPE OPTIONAL_INPUT_OUTPUT_CUSTOM_OP_MODEL_URI_2 = TSTR("testdata/foo_bar_2.onnx");
 static constexpr PATH_TYPE CUSTOM_OP_MODEL_WITH_ATTRIBUTES_URI = TSTR("testdata/foo_bar_3.onnx");
-static constexpr PATH_TYPE OPTIONAL_TYPE_GH_11717_MODEL = TSTR("testdata/gh_issue_11717.onnx");
 #if !defined(DISABLE_SPARSE_TENSORS)
 static constexpr PATH_TYPE SPARSE_OUTPUT_MODEL_URI = TSTR("testdata/sparse_initializer_as_output.onnx");
 #ifndef DISABLE_CONTRIB_OPS
@@ -2174,7 +2173,8 @@ TEST(CApiTest, TestCudaMemcpyToHostWithSequenceTensors) {
 // Reduced Ops build doesn't support OptionalHasElement (16) yet
 #if !defined(REDUCED_OPS_BUILD) && !defined(DISABLE_OPTIONAL_TYPE)
 TEST(CApiTest, GH_11717) {
-  const auto* model_path = OPTIONAL_TYPE_GH_11717_MODEL;
+  const auto* model_path = TSTR("testdata/gh_issue_11717.onnx");
+
   Ort::SessionOptions session_options{};
   // Just check if the model loads fine without a segmentation fault
   // in the default CPU EP


### PR DESCRIPTION
**Description**: 
There was a constant for a model name that is not used in a reduced ops build. We only use the model name once, so move it to within the test.

**Motivation and Context**
#12886 