### PR TITLE
Update SkipLayerNorm fusion rules

### DIFF
--- a/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
@@ -48,8 +48,18 @@ static bool CheckFirstAdd(Node& add, ProviderType providertype) {
     if (!utils::HasDimValue(add_input1_shape->dim(i)) ||
         !utils::HasDimValue(add_input2_shape->dim(i)) ||
         add_input1_shape->dim(i).dim_value() != add_input2_shape->dim(i).dim_value()) {
-      is_valid_input = false;
-      break;
+      // dim0 is batch_size, which could be only have dim_param.
+      if (i == 0) {
+        if (!utils::HasDimParam(add_input1_shape->dim(i)) ||
+            !utils::HasDimParam(add_input2_shape->dim(i)) ||
+            add_input1_shape->dim(i).dim_param() != add_input2_shape->dim(i).dim_param()) {
+          is_valid_input = false;
+          break;
+        }
+      } else {
+        is_valid_input = false;
+        break;
+      }
     }
   }
   return is_valid_input;

--- a/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
@@ -48,7 +48,7 @@ static bool CheckFirstAdd(Node& add, ProviderType providertype) {
     if (!utils::HasDimValue(add_input1_shape->dim(i)) ||
         !utils::HasDimValue(add_input2_shape->dim(i)) ||
         add_input1_shape->dim(i).dim_value() != add_input2_shape->dim(i).dim_value()) {
-      // dim0 is batch_size, which could be only have dim_param.
+      // Allow dim0 only has dim_param(e.g., batch_size).
       if (i == 0) {
         if (!utils::HasDimParam(add_input1_shape->dim(i)) ||
             !utils::HasDimParam(add_input2_shape->dim(i)) ||

--- a/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/skip_layer_norm_fusion.cc
@@ -48,15 +48,10 @@ static bool CheckFirstAdd(Node& add, ProviderType providertype) {
     if (!utils::HasDimValue(add_input1_shape->dim(i)) ||
         !utils::HasDimValue(add_input2_shape->dim(i)) ||
         add_input1_shape->dim(i).dim_value() != add_input2_shape->dim(i).dim_value()) {
-      // Allow dim0 only has dim_param(e.g., batch_size).
-      if (i == 0) {
-        if (!utils::HasDimParam(add_input1_shape->dim(i)) ||
-            !utils::HasDimParam(add_input2_shape->dim(i)) ||
-            add_input1_shape->dim(i).dim_param() != add_input2_shape->dim(i).dim_param()) {
-          is_valid_input = false;
-          break;
-        }
-      } else {
+      // Allow dimension only has dim_param.
+      if (!utils::HasDimParam(add_input1_shape->dim(i)) ||
+          !utils::HasDimParam(add_input2_shape->dim(i)) ||
+          add_input1_shape->dim(i).dim_param() != add_input2_shape->dim(i).dim_param()) {
         is_valid_input = false;
         break;
       }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

The subgraph below meet the SkipLayerNorm fusion pattern, but the fusion rules also required every input dimension has a certain value. So the subgraph below cannot fused to SkipLayerNorm.

subgraph we want to fuse
![image](https://user-images.githubusercontent.com/94887879/196386821-3e678a4c-83e4-4bca-8900-5ef4ea996868.png)

     
fusion pattern 3
 [Sub1]   [Sub2]
         \       /
          \     /
           \   /
            Add1
             |
     LayerNormalization

This change allow inputs of FirstAdd operator has dimension which only has dim_param.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


