### PR TITLE
anonymous namespace breaks gtest build

### DIFF
--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -100,7 +100,7 @@ TEST_P(SessionStateAddGetKernelTest, AddGetKernelTest) {
 
 INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateAddGetKernelTest, testing::Values(0, 1));
 
-namespace {
+namespace anon {
 class TestParam {
  public:
   int ir_version;
@@ -109,10 +109,10 @@ class TestParam {
 };
 TestParam param_list[] = {{3, true, 0}, {4, true, 0}, {3, false, 0}, {4, false, 0}, {3, true, 1}, {4, true, 1}, {3, false, 1}, {4, false, 1}};
 }  // namespace
-class SessionStateTestP : public testing::TestWithParam<TestParam> {};
+class SessionStateTestP : public testing::TestWithParam<anon::TestParam> {};
 // Test that we separate out constant and non-constant initializers correctly
 TEST_P(SessionStateTestP, TestInitializerProcessing) {
-  const TestParam& param = GetParam();
+  const anon::TestParam& param = GetParam();
   OrtThreadPoolParams to;
   to.thread_pool_size = to.thread_pool_size;
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
@@ -286,7 +286,7 @@ TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
 
 #endif
 
-INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(param_list));
+INSTANTIATE_TEST_SUITE_P(SessionStateTests, SessionStateTestP, testing::ValuesIn(anon::param_list));
 
 #ifndef ENABLE_TRAINING
 class PrePackingTestOpKernel : public OpKernel {


### PR DESCRIPTION
Although onnxruntime has its own gtest as a submodule, some versions of gtest complain about anonymous namespaces.  For example, the following build error occurred due to a different gtest being used for the build.  This PR gives the formerly anonymous namespace a name 'anon' to avoid the build error.

```
[2022-09-22T20:01:59.782Z] /opt/rocm/include/gtest/internal/gtest-param-util.h: In instantiation of class testing::internal::ParameterizedTestFactory<onnxruntime::test::SessionStateTestP_TestInitializerProcessing_Test>:
[2022-09-22T20:01:59.782Z] /opt/rocm/include/gtest/internal/gtest-param-util.h:439:12:   required from testing::internal::TestFactoryBase* testing::internal::TestMetaFactory<TestSuite>::CreateTestFactory(testing::internal::TestMetaFactory<TestSuite>::ParamType) [with TestSuite = onnxruntime::test::SessionStateTestP_TestInitializerProcessing_Test; testing::internal::TestMetaFactory<TestSuite>::ParamType = onnxruntime::test::{anonymous}::TestParam]
[2022-09-22T20:01:59.782Z] /opt/rocm/include/gtest/internal/gtest-param-util.h:438:20:   required from here
[2022-09-22T20:01:59.782Z] /opt/rocm/include/gtest/internal/gtest-param-util.h:394:7: error: testing::internal::ParameterizedTestFactory<onnxruntime::test::SessionStateTestP_TestInitializerProcessing_Test> has a field testing::internal::ParameterizedTestFactory<onnxruntime::test::SessionStateTestP_TestInitializerProcessing_Test>::parameter_ whose type uses the anonymous namespace [-Werror=subobject-linkage]
[2022-09-22T20:01:59.782Z]   394 | class ParameterizedTestFactory : public TestFactoryBase {
[2022-09-22T20:01:59.782Z]       |       ^~~~~~~~~~~~~~~~~~~~~~~~
```