### PR TITLE
Fix TSA warnings

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -344,7 +344,7 @@ void CUDAExecutionProvider::AddDeferredReleaseCPUPtr(void* p) {
   // AllocateBufferOnCPUPinned.
 
   std::lock_guard<OrtMutex> lock(deferred_release_mutex_);
-  void* stream = GetComputeStream();
+  cudaStream_t stream = static_cast<cudaStream_t>(GetComputeStream());
   auto it = deferred_release_buffer_pool_.find(stream);
   if (it != deferred_release_buffer_pool_.end()) {
     it->second.push_back(p);
@@ -397,7 +397,7 @@ Status CUDAExecutionProvider::EnqueueDeferredRelease() {
     // This iteration enqueues a callback to release all buffers
     // in it->second on it->first.
 
-    auto stream = static_cast<cudaStream_t>(it->first);
+    auto stream = it->first;
     auto& buffers = it->second;
     // Allocate a heap object to extend the lifetime of allocator and buffer pointers.
     std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -368,23 +368,21 @@ struct CpuBuffersInfo {
   // CUDA stream. For example, this fields
   // should contain all values in
   // deferred_release_buffer_pool_[my_stream]
-  // when release my_stream's buffers.
-  void** buffers;
-  // CPU buffer buffers[i].
-  // Number of buffer points in "buffers".
-  size_t n_buffers;
+  // when release my_stream's (type: cudaStream_t)
+  // buffers.
+  std::vector<void*> buffers;
 };
 
 static void CUDART_CB ReleaseCpuBufferCallback(void* raw_info) {
-  auto info = reinterpret_cast<CpuBuffersInfo*>(raw_info);
-  // Uncomment the following line to check if all previous stream
-  // operations are done correctly.
-  // checkCudaErrors(tmp->status);
-  for (size_t i = 0; i < info->n_buffers; ++i) {
-    info->allocator->Free(info->buffers[i]);
+  // The passed-in raw_info is a unmanaged pointer from
+  // std::unique_ptr<CpuBuffersInfo>.release().
+  // We rewrap raw_info as std::unique_ptr<CpuBuffersInfo> so that
+  // it will be cleaned up automatically at the end of this function.
+  std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();
+  cpu_buffers_info.reset(reinterpret_cast<CpuBuffersInfo*>(raw_info));
+  for (auto ptr : cpu_buffers_info->buffers) {
+    cpu_buffers_info->allocator->Free(ptr);
   }
-  delete[] info->buffers;
-  delete info;
 }
 
 Status CUDAExecutionProvider::EnqueueDeferredRelease() {
@@ -401,18 +399,15 @@ Status CUDAExecutionProvider::EnqueueDeferredRelease() {
 
     auto stream = static_cast<cudaStream_t>(it->first);
     auto& buffers = it->second;
-    // Allocate a heap object to extend the lifetime of allocator and buffer pointers
-    // until the end of callback (aka ReleaseCpuBufferCallback).
-    auto cpu_buffers_info = new CpuBuffersInfo;
+    // Allocate a heap object to extend the lifetime of allocator and buffer pointers.
+    std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();
     // This allocator must be the same to the allocator
     // used in AllocateBufferOnCPUPinned.
     cpu_buffers_info->allocator = GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
-    cpu_buffers_info->buffers = new void*[buffers.size()];
-    for (size_t i = 0; i < buffers.size(); ++i) {
-      cpu_buffers_info->buffers[i] = buffers.at(i);
-    }
-    cpu_buffers_info->n_buffers = buffers.size();
-    CUDA_RETURN_IF_ERROR(cudaLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info));
+    cpu_buffers_info->buffers = buffers;
+    // Release the ownership of cpu_buffers_info so that the underlying
+    // object will keep alive until the end of ReleaseCpuBufferCallback.
+    CUDA_RETURN_IF_ERROR(cudaLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info.release()));
   }
   // All buffers are scheduled for release.
   // Let's clear releated information so that

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -134,7 +134,7 @@ class CUDAExecutionProvider : public IExecutionProvider {
   // stream returned by GetComputeStream when calling AddDeferredReleaseCPUPtr) in OnRunEnd.
   // Those are pointers allocated by AllocateBufferOnCPUPinned and should be released
   // by CPU Allocator's Free function.
-  std::unordered_map<void*, std::vector<void*>> deferred_release_buffer_pool_;
+  std::unordered_map<cudaStream_t, std::vector<void*>> deferred_release_buffer_pool_;
   // To add a pointer to deferred_release_buffer_pool_, we need a mutex because
   // different threads may create CPU buffers at the same time. Releasing
   // buffers also needs this mutex.

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -321,7 +321,7 @@ void ReleaseCpuBufferCallback(hipStream_t /*stream*/, hipError_t /*status*/, voi
   // it will be cleaned up automatically at the end of this function.
   std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();
   cpu_buffers_info.reset(reinterpret_cast<CpuBuffersInfo*>(raw_info));
-  for (auto ptr: info->buffers) {
+  for (auto ptr: cpu_buffers_info->buffers) {
     cpu_buffers_info->allocator->Free(ptr);
   }
 }

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -355,6 +355,12 @@ Status ROCMExecutionProvider::EnqueueDeferredRelease() {
     //  hipLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info);
     HIP_RETURN_IF_ERROR(hipStreamAddCallback(stream, ReleaseCpuBufferCallback, cpu_buffers_info.release(), 0));
   }
+  // All buffers are scheduled for release.
+  // Let's clear releated information so that
+  // those buffers won't be released twice in
+  // the next EnqueueDeferredRelease call.
+  deferred_release_buffer_pool_.clear();
+  return Status::OK();
 }
 
 Status ROCMExecutionProvider::OnRunStart() {

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.cc
@@ -286,7 +286,7 @@ void ROCMExecutionProvider::AddDeferredReleaseCPUPtr(void* p) {
   // AllocateBufferOnCPUPinned.
 
   std::lock_guard<OrtMutex> lock(deferred_release_mutex_);
-  void* stream = GetComputeStream();
+  hipStream_t stream = static_cast<hipStream_t>(GetComputeStream());
   auto it = deferred_release_buffer_pool_.find(stream);
   if (it != deferred_release_buffer_pool_.end()) {
     it->second.push_back(p);
@@ -338,7 +338,7 @@ Status ROCMExecutionProvider::EnqueueDeferredRelease() {
     // This iteration enqueues a callback to release all buffers
     // in it->second on it->first.
 
-    auto stream = static_cast<hipStream_t>(it->first);
+    auto stream = it->first;
     auto& buffers = it->second;
     // Allocate a heap object to extend the lifetime of allocator and buffer pointers.
     std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.h
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.h
@@ -123,7 +123,7 @@ class ROCMExecutionProvider : public IExecutionProvider {
   // stream returned by GetComputeStream when calling AddDeferredReleaseCPUPtr) in OnRunEnd.
   // Those are pointers allocated by AllocateBufferOnCPUPinned and should be released
   // by CPU Allocator's Free function.
-  std::unordered_map<void*, std::vector<void*>> deferred_release_buffer_pool_;
+  std::unordered_map<hipStream_t, std::vector<void*>> deferred_release_buffer_pool_;
   // To add a pointer to deferred_release_buffer_pool_, we need a mutex because
   // different threads may create CPU buffers at the same time. Releasing
   // buffers also needs this mutex.


### PR DESCRIPTION
Fix two warnings:
1. Warning: Avoid calling new and delete explicitly, use std::make_unique<T> instead (r.11).
   Fix: new is replaced by creating unique_ptr and unique_ptr.release
          delete is replaced by unique_ptr.reset and unique_ptr's destructor.
2. Warning: Buffer overrun while writing to 'cpu_buffers_info->buffers': the writable size is 'buffers.public: unsigned __int64 __cdecl std::vector<void \*,class std::allocator<void\*> >::size(void)const () \* 8' bytes, but '16' bytes might be written.
   Fix: Replace void* with cudaStream_t and void** with std::vector<cudaStream_t>.



