### PR TITLE
make the UNSIGNEDPD_CHECK for Windows only

### DIFF
--- a/onnxruntime/core/providers/snpe/snpe_runtime_wrapper.h
+++ b/onnxruntime/core/providers/snpe/snpe_runtime_wrapper.h
@@ -37,10 +37,12 @@ class SnpeRuntimeWrapper {
 
   bool IsAvailable() const {
     zdl::DlSystem::RuntimeCheckOption_t runtime_check_option = zdl::DlSystem::RuntimeCheckOption_t::DEFAULT;
+#if defined(_WIN32) && defined(_M_ARM64)
     // check availability, explicitly requiring unsignedpd support
     if (runtime_ == zdl::DlSystem::Runtime_t::DSP) {
       runtime_check_option = zdl::DlSystem::RuntimeCheckOption_t::UNSIGNEDPD_CHECK;
     }
+#endif
     return zdl::SNPE::SNPEFactory::isRuntimeAvailable(runtime_, runtime_check_option);
   }
 


### PR DESCRIPTION
Fix issue reported from https://github.com/microsoft/onnxruntime/issues/13247
The UNSIGNEDPD_CHECK should apply to Windows only

