### PR TITLE
add --no_merge_qkv_weights for Attention fusion

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_options.py
+++ b/onnxruntime/python/tools/transformers/fusion_options.py
@@ -19,6 +19,7 @@ class FusionOptions:
         self.enable_gelu = True
         self.enable_layer_norm = True
         self.enable_attention = True
+        self.merge_qkv_weights = True  # Use merged weights for Q/K/V projection in Attention.
         self.enable_skip_layer_norm = True
         self.enable_embed_layer_norm = True
         self.enable_bias_skip_layer_norm = True
@@ -51,6 +52,10 @@ class FusionOptions:
             options.enable_layer_norm = False
         if args.disable_attention:
             options.enable_attention = False
+        if args.no_merge_qkv_weights:
+            if args.model_type == "bert":
+                raise ValueError(f"--no_merge_qkv_weights is not implemented for model type {args.model_type}")
+            options.merge_qkv_weights = False
         if args.disable_skip_layer_norm:
             options.enable_skip_layer_norm = False
         if args.disable_embed_layer_norm:
@@ -158,3 +163,11 @@ class FusionOptions:
             help="no attention mask. Only works for model_type=bert",
         )
         parser.set_defaults(no_attention_mask=False)
+
+        parser.add_argument(
+            "--no_merge_qkv_weights",
+            required=False,
+            action="store_true",
+            help="exclude MatMul weights in attention. Use separated query, key and value inputs instead.",
+        )
+        parser.set_defaults(no_merge_qkv_weights=False)

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -383,6 +383,7 @@ class BertOnnxModel(OnnxModel):
         if (options is None) or options.enable_attention:
             if options is not None:
                 self.attention_mask.set_mask_format(options.attention_mask_format)
+            self.attention_fusion.merge_qkv_weights = options.merge_qkv_weights
             self.fuse_attention()
 
         # Perform the MatMul fusion after the Attention fusion as we do not


### PR DESCRIPTION
### Description

Add an option to disable merged weights in Attention fusion. When this option is set, MatMul for Q/K/V projections will be left in graph, and Attention node will have 3 inputs for Q/K/V. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Sometime, use 3 MatMul instead of one merged MatMul might get better performance. This option adds some flexibility for testing such setting added in https://github.com/microsoft/onnxruntime/pull/13410.

