### PR TITLE
Replace std::exclusive_scan() with for loop because std::exclusive_scan() is not implemented in GCC 7.

### DIFF
--- a/onnxruntime/core/framework/kernel_registry.cc
+++ b/onnxruntime/core/framework/kernel_registry.cc
@@ -49,8 +49,14 @@ bool MatchKernelDefTypes(const Node& node,
   const auto actual_input_arg_offsets = [&actual_input_arg_counts]() {
     InlinedVector<int> offsets{};
     offsets.reserve(actual_input_arg_counts.size());
-    std::exclusive_scan(actual_input_arg_counts.begin(), actual_input_arg_counts.end(),
-                        std::back_inserter(offsets), 0);
+    // std::exclusive_scan() is not supported until GCC 9.3
+    // std::exclusive_scan(actual_input_arg_counts.begin(), actual_input_arg_counts.end(),
+    //                     std::back_inserter(offsets), 0);
+    int current_offset = 0;
+    for (size_t i = 0; i < actual_input_arg_counts.size(); ++i) {
+      offsets.push_back(current_offset);
+      current_offset += actual_input_arg_counts[i];
+    }
     return offsets;
   }();
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Replace std::exclusive_scan() with for loop because std::exclusive_scan() is not implemented in GCC 7.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix build on Ubuntu 18.04.
