### PR TITLE
speed up build with default use of all cores

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from distutils.version import LooseVersion
 from pathlib import Path
+from multiprocessing import cpu_count
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
@@ -163,7 +164,7 @@ def parse_arguments():
         "--parallel",
         nargs="?",
         const="0",
-        default="1",
+        default=str(cpu_count()),
         type=int,
         help="Use parallel build. The optional value specifies the maximum number of parallel jobs. "
         "If the optional value is 0 or unspecified, it is interpreted as the number of CPUs.",


### PR DESCRIPTION
### Description
The build process is changed to leverage many core systems by default. It is unlikely that builders will set parallel parameter by default. The current build process accounts for core counts and reduces the build process time by 38% on high core count systems
### Motivation and Context
The increases the developer productivity, especially on first build



