### PR TITLE
Objective-C static analysis - use different llvm path to try to find clang-tidy.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -33,7 +33,7 @@ jobs:
     displayName: Generate compile_commands.json and ONNX protobuf files
 
   - script: |
-      "$(brew --prefix llvm)/bin/clang-tidy" \
+      "$(brew --prefix llvm@14)/bin/clang-tidy" \
         -p="$(Build.BinariesDirectory)/Debug" \
         --checks="-*,clang-analyzer-*" \
         --header-filter="objectivec/include|objectivec/src|onnxruntime/core" \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use different llvm path to try to find clang-tidy.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Sometimes the build fails because it can't find clang-tidy. Hopefully this path works better.