### PR TITLE
Update Attention operator to support separated Q/K/V inputs

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -85,14 +85,27 @@ Do not modify directly.*
 ## com.microsoft
 ### <a name="com.microsoft.Attention"></a><a name="com.microsoft.attention">**com.microsoft.Attention**</a>
 
-  Multi-Head Self Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
-  The mask_index input is optional. Besides raw attention mask with shape (batch_size, past_sequence_length + sequence_length)
-  or (batch_size, sequence_length, past_sequence_length + sequence_length) with value 0 for masked and 1 otherwise,
-  we also support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
+  Multi-Head Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
+  
+  The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension, its shape
+  is (input_hidden_size, num_heads * q_head_size + num_heads * q_head_size + num_heads * v_head_size).
+  
+  The mask_index is optional. Besides raw attention mask with shape (batch_size, total_sequence_length)
+  or (batch_size, sequence_length, total_sequence_length) with value 0 for masked and 1 otherwise,
+  we support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
   where value of each element is the end position, or valid length of actual sequence excluding padding. When input has
   left-side padding, mask_index has shape (2 * batch_size), where the values are the exclusive end positions followed by
-  the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. For GPT-2, both past
-  and present state are optional. Present state could appear in output even when past state is not in input.
+  the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. Both
+  past and present state are optional.
+  
+  When weights is not provided, key and value are required. In this situation, MatMul for input projection is excluded,
+  and input is the query after projection. Add bias is included for performance consideration.
+  
+  The qkv_hidden_sizes is required only when K and V has different hidden size.
+  
+  When there is past state, hidden dimension for Q, K and V shall be the same.
+  
+  The total_sequence_length is past_sequence_length + kv_sequence_length.
 
 #### Version
 
@@ -104,35 +117,39 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>num_heads</tt> : int (required)</dt>
 <dd>Number of attention heads</dd>
 <dt><tt>qkv_hidden_sizes</tt> : list of ints</dt>
-<dd>Hidden layer sizes of Q, K, V paths in Attention</dd>
+<dd>Hidden dimension of Q, K, V: hidden_size, hidden_size and v_hidden_size</dd>
 <dt><tt>unidirectional</tt> : int</dt>
 <dd>Whether every token can only attend to previous tokens. Default value is 0.</dd>
 </dl>
 
-#### Inputs (3 - 6)
+#### Inputs (3 - 8)
 
 <dl>
-<dt><tt>input</tt> : T</dt>
-<dd>3D input tensor with shape (batch_size, sequence_length, input_hidden_size)</dd>
-<dt><tt>weight</tt> : T</dt>
-<dd>2D input tensor with shape (input_hidden_size, 3 * hidden_size), where hidden_size = num_heads * head_size</dd>
+<dt><tt>input</tt> (optional) : T</dt>
+<dd>Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is avaiable, or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not avaiable.</dd>
+<dt><tt>weights</tt> (optional) : T</dt>
+<dd>Merged Q/K/V weights with shape (input_hidden_size, hidden_size + hidden_size + v_hidden_size)</dd>
 <dt><tt>bias</tt> : T</dt>
-<dd>1D input tensor with shape (3 * hidden_size)</dd>
+<dd>Bias tensor with shape (hidden_size + hidden_size + v_hidden_size) for input projection</dd>
 <dt><tt>mask_index</tt> (optional) : M</dt>
-<dd>Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), (batch_size, past_sequence_length + sequence_length)or (batch_size, sequence_length, past_sequence_length + sequence_length), or index with shape (batch_size) or (2 * batch_size).</dd>
+<dd>Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), (batch_size, total_sequence_length) or (batch_size, sequence_length, total_sequence_length), or index with shape (batch_size) or (2 * batch_size).</dd>
 <dt><tt>past</tt> (optional) : T</dt>
 <dd>past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).</dd>
 <dt><tt>extra_add</tt> (optional) : T</dt>
 <dd>additional add to QxK' with shape (batch_size, num_heads, sequence_length, sequence_length).</dd>
+<dt><tt>key</tt> (optional) : T</dt>
+<dd>Input for key with shape (batch_size, kv_sequence_length, hidden_size). Required when weights is not avaiable</dd>
+<dt><tt>value</tt> (optional) : T</dt>
+<dd>Input for key with shape (batch_size, kv_sequence_length, v_hidden_size). Required when weights is not avaiable</dd>
 </dl>
 
 #### Outputs (1 - 2)
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>3D output tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+<dd>3D output tensor with shape (batch_size, sequence_length, v_hidden_size)</dd>
 <dt><tt>present</tt> (optional) : T</dt>
-<dd>present state for key and value with shape (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)</dd>
+<dd>past state for key and value with shape (2, batch_size, num_heads, total_sequence_length, head_size)</dd>
 </dl>
 
 #### Type Constraints

--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -87,25 +87,30 @@ Do not modify directly.*
 
   Multi-Head Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
   
-  The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension, its shape
-  is (input_hidden_size, num_heads * q_head_size + num_heads * q_head_size + num_heads * v_head_size).
+  The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension. Its shape
+  is (input_hidden_size, hidden_size + hidden_size + v_hidden_size). Here hidden_size is the hidden dimension of Q and K,
+  and v_hidden_size is that of V.
   
   The mask_index is optional. Besides raw attention mask with shape (batch_size, total_sequence_length)
   or (batch_size, sequence_length, total_sequence_length) with value 0 for masked and 1 otherwise,
   we support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
-  where value of each element is the end position, or valid length of actual sequence excluding padding. When input has
-  left-side padding, mask_index has shape (2 * batch_size), where the values are the exclusive end positions followed by
-  the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. Both
-  past and present state are optional.
+  where value is actual sequence length excluding padding. When input has left-side padding, mask_index has
+  shape (2 * batch_size), where the values are the exclusive end positions followed by the inclusive start positions.
+  
+  When unidirectional is 1, each token only attends to previous tokens.
+  
+  Both past and present state are optional. They shall be used together, and not allowed to use only one of them.
   
   When weights is not provided, key and value are required. In this situation, MatMul for input projection is excluded,
-  and input is the query after projection. Add bias is included for performance consideration.
+  and input is the query after projection. The bias is included for performance consideration.
   
-  The qkv_hidden_sizes is required only when K and V has different hidden size.
+  The qkv_hidden_sizes is required only when K and V have different hidden sizes.
   
   When there is past state, hidden dimension for Q, K and V shall be the same.
   
-  The total_sequence_length is past_sequence_length + kv_sequence_length.
+  The total_sequence_length is past_sequence_length + kv_sequence_length. Here kv_sequence_length is the length of K or V.
+  For self attention, kv_sequence_length equals to sequence_length (sequence length of Q).
+  For cross attention, query and key might have different lengths.
 
 #### Version
 
@@ -126,7 +131,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>input</tt> (optional) : T</dt>
-<dd>Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is avaiable, or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not avaiable.</dd>
+<dd>Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is available, or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not available.</dd>
 <dt><tt>weights</tt> (optional) : T</dt>
 <dd>Merged Q/K/V weights with shape (input_hidden_size, hidden_size + hidden_size + v_hidden_size)</dd>
 <dt><tt>bias</tt> : T</dt>
@@ -134,13 +139,13 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>mask_index</tt> (optional) : M</dt>
 <dd>Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), (batch_size, total_sequence_length) or (batch_size, sequence_length, total_sequence_length), or index with shape (batch_size) or (2 * batch_size).</dd>
 <dt><tt>past</tt> (optional) : T</dt>
-<dd>past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).</dd>
+<dd>past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size)</dd>
 <dt><tt>extra_add</tt> (optional) : T</dt>
-<dd>additional add to QxK' with shape (batch_size, num_heads, sequence_length, sequence_length).</dd>
+<dd>additional add to QxK' with shape (batch_size, num_heads, sequence_length, total_sequence_length)</dd>
 <dt><tt>key</tt> (optional) : T</dt>
-<dd>Input for key with shape (batch_size, kv_sequence_length, hidden_size). Required when weights is not avaiable</dd>
+<dd>Input for key with shape (batch_size, kv_sequence_length, hidden_size). Required when weights is not available.</dd>
 <dt><tt>value</tt> (optional) : T</dt>
-<dd>Input for key with shape (batch_size, kv_sequence_length, v_hidden_size). Required when weights is not avaiable</dd>
+<dd>Input for key with shape (batch_size, kv_sequence_length, v_hidden_size). Required when weights is not available.</dd>
 </dl>
 
 #### Outputs (1 - 2)

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -151,7 +151,8 @@ Do not modify directly.*
 |||[1, 12]|**T** = tensor(float)|
 |LSTM|*in* X:**T**<br> *in* W:**T**<br> *in* R:**T**<br> *in* B:**T**<br> *in* sequence_lens:**T1**<br> *in* initial_h:**T**<br> *in* initial_c:**T**<br> *in* P:**T**<br> *out* Y:**T**<br> *out* Y_h:**T**<br> *out* Y_c:**T**|14+|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
 |||[7, 13]|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
-|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|1+|**T** = tensor(double), tensor(float)<br/> **U** = tensor(double), tensor(float)<br/> **V** = tensor(double), tensor(float)|
+|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|17+|**T** = tensor(double), tensor(float)<br/> **U** = tensor(float)|
+|||[1, 16]|**T** = tensor(double), tensor(float)<br/> **U** = tensor(double), tensor(float)<br/> **V** = tensor(double), tensor(float)|
 |LeakyRelu|*in* X:**T**<br> *out* Y:**T**|16+|**T** = tensor(float)|
 |||[6, 15]|**T** = tensor(float)|
 |Less|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T1**|13+|**T** = tensor(double), tensor(float), tensor(int32), tensor(int64)<br/> **T1** = tensor(bool)|
@@ -394,7 +395,7 @@ Do not modify directly.*
 | |
 | |
 |**Operator Domain:** *com.microsoft*||||
-|Attention|*in* input:**T**<br> *in* weight:**T**<br> *in* bias:**T**<br> *in* mask_index:**M**<br> *in* past:**T**<br> *in* extra_add:**T**<br> *out* output:**T**<br> *out* present:**T**|1+|**T** = tensor(float)|
+|Attention|*in* input:**T**<br> *in* weights:**T**<br> *in* bias:**T**<br> *in* mask_index:**M**<br> *in* past:**T**<br> *in* extra_add:**T**<br> *in* key:**T**<br> *in* value:**T**<br> *out* output:**T**<br> *out* present:**T**|1+|**T** = tensor(float)|
 |AttnLSTM|*in* X:**T**<br> *in* W:**T**<br> *in* R:**T**<br> *in* B:**T**<br> *in* sequence_lens:**T1**<br> *in* initial_h:**T**<br> *in* initial_c:**T**<br> *in* P:**T**<br> *in* QW:**T**<br> *in* MW:**T**<br> *in* V:**T**<br> *in* M:**T**<br> *in* memory_seq_lens:**T1**<br> *in* AW:**T**<br> *out* Y:**T**<br> *out* Y_h:**T**<br> *out* Y_c:**T**|1+|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
 |BeamSearch|*in* input_ids:**I**<br> *in* max_length:**I**<br> *in* min_length:**I**<br> *in* num_beams:**I**<br> *in* num_return_sequences:**I**<br> *in* length_penalty:**T**<br> *in* repetition_penalty:**T**<br> *in* vocab_mask:**M**<br> *in* prefix_vocab_mask:**M**<br> *in* attention_mask:**I**<br> *out* sequences:**I**<br> *out* sequences_scores:**T**<br> *out* scores:**T**|1+|**T** = tensor(float)|
 |BiasGelu|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|1+|**T** = tensor(float)|
@@ -570,7 +571,8 @@ Do not modify directly.*
 |||[1, 12]|**T** = tensor(double), tensor(float), tensor(float16)|
 |LSTM|*in* X:**T**<br> *in* W:**T**<br> *in* R:**T**<br> *in* B:**T**<br> *in* sequence_lens:**T1**<br> *in* initial_h:**T**<br> *in* initial_c:**T**<br> *in* P:**T**<br> *out* Y:**T**<br> *out* Y_h:**T**<br> *out* Y_c:**T**|14+|**T** = tensor(double), tensor(float), tensor(float16)<br/> **T1** = tensor(int32)|
 |||[7, 13]|**T** = tensor(double), tensor(float), tensor(float16)<br/> **T1** = tensor(int32)|
-|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float)<br/> **V** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
+|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|17+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(float)|
+|||[1, 16]|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float)<br/> **V** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |LeakyRelu|*in* X:**T**<br> *out* Y:**T**|16+|**T** = tensor(double), tensor(float), tensor(float16)|
 |||[6, 15]|**T** = tensor(double), tensor(float), tensor(float16)|
 |Less|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T1**|13+|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)<br/> **T1** = tensor(bool)|
@@ -1062,7 +1064,7 @@ Do not modify directly.*
 | |
 | |
 |**Operator Domain:** *com.microsoft*||||
-|Attention|*in* input:**T**<br> *in* weight:**T**<br> *in* bias:**T**<br> *in* mask_index:**M**<br> *in* past:**T**<br> *in* extra_add:**T**<br> *out* output:**T**<br> *out* present:**T**|1+|**T** = tensor(float), tensor(float16)|
+|Attention|*in* input:**T**<br> *in* weights:**T**<br> *in* bias:**T**<br> *in* mask_index:**M**<br> *in* past:**T**<br> *in* extra_add:**T**<br> *in* key:**T**<br> *in* value:**T**<br> *out* output:**T**<br> *out* present:**T**|1+|**T** = tensor(float), tensor(float16)|
 |BeamSearch|*in* input_ids:**I**<br> *in* max_length:**I**<br> *in* min_length:**I**<br> *in* num_beams:**I**<br> *in* num_return_sequences:**I**<br> *in* length_penalty:**T**<br> *in* repetition_penalty:**T**<br> *in* vocab_mask:**M**<br> *in* prefix_vocab_mask:**M**<br> *in* attention_mask:**I**<br> *out* sequences:**I**<br> *out* sequences_scores:**T**<br> *out* scores:**T**|1+|**T** = tensor(float), tensor(float16)|
 |BiasDropout|*in* data:**T**<br> *in* bias:**T**<br> *in* residual:**T**<br> *in* ratio:**T1**<br> *in* training_mode:**T2**<br> *out* output:**T**<br> *out* mask:**T2**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **T2** = tensor(bool)|
 |BiasGelu|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
@@ -1074,6 +1076,7 @@ Do not modify directly.*
 |ConvTransposeWithDynamicPads|*in* X:**T**<br> *in* W:**T**<br> *in* Pads:**tensor(int64)**<br> *in* B:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
 |DecoderAttention|*in* query:**T**<br> *in* key:**T**<br> *in* q_weight:**T**<br> *in* kv_weight:**T**<br> *in* bias:**T**<br> *in* key_padding_mask:**B**<br> *in* key_cache:**T**<br> *in* value_cache:**T**<br> *in* static_kv:**B**<br> *in* use_past:**B**<br> *in* has_layer_state:**B**<br> *in* has_key_padding_mask:**B**<br> *out* output:**T**<br> *out* new_key_cache:**T**<br> *out* new_value_cache:**T**|1+|**T** = tensor(float), tensor(float16)|
 |DequantizeLinear|*in* x:**T1**<br> *in* x_scale:**T2**<br> *in* x_zero_point:**T1**<br> *out* y:**T2**|1+|**T1** = tensor(int8), tensor(uint8)<br/> **T2** = tensor(float16)|
+|DequantizeWithOrder|*in* input:**Q**<br> *in* scale_input:**S**<br> *out* output:**F**|1+|**F** = tensor(float), tensor(float16)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
 |EmbedLayerNormalization|*in* input_ids:**T1**<br> *in* segment_ids:**T1**<br> *in* word_embedding:**T**<br> *in* position_embedding:**T**<br> *in* segment_embedding:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* mask:**T1**<br> *in* position_ids:**T1**<br> *out* output:**T**<br> *out* mask_index:**T1**<br> *out* embedding_sum:**T**|1+|**T** = tensor(float), tensor(float16)|
 |FastGelu|*in* X:**T**<br> *in* bias:**T**<br> *out* Y:**T**|1+|**T** = tensor(bfloat16), tensor(float), tensor(float16)|
 |FusedConv|*in* X:**T**<br> *in* W:**T**<br> *in* B:**T**<br> *in* Z:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
@@ -1086,10 +1089,13 @@ Do not modify directly.*
 |LongformerAttention|*in* input:**T**<br> *in* weight:**T**<br> *in* bias:**T**<br> *in* mask:**T**<br> *in* global_weight:**T**<br> *in* global_bias:**T**<br> *in* global:**G**<br> *out* output:**T**|1+|**T** = tensor(float), tensor(float16)|
 |NGramRepeatBlock|*in* input_ids:**Tid**<br> *in* scores:**T**<br> *out* scores_out:**T**|1+|**T** = tensor(float)<br/> **Tid** = tensor(int64)|
 |QAttention|*in* input:**T1**<br> *in* weight:**T2**<br> *in* bias:**T3**<br> *in* input_scale:**T3**<br> *in* weight_scale:**T3**<br> *in* mask_index:**T4**<br> *in* input_zero_point:**T1**<br> *in* weight_zero_point:**T2**<br> *in* past:**T3**<br> *out* output:**T3**<br> *out* present:**T3**|1+|**T1** = tensor(int8)<br/> **T2** = tensor(int8)<br/> **T3** = tensor(float), tensor(float16)<br/> **T4** = tensor(int32)|
+|QOrderedAttention|*in* input:**Q**<br> *in* scale_input:**S**<br> *in* scale_Q_gemm:**S**<br> *in* scale_K_gemm:**S**<br> *in* scale_V_gemm:**S**<br> *in* Q_weight:**Q**<br> *in* K_weight:**Q**<br> *in* V_weight:**Q**<br> *in* scale_Q_weight:**S**<br> *in* scale_K_weight:**S**<br> *in* scale_V_weight:**S**<br> *in* Q_bias:**S**<br> *in* K_bias:**S**<br> *in* V_bias:**S**<br> *in* scale_QKT_gemm:**S**<br> *in* scale_QKT_softmax:**S**<br> *in* scale_values_gemm:**S**<br> *in* mask_index:**G**<br> *in* past:**Q**<br> *in* extra_add:**S**<br> *out* output:**Q**|1+|**G** = tensor(int32)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
 |QOrderedGelu|*in* X:**Q**<br> *in* scale_X:**S**<br> *in* scale_Y:**S**<br> *out* Y:**Q**|1+|**Q** = tensor(int8)<br/> **S** = tensor(float)|
 |QOrderedLayerNormalization|*in* X:**Q**<br> *in* scale_X:**S**<br> *in* scale:**F**<br> *in* B:**F**<br> *in* scale_Y:**S**<br> *out* Y:**Q**|1+|**F** = tensor(float), tensor(float16)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
+|QOrderedLongformerAttention|*in* input:**Q**<br> *in* scale_input:**S**<br> *in* weight:**Q**<br> *in* scale_weight:**S**<br> *in* bias:**S**<br> *in* scale_bias:**S**<br> *in* scale_qkv_gemm:**S**<br> *in* mask:**F**<br> *in* global_weight:**Q**<br> *in* scale_global_weight:**S**<br> *in* global_bias:**S**<br> *in* scale_global_gemm:**S**<br> *in* global:**G**<br> *in* scale_output:**S**<br> *out* output:**Q**|1+|**F** = tensor(float16)<br/> **G** = tensor(int32)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
 |QOrderedMatMul|*in* A:**Q**<br> *in* scale_A:**S**<br> *in* B:**Q**<br> *in* scale_B:**S**<br> *in* scale_Y:**S**<br> *in* bias:**S**<br> *in* C:**Q**<br> *in* scale_C:**S**<br> *out* Y:**Q**|1+|**Q** = tensor(int8)<br/> **S** = tensor(float)|
 |QuantizeLinear|*in* x:**T1**<br> *in* y_scale:**T1**<br> *in* y_zero_point:**T2**<br> *out* y:**T2**|1+|**T1** = tensor(float16)<br/> **T2** = tensor(int8), tensor(uint8)|
