### PR TITLE
enable arm32/arm64 target for .net apps built against OnnxRuntime.ML.OnnxRuntime

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/targets.xml
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/targets/netstandard/targets.xml
@@ -6,12 +6,12 @@
     the PlatformTarget is empty, and you don't know until runtime (i.e. which dotnet.exe)
     what processor architecture will be used.
   -->
-    <Error Condition="('$(PlatformTarget)' != 'x64' AND '$(PlatformTarget)' != 'x86' AND '$(PlatformTarget)' != 'AnyCPU') AND
+    <Error Condition="('$(PlatformTarget)' != 'x64' AND '$(PlatformTarget)' != 'arm32' AND '$(PlatformTarget)' != 'arm64' AND '$(PlatformTarget)' != 'x86' AND '$(PlatformTarget)' != 'AnyCPU') AND
                       ('$(OutputType)' == 'Exe' OR '$(OutputType)'=='WinExe') AND
                       !('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(PlatformTarget)' == '') AND
                       ('$(TargetFrameworkIdentifier)' != 'Xamarin.iOS' AND
                        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'ios') AND
                       '$(SuppressOnnxRuntimePlatformCompatibilityError)' != 'true'"
-           Text="Microsoft.ML.OnnxRuntime only supports the AnyCPU, x64, and x86 platforms at this time."/>
+           Text="Microsoft.ML.OnnxRuntime only supports the AnyCPU, x64, arm32, arm64 and x86 platforms at this time."/>
   </Target>
 </Project>


### PR DESCRIPTION

couldn't build arm64 .net app due to target file not allowing it.
