### PR TITLE
Fix hipify due to CUDA EP tensorrt_fused_multihead_attention optimization

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/attention.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/rocm/rocm_kernel.h"
+#include "contrib_ops/cpu/bert/attention_base.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+using namespace onnxruntime::rocm;
+
+template <typename T>
+class Attention final : public RocmKernel, public AttentionBase {
+ public:
+  Attention(const OpKernelInfo& info);
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime


### PR DESCRIPTION
**Description**: Recent change in CUDA EP #12814 makes hipify extremely slow and breaks the building. This PR fixes it by c

**Motivation and Context**
- Why is this change required? What problem does it solve?
The [onnxruntime/contrib_ops/rocm/bert/attention.h](https://github.com/microsoft/onnxruntime/compare/guangyunhan/fix-hipify-trt-attention?expand=1#diff-94d42408464e508748bf2d815932057aa5161320d178c1f4b5344afeb0a66eb3) is checkout-ed from the version before #12814 and manually hipify-ed. Slightly extend amd_hipify.py to allow wildcard file match.