### PR TITLE
fix cmp function when OrtDevice is in std::set

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -793,7 +793,9 @@ void SessionState::ResolveMemoryPatternFlag() {
     // TODO: we can improve memory pattern to support multiple streams
     bool multi_stream = false;
     auto cmp = [](const OrtDevice& op1, const OrtDevice& op2) {
-      return op1.Type() == op2.Type() && op1.MemType() == op2.MemType() && op1.Id() == op2.Id();
+      if (op1.Type() != op2.Type()) return op1.Type() < op2.Type();
+      if (op1.MemType() != op2.MemType()) return op1.MemType() < op2.MemType();
+      return op1.Id() < op2.Id();
     };
     std::set<OrtDevice, decltype(cmp)> device_set(cmp);
     auto& streams = GetExecutionPlan()->execution_plan;


### PR DESCRIPTION
### Description
The current compare function to decide whether two elements in std::set<OrtDevice> in SessionState::ResolveMemoryPatternFlag() is not right, which caused mem_pattern_ different behavior between main and pe branch



### Motivation and Context
This change is to make mem_pattern_ the same behavior between main and pe branch


