### PR TITLE
[Java] Fix OnnxSequence semantics

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxMap.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -137,7 +137,7 @@ public class OnnxMap implements OnnxValue {
    * @throws OrtException If the onnx runtime failed to read the entries.
    */
   @Override
-  public Map<Object, Object> getValue() throws OrtException {
+  public Map<? extends Object, ? extends Object> getValue() throws OrtException {
     Object[] keys = getMapKeys();
     Object[] values = getMapValues();
     HashMap<Object, Object> map = new HashMap<>(OrtUtil.capacityFromSize(keys.length));

--- a/java/src/main/native/ai_onnxruntime_OnnxSequence.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxSequence.c
@@ -6,202 +6,47 @@
 #include "onnxruntime/core/session/onnxruntime_c_api.h"
 #include "OrtJniUtil.h"
 #include "ai_onnxruntime_OnnxSequence.h"
-/*
- * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getStringKeys
- * Signature: (JJI)[Ljava/lang/String;
- */
-JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringKeys(JNIEnv* jniEnv, jobject jobj,
-                                                                              jlong apiHandle, jlong handle,
-                                                                              jlong allocatorHandle, jint index) {
-  (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
-  const OrtApi* api = (const OrtApi*)apiHandle;
-  OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jobjectArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
-  if (code == ORT_OK) {
-    // Extract keys from element
-    OrtValue* keys;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 0, allocator, &keys));
-
-    if (code == ORT_OK) {
-      // Convert to Java String array
-      output = createStringArrayFromTensor(jniEnv, api, keys);
-      // Release if valid
-      api->ReleaseValue(element);
-    }
-
-    // Keys is valid, so release
-    api->ReleaseValue(keys);
-  }
-  return output;
-}
 
 /*
  * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getLongKeys
- * Signature: (JJI)[J
+ * Method:    getMaps
+ * Signature: (JJJ)[Lai/onnxruntime/OnnxMap;
  */
-JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxSequence_getLongKeys(JNIEnv* jniEnv, jobject jobj, jlong apiHandle,
-                                                                          jlong handle, jlong allocatorHandle,
-                                                                          jint index) {
+JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getMaps(JNIEnv* jniEnv, jobject jobj,
+                                                                        jlong apiHandle, jlong handle,
+                                                                        jlong allocatorHandle) {
   (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
   const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtValue* sequence = (OrtValue*)handle;
   OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jlongArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
+
+  jobjectArray outputArray = NULL;
+
+  // Get the element count of this sequence
+  size_t count;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValueCount(sequence, &count));
   if (code == ORT_OK) {
-    // Extract keys from element
-    OrtValue* keys;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 0, allocator, &keys));
-
-    if (code == ORT_OK) {
-      // Convert to Java long array
-      output = createLongArrayFromTensor(jniEnv, api, keys);
-      // Release if valid
-      api->ReleaseValue(element);
+    jclass tensorClazz = (*jniEnv)->FindClass(jniEnv, "ai/onnxruntime/OnnxMap");
+    outputArray = (*jniEnv)->NewObjectArray(jniEnv, safecast_size_t_to_jsize(count), tensorClazz, NULL);
+    for (size_t i = 0; i < count; i++) {
+      // Extract element
+      OrtValue* element;
+      code = checkOrtStatus(jniEnv, api, api->GetValue(sequence, (int)i, allocator, &element));
+      if (code == ORT_OK) {
+        jobject str = createJavaMapFromONNX(jniEnv, api, allocator, element);
+        if (str == NULL) {
+          api->ReleaseValue(element);
+          // bail out as exception has been thrown
+          return NULL;
+        }
+        (*jniEnv)->SetObjectArrayElement(jniEnv, outputArray, (jsize)i, str);
+      } else {
+        // bail out as exception has been thrown
+        return NULL;
+      }
     }
-
-    // Keys is valid, so release
-    api->ReleaseValue(keys);
   }
-  return output;
-}
-
-/*
- * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getStringValues
- * Signature: (JJI)[Ljava/lang/String;
- */
-JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxSequence_getStringValues(JNIEnv* jniEnv, jobject jobj,
-                                                                                jlong apiHandle, jlong handle,
-                                                                                jlong allocatorHandle, jint index) {
-  (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
-  const OrtApi* api = (const OrtApi*)apiHandle;
-  OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jobjectArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
-  if (code == ORT_OK) {
-    // Extract values from element
-    OrtValue* values;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 1, allocator, &values));
-
-    if (code == ORT_OK) {
-      // Convert to Java String array
-      output = createStringArrayFromTensor(jniEnv, api, values);
-      // Release if valid
-      api->ReleaseValue(element);
-    }
-
-    // values is valid, so release
-    api->ReleaseValue(values);
-  }
-  return output;
-}
-
-/*
- * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getLongValues
- * Signature: (JJI)[J
- */
-JNIEXPORT jlongArray JNICALL Java_ai_onnxruntime_OnnxSequence_getLongValues(JNIEnv* jniEnv, jobject jobj,
-                                                                            jlong apiHandle, jlong handle,
-                                                                            jlong allocatorHandle, jint index) {
-  (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
-  const OrtApi* api = (const OrtApi*)apiHandle;
-  OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jlongArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
-  if (code == ORT_OK) {
-    // Extract values from element
-    OrtValue* values;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 1, allocator, &values));
-
-    if (code == ORT_OK) {
-      // Convert to Java long array
-      output = createLongArrayFromTensor(jniEnv, api, values);
-      // Release if valid
-      api->ReleaseValue(element);
-    }
-
-    // values is valid, so release
-    api->ReleaseValue(values);
-  }
-  return output;
-}
-
-/*
- * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getFloatValues
- * Signature: (JJI)[F
- */
-JNIEXPORT jfloatArray JNICALL Java_ai_onnxruntime_OnnxSequence_getFloatValues(JNIEnv* jniEnv, jobject jobj,
-                                                                              jlong apiHandle, jlong handle,
-                                                                              jlong allocatorHandle, jint index) {
-  (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
-  const OrtApi* api = (const OrtApi*)apiHandle;
-  OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jfloatArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
-  if (code == ORT_OK) {
-    // Extract values from element
-    OrtValue* values;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 1, allocator, &values));
-
-    if (code == ORT_OK) {
-      // Convert to Java float array
-      output = createFloatArrayFromTensor(jniEnv, api, values);
-      // Release if valid
-      api->ReleaseValue(element);
-    }
-
-    // values is valid, so release
-    api->ReleaseValue(values);
-  }
-  return output;
-}
-
-/*
- * Class:     ai_onnxruntime_OnnxSequence
- * Method:    getDoubleValues
- * Signature: (JJI)[D
- */
-JNIEXPORT jdoubleArray JNICALL Java_ai_onnxruntime_OnnxSequence_getDoubleValues(JNIEnv* jniEnv, jobject jobj,
-                                                                                jlong apiHandle, jlong handle,
-                                                                                jlong allocatorHandle, jint index) {
-  (void)jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
-  const OrtApi* api = (const OrtApi*)apiHandle;
-  OrtAllocator* allocator = (OrtAllocator*)allocatorHandle;
-  jdoubleArray output = NULL;
-  // Extract element
-  OrtValue* element;
-  OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetValue((OrtValue*)handle, index, allocator, &element));
-  if (code == ORT_OK) {
-    // Extract values from element
-    OrtValue* values;
-    code = checkOrtStatus(jniEnv, api, api->GetValue(element, 1, allocator, &values));
-
-    if (code == ORT_OK) {
-      // Convert to Java double array
-      output = createDoubleArrayFromTensor(jniEnv, api, values);
-      // Release if valid
-      api->ReleaseValue(element);
-    }
-
-    // values is valid, so release
-    api->ReleaseValue(values);
-  }
-  return output;
+  return outputArray;
 }
 
 /*

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -1303,7 +1303,8 @@ public class InferenceTest {
 
         // try-cast first element in sequence to map/dictionary type
         @SuppressWarnings("unchecked")
-        Map<Long, Float> map = (Map<Long, Float>) ((List<Object>) secondOutput.getValue()).get(0);
+        Map<Long, Float> map =
+            (Map<Long, Float>) ((List<OnnxMap>) secondOutput.getValue()).get(0).getValue();
         assertEquals(0.25938290, map.get(0L), 1e-6);
         assertEquals(0.40904793, map.get(1L), 1e-6);
         assertEquals(0.33156919, map.get(2L), 1e-6);
@@ -1370,7 +1371,7 @@ public class InferenceTest {
         // try-cast first element in sequence to map/dictionary type
         @SuppressWarnings("unchecked")
         Map<String, Float> map =
-            (Map<String, Float>) ((List<Object>) secondOutput.getValue()).get(0);
+            (Map<String, Float>) ((List<OnnxMap>) secondOutput.getValue()).get(0).getValue();
         assertEquals(0.25938290, map.get("0"), 1e-6);
         assertEquals(0.40904793, map.get("1"), 1e-6);
         assertEquals(0.33156919, map.get("2"), 1e-6);
@@ -1413,7 +1414,7 @@ public class InferenceTest {
         assertEquals(2, seq.getInfo().length);
 
         // try-cast the elements in sequence to tensor type
-        List<Object> elements = seq.getValue();
+        List<? extends OnnxValue> elements = seq.getValue();
         assertEquals(2, elements.size());
         assertTrue(elements.get(0) instanceof OnnxTensor);
         assertTrue(elements.get(1) instanceof OnnxTensor);

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
+import java.nio.LongBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1374,6 +1376,73 @@ public class InferenceTest {
         assertEquals(0.33156919, map.get("2"), 1e-6);
       }
       ov.close();
+    }
+  }
+
+  @Test
+  public void testModelSequenceOfTensors() throws OrtException {
+    String modelPath = TestHelpers.getResourcePath("/test_sequence_tensors.onnx").toString();
+
+    try (SessionOptions options = new SessionOptions();
+        OrtSession session = env.createSession(modelPath, options)) {
+      Map<String, NodeInfo> outputInfos = session.getOutputInfo();
+      NodeInfo outputInfo = outputInfos.get("output_sequence");
+      assertTrue(outputInfo.getInfo() instanceof SequenceInfo);
+
+      Map<String, OnnxTensor> container = new HashMap<>();
+      OnnxTensor firstInputTensor =
+          OnnxTensor.createTensor(
+              env, OrtUtil.reshape(new long[] {1, 2, 3, 4, 5, 6}, new long[] {2, 3}));
+      OnnxTensor secondInputTensor =
+          OnnxTensor.createTensor(
+              env, OrtUtil.reshape(new long[] {7, 8, 9, 10, 11, 12}, new long[] {2, 3}));
+
+      container.put("tensor1", firstInputTensor);
+      container.put("tensor2", secondInputTensor);
+
+      try (OrtSession.Result outputs = session.run(container)) {
+        // output is a sequence<tensors>
+        Optional<OnnxValue> output = outputs.get("output_sequence");
+        assertTrue(output.isPresent());
+        assertTrue(output.get() instanceof OnnxSequence);
+
+        // cast to a sequence
+        OnnxSequence seq = (OnnxSequence) output.get();
+
+        // make sure that the sequence holds only 2 elements (tensors)
+        assertEquals(2, seq.getInfo().length);
+
+        // try-cast the elements in sequence to tensor type
+        List<Object> elements = seq.getValue();
+        assertEquals(2, elements.size());
+        assertTrue(elements.get(0) instanceof OnnxTensor);
+        assertTrue(elements.get(1) instanceof OnnxTensor);
+
+        OnnxTensor firstTensor = (OnnxTensor) elements.get(0);
+        OnnxTensor secondTensor = (OnnxTensor) elements.get(1);
+
+        LongBuffer outputBuf = firstTensor.getLongBuffer();
+
+        // make sure the tensors in the output sequence hold the correct values
+        assertEquals(1, outputBuf.get(0));
+        assertEquals(2, outputBuf.get(1));
+        assertEquals(3, outputBuf.get(2));
+        assertEquals(4, outputBuf.get(3));
+        assertEquals(5, outputBuf.get(4));
+        assertEquals(6, outputBuf.get(5));
+
+        outputBuf = secondTensor.getLongBuffer();
+
+        assertEquals(7, outputBuf.get(0));
+        assertEquals(8, outputBuf.get(1));
+        assertEquals(9, outputBuf.get(2));
+        assertEquals(10, outputBuf.get(3));
+        assertEquals(11, outputBuf.get(4));
+        assertEquals(12, outputBuf.get(5));
+
+        firstTensor.close();
+        secondTensor.close();
+      }
     }
   }
 


### PR DESCRIPTION
**Description**:

Previously OnnxSequence would flatten out a list of tensors into a single output array assuming they were all scalar values. This doesn't accurately represent the semantics of an ONNX sequence, but was what the semantics appeared to be years ago when I first wrote that class. This PR changes it so that the `getValue` method on `OnnxSequence` unwraps the sequence and returns `List<? extends OnnxValue>` allowing the user to process the individual ONNX values separately. It's done this way rather than returning a multidimensional array for a tensor and a Java map for a map as multidimensional arrays are very inefficient in Java and best practice when operating with a OnnxTensor in Java is to use a `java.nio.ByteBuffer`. So allowing users to access each `OnnxTensor`s individually allows them to control how the data is materialised on the Java heap.

**Motivation and Context**
- Why is this change required? What problem does it solve? Fixes #12629.
- If it fixes an open issue, please link to the issue here.
