### PR TITLE
Disable clang-tidy CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,13 +92,13 @@ jobs:
             --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Generate ONNX protobuf files
         run: cmake --build build/Debug --config Debug --target onnx_proto
-      - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@526cbfb043719639f1ebdeedae0cc1eacd219d8f
-        with:
-          token: ${{ secrets.github_token }}
-          build_dir: "build/Debug"
-          config_file: ".clang-tidy"
-          lgtm_comment_body: ""
+#       - name: Run clang-tidy
+#         uses: ZedThree/clang-tidy-review@526cbfb043719639f1ebdeedae0cc1eacd219d8f
+#         with:
+#           token: ${{ secrets.github_token }}
+#           build_dir: "build/Debug"
+#           config_file: ".clang-tidy"
+#           lgtm_comment_body: ""
       - uses: reviewdog/action-cpplint@master
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
Disable clang-tidy for now because it is creating a lot of false positives