### PR TITLE
fix CuDNN lib path for Windows

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1037,7 +1037,7 @@ if (onnxruntime_USE_CUDA)
       #TODO: combine onnxruntime_CUDNN_HOME and onnxruntime_CUDA_HOME, assume they are the same
       if (WIN32)
         if(onnxruntime_CUDNN_HOME)
-          list(APPEND onnxruntime_LINK_DIRS ${onnxruntime_CUDNN_HOME}/lib/x64)
+          list(APPEND onnxruntime_LINK_DIRS ${onnxruntime_CUDNN_HOME}/lib ${onnxruntime_CUDNN_HOME}/lib/x64)
         endif()
         list(APPEND onnxruntime_LINK_DIRS ${onnxruntime_CUDA_HOME}/x64/lib64)
       else()


### PR DESCRIPTION
Fixes microsoft/onnxruntime#12969

### Motivation and Context

Build is broken, can't find cudnn.lib with nvidia official install of cuDNN

Alternative method is to use `IF(EXISTS ${onnxruntime_CUDNN_HOME}/lib/x64/cudnn.lib)` to test for legacy location and only add the legacy dir to the path, else add the current official `lib/` dir.