### PR TITLE
Fix deadlock in ROCM EP when profiling enabled

### DIFF
--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.h
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.h
@@ -17,6 +17,8 @@
 
 namespace onnxruntime {
 
+void RunOnUnload(std::function<void()> function);
+
 // Logical device representation.
 class ROCMExecutionProvider : public IExecutionProvider {
  public:
@@ -69,7 +71,7 @@ class ROCMExecutionProvider : public IExecutionProvider {
   // Release all buffers added by
   // AddDeferredReleaseCPUPtr using
   // GPU callback (so it's async).
-  Status EnqueueDeferredRelease();
+  Status EnqueueDeferredRelease(bool no_callbacks = false);
 
   template <typename T>
   IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Implement a workaround for a potential bug in the ROCm framework that causes deadlocks on StableDiffusion models when executed with profiling enabled.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
ORT deadlocks when executing the StableDiffusion model on AMD GPUs with ROCm profiling enabled. I suspect that this is most likely a bug in the ROCm framework, which is triggered by enqueueing a callback on the device stream, and then immediately synchronizing on the stream. 

In this particular case, there isn't really a necessity to do this: we can swap the order by first synchronizing on the stream and then releasing the buffers synchronously, once we know that the device stream has completed execution. 