### PR TITLE
Fix Deferred Release and Add New Test Framework for CUDA EP-specific Tests

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -411,7 +411,7 @@ Status CUDAExecutionProvider::EnqueueDeferredRelease() {
       // Release memory asynchronously to avoid blocking the compute stream.
       CUDA_RETURN_IF_ERROR(cudaLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info.release()));
     } else {
-      // cudaFreeHost and all other CUDA APIs cannot be called by cudaLaunchHostFunc per CUDA spec.
+      // cudaFreeHost and all other CUDA APIs cannot be called by cudaLaunchHostFunc per spec.
       // So we just do synchrous release.
       ReleaseCpuBufferCallback(cpu_buffers_info.release());
     }

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -407,7 +407,14 @@ Status CUDAExecutionProvider::EnqueueDeferredRelease() {
     cpu_buffers_info->buffers = buffers;
     // Release the ownership of cpu_buffers_info so that the underlying
     // object will keep alive until the end of ReleaseCpuBufferCallback.
-    CUDA_RETURN_IF_ERROR(cudaLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info.release()));
+    if (cpu_buffers_info->allocator->Info().alloc_type == OrtArenaAllocator) {
+      // Release memory asynchronously to avoid blocking the compute stream.
+      CUDA_RETURN_IF_ERROR(cudaLaunchHostFunc(stream, ReleaseCpuBufferCallback, cpu_buffers_info.release()));
+    } else {
+      // cudaFreeHost and all other CUDA APIs cannot be called by cudaLaunchHostFunc per CUDA spec.
+      // So we just do synchrous release.
+      ReleaseCpuBufferCallback(cpu_buffers_info.release());
+    }
   }
   // All buffers are scheduled for release.
   // Let's clear releated information so that

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.h
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.h
@@ -18,6 +18,8 @@
 
 namespace onnxruntime {
 
+void RunOnUnload(std::function<void()> function);
+
 // Logical device representation.
 class CUDAExecutionProvider : public IExecutionProvider {
  public:
@@ -90,6 +92,16 @@ class CUDAExecutionProvider : public IExecutionProvider {
       return nullptr;
 
     return IAllocator::MakeUniquePtr<T>(GetAllocator(info_.device_id, OrtMemTypeDefault), count_or_bytes, true);
+  }
+
+  template <typename T>
+  IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
+    // Note that OrtMemTypeCPU and OrtMemTypeCPUOutput are the same. See onnxruntime_c_api.h.
+    // In some CUDA async
+    if (count_or_bytes == 0)
+      return nullptr;
+    return IAllocator::MakeUniquePtr<T>(GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU),
+                                        count_or_bytes);
   }
 
   std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;

--- a/onnxruntime/core/providers/cuda/cuda_kernel.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel.h
@@ -40,14 +40,6 @@ class CudaKernel : public OpKernel {
   virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
 
   template <typename T>
-  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
-    AllocatorPtr allocator = provider_->GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
-    if (!allocator)
-      return nullptr;
-    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
-  }
-
-  template <typename T>
   inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
     return provider_->GetScratchBuffer<T>(count_or_bytes);
   }
