### PR TITLE
Expose CublasLtMatmul for use in the CUDA EP 

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.h
@@ -22,6 +22,7 @@ class Attention final : public CudaKernel, public AttentionBase {
 
  protected:
   bool disable_fused_runner_;
+  bool disable_cublaslt_matmul_;
   mutable std::unique_ptr<MHARunner> fused_fp16_runner_;
 };
 

--- a/onnxruntime/core/providers/cuda/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/math/gemm.cc
@@ -130,8 +130,11 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   CudaT alpha = ToCudaType<T>::FromFloat(alpha_);
   CudaT beta = ToCudaType<T>::FromFloat(beta_);
 
+  // CublasLtMatmul requires that M and K are multiples of 4
+  auto use_cublaslt_matmul = use_cublaslt_matmul_ && ((M % 4) == 0) && ((K % 4) == 0);
+  
   // General note : CUDA assumes col-major, so Y(N,M) = alpha * op(W) x op(X) + beta * Y
-  if (use_cublaslt_matmul_) { // Use CublasLtMatmul
+  if (use_cublaslt_matmul) { // Use CublasLtMatmul
      CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
         CublasLtHandle(),
         trans_B_ ? CUBLAS_OP_T : CUBLAS_OP_N,

--- a/onnxruntime/core/providers/cuda/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/math/gemm.cc
@@ -130,12 +130,13 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   CudaT alpha = ToCudaType<T>::FromFloat(alpha_);
   CudaT beta = ToCudaType<T>::FromFloat(beta_);
 
-  // CublasLtMatmul requires that M (which is actually N here) and K are multiples of 4
-  auto use_cublaslt_matmul = use_cublaslt_matmul_ && ((N % 4) == 0) && ((K % 4) == 0);
-  
+  // CublasLtMatmul requires that M (which is actually N here as the row-major inputs will be swapped to
+  // account for the col-major format of Cublas) and K are multiples of 4
+  auto use_cublaslt_matmul = !disable_cublaslt_matmul_ && ((N % 4) == 0) && ((K % 4) == 0);
+
   // General note : CUDA assumes col-major, so Y(N,M) = alpha * op(W) x op(X) + beta * Y
-  if (use_cublaslt_matmul) { // Use CublasLtMatmul
-     CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
+  if (use_cublaslt_matmul) {  // Use CublasLtMatmul
+    CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
         CublasLtHandle(),
         trans_B_ ? CUBLAS_OP_T : CUBLAS_OP_N,
         trans_A_ ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -147,8 +148,9 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
         (trans_A_ ? M : K),
         (B != nullptr) ? &beta : &zero,
         out_data, N,
+        NULL, 0,
         Stream()));
-  } else { // Use CublasGemm instead
+  } else {  // Use CublasGemm instead
     CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
         CublasHandle(),
         trans_B_ ? CUBLAS_OP_T : CUBLAS_OP_N,

--- a/onnxruntime/core/providers/cuda/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/math/gemm.cc
@@ -130,8 +130,8 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   CudaT alpha = ToCudaType<T>::FromFloat(alpha_);
   CudaT beta = ToCudaType<T>::FromFloat(beta_);
 
-  // CublasLtMatmul requires that M and K are multiples of 4
-  auto use_cublaslt_matmul = use_cublaslt_matmul_ && ((M % 4) == 0) && ((K % 4) == 0);
+  // CublasLtMatmul requires that M (which is actually N here) and K are multiples of 4
+  auto use_cublaslt_matmul = use_cublaslt_matmul_ && ((N % 4) == 0) && ((K % 4) == 0);
   
   // General note : CUDA assumes col-major, so Y(N,M) = alpha * op(W) x op(X) + beta * Y
   if (use_cublaslt_matmul) { // Use CublasLtMatmul

--- a/onnxruntime/core/providers/cuda/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/math/gemm.cc
@@ -132,7 +132,7 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   // General note : CUDA assumes col-major, so Y(N,M) = alpha * op(W) x op(X) + beta * Y
   if (use_cublaslt_matmul_) { // Use CublasLtMatmul
-    CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
+     CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
         CublasLtHandle(),
         trans_B_ ? CUBLAS_OP_T : CUBLAS_OP_N,
         trans_A_ ? CUBLAS_OP_T : CUBLAS_OP_N,

--- a/onnxruntime/core/providers/cuda/math/gemm.h
+++ b/onnxruntime/core/providers/cuda/math/gemm.h
@@ -9,8 +9,11 @@
 namespace onnxruntime {
 namespace cuda {
 
+namespace matmul_detail {
 // Environment variable to disable CublasLtMatmul and use CublasGemm instead. Default is false.
 constexpr const char* kDisableCublasLtMatmul = "ORT_DISABLE_CUBLASLT_MATMUL";
+
+}  // namespace matmul_detail
 
 template <typename T>
 class Gemm final : public CudaKernel {
@@ -28,7 +31,7 @@ class Gemm final : public CudaKernel {
     ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
     ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
 
-    use_cublaslt_matmul_ = !ParseEnvironmentVariableWithDefault<bool>(kDisableCublasLtMatmul, false) &&
+    use_cublaslt_matmul_ = !ParseEnvironmentVariableWithDefault<bool>(matmul_detail::kDisableCublasLtMatmul, false) &&
                            (std::is_same<T, float>::value || std::is_same<T, MLFloat16>::value);
   }
 

--- a/onnxruntime/core/providers/cuda/math/gemm.h
+++ b/onnxruntime/core/providers/cuda/math/gemm.h
@@ -31,9 +31,9 @@ class Gemm final : public CudaKernel {
     ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
     ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
 
-    use_cublaslt_matmul_ = !ParseEnvironmentVariableWithDefault<bool>(matmul_detail::kDisableCublasLtMatmul, false) &&
-                           // We will support CublasLtMatmul only for float and half types for now
-                           (std::is_same<T, float>::value || std::is_same<T, MLFloat16>::value);
+    // We will support CublasLtMatmul only for half type for now
+    disable_cublaslt_matmul_ = !std::is_same<T, MLFloat16>::value ||
+                               ParseEnvironmentVariableWithDefault<bool>(matmul_detail::kDisableCublasLtMatmul, false);
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -43,7 +43,7 @@ class Gemm final : public CudaKernel {
   bool trans_B_;
   float alpha_;
   float beta_;
-  bool use_cublaslt_matmul_;
+  bool disable_cublaslt_matmul_;
 };
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/gemm.h
+++ b/onnxruntime/core/providers/cuda/math/gemm.h
@@ -32,6 +32,7 @@ class Gemm final : public CudaKernel {
     ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
 
     use_cublaslt_matmul_ = !ParseEnvironmentVariableWithDefault<bool>(matmul_detail::kDisableCublasLtMatmul, false) &&
+                           // We will support CublasLtMatmul only for float and half types for now
                            (std::is_same<T, float>::value || std::is_same<T, MLFloat16>::value);
   }
 

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -125,23 +125,45 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   int64_t stride_A, stride_B, stride_C, batch_count;
   auto& device_prop = GetDeviceProp();
   if (helper.OutputOffsets().size() == 1) {
-    CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
-        Base::CublasHandle(),
-        transB,
-        transA,
-        static_cast<int>(helper.N()),
-        static_cast<int>(helper.M()),
-        static_cast<int>(helper.K()),
-        &alpha,
-        reinterpret_cast<const CudaT*>(right_X->Data<T>()),
-        ldb,
-        reinterpret_cast<const CudaT*>(left_X->Data<T>()),
-        lda,
-        &zero,
-        reinterpret_cast<CudaT*>(Y->MutableData<T>()),
-        ldc,
-        device_prop));
+    if (!disable_cublaslt_matmul_) {
+      CUBLAS_RETURN_IF_ERROR(cublasLtMatmulHelper(
+          CublasLtHandle(),
+          transB,
+          transA,
+          static_cast<int>(helper.N()),
+          static_cast<int>(helper.M()),
+          static_cast<int>(helper.K()),
+          &alpha,
+          reinterpret_cast<const CudaT*>(right_X->Data<T>()),
+          ldb,
+          reinterpret_cast<const CudaT*>(left_X->Data<T>()),
+          lda,
+          &zero,
+          reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+          ldc,
+          NULL, 0,
+          Stream()));
+    } else {
+      CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
+          Base::CublasHandle(),
+          transB,
+          transA,
+          static_cast<int>(helper.N()),
+          static_cast<int>(helper.M()),
+          static_cast<int>(helper.K()),
+          &alpha,
+          reinterpret_cast<const CudaT*>(right_X->Data<T>()),
+          ldb,
+          reinterpret_cast<const CudaT*>(left_X->Data<T>()),
+          lda,
+          &zero,
+          reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+          ldc,
+          device_prop));
+    }
+
     return Status::OK();
+
   } else if (CanUseStridedBatchedGemm(left_X->Shape(), right_X->Shape(),
                                       transa, transb, trans_batch_a_, trans_batch_b_, stride_A, stride_B, stride_C, batch_count)) {
     CUBLAS_RETURN_IF_ERROR(cublasGemmStridedBatchedHelper(Base::CublasHandle(),

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "core/providers/cuda/cuda_kernel.h"
+#include "core/providers/cuda/math/gemm.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -18,7 +19,10 @@ class MatMul final : public CudaKernel {
         trans_A_{info.GetAttrOrDefault<int64_t>("transA", 0) != 0},
         trans_B_{info.GetAttrOrDefault<int64_t>("transB", 0) != 0},
         trans_batch_a_{info.GetAttrOrDefault<int64_t>("transBatchA", 0) != 0},
-        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0} {}
+        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0},
+        disable_cublaslt_matmul_{!std::is_same<T, MLFloat16>::value ||
+                                 ParseEnvironmentVariableWithDefault<bool>(matmul_detail::kDisableCublasLtMatmul, false)} {
+  }
 
   Status ComputeInternal(OpKernelContext* context) const override;
 
@@ -28,6 +32,7 @@ class MatMul final : public CudaKernel {
   const bool trans_B_;
   const bool trans_batch_a_;
   const bool trans_batch_b_;
+  const bool disable_cublaslt_matmul_;
 };
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -174,6 +174,195 @@ inline cublasStatus_t cublasGemmHelper(cublasHandle_t, cublasOperation_t, cublas
 }
 #endif
 
+// CublasLtMatmul
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const half* alpha,
+                                           const half* A, int lda,
+                                           const half* B, int ldb,
+                                           const half* beta,
+                                           half* C, int ldc,
+                                           cudaStream_t stream) {
+  const HalfGemmOptions* half_options = HalfGemmOptions::GetInstance();
+
+  cudaDataType_t A_type = CUDA_R_16F, B_type = CUDA_R_16F, C_type = CUDA_R_16F;
+  cudaDataType_t scale_type = CUDA_R_16F;
+  cublasComputeType_t compute_type = half_options->GetComputeType();
+
+  bool is_compute_16f = half_options->IsCompute16F();
+
+  float f_alpha, f_beta;  // use (if needed) to convert eh half alpha and beta into float
+
+  if (!is_compute_16f) {
+    scale_type = CUDA_R_32F;
+    f_alpha = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(alpha));
+    f_beta = onnxruntime::math::halfToFloat(*reinterpret_cast<const uint16_t*>(beta));
+  }
+
+  cublasLtMatrixLayout_t A_desc = NULL, B_desc = NULL, C_desc = NULL;
+
+  auto clean_desc_A = gsl::finally([&A_desc]() {
+    if (A_desc) {
+      cublasLtMatrixLayoutDestroy(A_desc);
+    }
+  });
+
+  auto clean_desc_B = gsl::finally([&B_desc]() {
+    if (B_desc) {
+      cublasLtMatrixLayoutDestroy(B_desc);
+    }
+  });
+
+  auto clean_desc_C = gsl::finally([&C_desc]() {
+    if (C_desc) {
+      cublasLtMatrixLayoutDestroy(C_desc);
+    }
+  });
+
+  cublasLtMatmulDesc_t operation_desc = NULL;
+
+  auto clean_matmul_desc = gsl::finally([&operation_desc]() {
+    if (operation_desc) {
+      cublasLtMatmulDescDestroy(operation_desc);
+    }
+  });
+
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&A_desc, A_type, (transa == CUBLAS_OP_N) ? m : k, (transa == CUBLAS_OP_N) ? k : m, lda));
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&B_desc, B_type, (transb == CUBLAS_OP_N) ? k : n, (transb == CUBLAS_OP_N) ? n : k, ldb));
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&C_desc, C_type, m, n, ldc));
+
+  CUBLAS_CALL_THROW(cublasLtMatmulDescCreate(&operation_desc, compute_type, scale_type));
+  CUBLAS_CALL_THROW(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(cublasOperation_t)));
+  CUBLAS_CALL_THROW(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(cublasOperation_t)));
+
+  // TODO (hasesh): Allow CublasLtMatmul tuning for clients by allowing them to pass in the workspace and algo of their choice.
+  // According to the cublasLtMatmul documentation, passing in NULL for the algo means that "an implicit heuristics query with
+  // default search preferences will be performed to determine actual algorithm to use". Source: cublasLtMatmul documentation.
+  return cublasLtMatmul(
+      handle, operation_desc, is_compute_16f ? reinterpret_cast<const void*>(alpha) : reinterpret_cast<const void*>(&f_alpha), A, A_desc, B, B_desc,
+      is_compute_16f ? reinterpret_cast<const void*>(beta) : reinterpret_cast<const void*>(&f_beta), C, C_desc, C, C_desc,
+      /*algo*/ NULL, /*workspace memory*/ NULL, /*workspace size*/ 0, stream);
+}
+#else
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const half* alpha,
+                                           const half* A, int lda,
+                                           const half* B, int ldb,
+                                           const half* beta,
+                                           half* C, int ldc,
+                                           cudaStream_t stream) {
+  return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+#endif
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const float* alpha,
+                                           const float* A, int lda,
+                                           const float* B, int ldb,
+                                           const float* beta,
+                                           float* C, int ldc,
+                                           cudaStream_t stream) {
+  cudaDataType_t A_type = CUDA_R_32F, B_type = CUDA_R_32F, C_type = CUDA_R_32F;
+  cudaDataType_t scale_type = CUDA_R_32F;
+  cublasComputeType_t compute_type = CUBLAS_COMPUTE_32F;
+
+  cublasLtMatrixLayout_t A_desc = NULL, B_desc = NULL, C_desc = NULL;
+
+  auto clean_desc_A = gsl::finally([&A_desc]() {
+    if (A_desc) {
+      cublasLtMatrixLayoutDestroy(A_desc);
+    }
+  });
+
+  auto clean_desc_B = gsl::finally([&B_desc]() {
+    if (B_desc) {
+      cublasLtMatrixLayoutDestroy(B_desc);
+    }
+  });
+
+  auto clean_desc_C = gsl::finally([&C_desc]() {
+    if (C_desc) {
+      cublasLtMatrixLayoutDestroy(C_desc);
+    }
+  });
+
+  cublasLtMatmulDesc_t operation_desc = NULL;
+
+  auto clean_matmul_desc = gsl::finally([&operation_desc]() {
+    if (operation_desc) {
+      cublasLtMatmulDescDestroy(operation_desc);
+    }
+  });
+
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&A_desc, A_type, (transa == CUBLAS_OP_N) ? m : k, (transa == CUBLAS_OP_N) ? k : m, lda));
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&B_desc, B_type, (transb == CUBLAS_OP_N) ? k : n, (transb == CUBLAS_OP_N) ? n : k, ldb));
+  CUBLAS_CALL_THROW(cublasLtMatrixLayoutCreate(&C_desc, C_type, m, n, ldc));
+
+  CUBLAS_CALL_THROW(cublasLtMatmulDescCreate(&operation_desc, compute_type, scale_type));
+  CUBLAS_CALL_THROW(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(cublasOperation_t)));
+  CUBLAS_CALL_THROW(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(cublasOperation_t)));
+
+  // TODO (hasesh): Allow CublasLtMatmul tuning for clients by allowing them to pass in the workspace and algo of their choice.
+  // According to the cublasLtMatmul documentation, passing in NULL for the algo means that "an implicit heuristics query with
+  // default search preferences will be performed to determine actual algorithm to use". Source: cublasLtMatmul documentation.
+
+  return cublasLtMatmul(
+      handle, operation_desc, reinterpret_cast<const void*>(alpha), A, A_desc, B, B_desc,
+      reinterpret_cast<const void*>(beta), C, C_desc, C, C_desc,
+      /*algo*/ NULL, /*workspace memory*/ NULL, /*workspace size*/ 0, stream);
+}
+
+#else
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const float* alpha,
+                                           const float* A, int lda,
+                                           const float* B, int ldb,
+                                           const float* beta,
+                                           float* C, int ldc,
+                                           cudaStream_t stream) {
+  return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+#endif
+
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const double* alpha,
+                                           const double* A, int lda,
+                                           const double* B, int ldb,
+                                           const double* beta,
+                                           double* C, int ldc,
+                                           cudaStream_t stream) {
+  return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const BFloat16* alpha,
+                                           const BFloat16* A, int lda,
+                                           const BFloat16* B, int ldb,
+                                           const BFloat16* beta,
+                                           BFloat16* C, int ldc,
+                                           cudaStream_t stream) {
+  return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
 // batched gemm
 inline cublasStatus_t cublasGemmBatchedHelper(cublasHandle_t handle,
                                               cublasOperation_t transa,
@@ -403,7 +592,6 @@ inline cublasStatus_t cublasGemmStridedBatchedHelper(cublasHandle_t handle,
                                       CUBLAS_GEMM_DEFAULT);
   }
 }
