### PR TITLE
Make PythonOp report dtype mismatch by name, instead of by using enum index

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -3682,7 +3682,9 @@ Return true if all elements are true and false otherwise.
           ORT_ENFORCE(inferred_input_type->value_case() == TypeProto::kTensorType,
                       "PythonOp's ", i, "th input type must be a tensor.");
           ORT_ENFORCE(inferred_input_type->tensor_type().elem_type() == input_tensor_types_proto->ints().at(i),
-                      "PythonOp's ", i, "th input type must be ", input_tensor_types_proto->ints().at(i));
+                      "PythonOp's ", i, "th input type must be ",
+                      TensorProto_DataType_Name(input_tensor_types_proto->ints().at(i)), " but got ",
+                      TensorProto_DataType_Name(inferred_input_type->tensor_type().elem_type()));
         }
 
         // The first output is a pointer which points to


### PR DESCRIPTION
**Description**: This slightly improve the error message. Make developer's life easier.

