### PR TITLE
Add onnxruntime_BUILD_UNIT_TESTS=OFF definition to iOS package build options.

### DIFF
--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -15,7 +15,6 @@
         "--build_shared_lib",
         "--use_nnapi",
         "--use_xnnpack",
-        "--skip_tests",
-        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
+        "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -15,6 +15,7 @@
         "--build_shared_lib",
         "--use_nnapi",
         "--use_xnnpack",
-        "--skip_tests"
+        "--skip_tests",
+        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
     ]
 }

--- a/tools/ci_build/github/android/default_mobile_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_mobile_aar_build_settings.json
@@ -20,7 +20,6 @@
         "--disable_exceptions",
         "--enable_reduced_operator_type_support",
         "--use_nnapi",
-        "--skip_tests",
-        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
+        "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/android/default_mobile_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_mobile_aar_build_settings.json
@@ -20,6 +20,7 @@
         "--disable_exceptions",
         "--enable_reduced_operator_type_support",
         "--use_nnapi",
-        "--skip_tests"
+        "--skip_tests",
+        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
     ]
 }

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -15,6 +15,7 @@
         "--build_apple_framework",
         "--use_coreml",
         "--skip_tests",
+        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF",
         "--apple_deploy_target=11.0"
     ]
 }

--- a/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_mobile_ios_framework_build_settings.json
@@ -20,6 +20,7 @@
         "--enable_reduced_operator_type_support",
         "--use_coreml",
         "--skip_tests",
+        "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF",
         "--apple_deploy_target=11.0"
     ]
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add onnxruntime_BUILD_UNIT_TESTS=OFF definition to iOS package build options.
The `--skip_tests` option is already specified.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Reduce packaging pipeline build times.