### PR TITLE
bug fix for onnxruntime/python/tools/symbolic_shape_infer.py

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -567,13 +567,8 @@ class SymbolicShapeInference:
 
     def _pass_on_shape_and_type(self, node):
         vi = self.known_vi_[node.output[0]]
-        vi.CopyFrom(
-            helper.make_tensor_value_info(
-                node.output[0],
-                self.known_vi_[node.input[0]].type.tensor_type.elem_type,
-                self._get_shape(node, 0),
-            )
-        )
+        assert vi.name == node.output[0]
+        vi.type.CopyFrom(self.known_vi_[node.input[0]].type)
 
     def _new_symbolic_dim(self, prefix, dim):
         new_dim = "{}_d{}".format(prefix, dim)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Bug fix for "onnxruntime/python/tools/symbolic_shape_infer.py". Specifically, modified implementation of method "SymbolicShapeInference._pass_on_shape_and_type".

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

In current implementation, "self.known_vi_[node.input[0]].type.tensor_type.elem_type" is only for "tensor_type". But in practice, it could be "sequence_type". In this case, the elem_type will be UNDEFINED, and type info will be lost. This will lead to failures, for example, in "SymbolicShapeInference._fuse_tensor_type", the check "if dst_tensor_type.elem_type != src_tensor_type.elem_type" may fail due to one of the "elem_type" being UNDEFINED. Also, the assertion in "is_sequence" may fail due to "cls_type" being "None".
