### PR TITLE
[ORT+DML] Validate DML EP header files in ORT+DML NuGet pacakge

### DIFF
--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -93,7 +93,7 @@ def download_and_verify_directml_dlls(zip_file, platform, package_folder):
     dml_nuget_package_version = '1.9.1'
     dml_dependency_string = '<dependency id="' + dml_nuget_package_name + '" version="' + dml_nuget_package_version + '" />'
 
-    dml_related_dlls = [
+    dml_related_filenames = [
         "DirectML.Debug.dll",
         "DirectML.Debug.pdb",
         "DirectML.dll",
@@ -124,12 +124,12 @@ def download_and_verify_directml_dlls(zip_file, platform, package_folder):
             header_folder = "include"
 
             check_if_headers_are_present(dml_related_header_files, header_folder, dml_zip_file_list, platform)
-            for dll in dml_related_dlls:
-                path = folder + "/" + dll
+            for filename in dml_related_filenames:
+                path = folder + "/" + filename
                 print("Checking path: " + path)
                 if path not in dml_zip_file_list:
-                    print(dll + " not found for " + platform)
-                    raise Exception(dll + " not found for " + platform)
+                    print(filename + " not found for " + platform)
+                    raise Exception(filename + " not found for " + platform)
         else:
             print(dml_dependency_string + " not found for " + platform)
             raise Exception(dml_dependency_string + " not found for " + platform)

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -206,7 +206,7 @@ def validate_tarball(args):
         is_dml_package,
         args.platforms_supported,
         zip_file,
-        package_folder
+        package_folder,
     )
 
 
@@ -235,7 +235,7 @@ def validate_zip(args):
         is_dml_package,
         args.platforms_supported,
         zip_file,
-        package_folder
+        package_folder,
     )
 
 
@@ -292,7 +292,7 @@ def validate_nuget(args):
             is_dml_package,
             args.platforms_supported,
             zip_file,
-            None
+            None,
         )
 
         verify_nuget_signing = args.verify_nuget_signing.lower()

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -36,6 +36,7 @@ dmlep_related_header_files = [
     "dml_provider_factory.h",
 ]
 
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Validate ONNX Runtime native nuget containing native shared library artifacts spec script",
@@ -63,6 +64,7 @@ def parse_arguments():
 def check_exists(path):
     return os.path.exists(path)
 
+
 def remove_residual_files(path):
     if check_exists(path):
         os.remove(path)
@@ -72,15 +74,14 @@ def is_windows():
     return sys.platform.startswith("win")
 
 
-def check_if_headers_are_present(
-    header_files, header_folder, file_list_in_package, platform
-):
+def check_if_headers_are_present(header_files, header_folder, file_list_in_package, platform):
     for header in header_files:
         path = header_folder + "/" + header
         print("Checking path: " + path)
         if path not in file_list_in_package:
             print(header + " not found for " + platform)
             raise Exception(header + " not found for " + platform)