-
 
 inline cublasStatus_t cublasGemmStridedBatchedHelper(cublasHandle_t handle,
                                                      cublasOperation_t transa,

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -177,15 +177,15 @@ inline cublasStatus_t cublasGemmHelper(cublasHandle_t, cublasOperation_t, cublas
 // CublasLtMatmul
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 static Status InitializeCublasLtMatmulDescAndOperationHelper(cublasLtMatrixLayout_t& A_desc, int lda,
-                                                       cublasOperation_t transa,
-                                                       cublasLtMatrixLayout_t& B_desc, int ldb,
-                                                       cublasOperation_t transb,
-                                                       cublasLtMatrixLayout_t& C_desc, int ldc,
-                                                       cudaDataType_t data_type,
-                                                       int m, int n, int k,
-                                                       cublasLtMatmulDesc_t& operation_desc,
-                                                       cublasComputeType_t compute_type,
-                                                       cudaDataType_t scale_type) {
+                                                             cublasOperation_t transa,
+                                                             cublasLtMatrixLayout_t& B_desc, int ldb,
+                                                             cublasOperation_t transb,
+                                                             cublasLtMatrixLayout_t& C_desc, int ldc,
+                                                             cudaDataType_t data_type,
+                                                             int m, int n, int k,
+                                                             cublasLtMatmulDesc_t& operation_desc,
+                                                             cublasComputeType_t compute_type,
+                                                             cudaDataType_t scale_type) {
   CUBLAS_RETURN_IF_ERROR(cublasLtMatrixLayoutCreate(&A_desc, data_type,
                                                     (transa == CUBLAS_OP_N) ? m : k, (transa == CUBLAS_OP_N) ? k : m, lda));
 
@@ -260,15 +260,15 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
   });
 
   if (Status::OK() != InitializeCublasLtMatmulDescAndOperationHelper(A_desc, lda,
-                                                               transa,
-                                                               B_desc, ldb,
-                                                               transb,
-                                                               C_desc, ldc,
-                                                               data_type,
-                                                               m, n, k,
-                                                               operation_desc,
-                                                               compute_type,
-                                                               scale_type)) {
+                                                                     transa,
+                                                                     B_desc, ldb,
+                                                                     transb,
+                                                                     C_desc, ldc,
+                                                                     data_type,
+                                                                     m, n, k,
+                                                                     operation_desc,
+                                                                     compute_type,
+                                                                     scale_type)) {
     return CUBLAS_STATUS_ALLOC_FAILED;
   }
 
