### PR TITLE
setup.py: use packaging instead of wheel.vendored.packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ from os import environ, getcwd, path, popen, remove
 from pathlib import Path
 from shutil import copyfile
 
+from packaging.tags import sys_tags
 from setuptools import Extension, setup
 from setuptools.command.install import install as InstallCommandBase
-from packaging.tags import sys_tags
 
 nightly_build = False
 package_name = "onnxruntime"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from shutil import copyfile
 
 from setuptools import Extension, setup
 from setuptools.command.install import install as InstallCommandBase
-from wheel.vendored.packaging.tags import sys_tags
+from packaging.tags import sys_tags
 
 nightly_build = False
 package_name = "onnxruntime"


### PR DESCRIPTION
### Description

wheel.vendored is an implementation detail of wheel and onnxruntime should not rely on it. On the other hand, packaging is already required since [1].

The original code was introduced in [2].

@sfatimar (author of [2]) - does this change breaks OpenVINO execution provider?

[1] https://github.com/microsoft/onnxruntime/pull/11522
[2] https://github.com/microsoft/onnxruntime/pull/11834

### Motivation and Context

Importing wheel.vendored may be broken in some cases. For example, on Arch Linux, [wheel.vendored is patched away](https://github.com/archlinux/svntogit-community/commit/e691288eda92fb5982ac5ac18f6459c5da560d7a).