### PR TITLE
Fix prefast warning in upsample.cc.

### DIFF
--- a/include/onnxruntime/core/framework/tensor_shape.h
+++ b/include/onnxruntime/core/framework/tensor_shape.h
@@ -47,7 +47,7 @@ class TensorShapeVector : public std::vector<int64_t> {
   using Base = std::vector<int64_t>;
 
  public:
-   using Base::Base;
+  using Base::Base;
 };
 
 #endif  // DISABLE_ABSEIL
@@ -187,7 +187,7 @@ class TensorShape {
   void Allocate(size_t size);
 
   gsl::span<int64_t> values_;
-  int64_t small_buffer_[kTensorShapeSmallBufferElementsSize];
+  int64_t small_buffer_[kTensorShapeSmallBufferElementsSize]{0};
   std::unique_ptr<int64_t[]> allocated_buffer_;
 
   friend struct ProviderHostImpl;  // So that the shared provider interface can access Allocate

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -444,7 +444,7 @@ BilinearParams SetupUpsampleBilinear(const int32_t input_height,
   p.input_width_mul_y2 = p.input_width_mul_y1 + output_height;
 
   // stride for width is 1 (no multiplication needed)
-  p.in_x1 = p.input_width_mul_y1 + 2 * output_height;
+  p.in_x1 = p.input_width_mul_y1 + output_height + output_height;
   p.in_x2 = p.in_x1 + output_width;
 
   auto* const scale_data = reinterpret_cast<float*>(p.in_x2 + output_width);
@@ -452,7 +452,7 @@ BilinearParams SetupUpsampleBilinear(const int32_t input_height,
   p.dy1 = scale_data;
   p.dy2 = p.dy1 + output_height;
 
-  p.dx1 = p.dy1 + 2UL * output_height;  // 2UL is to make prefast happy
+  p.dx1 = p.dy1 + output_height + output_height;
   p.dx2 = p.dx1 + output_width;
 
   // Start processing
@@ -549,7 +549,7 @@ BilinearParamsInteger SetupUpsampleBilinearInteger(const int32_t input_height,
   p.input_width_mul_y2 = p.input_width_mul_y1 + output_height;
 
   // stride for width is 1 (no multiplication needed)
-  p.in_x1 = p.input_width_mul_y1 + 2 * output_height;
+  p.in_x1 = p.input_width_mul_y1 + output_height + output_height;
   p.in_x2 = p.in_x1 + output_width;
 
   auto* const scale_data = reinterpret_cast<int32_t*>(p.in_x2 + output_width);
@@ -557,7 +557,7 @@ BilinearParamsInteger SetupUpsampleBilinearInteger(const int32_t input_height,
   p.dy1_scale_10 = scale_data;
   p.dy2_scale_10 = p.dy1_scale_10 + output_height;
 
-  p.dx1_scale_10 = p.dy1_scale_10 + 2 * output_height;
+  p.dx1_scale_10 = p.dy1_scale_10 + output_height + output_height;
   p.dx2_scale_10 = p.dx1_scale_10 + output_width;
 
   // Start processing

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -452,7 +452,7 @@ BilinearParams SetupUpsampleBilinear(const int32_t input_height,
   p.dy1 = scale_data;
   p.dy2 = p.dy1 + output_height;
 
-  p.dx1 = p.dy1 + 2 * output_height;
+  p.dx1 = p.dy1 + 2UL * output_height;  // 2UL is to make prefast happy
   p.dx2 = p.dx1 + output_width;
 
   // Start processing

--- a/onnxruntime/core/providers/cpu/tensor/upsample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.cc
@@ -444,7 +444,8 @@ BilinearParams SetupUpsampleBilinear(const int32_t input_height,
   p.input_width_mul_y2 = p.input_width_mul_y1 + output_height;
 
   // stride for width is 1 (no multiplication needed)
-  p.in_x1 = p.input_width_mul_y1 + output_height + output_height;
+  const auto output_height_x2 = output_height * 2;  // this is to make prefast happy
+  p.in_x1 = p.input_width_mul_y1 + output_height_x2;
   p.in_x2 = p.in_x1 + output_width;
 
   auto* const scale_data = reinterpret_cast<float*>(p.in_x2 + output_width);
@@ -452,7 +453,7 @@ BilinearParams SetupUpsampleBilinear(const int32_t input_height,
   p.dy1 = scale_data;
   p.dy2 = p.dy1 + output_height;
 
-  p.dx1 = p.dy1 + output_height + output_height;
+  p.dx1 = p.dy1 + output_height_x2;
   p.dx2 = p.dx1 + output_width;
 
   // Start processing
@@ -549,7 +550,8 @@ BilinearParamsInteger SetupUpsampleBilinearInteger(const int32_t input_height,
   p.input_width_mul_y2 = p.input_width_mul_y1 + output_height;
 
   // stride for width is 1 (no multiplication needed)
-  p.in_x1 = p.input_width_mul_y1 + output_height + output_height;
+  const auto output_height_x2 = output_height * 2;  // this is to make prefast happy
+  p.in_x1 = p.input_width_mul_y1 + output_height_x2;
   p.in_x2 = p.in_x1 + output_width;
 
   auto* const scale_data = reinterpret_cast<int32_t*>(p.in_x2 + output_width);
@@ -557,7 +559,7 @@ BilinearParamsInteger SetupUpsampleBilinearInteger(const int32_t input_height,
   p.dy1_scale_10 = scale_data;
   p.dy2_scale_10 = p.dy1_scale_10 + output_height;
 
-  p.dx1_scale_10 = p.dy1_scale_10 + output_height + output_height;
+  p.dx1_scale_10 = p.dy1_scale_10 + output_height_x2;
   p.dx2_scale_10 = p.dx1_scale_10 + output_width;
 
   // Start processing
@@ -623,19 +625,19 @@ struct TrilinearParams {
 
   BufferUniquePtr idx_scale_data_buffer_holder;
 
-  int64_t* in_x1;
-  int64_t* in_x2;
-  int64_t* input_width_mul_y1;
-  int64_t* input_width_mul_y2;
-  int64_t* input_height_width_mul_z1;
-  int64_t* input_height_width_mul_z2;
+  int64_t* in_x1{nullptr};
+  int64_t* in_x2{nullptr};
+  int64_t* input_width_mul_y1{nullptr};
+  int64_t* input_width_mul_y2{nullptr};
+  int64_t* input_height_width_mul_z1{nullptr};
+  int64_t* input_height_width_mul_z2{nullptr};
 
-  float* dx1;
-  float* dx2;
-  float* dy1;
-  float* dy2;
-  float* dz1;
-  float* dz2;
+  float* dx1{nullptr};
+  float* dx2{nullptr};
+  float* dy1{nullptr};
+  float* dy2{nullptr};
+  float* dz1{nullptr};
+  float* dz2{nullptr};
 };
 
 static TrilinearParams SetupUpsampleTrilinear(int64_t input_depth,

--- a/onnxruntime/core/providers/cpu/tensor/upsample.h
+++ b/onnxruntime/core/providers/cpu/tensor/upsample.h
@@ -25,17 +25,17 @@ struct BilinearParams {
 
   BufferUniquePtr idx_scale_data_buffer_holder;
 
-  int32_t* input_width_mul_y1;
-  int32_t* input_width_mul_y2;
+  int32_t* input_width_mul_y1{nullptr};
+  int32_t* input_width_mul_y2{nullptr};
 
-  int32_t* in_x1;
-  int32_t* in_x2;
+  int32_t* in_x1{nullptr};
+  int32_t* in_x2{nullptr};
 
-  float* dx1;
-  float* dx2;
+  float* dx1{nullptr};
+  float* dx2{nullptr};
 
-  float* dy1;
-  float* dy2;
+  float* dy1{nullptr};
+  float* dy2{nullptr};
 };
 
 // Same as above, but doesn't use any floating-point for the coefficient (i.e., d*_scale_10)
@@ -45,17 +45,17 @@ struct BilinearParamsInteger {
 
   BufferUniquePtr idx_scale_data_buffer_holder;
 
-  int32_t* input_width_mul_y1;
-  int32_t* input_width_mul_y2;
+  int32_t* input_width_mul_y1{nullptr};
+  int32_t* input_width_mul_y2{nullptr};
 
-  int32_t* in_x1;
-  int32_t* in_x2;
+  int32_t* in_x1{nullptr};
+  int32_t* in_x2{nullptr};
 
-  int32_t* dx1_scale_10;
-  int32_t* dx2_scale_10;
+  int32_t* dx1_scale_10{nullptr};
+  int32_t* dx2_scale_10{nullptr};
 
-  int32_t* dy1_scale_10;
-  int32_t* dy2_scale_10;
+  int32_t* dy1_scale_10{nullptr};
+  int32_t* dy2_scale_10{nullptr};
 };
 
 template <typename T>


### PR DESCRIPTION
**Description**: 

> Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).

Avoid the `*` to address. Possibly a spurious warning as it doesn't happen in VS2022. 

**Motivation and Context**
Fix prefast warning