@@ -341,15 +341,15 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
   });
 
   if (Status::OK() != InitializeCublasLtMatmulDescAndOperationHelper(A_desc, lda,
-                                                               transa,
-                                                               B_desc, ldb,
-                                                               transb,
-                                                               C_desc, ldc,
-                                                               data_type,
-                                                               m, n, k,
-                                                               operation_desc,
-                                                               compute_type,
-                                                               scale_type)) {
+                                                                     transa,
+                                                                     B_desc, ldb,
+                                                                     transb,
+                                                                     C_desc, ldc,
+                                                                     data_type,
+                                                                     m, n, k,
+                                                                     operation_desc,
+                                                                     compute_type,
+                                                                     scale_type)) {
     return CUBLAS_STATUS_ALLOC_FAILED;
   }
 
@@ -390,6 +390,22 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            const double* beta,
                                            double* C, int ldc,
                                            cudaStream_t stream) {
+  ORT_UNUSED_PARAMETER(handle);
+  ORT_UNUSED_PARAMETER(transa);
+  ORT_UNUSED_PARAMETER(transb);
+  ORT_UNUSED_PARAMETER(m);
+  ORT_UNUSED_PARAMETER(n);
+  ORT_UNUSED_PARAMETER(k);
+  ORT_UNUSED_PARAMETER(alpha);
+  ORT_UNUSED_PARAMETER(A);
+  ORT_UNUSED_PARAMETER(lda);
+  ORT_UNUSED_PARAMETER(B);
+  ORT_UNUSED_PARAMETER(ldb);
+  ORT_UNUSED_PARAMETER(beta);
+  ORT_UNUSED_PARAMETER(C);
+  ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(stream);
+
   return CUBLAS_STATUS_NOT_SUPPORTED;
 }
 
