### PR TITLE
[ORTModule] Fix Graph Builder for Eval Mode

### DIFF
--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.cc
@@ -17,16 +17,15 @@ Status OrtModuleGraphBuilder::Initialize(std::istream& model_istream,
   // Save the model and config.
   ONNX_NAMESPACE::ModelProto model_proto;
   ORT_RETURN_IF_ERROR(Model::Load(model_istream, &model_proto));
-  ORT_RETURN_IF_ERROR(Model::Load(model_proto, model_, nullptr, *logger_));
+  ORT_RETURN_IF_ERROR(Model::Load(model_proto, original_model_, nullptr, *logger_));
   config_ = config;
 
   // Handle original model inputs, outputs and trainable initializers.
   // We need to move all the initializers to graph inputs and keep the order in config,
   // it's possible that the graph already has some initializers in graph inputs,
   // so we need to NOT assign these initializers to the user inputs list.
-  Graph& graph = model_->MainGraph();
-  std::unordered_set<std::string> initializer_names(config.initializer_names.begin(),
-                                                    config.initializer_names.end());
+  Graph& graph = original_model_->MainGraph();
+  std::unordered_set<std::string> initializer_names(config.initializer_names.begin(), config.initializer_names.end());
   const std::vector<const NodeArg*>& graph_inputs = graph.GetInputsIncludingInitializers();
   for (auto& node_arg : graph_inputs) {
     if (initializer_names.find(node_arg->Name()) == initializer_names.end()) {
@@ -41,8 +40,7 @@ Status OrtModuleGraphBuilder::Initialize(std::istream& model_istream,
 
   graph_info_.initializer_names_to_train.assign(config.initializer_names_to_train.begin(),
                                                 config.initializer_names_to_train.end());
-  graph_info_.initializer_names.assign(config.initializer_names.begin(),
-                                       config.initializer_names.end());
+  graph_info_.initializer_names.assign(config.initializer_names.begin(), config.initializer_names.end());
 
   std::vector<const NodeArg*> input_args;
   for (const auto& input_name : graph_info_.user_input_names) {
@@ -70,24 +68,23 @@ Status OrtModuleGraphBuilder::Initialize(std::istream& model_istream,
 // 3) build gradient graph, and finally 4) adjust the graph inputs and outputs.
 Status OrtModuleGraphBuilder::Build(const std::vector<std::vector<int64_t>>* input_shapes_ptr) {
   // Make a copy of the original model.
-  auto model_proto = model_->ToProto();
-  ORT_RETURN_IF_ERROR(Model::Load(model_proto, gradient_model_, nullptr, *logger_));
+  auto original_model_proto = original_model_->ToProto();
+  ORT_RETURN_IF_ERROR(Model::Load(original_model_proto, forward_model_, nullptr, *logger_));
 
   // Replace the user input shapes if input_shapes_ptr is not null_ptr.
   if (input_shapes_ptr) {
-    SetConcreteInputShapes(*input_shapes_ptr);
+    ORT_RETURN_IF_ERROR(SetConcreteInputShapes(*input_shapes_ptr));
   }
 
-  // This graph will be used only for inferencing, so stop right here.
+  // If this graph will be used only for inferencing, stop right here.
   // No need to apply the optimizations for training or build a gradient graph.
   if (!config_.build_gradient_graph) {
-    // Save a copy of inference optimized model
-    return Model::Load(gradient_model_->ToProto(), inference_optimized_model_, nullptr, *logger_);
+    return Status::OK();
   }
 
   // Optimize the inference graph and build the gradient graph.
   std::unordered_set<std::string> x_node_arg_names;
-  ORT_RETURN_IF_ERROR(OptimizeInferenceGraph(x_node_arg_names));
+  ORT_RETURN_IF_ERROR(OptimizeForwardGraph(x_node_arg_names));
   ORT_RETURN_IF_ERROR(BuildGradientGraph(x_node_arg_names));
 
   if (config_.enable_caching) {
@@ -106,7 +103,7 @@ Status OrtModuleGraphBuilder::Build(const std::vector<std::vector<int64_t>>* inp
   return Status::OK();
 }
 
-std::string OrtModuleGraphBuilder::GetModel() const {
+std::string OrtModuleGraphBuilder::GetGradientModel() const {
   std::string model_str;
   if (!gradient_model_->ToProto().SerializeToString(&model_str)) {
     ORT_THROW("Fail to serialize gradient model to string.");
@@ -114,22 +111,22 @@ std::string OrtModuleGraphBuilder::GetModel() const {
   return model_str;
 }
 
-std::string OrtModuleGraphBuilder::GetInferenceOptimizedModel() const {
+std::string OrtModuleGraphBuilder::GetForwardModel() const {
   std::string model_str;
-  if (!inference_optimized_model_->ToProto().SerializeToString(&model_str)) {
-    ORT_THROW("Fail to serialize inference optimized model to string.");
+  if (!forward_model_->ToProto().SerializeToString(&model_str)) {
+    ORT_THROW("Fail to serialize forward model to string.");
   }
   return model_str;
 }
 
-void OrtModuleGraphBuilder::SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes) {
+Status OrtModuleGraphBuilder::SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes) {
   ORT_ENFORCE(input_shapes.size() == graph_info_.user_input_names.size(),
               "The size of concrete input shapes and the size of user inputs does not match.");
-  Graph& gradient_graph = gradient_model_->MainGraph();
+  Graph& forward_graph = forward_model_->MainGraph();
   std::vector<const NodeArg*> input_args;
   size_t input_index = 0;
   for (const auto& input_name : graph_info_.user_input_names) {
-    NodeArg* input_node_arg = gradient_graph.GetNodeArg(input_name);
+    NodeArg* input_node_arg = forward_graph.GetNodeArg(input_name);
     ONNX_NAMESPACE::TensorShapeProto new_shape;
     for (size_t i = 0; i < input_shapes[input_index].size(); i++) {
       new_shape.add_dim()->set_dim_value(input_shapes[input_index][i]);
@@ -141,18 +138,19 @@ void OrtModuleGraphBuilder::SetConcreteInputShapes(const std::vector<std::vector
   }
 
   // Move over all training initializer inputs. They already have the concrete shapes.
-  const std::vector<const NodeArg*>& graph_inputs = gradient_graph.GetInputsIncludingInitializers();
+  const std::vector<const NodeArg*>& graph_inputs = forward_graph.GetInputsIncludingInitializers();
   for (; input_index < graph_inputs.size(); input_index++) {
     input_args.emplace_back(graph_inputs[input_index]);
   }
 
-  gradient_graph.SetInputs(input_args);
+  forward_graph.SetInputs(input_args);
+  return forward_graph.Resolve();
 }
 
-Status OrtModuleGraphBuilder::OptimizeInferenceGraph(std::unordered_set<std::string>& x_node_arg_names) {
+Status OrtModuleGraphBuilder::OptimizeForwardGraph(std::unordered_set<std::string>& x_node_arg_names) {
   // Resolve original graph, register and apply transformers for pre-training.
-  Graph& gradient_graph = gradient_model_->MainGraph();
-  ORT_RETURN_IF_ERROR(gradient_graph.Resolve());
+  Graph& forward_graph = forward_model_->MainGraph();
+  ORT_RETURN_IF_ERROR(forward_graph.Resolve());
 
   GraphTransformerManager graph_transformation_mgr{2};
   std::unique_ptr<CPUExecutionProvider> cpu_execution_provider =
@@ -179,16 +177,15 @@ Status OrtModuleGraphBuilder::OptimizeInferenceGraph(std::unordered_set<std::str
 
   for (int i = static_cast<int>(TransformerLevel::Level1); i <= static_cast<int>(TransformerLevel::MaxLevel); i++) {
     ORT_RETURN_IF_ERROR(
-        graph_transformation_mgr.ApplyTransformers(gradient_graph, static_cast<TransformerLevel>(i), *logger_));
+        graph_transformation_mgr.ApplyTransformers(forward_graph, static_cast<TransformerLevel>(i), *logger_));
   }
-
-  // Save a copy of inference optimized model
-  ORT_RETURN_IF_ERROR(Model::Load(gradient_model_->ToProto(), inference_optimized_model_, nullptr, *logger_));
 
   return Status::OK();
 }
 
 Status OrtModuleGraphBuilder::BuildGradientGraph(const std::unordered_set<std::string>& x_node_arg_names) {
+  // Copy the forward graph to create the gradient graph.
+  ORT_RETURN_IF_ERROR(Model::Load(forward_model_->ToProto(), gradient_model_, nullptr, *logger_));
   Graph& gradient_graph = gradient_model_->MainGraph();
 
   // Build gradient graph.
@@ -304,7 +301,8 @@ void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
       full_shape_outputs.add_ints(static_cast<int64_t>(i));
     }
 
-    if (std::find(non_differentiable_indices.begin(), non_differentiable_indices.end(), i) == non_differentiable_indices.end()) {
+    if (std::find(non_differentiable_indices.begin(), non_differentiable_indices.end(), i) ==
+        non_differentiable_indices.end()) {
       yield_output_node_args.emplace_back(gradient_graph.GetNodeArg(grad_name));
       graph_info_.module_output_gradient_name.emplace_back(grad_name);
     }
@@ -357,14 +355,15 @@ void OrtModuleGraphBuilder::HandleOutputsAndGrads() {
       int duplicate_counter = 0;
       for (size_t idx : indices) {
         std::string indexed_arg_name = arg_name + "_" + std::to_string(duplicate_counter++);
-        auto& indexed_node_arg = gradient_graph.GetOrCreateNodeArg(indexed_arg_name, yield_output_node_args[idx]->TypeAsProto());
+        auto& indexed_node_arg =
+            gradient_graph.GetOrCreateNodeArg(indexed_arg_name, yield_output_node_args[idx]->TypeAsProto());
         sum_input_node_args.push_back(&indexed_node_arg);
         yield_output_node_args[idx] = &indexed_node_arg;
       }
 
       // Insert the Sum node to sum-up the duplicated gradients
-      gradient_graph.AddNode("Sum_for_" + arg_name, "Sum", "Sum up duplicated gradient",
-                             sum_input_node_args, sum_output_node_arg, {}, kOnnxDomain);
+      gradient_graph.AddNode("Sum_for_" + arg_name, "Sum", "Sum up duplicated gradient", sum_input_node_args,
+                             sum_output_node_arg, {}, kOnnxDomain);
     }
   }
 

--- a/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
+++ b/orttraining/orttraining/core/framework/ortmodule_graph_builder.h
@@ -87,16 +87,16 @@ class OrtModuleGraphBuilder {
   Status Build(const std::vector<std::vector<int64_t>>* input_shapes_ptr = nullptr);
 
   /**
-   * Get inference/gradient model.
-   * @return The optimized inference/gradient model serialized to string.
+   * Get gradient model.
+   * @return The optimized gradient model serialized to string.
    */
-  std::string GetModel() const;
+  std::string GetGradientModel() const;
 
   /**
-   * Get inference optimized model.
-   * @return The gradient model serialized to string.
+   * Get inference/forward model. If it's training mode, the forward model is optimized.
+   * @return The inference/gradient model serialized to string.
    */
-  std::string GetInferenceOptimizedModel() const;
+  std::string GetForwardModel() const;
 
   /**
    * Get the graphs information.
@@ -106,10 +106,10 @@ class OrtModuleGraphBuilder {
 
  private:
   // Set concrete shapes for graph inputs.
-  void SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes);
+  Status SetConcreteInputShapes(const std::vector<std::vector<int64_t>>& input_shapes);
 
   // Apply graph transformers
-  Status OptimizeInferenceGraph(std::unordered_set<std::string>& x_node_arg_names);
+  Status OptimizeForwardGraph(std::unordered_set<std::string>& x_node_arg_names);
 
   // Build gradient graph.
   Status BuildGradientGraph(const std::unordered_set<std::string>& x_node_arg_names);
@@ -131,8 +131,10 @@ class OrtModuleGraphBuilder {
   void UpdatePythonOpInputsRequireGradInfo(
       const std::unordered_map<std::string, std::vector<int64_t>>& python_op_input_require_grad_info);
 
-  std::shared_ptr<onnxruntime::Model> model_;
-  std::shared_ptr<onnxruntime::Model> inference_optimized_model_;
+  std::shared_ptr<onnxruntime::Model> original_model_;
+  // For training case, the forward_model_ is the model after applying training graph transformers.
+  // For inference case, the forward_model_ is same as original_model_ and have concrete shapes set if required.
+  std::shared_ptr<onnxruntime::Model> forward_model_;
   std::shared_ptr<onnxruntime::Model> gradient_model_;
   GraphInfo graph_info_;
 

--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -739,13 +739,13 @@ void addObjectMethodsForTraining(py::module& m, ExecutionProviderRegistrationFn 
               const std::vector<std::vector<int64_t>>& input_shapes) {
              ORT_THROW_IF_ERROR(ortmodule_graph_builder->Build(&input_shapes));
            })
-      .def("get_model",
+      .def("get_gradient_model",
            [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
-             return py::bytes(ortmodule_graph_builder->GetModel());
+             return py::bytes(ortmodule_graph_builder->GetGradientModel());
            })
-      .def("get_inference_optimized_model",
+      .def("get_forward_model",
            [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
-             return py::bytes(ortmodule_graph_builder->GetInferenceOptimizedModel());
+             return py::bytes(ortmodule_graph_builder->GetForwardModel());
            })
       .def("get_graph_info", [](OrtModuleGraphBuilder* ortmodule_graph_builder) {
         return ortmodule_graph_builder->GetGraphInfo();

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -241,39 +241,42 @@ class GraphExecutionManager(GraphExecutionInterface):
         All other methods are internal"""
         pass
 
-    def _build_graph(self):
+    def _build_graph(self, training):
         if self._use_static_shape:
             self._graph_builder.build(self._input_info.shape)
         else:
             self._graph_builder.build()
 
-        self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_model())
-
-        self._onnx_models.optimized_pre_grad_model = onnx.load_model_from_string(
-            self._graph_builder.get_inference_optimized_model()
-        )
+        if training:
+            self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_gradient_model())
+            self._onnx_models.optimized_pre_grad_model = onnx.load_model_from_string(
+                self._graph_builder.get_forward_model()
+            )
+        else:
+            self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_forward_model())
 
         self._graph_info = self._graph_builder.get_graph_info()
 
-        # Map each input/initializer to its gradient index in the graph output, or -1 is gradient is not required.
-        self._gradient_map = []
-        num_user_input_grads = len(self._input_info.require_grad_names)
-        require_grad_names_set = set(self._input_info.require_grad_names)
-        require_grad_names_index = 0
-        for input_name in self._graph_info.user_input_names:
-            if input_name in require_grad_names_set:
-                self._gradient_map.append(require_grad_names_index)
-                require_grad_names_index += 1
-            else:
-                self._gradient_map.append(-1)
+        if training:
+            # Map each input/initializer to its gradient index in the graph output, or -1 is gradient is not required.
+            self._gradient_map = []
+            num_user_input_grads = len(self._input_info.require_grad_names)
+            require_grad_names_set = set(self._input_info.require_grad_names)
+            require_grad_names_index = 0
+            for input_name in self._graph_info.user_input_names:
+                if input_name in require_grad_names_set:
+                    self._gradient_map.append(require_grad_names_index)
+                    require_grad_names_index += 1
+                else:
+                    self._gradient_map.append(-1)
 
-        initializer_index = num_user_input_grads
-        for initializer_name in self._graph_info.initializer_names:
-            if initializer_name in self._graph_initializer_names_to_train:
-                self._gradient_map.append(initializer_index)
-                initializer_index += 1
-            else:
-                self._gradient_map.append(-1)
+            initializer_index = num_user_input_grads
+            for initializer_name in self._graph_info.initializer_names:
+                if initializer_name in self._graph_initializer_names_to_train:
+                    self._gradient_map.append(initializer_index)
+                    initializer_index += 1
+                else:
+                    self._gradient_map.append(-1)
 
     def _get_session_config(self):
         """Creates and returns the session configuration to be used for the ExecutionAgent"""

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -241,42 +241,13 @@ class GraphExecutionManager(GraphExecutionInterface):
         All other methods are internal"""
         pass
 
-    def _build_graph(self, training):
+    def _build_graph(self):
         if self._use_static_shape:
             self._graph_builder.build(self._input_info.shape)
         else:
             self._graph_builder.build()
 
-        if training:
-            self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_gradient_model())
-            self._onnx_models.optimized_pre_grad_model = onnx.load_model_from_string(
-                self._graph_builder.get_forward_model()
-            )
-        else:
-            self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_forward_model())
-
         self._graph_info = self._graph_builder.get_graph_info()
-
-        if training:
-            # Map each input/initializer to its gradient index in the graph output, or -1 is gradient is not required.
-            self._gradient_map = []
-            num_user_input_grads = len(self._input_info.require_grad_names)
-            require_grad_names_set = set(self._input_info.require_grad_names)
-            require_grad_names_index = 0
-            for input_name in self._graph_info.user_input_names:
-                if input_name in require_grad_names_set:
-                    self._gradient_map.append(require_grad_names_index)
-                    require_grad_names_index += 1
-                else:
-                    self._gradient_map.append(-1)
-
-            initializer_index = num_user_input_grads
-            for initializer_name in self._graph_info.initializer_names:
-                if initializer_name in self._graph_initializer_names_to_train:
-                    self._gradient_map.append(initializer_index)
-                    initializer_index += 1
-                else:
-                    self._gradient_map.append(-1)
 
     def _get_session_config(self):
         """Creates and returns the session configuration to be used for the ExecutionAgent"""
@@ -467,7 +438,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         graph_transformer_config.propagate_cast_ops_config.strategy = self._propagate_cast_ops_strategy
         return graph_transformer_config
 
-    def _initialize_graph_builder(self, training):
+    def _initialize_graph_builder(self):
         """Creates a new OrtModuleGraphBuilder, initializes it and saves it to self._graph_builder"""
 
         # All initializer names along with user inputs are a part of the onnx graph inputs
@@ -489,7 +460,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         grad_builder_config.initializer_names = initializer_names
         grad_builder_config.initializer_names_to_train = initializer_names_to_train
         grad_builder_config.input_names_require_grad = self._input_info.require_grad_names
-        grad_builder_config.build_gradient_graph = training
+        grad_builder_config.build_gradient_graph = self._export_mode == torch.onnx.TrainingMode.TRAINING
         grad_builder_config.graph_transformer_config = self._get_graph_transformer_config()
         grad_builder_config.enable_caching = self._enable_grad_acc_optimization
         grad_builder_config.loglevel = _logger.ortmodule_loglevel_to_onnxruntime_c_loglevel(

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -95,7 +95,7 @@ class InferenceManager(GraphExecutionManager):
 
                 # Build the inference graph
                 if build_graph:
-                    self._build_graph()
+                    self._build_graph(training=False)
 
             # If creating the execution agent for the first time, this skip check will not take effect.
             # It will only take effect on subsequent forward calls.
@@ -152,10 +152,10 @@ class InferenceManager(GraphExecutionManager):
         if self._fallback_manager.is_pending():
             return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
-    def _build_graph(self):
+    def _build_graph(self, training):
         """Build an optimized inference graph using the module_graph_builder"""
 
-        super()._build_graph(training=False)
+        super()._build_graph(training)
         if self._debug_options.save_onnx_models.save:
             self._onnx_models.save_optimized_model(
                 self._debug_options.save_onnx_models.path,

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -3,15 +3,17 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from . import _utils, _io, _logger, _are_deterministic_algorithms_enabled, _use_deterministic_algorithms
-from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo, _SkipCheck
-from ._execution_agent import InferenceAgent
-from .debug_options import DebugOptions
-from ._fallback import ORTModuleFallbackException, _FallbackPolicy, _FallbackManager
+import warnings
+
+import torch
 
 from onnxruntime.capi import _pybind_state as C
-import torch
-import warnings
+
+from . import _are_deterministic_algorithms_enabled, _io, _logger, _use_deterministic_algorithms, _utils
+from ._execution_agent import InferenceAgent
+from ._fallback import ORTModuleFallbackException, _FallbackManager, _FallbackPolicy
+from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo, _SkipCheck
+from .debug_options import DebugOptions
 
 
 class InferenceManager(GraphExecutionManager):
@@ -153,7 +155,7 @@ class InferenceManager(GraphExecutionManager):
     def _build_graph(self):
         """Build an optimized inference graph using the module_graph_builder"""
 
-        super()._build_graph()
+        super()._build_graph(training=False)
         if self._debug_options.save_onnx_models.save:
             self._onnx_models.save_optimized_model(
                 self._debug_options.save_onnx_models.path,

--- a/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
+++ b/orttraining/orttraining/python/training/ortmodule/_onnx_models.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 # _onnx_models.py
 
-from dataclasses import dataclass
-import onnx
 import os
+from dataclasses import dataclass
+
+import onnx
 import torch
 
 
@@ -22,8 +23,9 @@ class ONNXModels:
     """Encapsulates all ORTModule onnx models.
 
     1. exported_model: Model that is exported by torch.onnx.export
-    2. optimized_model: Optimized model after gradients graph has been built.
-    3. optimized_pre_grad_model: Optimized model before gradient graph is built.
+    2. optimized_model: For eval mode it's exported_model with concrete input shapes set if needed,
+                        for training mode, it's optimized model after gradients graph has been built.
+    3. optimized_pre_grad_model: Optimized model before gradient graph is built. It's None for eval mode.
     4. In addition, ORTModule also saves the execution_model which is the model
        that is being executed by ORT. It has further optimizations done by the
        InferenceSession and is saved by the InferenceSession.
@@ -44,7 +46,8 @@ class ONNXModels:
         _save_model(
             self.optimized_model, os.path.join(path, _get_onnx_file_name(name_prefix, "optimized", export_mode))
         )
-        _save_model(
-            self.optimized_pre_grad_model,
-            os.path.join(path, _get_onnx_file_name(name_prefix, "optimized_pre_grad", export_mode)),
-        )
+        if self.optimized_pre_grad_model is not None:
+            _save_model(
+                self.optimized_pre_grad_model,
+                os.path.join(path, _get_onnx_file_name(name_prefix, "optimized_pre_grad", export_mode)),
+            )

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -283,8 +283,7 @@ class TrainingManager(GraphExecutionManager):
     def _build_graph(self):
         """Build an optimized gradient graph using the module_graph_builder"""
 
-        super()._build_graph()
-
+        super()._build_graph(training=True)
         if self._debug_options.save_onnx_models.save:
             self._onnx_models.save_optimized_model(
                 self._debug_options.save_onnx_models.path,

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -222,7 +222,7 @@ class TrainingManager(GraphExecutionManager):
 
                 # Build the gradient graph
                 if build_gradient_graph:
-                    self._build_graph()
+                    self._build_graph(training=True)
 
             # If creating the execution agent for the first time, this skip check will not take effect.
             # It will only take effect on subsequent forward calls.
@@ -280,10 +280,10 @@ class TrainingManager(GraphExecutionManager):
         if self._fallback_manager.is_pending():
             return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
-    def _build_graph(self):
+    def _build_graph(self, training):
         """Build an optimized gradient graph using the module_graph_builder"""
 
-        super()._build_graph(training=True)
+        super()._build_graph(training)
         if self._debug_options.save_onnx_models.save:
             self._onnx_models.save_optimized_model(
                 self._debug_options.save_onnx_models.path,

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -5,6 +5,7 @@
 
 import warnings
 
+import onnx
 import torch
 
 from onnxruntime.capi import _pybind_state as C
@@ -206,7 +207,7 @@ class TrainingManager(GraphExecutionManager):
                 build_gradient_graph = self._export_model(*inputs, **kwargs)
                 if build_gradient_graph:
                     # If model was exported, then initialize the graph builder
-                    self._initialize_graph_builder(training=True)
+                    self._initialize_graph_builder()
 
                 # since the schema was just extracted while trying to export the model and it was either
                 # saved to self._input_info.schema or checked for equality with the self._input_info.schema
@@ -222,7 +223,7 @@ class TrainingManager(GraphExecutionManager):
 
                 # Build the gradient graph
                 if build_gradient_graph:
-                    self._build_graph(training=True)
+                    self._build_graph()
 
             # If creating the execution agent for the first time, this skip check will not take effect.
             # It will only take effect on subsequent forward calls.
@@ -280,16 +281,40 @@ class TrainingManager(GraphExecutionManager):
         if self._fallback_manager.is_pending():
             return self._fallback_manager.fallback(self._debug_options.logging.log_level, *inputs, **kwargs)
 
-    def _build_graph(self, training):
+    def _build_graph(self):
         """Build an optimized gradient graph using the module_graph_builder"""
 
-        super()._build_graph(training)
+        super()._build_graph()
+        self._onnx_models.optimized_model = onnx.load_model_from_string(self._graph_builder.get_gradient_model())
+        self._onnx_models.optimized_pre_grad_model = onnx.load_model_from_string(
+            self._graph_builder.get_forward_model()
+        )
         if self._debug_options.save_onnx_models.save:
             self._onnx_models.save_optimized_model(
                 self._debug_options.save_onnx_models.path,
                 self._debug_options.save_onnx_models.name_prefix,
                 self._export_mode,
             )
+
+        # Map each input/initializer to its gradient index in the graph output, or -1 is gradient is not required.
+        self._gradient_map = []
+        num_user_input_grads = len(self._input_info.require_grad_names)
+        require_grad_names_set = set(self._input_info.require_grad_names)
+        require_grad_names_index = 0
+        for input_name in self._graph_info.user_input_names:
+            if input_name in require_grad_names_set:
+                self._gradient_map.append(require_grad_names_index)
+                require_grad_names_index += 1
+            else:
+                self._gradient_map.append(-1)
+
+        initializer_index = num_user_input_grads
+        for initializer_name in self._graph_info.initializer_names:
+            if initializer_name in self._graph_initializer_names_to_train:
+                self._gradient_map.append(initializer_index)
+                initializer_index += 1
+            else:
+                self._gradient_map.append(-1)
 
     def _create_execution_agent(self):
         """Creates a TrainingAgent that can run the forward and backward graph on the training model"""
@@ -354,7 +379,7 @@ class TrainingManager(GraphExecutionManager):
             or initializer_names_to_train_set_user_model != self._graph_initializer_names_to_train
         ):
             self._input_info = input_info
-            self._initialize_graph_builder(training=True)
+            self._initialize_graph_builder()
             return True
         return False
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4187,7 +4187,8 @@ def test_debug_options_save_onnx_models_os_environment(mode):
         # assert that the onnx models have been saved
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_torch_exported_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_{mode}.onnx"))
-        assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_pre_grad_{mode}.onnx"))
+        if mode == "training":
+            assert os.path.exists(os.path.join(temporary_dir, f"my_model_optimized_pre_grad_{mode}.onnx"))
         assert os.path.exists(os.path.join(temporary_dir, f"my_model_execution_model_{mode}.onnx"))
         del os.environ["ORTMODULE_SAVE_ONNX_PATH"]
 
@@ -4207,12 +4208,14 @@ def test_debug_options_save_onnx_models_cwd(mode):
     # assert that the onnx models have been saved
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
-    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
+    if mode == "training":
+        assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
-    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
+    if mode == "training":
+        os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
 


### PR DESCRIPTION
Current graph builder for ORTModule will apply the training's graph optimizations for both training and eval mode. Take BatchNorm as example, one of training's graph optimizations will replace BatchNormalization Op to BatchNormInternal which is for training only. This PR is to fix this, for eval mode, we will not apply the training's graph optimizations. The inference's graph optimizations will be applied when InferenceSession initialization.
