### PR TITLE
Add getter/setter of C# OrtEnv log level

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ML.OnnxRuntime
 
     // NOTE: The order of the APIs in this struct should match exactly that in
     // OrtApi ort_api_1_to_<latest_version> (onnxruntime/core/session/onnxruntime_c_api.cc)
+    // If syncing your new C API, any other C APIs before yours also need to be synced here if haven't
     [StructLayout(LayoutKind.Sequential)]
     public struct OrtApi
     {
@@ -252,6 +253,12 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr ReleaseKernelInfo;
 
         public IntPtr GetTrainingApi;
+        public IntPtr SessionOptionsAppendExecutionProvider_CANN;
+        public IntPtr CreateCANNProviderOptions;
+        public IntPtr UpdateCANNProviderOptions;
+        public IntPtr GetCANNProviderOptionsAsString;
+        public IntPtr ReleaseCANNProviderOptions;
+        public IntPtr MemoryInfoGetDeviceType;
         public IntPtr UpdateEnvWithCustomLogLevel;
     }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -252,6 +252,7 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr ReleaseKernelInfo;
 
         public IntPtr GetTrainingApi;
+        public IntPtr UpdateEnvWithCustomLogLevel;
     }
 
     internal static class NativeMethods
@@ -427,6 +428,7 @@ namespace Microsoft.ML.OnnxRuntime
                 = (DSessionOptionsAppendExecutionProvider)Marshal.GetDelegateForFunctionPointer(
                     api_.SessionOptionsAppendExecutionProvider,
                     typeof(DSessionOptionsAppendExecutionProvider));
+            OrtUpdateEnvWithCustomLogLevel = (DOrtUpdateEnvWithCustomLogLevel)Marshal.GetDelegateForFunctionPointer(api_.UpdateEnvWithCustomLogLevel, typeof(DOrtUpdateEnvWithCustomLogLevel));
         }
 
         internal class NativeLib
@@ -466,9 +468,13 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /* OrtStatus* */DOrtDisableTelemetryEvents(IntPtr /*(OrtEnv*)*/ env);
         public static DOrtDisableTelemetryEvents OrtDisableTelemetryEvents;
 
-#endregion Runtime/Environment API
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */DOrtUpdateEnvWithCustomLogLevel(LogLevel custom_log_level, IntPtr /*(OrtEnv*)*/ env);
+        public static DOrtUpdateEnvWithCustomLogLevel OrtUpdateEnvWithCustomLogLevel;
 
-#region Provider Options API
+        #endregion Runtime/Environment API
+
+        #region Provider Options API
 
         /// <summary>
         /// Creates native OrtTensorRTProviderOptions instance

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OnnxRuntime.shared.cs
@@ -49,12 +49,13 @@ namespace Microsoft.ML.OnnxRuntime
     public sealed class OrtEnv : SafeHandle
     {
         private static readonly Lazy<OrtEnv> _instance = new Lazy<OrtEnv>(()=> new OrtEnv());
+        private static LogLevel currentLogLevel = LogLevel.Warning;
 
         #region private methods
         private OrtEnv()  //Problem: it is not possible to pass any option for a Singleton
     : base(IntPtr.Zero, true)
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateEnv(LogLevel.Warning, @"CSharpOnnxRuntime", out handle));
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateEnv(currentLogLevel, @"CSharpOnnxRuntime", out handle));
             try
             {
                 NativeApiStatus.VerifySuccess(NativeMethods.OrtSetLanguageProjection(handle, OrtLanguageProjection.ORT_PROJECTION_CSHARP));
@@ -149,6 +150,26 @@ namespace Microsoft.ML.OnnxRuntime
             }
 
             return availableProviders;
+        }
+
+
+        /// <summary>
+        /// Get current log level of OrtEnv instance
+        /// </summary>
+        /// <returns>current log level</returns>
+        public LogLevel GetLogLevel()
+        {
+            return currentLogLevel;
+        }
+
+        /// <summary>
+        /// Set desired log level of OrtEnv instance
+        /// <param name="logLevel">Custom LogLevel enum to be used for updating OrtEnv log level</param>
+        /// </summary>
+        public void SetLogLevel(LogLevel logLevel)
+        {
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtUpdateEnvWithCustomLogLevel(logLevel, Handle));
+            currentLogLevel = logLevel;
         }
         #endregion
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -221,6 +221,15 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 #endif
         }
 
