### PR TITLE
Skip failed models on training ci and openvino ci

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -246,18 +246,20 @@ TEST_P(ModelTest, Run) {
       {"softmax_cross_entropy_mean_weight", "type error", {"opset12"}},
       {"softmax_cross_entropy_mean_no_weight_ignore_index_4d", "type error", {"opset12"}},
       // models from model zoo
+      {"BERT-Squad-int8", "failed in training", {"opset12"}},
+      {"DenseNet-121-12-int8", "failed in training", {"opset12"}},
       {"EfficientNet-Lite4-int8", "failed in training", {"opset11"}},
       {"EfficientNet-Lite4-qdq", "failed in training", {"opset11"}},
-      {"ResNet50-qdq", "failed in training", {"opset11"}},
+      {"Faster R-CNN R-50-FPN-int8", "failed in training", {"opset12"}},
+      {"Inception-1-int8", "failed in training", {"opset12"}},
       {"MobileNet v2-1.0-int8", "failed in traning", {"opset12"}},
       {"MobileNet v2-1.0-qdq", "failed in training", {"opset12"}},
-      {"SSD-int8", "failed in training", {"opset12"}},
-      {"Inception-1-int8", "failed in training", {"opset12"}},
-      {"Faster R-CNN R-50-FPN-int8", "failed in training", {"opset12"}},
-      {"ShuffleNet-v2-int8", "failed in training", {"opset12"}},
-      {"VGG 16-int8", "failed in training", {"opset12"}},
-      {"BERT-Squad-int8", "failed in training", {"opset12"}},
+      {"ResNet50-qdq", "failed in training", {"opset12"}},
       {"ResNet50_int8", "failed in training", {"opset12"}},
+      {"ShuffleNet-v2-int8", "failed in training", {"opset12"}},
+      {"SSD-int8", "failed in training", {"opset12"}},
+      {"VGG 16-int8", "failed in training", {"opset12"}},
+      {"YOLOv3-12-int8", "failed in training", {"opset12"}},
 #endif
       {"mask_rcnn_keras", "this model currently has an invalid contrib op version set to 10", {}}};
 

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -946,7 +946,16 @@ TEST_P(ModelTest, Run) {
       ORT_TSTR("softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_none_no_weight"),
       ORT_TSTR("softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_none_no_weight_expanded"),
       ORT_TSTR("softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_none_no_weight_log_prob"),
-      ORT_TSTR("softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_none_no_weight_log_prob_expanded")};
+      ORT_TSTR("softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_none_no_weight_log_prob_expanded"),
+      // models from model zoo
+      ORT_TSTR("Tiny YOLOv3"),
+      ORT_TSTR("BERT-Squad"),
+      ORT_TSTR("YOLOv3"),
+      ORT_TSTR("Candy"),
+      ORT_TSTR("SSD"),
+      ORT_TSTR("ResNet101_DUC_HDC-12"),
+      ORT_TSTR("YOLOv3-12")
+      };
   static const ORTCHAR_T* dml_disabled_tests[] = {ORT_TSTR("mlperf_ssd_resnet34_1200"),
                                                   ORT_TSTR("mlperf_ssd_mobilenet_300"),
                                                   ORT_TSTR("mask_rcnn"),

--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -245,6 +245,19 @@ TEST_P(ModelTest, Run) {
       {"softmax_cross_entropy_input_shape_is_NCd1d2d3d4d5_mean_weight", "type error", {"opset12"}},
       {"softmax_cross_entropy_mean_weight", "type error", {"opset12"}},
       {"softmax_cross_entropy_mean_no_weight_ignore_index_4d", "type error", {"opset12"}},
+      // models from model zoo
+      {"EfficientNet-Lite4-int8", "failed in training", {"opset11"}},
+      {"EfficientNet-Lite4-qdq", "failed in training", {"opset11"}},
+      {"ResNet50-qdq", "failed in training", {"opset11"}},
+      {"MobileNet v2-1.0-int8", "failed in traning", {"opset12"}},
+      {"MobileNet v2-1.0-qdq", "failed in training", {"opset12"}},
+      {"SSD-int8", "failed in training", {"opset12"}},
+      {"Inception-1-int8", "failed in training", {"opset12"}},
+      {"Faster R-CNN R-50-FPN-int8", "failed in training", {"opset12"}},
+      {"ShuffleNet-v2-int8", "failed in training", {"opset12"}},
+      {"VGG 16-int8", "failed in training", {"opset12"}},
+      {"BERT-Squad-int8", "failed in training", {"opset12"}},
+      {"ResNet50_int8", "failed in training", {"opset12"}},
 #endif
       {"mask_rcnn_keras", "this model currently has an invalid contrib op version set to 10", {}}};
 
@@ -594,7 +607,7 @@ TEST_P(ModelTest, Run) {
     BrokenTest t = {ToUTF8String(test_case_name), ""};
     auto iter = broken_tests.find(t);
     auto opset_version = model_info->GetNominalOpsetVersion();
-    if (iter != broken_tests.end() && 
+    if (iter != broken_tests.end() &&
         (opset_version == TestModelInfo::unknown_version || iter->broken_opset_versions_.empty() ||
          iter->broken_opset_versions_.find(opset_version) != iter->broken_opset_versions_.end() )) {
       SkipTest("It's in broken_tests");


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->


### Motivation and Context
For training CI, those failed models are skipped in inference CI due to has training domain.

Not all *int8 skipped in inference CI failed in training CI
For example
```
2022-10-23T03:35:58.8091616Z [ RUN      ] ModelTests/ModelTest.Run/cpu__models_zoo_opset12_GoogleNetint8_googlenet12int8
2022-10-23T03:35:58.9999884Z /onnxruntime_src/onnxruntime/test/providers/cpu/model_tests.cc:86: Skipped
2022-10-23T03:35:59.0000864Z Skipping single test It has training domain
```
```
2022-10-27T11:34:32.4105220Z 1: [ RUN      ] ModelTests/ModelTest.Run/cpu__models_zoo_opset12_GoogleNetint8_googlenet12int8
2022-10-27T11:34:32.6790873Z 1: [       OK ] ModelTests/ModelTest.Run/cpu__models_zoo_opset12_GoogleNetint8_googlenet12int8 (268 ms)
```
```
2022-10-27T11:58:29.8591988Z 1: [ RUN      ] ModelTests/ModelTest.Run/cuda__models_zoo_opset12_GoogleNetint8_googlenet12int8
2022-10-27T11:58:30.0053914Z 1: [       OK ] ModelTests/ModelTest.Run/cuda__models_zoo_opset12_GoogleNetint8_googlenet12int8 (149 ms)
```

### verified in test workflows
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=796120&view=logs&j=8c952c3b-dbd4-5685-50d1-7e2a31304cbf
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=796091&view=logs&j=7536d2cd-87d4-54fe-4891-bfbbf2741d83
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=796085&view=logs&j=52024a78-4e9d-503c-68de-2b0746163a14


