### PR TITLE
Add CMAKE_CUDA_ARCHITECTURES list to python packaging pipeline

### DIFF
--- a/tools/ci_build/github/linux/build_linux_arm64_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_arm64_python_package.sh
@@ -36,8 +36,10 @@ if [ $ARCH == "x86_64" ]; then
     #ARM build machines do not have the test data yet.
     BUILD_ARGS="$BUILD_ARGS --enable_onnx_tests"
 fi
+
 if [ $BUILD_DEVICE == "GPU" ]; then
-    BUILD_ARGS="$BUILD_ARGS --use_cuda --use_tensorrt --cuda_version=11.6 --tensorrt_home=/usr --cuda_home=/usr/local/cuda-11.6 --cudnn_home=/usr/local/cuda-11.6"
+    #Enable CUDA and TRT EPs.
+    BUILD_ARGS="$BUILD_ARGS --use_cuda --use_tensorrt --cuda_version=11.6 --tensorrt_home=/usr --cuda_home=/usr/local/cuda-11.6 --cudnn_home=/usr/local/cuda-11.6 --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80'"
 fi
 export CFLAGS
 export CXXFLAGS

--- a/tools/ci_build/github/linux/build_linux_arm64_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_arm64_python_package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e -x
-mkdir /build/dist
+mkdir -p /build/dist
 CFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe -Wl,--strip-all"
 CXXFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -O3 -pipe -Wl,--strip-all"
 
@@ -15,31 +15,33 @@ d) BUILD_DEVICE=${OPTARG};;
 esac
 done
 
-GCC_VERSION=$(gcc -dumpversion)
+# Depending on how the compiler has been configured when it was built, sometimes "gcc -dumpversion" shows the full version.
+GCC_VERSION=$(gcc -dumpversion | cut -d . -f 1)
 #-fstack-clash-protection prevents attacks based on an overlapping heap and stack.
 if [ "$GCC_VERSION" -ge 8 ]; then
     CFLAGS="$CFLAGS -fstack-clash-protection"
     CXXFLAGS="$CXXFLAGS -fstack-clash-protection"
 fi
 
-ARCH=$(uname -i)
+ARCH=$(uname -m)
 
-if [ $ARCH == "x86_64" ] && [ "$GCC_VERSION" -ge 9 ]; then
+if [ "$ARCH" == "x86_64" ] && [ "$GCC_VERSION" -ge 9 ]; then
     CFLAGS="$CFLAGS -fcf-protection"
     CXXFLAGS="$CXXFLAGS -fcf-protection"
 fi
 
 
-BUILD_ARGS="--build_dir /build --config $BUILD_CONFIG --update --build --skip_submodule_sync --parallel --enable_lto --build_wheel"
+BUILD_ARGS=("--build_dir" "/build" "--config" "$BUILD_CONFIG" "--update" "--build" "--skip_submodule_sync" "--parallel" "--enable_lto" "--build_wheel")
 
-if [ $ARCH == "x86_64" ]; then
+if [ "$ARCH" == "x86_64" ]; then
     #ARM build machines do not have the test data yet.
-    BUILD_ARGS="$BUILD_ARGS --enable_onnx_tests"
+    BUILD_ARGS+=("--enable_onnx_tests")
 fi
 
-if [ $BUILD_DEVICE == "GPU" ]; then
+if [ "$BUILD_DEVICE" == "GPU" ]; then
     #Enable CUDA and TRT EPs.
-    BUILD_ARGS="$BUILD_ARGS --use_cuda --use_tensorrt --cuda_version=11.6 --tensorrt_home=/usr --cuda_home=/usr/local/cuda-11.6 --cudnn_home=/usr/local/cuda-11.6 --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80'"
+    ONNXRUNTIME_CUDA_VERSION="11.6"
+    BUILD_ARGS+=("--use_cuda" "--use_tensorrt" "--cuda_version=$ONNXRUNTIME_CUDA_VERSION" "--tensorrt_home=/usr" "--cuda_home=/usr/local/cuda-$ONNXRUNTIME_CUDA_VERSION" "--cudnn_home=/usr/local/cuda-$ONNXRUNTIME_CUDA_VERSION" "--cmake_extra_defines" "CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80")
 fi
 export CFLAGS
 export CXXFLAGS
@@ -47,7 +49,7 @@ PYTHON_EXES=("/opt/python/cp37-cp37m/bin/python3.7" "/opt/python/cp38-cp38/bin/p
 for PYTHON_EXE in "${PYTHON_EXES[@]}"
 do
   rm -rf /build/$BUILD_CONFIG
-  ${PYTHON_EXE} /onnxruntime_src/tools/ci_build/build.py $BUILD_ARGS
+  ${PYTHON_EXE} /onnxruntime_src/tools/ci_build/build.py "${BUILD_ARGS[@]}"
                   
   cp /build/$BUILD_CONFIG/dist/*.whl /build/dist
 done


### PR DESCRIPTION
### Description
Add CMAKE_CUDA_ARCHITECTURES list to python packaging pipeline. It was missed during a code refactoring in PR #13002


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


