### PR TITLE
[ORTModule] ATen Support for torch.nn.GroupNorm

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_gradient_registry.py
@@ -222,3 +222,16 @@ def numpy_T_gradient():
             {"operator": {"value": "numpy_T", "dtype": "string"}},
         ),
     ]
+
+
+@register_gradient("org.pytorch.aten", "ATen", "native_group_norm", "")
+def native_group_norm_gradient():
+    return [
+        ("Constant", [], ["Const_0"], {"value": {"value": [True, True, True], "dtype": "bool", "is_tensor": True}}),
+        (
+            ("ATen", "org.pytorch.aten"),
+            ["GO(0)", "I(0)", "O(1)", "O(2)", "I(1)", "I(3)", "I(4)", "I(5)", "I(6)", "Const_0"],
+            ["GI(0)", "GI(1)", "GI(2)"],
+            {"operator": {"value": "native_group_norm_backward", "dtype": "string"}},
+        ),
+    ]

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1635,6 +1635,41 @@ def test_numpy_T(input_shape):
     _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
 
 
+def test_aten_group_norm():
+    class NeuralNetGroupNorm(torch.nn.Module):
+        def __init__(self, num_groups, num_channels):
+            super(NeuralNetGroupNorm, self).__init__()
+            self.group_norm = torch.nn.GroupNorm(
+                num_groups=num_groups, num_channels=num_channels, eps=1e-5, affine=True
+            )
+
+        def forward(self, x, y):
+            return self.group_norm(x + y)
+
+    device = "cuda"
+    pt_model = NeuralNetGroupNorm(3, 6).to(device)
+    ort_model = ORTModule(copy.deepcopy(pt_model))
+
+    def run_step(model, x, y):
+        prediction = model(x, y)
+        prediction.sum().backward()
+        return prediction
+
+    # reset manual seed to reset the generator
+    torch.manual_seed(2333)
+    pt_x = torch.randn([20, 6, 10, 10], dtype=torch.float, device=device, requires_grad=True)
+    pt_y = torch.randn([20, 6, 10, 10], dtype=torch.float, device=device, requires_grad=True)
+    ort_x = copy.deepcopy(pt_x)
+    ort_y = copy.deepcopy(pt_y)
+    pt_prediction = run_step(pt_model, pt_x, pt_y)
+    ort_prediction = run_step(ort_model, ort_x, ort_y)
+
+    _test_helpers.assert_values_are_close(ort_prediction, pt_prediction)
+    _test_helpers.assert_values_are_close(ort_x.grad, pt_x.grad)
+    _test_helpers.assert_values_are_close(ort_y.grad, pt_y.grad)
+    _test_helpers.assert_gradients_match_and_reset_gradient(ort_model, pt_model)
+
+
 def test_gradient_correctness_cast_chain():
     class NeuralNetCast(torch.nn.Module):
         def __init__(self, D):


### PR DESCRIPTION
Model [huggingface's diffusers library](https://github.com/huggingface/diffusers) has torch.nn.GroupNorm which will be exported to sub-graph containing ONNX's InstanceNormalization, which is lack of gradient. The implementation of ORT's InstanceNormalization will call cuDNN's BatchNorm for part of computation, which is not efficient compared to PyTorch's implementation. This PR is to use ATen fallback to support this torch module, including its forward and backward.