### PR TITLE
Replace the source of TRT version and fix the build 

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -9,7 +9,7 @@
 #include "flatbuffers/idl.h"
 #include "ort_trt_int8_cal_table.fbs.h"
 #include "murmurhash3.h"
-#include <NvInfer.h>
+#include <NvInferVersion.h>
 #include "core/providers/cuda/cuda_pch.h"
 
 namespace fs = std::experimental::filesystem;


### PR DESCRIPTION
Replace the source of TRT version and fix the build issue happened on Linux environment

### Description
Replace the source of TRT version from NvInfer.h to NvInferVersion.h


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

On Linux platform, using nvinfer.h in tensorrt_execution_provider_utils.h would show error when building ORT unit tests, as ORT unit test show the deprecation warnings as errors. (Although this error didn't show up on Linux CI pipeline )

### Verification
The new change has been tested under both Linux & Windows environments.
