### PR TITLE
Upgrade the oneDNN ep to use oneDNNv2.7

### DIFF
--- a/cmake/external/dnnl.cmake
+++ b/cmake/external/dnnl.cmake
@@ -2,7 +2,7 @@ include (ExternalProject)
 
 set(DNNL_URL https://github.com/oneapi-src/onednn.git)
 # If DNNL_TAG is updated, check if MKLML_VERSION and platform.cmake.patch need to be updated.
-set(DNNL_TAG v2.6)
+set(DNNL_TAG v2.7)
 
 if(WIN32)
   set(DNNL_SHARED_LIB dnnl.dll)

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_dynamicquantizelinear.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_dynamicquantizelinear.cc
@@ -25,6 +25,7 @@ void DnnlDynamicQuantizeLinear::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlN
   auto x_md = x_mem.get_desc();
   auto x_size = x_md.dims().size();
   auto x_format = sp.GetDnnlFormat(x_size);
+  x_mem = sp.GetMemoryAndReshape(node.Input(IN_X), x_md, eng);
 
   // Dims for one dimensional tensor
   dnnl::memory::dims one_dim(x_size, 1);
@@ -129,7 +130,7 @@ void DnnlDynamicQuantizeLinear::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlN
                            {DNNL_ARG_SRC_1, y_scale_mem},
                            {DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1, y_zp_mem},
                            {DNNL_ARG_DST, y_mem}});
-  
+
   // Set outputs
   sp.SetMemory(node.Output(OUT_Y), y_mem);
   sp.SetMemory(node.Output(OUT_Y_SCALE), y_scale_mem, false, true);

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -2729,7 +2729,7 @@ TEST(ReductionOpTest, ReduceInfLogSum) {
                         {FLOAT_INF, FLOAT_INF,
                          -std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
                          std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kDnnlExecutionProvider});
+  test.Run();
 }
 
 TEST(ReductionOpTest, ReduceInfLogSumExp) {


### PR DESCRIPTION
### Description
This updates the oneDNN library used by oneDNN ep from version 2.6 to version 2.7



### Motivation and Context
This brings in the many improvements incorporated into the oneDNN library to the oneDNN execution provider.


