### PR TITLE
Fix clang-tidy(cppcoreguidelines-pro-bounds-array-to-pointer-decay)

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -92,11 +92,10 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
 #endif
 
 // Capture where a message is coming from. Use __FUNCTION__ rather than the much longer __PRETTY_FUNCTION__
-#define ORT_WHERE \
-  ::onnxruntime::CodeLocation(__FILE__, __LINE__, __FUNCTION__)
+#define ORT_WHERE ::onnxruntime::CodeLocation(__FILE__, __LINE__, static_cast<const char*>(__FUNCTION__))
 
 #define ORT_WHERE_WITH_STACK \
-  ::onnxruntime::CodeLocation(__FILE__, __LINE__, __PRETTY_FUNCTION__, ::onnxruntime::GetStackTrace())
+  ::onnxruntime::CodeLocation(__FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), ::onnxruntime::GetStackTrace())
 
 #ifdef ORT_NO_EXCEPTIONS
 
@@ -223,25 +222,25 @@ void LogRuntimeError(uint32_t session_id, const common::Status& status, const ch
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(TypeName);           \
   ORT_DISALLOW_MOVE(TypeName)
 
-#define ORT_RETURN_IF_ERROR_SESSIONID(expr, session_id)                                      \
-  do {                                                                                       \
-    auto _status = (expr);                                                                   \
-    if ((!_status.IsOK())) {                                                                 \
-      ::onnxruntime::LogRuntimeError(session_id, _status, __FILE__, __FUNCTION__, __LINE__); \
-      return _status;                                                                        \
-    }                                                                                        \
+#define ORT_RETURN_IF_ERROR_SESSIONID(expr, session_id)                                                                \
+  do {                                                                                                                 \
+    auto _status = (expr);                                                                                             \
+    if ((!_status.IsOK())) {                                                                                           \
+      ::onnxruntime::LogRuntimeError(session_id, _status, __FILE__, static_cast<const char*>(__FUNCTION__), __LINE__); \
+      return _status;                                                                                                  \
+    }                                                                                                                  \
   } while (0)
 
 #define ORT_RETURN_IF_ERROR_SESSIONID_(expr) ORT_RETURN_IF_ERROR_SESSIONID(expr, session_id_)
 #define ORT_RETURN_IF_ERROR(expr) ORT_RETURN_IF_ERROR_SESSIONID(expr, 0)
 
-#define ORT_THROW_IF_ERROR(expr)                                                    \
-  do {                                                                              \
-    auto _status = (expr);                                                          \
-    if ((!_status.IsOK())) {                                                        \
-      ::onnxruntime::LogRuntimeError(0, _status, __FILE__, __FUNCTION__, __LINE__); \
-      ORT_THROW(_status);                                                           \
-    }                                                                               \
+#define ORT_THROW_IF_ERROR(expr)                                                                              \
+  do {                                                                                                        \
+    auto _status = (expr);                                                                                    \
+    if ((!_status.IsOK())) {                                                                                  \
+      ::onnxruntime::LogRuntimeError(0, _status, __FILE__, static_cast<const char*>(__FUNCTION__), __LINE__); \
+      ORT_THROW(_status);                                                                                     \
+    }                                                                                                         \
   } while (0)
 
 // use this macro when cannot early return


### PR DESCRIPTION
### Description

clang-tidy says "Do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast instead"

It is a false positive scattering around all our codebase when using helper macros. It is becuase for function with 4 char name, say `main`, the type of __FUNCTION__ and __PRETTY_FUNCTION__ is `char [5]`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
  Address the issue mentioned at https://github.com/microsoft/onnxruntime/pull/12653#discussion_r976734309