@@ -403,6 +419,22 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            const BFloat16* beta,
                                            BFloat16* C, int ldc,
                                            cudaStream_t stream) {
+  ORT_UNUSED_PARAMETER(handle);
+  ORT_UNUSED_PARAMETER(transa);
+  ORT_UNUSED_PARAMETER(transb);
+  ORT_UNUSED_PARAMETER(m);
+  ORT_UNUSED_PARAMETER(n);
+  ORT_UNUSED_PARAMETER(k);
+  ORT_UNUSED_PARAMETER(alpha);
+  ORT_UNUSED_PARAMETER(A);
+  ORT_UNUSED_PARAMETER(lda);
+  ORT_UNUSED_PARAMETER(B);
+  ORT_UNUSED_PARAMETER(ldb);
+  ORT_UNUSED_PARAMETER(beta);
+  ORT_UNUSED_PARAMETER(C);
+  ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(stream);
+
   return CUBLAS_STATUS_NOT_SUPPORTED;
 }
 

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -175,7 +175,6 @@ inline cublasStatus_t cublasGemmHelper(cublasHandle_t, cublasOperation_t, cublas
 #endif
 
 // CublasLtMatmul
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 static Status InitializeCublasLtMatmulDescAndOperationHelper(cublasLtMatrixLayout_t& A_desc, int lda,
                                                              cublasOperation_t transa,
                                                              cublasLtMatrixLayout_t& B_desc, int ldb,
@@ -187,24 +186,28 @@ static Status InitializeCublasLtMatmulDescAndOperationHelper(cublasLtMatrixLayou
                                                              cublasComputeType_t compute_type,
                                                              cudaDataType_t scale_type) {
   CUBLAS_RETURN_IF_ERROR(cublasLtMatrixLayoutCreate(&A_desc, data_type,
-                                                    (transa == CUBLAS_OP_N) ? m : k, (transa == CUBLAS_OP_N) ? k : m, lda));
+                                                    (transa == CUBLAS_OP_N) ? m : k,
+                                                    (transa == CUBLAS_OP_N) ? k : m, lda));
 
   CUBLAS_RETURN_IF_ERROR(cublasLtMatrixLayoutCreate(&B_desc, data_type,
-                                                    (transb == CUBLAS_OP_N) ? k : n, (transb == CUBLAS_OP_N) ? n : k, ldb));
+                                                    (transb == CUBLAS_OP_N) ? k : n,
+                                                    (transb == CUBLAS_OP_N) ? n : k, ldb));
 
   CUBLAS_RETURN_IF_ERROR(cublasLtMatrixLayoutCreate(&C_desc, data_type, m, n, ldc));
 
   CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescCreate(&operation_desc, compute_type, scale_type));
 
