### PR TITLE
uset SearchOption for dotframework

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -215,7 +215,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
         private static Func<DirectoryInfo, IEnumerable<DirectoryInfo>> getOpsetDirectories = delegate (DirectoryInfo modelsDirInfo)
         {
-            return modelsDirInfo.EnumerateDirectories("opset*", new EnumerationOptions(){RecurseSubdirectories = true});
+            return modelsDirInfo.EnumerateDirectories("opset*", SearchOption.AllDirectories);
         };
 
         private static Dictionary<string, string> GetSkippedModels(DirectoryInfo modelsDirInfo)


### PR DESCRIPTION
### Description
As Title


### Motivation and Context
dotcore has EnumerationOptions but dotnetframewok hasn't

**netframework-4.6.1**
https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratedirectories?view=netframework-4.6.1#system-io-directory-enumeratedirectories(system-string-system-string-system-io-searchoption)

**net-5.0**
https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratedirectories?view=net-5.0

It breaks C#.net framework step in Packaging Pipeline

Testing workflow
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=238516&view=results



