### PR TITLE
Clone specific dldt version

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/install_openvino.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_openvino.sh
@@ -8,7 +8,7 @@ esac
 done
 
 OPENVINO_VERSION=${OPENVINO_VERSION:=2019_R1.1}
-git clone https://github.com/opencv/dldt.git /data/dldt/openvino_2019.1.144
+git clone --branch releases/2019/3 https://github.com/opencv/dldt.git /data/dldt/openvino_2019.1.144
 
 export INTEL_CVSDK_DIR=/data/dldt/openvino_2019.1.144
 apt-get update && apt-get -y  install libusb-1.0-0-dev


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
Modified git clone line to clone specific branch instead of main branch


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Motivation: I am trying to build nvidia trition  server v19.1 and this repo is one of the dependency and its build fails due to it clones wrong git branch of dldt repo.

Rel-1.0.0 build fails due to it clones wrong version dldt branch

