### PR TITLE
Document generation for operator kernels, enable internal overload of DML EP to initialize on software-only devices

### DIFF
--- a/onnxruntime/core/providers/dml/dml_provider_factory_creator.h
+++ b/onnxruntime/core/providers/dml/dml_provider_factory_creator.h
@@ -10,5 +10,6 @@
 namespace onnxruntime {
 struct DMLProviderFactoryCreator {
   static std::shared_ptr<IExecutionProviderFactory> Create(int device_id);
+  static std::shared_ptr<IExecutionProviderFactory> Create(int device_id, bool skip_software_device_check);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
+++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
@@ -62,7 +62,7 @@ void addGlobalSchemaFunctions(pybind11::module& m) {
             onnxruntime::ArmNNProviderFactoryCreator::Create(0),
 #endif
 #ifdef USE_DML
-            onnxruntime::DMLProviderFactoryCreator::Create(0),
+            onnxruntime::DMLProviderFactoryCreator::Create(0, /*skip_software_device_check*/ true),
 #endif
 #ifdef USE_NNAPI
             onnxruntime::NnapiProviderFactoryCreator::Create(0),


### PR DESCRIPTION
### Description
The documentation pipeline does not require an actual GPU, and running on GPU-capable agents costs more. So to enable running on CPU-only devices and to potentially consolidate future pipelines, and since the tests are not actually executed on this device anyway (it just needs to initialize the EP for the sake of operator kernel enumeration), add an initialization flag to skip the software device check - this is only an internal overload not exposed in the public API. See https://github.com/microsoft/onnxruntime/pull/13308.

### Motivation and Context
- *If it fixes an open issue, please link to the issue here.* NA