+|QuantizeWithOrder|*in* input:**F**<br> *in* scale_input:**S**<br> *out* output:**Q**|1+|**F** = tensor(float), tensor(float16)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
 |Rfft|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
 |SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**|1+|**T** = tensor(float), tensor(float16)|
 |TransposeMatMul|*in* A:**T**<br> *in* B:**T**<br> *out* Y:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|

--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -58,255 +58,8 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
         .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
     Attention<float>);
 
-Status AttentionBase::CheckInputs(const TensorShape& input_shape,
-                                  const TensorShape& weights_shape,
-                                  const TensorShape& bias_shape,
-                                  const Tensor*& mask_index,
-                                  const Tensor* past,
-                                  const Tensor* extra_add_qk) const {
-  // Input shapes:
-  //   input       : (batch_size, sequence_length, input_hidden_size)
-  //   weights     : (input_hidden_size, 3 * hidden_size)
-  //   bias        : (3 * hidden_size)
-  //   mask_index  : nullptr, (batch_size), (2 * batch_size),
-  //                 or (batch_size, 1), (1, 1)
-  //                 or (batch_size, past_sequence_length + sequence_length)
-  //                 or (batch_size, sequence_length, past_sequence_length + sequence_length)
-  //   past        : (2, batch_size, num_heads, past_sequence_length, head_size)
-  //   extra_add_qk: (batch_size, num_heads, sequence_length, sequence_length)
-  //
-  // Where hidden_size = num_heads * head_size.
-  // When a model is pruned (like some attention heads are removed), hidden_size < input_hidden_size.
-
-  if (past != nullptr && extra_add_qk != nullptr) {
-    // past is used on GPT-2 model with past state, we don't have a case for extra add qk yet
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Attention cannot have past sequence and extra add qk");
-  }
-
-  const auto& dims = input_shape.GetDims();
-  if (dims.size() != 3) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'input' is expected to have 3 dimensions, got ",
-                           dims.size());
-  }
-  int batch_size = static_cast<int>(dims[0]);
-  int sequence_length = static_cast<int>(dims[1]);
-
-  const auto& weights_dims = weights_shape.GetDims();
-  if (weights_dims.size() != 2) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'weights' is expected to have 2 dimensions, got ",
-                           weights_dims.size());
-  }
-  if (weights_dims[0] != dims[2]) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "Input 1 dimension 0 should have same length as dimension 2 of input 0");
-  }
-
-  const auto& bias_dims = bias_shape.GetDims();
-  if (bias_dims.size() != 1) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'bias' is expected to have 1 dimension, got ",
-                           bias_dims.size());
-  }
-
-  int hidden_size = 0;
-
-  if (qkv_hidden_sizes_.size() == 0) {
-    hidden_size = static_cast<int>(weights_dims[1]) / 3;
-    if (3 * hidden_size != static_cast<int>(weights_dims[1])) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 1 dimension 1 should be 3 times of hidden dimension");
-    }
-
-    if (hidden_size % num_heads_ != 0) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "hidden_size should be divisible by num_heads.");
-    }
-  } else {
-    int qkv_sizes = 0;
-
-    if (qkv_hidden_sizes_.size() != 3) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "qkv_hidden_sizes attribute should have 3 elements");
-    }
-
-    if (qkv_hidden_sizes_[0] != qkv_hidden_sizes_[1]) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "qkv_hidden_sizes first element should be same as the second");
-    }
-
-    for (size_t i = 0; i < qkv_hidden_sizes_.size(); i++) {
-      if (qkv_hidden_sizes_[i] % num_heads_ != 0) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "hidden_size should be divisible by num_heads:", qkv_hidden_sizes_[i]);
-      }
-
-      qkv_sizes += static_cast<int>(qkv_hidden_sizes_[i]);
-    }
-
-    int qkv_hidden_sizes_sum = static_cast<int>(weights_dims[1]);
-    if (qkv_hidden_sizes_sum != qkv_sizes) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "qkv_sizes doesn't match the wights dimension");
-    }
-
-    hidden_size = static_cast<int>(qkv_hidden_sizes_[2]);
-  }
-
-  if (bias_dims[0] != weights_dims[1]) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "Input 'bias' dimension 0 should have same length as dimension 1 of input 'weights'");
-  }
-
-  int past_sequence_length = 0;
-  if (past != nullptr) {  // past is optional
-    const auto& past_dims = past->Shape().GetDims();
-    if (past_dims.size() != 5) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'past' is expected to have 5 dimension, got ",
-                             past_dims.size());
-    }
-    if (static_cast<int>(past_dims[0]) != 2) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'past' dimension 0 shall have length of 2");
-    }
-    if (static_cast<int>(past_dims[1]) != batch_size) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Inputs 'past' dimension 1 shall have same length as dimension 0 of input 0");
-    }
-    if (static_cast<int>(past_dims[2]) != num_heads_) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Inputs 'past' dimension 2 shall have length of num_heads", num_heads_);
-    }
-    if (static_cast<int>(past_dims[4]) != hidden_size / num_heads_) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Inputs 'past' dimension 2 shall have length of ", hidden_size / num_heads_);
-    }
-    past_sequence_length = static_cast<int>(past_dims[3]);
-  }
-
-  if (mask_index != nullptr) {  // mask_index is optional
-    const auto& mask_dims = mask_index->Shape().GetDims();
-    if (mask_dims.size() == 1) {
-      if (static_cast<int>(mask_dims[0]) != batch_size && static_cast<int>(mask_dims[0]) != 2 * batch_size) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "Inputs 'mask_index' with 1D data shall have length of batch_size or 2 * batch_size");
-      }
-    } else if (mask_dims.size() == 2) {
-      if (static_cast<int>(mask_dims[0]) != batch_size ||
-          static_cast<int>(mask_dims[1]) != past_sequence_length + sequence_length) {
-        // Add operator supports broadcasting. Here we handle a case with only one element in the 2nd dimension.
-        if ((static_cast<int>(mask_dims[0]) == batch_size || static_cast<int>(mask_dims[0]) == 1) &&
-            static_cast<int>(mask_dims[1]) == 1) {
-          // Mask will have same value after propagation, which has same effect as no mask.
-          mask_index = nullptr;
-        } else {
-          return ORT_MAKE_STATUS(
-              ONNXRUNTIME, INVALID_ARGUMENT,
-              "Inputs 'mask_index' with 2D data shall have shape "
-              "batch_size x (past_sequence_length + sequence_length)");
-        }
-      }
-    } else if (mask_dims.size() == 3) {
-      if (static_cast<int>(mask_dims[0]) != batch_size ||
-          mask_dims[1] != sequence_length ||
-          static_cast<int>(mask_dims[2]) != past_sequence_length + sequence_length) {
-        return ORT_MAKE_STATUS(
-            ONNXRUNTIME, INVALID_ARGUMENT,
-            "Inputs 'mask_index' with 3D data shall have shape "
-            "batch_size x sequence_length x (past_sequence_length + sequence_length)");
-      }
-    } else if (mask_dims.size() == 4) {
-      if (static_cast<int>(mask_dims[0]) != batch_size ||
-          mask_dims[1] != 1 ||
-          mask_dims[2] != mask_dims[3] ||
-          mask_dims[2] < static_cast<int64_t>(past_sequence_length) + sequence_length) {
-        return ORT_MAKE_STATUS(
-            ONNXRUNTIME, INVALID_ARGUMENT,
-            "Inputs 'mask_index' with 4D data shall have shape "
-            "batch_size x 1 x max_sequence_length x max_sequence_length)");
-      }
-      if (is_unidirectional_ == true) {
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "Inputs 'mask_index' with 4D data shall have is_unidirectional_ set to false");
-      }
-    } else {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'mask_index' is expected to have 1, 2, 3 or 4 dimensions, got ",
-                             mask_dims.size());
-    }
-  }
-
-  if (extra_add_qk != nullptr) {
-    const auto& extra_add_qk_dims = extra_add_qk->Shape().GetDims();
-
-    if (extra_add_qk_dims.size() != 4) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'extra_add_qk' is expected to have 4 dimensions, got ",
-                             extra_add_qk_dims.size());
-    }
-
-    if (extra_add_qk_dims[0] != batch_size) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'extra_add_qk' dimension 0 should be same as batch_size, got ",
-                             extra_add_qk_dims[0]);
-    }
-    if (extra_add_qk_dims[1] != num_heads_) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'extra_add_qk' dimension 1 should be same as number of heads, got ",
-                             extra_add_qk_dims[1]);
-    }
-    if (extra_add_qk_dims[2] != sequence_length) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'extra_add_qk' dimension 2 should be same as sequence_length, got ",
-                             extra_add_qk_dims[2]);
-    }
-    if (extra_add_qk_dims[3] != sequence_length) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Input 'extra_add_qk' dimension 3 should be same as sequence_length, got ",
-                             extra_add_qk_dims[3]);
-    }
-  }
-
-  return Status::OK();
-}
-
-Status AttentionBase::CheckInputs(const TensorShape& input_shape,
-                                  const TensorShape& weights_shape,
-                                  const TensorShape& bias_shape,
-                                  const Tensor*& mask_index,
-                                  const Tensor* past,
-                                  const Tensor* extra_add_qk,
-                                  const int max_threads_per_block) const {
-  if (num_heads_ > max_threads_per_block) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
-  }
-
-  return CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past, extra_add_qk);
-}
-
-Tensor* AttentionBase::GetPresent(OpKernelContext* context,
-                                  const Tensor* past,
-                                  int batch_size,
-                                  int head_size,
-                                  int sequence_length,
-                                  int& past_sequence_length) const {
-  // Input and output shapes:
-  //   past        : (2, batch_size, num_heads, past_sequence_length, head_size)
-  //   present     : (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)
-
-  std::vector<int64_t> present_dims{2, batch_size, num_heads_, sequence_length, head_size};
-  if (nullptr != past) {
-    const auto& past_dims = past->Shape().GetDims();
-    past_sequence_length = static_cast<int>(past_dims[3]);
-    present_dims[3] += past_dims[3];
-  }
-
-  TensorShape present_shape(present_dims);
-  Tensor* present = context->Output(1, present_shape);
-  if (nullptr != past && nullptr == present) {
-    ORT_THROW("Expect to have present state output when past state input is given");
-  }
-
-  return present;
-}
-
 template <typename T>
-Attention<T>::Attention(const OpKernelInfo& info) : OpKernel(info), AttentionCPUBase(info) {
+Attention<T>::Attention(const OpKernelInfo& info) : OpKernel(info), AttentionCPUBase(info, false, true) {
 }
 
 template <typename T>
@@ -447,69 +200,51 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
   const Tensor* past = context->Input<Tensor>(4);
   const Tensor* extra_add_qk = context->Input<Tensor>(5);
 
+  const Tensor* key = context->Input<Tensor>(6);
+  const Tensor* value = context->Input<Tensor>(7);
+
   const TensorShape& weights_shape = (weights ? weights->Shape() : weight_shape_);
+
+  AttentionParameters parameters;
   ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(),
-                                  weights_shape,
+                                  (nullptr != weights || is_prepack_) ? &weights_shape : nullptr,
                                   bias->Shape(),
                                   mask_index,
                                   past,
-                                  extra_add_qk));
+                                  extra_add_qk,
+                                  key,
+                                  value,
+                                  &parameters));
 
-  const auto shape = input->Shape().GetDims();
-  const int batch_size = static_cast<int>(shape[0]);
-  const int sequence_length = static_cast<int>(shape[1]);
-  const int input_hidden_size = static_cast<int>(shape[2]);
-
-  int hidden_size;
-
-  if (qkv_hidden_sizes_.size() == 0) {
-    const auto& weights_dims = weights_shape.GetDims();
-    hidden_size = static_cast<int>(weights_dims[1]) / 3;
-  } else {
-    hidden_size = static_cast<int>(qkv_hidden_sizes_[2]);
-  }
-
-  const int head_size = hidden_size / num_heads_;
+  const int batch_size = parameters.batch_size;
+  const int sequence_length = parameters.sequence_length;
+  const int input_hidden_size = parameters.input_hidden_size;
 
   std::vector<int64_t> output_shape(3);
-  output_shape[0] = shape[0];
-  output_shape[1] = shape[1];
-  output_shape[2] = static_cast<int64_t>(hidden_size);
+  output_shape[0] = static_cast<int64_t>(batch_size);
+  output_shape[1] = static_cast<int64_t>(sequence_length);
+  output_shape[2] = static_cast<int64_t>(parameters.v_hidden_size);
   Tensor* output = context->Output(0, output_shape);
 
   constexpr size_t element_size = sizeof(T);
-
-  int q_hidden_size = 0;
-  int k_hidden_size = 0;
-  int v_hidden_size = 0;
-  if (qkv_hidden_sizes_.size() == 0) {
-    q_hidden_size = hidden_size;
-    k_hidden_size = hidden_size;
-    v_hidden_size = hidden_size;
-  } else {
-    q_hidden_size = static_cast<int>(qkv_hidden_sizes_[0]);
-    k_hidden_size = static_cast<int>(qkv_hidden_sizes_[1]);
-    v_hidden_size = static_cast<int>(qkv_hidden_sizes_[2]);
-  }
-  const int qkv_head_size[3] = {q_hidden_size / num_heads_, k_hidden_size / num_heads_, v_hidden_size / num_heads_};
 
   AllocatorPtr allocator;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
 
   auto* tp = context->GetOperatorThreadPool();
   // Compute Q, K, V
-  // gemm_data(BS, NT) = input(BS, D) x weights(D, NT) + bias(NT)
-  // D (input_hidden_size) is hidden dimension of input, where D could be larger than any of the hidden_sizes
-  // (NH) when model is pruned. T = H1 + H2 + H3, where H1, H2, H3 are head sizes of Q, K, V respectively
-  int qkv_hidden_size = (q_hidden_size + k_hidden_size + v_hidden_size);
+  // gemm_data(BS, D_t) = input(BS, D_i) x weights(D_i, D_t) + bias(D_t), where D_t = D + D + D_v
+  // Hidden dimension of input could be larger than that of Q, K and V when model is pruned.
+  int qkv_hidden_size = (parameters.hidden_size + parameters.hidden_size + parameters.v_hidden_size);
   auto gemm_data = allocator->Alloc(SafeInt<size_t>(batch_size) * sequence_length * qkv_hidden_size * element_size);
   BufferUniquePtr gemm_buffer(gemm_data, BufferDeleter(std::move(allocator)));
 
   auto Q = reinterpret_cast<T*>(gemm_data);
-  auto K = Q + static_cast<size_t>(batch_size) * sequence_length * q_hidden_size;
-  auto V = K + static_cast<size_t>(batch_size) * sequence_length * k_hidden_size;
+  auto K = Q + static_cast<size_t>(batch_size) * sequence_length * parameters.hidden_size;
+  auto V = K + static_cast<size_t>(batch_size) * sequence_length * parameters.hidden_size;
 
   T* QKV[3] = {Q, K, V};
+  const int qkv_head_size[3] = {parameters.head_size, parameters.head_size, parameters.v_head_size};
 
   {
     const int loop_len = 3 * batch_size * num_heads_;
@@ -517,8 +252,10 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
     const auto* weights_data = weights ? weights->Data<T>() : nullptr;
     const auto* bias_data = bias->Data<T>();
 
-    const double cost =
-        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(input_hidden_size);
+    // We use Q/K head size to estimate the cost, this is not accurate when Q/K and V head sizes are different.
+    const double cost = static_cast<double>(sequence_length) *
+                        static_cast<double>(parameters.head_size) * static_cast<double>(input_hidden_size);
+
     ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       for (std::ptrdiff_t i = begin; i != end; ++i) {
         const int batch_index = static_cast<int>((i / 3) / num_heads_);
@@ -530,7 +267,7 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
         T* qkv_dest = QKV[qkv_index];
         int head_size = qkv_head_size[qkv_index];
         int weights_offset = 0;
-        int bias_offset = qkv_index * q_hidden_size + head_index * head_size;
+        int bias_offset = qkv_index * parameters.hidden_size + head_index * head_size;
 
         if (!is_prepack_) {
           weights_offset = bias_offset;
@@ -551,9 +288,10 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
         }
 
         //                   original           transposed            iteration
-        // A: input          (BxSxD)            (B.)S x D             S x D
-        // B: weights        (DxNxT)             D x (N.)T            D x H
-        // C: QKV[qkv_index] (BxNxSxT)          (B.N.)S x T           S x H
+        // A: input          (BxSxD_i)          (B.)S x D_i           S x D_i
+        // B: weights        (D_ixNxH_t)        D_i x (N.)H_t         D_i x H_t
+        // C: QKV[qkv_index] (BxNxSxH_t)        (B.N.)S x H_t         S x H_t
+        // Here H_t = H + H + H_v is size of one head of Q, K and V
         if (is_prepack_) {
           uint8_t* packed_weight;
           packed_weight = static_cast<uint8_t*>(packed_weights_[qkv_index].get()) +
@@ -574,20 +312,20 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
               nullptr);                   // use single-thread
         } else {
           math::GemmEx<float, ThreadPool>(
-              CblasNoTrans,                                   // TransA = no
-              CblasNoTrans,                                   // TransB = no
-              sequence_length,                                // M      = S
-              head_size,                                      // N      = H
-              input_hidden_size,                              // K      = D
-              1.0f,                                           // alpha
-              input_data + input_offset,                      // A
-              input_hidden_size,                              // lda    = D
-              weights_data + weights_offset,                  // B
-              q_hidden_size + k_hidden_size + v_hidden_size,  // ldb = NH1 + NH2 + NH3
-              1.0f,                                           // beta
-              qkv_dest + qkv_offset,                          // C
-              head_size,                                      // ldc
-              nullptr                                         // use single-thread
+              CblasNoTrans,                   // TransA = no
+              CblasNoTrans,                   // TransB = no
+              sequence_length,                // M      = S
+              head_size,                      // N      = H
+              input_hidden_size,              // K      = D
+              1.0f,                           // alpha
+              input_data + input_offset,      // A
+              input_hidden_size,              // lda    = D
+              weights_data + weights_offset,  // B
+              qkv_hidden_size,                // ldb    = D + D + D_v
+              1.0f,                           // beta
+              qkv_dest + qkv_offset,          // C
+              head_size,                      // ldc
+              nullptr                         // use single-thread
           );
         }
       }