+        [Fact(DisplayName = "TestUpdatingEnvWithCustomLogLevel")]
+        public void TestUpdatingEnvWithCustomLogLevel()
+        {
+            var ortEnvInstance = OrtEnv.Instance();
+            Assert.Equal(LogLevel.Warning, ortEnvInstance.GetLogLevel());
+            ortEnvInstance.SetLogLevel(LogLevel.Verbose);
+            Assert.Equal(LogLevel.Verbose, ortEnvInstance.GetLogLevel());
+        }
+        
         [Fact(DisplayName = "CanCreateAndDisposeSessionWithModel")]
         public void CanCreateAndDisposeSessionWithModel()
         {

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3513,6 +3513,15 @@ struct OrtApi {
   * \since Version 1.12.
   */
   ORT_CLASS_RELEASE(KernelInfo);
+  
+  /* \brief Update the OrtEnv instance with custom log severity level
+   *
+   * \param[in] log_severity_level The log severity level.
+   * \param[in] ort_env The OrtEnv instance being used
+   *
+   * \since Version 1.13.
+   */
+  ORT_API2_STATUS(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
 
   /* \brief: Get the training C Api
   *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3514,15 +3514,6 @@ struct OrtApi {
   */
   ORT_CLASS_RELEASE(KernelInfo);
   
-  /* \brief Update the OrtEnv instance with custom log severity level
-   *
-   * \param[in] log_severity_level The log severity level.
-   * \param[in] ort_env The OrtEnv instance being used
-   *
-   * \since Version 1.13.
-   */
-  ORT_API2_STATUS(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
-
   /* \brief: Get the training C Api
   *
   * \since Version 1.13
@@ -3599,6 +3590,14 @@ struct OrtApi {
   */
   void(ORT_API_CALL* MemoryInfoGetDeviceType)(_In_ const OrtMemoryInfo* ptr, _Out_ OrtMemoryInfoDeviceType* out);
 
+  /* \brief Update the OrtEnv instance with custom log severity level
+   *
+   * \param[in] log_severity_level The log severity level.
+   * \param[in] ort_env The OrtEnv instance being used
+   *
+   * \since Version 1.13.
+   */
+  ORT_API2_STATUS(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
 
 #ifdef __cplusplus
   OrtApi(const OrtApi&)=delete; // Prevent users from accidentally copying the API structure, it should always be passed as a pointer

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -171,7 +171,8 @@ ORT_API_STATUS_IMPL(OrtApis::UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_se
                     _In_ const OrtEnv* ort_env) {
   API_IMPL_BEGIN
   LoggingManager* default_logging_manager = ort_env->GetLoggingManager();
-  default_logging_manager->SetDefaultLoggerSeverity(static_cast<logging::Severity>(log_severity_level));
+  int severity_level = static_cast<int>(log_severity_level);
+  default_logging_manager->SetDefaultLoggerSeverity(static_cast<logging::Severity>(severity_level));
   return nullptr;
   API_IMPL_END
 }
@@ -2599,7 +2600,9 @@ static constexpr OrtApi ort_api_1_to_12 = {
     &OrtApis::UpdateCANNProviderOptions,
     &OrtApis::GetCANNProviderOptionsAsString,
     &OrtApis::ReleaseCANNProviderOptions,
-    &OrtApis::MemoryInfoGetDeviceType};
+    &OrtApis::MemoryInfoGetDeviceType,
+    &OrtApis::UpdateEnvWithCustomLogLevel,
+};
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)
 // If any of these asserts hit, read the above 'Rules on how to add a new Ort API version'

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -167,6 +167,15 @@ ORT_API_STATUS_IMPL(OrtApis::DisableTelemetryEvents, _In_ const OrtEnv* ort_env)
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtApis::UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level,
+                    _In_ const OrtEnv* ort_env) {
+  API_IMPL_BEGIN
+  LoggingManager* default_logging_manager = ort_env->GetLoggingManager();
+  default_logging_manager->SetDefaultLoggerSeverity(static_cast<logging::Severity>(log_severity_level));
+  return nullptr;
+  API_IMPL_END
+}
+
 ORT_STATUS_PTR CreateTensorImpl(MLDataType ml_type, const int64_t* shape, size_t shape_len,
                                 _Inout_ OrtAllocator* allocator, OrtValue& value) {
   TensorShape tensor_shape(shape, shape_len);
@@ -2583,6 +2592,7 @@ static constexpr OrtApi ort_api_1_to_12 = {
     // End of Version 12 - DO NOT MODIFY ABOVE (see above text for more information)
 
     // Start of Version 13 API in progress, safe to modify/rename/rearrange until we ship
+    &OrtApis::UpdateEnvWithCustomLogLevel,
     &OrtApis::GetTrainingApi,
     &OrtApis::SessionOptionsAppendExecutionProvider_CANN,
     &OrtApis::CreateCANNProviderOptions,

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -388,6 +388,8 @@ ORT_API_STATUS_IMPL(CopyKernelInfo, _In_ const OrtKernelInfo* info, _Outptr_ Ort
 
 ORT_API(void, ReleaseKernelInfo, _Frees_ptr_opt_ OrtKernelInfo* info_copy);
 
+ORT_API_STATUS_IMPL(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
+
 ORT_API(const OrtTrainingApi*, GetTrainingApi, uint32_t version);
 
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CANN,

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -388,8 +388,6 @@ ORT_API_STATUS_IMPL(CopyKernelInfo, _In_ const OrtKernelInfo* info, _Outptr_ Ort
 
 ORT_API(void, ReleaseKernelInfo, _Frees_ptr_opt_ OrtKernelInfo* info_copy);
 
-ORT_API_STATUS_IMPL(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
-
 ORT_API(const OrtTrainingApi*, GetTrainingApi, uint32_t version);
 
 ORT_API_STATUS_IMPL(SessionOptionsAppendExecutionProvider_CANN,
@@ -405,4 +403,5 @@ ORT_API(void, ReleaseCANNProviderOptions, _Frees_ptr_opt_ OrtCANNProviderOptions
 
 ORT_API(void, MemoryInfoGetDeviceType, _In_ const OrtMemoryInfo* ptr, _Out_ OrtMemoryInfoDeviceType* out);
 
+ORT_API_STATUS_IMPL(UpdateEnvWithCustomLogLevel, OrtLoggingLevel log_severity_level, _In_ const OrtEnv* ort_env);
 }  // namespace OrtApis


### PR DESCRIPTION
### Description
* Add getter/setter to update and access C# OrtEnv log level
* Add C API about updating ort env with custom log level to support the setter above (Following [pybind implementation](https://github.com/microsoft/onnxruntime/blob/952c99304a764328070ac6c07f510deec06dedf4/onnxruntime/python/onnxruntime_pybind_state.cc#L923-L924))
* Add test case to verify getter & setter


### Motivation and Context
* For C++/Python, the log level can be adjusted via OrtEnv, and this feature is missing in C# binding
