### PR TITLE
workaround list(REMOVE_ITEM) with cmake<=3.19

### DIFF
--- a/cmake/onnxruntime_graph.cmake
+++ b/cmake/onnxruntime_graph.cmake
@@ -60,7 +60,8 @@ if(NOT onnxruntime_USE_DML)
 endif()
 
 file(GLOB onnxruntime_graph_src_exclude ${onnxruntime_graph_src_exclude_patterns})
-list(REMOVE_ITEM onnxruntime_graph_src ${onnxruntime_graph_src_exclude})
+#TODO: remove empty string "" param when project guarantees cmake 3.20+ due to https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5693
+list(REMOVE_ITEM onnxruntime_graph_src ${onnxruntime_graph_src_exclude} "")
 
 file(GLOB_RECURSE onnxruntime_ir_defs_src CONFIGURE_DEPENDS
   "${ONNXRUNTIME_ROOT}/core/defs/*.cc"


### PR DESCRIPTION
Fixes microsoft/onnxruntime#12967

### Motivation and Context

- build broken when using cmake <= 3.19 due to known cmake `list(REMOVE_ITEM...` bug https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5693
- easy fix as already used in vcpkg
- added TODO to remove workaround when onnxruntime project guarantees cmake is 3.20+

NOTE!! There are other locations of `list(REMOVE_ITEM...` in this onnxruntime project which may have this same bug. For example: 
* cmake/onnxruntime_framework.cmake line 33
* cmake/onnxruntime_providers.cmake lines 203, 232, etc.
* cmake/onnxruntime_session.cmake line 24
* ...and more
