### PR TITLE
Upgrade  protobuf version

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -162,7 +162,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "fc645b7626ebf86530dbd82fbece74d457e7ae07",
+          "commitHash": "c220895fd1163c01f0a8b44229fb9e4fe0ae0958",
           "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
         },
         "comments": "git submodule at cmake/external/emsdk"
@@ -342,7 +342,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "0dab03ba7bc438d7ba3eac2b2c1eb39ed520f928",
+          "commitHash": "a902b39270841beafc307dfa709610aa1cac2f06",
           "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
         },
         "comments": "git submodule at cmake/external/protobuf"


### PR DESCRIPTION
### Description
Upgrade protobuf version from 3.18.1 to 3.18.3 to address CVE-2022-1941

Though some other places also need be changed, I chose to leave them there to make this PR as small as possible, as we are doing a release and it is really at the last-minute.  And only the C++ protobuf library is included in ONNX Runtime packages. This is what I am updating. Though we also reference protobuf python/C#/... packages in ONNX Runtime source tree, but we don't ship these packages. So they are less concerned. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


