### PR TITLE
Windows build fix for on device training training.

### DIFF
--- a/orttraining/orttraining/python/orttraining_pybind_state.cc
+++ b/orttraining/orttraining/python/orttraining_pybind_state.cc
@@ -861,7 +861,7 @@ void addObjectMethodsForTraining(py::module& m, ExecutionProviderRegistrationFn 
   checkpoint_state.def(py::init([](
                                     const std::string& ckpt_uri) {
     onnxruntime::training::api::CheckpointState state;
-    ORT_THROW_IF_ERROR(onnxruntime::training::api::LoadCheckpoint(ckpt_uri, state));
+    ORT_THROW_IF_ERROR(onnxruntime::training::api::LoadCheckpoint(ToPathString(ckpt_uri), state));
     return state;
   }));
 


### PR DESCRIPTION
### Description
This is a fix for on device training wheel build.

### Motivation and Context
when building linux wheel it treats PathString same as std::string, but when trying to build the wheel on windows it fails because we needed to cast the std::string to a PathString.

This error was found manually because there is no pipeline that uses the --enable_training_on_device for windows.

