### PR TITLE
DML EP temporarily fall back to CPU for LayerNorm when Bias is not present

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -57,7 +57,7 @@ void CALLBACK QueryLayerNormalization(IMLOperatorSupportQueryContextPrivate* con
     *isSupported = false;
 
     // Mean and InvStdDev are not supported outputs.
-    // If only scale Tensor is present then fall back to CPU. This is temporarily until 
+    // If only scale Tensor is present then fall back to CPU. This is temporary until 
     // DML1.9.2 or DML1.10 gets released.
     if (context->GetInputCount() < 3 || context->GetOutputCount() > 1) 
     {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -54,14 +54,17 @@ public:
 
 void CALLBACK QueryLayerNormalization(IMLOperatorSupportQueryContextPrivate* context, /*out*/ bool* isSupported)
 {
-    *isSupported = true;
+    *isSupported = false;
 
     // Mean and InvStdDev are not supported outputs.
-    if (context->GetOutputCount() > 1)
+    // If only scale Tensor is present then fall back to CPU. This is temporarily until 
+    // DML1.9.2 or DML1.10 gets released.
+    if (context->GetInputCount() < 3 || context->GetOutputCount() > 1) 
     {
-        *isSupported = false;
         return;
     }
+
+    *isSupported = true;
 }
 
 DML_OP_DEFINE_CREATION_FUNCTION(LayerNormalization, DmlOperatorLayerNormalization);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -57,7 +57,7 @@ void CALLBACK QueryLayerNormalization(IMLOperatorSupportQueryContextPrivate* con
     *isSupported = false;
 
     // Mean and InvStdDev are not supported outputs.
-    // If only scale Tensor is present then fall back to CPU. This is temporary until 
+    // If only Scale tensor is present then fall back to CPU. This is temporary until 
     // DML1.9.2 or DML1.10 gets released.
     if (context->GetInputCount() < 3 || context->GetOutputCount() > 1) 
     {

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -592,7 +592,7 @@ namespace OperatorHelper
         int32_t transBatch,
         int32_t transpose)
     {
-        const uint32_t dimensionCount = sizes.size();
+        const uint32_t dimensionCount = gsl::narrow_cast<uint32_t>(sizes.size());
         std::vector<uint32_t> newStrides(dimensionCount);
         std::vector<uint32_t> newSizes(sizes.begin(), sizes.end());
 


### PR DESCRIPTION
**Description**: Until DML1.9.2 or DML1.10 gets released, DML EP will fall back to CPU for LayerNorm when Bias tensor is not present.

**Motivation and Context**
- Why is this change required? What problem does it solve? It prevents the crash in DML EP.
- If it fixes an open issue, please link to the issue here. N/A
