### PR TITLE
[ROCm] set parallel=16 when build on ROCm CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
@@ -57,7 +57,7 @@ jobs:
               --update \
               --build_dir /build \
               --build \
-              --parallel 8 \
+              --parallel 16 \
               --build_wheel \
               --skip_submodule_sync \
               --skip_tests

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
           --update \
           --build_dir ./build \
           --build \
-          --parallel 8 \
+          --parallel 16 \
           --build_wheel \
           --skip_tests
     displayName: 'Build onnxruntime'


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

ROCm CI build step takes more than one hour. Set parallel=16 when build on ROCm CI to reduce build time.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


