### PR TITLE
Improve thread pool creation failure handling.

### DIFF
--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -56,12 +56,6 @@ class UnmapFileParam {
  *
  * @return a pair of {errno, error message}
  */
-static std::pair<int, std::string> GetSystemError() {
-  auto e = errno;
-  return GetSystemError(e);
-}
-
-
 static std::pair<int, std::string> GetSystemError(int e) {
   char buf[1024];
   const char* msg = "";
@@ -78,6 +72,11 @@ static std::pair<int, std::string> GetSystemError(int e) {
   }
 
   return std::make_pair(e, msg);
+}
+
+static std::pair<int, std::string> GetSystemError() {
+  auto e = errno;
+  return GetSystemError(e);
 }
 
 static void UnmapFile(void* param) noexcept {
@@ -228,7 +227,7 @@ class PosixThread : public EnvThread {
         auto ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
         if (ret != 0) {
           auto [err_no, err_msg] = GetSystemError(ret);
-          LOGS_DEFAULT(ERROR) << "pthread_setaffinity_np failed for thread: " << gettid()
+          LOGS_DEFAULT(ERROR) << "pthread_setaffinity_np failed for thread: " << pthread_self()
                               << ", error code: ", err_no, " error msg: ", err_msg;
         }
       }

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -229,8 +229,9 @@ class PosixThread : public EnvThread {
         if (ret != 0) {
           auto [err_no, err_msg] = GetSystemError(ret);
           LOGS_DEFAULT(ERROR) << "pthread_setaffinity_np failed for thread: " << pthread_self()
+                              << ", mask: " << *p->affinity_mask
                               << ", error code: " << err_no << " error msg: " << err_msg
-                              << " Specify the number of threads explicitly so the affinity is not set.";
+                              << ". Specify the number of threads explicitly so the affinity is not set.";
         }
       }
 #endif

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -164,9 +164,10 @@ class WindowsThread : public EnvThread {
         if (!rc) {
           const auto error_code = GetLastError();
           LOGS_DEFAULT(ERROR) << "SetThreadAffinityMask failed for thread: " << GetCurrentThreadId()
-                              << " error code: " << error_code
-                              << " error msg: " << std::system_category().message(error_code)
-                              << " Specify the number of threads explicitly so the affinity is not set.";
+                              << ", mask: " << *p->affinity_mask
+                              << ", error code: " << error_code
+                              << ", error msg: " << std::system_category().message(error_code)
+                              << ". Specify the number of threads explicitly so the affinity is not set.";
         }
       }
 

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -122,7 +122,7 @@ class WindowsThread : public EnvThread {
 #pragma warning(push)
 #pragma warning(disable : 6387)
   static unsigned __stdcall ThreadMain(void* param) {
-    std::unique_ptr<Param> p((Param*)param);
+    std::unique_ptr<Param> p(static_cast<Param*>(param));
     // TODO: should I try to use SetThreadSelectedCpuSets?
     if (!p->thread_options.affinity.empty())
       SetThreadAffinityMask(GetCurrentThread(), p->thread_options.affinity[p->index]);
@@ -149,7 +149,7 @@ class WindowsThread : public EnvThread {
     ORT_TRY {
       ret = p->start_address(p->index, p->param);
     }
-    ORT_CATCH(const std::exception&) {
+    ORT_CATCH(...) {
       p->param->Cancel();
       ret = 1;
     }
@@ -158,11 +158,11 @@ class WindowsThread : public EnvThread {
 #pragma warning(pop)
 
   static void __stdcall CustomThreadMain(void* param) {
-    std::unique_ptr<Param> p((Param*)param);
+    std::unique_ptr<Param> p(static_cast<Param*>(param));
     ORT_TRY {
       p->start_address(p->index, p->param);
     }
-    ORT_CATCH(const std::exception&) {
+    ORT_CATCH(...) {
       p->param->Cancel();
     }
   }


### PR DESCRIPTION
### Description
Detect and report thread creation failure on Windows.
Make sure when a thread creation fails and throws, the thread pool destruction does not hang.

While we do not know why thread creation may fail on a particular environment, we want the actual error to be properly reported.

### Motivation and Context
Address issues https://github.com/microsoft/onnxruntime/issues/13291
And https://github.com/microsoft/onnxruntime/issues/13285#issuecomment-1278063223

