### PR TITLE
increase timeout to 5 hours

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -138,7 +138,7 @@ jobs:
     clean: all
   pool:
     vmImage: 'macOS-11'
-  timeoutInMinutes:  180
+  timeoutInMinutes:  300
   steps:
     - template: set-version-number-variables-step.yml
 


### PR DESCRIPTION
### Description
Increase MacOS pipeline timeout to 5 hours



### Motivation and Context
It blocks Release pipeline


