### PR TITLE
downgrade setuptools

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -9,5 +9,5 @@ torchvision==0.11.1+cu113
 torchtext==0.11.0
 tensorboard>=2.2.0,<2.5.0
 h5py
-setuptools>=41.4.0
+setuptools<=59.5.0
 parameterized>=0.8.1


### PR DESCRIPTION
**Description**: Describe your changes.

- downgrade setuptools from latest to 59.5.0

**Motivation and Context**

>Traceback (most recent call last):
  File "orttraining_test_transformers.py", line 12, in <module>
    from transformers import BertConfig, BertForPreTraining, BertModel
  File "/home/onnxruntimedev/miniconda3/lib/python3.8/site-packages/transformers/__init__.py", line 351, in <module>
    from .trainer import Trainer, set_seed, torch_distributed_zero_first, EvalPrediction
  File "/home/onnxruntimedev/miniconda3/lib/python3.8/site-packages/transformers/trainer.py", line 46, in <module>
    from torch.utils.tensorboard import SummaryWriter
  File "/home/onnxruntimedev/miniconda3/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py", line 4, in <module>
    LooseVersion = distutils.version.LooseVersion
AttributeError: module 'distutils' has no attribute 'version'

This is a known issue, fixing as per https://stackoverflow.com/questions/70520120/attributeerror-module-setuptools-distutils-has-no-attribute-version