### PR TITLE
Fix static analysis warning by making derived classes final.

### DIFF
--- a/onnxruntime/core/framework/kernel_lookup.h
+++ b/onnxruntime/core/framework/kernel_lookup.h
@@ -18,7 +18,7 @@ namespace onnxruntime {
  * Utility class for performing kernel lookup.
  * Primary usage pattern is to be created during graph partitioning and passed to IExecutionProvider::GetCapability().
  */
-class KernelLookup : public IExecutionProvider::IKernelLookup {
+class KernelLookup final : public IExecutionProvider::IKernelLookup {
  public:
   KernelLookup(ProviderType provider_type,
                gsl::span<const gsl::not_null<const KernelRegistry*>> kernel_registries,

--- a/onnxruntime/core/framework/kernel_type_str_resolver.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.h
@@ -62,7 +62,7 @@ class IKernelTypeStrResolver {
  * Supports loading information from op schemas in a full build and saving to/loading from an ORT format model
  * representation.
  */
-class KernelTypeStrResolver : public IKernelTypeStrResolver {
+class KernelTypeStrResolver final : public IKernelTypeStrResolver {
  public:
   Status ResolveKernelTypeStr(const Node& node, std::string_view kernel_type_str,
                               gsl::span<const ArgTypeAndIndex>& resolved_args) const override;
@@ -124,7 +124,7 @@ class KernelTypeStrResolver : public IKernelTypeStrResolver {
  *
  * As this requires node op schemas, it is only enabled in a full build.
  */
-class OpSchemaKernelTypeStrResolver : public IKernelTypeStrResolver {
+class OpSchemaKernelTypeStrResolver final : public IKernelTypeStrResolver {
  public:
   // Note: `node`'s op schema must be populated.
   Status ResolveKernelTypeStr(const Node& node, std::string_view kernel_type_str,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual

Follow up to #13059, which only updated the base classes. This change ensures that the derived classes will not be base classes.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Second attempt to fix warning. Verified it locally this time.
