### PR TITLE
Reduce test warning spew due to CPU fallback

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1026,7 +1026,7 @@ static Status VerifyEachNodeIsAssignedToAnEp(const Graph& graph, const logging::
   // If the user explicitly included the CPU provider anyway, then remain silent, but if it was implicitly added,
   // and unexpected fallback happened to a non-preferred provider, warn the user.
   size_t explicit_provider_count = providers.NumProviders() - (providers.GetCpuProviderWasImplicitlyAdded() ? 1 : 0);
-  if (node_placement_provider_set.size() > explicit_provider_count) {
+  if (node_placement_provider_set.size() > explicit_provider_count && explicit_provider_count > 0) {
     LOGS(logger, WARNING) << "Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.";
     if (!is_verbose_mode) {
       LOGS(logger, WARNING) << "Rerunning with verbose output on a non-minimal build will show node assignments.";


### PR DESCRIPTION
**Description**: I added a warning in https://github.com/microsoft/onnxruntime/pull/10831 a week ago, but it's noisy for onnxruntime_test_all.exe because very few tests explicitly specify the providers they use, relying on implicit CPU, which makes it harder to see actual errors in the output. So reduce this noise (that is, if no EP's were explicitly provided, display no warning).

Sample output spew:
```
2022-09-20 20:08:50.6299388 [W:onnxruntime:NchwcOptimizerTests, session_state.cc:1030 onnxruntime::VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
```

**Motivation and Context**
- *Why is this change required? What problem does it solve?* Test output noise makes it harder to debug real failures.
- *If it fixes an open issue, please link to the issue here.* NA
