### PR TITLE
Fix prefast static analysis warning by not calling delete explicilty.

### DIFF
--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -74,13 +74,12 @@ static std::pair<int, std::string> GetSystemError() {
 }
 
 static void UnmapFile(void* param) noexcept {
-  UnmapFileParam* p = reinterpret_cast<UnmapFileParam*>(param);
+  std::unique_ptr<UnmapFileParam> p(reinterpret_cast<UnmapFileParam*>(param));
   int ret = munmap(p->addr, p->len);
   if (ret != 0) {
     auto[err_no, err_msg] = GetSystemError();
     LOGS_DEFAULT(ERROR) << "munmap failed. error code: " << err_no << " error msg: " << err_msg;
   }
-  delete p;
 }
 
 struct FileDescriptorTraits {
@@ -150,7 +149,7 @@ class PosixThread : public EnvThread {
     if (custom_create_thread_fn) {
       custom_thread_handle = custom_create_thread_fn(custom_thread_creation_options, CustomThreadMain, new Param{name_prefix, index, start_address, param, thread_options});
       if (!custom_thread_handle) {
-        ORT_THROW("custom_create_thread_fn returned invalid handle."); 
+        ORT_THROW("custom_create_thread_fn returned invalid handle.");
       }
     } else {
       pthread_attr_t attr;

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -47,14 +47,13 @@ class UnmapFileParam {
 };
 
 static void UnmapFile(void* param) noexcept {
-  UnmapFileParam* p = reinterpret_cast<UnmapFileParam*>(param);
+  std::unique_ptr<UnmapFileParam> p(reinterpret_cast<UnmapFileParam*>(param));
   bool ret = UnmapViewOfFile(p->addr);
   if (!ret) {
     const auto error_code = GetLastError();
     LOGS_DEFAULT(ERROR) << "unmap view of file failed. error code: " << error_code
                         << " error msg: " << std::system_category().message(error_code);
   }
-  delete p;
 }
 
 std::wstring Basename(const std::wstring& path) {


### PR DESCRIPTION
### Description
Fix prefast static analysis warning by not calling delete explicilty.

### Motivation and Context
Prefast runs.

