### PR TITLE
Get files for XNNPACK wasm build from BUILD.bazel.

### DIFF
--- a/cmake/external/xnnpack.cmake
+++ b/cmake/external/xnnpack.cmake
@@ -8,8 +8,8 @@ set(FP16_BUILD_BENCHMARKS OFF CACHE INTERNAL "")
 set(CLOG_SOURCE_DIR "${PYTORCH_CPUINFO_DIR}/deps/clog")
 set(CPUINFO_SOURCE_DIR ${PYTORCH_CPUINFO_DIR})
 
-if (onnxruntime_BUILD_WEBASSEMBLY)
-  execute_process(COMMAND  git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenSupport.patch WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${XNNPACK_DIR})
+if(onnxruntime_BUILD_WEBASSEMBLY)
+  execute_process(COMMAND git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenSupport.patch WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${XNNPACK_DIR})
 endif()
 
 add_subdirectory(external/FP16)
@@ -24,43 +24,67 @@ set(onnxruntime_EXTERNAL_LIBRARIES_XNNPACK XNNPACK pthreadpool)
 list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK})
 
 # the XNNPACK CMake setup doesn't include the WASM kernels so we have to manually set those up
-if (onnxruntime_BUILD_WEBASSEMBLY)
-  if (onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
+if(onnxruntime_BUILD_WEBASSEMBLY)
+  file(READ "${XNNPACK_DIR}/BUILD.bazel" xnnpack_bazel_config)
+
+  # Replace newlines with semicolon so that it is treated as a list by CMake
+  # Also replace '[' and ']' so the bazel source lists don't get parsed as a nested list by cmake
+  string(REPLACE "\n" ";" xnnpack_bazel_config "${xnnpack_bazel_config}")
+  string(REPLACE "[" "{" xnnpack_bazel_config "${xnnpack_bazel_config}")
+  string(REPLACE "]" "}" xnnpack_bazel_config "${xnnpack_bazel_config}")
+
+  function(GetSrcListFromBazel src_list_name target_srcs)
+    set(_InSection FALSE)
+    set(bazel_srcs "")
+
+    foreach(_line ${xnnpack_bazel_config})
+      if(NOT _InSection)
+        if(_line MATCHES "^${src_list_name} = \\{")
+          set(_InSection TRUE)
+        endif()
+      else()
+        if(_line MATCHES "^\\}")
+          set(_InSection FALSE)
+        else()
+          # parse filename from quoted string with trailing comma
+          string(REPLACE "\"" "" _line "${_line}")
+          string(REPLACE "," "" _line "${_line}")
+          string(STRIP "${_line}" _line)
+
+          list(APPEND bazel_srcs "${XNNPACK_DIR}/${_line}")
+        endif()
+      endif()
+    endforeach()
+
+    set(${target_srcs} ${bazel_srcs} PARENT_SCOPE)
+  endfunction()
+
+  if(onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
     target_compile_options(XNNPACK PRIVATE "-pthread")
   endif()
 
+  GetSrcListFromBazel("PROD_SCALAR_WASM_MICROKERNEL_SRCS" prod_scalar_wasm_srcs)
+  GetSrcListFromBazel("ALL_WASM_MICROKERNEL_SRCS" all_wasm_srcs)
+  GetSrcListFromBazel("WASM32_ASM_MICROKERNEL_SRCS" wasm32_asm_srcs)
+
+  message(DEBUG "prod_scalar_wasm_srcs: ${prod_scalar_wasm_srcs}\n")
+  message(DEBUG "all_wasm_srcs: ${all_wasm_srcs}\n")
+  message(DEBUG "wasm32_asm_srcs: ${wasm32_asm_srcs}\n")
+
   message("Adding WebAssembly Source Files to XNNPACK")
-  set(wasm_src_patterns "${XNNPACK_DIR}/src/init.c"
-                        "${XNNPACK_DIR}/src/params-init.c"
-                        "${XNNPACK_DIR}/src/qu8-avgpool/9*-minmax-scalar-c1.c"
-                        "${XNNPACK_DIR}/src/u8-rmax/scalar.c"
-                        "${XNNPACK_DIR}/src/x8-zip/x*-scalar.c"
-                        "${XNNPACK_DIR}/src/x*-transposec/gen/2x4-scalar-int.c"
-                        "${XNNPACK_DIR}/src/wasm-*.c"
-                        "${XNNPACK_DIR}/src/*-wasm-*.c"
-                        "${XNNPACK_DIR}/src/*-wasm.c")
-  set(wasm32_asm_src_patterns "${XNNPACK_DIR}/src/wasm_shr_*.S")
+  set(wasm_srcs "")
+  list(APPEND wasm_srcs ${prod_scalar_wasm_srcs})
+  list(APPEND wasm_srcs ${all_wasm_srcs})
+  list(APPEND wasm_srcs ${wasm32_asm_srcs})
 
-  file(GLOB_RECURSE XNNPACK_WASM_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasm_src_patterns})
-  file(GLOB_RECURSE XNNPACK_WASM32_ASM_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasm32_asm_src_patterns})
+  target_sources(XNNPACK PRIVATE ${wasm_srcs})
 
-  message(DEBUG "XNNPACK_WASM_MICROKERNEL_SRCS:${XNNPACK_WASM_MICROKERNEL_SRCS}")
-  message(DEBUG "XNNPACK_WASM32_ASM_MICROKERNEL_SRCS:${XNNPACK_WASM32_ASM_MICROKERNEL_SRCS}")
+  if(onnxruntime_ENABLE_WEBASSEMBLY_SIMD)
+    GetSrcListFromBazel("ALL_WASMSIMD_MICROKERNEL_SRCS" all_wasmsimd_srcs)
+    message(DEBUG "all_wasmsimd_srcs: ${all_wasmsimd_srcs}")
 
-  target_sources(XNNPACK PRIVATE ${XNNPACK_WASM_MICROKERNEL_SRCS}
-                                 ${XNNPACK_WASM32_ASM_MICROKERNEL_SRCS})
-
-  if (onnxruntime_ENABLE_WEBASSEMBLY_SIMD)
+    target_compile_options(params_init PRIVATE "-msimd128")
     target_compile_options(XNNPACK PRIVATE "-msimd128")
-
-    set(wasmsimd_src_patterns "${XNNPACK_DIR}/src/wasmsimd-*.c"
-                              "${XNNPACK_DIR}/src/*-wasmsimd-*.c"
-                              "${XNNPACK_DIR}/src/*-wasmsimd.c"
-                              "${XNNPACK_DIR}/src/*/wasmsimd.c")
-
-    file(GLOB_RECURSE XNNPACK_WASMSIMD_MICROKERNEL_SRCS CONFIGURE_DEPENDS ${wasmsimd_src_patterns})
-    message(DEBUG "XNNPACK_WASMSIMD_MICROKERNEL_SRCS:${XNNPACK_WASMSIMD_MICROKERNEL_SRCS}")
-
-    target_sources(XNNPACK PRIVATE ${XNNPACK_WASMSIMD_MICROKERNEL_SRCS})
+    target_sources(XNNPACK PRIVATE ${all_wasmsimd_srcs})
   endif()
 endif()


### PR DESCRIPTION
**Description**: 
Read the wasm filelists from BUILD.bazel. Trying to match files with wildcards and manually updated lists is to fragile.

**Motivation and Context**
Make xnnpack wasm build better.