### PR TITLE
Skip some failed models winml and training workflows on Windows CPU 

### DIFF
--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -75,7 +75,7 @@ class ModelTest : public testing::TestWithParam<std::tuple<ITestCase*, winml::Le
     for (const auto& [name, value] : expectedOutputFeeds) {
       // Extract the output buffer from the evaluation output
       std::wstring outputName = _winml::Strings::WStringFromString(name);
-      
+
       // find the output descriptor
       ILearningModelFeatureDescriptor outputDescriptor = nullptr;
       for (const auto& descriptor : outputFeatureDescriptors) {
@@ -230,7 +230,7 @@ static std::vector<ITestCase*> GetAllTestCases() {
 // Bad onnx test output caused by previously wrong SAME_UPPER/SAME_LOWER for ConvTranspose
 allDisabledTests.insert(ORT_TSTR("cntk_simple_seg"));
 
-  
+
   WINML_EXPECT_NO_THROW(LoadTests(dataDirs, whitelistedTestCases, TestTolerances(1e-3, 1e-3, {}, {}),
                                   allDisabledTests,
                                   [&tests](std::unique_ptr<ITestCase> l) {
@@ -248,7 +248,7 @@ bool ShouldSkipTestOnGpuAdapterDxgi(std::string& testName) {
   while (spFactory->EnumAdapters1(i, spAdapter.put()) != DXGI_ERROR_NOT_FOUND) {
     DXGI_ADAPTER_DESC1 pDesc;
     WINML_EXPECT_HRESULT_SUCCEEDED(spAdapter->GetDesc1(&pDesc));
-    
+
     // Check if WARP adapter
     // see here for documentation on filtering WARP adapter:
     // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
@@ -281,7 +281,7 @@ bool ShouldSkipTestOnGpuAdapterDxcore(std::string& testName) {
   WINML_EXPECT_HRESULT_SUCCEEDED(spFactory->CreateAdapterList(1, gpuFilter, IID_PPV_ARGS(spAdapterList.put())));
 
   winrt::com_ptr<IDXCoreAdapter> firstHardwareAdapter;
-  
+
   // select first hardware adapter
   for (uint32_t i = 0; i < spAdapterList->GetAdapterCount(); i++) {
     winrt::com_ptr<IDXCoreAdapter> spCurrAdapter;
@@ -365,6 +365,13 @@ std::string GetFullNameOfTest(ITestCase* testCase, winml::LearningModelDeviceKin
   // The desired naming of the test is like this <model_name>_<opset>_<CPU/GPU>
   name += tokenizedModelPath[tokenizedModelPath.size() - 2] += "_";  // model name
   name += tokenizedModelPath[tokenizedModelPath.size() - 3];         // opset version
+
+  // To introduce models from model zoo, the model path is structured like this "<source>/<opset>/<model_name>/?.onnx"
+  std::string source = tokenizedModelPath[tokenizedModelPath.size() - 4];
+  // `models` means the root of models, to be ompatible with the old structure, that is, the source name is empty.
+  if (source != "models"){
+    name += "_" + source;
+  }
 
   std::replace_if(name.begin(), name.end(), [](char c) { return !google::protobuf::ascii_isalnum(c); }, '_');
 

--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -124,6 +124,22 @@ std::unordered_map<std::string, std::string> disabledTests(
      {"fp16_tiny_yolov2_opset8_GPU", "Bug 31005780: Result of fp16_test_tiny_yolov2_opset7 and fp16_coreml_FNS_Candy_opset7 models on DirectML aren't as accurate as on CPU https://microsoft.visualstudio.com/OS/_workitems/edit/31005780"},
      {"fp16_coreml_FNS_Candy_opset7_GPU", "Bug 31005780: Result of fp16_test_tiny_yolov2_opset7 and fp16_coreml_FNS_Candy_opset7 models on DirectML aren't as accurate as on CPU https://microsoft.visualstudio.com/OS/_workitems/edit/31005780"},
      {"mlperf_ssd_mobilenet_300_opset10_GPU", "Bug 31005624: mlperf_ssd_mobilenet_300 opset 10 model fails to evaluate in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005624"},
+
+     // from model zoo with source name
+     {"VGG_16_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"SSD_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"ShuffleNet_v2_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"ResNet50_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"ResNet50_qdq_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"MobileNet_v2_1_0_qdq_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"MobileNet_v2_1_0_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"Inception_1_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"Faster_R_CNN_R_50_FPN_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"BERT_Squad_int8_opset12_zoo_CPU", disabledTestDefaultReason},
+     {"FCN_ResNet_50_opset11_zoo_CPU", disabledTestDefaultReason},
+     {"FCN_ResNet_101_opset11_zoo_CPU", disabledTestDefaultReason},
+     {"EfficientNet_Lite4_qdq_opset11_zoo_CPU", disabledTestDefaultReason},
+     {"EfficientNet_Lite4_int8_opset11_zoo_CPU", disabledTestDefaultReason},
     }
 );
 

--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -125,21 +125,21 @@ std::unordered_map<std::string, std::string> disabledTests(
      {"fp16_coreml_FNS_Candy_opset7_GPU", "Bug 31005780: Result of fp16_test_tiny_yolov2_opset7 and fp16_coreml_FNS_Candy_opset7 models on DirectML aren't as accurate as on CPU https://microsoft.visualstudio.com/OS/_workitems/edit/31005780"},
      {"mlperf_ssd_mobilenet_300_opset10_GPU", "Bug 31005624: mlperf_ssd_mobilenet_300 opset 10 model fails to evaluate in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005624"},
 
-     // from model zoo with source name
-     {"VGG_16_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"SSD_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"ShuffleNet_v2_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"ResNet50_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"ResNet50_qdq_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"MobileNet_v2_1_0_qdq_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"MobileNet_v2_1_0_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"Inception_1_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"Faster_R_CNN_R_50_FPN_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"BERT_Squad_int8_opset12_zoo_CPU", disabledTestDefaultReason},
-     {"FCN_ResNet_50_opset11_zoo_CPU", disabledTestDefaultReason},
-     {"FCN_ResNet_101_opset11_zoo_CPU", disabledTestDefaultReason},
-     {"EfficientNet_Lite4_qdq_opset11_zoo_CPU", disabledTestDefaultReason},
-     {"EfficientNet_Lite4_int8_opset11_zoo_CPU", disabledTestDefaultReason},
+     // from model zoo
+     {"VGG_16_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"SSD_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"ShuffleNet_v2_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"ResNet50_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"ResNet50_qdq_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"MobileNet_v2_1_0_qdq_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"MobileNet_v2_1_0_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"Inception_1_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"Faster_R_CNN_R_50_FPN_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"BERT_Squad_int8_opset12_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"FCN_ResNet_50_opset11_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"FCN_ResNet_101_opset11_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"EfficientNet_Lite4_qdq_opset11_zoo_CPU", "https://github.com/onnx/models/issues/568"},
+     {"EfficientNet_Lite4_int8_opset11_zoo_CPU", "https://github.com/onnx/models/issues/568"},
     }
 );
 


### PR DESCRIPTION
### Description
1. update model name structure in model_tests.cpp with source name. To avoid
`Condition test_param_names.count(param_name) == 0 failed. Duplicate parameterized test name 'BERT_Squad_opset10_CPU'`
2. skip some failed models https://github.com/onnx/models/issues/568


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