@@ -59,6 +51,11 @@ class CudaKernel : public OpKernel {
   template <typename T>
   inline IAllocatorUniquePtr<T> GetTransientScratchBuffer(size_t count_or_bytes) const {
     return provider_->GetTransientScratchBuffer<T>(count_or_bytes);
+  }
+
+  template <typename T>
+  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
+    return provider_->AllocateBufferOnCPUPinned<T>(count_or_bytes);
   }
 
   inline void AddDeferredReleaseCPUPtr(void* p) const {

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -16,6 +16,7 @@
 #include "core/providers/cuda/cuda_allocator.h"
 #include "core/providers/cuda/gpu_data_transfer.h"
 #include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
+#include "core/providers/cuda/test/all_tests.h"
 
 #ifdef ENABLE_NVTX_PROFILE
 #include "nvtx_profile.h"
@@ -179,6 +180,15 @@ struct ProviderInfo_CUDA_Impl : ProviderInfo_CUDA {
   std::shared_ptr<IAllocator> CreateCudaAllocator(int16_t device_id, size_t gpu_mem_limit, onnxruntime::ArenaExtendStrategy arena_extend_strategy, onnxruntime::CUDAExecutionProviderExternalAllocatorInfo& external_allocator_info, OrtArenaCfg* default_memory_arena_cfg) override {
     return CUDAExecutionProvider::CreateCudaAllocator(device_id, gpu_mem_limit, arena_extend_strategy, external_allocator_info, default_memory_arena_cfg);
   }
+
+#ifndef NDEBUG
+  bool TestAll() override {
+    if (!onnxruntime::cuda::test::TestDeferredRelease()) {
+      return false;
+    }
+    return false;
+  }
+#endif
 
 } g_info;
 

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -183,9 +183,21 @@ struct ProviderInfo_CUDA_Impl : ProviderInfo_CUDA {
 
 #ifndef NDEBUG
   bool TestAll() override {
+    // TestAll is the entry point of CUDA EP's insternal tests.
+    // Those internal tests are not directly callable from onnxruntime_test_all
+    // because CUDA EP is a shared library now.
+
+    // This is just one test. Call other test functions below.
     if (!onnxruntime::cuda::test::TestDeferredRelease()) {
       return false;
     }
+
+    if (!onnxruntime::cuda::test::TestDeferredReleaseWithoutArena()) {
+      return false;
+    }
+
+    // TODO(wechi): brings disabled tests in onnxruntime/test/providers/cuda/*
+    // back alive here.
     return false;
   }
 #endif

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -16,7 +16,9 @@
 #include "core/providers/cuda/cuda_allocator.h"
 #include "core/providers/cuda/gpu_data_transfer.h"
 #include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
+#ifndef NDEBUG
 #include "core/providers/cuda/test/all_tests.h"
+#endif
 
 #ifdef ENABLE_NVTX_PROFILE
 #include "nvtx_profile.h"
@@ -201,7 +203,6 @@ struct ProviderInfo_CUDA_Impl : ProviderInfo_CUDA {
     return false;
   }
 #endif
-
 } g_info;
 
 struct CUDA_Provider : Provider {

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.h
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.h
@@ -52,6 +52,12 @@ struct ProviderInfo_CUDA {
 
   virtual std::shared_ptr<onnxruntime::IExecutionProviderFactory> CreateExecutionProviderFactory(const onnxruntime::CUDAExecutionProviderInfo& info) = 0;
   virtual std::shared_ptr<onnxruntime::IAllocator> CreateCudaAllocator(int16_t device_id, size_t gpu_mem_limit, onnxruntime::ArenaExtendStrategy arena_extend_strategy, onnxruntime::CUDAExecutionProviderExternalAllocatorInfo& external_allocator_info, OrtArenaCfg* default_memory_arena_cfg) = 0;
+
+#ifndef NDEBUG
+  // This function is the entry point to CUDA EP's internal (aka not accessible from bridge code for shared library)
+  // tests and is only called from onnxruntime_test_all. Release builds don't need this function.
+  virtual bool TestAll() = 0;
+#endif
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/test/all_tests.h
+++ b/onnxruntime/core/providers/cuda/test/all_tests.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+namespace onnxruntime {
+namespace cuda {
+namespace test {
+
+bool TestDeferredRelease();
+
+} // onnxruntime
+} // cuda
+} // test

--- a/onnxruntime/core/providers/cuda/test/all_tests.h
+++ b/onnxruntime/core/providers/cuda/test/all_tests.h
@@ -4,7 +4,9 @@ namespace onnxruntime {
 namespace cuda {
 namespace test {
 
+// Test header provides function declarations in EP-side bridge.
 bool TestDeferredRelease();
+bool TestDeferredReleaseWithoutArena();
 
 } // onnxruntime
 } // cuda

--- a/onnxruntime/core/providers/cuda/test/all_tests.h
+++ b/onnxruntime/core/providers/cuda/test/all_tests.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#ifndef NDEBUG
 namespace onnxruntime {
 namespace cuda {
 namespace test {
@@ -8,6 +9,7 @@ namespace test {
 bool TestDeferredRelease();
 bool TestDeferredReleaseWithoutArena();
 
-} // onnxruntime
-} // cuda
-} // test
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
+++ b/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
@@ -16,10 +16,6 @@ namespace cuda {
 namespace test {
 
 bool TestDeferredRelease() {
-  OrtArenaCfg ort_arena_cfg;
-  // 1 means ArenaExtendStrategy::kSameAsRequested.
-  // See allocator.h for details.
-  ort_arena_cfg.arena_extend_strategy = 1;
   // Create CUDA EP.
   CUDAExecutionProviderInfo info;
   CUDAExecutionProvider ep(info);
@@ -45,6 +41,50 @@ bool TestDeferredRelease() {
   cpu_pinned_alloc->GetStats(&stats);
   ORT_ENFORCE(stats.num_allocs == n_allocs);
   ORT_THROW_IF_ERROR(ep.OnRunEnd(true));
+  return true;
+}
+
+bool TestDeferredReleaseWithoutArena() {
+  // Create CUDA EP.
+  CUDAExecutionProviderInfo info;
+  CUDAExecutionProvider ep(info);
+  // Initialize allocators in EP.
+  onnxruntime::AllocatorManager allocator_manager;
+
+  OrtDevice pinned_device{OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, DEFAULT_CPU_ALLOCATOR_DEVICE_ID};
+  // Create allocator without BFCArena
+  AllocatorCreationInfo pinned_memory_info(
+      [](OrtDevice::DeviceId device_id) {
+        return std::make_unique<CUDAPinnedAllocator>(device_id, CUDA_PINNED);
+      },
+      pinned_device.Id(),
+      false /* no arena */);
+  auto cuda_pinned_alloc = CreateAllocator(pinned_memory_info);
+  allocator_manager.InsertAllocator(cuda_pinned_alloc);
+
+  // Use existing allocator in allocator_manager.
+  // Also register new allocator created by this EP in allocator_manager.
+  ep.RegisterAllocator(allocator_manager);
+  // Allocator for call cudaMallocHost and cudaFreeHost
+  // For details, see CUDAPinnedAllocator in cuda_allocator.cc.
+  AllocatorPtr cpu_pinned_alloc = ep.GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
+  // 10 MB
+  const size_t n_bytes = 10 * 1000000;
+  const int64_t n_allocs = 64;
+  ORT_THROW_IF_ERROR(ep.OnRunStart());
+  for (size_t i = 0; i < n_allocs; ++i) {
+    // Allocate 10MB CUDA pinned memory.
+    auto pinned_buffer = ep.AllocateBufferOnCPUPinned<void>(n_bytes);
+    // Release it using CUDA callback.
+    ep.AddDeferredReleaseCPUPtr(pinned_buffer.release());
+  }
+
+  // Memory stats
+  AllocatorStats stats;
+  cpu_pinned_alloc->GetStats(&stats);
+  std::cout << stats.DebugString() << std::endl;
+  ORT_THROW_IF_ERROR(ep.OnRunEnd(true));
+  std::cout << stats.DebugString() << std::endl;
   return true;
 }
 

--- a/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
+++ b/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
@@ -79,12 +79,7 @@ bool TestDeferredReleaseWithoutArena() {
     ep.AddDeferredReleaseCPUPtr(pinned_buffer.release());
   }
 
-  // Memory stats
-  AllocatorStats stats;
-  cpu_pinned_alloc->GetStats(&stats);
-  std::cout << stats.DebugString() << std::endl;
   ORT_THROW_IF_ERROR(ep.OnRunEnd(true));
-  std::cout << stats.DebugString() << std::endl;
   return true;
 }
 

--- a/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
+++ b/onnxruntime/core/providers/cuda/test/cuda_execution_provider_test.cc
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This test is built only under DEBUG mode because it requires
+// extra code in the core of CUDA EP and that code may
+//  1. slow down performance critical applications and
+//  2. increase binary size of ORT.
+#ifndef NDEBUG
+#include <iostream>
+#include "core/providers/cuda/test/all_tests.h"
+#include "core/providers/cuda/cuda_execution_provider.h"
+#include "core/providers/cuda/cuda_allocator.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace test {
+
+bool TestDeferredRelease() {
+  OrtArenaCfg ort_arena_cfg;
+  // 1 means ArenaExtendStrategy::kSameAsRequested.
+  // See allocator.h for details.
+  ort_arena_cfg.arena_extend_strategy = 1;
+  // Create CUDA EP.
+  CUDAExecutionProviderInfo info;
+  CUDAExecutionProvider ep(info);
+  // Initialize allocators in EP.
+  onnxruntime::AllocatorManager allocator_manager;
+  ep.RegisterAllocator(allocator_manager);
+  // Allocator for call cudaMallocHost and cudaFreeHost
+  // For details, see CUDAPinnedAllocator in cuda_allocator.cc.
+  AllocatorPtr cpu_pinned_alloc = ep.GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
+  // 10 MB
+  const size_t n_bytes = 10 * 1000000;
+  const int64_t n_allocs = 64;
+  ORT_THROW_IF_ERROR(ep.OnRunStart());
+  for (size_t i = 0; i < n_allocs; ++i) {
+    // Allocate 10MB CUDA pinned memory.
+    auto pinned_buffer = ep.AllocateBufferOnCPUPinned<void>(n_bytes);
+    // Release it using CUDA callback.
+    ep.AddDeferredReleaseCPUPtr(pinned_buffer.release());
+  }
+
+  // Memory stats
+  AllocatorStats stats;
+  cpu_pinned_alloc->GetStats(&stats);
+  ORT_ENFORCE(stats.num_allocs == n_allocs);
+  ORT_THROW_IF_ERROR(ep.OnRunEnd(true));
+  return true;
+}
+
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime
+#endif

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -40,14 +40,6 @@ class RocmKernel : public OpKernel {
   virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
 
   template <typename T>
-  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
-    AllocatorPtr allocator = provider_->GetAllocator(DEFAULT_CPU_ALLOCATOR_DEVICE_ID, OrtMemTypeCPU);
-    if (!allocator)
-      return nullptr;
-    return IAllocator::MakeUniquePtr<T>(allocator, count_or_bytes);
-  }
-
-  template <typename T>
   inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
     return provider_->GetScratchBuffer<T>(count_or_bytes);
   }
@@ -61,6 +53,10 @@ class RocmKernel : public OpKernel {
     return provider_->GetTransientScratchBuffer<T>(count_or_bytes);
   }
 
+  template <typename T>
+  inline IAllocatorUniquePtr<T> AllocateBufferOnCPUPinned(size_t count_or_bytes) const {
+    return provider_->AllocateBufferOnCPUPinned<T>(count_or_bytes);
+  }
 
   inline void AddDeferredReleaseCPUPtr(void* p) const {
     provider_->AddDeferredReleaseCPUPtr(p);


### PR DESCRIPTION
Since CUDA EP became a shared library, most of internal functions are not accessible from `onnxruntime_test_all`, we need a new mechanism to write CUDA EP-specific tests. To this end, this PR introduces a general infra and an example test for deferred release in CUDA EP. When adding this test, we also found the current deferred release will cause error when pinned CPU buffer is not allocated by BFCArena, and this PR also makes a small fix (see changes in rocm_execution_provider.cc and cuda_execution_provider.cc)

1. Changes for fixing deferred release (ROCM EP has similar changes):
![image](https://user-images.githubusercontent.com/3524474/191135095-ddd7f7bb-16e2-4dcd-afcb-986e453431e7.png)

2. Changes for moving CudaKernel::AddDeferredReleaseCPUPtr's core function to CUDAExecutionProvider (ROCM EP has similar changes)
![image](https://user-images.githubusercontent.com/3524474/191134375-a0880ec8-2c7c-46bb-b3dc-e329ad51b660.png)
![image](https://user-images.githubusercontent.com/3524474/191134413-f5ed1a5b-22d5-4427-bcd8-6f5e0c78428d.png)
CudaKernel::AddDeferredReleaseCPUPtr now delegates its call to CUDAExecutionProvider::AddDeferredReleaseCPUPtr.

3. The rest changes are for the new test framework. They can be summarized into several steps below.
   1. declare entry point to all tests, ProviderInfo_CUDA::TestAll.
   2. implement test entry point in ProviderInfo_CUDA_Impl::TestAll.
   3. implement some tests in cuda_execution_provider_test.cc and call them in ProviderInfo_CUDA_Impl::TestAll.
   4. call TestAll in onnxruntime_test_all by adding TEST(CUDAEPTEST, ALL) in cuda_provider_test.cc.
