### PR TITLE
Remove old enable_linux_gpu_tests parameter from template invocation.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/build-perf-test-binaries-pipeline.yml
@@ -36,7 +36,6 @@ stages:
   - template: templates/py-packaging-stage.yml
     parameters:
       enable_linux_gpu: true
-      enable_linux_gpu_tests: false
       enable_ubuntu_cpu: false
       enable_linux_cpu: false
       enable_windows_cpu: false


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove old enable_linux_gpu_tests parameter from template invocation in build-perf-test-binaries-pipeline.yml.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix build failure. The template parameter was removed by #13002 but this build definition wasn't updated.
