### PR TITLE
Enable command list reuse for Xbox

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/FusedGraphKernel.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/FusedGraphKernel.cpp
@@ -335,16 +335,13 @@ namespace Dml
                 m_provider->GetCommandListTypeForQueue(),
                 IID_GRAPHICS_PPV_ARGS(m_commandAllocator.ReleaseAndGetAddressOf())));
 
-            ComPtr<ID3D12CommandList> commandList;
             ORT_THROW_IF_FAILED(d3dDevice->CreateCommandList(
                 0,
                 m_provider->GetCommandListTypeForQueue(),
                 m_commandAllocator.Get(),
                 nullptr,
-                IID_GRAPHICS_PPV_ARGS(commandList.ReleaseAndGetAddressOf())));
+                IID_GRAPHICS_PPV_ARGS(m_graphicsCommandList.ReleaseAndGetAddressOf())));
             
-            ORT_THROW_IF_FAILED(commandList.As(&m_graphicsCommandList));
-
             if (m_persistentResource)
             {
                 DML_BINDING_DESC persistentResourceBindingDesc =
@@ -358,7 +355,7 @@ namespace Dml
             ComPtr<IDMLCommandRecorder> recorder;
             ORT_THROW_IF_FAILED(device->CreateCommandRecorder(IID_PPV_ARGS(recorder.GetAddressOf())));
 
-            recorder->RecordDispatch(commandList.Get(), m_compiledExecutionPlanOperator.Get(), m_bindingTable.Get());
+            recorder->RecordDispatch(m_graphicsCommandList.Get(), m_compiledExecutionPlanOperator.Get(), m_bindingTable.Get());
 
             ORT_THROW_IF_FAILED(m_graphicsCommandList->Close());
         }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/FusedGraphKernel.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/FusedGraphKernel.cpp
@@ -331,16 +331,15 @@ namespace Dml
 
             ORT_THROW_IF_FAILED(device->CreateBindingTable(&bindingTableDesc, IID_PPV_ARGS(&m_bindingTable)));
 
-            ComPtr<ID3D12CommandAllocator> allocator;
             ORT_THROW_IF_FAILED(d3dDevice->CreateCommandAllocator(
                 m_provider->GetCommandListTypeForQueue(),
-                IID_GRAPHICS_PPV_ARGS(allocator.ReleaseAndGetAddressOf())));
+                IID_GRAPHICS_PPV_ARGS(m_commandAllocator.ReleaseAndGetAddressOf())));
 
             ComPtr<ID3D12CommandList> commandList;
             ORT_THROW_IF_FAILED(d3dDevice->CreateCommandList(
                 0,
                 m_provider->GetCommandListTypeForQueue(),
-                allocator.Get(),
+                m_commandAllocator.Get(),
                 nullptr,
                 IID_GRAPHICS_PPV_ARGS(commandList.ReleaseAndGetAddressOf())));
             
@@ -496,6 +495,7 @@ namespace Dml
 
         // Re-usable command list, supporting descriptor heap, and DML binding table to update that heap.
         ComPtr<ID3D12GraphicsCommandList> m_graphicsCommandList;
+        ComPtr<ID3D12CommandAllocator> m_commandAllocator;
         ComPtr<ID3D12DescriptorHeap> m_heap;
         ComPtr<IDMLBindingTable> m_bindingTable;
         std::optional<DML_BUFFER_BINDING> m_persistentResourceBinding;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -95,11 +95,6 @@ namespace Dml::GraphDescBuilder
             reuseCommandList = true;
         }
 
-#ifdef _GAMING_XBOX
-        // #40265989
-        reuseCommandList = false;
-#endif
-
         auto constantCpuGraphInputGetter = [&transferredInitializerMap](const std::string& argName)
         {
             ComPtr<OnnxTensorWrapper> tensorWrapper;


### PR DESCRIPTION
Removes the workaround introduced in #12063, which disabled DML command list reuse for Xbox builds.

The ID3D12CommandList created in FusedGraphKernel takes points to an ID3D12CommandAllocator that is local to the `BuildReusableCommandList` function. On PC it would seem the command list is keeping the command allocator alive, but this is highly suspect logic that definitely doesn't work on Xbox. I find no documentation indicating this logic should work (a section on [reference counting](https://learn.microsoft.com/en-us/windows/win32/direct3d12/recording-command-lists-and-bundles#reference-counting) makes it clear command lists take no refs on D3D objects passed as args to its APIs; however, it's unclear if this also applies to its construction).

A second (small) change is constructing the command list straight into `ID3D12GraphicsCommandList` and removing an unnecessary QI.