### PR TITLE
Make classes IKernelTypeStrResolver and IKernelLookup have protected destructors.

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -99,6 +99,9 @@ class IExecutionProvider {
      * The return value is non-null if and only if a matching kernel was found.
      */
     virtual const KernelCreateInfo* LookUpKernel(const Node& node) const = 0;
+
+   protected:
+    ~IKernelLookup() = default;
   };
 
   /**

--- a/onnxruntime/core/framework/kernel_type_str_resolver.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.h
@@ -51,6 +51,9 @@ class IKernelTypeStrResolver {
    */
   virtual Status ResolveKernelTypeStr(const Node& node, std::string_view kernel_type_str,
                                       gsl::span<const ArgTypeAndIndex>& resolved_args) const = 0;
+
+ protected:
+  ~IKernelTypeStrResolver() = default;
 };
 
 /**


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Make classes IKernelTypeStrResolver and IKernelLookup have protected destructors.

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Prevent destruction through base class pointer. Address static analysis warning.