### PR TITLE
bug fix for symbolic shape infer

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -41,6 +41,13 @@ def get_shape_from_type_proto(type_proto):
         return None  # note no shape is different from shape without dim (scalar)
 
 
+def get_elem_type_from_type_proto(type_proto):
+    if is_sequence(type_proto):
+        return type_proto.sequence_type.elem_type.tensor_type.elem_type
+    else:
+        return type_proto.tensor_type.elem_type
+
+
 def get_shape_from_value_info(vi):
     cls_type = vi.type.WhichOneof("value")
     if cls_type is None:
@@ -570,7 +577,7 @@ class SymbolicShapeInference:
         vi.CopyFrom(
             helper.make_tensor_value_info(
                 node.output[0],
-                self.known_vi_[node.input[0]].type.tensor_type.elem_type,
+                get_elem_type_from_type_proto(self.known_vi_[node.input[0]].type),
                 self._get_shape(node, 0),
             )
         )


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Bug fix for `onnxruntime/python/tools/symbolic_shape_infer.py`. Specifically, modified implementation of method `SymbolicShapeInference._pass_on_shape_and_type`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

In current implementation, `self.known_vi_[node.input[0]].type.tensor_type.elem_type` assumes the type is `tensor_type`. But in practice, it could be `sequence_type`. In this case, the `elem_type` will be `UNDEFINED`, and type info will be lost. This will lead to failures, for example, in `SymbolicShapeInference._fuse_tensor_type`, the check `if dst_tensor_type.elem_type != src_tensor_type.elem_type` may fail due to one of the `elem_type` being `UNDEFINED`.
