### PR TITLE
TRT EP race condition fix during ep compile time

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1370,10 +1370,7 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
           }
 
           // Build engine
-          {
-            auto lock = GetApiLock();
-            trt_engine = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(trt_builder->buildEngineWithConfig(*trt_network, *trt_config));
-          }
+          trt_engine = tensorrt_ptr::unique_pointer<nvinfer1::ICudaEngine>(trt_builder->buildEngineWithConfig(*trt_network, *trt_config));
           if (trt_engine == nullptr) {
             return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                                    "TensorRT EP could not build engine for fused node: " + fused_node.Name());

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1398,13 +1398,13 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
 
       // Build context
       if (context_memory_sharing_enable_) {
-          size_t mem_size = trt_engine->getDeviceMemorySize();
-          if (mem_size > max_ctx_mem_size_) {
-            max_ctx_mem_size_ = mem_size;
-            context_memory_ = IAllocator::MakeUniquePtr<void>(allocator_, max_ctx_mem_size_);
-          }
-          trt_context = tensorrt_ptr::unique_pointer<nvinfer1::IExecutionContext>(trt_engine->createExecutionContextWithoutDeviceMemory());
-        } else {
+        size_t mem_size = trt_engine->getDeviceMemorySize();
+        if (mem_size > max_ctx_mem_size_) {
+          max_ctx_mem_size_ = mem_size;
+          context_memory_ = IAllocator::MakeUniquePtr<void>(allocator_, max_ctx_mem_size_);
+        }
+        trt_context = tensorrt_ptr::unique_pointer<nvinfer1::IExecutionContext>(trt_engine->createExecutionContextWithoutDeviceMemory());
+      } else {
         trt_context = tensorrt_ptr::unique_pointer<nvinfer1::IExecutionContext>(trt_engine->createExecutionContext());
       }
       if (trt_context == nullptr) {

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1326,7 +1326,9 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
       const std::string cache_path = GetCachePath(cache_path_, trt_node_name_with_precision);
       const std::string engine_cache_path = cache_path + ".engine";
       {
+        // engine serialization/deserialization, engine build and context build are in critical section. It needs lock protection to prevent race conditions when inferencing with multithreading. 
         auto lock = GetApiLock();
+
         std::ifstream engine_file(engine_cache_path, std::ios::binary | std::ios::in);
         if (engine_cache_enable_ && engine_file) {
           engine_file.seekg(0, std::ios::end);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1326,7 +1326,7 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
       const std::string cache_path = GetCachePath(cache_path_, trt_node_name_with_precision);
       const std::string engine_cache_path = cache_path + ".engine";
       {
-        // engine serialization/deserialization, engine build and context build are in critical section. It needs lock protection to prevent race conditions when inferencing with multithreading. 
+        // Engine serialization/deserialization, engine build and context build are in critical section. It needs lock protection to prevent race condition when inferencing with multithreading. 
         auto lock = GetApiLock();
 
         std::ifstream engine_file(engine_cache_path, std::ios::binary | std::ios::in);

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -247,7 +247,7 @@ void RunWithOneSessionMultiThreadsInference(std::string model_name, std::string 
       th.join();
 }
 
-TEST(TensorrtExecutionProviderTest, SessionWithMultiThreadsAndInferenceWithMultiThreads) {
+TEST(TensorrtExecutionProviderTest, SessionCreationWithMultiThreadsAndInferenceWithMultiThreads) {
   std::vector<std::thread> threads;
   std::string model_name = "trt_execution_provider_multithreading_test.onnx";
   std::string graph_name = "multithreading_test";
@@ -264,7 +264,7 @@ TEST(TensorrtExecutionProviderTest, SessionWithMultiThreadsAndInferenceWithMulti
     th.join();
 }
 
-TEST(TensorrtExecutionProviderTest, SessionWithSingleThreadAndInferenceWithMultiThreads) {
+TEST(TensorrtExecutionProviderTest, SessionCreationWithSingleThreadAndInferenceWithMultiThreads) {
   std::string model_name = "trt_execution_provider_multithreading_test.onnx";
   std::string graph_name = "multithreading_test";
   std::string sess_log_id = "TRTEPMultiThreadingTestWithOneSessionMultiThreads";

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -247,7 +247,7 @@ void RunWithOneSessionMultiThreadsInference(std::string model_name, std::string 
       th.join();
 }
 
-TEST(TensorrtExecutionProviderTest, MultiThreadsTestWithOneSessionSingleThreadInference) {
+TEST(TensorrtExecutionProviderTest, SessionWithMultiThreadsAndInferenceWithMultiThreads) {
   std::vector<std::thread> threads;
   std::string model_name = "trt_execution_provider_multithreading_test.onnx";
   std::string graph_name = "multithreading_test";
@@ -264,7 +264,7 @@ TEST(TensorrtExecutionProviderTest, MultiThreadsTestWithOneSessionSingleThreadIn
     th.join();
 }
 
-TEST(TensorrtExecutionProviderTest, MultiThreadsTestWithOneSessionMultiThreadsInference) {
+TEST(TensorrtExecutionProviderTest, SessionWithSingleThreadAndInferenceWithMultiThreads) {
   std::string model_name = "trt_execution_provider_multithreading_test.onnx";
   std::string graph_name = "multithreading_test";
   std::string sess_log_id = "TRTEPMultiThreadingTestWithOneSessionMultiThreads";


### PR DESCRIPTION
### Description
TRT EP has the chance to encounter race condition when multiple threads are doing engine serialization/deserialization during EP compile time. 
Let's say one thread is serializing the engine and has not yet completely written all the data to file, and at this moment, another thread finds the engine file is existed and begins to deserialize the engine, it will end up deserialize the corrupt file.
The fix is to put a lock around engine deserialization/serialization, engine build and context build.



### Motivation and Context
The TensorRT EP Windows CI sometimes fails because of `TensorrtExecutionProviderTest.MultiThreadsTestWithOneSessionSingleThreadInference` unit test fails (This PR changes the name to SessionCreationWithMultiThreadsAndInferenceWithMultiThreads). It's highly possible due to race condition. 
The TensorRT CI failure also been reported [here](https://github.com/microsoft/onnxruntime/issues/13030)