### PR TITLE
Reduce Objective-C static analysis build time.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -24,9 +24,9 @@ jobs:
         --config Debug \
         --build_shared_lib --use_coreml --build_objc \
         --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        --update \
-        --build --parallel
-    displayName: Generate compile_commands.json
+        --update
+        --build --parallel --target onnx_proto
+    displayName: Generate compile_commands.json and ONNX protobuf files
 
   - script: |
       "$(brew --prefix llvm)/bin/clang-tidy" \

--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -7,6 +7,10 @@ jobs:
   timeoutInMinutes: 30
 
   steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+
   - task: UsePythonVersion@0
     inputs:
       versionSpec: "3.9"
@@ -24,7 +28,7 @@ jobs:
         --config Debug \
         --build_shared_lib --use_coreml --build_objc \
         --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        --update \
+        --update --skip_submodule_sync \
         --build --parallel --target onnx_proto
     displayName: Generate compile_commands.json and ONNX protobuf files
 

--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -2,9 +2,9 @@ jobs:
 - job: ObjCStaticAnalysis
 
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-12'
 
-  timeoutInMinutes: 90
+  timeoutInMinutes: 30
 
   steps:
   - task: UsePythonVersion@0
@@ -24,7 +24,7 @@ jobs:
         --config Debug \
         --build_shared_lib --use_coreml --build_objc \
         --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        --update
+        --update \
         --build --parallel --target onnx_proto
     displayName: Generate compile_commands.json and ONNX protobuf files
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Build only the onnx_proto target required for static analysis instead of a full build.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Reduce build time.