-  CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(cublasOperation_t)));
+  CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescSetAttribute(operation_desc,
+                                                        CUBLASLT_MATMUL_DESC_TRANSA,
+                                                        &transa, sizeof(cublasOperation_t)));
 
-  CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescSetAttribute(operation_desc, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(cublasOperation_t)));
+  CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescSetAttribute(operation_desc,
+                                                        CUBLASLT_MATMUL_DESC_TRANSB,
+                                                        &transb, sizeof(cublasOperation_t)));
 
   return Status::OK();
 }
-#endif
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            cublasOperation_t transa,
                                            cublasOperation_t transb,
@@ -214,6 +217,8 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            const half* B, int ldb,
                                            const half* beta,
                                            half* C, int ldc,
+                                           void* workspace_memory,
+                                           size_t workspace_size,
                                            cudaStream_t stream) {
   const HalfGemmOptions* half_options = HalfGemmOptions::GetInstance();
 
@@ -272,33 +277,24 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
     return CUBLAS_STATUS_ALLOC_FAILED;
   }
 
-  // TODO (hasesh): Allow CublasLtMatmul tuning for clients by allowing them to pass in the workspace and algo of their choice.
-  // According to the cublasLtMatmul documentation, passing in NULL for the algo means that "an implicit heuristics query with
-  // default search preferences will be performed to determine actual algorithm to use". Source: cublasLtMatmul documentation.
+  // TODO (hasesh): Allow CublasLtMatmul tuning for clients by allowing them to pass in the
+  // workspace and algo of their choice.
+  // According to the cublasLtMatmul documentation, passing in NULL for the algo means that
+  // "an implicit heuristics query with
+  // default search preferences will be performed to determine actual algorithm to use".
+  // Source: cublasLtMatmul documentation.
   return cublasLtMatmul(
-      handle, operation_desc, is_compute_16f ? reinterpret_cast<const void*>(alpha) : reinterpret_cast<const void*>(&f_alpha),
+      handle, operation_desc,
+      is_compute_16f ? reinterpret_cast<const void*>(alpha) : reinterpret_cast<const void*>(&f_alpha),
       A, A_desc, B, B_desc,
       is_compute_16f ? reinterpret_cast<const void*>(beta) : reinterpret_cast<const void*>(&f_beta),
       C, C_desc,
       C, C_desc,
-      /*algo*/ NULL, /*workspace memory*/ NULL, /*workspace size*/ 0, stream);
+      /*algo*/ NULL,
+      workspace_memory, workspace_size,
+      stream);
 }