+
 
 def check_if_dlls_are_present(
     package_type, is_windows_ai_package, is_gpu_package, is_dml_package, platforms_supported, zip_file, package_path
@@ -199,7 +200,13 @@ def validate_tarball(args):
     zip_file = None
     is_dml_package = False
     check_if_dlls_are_present(
-        args.package_type, is_windows_ai_package, is_gpu_package, is_dml_package, args.platforms_supported, zip_file, package_folder
+        args.package_type,
+        is_windows_ai_package,
+        is_gpu_package,
+        is_dml_package,
+        args.platforms_supported,
+        zip_file,
+        package_folder
     )
 
 
@@ -222,7 +229,13 @@ def validate_zip(args):
     is_dml_package = False
     zip_file = zipfile.ZipFile(package_name)
     check_if_dlls_are_present(
-        args.package_type, is_windows_ai_package, is_gpu_package, is_dml_package, args.platforms_supported, zip_file, package_folder
+        args.package_type,
+        is_windows_ai_package,
+        is_gpu_package,
+        is_dml_package,
+        args.platforms_supported,
+        zip_file,
+        package_folder
     )
 
 
@@ -273,7 +286,13 @@ def validate_nuget(args):
         print("Checking if the Nuget contains relevant dlls")
         is_windows_ai_package = os.path.basename(full_nuget_path).startswith("Microsoft.AI.MachineLearning")
         check_if_dlls_are_present(
-            args.package_type, is_windows_ai_package, is_gpu_package, is_dml_package, args.platforms_supported, zip_file, None
+            args.package_type,
+            is_windows_ai_package,
+            is_gpu_package,
+            is_dml_package,
+            args.platforms_supported,
+            zip_file,
+            None
         )
 
         verify_nuget_signing = args.verify_nuget_signing.lower()

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -38,13 +38,7 @@ dmlep_related_header_files = [
 ]
 dml_related_header_files = [
     "DirectML.h",
-]
-dml_related_dlls = [
-    "DirectML.Debug.dll",
-    "DirectML.Debug.pdb",
-    "DirectML.dll",
-    "DirectML.lib",
-    "DirectML.pdb",
+    "DirectMLConfig.h"
 ]
 
 def parse_arguments():
@@ -96,19 +90,29 @@ def check_if_headers_are_present(
 def download_and_verify_directml_dlls(zip_file, platform, package_folder):
     dml_nuget_spec_file_name = "Microsoft.ML.OnnxRuntime.DirectML.nuspec"
     dml_nuget_package_name = 'Microsoft.AI.DirectML'
-    dml_nuget_package_version = '1.9.0'
+    dml_nuget_package_version = '1.9.1'
     dml_dependency_string = '<dependency id="' + dml_nuget_package_name + '" version="' + dml_nuget_package_version + '" />'
+
+    dml_related_dlls = [
+        "DirectML.Debug.dll",
+        "DirectML.Debug.pdb",
+        "DirectML.dll",
+        "DirectML.lib",
+        "DirectML.pdb",
+    ]
 
     with zip_file.open(dml_nuget_spec_file_name, 'r') as file:
         content = file.read().decode('UTF-8')
         if dml_dependency_string in content:
-            dml_nupkg_name = package_folder + "/DirectML.nupkg"
-            dml_nupkg_zip = package_folder + "/DirectML.zip"
+            dml_nupkg_zip = package_folder + '/' + dml_nuget_package_name + '.' + dml_nuget_package_version + '.zip'
 
             if not check_exists(dml_nupkg_zip):
-                request.urlretrieve('https://api.nuget.org/v3-flatcontainer/' + dml_nuget_package_name +'/' + dml_nuget_package_version + '/' +
-                                        dml_nuget_package_name + '.' + dml_nuget_package_version + '.nupkg', dml_nupkg_name)
-                os.rename(dml_nupkg_name, dml_nupkg_zip)
+                dml_nuget_url = 'https://api.nuget.org/v3-flatcontainer/' + dml_nuget_package_name + '/' + dml_nuget_package_version + '/' + dml_nuget_package_name + '.' + dml_nuget_package_version + '.nupkg'
+                try:
+                    request.urlretrieve(dml_nuget_url, dml_nupkg_zip)
+                except Exception as e:
+                    print(e)
+                    raise Exception("Unable to download" + dml_nuget_url+  "NuGet package")
 
             dml_zip_file_list = zipfile.ZipFile(dml_nupkg_zip).namelist()
 


### PR DESCRIPTION
### Description
Today, ORT+DML NuGet package does not validate the existence of the DML EP header files and DML dlls. This change extends the existing python script to verify the existence of DML EP related headers.
For DML as a dependent package, we will be using another task and it will a separate PR.

### Motivation and Context
- Why is this change required? What problem does it solve?
Pro-actively verifies the ORT+DML release candidate rather than a customer raise an issue after it gets published to NuGet.
- If it fixes an open issue, please link to the issue here. N/A


