### PR TITLE
Replace or remove some characters to meet gtest name convention

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -1130,9 +1130,12 @@ auto ExpandModelName = [](const ::testing::TestParamInfo<ModelTest::ParamType>& 
   std::replace(name.begin(), name.end(), '/', '_');
   std::replace(name.begin(), name.end(), '\\', '_');
 
+  // in case there's whitespace in directory name
+  std::replace(name.begin(), name.end(), ' ', '_');
+
   // Note: test name only accepts '_' and alphanumeric
   // remove '.', '-', ':'
-  char chars[] = ".-:";
+  char chars[] = ".-:()";
   for (unsigned int i = 0; i < strlen(chars); ++i) {
     name.erase(std::remove(name.begin(), name.end(), chars[i]), name.end());
   }


### PR DESCRIPTION
### Description
To construct test name, replace whitespace to underscore and remove parentheses

### Motivation and Context
gtest name only accepts '_' and alphanumeric


