### PR TITLE
Remove usage of torch.onnx symbolic_registry

### DIFF
--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -17,7 +17,6 @@ except ModuleNotFoundError:
 
 from torch.onnx import symbolic_helper
 
-
 _OPSET_VERSION = 1
 _registered_ops: typing.AbstractSet[str] = set()
 

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -15,8 +15,8 @@ except ModuleNotFoundError:
         "This module is only useful in combination with PyTorch. To install PyTorch see https://pytorch.org/."
     )
 
-import torch.onnx.symbolic_helper as sym_help
-import torch.onnx.symbolic_registry as sym_registry
+from torch.onnx import symbolic_helper
+
 
 _OPSET_VERSION = 1
 _registered_ops: typing.AbstractSet[str] = set()
@@ -43,11 +43,11 @@ def register():
         #   'zeros'         : onnx::Constant[value={0}]
         #   'border'        : onnx::Constant[value={1}]
         #   'reflection'    : onnx::Constant[value={2}]
-        mode = sym_help._maybe_get_const(mode, "i")
-        padding_mode = sym_help._maybe_get_const(padding_mode, "i")
+        mode = symbolic_helper._maybe_get_const(mode, "i")
+        padding_mode = symbolic_helper._maybe_get_const(padding_mode, "i")
         mode_str = ["bilinear", "nearest", "bicubic"][mode]
         padding_mode_str = ["zeros", "border", "reflection"][padding_mode]
-        align_corners = int(sym_help._maybe_get_const(align_corners, "b"))
+        align_corners = int(symbolic_helper._maybe_get_const(align_corners, "b"))
 
         # From opset v13 onward, the output shape can be specified with
         # (N, C, H, W) (N, H_out, W_out, 2) => (N, C, H_out, W_out)
@@ -98,8 +98,9 @@ def unregister():
         try:
             torch.onnx.unregister_custom_op_symbolic(name, _OPSET_VERSION)
         except AttributeError:
+            from torch.onnx import symbolic_registry
             # unregister_custom_op_symbolic is not available before PyTorch 1.12
             namespace, kind = name.split("::")
-            for version in sym_help._onnx_stable_opsets:
-                if version >= _OPSET_VERSION and sym_registry.is_registered_op(kind, namespace, version):
-                    del sym_registry._registry[(namespace, version)][kind]
+            for version in symbolic_helper._onnx_stable_opsets:
+                if version >= _OPSET_VERSION and symbolic_registry.is_registered_op(kind, namespace, version):
+                    del symbolic_registry._registry[(namespace, version)][kind]

--- a/onnxruntime/python/tools/pytorch_export_contrib_ops.py
+++ b/onnxruntime/python/tools/pytorch_export_contrib_ops.py
@@ -98,8 +98,11 @@ def unregister():
         try:
             torch.onnx.unregister_custom_op_symbolic(name, _OPSET_VERSION)
         except AttributeError:
+            # The symbolic_registry module was removed in PyTorch 1.13.
+            # We are importing it here for backwards compatibility
+            # because unregister_custom_op_symbolic is not available before PyTorch 1.12
             from torch.onnx import symbolic_registry
-            # unregister_custom_op_symbolic is not available before PyTorch 1.12
+
             namespace, kind = name.split("::")
             for version in symbolic_helper._onnx_stable_opsets:
                 if version >= _OPSET_VERSION and symbolic_registry.is_registered_op(kind, namespace, version):


### PR DESCRIPTION
**Description**: symbolic_registry is deprecated in torch.onnx. This PR removes its usage. 

Fixes #13008