### PR TITLE
Modify MIGraphX EP for Accuracy tests

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -527,11 +527,6 @@ static bool IsUnsupportedOpMode(const onnxruntime::GraphViewer& graph_viewer, co
 }
 
 void SubgraphPostProcessing(const onnxruntime::GraphViewer& graph_viewer, std::vector<std::vector<NodeIndex>>& clusters, const logging::Logger& logger) {
-  // If the number of nodes in the graph is less than 5, do nothing
-  // this is to deal with onnx unit tests
-  if (graph_viewer.NumberOfNodes() <= 5) {
-    return;
-  }
 
   // Then check whether a subgraph should fallback to CPU
   // 1. Check whether a subgraph contains a RNN operator
@@ -554,11 +549,6 @@ void SubgraphPostProcessing(const onnxruntime::GraphViewer& graph_viewer, std::v
           }
         }
       }
-    }
-
-    // if 6 operators or more
-    if (git.size() > 5) {
-      return false;
     }
 
     // rnn operators, run on GPU

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -164,8 +164,9 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
             ), "Please install onnxruntime-directml package to test GPU inference."
 
         else:
-            assert (
-                any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"])
+            assert any(
+                gpu_ep in onnxruntime.get_available_providers()
+                for gpu_ep in ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,8 +165,8 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert (
-                "CUDAExecutionProvider" in onnxruntime.get_available_providers()
-            ), "Please install onnxruntime-gpu package to test GPU inference."
+            'CUDAExecutionProvider' or 'ROCMExecutionProvider' in onnxruntime.get_available_providers(
+            ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")
     logger.info(f"Transformers Version:{transformers.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -164,10 +164,8 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
             ), "Please install onnxruntime-directml package to test GPU inference."
 
         else:
-            assert any(
-                set(onnxruntime.get_available_providers()).isdisjoint(
-                    ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
-                )
+            assert set(onnxruntime.get_available_providers()).isdisjoint(
+                ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,8 +165,9 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert any(
-                gpu_ep in onnxruntime.get_available_providers()
-                for gpu_ep in ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+                set(onnxruntime.get_available_providers()).isdisjoint(["CUDAExecutionProvider",
+                                                                       "ROCMExecutionProvider",
+                                                                       "MIGraphXExecutionProvider"])
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,7 +165,7 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert (
-            "CUDAExecutionProvider" or "ROCMExecutionProvider" in onnxruntime.get_available_providers()
+                any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"])
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,7 +165,7 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert (
-            'CUDAExecutionProvider' or 'ROCMExecutionProvider' in onnxruntime.get_available_providers(
+            "CUDAExecutionProvider" or "ROCMExecutionProvider" in onnxruntime.get_available_providers()
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,9 +165,9 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert any(
-                set(onnxruntime.get_available_providers()).isdisjoint(["CUDAExecutionProvider",
-                                                                       "ROCMExecutionProvider",
-                                                                       "MIGraphXExecutionProvider"])
+                set(onnxruntime.get_available_providers()).isdisjoint(
+                    ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+                )
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/benchmark_helper.py
+++ b/onnxruntime/python/tools/transformers/benchmark_helper.py
@@ -165,7 +165,7 @@ def prepare_environment(cache_dir, output_dir, use_gpu, provider=None):
 
         else:
             assert (
-                any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"])
+                any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"])
             ), "Please install onnxruntime-gpu package, or install ROCm support, to test GPU inference."
 
     logger.info(f"PyTorch Version:{torch.__version__}")

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -44,7 +44,9 @@ def get_package_version(package_name: str):
         return None
 
 
-def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"):
+def load_onnx_model(
+    model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, provider="CUDAExecutionProvider"
+):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
 
@@ -258,12 +260,20 @@ def parse_arguments(argv=None):
         help="Optional onnx model path. If not specified, optimum will be used to export onnx model for testing.",
     )
 
+<<<<<<< HEAD
+=======
+    parser.add_argument("--use_gpu", required=False, action="store_true", help="Allow GPU RUN.")
+>>>>>>> 5488d4e72f... Fix formatting
     parser.add_argument(
         "--provider",
         required=False,
         default="CUDAExcecutionProvider",
         help="Select which Execution Provider to use for runs.",
     )
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5488d4e72f... Fix formatting
 
     args = parser.parse_args(argv)
 

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -45,7 +45,7 @@ def get_package_version(package_name: str):
 
 
 def load_onnx_model(
-    model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, provider="CUDAExecutionProvider"
+    model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"
 ):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -44,9 +44,7 @@ def get_package_version(package_name: str):
         return None
 
 
-def load_onnx_model(
-    model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"
-):
+def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
 

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -258,20 +258,12 @@ def parse_arguments(argv=None):
         help="Optional onnx model path. If not specified, optimum will be used to export onnx model for testing.",
     )
 
-<<<<<<< HEAD
-=======
-    parser.add_argument("--use_gpu", required=False, action="store_true", help="Allow GPU RUN.")
->>>>>>> 5488d4e72f... Fix formatting
     parser.add_argument(
         "--provider",
         required=False,
         default="CUDAExcecutionProvider",
         help="Select which Execution Provider to use for runs.",
     )
-<<<<<<< HEAD
-=======
-
->>>>>>> 5488d4e72f... Fix formatting
 
     args = parser.parse_args(argv)
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -70,8 +70,9 @@ def optimize_by_onnxruntime(
         optimized_model_path (str): the path of optimized model
     """
     assert opt_level in [1, 2, 99]
-    import onnxruntime
     from torch import version as torch_version
+
+    import onnxruntime
 
     if use_gpu and not any(
         gpu_ep in onnxruntime.get_available_providers()

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -102,7 +102,7 @@ def optimize_by_onnxruntime(
         session = onnxruntime.InferenceSession(
             onnx_model_path, sess_options, providers=["CUDAExecutionProvider", "ROCMExecutionProvider"], **kwargs
         )
-        assert "CUDAExecutionProvider" or "ROCMExecutionProvider" in session.get_providers()  # Make sure there is GPU
+        assert any(gpu_ep in session.get_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"]) # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -72,7 +72,7 @@ def optimize_by_onnxruntime(
     assert opt_level in [1, 2, 99]
     import onnxruntime
 
-    if use_gpu and "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
+    if use_gpu and "CUDAExecutionProvider" and "ROCMExecutionProvider" not in onnxruntime.get_available_providers():
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
@@ -100,9 +100,9 @@ def optimize_by_onnxruntime(
         )
     else:
         session = onnxruntime.InferenceSession(
-            onnx_model_path, sess_options, providers=["CUDAExecutionProvider"], **kwargs
+            onnx_model_path, sess_options, providers=["CUDAExecutionProvider", "ROCMExecutionProvider"], **kwargs
         )
-        assert "CUDAExecutionProvider" in session.get_providers()  # Make sure there is GPU
+        assert "CUDAExecutionProvider" or "ROCMExecutionProvider" in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to {}".format(optimized_model_path))

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -75,9 +75,9 @@ def optimize_by_onnxruntime(
     import onnxruntime
 
     if use_gpu and not any(
-        set(onnxruntime.get_available_providers()).isdisjoint(["CUDAExecutionProvider",
-                                                                "ROCMExecutionProvider",
-                                                                "MIGraphXExecutionProvider"])
+        set(onnxruntime.get_available_providers()).isdisjoint(
+            ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+        )
     ):
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
@@ -115,9 +115,9 @@ def optimize_by_onnxruntime(
 
         session = onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=gpu_ep, **kwargs)
         assert any(
-            set(onnxruntime.get_available_providers()).isdisjoint(["CUDAExecutionProvider",
-                                                                   "ROCMExecutionProvider",
-                                                                    "MIGraphXExecutionProvider"])
+            set(onnxruntime.get_available_providers()).isdisjoint(
+                ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+            )
         )  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -73,7 +73,10 @@ def optimize_by_onnxruntime(
     import onnxruntime
     from torch import version as torch_version
 
-    if use_gpu and not any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"]):
+    if use_gpu and not any(
+        gpu_ep in onnxruntime.get_available_providers()
+        for gpu_ep in ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+    ):
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
@@ -108,10 +111,11 @@ def optimize_by_onnxruntime(
             gpu_ep.append("ROCMExecutionProvider")
             gpu_ep.append("MIGraphXExecutionProvider")
 
-        session = onnxruntime.InferenceSession(
-            onnx_model_path, sess_options, providers=gpu_ep, **kwargs
-        )
-        assert any(gpu_ep in session.get_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"]) # Make sure there is GPU
+        session = onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=gpu_ep, **kwargs)
+        assert any(
+            gpu_ep in session.get_providers()
+            for gpu_ep in ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+        )  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -73,7 +73,7 @@ def optimize_by_onnxruntime(
     import onnxruntime
     from torch import version as torch_version
 
-    if use_gpu and not any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"]):
+    if use_gpu and not any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"]):
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
@@ -106,11 +106,12 @@ def optimize_by_onnxruntime(
             gpu_ep.append("CUDAExecutionProvider")
         elif torch_version.hip:
             gpu_ep.append("ROCMExecutionProvider")
+            gpu_ep.append("MIGraphXExecutionProvider")
 
         session = onnxruntime.InferenceSession(
             onnx_model_path, sess_options, providers=gpu_ep, **kwargs
         )
-        assert any(gpu_ep in session.get_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"]) # Make sure there is GPU
+        assert any(gpu_ep in session.get_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider", "MIGraphXExecutionProvider"]) # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -74,10 +74,8 @@ def optimize_by_onnxruntime(
 
     import onnxruntime
 
-    if use_gpu and not any(
-        set(onnxruntime.get_available_providers()).isdisjoint(
-            ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
-        )
+    if use_gpu and not set(onnxruntime.get_available_providers()).isdisjoint(
+        ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
     ):
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
@@ -114,11 +112,9 @@ def optimize_by_onnxruntime(
             gpu_ep.append("ROCMExecutionProvider")
 
         session = onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=gpu_ep, **kwargs)
-        assert any(
-            set(onnxruntime.get_available_providers()).isdisjoint(
-                ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
-            )
-        )  # Make sure there is GPU
+        assert set(onnxruntime.get_available_providers()).isdisjoint(
+            ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
+        )
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -72,7 +72,7 @@ def optimize_by_onnxruntime(
     assert opt_level in [1, 2, 99]
     import onnxruntime
 
-    if use_gpu and "CUDAExecutionProvider" and "ROCMExecutionProvider" not in onnxruntime.get_available_providers():
+    if use_gpu and not any(gpu_ep in onnxruntime.get_available_providers() for gpu_ep in ["CUDAExecutionProvider","ROCMExecutionProvider"]):
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
@@ -105,7 +105,7 @@ def optimize_by_onnxruntime(
         assert "CUDAExecutionProvider" or "ROCMExecutionProvider" in session.get_providers()  # Make sure there is GPU
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
-    logger.debug("Save optimized model by onnxruntime to {}".format(optimized_model_path))
+    logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)
     return optimized_model_path
 
 

--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -145,6 +145,7 @@ def create_ort_session(onnx_model_path, use_gpu=True):
             execution_providers.append('CUDAExecutionProvider')
         elif torch.version.hip:
             execution_providers.append('ROCMExecutionProvider')
+            execution_providers.append('MIGraphXExecutionProvider')
 
     return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
 

--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -138,16 +138,17 @@ def create_ort_session(onnx_model_path, use_gpu=True):
     sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_DISABLE_ALL
     sess_options.intra_op_num_threads = 2
     sess_options.log_severity_level = 2
-    execution_providers= ['CPUExecutionProvider']
+    execution_providers = ["CPUExecutionProvider"]
 
     if use_gpu:
         if torch.version.cuda:
-            execution_providers.append('CUDAExecutionProvider')
+            execution_providers.append("CUDAExecutionProvider")
         elif torch.version.hip:
-            execution_providers.append('ROCMExecutionProvider')
-            execution_providers.append('MIGraphXExecutionProvider')
+            execution_providers.append("ROCMExecutionProvider")
+            execution_providers.append("MIGraphXExecutionProvider")
 
     return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
+
 
 def onnxruntime_inference(ort_session, input):
     ort_inputs = {"input": numpy.ascontiguousarray(input.cpu().numpy())}

--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -138,9 +138,15 @@ def create_ort_session(onnx_model_path, use_gpu=True):
     sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_DISABLE_ALL
     sess_options.intra_op_num_threads = 2
     sess_options.log_severity_level = 2
-    execution_providers = ["CPUExecutionProvider"] if not use_gpu else ["CUDAExecutionProvider", "CPUExecutionProvider"]
-    return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
+    execution_providers= ['CPUExecutionProvider']
 
+    if use_gpu:
+        if torch.version.cuda:
+            execution_providers.append('CUDAExecutionProvider')
+        elif torch.version.hip:
+            execution_providers.append('ROCMExecutionProvider')
+
+    return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
 
 def onnxruntime_inference(ort_session, input):
     ort_inputs = {"input": numpy.ascontiguousarray(input.cpu().numpy())}

--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -144,8 +144,8 @@ def create_ort_session(onnx_model_path, use_gpu=True):
         if torch.version.cuda:
             execution_providers.append("CUDAExecutionProvider")
         elif torch.version.hip:
-            execution_providers.append("ROCMExecutionProvider")
             execution_providers.append("MIGraphXExecutionProvider")
+            execution_providers.append("ROCMExecutionProvider")
 
     return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Changes to allow MIGraphX EP while leveraging the work ROCm has done for the EP for getting additional accuracy tests running. 


### Motivation and Context

Allows MIGraphX EP to run the following additional tests

test_parity_gelu.py
 test_parity_layernorm.py
 test_parity_huggingface_gpt_attention.py
 convert_to_onnx.py

Reference to the Rocm EP changes: https://github.com/microsoft/onnxruntime/pull/13306

Also adds support to get MIGraphX to run eval_squad.py