### PR TITLE
fix memory issue when run with multi-stream

### DIFF
--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -164,11 +164,11 @@ Status BFCArena::Extend(size_t rounded_bytes) {
   static constexpr float kBackpedalFactor = 0.9f;
   // Try allocating less memory.
   while (mem_addr == nullptr) {
-  // kBackpedalFactor is float, bytes is size_t. The result of bytes * kBackpedalFactor is float. When we cast it to
-  // size_t, which is a smaller type, it could loss data. This is what C4244 complains. The "static_cast<size_t>" here 
-  // is to suppress the warning. C26451 suggest we may change kBackpedalFactor to double to get better accuary. But if
-  // we do that, AMD GPU CI build pipeline will have an "out-of-memory" error. So I choose to keep this piece of code
-  // untouched and disable the warning first.
+    // kBackpedalFactor is float, bytes is size_t. The result of bytes * kBackpedalFactor is float. When we cast it to
+    // size_t, which is a smaller type, it could loss data. This is what C4244 complains. The "static_cast<size_t>" here
+    // is to suppress the warning. C26451 suggest we may change kBackpedalFactor to double to get better accuary. But if
+    // we do that, AMD GPU CI build pipeline will have an "out-of-memory" error. So I choose to keep this piece of code
+    // untouched and disable the warning first.
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable : 26451)
@@ -243,7 +243,7 @@ BFCArena::ChunkHandle BFCArena::AllocateChunk() {
 
 void BFCArena::DeallocateChunk(ChunkHandle h) {
   Chunk* c = ChunkFromHandle(h);
-  //clean the stream / timestamp when deallocate chunk
+  // clean the stream / timestamp when deallocate chunk
   c->stream = nullptr;
   c->stream_timestamp = 0;
   c->next = free_chunks_list_;
@@ -300,7 +300,7 @@ size_t BFCArena::AllocatedSize(const void* ptr) {
 }
 
 void* BFCArena::AllocateRawInternal(size_t num_bytes,
-                                    bool dump_log_on_failure, 
+                                    bool dump_log_on_failure,
                                     Stream* stream,
                                     bool enable_cross_stream_reusing,
                                     WaitNotificationFn wait_fn) {
@@ -323,12 +323,12 @@ void* BFCArena::AllocateRawInternal(size_t num_bytes,
   if (!chunk && enable_cross_stream_reusing) {
     chunk = FindChunkPtr(bin_num, rounded_bytes, num_bytes, stream, true);
     if (chunk->stream && stream && chunk->stream != stream) {
-        auto notificaiton = chunk->stream->CreateNotification(1);
-        notificaiton->ActivateAndUpdate();
-        if (wait_fn)
-          wait_fn(*stream, *notificaiton);
-        stream->UpdateStreamClock(notificaiton->stream_clock_);
-        // it should be ok to release the notification now, as the wait is already launch to stream.
+      auto notificaiton = chunk->stream->CreateNotification(1);
+      notificaiton->ActivateAndUpdate();
+      if (wait_fn)
+        wait_fn(*stream, *notificaiton);
+      stream->UpdateStreamClock(notificaiton->stream_clock_);
+      // it should be ok to release the notification now, as the wait is already launch to stream.
     }
   }
   if (chunk != nullptr) {
@@ -380,8 +380,8 @@ void BFCArena::GetStats(AllocatorStats* stats) {
 }
 
 BFCArena::Chunk* BFCArena::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
-                             size_t num_bytes, Stream* stream, 
-                             bool enable_cross_stream_reusing) {
+                                        size_t num_bytes, Stream* stream,
+                                        bool enable_cross_stream_reusing) {
   // First identify the first bin that could satisfy rounded_bytes.
   for (; bin_num < kNumBins; bin_num++) {
     // Start searching from the first bin for the smallest chunk that fits
@@ -445,6 +445,10 @@ void BFCArena::SplitChunk(BFCArena::ChunkHandle h, size_t num_bytes) {
 
   // Create a new chunk starting num_bytes after c
   BFCArena::Chunk* new_chunk = ChunkFromHandle(h_new_chunk);
+  // set the new chunk's stream and timestamp
+  new_chunk->stream = c->stream;
+  new_chunk->stream_timestamp = c->stream_timestamp;
+
   new_chunk->ptr = static_cast<void*>(static_cast<char*>(c->ptr) + num_bytes);
   region_manager_.set_handle(new_chunk->ptr, h_new_chunk);
 
@@ -558,7 +562,6 @@ void BFCArena::DeallocateRawInternal(void* ptr) {
 
   // Consider coalescing it.
   FreeAndMaybeCoalesce(h);
-  
 }
 
 // Merges h1 and h2 when Chunk(h1)->next is h2 and Chunk(h2)->prev is c1.
@@ -786,19 +789,18 @@ void BFCArena::DumpMemoryLog(size_t num_bytes) {
 }
 
 StreamAwareArena::StreamAwareArena(std::unique_ptr<IAllocator> resource_allocator,
-    size_t total_memory,
-    bool enable_cross_stream_sharing,
-    ArenaExtendStrategy arena_extend_strategy,
-    int initial_chunk_size_bytes,
-    int max_dead_bytes_per_chunk,
-    int initial_growth_chunk_size_bytes) : 
-    BFCArena(std::move(resource_allocator), 
-             total_memory, 
-             arena_extend_strategy, 
-             initial_chunk_size_bytes, 
-             max_dead_bytes_per_chunk, 
-             initial_growth_chunk_size_bytes), enable_cross_stream_reusing_(enable_cross_stream_sharing) {
-
+                                   size_t total_memory,
+                                   bool enable_cross_stream_sharing,
+                                   ArenaExtendStrategy arena_extend_strategy,
+                                   int initial_chunk_size_bytes,
+                                   int max_dead_bytes_per_chunk,
+                                   int initial_growth_chunk_size_bytes) : BFCArena(std::move(resource_allocator),
+                                                                                   total_memory,
+                                                                                   arena_extend_strategy,
+                                                                                   initial_chunk_size_bytes,
+                                                                                   max_dead_bytes_per_chunk,
+                                                                                   initial_growth_chunk_size_bytes),
+                                                                          enable_cross_stream_reusing_(enable_cross_stream_sharing) {
 }
 
 void* StreamAwareArena::AllocOnStream(size_t size, Stream* current_stream, WaitNotificationFn wait_fn) {
@@ -821,8 +823,8 @@ void StreamAwareArena::ReleaseStreamBuffers(Stream* stream) {
     }
   }
 
-  //FreeAndMaybeCoalesce
-  //since a set of chunks are set to nullptr, merge them if possibe
+  // FreeAndMaybeCoalesce
+  // since a set of chunks are set to nullptr, merge them if possibe
   for (const auto& region : region_manager_.regions()) {
     ChunkHandle region_begin_chunk = region_manager_.get_handle(region.ptr());
     ChunkHandle h = region_begin_chunk;

--- a/onnxruntime/core/framework/execution_context.cc
+++ b/onnxruntime/core/framework/execution_context.cc
@@ -24,7 +24,7 @@ class DeviceStreamCollectionImpl {
       }
     }
     // only clean the streams that is owned by current context
-    for (auto& stream : device_streams_containers) {
+    /*for (auto& stream : device_streams_containers) {
       if (stream) {
         for (auto& ep : eps_) {
           auto& allocators = ep->GetAllocators();
@@ -40,7 +40,7 @@ class DeviceStreamCollectionImpl {
           }
         }
       }
-    }
+    }*/
   }
 
   void SetDeviceStream(size_t idx, std::unique_ptr<Stream> stream) {

--- a/onnxruntime/core/framework/execution_context.cc
+++ b/onnxruntime/core/framework/execution_context.cc
@@ -24,7 +24,7 @@ class DeviceStreamCollectionImpl {
       }
     }
     // only clean the streams that is owned by current context
-    /*for (auto& stream : device_streams_containers) {
+    for (auto& stream : device_streams_containers) {
       if (stream) {
         for (auto& ep : eps_) {
           auto& allocators = ep->GetAllocators();
@@ -40,7 +40,7 @@ class DeviceStreamCollectionImpl {
           }
         }
       }
-    }*/
+    }
   }
 
   void SetDeviceStream(size_t idx, std::unique_ptr<Stream> stream) {

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -7,6 +7,7 @@
 
 #include "core/graph/graph_viewer.h"
 #include "core/framework/data_transfer_manager.h"
+#include "core/framework/bfc_arena.h"
 #include "core/framework/execution_frame.h"
 #include "core/framework/execution_context.h"
 #include "core/framework/execution_providers.h"
@@ -69,6 +70,7 @@ bool ProviderIsCpuBased(const std::string& provider_type) {
 }
 
 static common::Status AllocateHelper(const AllocatorPtr& allocator,
+                                     Stream* target_stream,
                                      const OrtValue& source_mlvalue,
                                      OrtValue& target_mlvalue) {
   if (!allocator) {
@@ -77,9 +79,28 @@ static common::Status AllocateHelper(const AllocatorPtr& allocator,
 
   if (source_mlvalue.IsTensor()) {
     const Tensor& source_tensor = source_mlvalue.Get<Tensor>();
-    Tensor::InitOrtValue(source_tensor.DataType(),
-                         source_tensor.Shape(),
-                         allocator, target_mlvalue);
+    auto create_fn = [allocator, target_stream](size_t len) {
+      if (allocator->Info().alloc_type == OrtArenaAllocator) {
+        BFCArena* arena_ptr = static_cast<BFCArena*>(allocator.get());
+        auto* stream_aware_alloc = arena_ptr->AsStreamAwareAreana();
+        if (stream_aware_alloc && target_stream) {
+          return stream_aware_alloc->AllocOnStream(len, target_stream, nullptr);
+        } else {
+          return allocator->Alloc(len);
+        }
+      } else {
+        return allocator->Alloc(len);
+      }
+    };
+
+    auto delete_fn = [allocator](void* buf) { if (buf) allocator->Free(buf); };
+    Tensor::InitOrtValue(
+        source_tensor.DataType(),
+        source_tensor.Shape(),
+        allocator->Info(),
+        create_fn,
+        delete_fn,
+        target_mlvalue);
   } else if (source_mlvalue.IsSparseTensor()) {
 #if !defined(DISABLE_SPARSE_TENSORS)
     const SparseTensor& source_tensor = source_mlvalue.Get<SparseTensor>();
@@ -143,7 +164,7 @@ static Status BatchOrCopyMLValue(const SessionState& session_state,
   auto allocator = session_state.GetAllocator(copy_info.target_device);
   if (!target_mlvalue.IsAllocated()) {
     ORT_ENFORCE(allocator != nullptr, "Failed to find allocator for device ", copy_info.target_device.ToString());
-    ORT_RETURN_IF_ERROR(utils::AllocateHelper(allocator, source_mlvalue, target_mlvalue));
+    ORT_RETURN_IF_ERROR(utils::AllocateHelper(allocator, stream, source_mlvalue, target_mlvalue));
   }
 
   if (source_mlvalue.IsTensor()) {
@@ -429,9 +450,11 @@ static void FinalizeFeedFetchCopyInfo(FeedsFetchesManager& feeds_fetches_manager
 static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
                                               gsl::span<const OrtValue> orig_feeds,
                                               std::vector<OrtValue>& new_feeds,
-                                              gsl::span<const MLValueCopyInfo> copy_info) {
+                                              gsl::span<const MLValueCopyInfo> copy_info,
+                                              std::vector<Stream*>& feed_streams) {
   size_t num_feeds = orig_feeds.size();
   ORT_ENFORCE(copy_info.size() == num_feeds);
+  ORT_ENFORCE(feed_streams.size() == num_feeds);
 
   new_feeds.resize(num_feeds);
   std::vector<IDataTransfer::SrcDstPair> batched_data_transfers;
@@ -442,11 +465,11 @@ static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
   for (size_t idx = 0; idx < num_feeds; ++idx) {
 #if !defined(DISABLE_SPARSE_TENSORS)
     ORT_RETURN_IF_ERROR(BatchOrCopyMLValue(session_state, copy_info[idx], orig_feeds[idx], new_feeds[idx],
-                                           /*copy input from cpu to device doesn't need to sync from src stream*/ nullptr,
+                                           feed_streams[idx],
                                            &batched_data_transfers, &batched_sparse_data_transfers));
 #else
     ORT_RETURN_IF_ERROR(BatchOrCopyMLValue(session_state, copy_info[idx], orig_feeds[idx], new_feeds[idx],
-                                           /*copy input from cpu to device doesn't need to sync from src stream*/ nullptr,
+                                           feed_streams[idx],
                                            &batched_data_transfers));
 #endif
   }
@@ -461,6 +484,14 @@ static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
   }
 #endif
 
+  // flush the stream to make sure the inputs are ready before launch the inference.
+  // TODO: this sync is because the graph inputs can be consumed by multiple stream,
+  // but we can only place the MemCpyAsync on one of the stream. Ideally we should make
+  // other stream wait on the event of the memory copy stream, instead of host sync stream.
+  for (auto* stream : feed_streams) {
+    if (stream)
+      stream->Flush();
+  }
   return Status::OK();
 }
 
@@ -569,7 +600,23 @@ static common::Status ExecuteGraphImpl(const SessionState& session_state,
 
     if (device_copy_checks.input_copy_needed == DeviceCopyCheck::Copy) {
       const auto& feed_copy_info = feeds_fetches_manager.GetFeedsDeviceCopyInfo();
-      ORT_RETURN_IF_ERROR(CopyInputsAcrossDevices(session_state, feeds, device_feeds, feed_copy_info));
+      std::vector<Stream*> feed_streams;
+      // TODO: we can pre-calculate the stream index for graph inputs in execution plan
+      for (auto& copy_info : feed_copy_info) {
+        auto& device = copy_info.target_device;
+        auto& streams = device_stream_collection.GetStreams();
+        bool found = false;
+        for (auto* stream : streams) {
+          if (stream && stream->device.Type() == device.Type()) {
+            feed_streams.push_back(stream);
+            found = true;
+            break;
+          }
+        }
+        if (!found)
+          feed_streams.push_back(nullptr);
+      }
+      ORT_RETURN_IF_ERROR(CopyInputsAcrossDevices(session_state, feeds, device_feeds, feed_copy_info, feed_streams));
       feeds_to_use = device_feeds;
     }
 


### PR DESCRIPTION
**Description**: two issues here: 1) the bfc arena doesn't specify stream correctly when split a chunk. 2) when copy graph input, specify the correct stream to avoid been reused by other stream. 