### PR TITLE
Declutter pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
-**Description**: Describe your changes.
+### Description
+<!-- Describe your changes. -->
 
-**Motivation and Context**
-- Why is this change required? What problem does it solve?
-- If it fixes an open issue, please link to the issue here.
+
+
+### Motivation and Context
+<!-- - Why is this change required? What problem does it solve?
+- If it fixes an open issue, please link to the issue here. -->
+
+


### PR DESCRIPTION
Turn the instructions in pull_request_template into comments so templated language no longer clutter the PR description section.