@@ -597,7 +335,7 @@ Status Attention<T>::Compute(OpKernelContext* context) const {
   // Compute the attention score and apply the score to V
   return ApplyAttention(Q, K, V, mask_index, past, output,
                         batch_size, sequence_length,
-                        qkv_head_size[0], qkv_head_size[2], v_hidden_size,
+                        parameters.head_size, parameters.v_head_size, parameters.v_hidden_size,
                         extra_add_qk, context);
 }
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.cc
@@ -1,0 +1,390 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cpu/bert/attention_base.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+Status AttentionBase::CheckInputs(const TensorShape& input_shape,
+                                  const TensorShape* weights_shape,
+                                  const TensorShape& bias_shape,
+                                  const Tensor*& mask_index,
+                                  const Tensor* past,
+                                  const Tensor* extra_add_qk,
+                                  const Tensor* key,
+                                  const Tensor* value,
+                                  void* parameters) const {
+  // Abbreviation and Meanings:
+  //   B:    batch_size
+  //   S:    sequence_length (input sequence length of query)
+  //   P:    past_sequence_length (past sequence length of key or value)
+  //   L:    kv_sequence_length (input sequence length of key or value)
+  //   M:    max_sequence_length
+  //   T:    total_sequence_length = past_sequence_length + kv_sequence_length
+  //   N:    num_heads
+  //   H:    head size for Q and K, aka q_head_size or v_head_size or qk_head_size
+  //   H_v:  v_head_size
+  //   D_i:  input hidden size
+  //   D:    hidden size for Q and K (D = N * H), aka q_hidden_size or k_hidden_size or qk_hidden_size
+  //   D_v:  v_hidden_size = num_heads * v_head_size
+
+  // When past state is used, Q, K and V should have same hidden size (unless we split it into past_key and past_value).
+
+  // Input shapes with weights:
+  //   input        (Q/K/V)    : (B, S, D_i)
+  //   weights      (Q/K/V)    : (D_i, D + D + D_v)
+  //   bias         (Q/K/V)    : (D + D + D_v)
+  //   mask_index              : see below
+  //   past         (K/V)      : (2, B, N, P, H) or NULL
+  //   extra_add_qk            : (B, N, S, T) or NULL
+  //   key                     : NULL
+  //   value                   : NULL
+
+  // Input shapes without weights (only bias is provided):
+  //   input         (Q)       : (B, S, D)
+  //   weights                 : NULL
+  //   bias          (Q/K/V)   : (D + D + D_v)
+  //   mask_index              : see below
+  //   past          (K/V)     : (2, B, N, P, H) or NULL
+  //   extra_add_qk            : (B, N, S, T) or NULL
+  //   key           (K)       : (B, L, D)
+  //   value         (V)       : (B, L, D_v)
+
+  // For mask_index, the following shapes are supported:
+  //     NULL, (B, 1), (1, 1)
+  //     (B), (2 * B),
+  //     (B, T)
+  //     (B, S, T)
+  //     (B, 1, M, M)
+  //
+  // When a model is pruned (like some attention heads are removed in Q/K/V), input_hidden_size could be larger
+  // than hidden dimension of Q, K and V.
+
+  if (past != nullptr && extra_add_qk != nullptr) {
+    // past is used on GPT-2 model with past state, we don't have a case for extra add qk yet
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Attention cannot have both past and extra_add_qk");
+  }
+
+  const auto& dims = input_shape.GetDims();
+  if (dims.size() != 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'input' is expected to have 3 dimensions, got ",
+                           dims.size());
+  }
+
+  auto& batch_size = dims[0];
+  auto& sequence_length = dims[1];
+  int64_t input_hidden_size = dims[2];
+
+  const auto& bias_dims = bias_shape.GetDims();
+  if (bias_dims.size() != 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'bias' is expected to have 1 dimension, got ",
+                           bias_dims.size());
+  }
+
+  if (weights_shape != nullptr) {
+    const auto& weights_dims = weights_shape->GetDims();
+    if (weights_dims.size() != 2) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'weights' is expected to have 2 dimensions, got ",
+                             weights_dims.size());
+    }
+    if (weights_dims[0] != input_hidden_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 1 dimension 0 should have same length as dimension 2 of input 0");
+    }
+
+    if (bias_dims[0] != weights_dims[1]) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'bias' dimension 0 should have same length as dimension 1 of input 'weights'");
+    }
+  }
+
+  int64_t q_hidden_size = bias_dims[0] / static_cast<int64_t>(3);
+  int64_t k_hidden_size = q_hidden_size;
+  int64_t v_hidden_size = k_hidden_size;
+  if (qkv_hidden_sizes_.size() != 0) {
+    if (qkv_hidden_sizes_.size() != 3) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "qkv_hidden_sizes attribute should have 3 elements");
+    }
+
+    for (size_t i = 0; i < qkv_hidden_sizes_.size(); i++) {
+      if (qkv_hidden_sizes_[i] % num_heads_ != 0) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "hidden_size should be divisible by num_heads:", qkv_hidden_sizes_[i]);
+      }
+    }
+
+    q_hidden_size = qkv_hidden_sizes_[0];
+    k_hidden_size = qkv_hidden_sizes_[1];
+    v_hidden_size = qkv_hidden_sizes_[2];
+  }
+
+  int64_t kv_sequence_length = sequence_length;
+  if (weights_shape == nullptr) {  // no weights
+    if (this->require_weights_) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "This operator requires weights");
+    }
+
+    if (key == nullptr || value == nullptr) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "When weights is not provided, key and value are required");
+    }
+
+    const auto& key_dims = key->Shape().GetDims();
+    if (key_dims.size() != 3) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'key' is expected to have 3 dimensions, got ",
+                             key_dims.size());
+    }
+    if (key_dims[0] != batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'key' dimension 0 should have same length as dimension 0 of input 0");
+    }
+
+    const auto& value_dims = value->Shape().GetDims();
+    if (value_dims.size() != 3) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'value' is expected to have 3 dimensions, got ",
+                             value_dims.size());
+    }
+    if (value_dims[0] != batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'value' dimension 0 should have same length as dimension 0 of input 0");
+    }
+
+    if (value_dims[1] != key_dims[1]) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'key' and 'value' dimension 1 should have same length");
+    }
+
+    q_hidden_size = dims[2];
+    k_hidden_size = key_dims[2];
+    v_hidden_size = value_dims[2];
+    kv_sequence_length = key_dims[1];
+
+    if (qkv_hidden_sizes_.size() != 0 &&
+        (q_hidden_size != qkv_hidden_sizes_[0] ||
+         k_hidden_size != qkv_hidden_sizes_[1] ||
+         v_hidden_size != qkv_hidden_sizes_[2])) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "qkv_hidden_sizes does not match with query, key and value input shape",
+                             " q_hidden_size=", q_hidden_size,
+                             " k_hidden_size=", k_hidden_size,
+                             " v_hidden_size=", v_hidden_size,
+                             "qkv_hidden_sizes[0]=", qkv_hidden_sizes_[0],
+                             "qkv_hidden_sizes[1]=", qkv_hidden_sizes_[1],
+                             "qkv_hidden_sizes[2]=", qkv_hidden_sizes_[2]);
+    }
+  }
+
+  if (q_hidden_size != k_hidden_size) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "qkv_hidden_sizes first element should be same as the second");
+  }
+
+  if (this->require_same_hidden_size_ && k_hidden_size != v_hidden_size) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Hidden size of Q, K and V shall be same");
+  }
+
+  if (bias_dims[0] != q_hidden_size + k_hidden_size + v_hidden_size) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Input 'bias' dimension 0 should have same length as sum of Q/K/V hidden sizes:",
+                           " q_hidden_size=", q_hidden_size, " k_hidden_size=", k_hidden_size, " v_hidden_size=",
+                           v_hidden_size, "bias_dims[0]=", bias_dims[0]);
+  }
+
+  int64_t past_sequence_length = 0;
+  if (past != nullptr) {  // past is optional
+    if (k_hidden_size != v_hidden_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'past' expect k_hidden_size == v_hidden_size");
+    }
+
+    const auto& past_dims = past->Shape().GetDims();
+    if (past_dims.size() != 5) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input 'past' is expected to have 5 dimension, got ",
+                             past_dims.size());
+    }
+
+    if (past_dims[0] != 2) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Inputs 'past' dimension 0 shall have length of 2");
+    }
+
+    if (past_dims[1] != batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Inputs 'past' dimension 1 shall have same length as dimension 0 of input 0");
+    }
+
+    if (static_cast<int>(past_dims[2]) != num_heads_) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Inputs 'past' dimension 2 shall have length of num_heads", num_heads_);
+    }
+
+    if (static_cast<int>(past_dims[4]) != k_hidden_size / num_heads_) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Inputs 'past' dimension 2 shall have length of ", k_hidden_size / num_heads_);
+    }
+
+    past_sequence_length = past_dims[3];
+  }
+
+  int64_t total_sequence_length = kv_sequence_length + past_sequence_length;
+  int64_t max_sequence_length = -1;
+  if (mask_index != nullptr) {  // mask_index is optional
+    bool is_dummy = false;
+    auto status = this->CheckMask(mask_index, is_dummy,
+                                  max_sequence_length, batch_size, sequence_length, total_sequence_length);
+    if (status != Status::OK()) {
+      return status;
+    }
+    if (is_dummy) {
+      mask_index = nullptr;
+    }
+  }
+
+  if (extra_add_qk != nullptr) {
+    const auto& extra_add_qk_dims = extra_add_qk->Shape().GetDims();
+
+    if (extra_add_qk_dims.size() != 4) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'extra_add_qk' is expected to have 4 dimensions, got ",
+                             extra_add_qk_dims.size());
+    }
+
+    if (extra_add_qk_dims[0] != batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'extra_add_qk' dimension 0 should be same as batch_size, got ",
+                             extra_add_qk_dims[0]);
+    }
+    if (extra_add_qk_dims[1] != num_heads_) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'extra_add_qk' dimension 1 should be same as number of heads, got ",
+                             extra_add_qk_dims[1]);
+    }
+    if (extra_add_qk_dims[2] != sequence_length) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'extra_add_qk' dimension 2 should be same as sequence_length, got ",
+                             extra_add_qk_dims[2]);
+    }
+    if (extra_add_qk_dims[3] != total_sequence_length) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'extra_add_qk' dimension 3 should be same as total_sequence_length, got ",
+                             extra_add_qk_dims[3]);
+    }
+  }
+
+  if (parameters != nullptr) {
+    AttentionParameters* output_parameters = reinterpret_cast<AttentionParameters*>(parameters);
+    output_parameters->batch_size = static_cast<int>(batch_size);
+    output_parameters->sequence_length = static_cast<int>(sequence_length);
+    output_parameters->past_sequence_length = static_cast<int>(past_sequence_length);
+    output_parameters->kv_sequence_length = static_cast<int>(kv_sequence_length);
+    output_parameters->total_sequence_length = static_cast<int>(total_sequence_length);
+    output_parameters->max_sequence_length = static_cast<int>(max_sequence_length);
+    output_parameters->input_hidden_size = static_cast<int>(input_hidden_size);
+    output_parameters->hidden_size = static_cast<int>(q_hidden_size);
+    output_parameters->v_hidden_size = static_cast<int>(v_hidden_size);
+    output_parameters->head_size = static_cast<int>(q_hidden_size) / num_heads_;
+    output_parameters->v_head_size = static_cast<int>(v_hidden_size) / num_heads_;
+    output_parameters->num_heads = num_heads_;
+    output_parameters->is_unidirectional = is_unidirectional_;
+  }
+
+  return Status::OK();
+}
+
+Status AttentionBase::CheckMask(const Tensor* mask_index,
+                                bool& is_dummy,
+                                int64_t& max_sequence_length,
+                                int64_t batch_size,
+                                int64_t sequence_length,
+                                int64_t total_sequence_length) const {
+  is_dummy = false;
+  const auto& mask_dims = mask_index->Shape().GetDims();
+  if (mask_dims.size() == 1) {
+    if (mask_dims[0] != batch_size && mask_dims[0] != 2 * batch_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Inputs 'mask_index' with 1D data shall have length of batch_size or 2 * batch_size");
+    }
+  } else if (mask_dims.size() == 2) {
+    if (mask_dims[0] != batch_size || mask_dims[1] != total_sequence_length) {
+      // Add operator supports broadcasting. Here we handle a case with only one element in the 2nd dimension.
+      if ((mask_dims[0] == batch_size || mask_dims[0] == 1) && mask_dims[1] == 1) {
+        // Mask will have same value after propagation, which has same effect as no mask.
+        is_dummy = true;
+      } else {
+        return ORT_MAKE_STATUS(
+            ONNXRUNTIME, INVALID_ARGUMENT,
+            "Inputs 'mask_index' with 2D data shall have shape "
+            "batch_size x total_sequence_length");
+      }
+    }
+  } else if (mask_dims.size() == 3) {
+    if (mask_dims[0] != batch_size || mask_dims[1] != sequence_length || mask_dims[2] != total_sequence_length) {
+      return ORT_MAKE_STATUS(
+          ONNXRUNTIME, INVALID_ARGUMENT,
+          "Inputs 'mask_index' with 3D data shall have shape "
+          "batch_size x sequence_length x total_sequence_length");
+    }
+  } else if (mask_dims.size() == 4) {
+    if (mask_dims[0] != batch_size || mask_dims[1] != 1 || mask_dims[2] != mask_dims[3] ||
+        mask_dims[2] < total_sequence_length) {
+      return ORT_MAKE_STATUS(
+          ONNXRUNTIME, INVALID_ARGUMENT,
+          "Inputs 'mask_index' with 4D data shall have shape "
+          "batch_size x 1 x max_sequence_length x max_sequence_length)");
+    }
+    max_sequence_length = mask_dims[3];
+
+    if (is_unidirectional_ == true) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Inputs 'mask_index' with 4D data shall have is_unidirectional_ set to false");
+    }
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Input 'mask_index' is expected to have 1, 2, 3 or 4 dimensions, got ",
+                           mask_dims.size());
+  }
+
+  return Status::OK();
+}
+
+Status AttentionBase::CheckInputs(const TensorShape& input_shape,
+                                  const TensorShape* weights_shape,
+                                  const TensorShape& bias_shape,
+                                  const Tensor*& mask_index,
+                                  const Tensor* past,
+                                  const Tensor* extra_add_qk,
+                                  const Tensor* key,
+                                  const Tensor* value,
+                                  void* parameters,
+                                  const int max_threads_per_block) const {
+  if (num_heads_ > max_threads_per_block) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
+  }
+
+  return CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past, extra_add_qk, key, value, parameters);
+}
+
+Tensor* AttentionBase::GetPresent(OpKernelContext* context,
+                                  const Tensor* past,
+                                  int batch_size,
+                                  int head_size,
+                                  int kv_sequence_length,
+                                  int& past_sequence_length) const {
+  // Input and output shapes:
+  //   past        : (2, batch_size, num_heads, past_sequence_length, head_size)
+  //   present     : (2, batch_size, num_heads, past_sequence_length + kv_sequence_length, head_size)
+
+  past_sequence_length = (nullptr != past) ? static_cast<int>(past->Shape().GetDims()[3]) : 0;
+  std::vector<int64_t> present_dims{2, batch_size, num_heads_, kv_sequence_length + past_sequence_length, head_size};
+
+  TensorShape present_shape(present_dims);
+  Tensor* present = context->Output(1, present_shape);
+  if (nullptr != past && nullptr == present) {
+    ORT_THROW("Expect to have present state output when past state input is given");
+  }
+
+  return present;
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_base.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "core/common/common.h"
 #include "core/framework/op_kernel.h"
+#include "contrib_ops/cpu/bert/attention_common.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -14,11 +15,14 @@ class AttentionBase {
  public:
   // This check function is specifically used in cuda
   Status CheckInputs(const TensorShape& input_shape,
-                     const TensorShape& weights_shape,
+                     const TensorShape* weights_shape,
                      const TensorShape& bias_shape,
-                     const Tensor*& mask_index,  // For dummy mask with shape (1, 1) or (batch_size, 1), it will be updated to nullptr.
+                     const Tensor*& mask_index,  // Dummy mask of shape (1 or batch_size, 1) will be updated to nullptr.
                      const Tensor* past,
                      const Tensor* extra_add_qk,
+                     const Tensor* key,
+                     const Tensor* value,
+                     void* parameters,
                      const int max_threads_per_block) const;
 
   Tensor* GetPresent(OpKernelContext* context,
@@ -29,28 +33,43 @@ class AttentionBase {
                      int& past_sequence_length) const;
 
  protected:
-  AttentionBase(const OpKernelInfo& info) {
+  AttentionBase(const OpKernelInfo& info, bool require_same_hidden_size, bool require_weights) {
     int64_t num_heads = 0;
     ORT_ENFORCE(info.GetAttr("num_heads", &num_heads).IsOK() && num_heads > 0);
     num_heads_ = static_cast<int>(num_heads);
 
     is_unidirectional_ = info.GetAttrOrDefault<int64_t>("unidirectional", 0) == 1;
 
-    if (!info.GetAttrs<int64_t>("qkv_hidden_sizes", qkv_hidden_sizes_).IsOK() || qkv_hidden_sizes_.empty()) {
-      qkv_hidden_sizes_.resize(0);
+    if (!info.GetAttrs<int64_t>("qkv_hidden_sizes", qkv_hidden_sizes_).IsOK()) {
+      qkv_hidden_sizes_.clear();
     }
+
+    require_same_hidden_size_ = require_same_hidden_size;
+    require_weights_ = require_weights;
   }
 
+  Status CheckMask(const Tensor* mask_index,
+                   bool& is_dummy,                // output: whether the mask is dummy with shape (1 or batch_size, 1)
+                   int64_t& max_sequence_length,  // output: max_sequence_length when mask_index is 4D tensor
+                   int64_t batch_size,
+                   int64_t sequence_length,
+                   int64_t total_sequence_length) const;
+
   Status CheckInputs(const TensorShape& input_shape,
-                     const TensorShape& weights_shape,
+                     const TensorShape* weights_shape,
                      const TensorShape& bias_shape,
-                     const Tensor*& mask_index,  // For dummy mask with shape (1, 1) or (batch_size, 1), it will be updated to nullptr.
+                     const Tensor*& mask_index,  // Dummy mask of shape (1 or batch_size, 1) will be updated to nullptr.
                      const Tensor* past,
-                     const Tensor* extra_add_qk) const;
+                     const Tensor* extra_add_qk,
+                     const Tensor* key,
+                     const Tensor* value,
+                     void* parameters) const;
 
   int num_heads_;                          // number of attention heads
   bool is_unidirectional_;                 // whether every token can only attend to previous tokens.
-  std::vector<int64_t> qkv_hidden_sizes_;  // Q, K, V path hidden layer sizes
+  std::vector<int64_t> qkv_hidden_sizes_;  // Q, K, V hidden sizes parsed from the qkv_hidden_sizes attribute.
+  bool require_same_hidden_size_;          // whether the implementation supports different hidden sizes of Q/K/V.
+  bool require_weights_;                   // whether the implementation requires weights for Q/K/V.
 };
 
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cpu/bert/attention_common.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_common.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime {
+namespace contrib {
+
+struct AttentionParameters {
+  int batch_size;
+  int sequence_length;
+  int kv_sequence_length;     // input sequence length of K or V
+  int past_sequence_length;   // sequence length in past state of K or V
+  int total_sequence_length;  // total sequence length of K or V
+  int max_sequence_length;
+  int input_hidden_size;
+  int hidden_size;    // hidden size of Q or K
+  int head_size;      // hidden size per head of Q or K
+  int v_hidden_size;  // hidden size of V
+  int v_head_size;    // hidden size per head of V
+  int num_heads;
+  bool is_unidirectional;
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h
@@ -15,22 +15,25 @@ namespace contrib {
 
 class AttentionCPUBase : public AttentionBase {
  protected:
-  AttentionCPUBase(const OpKernelInfo& info) : AttentionBase(info) {}
+  AttentionCPUBase(const OpKernelInfo& info, bool require_same_hidden_size, bool require_weights)
+  : AttentionBase(info, require_same_hidden_size, require_weights) {}
 
   template <typename T>
-  Status ApplyAttention(const T* Q,                  // Q data. Its size is BxNxSxH
-                        const T* K,                  // K data. Its size is BxNxSxH
-                        const T* V,                  // V value with size BxNxSxH
+  Status ApplyAttention(const T* Q,                  // Q data with shape BxNxSxH
+                        const T* K,                  // K data with shape BxNxSxH
+                        const T* V,                  // V value with size BxNxSxH_v
                         const Tensor* mask_index,    // mask index. nullptr if no mask or its size is B
                         const Tensor* past,          // past state
                         Tensor* output,              // output tensor
-                        int batch_size,              // batch size
-                        int sequence_length,         // sequence length
-                        int qk_head_size,            // qk_head_size
-                        int v_head_size,             // head_size
-                        int v_hidden_size,           // hidden_size
-                        const Tensor* extra_add_qk,  // extra add in QK. Its size is BxNxSxS
+                        int batch_size,              // batch size (B)
+                        int sequence_length,         // sequence length (S)
+                        int qk_head_size,            // head size of Q or K (H)
+                        int v_head_size,             // head size of V (H_v)
+                        int v_hidden_size,           // hidden size of V (D_v)
+                        const Tensor* extra_add_qk,  // extra add in QK. Its size is BxNxSxT
                         OpKernelContext* context) const {
+    const int kv_sequence_length = sequence_length;
+
     AllocatorPtr allocator;
     ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
 
@@ -39,14 +42,11 @@ class AttentionCPUBase : public AttentionBase {
     int past_sequence_length = 0;
     Tensor* present = GetPresent(context, past, batch_size, v_head_size, sequence_length, past_sequence_length);
 
-    // Total sequence length including that of past state: S* = S' + S
-    const int all_sequence_length = past_sequence_length + sequence_length;
+    // Total sequence length including that of past state: T = P + L
+    const int total_sequence_length = past_sequence_length + kv_sequence_length;
 
-    // Compute the attention score. It does 2 things:
-    //         I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
-    //                                           1 x mask_data(B, N, S, S*)
-    //         II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
-    size_t bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T);
+    // Compute the attention score.
+    size_t bytes = SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * total_sequence_length * sizeof(T);
     auto attention_probs = allocator->Alloc(bytes);
     BufferUniquePtr scratch_buffer(attention_probs, BufferDeleter(allocator));
 
@@ -54,7 +54,7 @@ class AttentionCPUBase : public AttentionBase {
 
     void* mask_data = nullptr;
     if (mask_index != nullptr || has_unidirectional) {
-      size_t mask_data_bytes = SafeInt<size_t>(batch_size) * sequence_length * all_sequence_length * sizeof(T);
+      size_t mask_data_bytes = SafeInt<size_t>(batch_size) * sequence_length * total_sequence_length * sizeof(T);
       mask_data = allocator->Alloc(mask_data_bytes);
       memset(mask_data, 0, mask_data_bytes);
     }
@@ -78,14 +78,15 @@ class AttentionCPUBase : public AttentionBase {
                              qk_head_size == 0 ? v_head_size : qk_head_size,
                              past_data, present_data, tp, extra_add_qk_data);
 
-    // Compute the attentionScore * Value. It does: out_tmp(B, N, S, H) = attention_probs(B, N, S, S*) x V(B, N, S*, H)
+    // Compute the attentionScore * Value: out_tmp(B, N, S, H_v) = attention_probs(B, N, S, T) x V(B, N, T, H_v)
     auto out_tmp_data =
         allocator->Alloc(SafeInt<size_t>(batch_size) * num_heads_ * sequence_length * v_head_size * sizeof(T));
     BufferUniquePtr out_tmp_buffer(out_tmp_data, BufferDeleter(std::move(allocator)));
 
     ComputeVxAttentionScore(output->MutableData<T>(), static_cast<T*>(out_tmp_data),
                             static_cast<T*>(attention_probs), V,
-                            batch_size, sequence_length, past_sequence_length, v_head_size, v_hidden_size,
+                            batch_size, sequence_length, kv_sequence_length, past_sequence_length,
+                            v_head_size, v_hidden_size,
                             past_data, present_data, tp);
 
     return Status::OK();
@@ -93,13 +94,13 @@ class AttentionCPUBase : public AttentionBase {
 
  private:
   // Helper function to compute the attention probs. It does 2 things:
-  //  I. attention_probs(B, N, S, S*) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, S*, H -> B, N, H, S*) +
-  //                                    1 x mask_data(B, N, S, S*)
-  //  II.attention_probs(B, N, S, S*) = Softmax(attention_probs)
+  //  attention_probs(B, N, S, T) = 1/sqrt(H) x Q(B, N, S, H) x K'(B, N, T, H -> B, N, H, T) +
+  //                                1 x mask_data(B, N, S, T)
+  //  attention_probs(B, N, S, T) = Softmax(attention_probs)
   template <typename T>
-  void ComputeAttentionProbs(T* attention_probs,                        // output buffer with size BxNxSxS*
+  void ComputeAttentionProbs(T* attention_probs,                        // output buffer with size BxNxSxT
                              const T* Q,                                // Q data. Its size is BxNxSxH
-                             const T* K,                                // k data. Its size is BxNxSxH
+                             const T* K,                                // k data. Its size is BxNxLxH
                              const int32_t* mask_index,                 // mask index. nullptr if no mask.
                              gsl::span<const int64_t> mask_index_dims,  // mask index shape
                              T* mask_data,                              // buffer for mask data.
@@ -111,20 +112,20 @@ class AttentionCPUBase : public AttentionBase {
                              const T* past,                             // past state
                              T* present,                                // present state
                              ThreadPool* tp,                            // thread pool
-                             const T* extra_add_qk_data                 // extra add matrix with shape BxNxSxS*
+                             const T* extra_add_qk_data                 // extra add matrix with shape BxNxSxT
   ) const {
-    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
-    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // S' x H
-    const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // S x H
-    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
+    const int total_sequence_length = past_sequence_length + sequence_length;                // T = P + L
+    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length) * head_size;  // P x H
+    const size_t input_chunk_length = static_cast<size_t>(sequence_length) * head_size;      // L x H
+    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // T x H
 
     {
-      // mask_data is nullptr when mask_index is nullptr and not unidirectional, otherwise its shape is BxSxS*
+      // mask_data is nullptr when mask_index is nullptr and not unidirectional, otherwise its shape is BxSxT
       if (mask_data != nullptr) {
         PrepareMask(mask_index, mask_index_dims, mask_data,
                     has_unidirectional, batch_size, sequence_length, past_sequence_length);
       } else {  // no any mask
-        size_t bytes = static_cast<size_t>(batch_size) * num_heads_ * sequence_length * all_sequence_length * sizeof(T);
+        size_t bytes = static_cast<size_t>(batch_size) * num_heads_ * sequence_length * total_sequence_length * sizeof(T);
         memset(attention_probs, 0, bytes);
       }
 
@@ -132,50 +133,50 @@ class AttentionCPUBase : public AttentionBase {
       const float alpha = 1.0f / sqrt(static_cast<float>(head_size));
 
       // The cost of Gemm
-      const double cost = static_cast<double>(head_size) * sequence_length * all_sequence_length;
+      const double cost = static_cast<double>(head_size) * sequence_length * total_sequence_length;
 
       ThreadPool::TryParallelFor(tp, loop_len, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
         for (std::ptrdiff_t i = begin; i != end; ++i) {
           const int batch_index = static_cast<int>(i) / num_heads_;
 
-          const int output_offset = static_cast<int>(i) * sequence_length * all_sequence_length;
-          const int mask_offset = batch_index * sequence_length * all_sequence_length;
+          const int output_offset = static_cast<int>(i) * sequence_length * total_sequence_length;
+          const int mask_offset = batch_index * sequence_length * total_sequence_length;
           T* output = attention_probs + output_offset;
 
-          // Broadcast mask data: (Bx)SxS* -> (BxNx)SxS*
+          // Broadcast mask data: (Bx)SxT -> (BxNx)SxT
           if (mask_data != nullptr) {
             memcpy(output,
                    mask_data + mask_offset,
-                   static_cast<size_t>(sequence_length) * all_sequence_length * sizeof(T));
+                   static_cast<size_t>(sequence_length) * total_sequence_length * sizeof(T));
           }
 
           const T* k = K + input_chunk_length * i;
           if (nullptr != present) {
-            // Concatenate past_K and K : (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+            // Concatenate past_K and K : (BxNx)PxH, (BxNx)LxH -> (BxNx)TxH
             k = ConcatStateChunk(past, k, present, past_chunk_length, present_chunk_length, i);
           }
 
           // Compute Q*K' + AttentionMask
           //                     original                 transposed             each iteration
           // A: Q                (B x N x) S x H          (B x N x) S x H        S x H
-          // B: K'               (B x N x) S* x H         (B x N x) H x S*       H x S*
-          // C: attention_probs  (B x N x) S x S*         (B x N x) S x S*       S x S*
-          math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, all_sequence_length, head_size, alpha,
+          // B: K'               (B x N x) T x H          (B x N x) H x T        H x T
+          // C: attention_probs  (B x N x) S x T          (B x N x) S x T        S x T
+          math::Gemm<T, ThreadPool>(CblasNoTrans, CblasTrans, sequence_length, total_sequence_length, head_size, alpha,
                                     Q + input_chunk_length * i, k, 1.0,
                                     output, nullptr);
 
           // Fix unidirectional mask to be parity with huggingface implementation.
           if (has_unidirectional && mask_data != nullptr) {
             for (int s_i = 0; s_i < sequence_length - 1; s_i++) {
-              for (int m_i = past_sequence_length + s_i + 1; m_i < all_sequence_length; m_i++) {
-                int j = s_i * all_sequence_length + m_i;
+              for (int m_i = past_sequence_length + s_i + 1; m_i < total_sequence_length; m_i++) {
+                int j = s_i * total_sequence_length + m_i;
                 output[j] = mask_data[mask_offset + j];
               }
             }
           }
 
           if (extra_add_qk_data != nullptr) {
-            for (int j = 0; j < sequence_length * all_sequence_length; j++) {
+            for (int j = 0; j < sequence_length * total_sequence_length; j++) {
               output[j] += extra_add_qk_data[output_offset + j];
             }
           }
@@ -183,66 +184,67 @@ class AttentionCPUBase : public AttentionBase {
       });
     }
 
-    //  attention_probs(B, N, S, S*) = Softmax(attention_probs)
+    //  attention_probs(B, N, S, T) = Softmax(attention_probs)
     {
       const int N = batch_size * num_heads_ * sequence_length;
-      const int D = all_sequence_length;
+      const int D = total_sequence_length;
       ComputeAttentionSoftmaxInplace(attention_probs, N, D, tp);
     }
   }
 
   template <typename T>
-  void ComputeVxAttentionScore(T* output,                 // buffer for the result with size BxSxNxH
-                               T* tmp_buffer,             // buffer for temp use with size is BxNxSxH
-                               const T* attention_probs,  // Attention probs with size BxNxSxS*
-                               const T* V,                // V value with size BxNxSxH
+  void ComputeVxAttentionScore(T* output,                 // buffer for the result with size BxSxNxH_v
+                               T* tmp_buffer,             // buffer for temp use with size is BxNxSxH_v
+                               const T* attention_probs,  // Attention probs with size BxNxSxT
+                               const T* V,                // V value with size BxNxLxH_v
                                int batch_size,            // batch size
                                int sequence_length,       // sequence length
+                               int kv_sequence_length,    // sequence length of K or V
                                int past_sequence_length,  // sequence length in past state
-                               int head_size,             // head size
-                               int hidden_size,           // hidden size
+                               int v_head_size,           // head size of V (H_v)
+                               int v_hidden_size,         // hidden size of V (D_v)
                                const T* past,             // past state
                                T* present,                // present state
                                ThreadPool* tp) const {
-    const int all_sequence_length = past_sequence_length + sequence_length;                  // S* = S' + S
-    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length * head_size);  // S' x H
-    const size_t input_chunk_length = static_cast<size_t>(sequence_length * head_size);      // S x H
-    const size_t present_chunk_length = past_chunk_length + input_chunk_length;              // S* x H
+    const int total_sequence_length = past_sequence_length + kv_sequence_length;               // T = P + L
+    const size_t past_chunk_length = static_cast<size_t>(past_sequence_length * v_head_size);  // P x H_v
+    const size_t input_chunk_length = static_cast<size_t>(kv_sequence_length * v_head_size);   // L x H_v
+    const size_t present_chunk_length = past_chunk_length + input_chunk_length;                // T x H_v
 
     // Move the pointer of past and present to start of v values.
     if (nullptr != past) {
-      past += batch_size * num_heads_ * past_sequence_length * head_size;
+      past += batch_size * num_heads_ * past_sequence_length * v_head_size;
     }
     if (nullptr != present) {
-      present += batch_size * num_heads_ * all_sequence_length * head_size;
+      present += batch_size * num_heads_ * total_sequence_length * v_head_size;
     }
 
     const double cost =
-        static_cast<double>(sequence_length) * static_cast<double>(head_size) * static_cast<double>(sequence_length);
+        static_cast<double>(sequence_length) * static_cast<double>(v_head_size) * static_cast<double>(sequence_length);
 
     ThreadPool::TryParallelFor(tp, batch_size * num_heads_, cost, [&](std::ptrdiff_t begin, std::ptrdiff_t end) {
       for (std::ptrdiff_t i = begin; i != end; ++i) {
         const T* v = V + input_chunk_length * i;
         if (nullptr != present) {
-          // concatenate past_V and V: (BxNx)S'xH, (BxNx)SxH -> (BxNx)S*xH
+          // Concatenate past_V and V: (BxNx)PxH_v, (BxNx)LxH_v -> (BxNx)TxH_v
           v = ConcatStateChunk(past, v, present, past_chunk_length, present_chunk_length, i);
         }
 
         T* current_tmp_data = reinterpret_cast<T*>(tmp_buffer) + input_chunk_length * i;
-        math::MatMul<T>(sequence_length, head_size, all_sequence_length,
-                        attention_probs + sequence_length * all_sequence_length * i,
+        math::MatMul<T>(sequence_length, v_head_size, total_sequence_length,
+                        attention_probs + sequence_length * total_sequence_length * i,
                         v, current_tmp_data, nullptr);
 
-        // transpose: out(B, S, N, H) = transpose out_tmp(B, N, S, H)
+        // Transpose: out(B, S, N, H_v) -> out_tmp(B, N, S, H_v)
         const int batch_index = static_cast<int>(i / num_heads_);
         const int head_index = static_cast<int>(i % num_heads_);
         T* src = current_tmp_data;
-        T* dest = output + (batch_index * sequence_length * num_heads_ + head_index) * head_size;
-        const auto bytes_to_copy = SafeInt<size_t>(head_size) * sizeof(T);
+        T* dest = output + (batch_index * sequence_length * num_heads_ + head_index) * v_head_size;
+        const auto bytes_to_copy = SafeInt<size_t>(v_head_size) * sizeof(T);
         for (int j = 0; j < sequence_length; j++) {
           memcpy(dest, src, bytes_to_copy);
-          src += head_size;
-          dest += hidden_size;
+          src += v_head_size;
+          dest += v_hidden_size;
         }
       }
     });

--- a/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_helper.h
@@ -70,7 +70,7 @@ void PrepareMask(const int32_t* mask_index,
                  int past_sequence_length) {
   const int all_sequence_length = past_sequence_length + sequence_length;
 
-  // mask_data has been filled with 0, and its shape is BxSxS*
+  // mask_data has been filled with 0, and its shape is BxSxT
   T* p_mask = mask_data;
 
   // 4D mask in Megatron GPT2 is currently not support in CPU kernel
@@ -113,7 +113,7 @@ void PrepareMask(const int32_t* mask_index,
           p_mask[m_i] = (raw_mask[m_i] > 0) ? static_cast<T>(0.0f) : static_cast<T>(-10000.0f);
         }
       } else {
-        // mask_index is 1D: (B) or (2B) => (Bx)S*
+        // mask_index is 1D: (B) or (2B) => (Bx)T
 
         // Handle right-side padding: mask value at or after the end position will be -10000.0
         int end_position = mask_index[b_i];
@@ -131,7 +131,7 @@ void PrepareMask(const int32_t* mask_index,
       }
     }
 
-    // Broadcast mask from (Bx)S* to (Bx)SxS*
+    // Broadcast mask from (Bx)T to (Bx)SxT
     for (int s_i = 1; s_i < sequence_length; s_i++) {
       memcpy(p_mask + s_i * all_sequence_length, p_mask, all_sequence_length * sizeof(T));
     }
@@ -149,7 +149,7 @@ void PrepareMask(const int32_t* mask_index,
   }
 }
 
-// Concatenate a past state chunk S'xH with input state chunk SxH into present state chunk S*xH
+// Concatenate a past state chunk PxH with input state chunk LxH into present state chunk TxH
 // Returns a pointer to the start of present state chunk.
 template <typename T>
 T* ConcatStateChunk(const T* past,

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -53,7 +53,8 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
     QAttention<float>);
 
 template <typename T>
-QAttention<T>::QAttention(const OpKernelInfo& info) : OpKernel(info), AttentionCPUBase(info) {}
+QAttention<T>::QAttention(const OpKernelInfo& info) : OpKernel(info), AttentionCPUBase(info, true, true) {
+}
 
 template <typename T>
 Status QAttention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr alloc,
@@ -155,11 +156,15 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
 
   const TensorShape& weights_shape = (packed_weights_ ? weight_shape_ : weights->Shape());
   ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(),
-                                                 weights_shape,
+                                                 &weights_shape,
                                                  bias->Shape(),
                                                  mask_index,
                                                  past_tensor,
-                                                 nullptr));
+                                                 nullptr,  // extra_add_qk
+                                                 nullptr,  // key
+                                                 nullptr,  // value
+                                                 nullptr   // parameters
+                                                 ));
 
   ORT_RETURN_IF_NOT(IsScalarOr1ElementVector(input_scale_tensor),
                     "input scale must be a scalar or 1D tensor of size 1");

--- a/onnxruntime/contrib_ops/cuda/bert/add_bias_transpose.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/add_bias_transpose.cu
@@ -89,6 +89,61 @@ __global__ void AddBiasTransposeTrtLarge(const int head_size, const T* input, co
 }
 
 template <typename T>
+__global__ void AddBiasTransposeTrt(const T* query, const T* key, const T* value, const T* biases, T* output) {
+  // Q:  BxSxNxH
+  // K:  BxSxNxH
+  // V:  BxSxNxH
+  // Output: BxSxNxMxH
+  // B is batch_size, S is sequence_length, M is number of matrices (3), N is num_heads, H is head_size
+
+  int n = threadIdx.y;
+  int s = blockIdx.x;
+  int b = blockIdx.y;
+  int m = blockIdx.z;  // matrix id
+
+  const int H = blockDim.x;
+  const int N = blockDim.y;
+  const int S = gridDim.x;
+  const int M = gridDim.z;
+
+  const T* input = (m == 0 ? query : (m == 1 ? key : value));
+  const int NH = N * H;
+  const int in_offset = (b * S + s) * NH + n * H;
+  const int out_offset = (b * S + s) * M * NH + (n * M + m) * H;
+
+  const int h = threadIdx.x;
+  if (h < H) {
+    output[out_offset + h] = input[in_offset + h] + biases[m * NH + n * H + h];
+  }
+}
+
+template <typename T>
+__global__ void AddBiasTransposeTrtLarge(const int head_size,
+                                         const T* query, const T* key, const T* value, const T* biases, T* output) {
+  int n = threadIdx.y;
+  int s = blockIdx.x;
+  int b = blockIdx.y;
+  int m = blockIdx.z;  // matrix id
+
+  const int stride = blockDim.x;
+  const int H = head_size;
+  const int N = blockDim.y;
+  const int S = gridDim.x;
+  const int M = gridDim.z;
+
+  const T* input = (m == 0 ? query : (m == 1 ? key : value));
+  const int NH = N * H;
+  const int in_offset = (b * S + s) * NH + n * H;
+  const int out_offset = (b * S + s) * M * NH + (n * M + m) * H;
+
+  int h = threadIdx.x;
+  if (h < H) {
+    output[out_offset + h] = input[in_offset + h] + biases[m * NH + n * H + h];
+    h += stride;
+  }
+}
+
+template <typename T>
 __global__ void AddBiasTransposeQKV(const T* input, const T* biases, T* output) {
   // Input:  BxSxMxNxH  (Format 1)
   // Output: MxBxNxSxH
@@ -124,11 +179,11 @@ __global__ void AddBiasTransposeQKV(const T* input, const T* biases, T* output, 
   // Output: MxBxNxSxH
   // B is batch_size, S is sequence_length, M is number of matrices, N is num_heads, H is head_size
 
-  int n = threadIdx.y;          // head_num_id
-  int s = blockIdx.x;           // sequence_id
-  int b = blockIdx.y;           // batch_id
-  int m = blockIdx.z;           // matrix id (Q=0, K=1, V=2)
-  const int h = threadIdx.x;    // head_element_id
+  int n = threadIdx.y;        // head_num_id
+  int s = blockIdx.x;         // sequence_id
+  int b = blockIdx.y;         // batch_id
+  int m = blockIdx.z;         // matrix id (Q=0, K=1, V=2)
+  const int h = threadIdx.x;  // head_element_id
 
   const int qk_head_size = blockDim.x;
   const int num_heads = blockDim.y;
@@ -136,9 +191,9 @@ __global__ void AddBiasTransposeQKV(const T* input, const T* biases, T* output, 
   const int sequence_length = gridDim.x;
   const int batch_size = gridDim.y;
 
-  const int qkv_head_sizes[3] = {qk_head_size, qk_head_size, v_head_size};
+  const int head_size = (m == 2 ? v_head_size : qk_head_size);
 
-  const int total_head_size = num_heads * (qkv_head_sizes[0] + qkv_head_sizes[1] + qkv_head_sizes[2]);
+  const int total_head_size = num_heads * (qk_head_size + qk_head_size + v_head_size);
 
   int in_offset;
   int out_offset;
@@ -146,21 +201,21 @@ __global__ void AddBiasTransposeQKV(const T* input, const T* biases, T* output, 
   in_offset = b * (total_head_size * sequence_length) +  // B
               s * (total_head_size) +                    // S
               m * (qk_head_size * num_heads) +           // M
-              n * qkv_head_sizes[m] +                    // N
+              n * head_size +                            // N
               h;                                         // H
 
   out_offset = m * (num_heads * qk_head_size * sequence_length * batch_size) +  // M
-               b * (num_heads * qkv_head_sizes[m] * sequence_length) +          // B
-               n * (sequence_length * qkv_head_sizes[m]) +                      // N
-               s * (qkv_head_sizes[m]) +                                        // S
+               b * (num_heads * head_size * sequence_length) +                  // B
+               n * (sequence_length * head_size) +                              // N
+               s * (head_size) +                                                // S
                h;                                                               // H
 
-  bias_offset = m * (num_heads * qk_head_size)+  // QKV
-                n * (qkv_head_sizes[m]) +        // N
-                h;                               // H
+  bias_offset = m * (num_heads * qk_head_size) +  // M
+                n * (head_size) +                 // N
+                h;                                // H
 
-  if (h < qkv_head_sizes[m]) {
-      output[out_offset] = input[in_offset] + biases[bias_offset];
+  if (h < head_size) {
+    output[out_offset] = input[in_offset] + biases[bias_offset];
   }
 }
 
@@ -257,7 +312,7 @@ void InvokeAddBiasTranspose(
     if (format == 2) {
       AddBiasTransposeTrt<T><<<grid, block, 0, stream>>>(input, biases, output);
     } else if (format == 1) {
-      if ((v_head_size == -1) || (qk_head_size == v_head_size)) {
+      if (v_head_size == -1 || qk_head_size == v_head_size) {
         AddBiasTransposeQKV<T><<<grid, block, 0, stream>>>(input, biases, output);
       } else {
         AddBiasTransposeQKV<T><<<grid, block, 0, stream>>>(input, biases, output, v_head_size);
@@ -270,7 +325,11 @@ void InvokeAddBiasTranspose(
     if (format == 2) {
       AddBiasTransposeTrtLarge<T><<<grid, block, 0, stream>>>(qk_head_size, input, biases, output);
     } else if (format == 1) {
-      AddBiasTransposeQKVLarge<T><<<grid, block, 0, stream>>>(qk_head_size, input, biases, output);
+      if (v_head_size == -1 || qk_head_size == v_head_size) {
+        AddBiasTransposeQKVLarge<T><<<grid, block, 0, stream>>>(qk_head_size, input, biases, output);
+      } else {
+        ORT_THROW("AddBiasTranspose (format 1) not implemented for hidden_size > max_threads_per_block");
+      }
     } else {
       AddBiasTransposeLarge<T><<<grid, block, 0, stream>>>(qk_head_size, input, biases, output);
     }
@@ -284,24 +343,25 @@ void LaunchAddBiasTranspose(
     const half* input, const half* biases, half* output,
     bool enable_half4, const int v_head_size) {
   if (enable_half4 && 0 == (qk_head_size % 4) && 0 == (v_head_size % 4)) {
-    const int H_q = qk_head_size / 4;
+    const int H = qk_head_size / 4;
     const int H_v = v_head_size / 4;
     const Half4* input2 = reinterpret_cast<const Half4*>(input);
     const Half4* biases2 = reinterpret_cast<const Half4*>(biases);
     Half4* output2 = reinterpret_cast<Half4*>(output);
     InvokeAddBiasTranspose<Half4>(stream, num_matrices, format, max_threads_per_block,
-                                  batch_size, sequence_length, num_heads, H_q, input2, biases2, output2, H_v);
+                                  batch_size, sequence_length, num_heads, H, input2, biases2, output2, H_v);
   } else if (0 == (qk_head_size & 1) && 0 == (v_head_size % 1)) {
-    const int H_q = qk_head_size / 2;
+    const int H = qk_head_size / 2;
     const int H_v = v_head_size / 2;
     const half2* input2 = reinterpret_cast<const half2*>(input);
     const half2* biases2 = reinterpret_cast<const half2*>(biases);
     half2* output2 = reinterpret_cast<half2*>(output);
     InvokeAddBiasTranspose<half2>(stream, num_matrices, format, max_threads_per_block,
-                                  batch_size, sequence_length, num_heads, H_q, input2, biases2, output2, H_v);
+                                  batch_size, sequence_length, num_heads, H, input2, biases2, output2, H_v);
   } else {
-    InvokeAddBiasTranspose<half>(stream, num_matrices, format, max_threads_per_block,
-                                 batch_size, sequence_length, num_heads, qk_head_size, input, biases, output, v_head_size);
+    InvokeAddBiasTranspose<half>(
+        stream, num_matrices, format, max_threads_per_block,
+        batch_size, sequence_length, num_heads, qk_head_size, input, biases, output, v_head_size);
   }
 }
 
@@ -316,19 +376,80 @@ void LaunchAddBiasTranspose(
     const float4* input2 = reinterpret_cast<const float4*>(input);
     const float4* biases2 = reinterpret_cast<const float4*>(biases);
     float4* output2 = reinterpret_cast<float4*>(output);
-    InvokeAddBiasTranspose<float4>(stream, num_matrices, format, max_threads_per_block,
-                                   batch_size, sequence_length, num_heads, H, input2, biases2, output2, v_head_size / 4);
+    InvokeAddBiasTranspose<float4>(
+        stream, num_matrices, format, max_threads_per_block,
+        batch_size, sequence_length, num_heads, H, input2, biases2, output2, v_head_size / 4);
   } else if (0 == (qk_head_size & 1)) {
     const int H = qk_head_size / 2;
     const float2* input2 = reinterpret_cast<const float2*>(input);
     const float2* biases2 = reinterpret_cast<const float2*>(biases);
     float2* output2 = reinterpret_cast<float2*>(output);
 
-    InvokeAddBiasTranspose<float2>(stream, num_matrices, format, max_threads_per_block,
-                                   batch_size, sequence_length, num_heads, H, input2, biases2, output2, v_head_size / 2);
+    InvokeAddBiasTranspose<float2>(
+        stream, num_matrices, format, max_threads_per_block,
+        batch_size, sequence_length, num_heads, H, input2, biases2, output2, v_head_size / 2);
   } else {
-    InvokeAddBiasTranspose<float>(stream, num_matrices, format, max_threads_per_block,
-                                  batch_size, sequence_length, num_heads, qk_head_size, input, biases, output, v_head_size);
+    InvokeAddBiasTranspose<float>(
+        stream, num_matrices, format, max_threads_per_block,
+        batch_size, sequence_length, num_heads, qk_head_size, input, biases, output, v_head_size);
+  }
+}
+
+template <typename T>
+void InvokeAddBiasTransposeTrt(
+    cudaStream_t stream, const int max_threads_per_block,
+    const int batch_size, const int sequence_length, const int num_heads, const int head_size,
+    const T* biases, const T* query, const T* key, const T* value, T* output) {
+  constexpr int num_matrices = 3;
+  const dim3 grid(sequence_length, batch_size, num_matrices);
+  if (head_size * num_heads <= max_threads_per_block) {
+    const dim3 block(head_size, num_heads, 1);
+    AddBiasTransposeTrt<T><<<grid, block, 0, stream>>>(query, key, value, biases, output);
+  } else {
+    const dim3 block(CeilDiv(max_threads_per_block, num_heads), num_heads, 1);
+    AddBiasTransposeTrtLarge<T><<<grid, block, 0, stream>>>(head_size, query, key, value, biases, output);
+  }
+}
+
+template <>
+void LaunchAddBiasTransposeTrt(
+    cudaStream_t stream, const int max_threads_per_block,
+    const int batch_size, const int sequence_length,
+    const int num_heads, const int head_size,
+    const float* biases, const float* query, const float* key, const float* value, float* output) {
+  ORT_ENFORCE(false, "Shall not call this since fused kernel does not support float input.");
+}
+
+template <>
+void LaunchAddBiasTransposeTrt(
+    cudaStream_t stream, const int max_threads_per_block,
+    const int batch_size, const int sequence_length,
+    const int num_heads, const int head_size,
+    const half* biases, const half* query, const half* key, const half* value, half* output) {
+  if (0 == (head_size % 4)) {
+    const int H = head_size / 4;
+    const Half4* query2 = reinterpret_cast<const Half4*>(query);
+    const Half4* key2 = reinterpret_cast<const Half4*>(key);
+    const Half4* value2 = reinterpret_cast<const Half4*>(value);
+    const Half4* biases2 = reinterpret_cast<const Half4*>(biases);
+    Half4* output2 = reinterpret_cast<Half4*>(output);
+    InvokeAddBiasTransposeTrt<Half4>(stream, max_threads_per_block,
+                                     batch_size, sequence_length, num_heads, H,
+                                     biases2, query2, key2, value2, output2);
+  } else if (0 == (head_size & 1)) {
+    const int H = head_size / 2;
+    const half2* query2 = reinterpret_cast<const half2*>(query);
+    const half2* key2 = reinterpret_cast<const half2*>(key);
+    const half2* value2 = reinterpret_cast<const half2*>(value);
+    const half2* biases2 = reinterpret_cast<const half2*>(biases);
+    half2* output2 = reinterpret_cast<half2*>(output);
+    InvokeAddBiasTransposeTrt<half2>(stream, max_threads_per_block,
+                                     batch_size, sequence_length, num_heads, H,
+                                     biases2, query2, key2, value2, output2);
+  } else {
+    InvokeAddBiasTransposeTrt<half>(stream, max_threads_per_block,
+                                    batch_size, sequence_length, num_heads, head_size,
+                                    biases, query, key, value, output);
   }
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/add_bias_transpose.h
+++ b/onnxruntime/contrib_ops/cuda/bert/add_bias_transpose.h
@@ -27,6 +27,17 @@ void LaunchAddBiasTranspose(
     const int batch_size, const int sequence_length, const int num_heads, const int qk_head_size,
     const T* input, const T* biases, T* output, bool enable_half4, const int v_head_size);
 
+
+// Add (bias) and Transpose for separated inputs of Q, K and V, and output Trt format.
+//   output:  (batch_size, sequence_length, num_heads, num_matrices, head_size)
+// It assumes sequence_length == kv_sequence_length and head_size == v_head_size.
+template <typename T>
+void LaunchAddBiasTransposeTrt(
+    cudaStream_t stream, const int max_threads_per_block,
+    const int batch_size, const int sequence_length,
+    const int num_heads, const int head_size,
+    const T* biases, const T* query, const T* key, const T* value, T* output);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -52,7 +52,7 @@ static inline bool HasFusedFp16Kernel(int sm, int head_size, int sequence_length
 }
 
 template <typename T>
-Attention<T>::Attention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info) {
+Attention<T>::Attention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info, false, false) {
   disable_fused_runner_ = sizeof(T) != 2 || ParseEnvironmentVariableWithDefault<bool>(kDisableFusedAttention, false);
 }
 
@@ -64,49 +64,35 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* mask_index = context->Input<Tensor>(3);
   const Tensor* past = context->Input<Tensor>(4);
   const Tensor* extra_add_qk = context->Input<Tensor>(5);
+  const Tensor* key = context->Input<Tensor>(6);
+  const Tensor* value = context->Input<Tensor>(7);
 
   auto& device_prop = GetDeviceProp();
+  AttentionParameters parameters;
   ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(),
-                                  weights->Shape(),
+                                  nullptr == weights ? nullptr : &(weights->Shape()),
                                   bias->Shape(),
                                   mask_index,
                                   past,
                                   extra_add_qk,
+                                  key,
+                                  value,
+                                  &parameters,
                                   device_prop.maxThreadsPerBlock));
 
-  // input shape (batch_size, sequence_length, input_hidden_size)
-  const auto& shape = input->Shape();
-  int batch_size = static_cast<int>(shape[0]);
-  int sequence_length = static_cast<int>(shape[1]);
-  int input_hidden_size = static_cast<int>(shape[2]);
-
-  // bias shape (3 * hidden_size)
-  const auto& bias_shape = bias->Shape();
-  int q_hidden_size;
-  int k_hidden_size;
-  int v_hidden_size;
-
-
-  if (qkv_hidden_sizes_.size() == 0) {
-    q_hidden_size = static_cast<int>(bias_shape[0]) / 3;
-    k_hidden_size = static_cast<int>(bias_shape[0]) / 3;
-    v_hidden_size = static_cast<int>(bias_shape[0]) / 3;
-  } else {
-    q_hidden_size = static_cast<int>(qkv_hidden_sizes_[0]);
-    k_hidden_size = static_cast<int>(qkv_hidden_sizes_[1]);
-    v_hidden_size = static_cast<int>(qkv_hidden_sizes_[2]);
-  }
-
-  const int qkv_head_size[3] = {q_hidden_size / num_heads_, k_hidden_size / num_heads_, v_hidden_size / num_heads_};
+  int batch_size = parameters.batch_size;
+  int sequence_length = parameters.sequence_length;
 
   TensorShapeVector output_shape(3);
-  output_shape[0] = shape[0];
-  output_shape[1] = shape[1];
-  output_shape[2] = static_cast<int64_t>(v_hidden_size);
+  output_shape[0] = static_cast<int64_t>(batch_size);
+  output_shape[1] = static_cast<int64_t>(sequence_length);
+  output_shape[2] = static_cast<int64_t>(parameters.v_hidden_size);
   Tensor* output = context->Output(0, output_shape);
 
-  int past_sequence_length = 0;
-  Tensor* present = GetPresent(context, past, batch_size, qkv_head_size[1], sequence_length, past_sequence_length);
+  std::vector<int64_t> present_dims{2, parameters.batch_size, parameters.num_heads,
+                                    parameters.total_sequence_length, parameters.head_size};
+  TensorShape present_shape(present_dims);
+  Tensor* present = context->Output(1, present_shape);
 
   // Check whether we can use fused kernel
   int sm = device_prop.major * 10 + device_prop.minor;
@@ -116,16 +102,16 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                            nullptr == present &&
                            nullptr == extra_add_qk &&
                            !is_unidirectional_ &&
-                           qkv_head_size[0] == qkv_head_size[1] &&
-                           qkv_head_size[1] == qkv_head_size[2] &&
-                           HasFusedFp16Kernel(sm, qkv_head_size[0], sequence_length));
+                           parameters.hidden_size == parameters.v_hidden_size &&
+                           parameters.sequence_length == parameters.kv_sequence_length &&
+                           HasFusedFp16Kernel(sm, parameters.head_size, sequence_length));
 
   MHARunner* fused_runner = nullptr;
   if (use_fused_runner) {
     if (nullptr == fused_fp16_runner_.get()) {
-      fused_fp16_runner_.reset(new FusedMHARunnerFP16v2(num_heads_, qkv_head_size[0], sm));
+      fused_fp16_runner_.reset(new FusedMHARunnerFP16v2(num_heads_, parameters.head_size, sm));
     }
-    // In case some kernel  not loaded due to shared memory limit, we need to double check here.
+    // In case some kernel not loaded due to shared memory limit, we need to double check here.
     if (fused_fp16_runner_->isValid(sequence_length)) {
       fused_runner = fused_fp16_runner_.get();
     }
@@ -134,58 +120,55 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   cublasHandle_t cublas = CublasHandle();
   constexpr size_t element_size = sizeof(T);
 
-  // Use GEMM for fully connection.
-  int m = batch_size * sequence_length;
-  int n = (q_hidden_size + k_hidden_size + v_hidden_size);
-  int k = input_hidden_size;
-  size_t gemm_buffer_size = static_cast<size_t>(batch_size) * sequence_length * n * element_size;
-  auto gemm_buffer = GetScratchBuffer<T>(gemm_buffer_size);
+  IAllocatorUniquePtr<T> gemm_buffer;
+  if (weights != nullptr) {
+    // Use GEMM for fully connection.
+    int m = batch_size * sequence_length;
+    int n = (parameters.hidden_size + parameters.hidden_size + parameters.v_hidden_size);
+    int k = parameters.input_hidden_size;
+    size_t gemm_buffer_size = static_cast<size_t>(batch_size) * sequence_length * n * element_size;
+    gemm_buffer = GetScratchBuffer<T>(gemm_buffer_size);
 
-  typedef typename ToCudaType<T>::MappedType CudaT;
-  CudaT one = ToCudaType<T>::FromFloat(1.0f);
-  CudaT zero = ToCudaType<T>::FromFloat(0.0f);
+    typedef typename ToCudaType<T>::MappedType CudaT;
+    CudaT one = ToCudaType<T>::FromFloat(1.0f);
+    CudaT zero = ToCudaType<T>::FromFloat(0.0f);
 
-  // Gemm, note that CUDA assumes col-major, so result(N, M) = 1 * weights x input + 1 x B.
-  CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
-      cublas, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &one,
-      reinterpret_cast<const CudaT*>(weights->Data<T>()), n,
-      reinterpret_cast<const CudaT*>(input->Data<T>()), k,
-      &zero, reinterpret_cast<CudaT*>(gemm_buffer.get()), n, device_prop));
+    // Gemm, note that CUDA assumes col-major, so result(N, M) = 1 * weights x input + 1 x B.
+    CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
+        cublas, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &one,
+        reinterpret_cast<const CudaT*>(weights->Data<T>()), n,
+        reinterpret_cast<const CudaT*>(input->Data<T>()), k,
+        &zero, reinterpret_cast<CudaT*>(gemm_buffer.get()), n, device_prop));
+  }
 
   size_t workSpaceSize = GetAttentionWorkspaceSize(element_size,
-                                                   batch_size,
-                                                   num_heads_,
-                                                   qkv_head_size[0],
-                                                   sequence_length,
-                                                   past_sequence_length,
-                                                   fused_runner,
-                                                   qkv_head_size[2]);
+                                                   parameters.batch_size,
+                                                   parameters.num_heads,
+                                                   parameters.head_size,
+                                                   parameters.v_head_size,
+                                                   parameters.sequence_length,
+                                                   parameters.kv_sequence_length,
+                                                   parameters.total_sequence_length,
+                                                   fused_runner);
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize);
-  ORT_RETURN_IF_ERROR(LaunchAttentionKernel(
-      device_prop,
-      Stream(),
-      cublas,
-      element_size,
-      batch_size,
-      sequence_length,
-      num_heads_,
-      qkv_head_size[0],
-      past_sequence_length,
-      is_unidirectional_,
-      reinterpret_cast<const void*>(gemm_buffer.get()),
-      bias->Data<T>(),
-      nullptr == mask_index ? nullptr : mask_index->Data<int>(),
-      nullptr == mask_index ? gsl::span<const int64_t>() : mask_index->Shape().GetDims(),
-      nullptr == past ? nullptr : past->Data<T>(),
-      nullptr == extra_add_qk ? nullptr : extra_add_qk->Data<T>(),
-      work_space.get(),
-      output->MutableData<T>(),
-      nullptr == present ? nullptr : present->MutableData<T>(),
-      fused_runner,
-      qkv_head_size[2]));
 
-  return Status::OK();
+  typedef typename ToCudaType<T>::MappedType CudaT;
+  AttentionData<CudaT> data;
+  data.gemm_buffer = (nullptr == weights) ? nullptr : reinterpret_cast<const CudaT*>(gemm_buffer.get());
+  data.bias = reinterpret_cast<const CudaT*>(bias->Data<T>());
+  data.query = (nullptr != weights) ? nullptr : reinterpret_cast<const CudaT*>(input->Data<T>());
+  data.key = (nullptr == key) ? nullptr : reinterpret_cast<const CudaT*>(key->Data<T>());
+  data.value = (nullptr == value) ? nullptr : reinterpret_cast<const CudaT*>(value->Data<T>());
+  data.mask_index = (nullptr == mask_index) ? nullptr : mask_index->Data<int>();
+  data.mask_index_dims = (nullptr == mask_index) ? gsl::span<const int64_t>() : mask_index->Shape().GetDims();
+  data.past = (nullptr == past) ? nullptr : reinterpret_cast<const CudaT*>(past->Data<T>());
+  data.extra_add_qk = (nullptr == extra_add_qk) ? nullptr : reinterpret_cast<const CudaT*>(extra_add_qk->Data<T>());
+  data.workspace = reinterpret_cast<CudaT*>(work_space.get());
+  data.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
+  data.present = (nullptr == present) ? nullptr : reinterpret_cast<CudaT*>(present->MutableData<T>());
+
+  return QkvToContext<CudaT>(device_prop, cublas, Stream(), parameters, data, reinterpret_cast<void*>(fused_runner));
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/attention_concat.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_concat.cu
@@ -27,9 +27,9 @@ __global__ void ConcatTensorToTensor(const int tensor_add_sequence_length,
   const int H = blockDim.x;
 
   // K: number of identical tensors
-  // tensor_in:    K x BxNxS'xH
-  // tensor_add:   K x BxNxSxH
-  // tensor_out:   K x BxNx(S'+S)xH
+  // tensor_in:    K x BxNxPxH
+  // tensor_add:   K x BxNxLxH
+  // tensor_out:   K x BxNxTxH, where T = P + L
   const int tensor_in_sequence_length = all_sequence_length - tensor_add_sequence_length;
 
   const int present_SH = all_sequence_length * H;
@@ -67,9 +67,9 @@ __global__ void ConcatTensorToTensorLarge(const int tensor_add_sequence_length,
   const int stride = blockDim.x;
 
   // K: number of identical tensor
-  // tensor_in:    K x BxNxS'xH
-  // tensor_add:   K x BxNxSxH
-  // tensor_out:   K x BxNx(S'+S)xH
+  // tensor_in:    K x BxNxPxH
+  // tensor_add:   K x BxNxLxH
+  // tensor_out:   K x BxNxTxH
   const int tensor_in_sequence_length = all_sequence_length - tensor_add_sequence_length;
 
   const int present_SH = all_sequence_length * H;

--- a/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/longformer_attention_impl.cu
@@ -868,7 +868,7 @@ Status LongformerQkvToContext(
   // The order of qkv space:
   //  Q, K, V, Global_K, Global_V, Global_Q (format 0)
   //  Q, K, V, Global_Q, Global_K, Global_V (format 1)
-  // Assume H_q == H_k == H_v
+  // Assume Q, K and V has same hidden size
   if (format == 1 || max_num_global == 0 || nullptr == global_input) {
     if (bias == nullptr) {
       ORT_RETURN_IF_ERROR(LaunchTransQkv(stream, 3, sequence_length, batch_size, head_size, num_heads,

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -47,10 +47,17 @@ Status QAttention<T, int8_t>::CheckInputs(const Tensor* input,
                                           const Tensor*& mask_index,
                                           const Tensor* i_zp_tensor,
                                           const Tensor* w_zp_tensor,
-                                          const Tensor* past_tensor) const {
+                                          const Tensor* past_tensor,
+                                          void* parameters) const {
   auto& device_prop = GetDeviceProp();
-  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(), weights->Shape(), bias->Shape(),
-                                                 mask_index, past_tensor, nullptr, device_prop.maxThreadsPerBlock));
+  auto& weights_shape = weights->Shape();
+  ORT_RETURN_IF_ERROR(AttentionBase::CheckInputs(input->Shape(), &weights_shape, bias->Shape(),
+                                                 mask_index, past_tensor,
+                                                 nullptr,  // extra_add_qk
+                                                 nullptr,  // key
+                                                 nullptr,  // value
+                                                 parameters,
+                                                 device_prop.maxThreadsPerBlock));
 
   ORT_RETURN_IF_NOT(IsScalarOr1ElementVector(input_scale_tensor),
                     "input scale must be a scalar or 1D tensor of size 1");
@@ -84,14 +91,13 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   //   Input 2  - bias              : (3 * hidden_size)
   //   Input 3  - input_scale       : scalar
   //   Input 4  - weight_scale      : scalar
-  //   Input 5  - mask_index        : nullptr, (batch_size), (2 * batch_size), (batch_size, 1), (1, 1)
-  //                                  or (batch_size, past_sequence_length + sequence_length)
+  //   Input 5  - mask_index        : see Attention operator spec
   //   Input 6  - input_zero_point  : scalar
   //   Input 7  - weight_zero_point : scalar
   //   Input 8  - past              : (2, batch_size, num_heads, past_sequence_length, head_size)
   //   Output 0 - output            : (batch_size, sequence_length, hidden_size)
   //   Output 1 - present           : (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)
-  //   ORT_RETURN_IF_ERROR(CheckInputs(context));
+
   const Tensor* input = context->Input<Tensor>(0);
   const Tensor* weights = context->Input<Tensor>(1);
   const Tensor* bias = context->Input<Tensor>(2);
@@ -102,6 +108,7 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* w_zp_tensor = context->Input<Tensor>(7);
   const Tensor* past_tensor = context->Input<Tensor>(8);
 
+  AttentionParameters parameters;
   ORT_RETURN_IF_ERROR(CheckInputs(input,
                                   weights,
                                   bias,
@@ -110,22 +117,18 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
                                   mask_index,
                                   i_zp_tensor,
                                   w_zp_tensor,
-                                  past_tensor));
+                                  past_tensor,
+                                  &parameters));
 
-  const auto& shape = input->Shape();
-  int batch_size = SafeInt<int>(shape[0]);
-  int sequence_length = SafeInt<int>(shape[1]);
-  int input_hidden_size = SafeInt<int>(shape[2]);
-
-  const auto& bias_shape = bias->Shape();
-  const int hidden_size = SafeInt<int>(bias_shape.GetDims()[0]) / 3;
-  // Note: Scenario where q_hidden_size == k_hidden_size != v_hidden_size is not supported in quantization
-  const int qkv_head_size[3] = {hidden_size / num_heads_, hidden_size / num_heads_, hidden_size / num_heads_};
+  int batch_size = parameters.batch_size;
+  int sequence_length = parameters.sequence_length;
+  int hidden_size = parameters.hidden_size;
+  int head_size = parameters.head_size;
 
   TensorShapeVector output_shape(3);
-  output_shape[0] = shape[0];
-  output_shape[1] = shape[1];
-  output_shape[2] = SafeInt<int64_t>(hidden_size);
+  output_shape[0] = static_cast<int64_t>(batch_size);
+  output_shape[1] = static_cast<int64_t>(sequence_length);
+  output_shape[2] = static_cast<int64_t>(parameters.v_hidden_size);
   Tensor* output = context->Output(0, output_shape);
 
   cublasHandle_t cublas = CublasHandle();
@@ -134,9 +137,10 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   // Use GEMM for fully connection.
   int m = batch_size * sequence_length;
   int n = 3 * hidden_size;
-  int k = input_hidden_size;
-  auto gemm_buffer = GetScratchBuffer<T>(SafeInt<size_t>(batch_size) * sequence_length * 3 * hidden_size * element_size);
-  auto gemm_buffer_quantized = GetScratchBuffer<int32_t>(SafeInt<size_t>(batch_size) * sequence_length * 3 * hidden_size);
+  int k = parameters.input_hidden_size;
+  size_t num_elements = SafeInt<size_t>(m) * n;
+  auto gemm_buffer = GetScratchBuffer<T>(num_elements * element_size);
+  auto gemm_buffer_quantized = GetScratchBuffer<int32_t>(num_elements);
 
   typedef typename ToCudaType<T>::MappedType CudaT;
 
@@ -166,37 +170,46 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
                                              m,
                                              n));
 
-  int past_sequence_length = 0;
-  Tensor* present_tensor = GetPresent(context, past_tensor, batch_size, qkv_head_size[1],
-                                      sequence_length, past_sequence_length);
+  std::vector<int64_t> present_dims{2, parameters.batch_size, parameters.num_heads,
+                                    parameters.total_sequence_length, parameters.head_size};
+  TensorShape present_shape(present_dims);
+  Tensor* present = context->Output(1, present_shape);
 
   void* fused_runner = nullptr;  // TODO(tianleiwu): use fused kernel to speed up
-  size_t workSpaceSize = GetAttentionWorkspaceSize(element_size, batch_size, num_heads_, qkv_head_size[0],
-                                                   sequence_length, past_sequence_length, fused_runner, qkv_head_size[2]);
+  size_t workSpaceSize = GetAttentionWorkspaceSize(element_size,
+                                                   batch_size,
+                                                   parameters.num_heads,
+                                                   head_size,
+                                                   parameters.v_head_size,
+                                                   sequence_length,
+                                                   parameters.kv_sequence_length,
+                                                   parameters.total_sequence_length,
+                                                   fused_runner);
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize);
-  return LaunchAttentionKernel(
-          GetDeviceProp(),
-          Stream(),
-          cublas,
-          element_size,
-          batch_size,
-          sequence_length,
-          num_heads_,
-          qkv_head_size[0],
-          past_sequence_length,
-          is_unidirectional_,
-          reinterpret_cast<const void*>(gemm_buffer.get()),
-          nullptr,  // bias has been added
-          nullptr == mask_index ? nullptr : mask_index->Data<int>(),
-          nullptr == mask_index ? gsl::span<const int64_t>() : mask_index->Shape().GetDims(),
-          nullptr == past_tensor ? nullptr : past_tensor->Data<T>(),
-          nullptr,  // TODO: support add_qk in quantized attention
-          work_space.get(),
-          output->MutableData<T>(),
-          nullptr == present_tensor ? nullptr : present_tensor->MutableData<T>(),
-          fused_runner,
-          qkv_head_size[2]);
+
+  typedef typename ToCudaType<T>::MappedType CudaT;
+  AttentionData<CudaT> data;
+  data.gemm_buffer = reinterpret_cast<const CudaT*>(gemm_buffer.get());
+  data.bias = nullptr;  // bias has been added
+  data.query = nullptr;
+  data.key = nullptr;
+  data.value = nullptr;
+  data.mask_index = (nullptr == mask_index) ? nullptr : mask_index->Data<int>();
+  data.mask_index_dims = (nullptr == mask_index) ? gsl::span<const int64_t>() : mask_index->Shape().GetDims();
+  data.past = (nullptr == past_tensor) ? nullptr : reinterpret_cast<const CudaT*>(past_tensor->Data<T>());
+  data.extra_add_qk = nullptr;  // add_qk is not supported in quantized attention
+  data.workspace = reinterpret_cast<CudaT*>(work_space.get());
+  data.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
+  data.present = (nullptr == present) ? nullptr : reinterpret_cast<CudaT*>(present->MutableData<T>());
+
+  return QkvToContext<CudaT>(
+      GetDeviceProp(),
+      cublas,
+      Stream(),
+      parameters,
+      data,
+      fused_runner);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.h
@@ -22,7 +22,7 @@ class QAttention<T, int8_t> final : public CudaKernel, public AttentionBase {
 
  public:
   QAttention(const OpKernelInfo& info) : CudaKernel(info),
-                                         AttentionBase(info) {
+                                         AttentionBase(info, true, true) {
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
@@ -36,7 +36,8 @@ class QAttention<T, int8_t> final : public CudaKernel, public AttentionBase {
                      const Tensor*& mask_index,
                      const Tensor* i_zp_tensor,
                      const Tensor* w_zp_tensor,
-                     const Tensor* past_tensor) const;
+                     const Tensor* past_tensor,
+                     void* parameters) const;
 };
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/quantization/qordered_ops/qordered_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/qordered_ops/qordered_attention.cc
@@ -156,7 +156,7 @@ inline void debug_print([[maybe_unused]] const T* arr,
 
 #endif
 
-QOrderedAttention::QOrderedAttention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info) {
+QOrderedAttention::QOrderedAttention(const OpKernelInfo& info) : CudaKernel(info), AttentionBase(info, true, true) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11040
   input_hidden_size_ = 0;
   int cuda_runtime_version = 0;
@@ -208,8 +208,14 @@ Status QOrderedAttention::ComputeInternal(OpKernelContext* context) const {
   const Tensor* mask_index = context->Input<Tensor>(InputIds::Mask_Index);
 
   auto& device_prop = GetDeviceProp();
-  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), merged_weights_shape, merged_bias_shape,
-                                  mask_index, nullptr, nullptr, device_prop.maxThreadsPerBlock));
+  ORT_RETURN_IF_ERROR(CheckInputs(input->Shape(), &merged_weights_shape, merged_bias_shape,
+                                  mask_index,
+                                  nullptr,  // past
+                                  nullptr,  // extra_add_qk
+                                  nullptr,  // key
+                                  nullptr,  // value
+                                  nullptr,  // parameters
+                                  device_prop.maxThreadsPerBlock));
 
   const Tensor* tensor_scale_attn_scores = context->Input<Tensor>(InputIds::Scale_QK_Gemm);
   const float* scale_attn_scores_data = tensor_scale_attn_scores->Data<float>();

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -60,25 +60,30 @@ void DecoderAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& ctx
 constexpr const char* Attention_ver1_doc = R"DOC(
 Multi-Head Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
 
-The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension, its shape
-is (input_hidden_size, num_heads * q_head_size + num_heads * q_head_size + num_heads * v_head_size).
+The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension. Its shape
+is (input_hidden_size, hidden_size + hidden_size + v_hidden_size). Here hidden_size is the hidden dimension of Q and K,
+and v_hidden_size is that of V.
 
 The mask_index is optional. Besides raw attention mask with shape (batch_size, total_sequence_length)
 or (batch_size, sequence_length, total_sequence_length) with value 0 for masked and 1 otherwise,
 we support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
-where value of each element is the end position, or valid length of actual sequence excluding padding. When input has
-left-side padding, mask_index has shape (2 * batch_size), where the values are the exclusive end positions followed by
-the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. Both
-past and present state are optional.
+where value is actual sequence length excluding padding. When input has left-side padding, mask_index has
+shape (2 * batch_size), where the values are the exclusive end positions followed by the inclusive start positions.
+
+When unidirectional is 1, each token only attends to previous tokens.
+
+Both past and present state are optional. They shall be used together, and not allowed to use only one of them.
 
 When weights is not provided, key and value are required. In this situation, MatMul for input projection is excluded,
-and input is the query after projection. Add bias is included for performance consideration.
+and input is the query after projection. The bias is included for performance consideration.
 
-The qkv_hidden_sizes is required only when K and V has different hidden size.
+The qkv_hidden_sizes is required only when K and V have different hidden sizes.
 
 When there is past state, hidden dimension for Q, K and V shall be the same.
 
-The total_sequence_length is past_sequence_length + kv_sequence_length.
+The total_sequence_length is past_sequence_length + kv_sequence_length. Here kv_sequence_length is the length of K or V.
+For self attention, kv_sequence_length equals to sequence_length (sequence length of Q).
+For cross attention, query and key might have different lengths.
 )DOC";
 
 ONNX_MS_OPERATOR_SET_SCHEMA(
@@ -96,8 +101,8 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               OPTIONAL_VALUE)
         .Input(0,
                "input",
-               "Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is avaiable, "
-               "or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not avaiable.",
+               "Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is available, "
+               "or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not available.",
                "T",
                OpSchema::Optional)
         .Input(1,
@@ -118,24 +123,24 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(4,
                "past",
-               "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).",
+               "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size)",
                "T",
                OpSchema::Optional)
         .Input(5,
                "extra_add",
-               "additional add to QxK' with shape (batch_size, num_heads, sequence_length, sequence_length).",
+               "additional add to QxK' with shape (batch_size, num_heads, sequence_length, total_sequence_length)",
                "T",
                OpSchema::Optional)
         .Input(6,
                "key",
                "Input for key with shape (batch_size, kv_sequence_length, hidden_size). "
-               "Required when weights is not avaiable",
+               "Required when weights is not available.",
                "T",
                OpSchema::Optional)
         .Input(7,
                "value",
                "Input for key with shape (batch_size, kv_sequence_length, v_hidden_size). "
-               "Required when weights is not avaiable",
+               "Required when weights is not available.",
                "T",
                OpSchema::Optional)
         .Output(0,

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -58,45 +58,105 @@ void DecoderAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& ctx
 }
 
 constexpr const char* Attention_ver1_doc = R"DOC(
-Multi-Head Self Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
-The mask_index input is optional. Besides raw attention mask with shape (batch_size, past_sequence_length + sequence_length)
-or (batch_size, sequence_length, past_sequence_length + sequence_length) with value 0 for masked and 1 otherwise,
-we also support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
+Multi-Head Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
+
+The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension, its shape
+is (input_hidden_size, num_heads * q_head_size + num_heads * q_head_size + num_heads * v_head_size).
+
+The mask_index is optional. Besides raw attention mask with shape (batch_size, total_sequence_length)
+or (batch_size, sequence_length, total_sequence_length) with value 0 for masked and 1 otherwise,
+we support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
 where value of each element is the end position, or valid length of actual sequence excluding padding. When input has
 left-side padding, mask_index has shape (2 * batch_size), where the values are the exclusive end positions followed by
-the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. For GPT-2, both past
-and present state are optional. Present state could appear in output even when past state is not in input.
+the inclusive start positions. When unidirectional is 1, and each token only attend to previous tokens. Both
+past and present state are optional.
+
+When weights is not provided, key and value are required. In this situation, MatMul for input projection is excluded,
+and input is the query after projection. Add bias is included for performance consideration.
+
+The qkv_hidden_sizes is required only when K and V has different hidden size.
+
+When there is past state, hidden dimension for Q, K and V shall be the same.
+
+The total_sequence_length is past_sequence_length + kv_sequence_length.
 )DOC";
 
-ONNX_MS_OPERATOR_SET_SCHEMA(Attention, 1,
-                            OpSchema()
-                                .SetDoc(Attention_ver1_doc)
-                                .Attr("num_heads", "Number of attention heads", AttributeProto::INT)
-                                .Attr("unidirectional",
-                                      "Whether every token can only attend to previous tokens. Default value is 0.",
-                                      AttributeProto::INT,
-                                      static_cast<int64_t>(0))
-                                .Attr("qkv_hidden_sizes",
-                                      "Hidden layer sizes of Q, K, V paths in Attention",
-                                      AttributeProto::INTS,
-                                      OPTIONAL_VALUE)
-                                .Input(0, "input", "3D input tensor with shape (batch_size, sequence_length, input_hidden_size)", "T")
-                                .Input(1, "weight", "2D input tensor with shape (input_hidden_size, 3 * hidden_size), where hidden_size = num_heads * head_size", "T")
-                                .Input(2, "bias", "1D input tensor with shape (3 * hidden_size)", "T")
-                                .Input(3, "mask_index",
-                                       "Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), (batch_size, past_sequence_length + sequence_length)"
-                                       "or (batch_size, sequence_length, past_sequence_length + sequence_length), or index with shape (batch_size) or (2 * batch_size).",
-                                       "M", OpSchema::Optional)
-                                .Input(4, "past", "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).", "T", OpSchema::Optional)
-                                .Input(5, "extra_add", "additional add to QxK' with shape (batch_size, num_heads, sequence_length, sequence_length).", "T", OpSchema::Optional)
-                                .Output(0, "output", "3D output tensor with shape (batch_size, sequence_length, hidden_size)", "T")
-                                .Output(1, "present", "present state for key and value with shape (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)", "T", OpSchema::Optional)
-                                .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float tensors.")
-                                .TypeConstraint("M", {"tensor(int32)"}, "Constrain mask index to integer types")
-                                .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-                                  constexpr int past_input_index = 4;
-                                  AttentionTypeAndShapeInference(ctx, past_input_index);
-                                }));
+ONNX_MS_OPERATOR_SET_SCHEMA(
+    Attention, 1,
+    OpSchema()
+        .SetDoc(Attention_ver1_doc)
+        .Attr("num_heads", "Number of attention heads", AttributeProto::INT)
+        .Attr("unidirectional",
+              "Whether every token can only attend to previous tokens. Default value is 0.",
+              AttributeProto::INT,
+              static_cast<int64_t>(0))
+        .Attr("qkv_hidden_sizes",
+              "Hidden dimension of Q, K, V: hidden_size, hidden_size and v_hidden_size",
+              AttributeProto::INTS,
+              OPTIONAL_VALUE)
+        .Input(0,
+               "input",
+               "Input tensor with shape (batch_size, sequence_length, input_hidden_size) when weights is avaiable, "
+               "or query tensor with shape (batch_size, sequence_length, hidden_size) when weights is not avaiable.",
+               "T",
+               OpSchema::Optional)
+        .Input(1,
+               "weights",
+               "Merged Q/K/V weights with shape (input_hidden_size, hidden_size + hidden_size + v_hidden_size)",
+               "T",
+               OpSchema::Optional)
+        .Input(2,
+               "bias",
+               "Bias tensor with shape (hidden_size + hidden_size + v_hidden_size) for input projection",
+               "T")
+        .Input(3,
+               "mask_index",
+               "Attention mask with shape (batch_size, 1, max_sequence_length, max_sequence_length), "
+               "(batch_size, total_sequence_length) or (batch_size, sequence_length, total_sequence_length), "
+               "or index with shape (batch_size) or (2 * batch_size).",
+               "M",
+               OpSchema::Optional)
+        .Input(4,
+               "past",
+               "past state for key and value with shape (2, batch_size, num_heads, past_sequence_length, head_size).",
+               "T",
+               OpSchema::Optional)
+        .Input(5,
+               "extra_add",
+               "additional add to QxK' with shape (batch_size, num_heads, sequence_length, sequence_length).",
+               "T",
+               OpSchema::Optional)
+        .Input(6,
+               "key",
+               "Input for key with shape (batch_size, kv_sequence_length, hidden_size). "
+               "Required when weights is not avaiable",
+               "T",
+               OpSchema::Optional)
+        .Input(7,
+               "value",
+               "Input for key with shape (batch_size, kv_sequence_length, v_hidden_size). "
+               "Required when weights is not avaiable",
+               "T",
+               OpSchema::Optional)
+        .Output(0,
+                "output",
+                "3D output tensor with shape (batch_size, sequence_length, v_hidden_size)",
+                "T")
+        .Output(1,
+                "present",
+                "past state for key and value with shape (2, batch_size, num_heads, total_sequence_length, head_size)",
+                "T",
+                OpSchema::Optional)
+        .TypeConstraint("T",
+                        {"tensor(float)", "tensor(float16)"},
+                        "Constrain input and output types to float tensors.")
+        .TypeConstraint("M",
+                        {"tensor(int32)"},
+                        "Constrain mask index to integer types")
+        .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          constexpr int past_input_index = 4;
+          AttentionTypeAndShapeInference(ctx, past_input_index);
+        }));
 
 constexpr const char* Longformer_Attention_doc = R"DOC(
 Longformer Self Attention with a local context and a global context. Tokens attend locally: Each token
@@ -311,5 +371,5 @@ ONNX_MS_OPERATOR_SET_SCHEMA(GemmFastGelu, 1,
                                   ONNX_NAMESPACE::matmulShapeInference(ctx, 0, 1);
                                 }));
 
-}
+}  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/cpu_provider_shared.cc
+++ b/onnxruntime/core/providers/cpu/cpu_provider_shared.cc
@@ -167,21 +167,81 @@ struct ProviderHostCPUImpl : ProviderHostCPU {
   Status EinsumTypedComputeProcessor__Run(EinsumTypedComputeProcessor<MLFloat16>* p) override { return p->Run(); }
 
 #ifndef DISABLE_CONTRIB_OPS
-  Status embed_layer_norm__CheckInputs(const OpKernelContext* context, bool quantizedVersion) override { return contrib::embed_layer_norm::CheckInputs(context, quantizedVersion); }
-  Status bias_gelu_helper__CheckInputs(const OpKernelContext* context) override { return contrib::bias_gelu_helper::CheckInputs(context); }
-  Status LongformerAttentionBase__CheckInputs(const contrib::LongformerAttentionBase* p, const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const TensorShape& mask_shape, const TensorShape& global_weights_shape, const TensorShape& global_bias_shape, const TensorShape& global_shape) override {
-    return p->contrib::LongformerAttentionBase::CheckInputs(input_shape, weights_shape, bias_shape, mask_shape, global_weights_shape, global_bias_shape, global_shape);
+  Status embed_layer_norm__CheckInputs(const OpKernelContext* context, bool quantizedVersion) override {
+    return contrib::embed_layer_norm::CheckInputs(context, quantizedVersion);
   }
-  Status AttentionBase__CheckInputs(const contrib::AttentionBase* p, const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const Tensor*& mask_index, const Tensor* past, const Tensor* extra_add_qk, const int max_threads_per_block) override { return p->contrib::AttentionBase::CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past, extra_add_qk, max_threads_per_block); }
-  Tensor* AttentionBase__GetPresent(const contrib::AttentionBase* p, OpKernelContext* context, const Tensor* past, int batch_size, int head_size, int sequence_length, int& past_sequence_length) override { return p->contrib::AttentionBase::GetPresent(context, past, batch_size, head_size, sequence_length, past_sequence_length); }
 
-  void BeamSearch__Init(contrib::transformers::BeamSearch* p, const OpKernelInfo& info) override { p->contrib::transformers::BeamSearch::Init(info); }
-  Status BeamSearch__Compute(const contrib::transformers::BeamSearch* p, OpKernelContext* ctx) override { return p->contrib::transformers::BeamSearch::Compute(ctx); }
-  Status BeamSearch__SetupSubgraphExecutionInfo(contrib::transformers::BeamSearch* p, const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) override { return p->contrib::transformers::BeamSearch::SetupSubgraphExecutionInfo(session_state, attribute_name, subgraph_session_state); }
+  Status bias_gelu_helper__CheckInputs(const OpKernelContext* context) override {
+    return contrib::bias_gelu_helper::CheckInputs(context);
+  }
 
-  void GreedySearch__Init(contrib::transformers::GreedySearch* p, const OpKernelInfo& info) override { p->contrib::transformers::GreedySearch::Init(info); }
-  Status GreedySearch__Compute(const contrib::transformers::GreedySearch* p, OpKernelContext* ctx) override { return p->contrib::transformers::GreedySearch::Compute(ctx); }
-  Status GreedySearch__SetupSubgraphExecutionInfo(contrib::transformers::GreedySearch* p, const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) override { return p->contrib::transformers::GreedySearch::SetupSubgraphExecutionInfo(session_state, attribute_name, subgraph_session_state); }
+  Status LongformerAttentionBase__CheckInputs(const contrib::LongformerAttentionBase* p,
+                                              const TensorShape& input_shape,
+                                              const TensorShape& weights_shape,
+                                              const TensorShape& bias_shape,
+                                              const TensorShape& mask_shape,
+                                              const TensorShape& global_weights_shape,
+                                              const TensorShape& global_bias_shape,
+                                              const TensorShape& global_shape) override {
+    return p->contrib::LongformerAttentionBase::CheckInputs(input_shape, weights_shape, bias_shape, mask_shape,
+                                                            global_weights_shape, global_bias_shape, global_shape);
+  }
+
+  Status AttentionBase__CheckInputs(const contrib::AttentionBase* p,
+                                    const TensorShape& input_shape,
+                                    const TensorShape* weights_shape,
+                                    const TensorShape& bias_shape,
+                                    const Tensor*& mask_index,
+                                    const Tensor* past,
+                                    const Tensor* extra_add_qk,
+                                    const Tensor* key,
+                                    const Tensor* value,
+                                    void* parameters,
+                                    const int max_threads_per_block) override {
+    return p->contrib::AttentionBase::CheckInputs(input_shape, weights_shape, bias_shape, mask_index, past,
+                                                  extra_add_qk,
+                                                  key, value, parameters,
+                                                  max_threads_per_block);
+  }
+
+  Tensor* AttentionBase__GetPresent(const contrib::AttentionBase* p,
+                                    OpKernelContext* context, const Tensor* past, int batch_size, int head_size,
+                                    int sequence_length, int& past_sequence_length) override {
+    return p->contrib::AttentionBase::GetPresent(context, past, batch_size, head_size,
+                                                 sequence_length, past_sequence_length);
+  }
+
+  void BeamSearch__Init(contrib::transformers::BeamSearch* p, const OpKernelInfo& info) override {
+    p->contrib::transformers::BeamSearch::Init(info);
+  }
+
+  Status BeamSearch__Compute(const contrib::transformers::BeamSearch* p, OpKernelContext* ctx) override {
+    return p->contrib::transformers::BeamSearch::Compute(ctx);
+  }
+
+  Status BeamSearch__SetupSubgraphExecutionInfo(contrib::transformers::BeamSearch* p, const SessionState& session_state,
+                                                const std::string& attribute_name,
+                                                const SessionState& subgraph_session_state) override {
+    return p->contrib::transformers::BeamSearch::SetupSubgraphExecutionInfo(session_state, attribute_name,
+                                                                            subgraph_session_state);
+  }
+
+  void GreedySearch__Init(contrib::transformers::GreedySearch* p, const OpKernelInfo& info) override {
+    p->contrib::transformers::GreedySearch::Init(info);
+  }
+
+  Status GreedySearch__Compute(const contrib::transformers::GreedySearch* p, OpKernelContext* ctx) override {
+    return p->contrib::transformers::GreedySearch::Compute(ctx);
+  }
+
+  Status GreedySearch__SetupSubgraphExecutionInfo(contrib::transformers::GreedySearch* p,
+                                                  const SessionState& session_state,
+                                                  const std::string& attribute_name,
+                                                  const SessionState& subgraph_session_state) override {
+    return p->contrib::transformers::GreedySearch::SetupSubgraphExecutionInfo(session_state,
+                                                                              attribute_name,
+                                                                              subgraph_session_state);
+  }
 
 #ifdef ENABLE_ATEN
   Status ATen__Compute(const contrib::ATen* p, OpKernelContext* p_ctx) override { return p->ATen::Compute(p_ctx); }

--- a/onnxruntime/core/providers/cpu/cpu_provider_shared.h
+++ b/onnxruntime/core/providers/cpu/cpu_provider_shared.h
@@ -127,19 +127,51 @@ struct ProviderHostCPU {
 #ifndef DISABLE_CONTRIB_OPS
   virtual Status embed_layer_norm__CheckInputs(const OpKernelContext* context, bool quantizedVersion) = 0;
   virtual Status bias_gelu_helper__CheckInputs(const OpKernelContext* context) = 0;
-  virtual Status LongformerAttentionBase__CheckInputs(const contrib::LongformerAttentionBase* p, const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const TensorShape& mask_shape, const TensorShape& global_weights_shape, const TensorShape& global_bias_shape, const TensorShape& global_shape) = 0;
-  virtual Status AttentionBase__CheckInputs(const contrib::AttentionBase* p, const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const Tensor*& mask_index, const Tensor* past, const Tensor* extra_add_qk, const int max_threads_per_block) = 0;
-  virtual Tensor* AttentionBase__GetPresent(const contrib::AttentionBase* p, OpKernelContext* context, const Tensor* past, int batch_size, int head_size, int sequence_length, int& past_sequence_length) = 0;
+
+  virtual Status LongformerAttentionBase__CheckInputs(const contrib::LongformerAttentionBase* p,
+  const TensorShape& input_shape,
+  const TensorShape& weights_shape,
+  const TensorShape& bias_shape,
+  const TensorShape& mask_shape,
+  const TensorShape& global_weights_shape,
+  const TensorShape& global_bias_shape,
+  const TensorShape& global_shape) = 0;
+
+  virtual Status AttentionBase__CheckInputs(const contrib::AttentionBase* p,
+                                            const TensorShape& input_shape,
+                                            const TensorShape* weights_shape,
+                                            const TensorShape& bias_shape,
+                                            const Tensor*& mask_index,
+                                            const Tensor* past,
+                                            const Tensor* extra_add_qk,
+                                            const Tensor* key,
+                                            const Tensor* value,
+                                            void* parameters,
+                                            const int max_threads_per_block) = 0;
+
+  virtual Tensor* AttentionBase__GetPresent(const contrib::AttentionBase* p,
+                                            OpKernelContext* context,
+                                            const Tensor* past,
+                                            int batch_size,
+                                            int head_size,
+                                            int sequence_length,
+                                            int& past_sequence_length) = 0;
 
   // BeamSearch
   virtual void BeamSearch__Init(contrib::transformers::BeamSearch* p, const OpKernelInfo& info) = 0;
   virtual Status BeamSearch__Compute(const contrib::transformers::BeamSearch* p, OpKernelContext* ctx) = 0;
-  virtual Status BeamSearch__SetupSubgraphExecutionInfo(contrib::transformers::BeamSearch* p, const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) = 0;
+  virtual Status BeamSearch__SetupSubgraphExecutionInfo(contrib::transformers::BeamSearch* p,
+                                                        const SessionState& session_state,
+                                                        const std::string& attribute_name,
+                                                        const SessionState& subgraph_session_state) = 0;
 
   // GreedySearch
   virtual void GreedySearch__Init(contrib::transformers::GreedySearch* p, const OpKernelInfo& info) = 0;
   virtual Status GreedySearch__Compute(const contrib::transformers::GreedySearch* p, OpKernelContext* ctx) = 0;
-  virtual Status GreedySearch__SetupSubgraphExecutionInfo(contrib::transformers::GreedySearch* p, const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) = 0;
+  virtual Status GreedySearch__SetupSubgraphExecutionInfo(contrib::transformers::GreedySearch* p,
+                                                          const SessionState& session_state,
+                                                          const std::string& attribute_name,
+                                                          const SessionState& subgraph_session_state) = 0;
 
 #ifdef ENABLE_ATEN
   virtual Status ATen__Compute(const contrib::ATen* p, OpKernelContext* p_ctx) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -535,28 +535,63 @@ std::unique_ptr<EinsumTypedComputeProcessor<MLFloat16>> EinsumTypedComputeProces
 
 #ifndef DISABLE_CONTRIB_OPS
 namespace contrib {
-Status embed_layer_norm::CheckInputs(const OpKernelContext* context, bool quantizedVersion) { return g_host_cpu.embed_layer_norm__CheckInputs(context, quantizedVersion); }
-Status bias_gelu_helper::CheckInputs(const OpKernelContext* context) { return g_host_cpu.bias_gelu_helper__CheckInputs(context); }
-Status LongformerAttentionBase::CheckInputs(const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const TensorShape& mask_shape, const TensorShape& global_weights_shape, const TensorShape& global_bias_shape, const TensorShape& global_shape) const {
-  return g_host_cpu.LongformerAttentionBase__CheckInputs(this, input_shape, weights_shape, bias_shape, mask_shape, global_weights_shape, global_bias_shape, global_shape);
+Status embed_layer_norm::CheckInputs(const OpKernelContext* context, bool quantizedVersion) {
+  return g_host_cpu.embed_layer_norm__CheckInputs(context, quantizedVersion);
 }
 
-Status AttentionBase::CheckInputs(const TensorShape& input_shape, const TensorShape& weights_shape, const TensorShape& bias_shape, const Tensor*& mask_index, const Tensor* past, const Tensor* extra_add_qk, const int max_threads_per_block) const {
-  return g_host_cpu.AttentionBase__CheckInputs(this, input_shape, weights_shape, bias_shape, mask_index, past, extra_add_qk, max_threads_per_block);
+Status bias_gelu_helper::CheckInputs(const OpKernelContext* context) { return g_host_cpu.bias_gelu_helper__CheckInputs(context); }
+
+Status LongformerAttentionBase::CheckInputs(const TensorShape& input_shape,
+                                            const TensorShape& weights_shape,
+                                            const TensorShape& bias_shape,
+                                            const TensorShape& mask_shape,
+                                            const TensorShape& global_weights_shape,
+                                            const TensorShape& global_bias_shape,
+                                            const TensorShape& global_shape) const {
+  return g_host_cpu.LongformerAttentionBase__CheckInputs(this, input_shape, weights_shape, bias_shape, mask_shape,
+                                                         global_weights_shape, global_bias_shape, global_shape);
 }
-Tensor* AttentionBase::GetPresent(OpKernelContext* context, const Tensor* past, int batch_size, int head_size, int sequence_length, int& past_sequence_length) const {
-  return g_host_cpu.AttentionBase__GetPresent(this, context, past, batch_size, head_size, sequence_length, past_sequence_length);
+
+Status AttentionBase::CheckInputs(const TensorShape& input_shape,
+                                  const TensorShape* weights_shape,
+                                  const TensorShape& bias_shape,
+                                  const Tensor*& mask_index,
+                                  const Tensor* past,
+                                  const Tensor* extra_add_qk,
+                                  const Tensor* key,
+                                  const Tensor* value,
+                                  void* parameters,
+                                  const int max_threads_per_block) const {
+  return g_host_cpu.AttentionBase__CheckInputs(this, input_shape, weights_shape, bias_shape,
+                                               mask_index, past, extra_add_qk,
+                                               key, value, parameters,
+                                               max_threads_per_block);
+}
+Tensor* AttentionBase::GetPresent(OpKernelContext* context, const Tensor* past, int batch_size, int head_size,
+                                  int sequence_length, int& past_sequence_length) const {
+  return g_host_cpu.AttentionBase__GetPresent(this, context, past, batch_size, head_size,
+                                              sequence_length, past_sequence_length);
 }
 
 namespace transformers {
 void BeamSearch::Init(const OpKernelInfo& info) { g_host_cpu.BeamSearch__Init(this, info); }
+
 Status BeamSearch::Compute(OpKernelContext* ctx) const { return g_host_cpu.BeamSearch__Compute(this, ctx); }
-Status BeamSearch::SetupSubgraphExecutionInfo(const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) { return g_host_cpu.BeamSearch__SetupSubgraphExecutionInfo(this, session_state, attribute_name, subgraph_session_state); }
+
+Status BeamSearch::SetupSubgraphExecutionInfo(const SessionState& session_state, const std::string& attribute_name,
+                                              const SessionState& subgraph_session_state) {
+  return g_host_cpu.BeamSearch__SetupSubgraphExecutionInfo(this, session_state, attribute_name, subgraph_session_state);
+}
 
 void GreedySearch::Init(const OpKernelInfo& info) { g_host_cpu.GreedySearch__Init(this, info); }
-Status GreedySearch::Compute(OpKernelContext* ctx) const { return g_host_cpu.GreedySearch__Compute(this, ctx); }
-Status GreedySearch::SetupSubgraphExecutionInfo(const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) { return g_host_cpu.GreedySearch__SetupSubgraphExecutionInfo(this, session_state, attribute_name, subgraph_session_state); }
 
+Status GreedySearch::Compute(OpKernelContext* ctx) const { return g_host_cpu.GreedySearch__Compute(this, ctx); }
+
+Status GreedySearch::SetupSubgraphExecutionInfo(const SessionState& session_state, const std::string& attribute_name,
+                                                const SessionState& subgraph_session_state) {
+  return g_host_cpu.GreedySearch__SetupSubgraphExecutionInfo(this, session_state, attribute_name,
+                                                             subgraph_session_state);
+}
 }  // namespace transformers
 
 #ifdef ENABLE_ATEN

--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
@@ -10,20 +9,20 @@
 namespace onnxruntime {
 namespace test {
 enum MaskIndexType {
-  kMaskIndexEnd = 0,
-  kMaskIndexEndAndStart,
-  kMaskRaw,
-  kMask3D,
-  kMaskDummy,  // Dummy mask with shape [1, 1] or [batch_size, 1]
-  kMask4D      // Megatron GPT2 mask with shape [batch_size, 1, max_sequence_length, max_sequence_length]
+  kMaskIndexEnd = 0,      // [batch_size]
+  kMaskIndexEndAndStart,  // [2 * batch_size]
+  kMaskRaw,               // [batch_size, total_sequence_length]
+  kMask3D,                // [batch_size, sequence_length, total_sequence_length]
+  kMaskDummy,             // Dummy mask with shape [1, 1] or [batch_size, 1]
+  kMask4D                 // Megatron causal mask with shape [batch_size, 1, max_sequence_length, max_sequence_length]
 };
 
 static void RunAttentionTest(
-    const std::vector<float>& input_data,    // input:      [batch_size, sequence_length, hidden_size]
-    const std::vector<float>& weights_data,  // weights:    [hidden_size, 3 * hidden_size]
-    bool is_weights_constant,
+    const std::vector<float>& input_data,         // input:      [batch_size, sequence_length, hidden_size]
+    const std::vector<float>& weights_data,       // weights:    [hidden_size, 3 * hidden_size]
+    bool is_weights_constant,                     // weights is constant
     const std::vector<float>& bias_data,          // bias:       [3 * hidden_size]
-    const std::vector<int32_t>& mask_index_data,  // mask_index: [batch_size] or [batch_size, past_sequence_length + sequence_length] or empty
+    const std::vector<int32_t>& mask_index_data,  // mask_index: see MaskIndexType for supported shape
     const std::vector<float>& output_data,        // output:     [batch_size, sequence_length, hidden_size]
     int batch_size,
     int sequence_length,
@@ -38,17 +37,21 @@ static void RunAttentionTest(
     MaskIndexType mask_index_type = kMaskIndexEnd,
     int input_hidden_size = 0,
     int max_sequence_length = 0,
-    bool only_enable_cuda = false,
-    bool only_enable_cpu = false,
+    const bool disable_cpu = false,
+    const bool disable_cuda = false,
+    const bool disable_rocm = false,
     std::vector<int32_t> qkv_sizes = {},
     const std::vector<float>& extra_add_data = {},
-    const bool disable_rocm = false) {
+    int kv_sequence_length = 0,
+    const std::vector<float>* key_data = nullptr,
+    const std::vector<float>* value_data = nullptr) {
   input_hidden_size = (input_hidden_size == 0 ? hidden_size : input_hidden_size);  // By default, no pruning.
+  kv_sequence_length = (kv_sequence_length == 0 ? sequence_length : kv_sequence_length);
 
   int min_cuda_architecture = use_float16 ? 530 : 0;
-  bool enable_cuda = HasCudaEnvironment(min_cuda_architecture) && !is_weights_constant && !only_enable_cpu;
-  bool enable_rocm = (nullptr != DefaultRocmExecutionProvider().get()) && !is_weights_constant && !only_enable_cpu && !disable_rocm;
-  bool enable_cpu = (nullptr != DefaultCpuExecutionProvider().get()) && !use_float16 && !only_enable_cuda;
+  bool enable_cuda = HasCudaEnvironment(min_cuda_architecture) && !is_weights_constant && !disable_cuda;
+  bool enable_rocm = (nullptr != DefaultRocmExecutionProvider().get()) && !is_weights_constant && !disable_rocm;
+  bool enable_cpu = (nullptr != DefaultCpuExecutionProvider().get()) && !use_float16 && !disable_cpu;
 
   int head_size = hidden_size / number_of_heads;
   if (enable_cpu || enable_cuda || enable_rocm) {
@@ -56,27 +59,50 @@ static void RunAttentionTest(
     tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
     tester.AddAttribute<int64_t>("unidirectional", static_cast<int64_t>(is_unidirectional ? 1 : 0));
 
-    int32_t matrix_size;
-    int32_t output_hidden_size;
+    int32_t qkv_hidden_size_sum;
+    int32_t v_hidden_size;
     if (qkv_sizes.size() != 0) {
-      matrix_size = qkv_sizes[0] + qkv_sizes[1] + qkv_sizes[2];
+      qkv_hidden_size_sum = qkv_sizes[0] + qkv_sizes[1] + qkv_sizes[2];
       std::vector<int64_t> sizes_attribute{qkv_sizes[0], qkv_sizes[1], qkv_sizes[2]};
       tester.AddAttribute<std::vector<int64_t>>("qkv_hidden_sizes", sizes_attribute);
-      output_hidden_size = qkv_sizes[2];
+      v_hidden_size = qkv_sizes[2];
     } else {
-      matrix_size = 3 * hidden_size;
-      output_hidden_size = hidden_size;
+      qkv_hidden_size_sum = 3 * hidden_size;
+      v_hidden_size = hidden_size;
     }
 
+    int64_t total_sequence_length = past_sequence_length + kv_sequence_length;
+
     std::vector<int64_t> input_dims = {batch_size, sequence_length, input_hidden_size};
-    std::vector<int64_t> weights_dims = {input_hidden_size, matrix_size};
-    std::vector<int64_t> bias_dims = {matrix_size};
+    std::vector<int64_t> weights_dims = {input_hidden_size, qkv_hidden_size_sum};
+    std::vector<int64_t> bias_dims = {qkv_hidden_size_sum};
+    std::vector<int64_t> output_dims = {batch_size, sequence_length, v_hidden_size};
+    if (use_float16) {
+      tester.AddInput<MLFloat16>("input", input_dims, ToFloat16(input_data));
+
+      if (weights_data.empty()) {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      } else {
+        tester.AddInput<MLFloat16>("weight", weights_dims, ToFloat16(weights_data), is_weights_constant);
+      }
+      tester.AddInput<MLFloat16>("bias", bias_dims, ToFloat16(bias_data));
+      tester.AddOutput<MLFloat16>("output", output_dims, ToFloat16(output_data));
+    } else {
+      tester.AddInput<float>("input", input_dims, input_data);
+      if (weights_data.empty()) {
+        tester.AddOptionalInputEdge<float>();
+      } else {
+        tester.AddInput<float>("weight", weights_dims, weights_data, is_weights_constant);
+      }
+      tester.AddInput<float>("bias", bias_dims, bias_data);
+      tester.AddOutput<float>("output", output_dims, output_data);
+    }
 
     std::vector<int64_t> mask_index_dims_1 = {batch_size};
     std::vector<int64_t> mask_index_dims_2 = {2 * batch_size};
-    std::vector<int64_t> mask_index_dims_3 = {batch_size, past_sequence_length + sequence_length};
+    std::vector<int64_t> mask_index_dims_3 = {batch_size, total_sequence_length};
     std::vector<int64_t> mask_index_dims_4 = {batch_size, 1};
-    std::vector<int64_t> mask_index_dims_5 = {batch_size, sequence_length, past_sequence_length + sequence_length};
+    std::vector<int64_t> mask_index_dims_5 = {batch_size, sequence_length, total_sequence_length};
     std::vector<int64_t> mask_index_dims_6 = {batch_size, 1, max_sequence_length, max_sequence_length};
     std::vector<int64_t> mask_index_dims;
     switch (mask_index_type) {
@@ -102,29 +128,14 @@ static void RunAttentionTest(
         assert(0);  // shall not reach here.
         break;
     }
-
-    std::vector<int64_t> past_dims = {2, batch_size, number_of_heads, past_sequence_length, head_size};
-    std::vector<int64_t> present_dims = {2, batch_size, number_of_heads, past_sequence_length + sequence_length, head_size};
-    std::vector<int64_t> output_dims = {batch_size, sequence_length, output_hidden_size};
-
-    if (use_float16) {
-      tester.AddInput<MLFloat16>("input", input_dims, ToFloat16(input_data));
-      tester.AddInput<MLFloat16>("weight", weights_dims, ToFloat16(weights_data), is_weights_constant);
-      tester.AddInput<MLFloat16>("bias", bias_dims, ToFloat16(bias_data));
-      tester.AddOutput<MLFloat16>("output", output_dims, ToFloat16(output_data));
-    } else {
-      tester.AddInput<float>("input", input_dims, input_data);
-      tester.AddInput<float>("weight", weights_dims, weights_data, is_weights_constant);
-      tester.AddInput<float>("bias", bias_dims, bias_data);
-      tester.AddOutput<float>("output", output_dims, output_data);
-    }
-
     if (mask_index_data.size() > 0) {  // mask index is optional.
       tester.AddInput<int32_t>("mask_index", mask_index_dims, mask_index_data);
     } else {
       tester.AddOptionalInputEdge<int32_t>();
     }
 
+    std::vector<int64_t> past_dims = {2, batch_size, number_of_heads, past_sequence_length, head_size};
+    std::vector<int64_t> present_dims = {2, batch_size, number_of_heads, total_sequence_length, head_size};
     if (use_past_state) {
       if (use_float16) {
         if (past_sequence_length > 0) {
@@ -137,14 +148,53 @@ static void RunAttentionTest(
         }
         tester.AddOutput<float>("present", present_dims, *present_data);
       }
-    }
-
-    if (extra_add_data.size() > 0) {
-      if (!use_past_state) {
+    } else {
+      if (use_float16) {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      } else {
         tester.AddOptionalInputEdge<float>();
       }
-      std::vector<int64_t> extra_add_data_dims = {batch_size, number_of_heads, sequence_length, sequence_length};
-      tester.AddInput<float>("extra_add_qk", extra_add_data_dims, extra_add_data);
+    }
+
+    std::vector<int64_t> extra_add_data_dims = {batch_size, number_of_heads, sequence_length, sequence_length};
+    if (extra_add_data.size() > 0) {
+      if (use_float16) {
+        tester.AddInput<MLFloat16>("extra_add_qk", extra_add_data_dims, ToFloat16(extra_add_data));
+      } else {
+        tester.AddInput<float>("extra_add_qk", extra_add_data_dims, extra_add_data);
+      }
+    } else {
+      if (use_float16) {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      } else {
+        tester.AddOptionalInputEdge<float>();
+      }
+    }
+
+    std::vector<int64_t> key_dims = {batch_size, kv_sequence_length, hidden_size};
+    std::vector<int64_t> value_dims = {batch_size, kv_sequence_length, v_hidden_size};
+    if (use_float16) {
+      if (key_data != nullptr) {
+        tester.AddInput<MLFloat16>("key", key_dims, ToFloat16(*key_data));
+      } else {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      }
+      if (value_data != nullptr) {
+        tester.AddInput<MLFloat16>("value", value_dims, ToFloat16(*value_data));
+      } else {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      }
+    } else {
+      if (key_data != nullptr) {
+        tester.AddInput<float>("key", key_dims, *key_data);
+      } else {
+        tester.AddOptionalInputEdge<float>();
+      }
+      if (value_data != nullptr) {
+        tester.AddInput<float>("value", value_dims, *value_data);
+      } else {
+        tester.AddOptionalInputEdge<float>();
+      }
     }
 
     if (enable_cuda) {
@@ -171,7 +221,7 @@ static void RunAttentionTest(
     const std::vector<float>& input_data,         // input:      [batch_size, sequence_length, hidden_size]
     const std::vector<float>& weights_data,       // weights:    [hidden_size, 3 * hidden_size]
     const std::vector<float>& bias_data,          // bias:       [3 * hidden_size]
-    const std::vector<int32_t>& mask_index_data,  // mask_index: [batch_size] or [batch_size, past_sequence_length + sequence_length] or empty
+    const std::vector<int32_t>& mask_index_data,  // mask_index
     const std::vector<float>& output_data,        // output:     [batch_size, sequence_length, hidden_size]
     int batch_size,
     int sequence_length,
@@ -186,21 +236,26 @@ static void RunAttentionTest(
     MaskIndexType mask_index_type = kMaskIndexEnd,
     int input_hidden_size = 0,
     int max_sequence_length = 0,
-    bool only_enable_cuda = false,
-    bool only_enable_cpu = false,
+    const bool disable_cpu = false,
+    const bool disable_cuda = false,
+    const bool disable_rocm = false,
     const std::vector<int32_t> qkv_sizes = {},
     const std::vector<float>& extra_add_data = {},
-    const bool disable_rocm = false) {
+    int kv_sequence_length = 0,
+    const std::vector<float>* key_data = nullptr,
+    const std::vector<float>* value_data = nullptr) {
   RunAttentionTest(input_data, weights_data, false, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    use_float16, is_unidirectional, use_past_state, past_sequence_length,
                    past_data, present_data, mask_index_type, input_hidden_size, max_sequence_length,
-                   only_enable_cuda, only_enable_cpu, qkv_sizes, extra_add_data, disable_rocm);
+                   disable_cpu, disable_cuda, disable_rocm, qkv_sizes, extra_add_data,
+                   kv_sequence_length, key_data, value_data);
   RunAttentionTest(input_data, weights_data, true, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    use_float16, is_unidirectional, use_past_state, past_sequence_length,
                    past_data, present_data, mask_index_type, input_hidden_size, max_sequence_length,
-                   only_enable_cuda, only_enable_cpu, qkv_sizes, extra_add_data, disable_rocm);
+                   disable_cpu, disable_cuda, disable_rocm, qkv_sizes, extra_add_data,
+                   kv_sequence_length, key_data, value_data);
 }
 
 TEST(AttentionTest, AttentionBatch1) {
@@ -266,14 +321,11 @@ TEST(AttentionTest, AttentionBatch1WithQKVAttr1) {
       3.1967618465423584f, 0.51903456449508667f, 0.63051539659500122f, 2.9394614696502686f,
       0.65332180261611938f, 1.000949501991272f, 0.74175024032592773f, 2.8231701850891113f};
 
+  const bool disable_rocm = true;
   RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, true, false, qkv_sizes, {}, true);
-  RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
-                   batch_size, sequence_length, hidden_size, number_of_heads,
-                   false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, false, true, qkv_sizes, {}, true);
+                   0, false, false, disable_rocm, qkv_sizes);
 }
 
 TEST(AttentionTest, AttentionBatch1WithQKVAttr2) {
@@ -307,14 +359,11 @@ TEST(AttentionTest, AttentionBatch1WithQKVAttr2) {
   std::vector<float> output_data = {
       0.64932525157928467f, 0.79390722513198853f, 0.64932847023010254f, 0.79375863075256348f};
 
+  const bool disable_rocm = true;
   RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, true, false, qkv_sizes, {}, true);
-  RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
-                   batch_size, sequence_length, hidden_size, number_of_heads,
-                   false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, false, true, qkv_sizes, {}, true);
+                   0, false, false, disable_rocm, qkv_sizes);
 }
 
 TEST(AttentionTest, AttentionBatch1ExtraAdd) {
@@ -348,10 +397,13 @@ TEST(AttentionTest, AttentionBatch1ExtraAdd) {
       4.066014289855957f, 0.068997815251350403f, 4.25f, 5.6499996185302734f,
       -1.8799558877944946f, 0.32488855719566345f, 4.25f, 5.6499996185302734f};
 
+  const bool disable_cpu = false;
+  const bool disable_cuda = false;
+  const bool disable_rocm = false;
   RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, true, true, qkv_sizes, extra_add_qk);
+                   0, disable_cpu, disable_cuda, disable_rocm, qkv_sizes, extra_add_qk);
 }
 
 TEST(AttentionTest, AttentionBatch2ExtraAdd) {
@@ -390,10 +442,13 @@ TEST(AttentionTest, AttentionBatch2ExtraAdd) {
       4.066014289855957f, 0.068997815251350403f, 4.25f, 5.6499996185302734f,
       -1.8799558877944946f, 0.32488855719566345f, 4.25f, 5.6499996185302734f};
 
+  const bool disable_cpu = false;
+  const bool disable_cuda = false;
+  const bool disable_rocm = false;
   RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    false, false, false, 0, nullptr, nullptr, kMaskIndexEnd, 0,
-                   0, true, true, qkv_sizes, extra_add_qk);
+                   0, disable_cpu, disable_cuda, disable_rocm, qkv_sizes, extra_add_qk);
 }
 
 TEST(AttentionTest, AttentionBatch1_Float16) {
@@ -1609,14 +1664,14 @@ TEST(AttentionTest, Attention4DMask) {
   int past_sequence_length = 0;
   int input_hidden_size = 0;
   int max_sequence_length = 4;
-  bool only_enable_cuda = true;  // only support 4D mask in cuda
+  bool disable_cpu = true;  // 4D mask not support in CPU kernel
   const std::vector<float>* past_data = nullptr;
   const std::vector<float>* present_data = nullptr;
   RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
                    batch_size, sequence_length, hidden_size, number_of_heads,
                    use_float16, is_unidirectional, use_past_state, past_sequence_length,
                    past_data, present_data, kMask4D, input_hidden_size, max_sequence_length,
-                   only_enable_cuda);
+                   disable_cpu);
 }
 
 TEST(AttentionTest, AttentionMaskIndexOutOfRange) {
@@ -1938,6 +1993,59 @@ TEST(AttentionTest, DISABLED_Attention_Mask1D_Fp16_B2_FusedNoPadding) {
         onnx_model,
         true);
   }
+}
+
+TEST(AttentionTest, AttentionBatch1_No_Weights) {
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int number_of_heads = 2;
+  int kv_sequence_length = 3;
+  int v_hidden_size = 2;
+
+  // query: (batch_size, sequence_length, hidden_size)
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {};
+
+  // (hidden_size + hidden_size + v_hidden_size)
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f};
+
+  std::vector<int32_t> mask_index_data = {2L};
+
+  // (batch_size, kv_sequence_length, hidden_size)
+  std::vector<float> key_data = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f};
+
+  // (batch_size, kv_sequence_length, v_hidden_size)
+  std::vector<float> value_data = {0.6f, 0.5f, 0.4f, 0.3f, 0.2f, 0.1f};
+
+  // (batch_size, sequence_length, v_hidden_size)
+  std::vector<float> output_data = {0.99434918f, 0.0f, 0.9887343f, 0.74572039f};
+
+  bool use_float16 = false;
+  bool is_unidirectional = false;
+  bool use_past_state = false;
+  int past_sequence_length = 0;
+  const std::vector<float>* past_data = nullptr;
+  const std::vector<float>* present_data = nullptr;
+  MaskIndexType mask_index_type = kMaskIndexEnd;
+  int input_hidden_size = 0;
+  int max_sequence_length = 0;
+  const bool disable_cpu = true;  // not supported in cpu right now.
+  const bool disable_cuda = false;
+  const bool disable_rocm = true;  // not supported in rocm right now.
+  const std::vector<int32_t> qkv_sizes = {hidden_size, hidden_size, v_hidden_size};
+  const std::vector<float>& extra_add_data = {};
+
+  RunAttentionTest(input_data, weight_data, bias_data, mask_index_data, output_data,
+                   batch_size, sequence_length, hidden_size, number_of_heads,
+                   use_float16, is_unidirectional, use_past_state, past_sequence_length,
+                   past_data, present_data, mask_index_type, input_hidden_size, max_sequence_length,
+                   disable_cpu, disable_cuda, disable_rocm, qkv_sizes, extra_add_data,
+                   kv_sequence_length, &key_data, &value_data);
 }
 
 #ifndef ENABLE_TRAINING  // Prepacking is enabled only on non-training builds


### PR DESCRIPTION
### Description
Allow separated Q, K and V inputs to support cross attention:
* Q: [batch_size, sequence_length, hidden_size]
* K: [batch_size, kv_sequence_length, hidden_size]
* V: [batch_size, kv_sequence_length, v_hidden_size]
* Output: [batch_size, sequence_length, v_hidden_size]

To use separated Q/K/V inputs, the input tensor is for query, and two optional inputs are added for key and value. Weights for input projection is not included for now, so the MatMul of input projection shall be done out of Attention operator, but Add bias is included for performance consideration. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

(1) Support cross attention
(2) Support different sequence length for Q and K
