### PR TITLE
Increase timeout for binary-size-checks-pipeline.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/binary-size-checks-pipeline.yml
@@ -23,7 +23,7 @@ resources:
 
 jobs:
 - job: BinarySizeChecks
-  timeoutInMinutes: 30
+  timeoutInMinutes: 60
   workspace:
     clean: all
   pool: Linux-CPU-2019


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Increase timeout for binary-size-checks-pipeline to 60 minutes.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

If it has to build the docker image, it can take a bit longer.