-#else
-inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
-                                           cublasOperation_t transa,
-                                           cublasOperation_t transb,
-                                           int m, int n, int k,
-                                           const half* alpha,
-                                           const half* A, int lda,
-                                           const half* B, int ldb,
-                                           const half* beta,
-                                           half* C, int ldc,
-                                           cudaStream_t stream) {
-  return CUBLAS_STATUS_NOT_SUPPORTED;
-}
-#endif
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
 inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            cublasOperation_t transa,
                                            cublasOperation_t transb,
@@ -308,87 +304,8 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            const float* B, int ldb,
                                            const float* beta,
                                            float* C, int ldc,
-                                           cudaStream_t stream) {
-  cudaDataType_t data_type = CUDA_R_32F;
-  cudaDataType_t scale_type = CUDA_R_32F;
-  cublasComputeType_t compute_type = CUBLAS_COMPUTE_32F;
-
-  cublasLtMatrixLayout_t A_desc = NULL, B_desc = NULL, C_desc = NULL;
-  cublasLtMatmulDesc_t operation_desc = NULL;
-
-  auto clean_desc_A = gsl::finally([&A_desc]() {
-    if (A_desc) {
-      cublasLtMatrixLayoutDestroy(A_desc);
-    }
-  });
-
-  auto clean_desc_B = gsl::finally([&B_desc]() {
-    if (B_desc) {
-      cublasLtMatrixLayoutDestroy(B_desc);
-    }
-  });
-
-  auto clean_desc_C = gsl::finally([&C_desc]() {
-    if (C_desc) {
-      cublasLtMatrixLayoutDestroy(C_desc);
-    }
-  });
-
-  auto clean_matmul_desc = gsl::finally([&operation_desc]() {
-    if (operation_desc) {
-      cublasLtMatmulDescDestroy(operation_desc);
-    }
-  });
-
-  if (Status::OK() != InitializeCublasLtMatmulDescAndOperationHelper(A_desc, lda,
-                                                                     transa,
-                                                                     B_desc, ldb,
-                                                                     transb,
-                                                                     C_desc, ldc,
-                                                                     data_type,
-                                                                     m, n, k,
-                                                                     operation_desc,
-                                                                     compute_type,
-                                                                     scale_type)) {
-    return CUBLAS_STATUS_ALLOC_FAILED;
-  }
-
-  // TODO (hasesh): Allow CublasLtMatmul tuning for clients by allowing them to pass in the workspace and algo of their choice.
-  // According to the cublasLtMatmul documentation, passing in NULL for the algo means that "an implicit heuristics query with
-  // default search preferences will be performed to determine actual algorithm to use". Source: cublasLtMatmul documentation.
-  return cublasLtMatmul(
-      handle, operation_desc, reinterpret_cast<const void*>(alpha),
-      A, A_desc, B, B_desc,
-      reinterpret_cast<const void*>(beta),
-      C, C_desc,
-      C, C_desc,
-      /*algo*/ NULL, /*workspace memory*/ NULL, /*workspace size*/ 0, stream);
-}
-
-#else
-inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
-                                           cublasOperation_t transa,
-                                           cublasOperation_t transb,
-                                           int m, int n, int k,
-                                           const float* alpha,
-                                           const float* A, int lda,
-                                           const float* B, int ldb,
-                                           const float* beta,
-                                           float* C, int ldc,
-                                           cudaStream_t stream) {
-  return CUBLAS_STATUS_NOT_SUPPORTED;
-}
-#endif
-
-inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
-                                           cublasOperation_t transa,
-                                           cublasOperation_t transb,
-                                           int m, int n, int k,
-                                           const double* alpha,
-                                           const double* A, int lda,
-                                           const double* B, int ldb,
-                                           const double* beta,
-                                           double* C, int ldc,
+                                           void* workspace_memory,
+                                           size_t workspace_size,
                                            cudaStream_t stream) {
   ORT_UNUSED_PARAMETER(handle);
   ORT_UNUSED_PARAMETER(transa);
@@ -404,6 +321,41 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
   ORT_UNUSED_PARAMETER(beta);
   ORT_UNUSED_PARAMETER(C);
   ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(workspace_memory);
+  ORT_UNUSED_PARAMETER(workspace_size);
+  ORT_UNUSED_PARAMETER(stream);
+
+  return CUBLAS_STATUS_NOT_SUPPORTED;
+}
+
+inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
+                                           cublasOperation_t transa,
+                                           cublasOperation_t transb,
+                                           int m, int n, int k,
+                                           const double* alpha,
+                                           const double* A, int lda,
+                                           const double* B, int ldb,
+                                           const double* beta,
+                                           double* C, int ldc,
+                                           void* workspace_memory,
+                                           size_t workspace_size,
+                                           cudaStream_t stream) {
+  ORT_UNUSED_PARAMETER(handle);
+  ORT_UNUSED_PARAMETER(transa);
+  ORT_UNUSED_PARAMETER(transb);
+  ORT_UNUSED_PARAMETER(m);
+  ORT_UNUSED_PARAMETER(n);
+  ORT_UNUSED_PARAMETER(k);
+  ORT_UNUSED_PARAMETER(alpha);
+  ORT_UNUSED_PARAMETER(A);
+  ORT_UNUSED_PARAMETER(lda);
+  ORT_UNUSED_PARAMETER(B);
+  ORT_UNUSED_PARAMETER(ldb);
+  ORT_UNUSED_PARAMETER(beta);
+  ORT_UNUSED_PARAMETER(C);
+  ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(workspace_memory);
+  ORT_UNUSED_PARAMETER(workspace_size);
   ORT_UNUSED_PARAMETER(stream);
 
   return CUBLAS_STATUS_NOT_SUPPORTED;
@@ -418,6 +370,8 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
                                            const BFloat16* B, int ldb,
                                            const BFloat16* beta,
                                            BFloat16* C, int ldc,
+                                           void* workspace_memory,
+                                           size_t workspace_size,
                                            cudaStream_t stream) {
   ORT_UNUSED_PARAMETER(handle);
   ORT_UNUSED_PARAMETER(transa);
@@ -433,6 +387,8 @@ inline cublasStatus_t cublasLtMatmulHelper(cublasLtHandle_t handle,
   ORT_UNUSED_PARAMETER(beta);
   ORT_UNUSED_PARAMETER(C);
   ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(workspace_memory);
+  ORT_UNUSED_PARAMETER(workspace_size);
   ORT_UNUSED_PARAMETER(stream);
 
   return CUBLAS_STATUS_NOT_SUPPORTED;

--- a/orttraining/orttraining/test/python/_test_helpers.py
+++ b/orttraining/orttraining/test/python/_test_helpers.py
@@ -224,10 +224,11 @@ def assert_values_are_close(input, other, rtol=1e-05, atol=1e-06):
     are_close = torch.allclose(input, other, rtol=rtol, atol=atol)
     if not are_close:
         abs_diff = torch.abs(input - other)
+        max_abs_diff = torch.max(abs_diff)
         abs_other = torch.abs(other)
         max_atol = torch.max((abs_diff - rtol * abs_other))
         max_rtol = torch.max((abs_diff - atol) / abs_other)
-        err_msg = "The maximum atol is {}, maximum rtol is {}".format(max_atol, max_rtol)
+        err_msg = "The maximum atol is {}, maximum rtol is {} and the maximum abs diff is {}".format(max_atol, max_rtol, max_abs_diff)
         assert False, err_msg
 
 


### PR DESCRIPTION
**Description**: 

NOTE: This change is not for the 1.13 release and can be merged once the release branch is cut. PR comments welcome.

This change introduces the fp16 CublasLtMatmul for use in various kernels in the CUDA EP. To start with, its use is demonstrated in the `Gemm`, `Attention`, and `Matmul` kernels. 

By default, if CublasLtMatmul can be used, it will be used. An environment variable can be used to force usage of CublasGemm by the user.