### PR TITLE
Fix CVE-2022-37434: Update zlib to 1.2.13

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -169,7 +169,7 @@
          "component": {
             "type": "git",
             "git": {
-               "commitHash": "50893291621658f355bc5b4d450a8d06a563053d",
+               "commitHash": "04f42ceca40f73e2978b50e93806c2a18c1281fc",
                "repositoryUrl": "https://github.com/madler/zlib.git"
             }
          }

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -4,7 +4,7 @@ set(zlib_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/zlib_archive)
 set(ZLIB_URL https://github.com/madler/zlib.git)
 set(ZLIB_BUILD ${CMAKE_CURRENT_BINARY_DIR}/zlib/src/zlib)
 set(ZLIB_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/zlib/install)
-set(ZLIB_TAG 50893291621658f355bc5b4d450a8d06a563053d)
+set(ZLIB_TAG 04f42ceca40f73e2978b50e93806c2a18c1281fc)
 
 if(WIN32)
   set(zlib_STATIC_LIBRARIES


### PR DESCRIPTION
The main driving force for this change is to resolve CVE-2022-37434, which is a buffer overflow when getting a gzip header extra field with inflateGetHeader().