### PR TITLE
rocblas alt impl during backward pass only

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -208,8 +208,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       auto cpu_allocator = cpu_execution_provider.GetAllocator(0, OrtMemTypeDefault);
       transformers.emplace_back(std::make_unique<TransposeOptimizer>(std::move(cpu_allocator)));
 
-      std::cerr << __FILE__ << ":" << __LINE__ << " emplace_back RocmBlasAltImpl" << std::endl;
-      // TODO document
+      // add __backwardpass attribute to nodes after YieldOp, ROCm-only
       const InlinedHashSet<std::string_view> rocm_ep = {onnxruntime::kRocmExecutionProvider};
       transformers.emplace_back(std::make_unique<RocmBlasAltImpl>(rocm_ep));
     } break;

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -10,6 +10,7 @@
 #include "core/optimizer/nhwc_transformer.h"
 #include "core/optimizer/qdq_transformer/qdq_final_cleanup.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
+#include "core/optimizer/rocm_blas_alt_impl.h"
 #include "core/optimizer/selectors_actions/selector_action_transformer_apply_contexts.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/optimizer/conv_add_act_fusion.h"
@@ -206,6 +207,11 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       // shouldn't affect the end result - just easier to debug any issue if it's last.
       auto cpu_allocator = cpu_execution_provider.GetAllocator(0, OrtMemTypeDefault);
       transformers.emplace_back(std::make_unique<TransposeOptimizer>(std::move(cpu_allocator)));
