### PR TITLE
[EP-Perf-Dashboard] Decouple docker image name from branch name

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
       value: -a "-a -z -g $(optimizeGraph) -b $(bindInputs) $(trtEPOptionsArg) $(cudaEPOptionsArg)"
 
     - name: image
-      value: ort-image_$(Build.BuildId)
+      value: ort-image-$(Build.BuildId)
 
   steps:
     - ${{ if eq(parameters.TrtVersion, 'BIN') }}:

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-tensorrt-daily-perf-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
       value: -a "-a -z -g $(optimizeGraph) -b $(bindInputs) $(trtEPOptionsArg) $(cudaEPOptionsArg)"
 
     - name: image
-      value: ort-$(branchName)
+      value: ort-image_$(Build.BuildId)
 
   steps:
     - ${{ if eq(parameters.TrtVersion, 'BIN') }}:


### PR DESCRIPTION
### Description
Updates naming scheme for docker images built by the EP Perf pipeline. Specifically, the docker image name is no longer based on the branch name.

### Motivation and Context
The docker image name used by EP Perf pipeline is built from the branch name. This makes the pipeline fail for branches with uppercase letters because docker image names can only contain lower-case letters.


