### PR TITLE
Ignore settings.json in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ onnxruntime.egg-info
 nuget_root/
 .packages/
 .vscode
-!/.vscode/settings.json
 *.code-workspace
 __pycache__
 onnxruntime_profile*.json


### PR DESCRIPTION
**Description**: Remove the `settings.json` line in gitignore.

**Motivation and Context**

Having `settings.json` tracked in git has created annoying diffs when it is modified locally. This PR removes the entry in gitignore but maintains the `settings.json` in the repo so that we have a good default.