+
+      std::cerr << __FILE__ << ":" << __LINE__ << " emplace_back RocmBlasAltImpl" << std::endl;
+      // TODO document
+      const InlinedHashSet<std::string_view> rocm_ep = {onnxruntime::kRocmExecutionProvider};
+      transformers.emplace_back(std::make_unique<RocmBlasAltImpl>(rocm_ep));
     } break;
 
     case TransformerLevel::Level2: {

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -12,6 +12,9 @@
 #include "core/graph/graph_viewer.h"
 #include "core/optimizer/utils.h"
 
+//#include <thread>
+//#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+
 namespace onnxruntime {
 
 namespace {
@@ -254,6 +257,14 @@ Status ProcessNode(
       kMSDomain);
 
   matmul_scale_node.SetExecutionProviderType(node.GetExecutionProviderType());
+#ifdef USE_ROCM
+    // forward the __altimpl, if present
+    auto& attrs = node.GetAttributes();
+    if (attrs.count("__altimpl")) {
+      //std::cerr << PRE << " forwarding __altimpl attr " << static_cast<int64_t>(attrs.at("__altimpl").i()) << std::endl;
+      matmul_scale_node.AddAttribute("__altimpl", static_cast<int64_t>(attrs.at("__altimpl").i()));
+    }
+#endif
 
   {
     InlinedVector<std::reference_wrapper<Node>> nodes_to_remove{node};

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -255,10 +255,10 @@ Status ProcessNode(
 
   matmul_scale_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
-    // forward the __altimpl, if present
+    // forward the __backwardpass, if present
     auto& attrs = node.GetAttributes();
-    if (attrs.count("__altimpl")) {
-      matmul_scale_node.AddAttribute("__altimpl", static_cast<int64_t>(attrs.at("__altimpl").i()));
+    if (attrs.count("__backwardpass")) {
+      matmul_scale_node.AddAttribute("__backwardpass", static_cast<int64_t>(attrs.at("__backwardpass").i()));
     }
 #endif
 

--- a/onnxruntime/core/optimizer/matmul_scale_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_scale_fusion.cc
@@ -12,9 +12,6 @@
 #include "core/graph/graph_viewer.h"
 #include "core/optimizer/utils.h"
 
-//#include <thread>
-//#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 namespace onnxruntime {
 
 namespace {
@@ -261,7 +258,6 @@ Status ProcessNode(
     // forward the __altimpl, if present
     auto& attrs = node.GetAttributes();
     if (attrs.count("__altimpl")) {
-      //std::cerr << PRE << " forwarding __altimpl attr " << static_cast<int64_t>(attrs.at("__altimpl").i()) << std::endl;
       matmul_scale_node.AddAttribute("__altimpl", static_cast<int64_t>(attrs.at("__altimpl").i()));
     }
 #endif

--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -6,9 +6,6 @@
 #include "core/graph/graph_utils.h"
 #include <deque>
 
-//#include <thread>
-//#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;
 namespace onnxruntime {
@@ -411,7 +408,6 @@ Status MatmulTransposeFusion::ApplyImpl(Graph& graph, bool& modified, int graph_
     // forward the __altimpl, if present
     auto& attrs = node.GetAttributes();
     if (attrs.count("__altimpl")) {
-      //std::cerr << PRE << " forwarding __altimpl attr " << static_cast<int64_t>(attrs.at("__altimpl").i()) << std::endl;
       matmul_node.AddAttribute("__altimpl", static_cast<int64_t>(attrs.at("__altimpl").i()));
     }
 #endif

--- a/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/matmul_transpose_fusion.cc
@@ -405,10 +405,10 @@ Status MatmulTransposeFusion::ApplyImpl(Graph& graph, bool& modified, int graph_
     // Assign provider to this new node. Provider should be same as the provider for old node.
     matmul_node.SetExecutionProviderType(node.GetExecutionProviderType());
 #ifdef USE_ROCM
-    // forward the __altimpl, if present
+    // forward the __backwardpass, if present
     auto& attrs = node.GetAttributes();
-    if (attrs.count("__altimpl")) {
-      matmul_node.AddAttribute("__altimpl", static_cast<int64_t>(attrs.at("__altimpl").i()));
+    if (attrs.count("__backwardpass")) {
+      matmul_node.AddAttribute("__backwardpass", static_cast<int64_t>(attrs.at("__backwardpass").i()));
     }
 #endif
 

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -21,11 +21,9 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
     if (node.OpType() == "YieldOp") {
       is_backward_pass = true;
-      ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
     }
-    else {
-      ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
-    }
+
+    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
 
     if (is_backward_pass) {
       node.AddAttribute(std::string("__backwardpass"), static_cast<int64_t>(1));

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -19,25 +19,18 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
   for (auto node_index : node_topology_list) {
     auto& node = *graph.GetNode(node_index);
 
-#if 1
     if (node.OpType() == "YieldOp") {
       is_backward_pass = true;
       ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
     }
-    else
-#else
-    is_backward_pass = true;
-#endif
-    {
+    else {
       ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
     }
 
-    //if (node.OpType() == "MatMul" || node.OpType() == "FusedMatMul" || node.OpType() == "Gemm") {
-      if (is_backward_pass) {
-        node.AddAttribute(std::string("__altimpl"), static_cast<int64_t>(1));
-        modified = true;
-      }
-    //}
+    if (is_backward_pass) {
+      node.AddAttribute(std::string("__backwardpass"), static_cast<int64_t>(1));
+      modified = true;
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -21,9 +21,9 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
   for (auto node_index : node_topology_list) {
     auto& node = *graph.GetNode(node_index);
 
-    std::cerr << PRE << node << std::endl;
+    //std::cerr << PRE << node << std::endl;
 
-#if 0
+#if 1
     if (node.OpType() == "YieldOp") {
       is_backward_pass = true;
       //std::cerr << PRE << "YieldOp found, before recurse" << std::endl;

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -6,8 +6,6 @@
 #include "core/optimizer/rocm_blas_alt_impl.h"
 #include "core/graph/graph_utils.h"
 
-#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 using namespace ONNX_NAMESPACE;
 using namespace ::onnxruntime::common;
 namespace onnxruntime {
@@ -21,14 +19,10 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
   for (auto node_index : node_topology_list) {
     auto& node = *graph.GetNode(node_index);
 
-    //std::cerr << PRE << node << std::endl;
-
 #if 1
     if (node.OpType() == "YieldOp") {
       is_backward_pass = true;
-      //std::cerr << PRE << "YieldOp found, before recurse" << std::endl;
       ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
-      //std::cerr << PRE << "YieldOp found, after recurse" << std::endl;
     }
     else
 #else
@@ -39,7 +33,6 @@ Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     }
 
     //if (node.OpType() == "MatMul" || node.OpType() == "FusedMatMul" || node.OpType() == "Gemm") {
-      //std::cerr << PRE << "HIT, is_backward_pass " << is_backward_pass << std::endl;
       if (is_backward_pass) {
         node.AddAttribute(std::string("__altimpl"), static_cast<int64_t>(1));
         modified = true;

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.cc
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include <thread>
+
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/rocm_blas_alt_impl.h"
+#include "core/graph/graph_utils.h"
+
+#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+
+using namespace ONNX_NAMESPACE;
+using namespace ::onnxruntime::common;
+namespace onnxruntime {
+
+Status RocmBlasAltImpl::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  bool is_backward_pass = false;
+
+  for (auto node_index : node_topology_list) {
+    auto& node = *graph.GetNode(node_index);
+
+    std::cerr << PRE << node << std::endl;
+
+#if 0
+    if (node.OpType() == "YieldOp") {
+      is_backward_pass = true;
+      //std::cerr << PRE << "YieldOp found, before recurse" << std::endl;
+      ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+      //std::cerr << PRE << "YieldOp found, after recurse" << std::endl;
+    }
+    else
+#else
+    is_backward_pass = true;
+#endif
+    {
+      ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+    }
+
+    //if (node.OpType() == "MatMul" || node.OpType() == "FusedMatMul" || node.OpType() == "Gemm") {
+      //std::cerr << PRE << "HIT, is_backward_pass " << is_backward_pass << std::endl;
+      if (is_backward_pass) {
+        node.AddAttribute(std::string("__altimpl"), static_cast<int64_t>(1));
+        modified = true;
+      }
+    //}
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/rocm_blas_alt_impl.h
+++ b/onnxruntime/core/optimizer/rocm_blas_alt_impl.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+#include "core/graph/graph_utils.h"
+
+namespace onnxruntime {
+
+class RocmBlasAltImpl : public GraphTransformer {
+ public:
+  RocmBlasAltImpl(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("RocmBlasAltImpl", compatible_execution_providers) {}
+
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/backward_guard.cc
+++ b/onnxruntime/core/providers/rocm/backward_guard.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "core/providers/rocm/backward_guard.h"
+
+#include <iostream>
+#include <thread>
+#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+
+namespace onnxruntime {
+
+thread_local bool BackwardPassGuard::is_backward_pass_;
+
+BackwardPassGuard::BackwardPassGuard() {
+  //std::cerr << PRE << "BackwardPassGuard ctor pre " << is_backward_pass_ << std::endl;
+  is_backward_pass_ = true;
+  //std::cerr << PRE << "BackwardPassGuard ctor post " << is_backward_pass_ << std::endl;
+}
+
+BackwardPassGuard::~BackwardPassGuard() {
+  //std::cerr << PRE << "BackwardPassGuard dtor pre " << is_backward_pass_ << std::endl;
+  is_backward_pass_ = false;
+  //std::cerr << PRE << "BackwardPassGuard dtor post " << is_backward_pass_ << std::endl;
+}
+
+bool BackwardPassGuard::is_backward_pass() {
+  //std::cerr << PRE << "is_backward_pass_ " << is_backward_pass_ << std::endl;
+  return is_backward_pass_;
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/backward_guard.cc
+++ b/onnxruntime/core/providers/rocm/backward_guard.cc
@@ -2,28 +2,19 @@
 // Licensed under the MIT License.
 #include "core/providers/rocm/backward_guard.h"
 
-#include <iostream>
-#include <thread>
-#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 namespace onnxruntime {
 
 thread_local bool BackwardPassGuard::is_backward_pass_;
 
 BackwardPassGuard::BackwardPassGuard() {
-  //std::cerr << PRE << "BackwardPassGuard ctor pre " << is_backward_pass_ << std::endl;
   is_backward_pass_ = true;
-  //std::cerr << PRE << "BackwardPassGuard ctor post " << is_backward_pass_ << std::endl;
 }
 
 BackwardPassGuard::~BackwardPassGuard() {
-  //std::cerr << PRE << "BackwardPassGuard dtor pre " << is_backward_pass_ << std::endl;
   is_backward_pass_ = false;
-  //std::cerr << PRE << "BackwardPassGuard dtor post " << is_backward_pass_ << std::endl;
 }
 
 bool BackwardPassGuard::is_backward_pass() {
-  //std::cerr << PRE << "is_backward_pass_ " << is_backward_pass_ << std::endl;
   return is_backward_pass_;
 }
 

--- a/onnxruntime/core/providers/rocm/backward_guard.h
+++ b/onnxruntime/core/providers/rocm/backward_guard.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+namespace onnxruntime {
+
+struct BackwardPassGuard {
+  BackwardPassGuard();
+  ~BackwardPassGuard();
+  static bool is_backward_pass();
+private:
+  static thread_local bool is_backward_pass_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/gemm.cc
+++ b/onnxruntime/core/providers/rocm/math/gemm.cc
@@ -6,8 +6,6 @@
 #include "core/providers/rocm/rocm_common.h"
 #include "core/providers/rocm/shared_inc/fpgeneric.h"
 
-#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 namespace onnxruntime {
 namespace rocm {
 
@@ -61,8 +59,6 @@ template <typename T>
 Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   typedef typename ToHipType<T>::MappedType HipT;
 
-  //auto altimpl = Info().GetAttrOrDefault<int64_t>("altimpl", 0);
-  //std::cerr << PRE << "wtf altimpl " << altimpl << std::endl;
   const auto* X = ctx->Input<Tensor>(0);
   const auto* W = ctx->Input<Tensor>(1);
   const auto* B = ctx->Input<Tensor>(2);

--- a/onnxruntime/core/providers/rocm/math/gemm.cc
+++ b/onnxruntime/core/providers/rocm/math/gemm.cc
@@ -6,6 +6,8 @@
 #include "core/providers/rocm/rocm_common.h"
 #include "core/providers/rocm/shared_inc/fpgeneric.h"
 
+#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+
 namespace onnxruntime {
 namespace rocm {
 
@@ -59,6 +61,8 @@ template <typename T>
 Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   typedef typename ToHipType<T>::MappedType HipT;
 
+  //auto altimpl = Info().GetAttrOrDefault<int64_t>("altimpl", 0);
+  //std::cerr << PRE << "wtf altimpl " << altimpl << std::endl;
   const auto* X = ctx->Input<Tensor>(0);
   const auto* W = ctx->Input<Tensor>(1);
   const auto* B = ctx->Input<Tensor>(2);

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -8,7 +8,7 @@
 #include "core/providers/rocm/rocm_execution_provider.h"
 #include "core/providers/rocm/rocm_fwd.h"
 
-#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+//#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
 
 namespace onnxruntime {
 namespace rocm {
@@ -26,10 +26,11 @@ class RocmKernel : public OpKernel {
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
     Status s;
+    const std::string& op_name = Info().GetKernelDef().OpName();
     auto altimpl = Info().GetAttrOrDefault<int64_t>("__altimpl", 0);
-    //std::cerr << PRE << "altimpl " << altimpl << std::endl;
+    //std::cerr << PRE << op_name << " altimpl " << altimpl << std::endl;
     if (altimpl) {
-      //std::cerr << PRE << "creating BackwardPassGuard" << std::endl;
+      //std::cerr << PRE << op_name << " creating BackwardPassGuard" << std::endl;
       BackwardPassGuard guard;
       s = ComputeInternal(p_op_kernel_context);
     }

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -24,7 +24,6 @@ class RocmKernel : public OpKernel {
 
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
     Status s;
-    const std::string& op_name = Info().GetKernelDef().OpName();
     auto is_backward_pass = Info().GetAttrOrDefault<int64_t>("__backwardpass", 0);
     if (is_backward_pass) {
       BackwardPassGuard guard;

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -8,8 +8,6 @@
 #include "core/providers/rocm/rocm_execution_provider.h"
 #include "core/providers/rocm/rocm_fwd.h"
 
-//#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 namespace onnxruntime {
 namespace rocm {
 
@@ -28,9 +26,7 @@ class RocmKernel : public OpKernel {
     Status s;
     const std::string& op_name = Info().GetKernelDef().OpName();
     auto altimpl = Info().GetAttrOrDefault<int64_t>("__altimpl", 0);
-    //std::cerr << PRE << op_name << " altimpl " << altimpl << std::endl;
     if (altimpl) {
-      //std::cerr << PRE << op_name << " creating BackwardPassGuard" << std::endl;
       BackwardPassGuard guard;
       s = ComputeInternal(p_op_kernel_context);
     }

--- a/onnxruntime/core/providers/rocm/rocm_kernel.h
+++ b/onnxruntime/core/providers/rocm/rocm_kernel.h
@@ -25,8 +25,8 @@ class RocmKernel : public OpKernel {
   Status Compute(OpKernelContext* p_op_kernel_context) const override {
     Status s;
     const std::string& op_name = Info().GetKernelDef().OpName();
-    auto altimpl = Info().GetAttrOrDefault<int64_t>("__altimpl", 0);
-    if (altimpl) {
+    auto is_backward_pass = Info().GetAttrOrDefault<int64_t>("__backwardpass", 0);
+    if (is_backward_pass) {
       BackwardPassGuard guard;
       s = ComputeInternal(p_op_kernel_context);
     }

--- a/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
@@ -3,9 +3,25 @@
 
 #pragma once
 
+#include "core/providers/rocm/backward_guard.h"
 #include "core/providers/rocm/rocm_common.h"
 
+#define ORT_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
+#if ORT_ROCBLAS_VERSION_DECIMAL >= 242
+#define FLAG rocblas_gemm_flags_fp16_alt_impl
+#else
+#define FLAG 0
+#endif
+
+#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
+
 using namespace onnxruntime;
+
+inline int get_flag() {
+  int result = BackwardPassGuard::is_backward_pass() ? FLAG : 0;
+  //std::cerr << PRE << "get_flag() " << result << std::endl;
+  return result;
+}
 
 // Generalize library calls to be use in template functions
 
@@ -67,7 +83,7 @@ inline rocblas_status rocblasGemmHelper(rocblas_handle handle,
                          C, rocblas_datatype_f16_r, ldc,
                          C, rocblas_datatype_f16_r, ldc,
                          rocblas_datatype_f32_r,
-                         rocblas_gemm_algo_standard, 0, 0);
+                         rocblas_gemm_algo_standard, 0, get_flag());
 }
 
 inline rocblas_status rocblasGemmHelper(rocblas_handle handle,
@@ -90,7 +106,7 @@ inline rocblas_status rocblasGemmHelper(rocblas_handle handle,
                          C, rocblas_datatype_f16_r, ldc,
                          C, rocblas_datatype_f16_r, ldc,
                          rocblas_datatype_f32_r,
-                         rocblas_gemm_algo_standard, 0, 0);
+                         rocblas_gemm_algo_standard, 0, get_flag());
 }
 
 inline rocblas_status rocblasGemmHelper(rocblas_handle handle,
@@ -225,7 +241,7 @@ inline rocblas_status rocblasGemmBatchedHelper(rocblas_handle handle,
                                  (void**)Carray, rocblas_datatype_f16_r, ldc,
                                  batchCount,
                                  rocblas_datatype_f32_r,
-                                 rocblas_gemm_algo_standard, 0, 0);
+                                 rocblas_gemm_algo_standard, 0, get_flag());
 }
 
 inline rocblas_status rocblasGemmBatchedHelper(rocblas_handle handle,
@@ -329,7 +345,7 @@ inline rocblas_status rocblasGemmStridedBatchedHelper(rocblas_handle handle,
                                          C, rocblas_datatype_f16_r, ldc, strideC,
                                          batchCount,
                                          rocblas_datatype_f32_r,
-                                         rocblas_gemm_algo_standard, 0, 0);
+                                         rocblas_gemm_algo_standard, 0, get_flag());
 }
 
 inline rocblas_status rocblasGemmStridedBatchedHelper(rocblas_handle handle,
@@ -357,7 +373,7 @@ inline rocblas_status rocblasGemmStridedBatchedHelper(rocblas_handle handle,
                                          C, rocblas_datatype_f16_r, ldc, strideC,
                                          batchCount,
                                          rocblas_datatype_f32_r,
-                                         rocblas_gemm_algo_standard, 0, 0);
+                                         rocblas_gemm_algo_standard, 0, get_flag());
 }
 
 inline rocblas_status rocblasGemmStridedBatchedHelper(rocblas_handle handle,

--- a/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
@@ -13,13 +13,10 @@
 #define FLAG 0
 #endif
 
-#define PRE __FILE__ << ":" << __LINE__ << ":" << std::this_thread::get_id() << " "
-
 using namespace onnxruntime;
 
 inline int get_flag() {
   int result = BackwardPassGuard::is_backward_pass() ? FLAG : 0;
-  //std::cerr << PRE << "get_flag() " << result << std::endl;
   return result;
 }
 


### PR DESCRIPTION
On AMD Instinct MI200 GPUs, the FP16 and BF16 V_DOT2 and MFMA matrix instructions flush input and output denormal values to zero.  When training using FP16 precision, some models may fail to converge with FP16 denorms flushed to zero.  The affected instructions are only used by rocBLAS (GEMM) and MIOpen (convolution) kernels; all other onnxruntime operations will not encounter this behavior. All other supported AMD GPUs will not encounter this behavior.

rocBLAS and MIOpen provide alternate implementations for affected FP16 operations. Alternate implementations for BF16 operations are not provided; BF16 numbers have a larger dynamic range than FP16 numbers and are less likely to encounter denormal values. For the FP16 alternate implementations, FP16 input values are cast to an intermediate BF16 value and then cast back to FP16 output after the accumulate FP32 operations. In this way, the input and output types are unchanged.

Denormal values more frequently occur in the backward pass of training during gradient calculation.  Therefore, it is necessary to track when the backward pass of training is executing.  For the ROCm EP only, the `__backwardpass` attribute is added to all Nodes after the YieldOp is detected.  This takes place in a level1 graph optimization pass.  The attribute is forwarded to any newly created FusedMatMul Nodes.  In addition, the scope-based helper class `BackwardPassGuard` is provided to toggle state for rocblas.  This behavior of using the alternate implementations during the backward pass is made automatic with this PR.  This default behavior can be overridden using environment variables, ROCBLAS_INTERNAL_FP16_ALT_IMPL and MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL. The behavior of these environment variables is as follows:

|              | forward   | backward  |
|--------------|-----------|-----------|
| Env unset    | original  | alternate |
| Env set to 1 | alternate | alternate |
| Env set to 0 | original  | original  |

See also:

https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices

