### PR TITLE
register ATen fallback for instance_norm2d gradient

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
@@ -114,6 +114,18 @@ def diagonal_gradient():
     ]
 
 
+@register_gradient("org.pytorch.aten", "ATen", "instance_norm2d", "")
+def instance_norm2d_gradient():
+    return [
+        (
+            ("ATen", "org.pytorch.aten"),
+            ["GO(0)", "I(0)", "I(1)", "I(2)", "I(3)", "I(4)", "I(5)", "O(1)"],
+            ["GI(0)"],
+            {"operator": {"value": "instance_norm2d_backward", "dtype": "string"}},
+        ),
+    ]
+
+
 @register_gradient("org.pytorch.aten", "ATen", "max_pool2d_with_indices", "")
 def max_pool2d_gradient():
     return [
@@ -124,7 +136,6 @@ def max_pool2d_gradient():
             {"operator": {"value": "max_pool2d_with_indices_backward", "dtype": "string"}},
         ),
     ]
-
 
 def minmax_gradient():
     # Gradient of torch.min(input) (and max)


### PR DESCRIPTION
### Description
We currently have an inference kernel for Instance Normalization but no gradient kernel. Falling back to ATen for now to verify stable diffusion model works with this gradient before investing time in writing a cuda kernel for this op.

### Motivation and Context
Instance Normalization gradient required for [huggingface's diffusers library](https://github.com/huggingface/diffusers)


