### PR TITLE
Skip Int8 and float16 Tests on Windows GPU

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -588,6 +588,16 @@ TEST_P(ModelTest, Run) {
   std::basic_string<ORTCHAR_T> model_dir;
   (void)GetDirNameFromFilePath(model_path, model_dir);
   std::basic_string<PATH_CHAR_TYPE> test_case_name = GetLastComponent(model_dir);
+
+#ifdef _WIN32
+  if (provider_name == "cuda") {
+    if (test_case_name.find(ORT_TSTR("int8")) != std::string::npos || test_case_name.find(ORT_TSTR("fp16"))) {
+      SkipTest("Windows CUDA doesn't support INT8 or FP16");
+      return;
+    }
+  }
+#endif
+
   if (test_case_name.compare(0, 5, ORT_TSTR("test_")) == 0)
     test_case_name = test_case_name.substr(5);
   {

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <codecvt>
 #include <locale>
+#include <algorithm>
 
 #ifdef USE_DNNL
 #include "core/providers/dnnl/dnnl_provider_factory.h"
@@ -591,7 +592,10 @@ TEST_P(ModelTest, Run) {
 
 #ifdef _WIN32
   if (provider_name == "cuda") {
-    if (test_case_name.find(ORT_TSTR("int8")) != std::string::npos || test_case_name.find(ORT_TSTR("fp16"))) {
+    std::string temp_name = ToUTF8String(test_case_name);
+    std::transform(temp_name.begin(), temp_name.end(), temp_name.begin(), [](char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (temp_name.find("int8") != std::string::npos || temp_name.find("fp16") != std::string::npos || temp_name.find("float16") != std::string::npos) {
       SkipTest("Windows CUDA doesn't support INT8 or FP16");
       return;
     }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
As title

### Motivation and Context
To pass the beta pool whose GPU card is T4

The below is the test run on beta pool
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=781451&view=logs&s=3618b4c0-1011-591a-85b8-671e72e2cff1
```
2022-10-12T12:23:25.1648558Z 1: [ RUN ] ModelTests/ModelTest.Run/cuda_c_local_data_onnx_test_data_node_opset17_test_min_float16_model
2022-10-12T12:23:25.1659785Z 1: D:\a\_work\1\s\onnxruntime\test\providers\cpu\model_tests.cc(87): Skipped
2022-10-12T12:23:25.1660388Z 1: Skipping single test Windows CUDA doesn't support INT8 or FP16
```

