### PR TITLE
static cast stream to cudastream for cudaKernel

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_kernel.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel.h
@@ -78,8 +78,8 @@ class CudaKernel : public OpKernel {
   }
 
   static inline cudnnHandle_t GetCudnnHandle(onnxruntime::Stream* stream) {
-    auto* cuda_stream = dynamic_cast<CudaStream*>(stream);
-    return cuda_stream ? cuda_stream->cudnn_handle_ : nullptr;
+    ORT_ENFORCE(stream->device.Type() == OrtDevice::GPU);
+    return static_cast<CudaStream*>(stream)->cudnn_handle_;
   }
 
   inline cublasHandle_t GetCublasHandle(OpKernelContext* ctx) const {
@@ -87,8 +87,8 @@ class CudaKernel : public OpKernel {
   }
 
   static inline cublasHandle_t GetCublasHandle(onnxruntime::Stream* stream) {
-    auto* cuda_stream = dynamic_cast<CudaStream*>(stream);
-    return cuda_stream ? cuda_stream->cublas_handle_ : nullptr;
+    ORT_ENFORCE(stream->device.Type() == OrtDevice::GPU);
+    return static_cast<CudaStream*>(stream)->cublas_handle_;
   }
 
   inline onnxruntime::Stream* OrtStream(OpKernelContext* ctx) const {

--- a/onnxruntime/core/providers/cuda/cuda_stream_handle.h
+++ b/onnxruntime/core/providers/cuda/cuda_stream_handle.h
@@ -5,8 +5,6 @@
 #include "core/framework/stream_handles.h"
 
 namespace onnxruntime {
-using CudaStreamHandle = cudaStream_t;
-
 
 struct CudaStream : Stream {
   CudaStream(cudaStream_t stream, const OrtDevice& device, bool own_flag, cudnnHandle_t external_cudnn_handle, cublasHandle_t external_cublass_handle);


### PR DESCRIPTION
**Description**: static cast stream to cudastream for cudaKernel.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
