### PR TITLE
Add log level customization during C# OrtEnv initialization

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.shared.cs
@@ -90,6 +90,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// Returns an instance of OrtEnv, with customized log level
         /// It returns the same instance on every call - `OrtEnv` is singleton
         /// </summary>
+        /// <param name="logLevel">LogLevel instance to be used for OrtEnv initialization</param>
         /// <returns>Returns a singleton instance of OrtEnv that represents native OrtEnv object</returns>
         public static OrtEnv Instance(LogLevel logLevel)
         {

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -192,6 +192,20 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             }
         }
 
+        [Fact(DisplayName = "TestInitOrtEnv")]
+        public void TestInitOrtEnv()
+        {
+            var ortEnvInstance = OrtEnv.Instance();
+            Assert.Equal(LogLevel.Warning, ortEnvInstance.GetCurrentLogLevel());
+        }
+        
+        [Fact(DisplayName = "TestInitOrtEnvWithCustomizedLogLevel")]
+        public void TestInitOrtEnvWithCustomizedLogLevel()
+        {
+            var ortEnvInstance = OrtEnv.Instance(LogLevel.Verbose);
+            Assert.Equal(LogLevel.Verbose, ortEnvInstance.GetCurrentLogLevel());
+        }
+
         [Fact(DisplayName = "EnablingAndDisablingTelemetryEventCollection")]
         public void EnablingAndDisablingTelemetryEventCollection()
         {


### PR DESCRIPTION
### Update: This PR is replaced by [#13377](https://github.com/microsoft/onnxruntime/pull/13377), which simplifies the idea by adding C API/getter and setter of log level in C# OrtEnv and not modifying the existing lazy initialization


### Description
<!-- Describe your changes. -->
* Provide ability to pass desired log level parameter while constructing OrtEnv instance in C# binding
* Provide GetCurrentLogLevel() in order to peek on the defined log level during OrtEnv initialization
* Add two test cases to verify initializing OrtEnv w/o passing log level parameter

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
For C++/Python, the log level can be adjusted via OrtEnv, and this feature is missing in C# binding

