### PR TITLE
Skip some models failed in Windows CPU C# tests

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -425,7 +425,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 //var modelRoot = new DirectoryInfo(Path.Combine(modelsDir, opsetDir.Name));
                 foreach (var modelDir in opsetDir.EnumerateDirectories())
                 {
+#if USE_CUDA
                     if (!skipModels.ContainsKey(modelDir.Name))
+#else
+                    if (!(skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase)))
+#endif
                     {
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };
                     }
@@ -443,7 +447,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 foreach (var modelDir in opsetDir.EnumerateDirectories())
                 {
+#if USE_CUDA
                     if (skipModels.ContainsKey(modelDir.Name))
+#else
+                    if (skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase))
+#endif
                     {
                         //Console.WriteLine("Model {0} is skipped due to the error: {1}", modelDir.FullName, skipModels[modelDir.Name]);
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -428,7 +428,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 #if USE_CUDA
                     if (!skipModels.ContainsKey(modelDir.Name))
 #else
-                    if (!(skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase)))
+                    if (!(skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
+                        modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase)))
 #endif
                     {
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };
@@ -450,7 +451,8 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 #if USE_CUDA
                     if (skipModels.ContainsKey(modelDir.Name))
 #else
-                    if (skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase))
+                    if (skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
+                        modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase))
 #endif
                     {
                         //Console.WriteLine("Model {0} is skipped due to the error: {1}", modelDir.FullName, skipModels[modelDir.Name]);

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -409,6 +409,13 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 skipModels["coreml_VGG16_ImageNet"] = "System out of memory";
                 skipModels["test_ssd"] = "System out of memory";
                 skipModels["roberta_sequence_classification"] = "System out of memory";
+                // models from model zoo
+                skipModels["VGG 19"] = "bad allocation";
+                skipModels["VGG 19-caffe2"] = "bad allocation";
+                skipModels["VGG 19-bn"] = "bad allocation";
+                skipModels["VGG 16"] = "bad allocation";
+                skipModels["VGG 16-bn"] = "bad allocation";
+                skipModels["VGG 16-fp32"] = "bad allocation";
             }
 
             return skipModels;
@@ -428,8 +435,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 #if USE_CUDA
                     if (!skipModels.ContainsKey(modelDir.Name))
 #else
-                    if (!(skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
-                        modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase)))
+                    if (!(skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase)))
 #endif
                     {
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };
@@ -451,8 +457,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 #if USE_CUDA
                     if (skipModels.ContainsKey(modelDir.Name))
 #else
-                    if (skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
-                        modelDir.Name.Contains("fp16", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase))
+                    if (skipModels.ContainsKey(modelDir.Name) || modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) || modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase))
 #endif
                     {
                         //Console.WriteLine("Model {0} is skipped due to the error: {1}", modelDir.FullName, skipModels[modelDir.Name]);


### PR DESCRIPTION
### Description
For models from model zoo, in C# tests of Windows CPU CI
skip models whose name contains int8 or qdq.
skip some models (VGG16, VGG19) in x86 workflow

### Motivation and Context
These models always failed in Windows CPU C# tests 
(https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=789442&view=results)


### verified
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=789861&view=results
C# tests passed
