### PR TITLE
Add `pull-requests: write` to lint actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ jobs:
   lint-python:
     name: Lint Python
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - name: flake8
@@ -114,8 +112,6 @@ jobs:
   lint-js:
     name: Lint JavaScript
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
   lint-python:
     name: Lint Python
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - name: flake8
@@ -79,6 +81,8 @@ jobs:
   lint-cpp:
     name: Lint C++
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@master
       - name: Install ninja
@@ -110,6 +114,8 @@ jobs:
   lint-js:
     name: Lint JavaScript
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-eslint@v1


### PR DESCRIPTION
### Description
Add `pull-requests: write` to `clang-tidy-review` to allow it to comment in PRs.

### Motivation and Context

A change in actions default permissions prevented lint actions to create comments in pull requests. This change gives them the ability to do so.