### PR TITLE
[EP Perf Dashboard] Fix incorrect calls to trtexec with fp16 inputs

### DIFF
--- a/onnxruntime/python/tools/tensorrt/perf/benchmark.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark.py
@@ -138,7 +138,7 @@ def run_trt_standalone(trtexec, model_name, model_path, all_inputs_shape, fp16, 
         onnx_model_path,
         "--duration=50",
         "--percentile=90",
-        "--workspace=4096",
+        "--memPoolSize=workspace:4096",
     ]
     command.extend([inputs_arg])
 
@@ -270,7 +270,14 @@ def get_max_memory():
     df = pd.read_csv(MEMORY_FILE)
     pid = df["pid"].iloc[0]
     mem_series = df.loc[df["pid"] == pid, " used_gpu_memory [MiB]"]
-    max_mem = max(mem_series.str.replace(" MiB", "").astype(int))
+
+    try:
+        max_mem = max(mem_series.str.replace(" MiB", "").astype(int))
+    except ValueError:
+        # This exception occurs when nvidia-smi is unable to compute used memory.
+        # Ex: running these scripts in a Windows-hosted VM, such as WSL2
+        max_mem = 0
+
     return max_mem
 
 
@@ -1136,7 +1143,7 @@ def run_onnxruntime(args, models):
     model_to_fail_ep = {}  # model -> failing ep
     model_to_session = {}  # models -> session creation time
 
-    if args.running_mode == "benchmark":
+    if args.running_mode == "benchmark" and os.path.exists(SESSION_FILE):
         model_to_session = read_map_from_file(SESSION_FILE)
 
     ep_list = []
@@ -1195,7 +1202,7 @@ def run_onnxruntime(args, models):
             if "ORT-TRT" in ep:
                 trt_ep_options["trt_fp16_enable"] = "True" if "Fp16" in ep else "False"
 
-            fp16 = False
+            convert_input_fp16 = False
 
             # use float16.py for cuda fp16 only
             if cuda_fp16 == ep:
@@ -1207,7 +1214,7 @@ def run_onnxruntime(args, models):
                 else:
                     try:
                         model_path = convert_model_from_float_to_float16(model_path)
-                        fp16 = True
+                        convert_input_fp16 = True
                     except Exception as e:
                         logger.error(e)
                         update_fail_model_map(model_to_fail_ep, name, ep, "script error", e)
@@ -1216,12 +1223,9 @@ def run_onnxruntime(args, models):
                 # handle test data
                 if "test_data_path_fp16" in model_info:
                     test_data_dir = model_info["test_data_path_fp16"]
-                    fp16 = False
+                    convert_input_fp16 = False
 
-            if standalone_trt_fp16 == ep:
-                fp16 = True
-
-            inputs, ref_outputs = get_test_data(fp16, test_data_dir, all_inputs_shape)
+            inputs, ref_outputs = get_test_data(convert_input_fp16, test_data_dir, all_inputs_shape)
             # generate random input data
             if args.input_data == "random":
                 inputs = generate_onnx_model_random_input(args.test_times, inputs[0])
@@ -1245,7 +1249,7 @@ def run_onnxruntime(args, models):
                             name,
                             model_path,
                             all_inputs_shape,
-                            fp16,
+                            ep == standalone_trt_fp16,
                             args.track_memory,
                         )
                     except Exception as e:
@@ -1299,7 +1303,7 @@ def run_onnxruntime(args, models):
                         "engine": "onnxruntime",
                         "version": onnxruntime.__version__,
                         "device": ep,
-                        "fp16": fp16,
+                        "fp16": convert_input_fp16,
                         "io_binding": args.io_binding,
                         "graph_optimizations": args.graph_enablement,
                         "enable_cache": args.trt_ep_options.get("trt_engine_cache_enable", "False"),
@@ -1626,8 +1630,11 @@ def output_status(results, csv_filename):
 
 
 def output_specs(info, csv_filename):
-    cpu_version = info["cpu_info"][2]
-    gpu_version = info["gpu_info"][0]
+    cpu_infos = info["cpu_info"]
+    gpu_infos = info["gpu_info"]
+
+    cpu_version = cpu_infos[2] if len(cpu_infos) > 2 else "Unknown"
+    gpu_version = gpu_infos[0] if len(gpu_infos) > 0 else "Unknown"
     tensorrt_version = info["trt"] + " , *All ORT-TRT and TRT are run in Mixed Precision mode (Fp16 and Fp32)."
     cuda_version = info["cuda"]
     cudnn_version = info["cudnn"]
@@ -2064,7 +2071,8 @@ def parse_arguments():
         "-z",
         "--track_memory",
         required=False,
-        default=True,
+        default=False,
+        action="store_true",
         help="Track CUDA and TRT Memory Usage",
     )
 

--- a/onnxruntime/python/tools/tensorrt/perf/benchmark_wrapper.py
+++ b/onnxruntime/python/tools/tensorrt/perf/benchmark_wrapper.py
@@ -99,6 +99,9 @@ def main():
                 "false",
             ]
 
+            if args.track_memory:
+                command.append("-z")
+
             if ep == standalone_trt or ep == standalone_trt_fp16:
                 if args.running_mode == "validate":
                     continue

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
         value: --cuda_ep_options ${{ join(',',parameters.CUDAEPOptions) }}
 
     - name: optional_arguments
-      value: -a "-a -g $(optimizeGraph) -b $(bindInputs) $(trtEPOptionsArg) $(cudaEPOptionsArg)"
+      value: -a "-a -z -g $(optimizeGraph) -b $(bindInputs) $(trtEPOptionsArg) $(cudaEPOptionsArg)"
 
   steps:
     - ${{ if and( eq(parameters.BuildORT, false), eq(parameters.TrtVersion, '8.2.1.8')) }}:


### PR DESCRIPTION
**Description**: The EP dashboard benchmarking script unnecessarily converts fp32 input to fp16 when calling trtexec with the --fp16 flag. This PR removes this unnecessary step.

Additionally, this PR adds additional error handling to permit use in environments where: 
 -  `nvidia-smi` cannot properly compute memory consumption (e.g., WSL2).
 -  only one EP/Model is tested.

**Motivation and Context**
The upcoming version of trtexec in TensorRT 8.5 now checks that the sizes of input files match the sizes expected by the provided ONNX model. The current version of trtexec (8.4.x) does not validate the sizes of input files.

The benchmarking script converts fp32 inputs to fp16 when trying to run an fp32 ONNX model in fp16 mode. This will fail in TensorRT 8.5.