### PR TITLE
Assign generate document job to CPU pool.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -72,5 +72,5 @@ stages:
         RunOnnxRuntimeTests: false
         RunStaticCodeAnalysis: false
         ORT_EP_NAME: CUDA # It doesn't really matter which EP is selected here since this stage is for documentation.
-        MachinePool: onnxruntime-Win2019-GPU
+        MachinePool: Win-CPU-2019
         DocUpdateNeeded: true


### PR DESCRIPTION
**Description**: 
Set generate document pool to Windows CPU

**Motivation and Context**
It's NOT necessary to use GPU machine.
And it takes less time in CPU machine.