### PR TITLE
Fix move Base::operator=

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -292,8 +292,8 @@ struct Base<Unowned<T>> {
 
   Base(Base&& v) noexcept : p_{v.p_} { v.p_ = nullptr; }
   Base& operator=(Base&& v) noexcept {
-    auto t = nullptr;
-    std::swap(t, v.p_);
+    p_ = nullptr;
+    std::swap(p_, v.p_);
     return *this;
   }
 


### PR DESCRIPTION
### Description
Base::operator= move is broken, loses a valid ptr.

### Motivation and Context
Address https://github.com/microsoft/onnxruntime/pull/13215#discussion_r997814275

