### PR TITLE
Consume ONNX 1.12.1 to prevent vulnerability issue while loading external file

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -252,7 +252,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "26a4fac252458573bf8668fe6a34ebba25f5579e",
+          "commitHash": "ca89956ed470f52c07f52ea0f17ea2b42c27fef1",
           "repositoryUrl": "https://github.com/jcwchen/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -252,8 +252,8 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "f7ee1ac60d06abe8e26c9b6bbe1e3db5286b614b",
-          "repositoryUrl": "https://github.com/onnx/onnx.git"
+          "commitHash": "26a4fac252458573bf8668fe6a34ebba25f5579e",
+          "repositoryUrl": "https://github.com/jcwchen/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"
       }

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -252,7 +252,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "ca89956ed470f52c07f52ea0f17ea2b42c27fef1",
+          "commitHash": "00db57fc42c9a005745f9100ed0310fecaf1f40b",
           "repositoryUrl": "https://github.com/jcwchen/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -252,8 +252,8 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "00db57fc42c9a005745f9100ed0310fecaf1f40b",
-          "repositoryUrl": "https://github.com/jcwchen/onnx.git"
+          "commitHash": "5a5f8a5935762397aa68429b5493084ff970f774",
+          "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "git submodule at cmake/external/onnx"
       }


### PR DESCRIPTION
**Description**:
Consume ONNX 1.12.1 to prevent vulnerability issue while loading external file. That rel-1.12.1 branch uses the base of rel-1.12.0 with 2 additional PRs: https://github.com/onnx/onnx/pull/4400 and https://github.com/onnx/onnx/pull/4470.

**Motivation and Context**
To prevent vulnerability issue: ONNX checker load external file outside the directory, ONNX 1.12.1 will include these 2 PRs:
- https://github.com/onnx/onnx/pull/4400
- https://github.com/onnx/onnx/pull/4470