### PR TITLE
[DO NOT MERGE] remove custom kernel registries from result of KernelRegistryManager::GetKernelRegistriesByProviderType and see what happens

### DIFF
--- a/onnxruntime/core/framework/kernel_registry_manager.h
+++ b/onnxruntime/core/framework/kernel_registry_manager.h
@@ -50,9 +50,9 @@ class KernelRegistryManager {
    */
   std::vector<const KernelRegistry*> GetKernelRegistriesByProviderType(const std::string& type) const {
     std::vector<const KernelRegistry*> result;
-    for (auto& registry : custom_kernel_registries_) {
-      result.push_back(registry.get());
-    }
+    // for (auto& registry : custom_kernel_registries_) {
+    //   result.push_back(registry.get());
+    // }
     auto iter = provider_type_to_registry_.find(type);
     if (iter != provider_type_to_registry_.end()) result.push_back(iter->second.get());
     return result;


### PR DESCRIPTION
**Description**: Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
