### PR TITLE
Fix nightly ci failure

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1710,7 +1710,7 @@ def test_aten_upsample_nearest(input_rank, use_factor):
 
     device = "cuda"
     pt_model = _NeuralNetUpsampleNearest().to(device)
-    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix="test_aten_upsample_nearest"))
+    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix="test_aten_upsample_nearest", log_level=LogLevel.VERBOSE))
 
     def run_step(model, input):
         prediction = model(input)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1710,7 +1710,7 @@ def test_aten_upsample_nearest(input_rank, use_factor):
 
     device = "cuda"
     pt_model = _NeuralNetUpsampleNearest().to(device)
-    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix="test_aten_upsample_nearest", log_level=LogLevel.VERBOSE))
+    ort_model = ORTModule(copy.deepcopy(pt_model))
 
     def run_step(model, input):
         prediction = model(input)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1696,9 +1696,6 @@ def test_aten_group_norm():
 
 @pytest.mark.parametrize("input_rank", (3, 4, 5))
 @pytest.mark.parametrize("use_factor", (True, False))
-#TODO(pengwa): fix this.
-@pytest.mark.skipif(Version(torch.__version__) >= Version("1.13.0"),
-    reason="torch.nn.functional.interpolate conversion introduced Resize, ORT gradient builder fail to handle.")
 def test_aten_upsample_nearest(input_rank, use_factor):
     class _NeuralNetUpsampleNearest(torch.nn.Module):
         def __init__(self):
@@ -1713,7 +1710,7 @@ def test_aten_upsample_nearest(input_rank, use_factor):
 
     device = "cuda"
     pt_model = _NeuralNetUpsampleNearest().to(device)
-    ort_model = ORTModule(copy.deepcopy(pt_model))
+    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=True, onnx_prefix="test_aten_upsample_nearest"))
 
     def run_step(model, input):
         prediction = model(input)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -822,6 +822,9 @@ def test_gradient_correctness_conv1d(use_fp16, input_requires_grad, conv_algo_se
     if conv_algo_search is not None:
         del os.environ["ORTMODULE_CONV_ALGO_SEARCH"]
 
+    # Make sure all async computation are done before we change the system environment variables.
+    torch.cuda.synchronize()
+
 
 def _run_gradient_correctness_transpose(perm, shape):
     class NeuralNetTranspose(torch.nn.Module):
@@ -1693,6 +1696,9 @@ def test_aten_group_norm():
 
 @pytest.mark.parametrize("input_rank", (3, 4, 5))
 @pytest.mark.parametrize("use_factor", (True, False))
+#TODO(pengwa): fix this.
+@pytest.mark.skipif(Version(torch.__version__) >= Version("1.13.0"),
+    reason="torch.nn.functional.interpolate conversion introduced Resize, ORT gradient builder fail to handle.")
 def test_aten_upsample_nearest(input_rank, use_factor):
     class _NeuralNetUpsampleNearest(torch.nn.Module):
         def __init__(self):


### PR DESCRIPTION
### fix nightly ci failure
<!-- Describe your changes. -->

Our nightly CI (https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=198&_a=summary) fail for few days. 

An example:

```
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_gradient_correctness_conv1d[EXHAUSTIVE-False-False]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_gradient_correctness_conv1d[EXHAUSTIVE-False-True]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_gradient_correctness_conv1d[EXHAUSTIVE-True-False]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_gradient_correctness_conv1d[EXHAUSTIVE-True-True]
        provider_options = ort_model._torch_module._execution_manager(
            ort_model._is_training()
        )._execution_agent._inference_session._provider_options
    
        expected_conv_algo_search = "HEURISTIC" if conv_algo_search is None else conv_algo_search
        actual_conv_algo_search = None
        if "CUDAExecutionProvider" in provider_options:
            actual_conv_algo_search = provider_options["CUDAExecutionProvider"]["cudnn_conv_algo_search"]
        elif "ROCMExecutionProvider" in provider_options:
            actual_conv_algo_search = provider_options["ROCMExecutionProvider"]["cudnn_conv_algo_search"]
>       assert actual_conv_algo_search == expected_conv_algo_search
E       AssertionError: assert 'HEURISTIC' == 'EXHAUSTIVE'
E         - EXHAUSTIVE
E         + HEURISTIC



FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[True-3]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[True-4]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[True-5]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[False-3]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[False-4]
FAILED onnxruntime_src/orttraining_test_ortmodule_api.py::test_aten_upsample_nearest[False-5]

onnxruntime_src/orttraining_test_ortmodule_api.py:1713: in run_step
    prediction = model(input)
opt/conda/envs/ptca/lib/python3.8/site-packages/torch/nn/modules/module.py:1357: in _call_impl
    return forward_call(*input, **kwargs)
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_utils.py:371: in _forward
    return ortmodule._torch_module.forward(*inputs, **kwargs)
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_utils.py:351: in _forward
    return torch_module_ort._execution_manager(torch_module_ort.is_training()).forward(*inputs, **kwargs)
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_training_manager.py:273: in forward
    self._fallback_manager.handle_exception(
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_fallback.py:162: in handle_exception
    raise exception
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_training_manager.py:226: in forward
    self._build_graph()
opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_training_manager.py:287: in _build_graph
    super()._build_graph()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <onnxruntime.training.ortmodule._training_manager.TrainingManager object at 0x7f42a011a820>

    def _build_graph(self):
        if self._use_static_shape:
            self._graph_builder.build(self._input_info.shape)
        else:
>           self._graph_builder.build()
E           RuntimeError: /onnxruntime_src/orttraining/orttraining/core/graph/gradient_builder_registry.cc:29 onnxruntime::training::GradientDef onnxruntime::training::GetGradientForOp(const onnxruntime::training::GradientGraphConfiguration&, onnxruntime::Graph*, const onnxruntime::Node*, const std::unordered_set<std::basic_string<char> >&, const std::unordered_set<std::basic_string<char> >&, const onnxruntime::logging::Logger&, std::unordered_set<std::basic_string<char> >&, std::unordered_map<std::basic_string<char>, std::vector<long int> >&) gradient_builder != nullptr was false. The gradient builder has not been registered: Resize for node /_original_module/Resize

opt/conda/envs/ptca/lib/python3.8/site-packages/onnxruntime/training/ortmodule/_graph_execution_manager.py:248: RuntimeError
```

Two Issues:
1. Looks there is problem when some async compute did not complete but our env variable got changed. 
2. Seems our custom op export is not correctly used for torch.nn.functional.interpolate conversion. So a subgraph containing Resize is exported, and failed gradient graph build currently.
  
Fixes:
1. Add barrier to make sure every test config run in sync mode.
2. It is weird when the 1st issue got fixed, this one also disappeared. Let's see whether it comes again or not. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


