### PR TITLE
Fix pythonop training_mode in evaluation mode

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -90,7 +90,11 @@ def _export_pt_1_10(g, n, *args, **kwargs):
         if runtime_pytorch_version >= version.parse("1.12"):
             from torch.onnx import _globals
 
-            training_mode = _globals.GLOBALS.training_mode
+            assert _globals.GLOBALS.training_mode in [
+                _globals.GLOBALS.training_mode.EVAL,
+                _globals.GLOBALS.training_mode.TRAINING,
+            ], f"Unexpected training mode, expected EVAL or TRAINING, while it's {_globals.GLOBALS.training_mode} now"
+            training_mode = 1 if _globals.GLOBALS.training_mode == _globals.GLOBALS.training_mode.TRAINING else 0
         else:
             training_mode = symbolic_helper._training_mode
         cconv = n.cconv()

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -90,11 +90,15 @@ def _export_pt_1_10(g, n, *args, **kwargs):
         if runtime_pytorch_version >= version.parse("1.12"):
             from torch.onnx import _globals
 
-            assert _globals.GLOBALS.training_mode in [
-                _globals.GLOBALS.training_mode.EVAL,
-                _globals.GLOBALS.training_mode.TRAINING,
-            ], f"Unexpected training mode, expected EVAL or TRAINING, while it's {_globals.GLOBALS.training_mode} now"
-            training_mode = 1 if _globals.GLOBALS.training_mode == _globals.GLOBALS.training_mode.TRAINING else 0
+            # before https://github.com/pytorch/pytorch/commit/c8b9b6266b505328e503b12f6a42fd88c56374f9, training_mode is still a bool type
+            if isinstance(_globals.GLOBALS.training_mode, bool):
+                training_mode = _globals.GLOBALS.training_mode
+            else:
+                assert _globals.GLOBALS.training_mode in [
+                    torch.onnx.TrainingMode.EVAL,
+                    torch.onnx.TrainingMode.TRAINING,
+                ], f"Unexpected training mode, expected EVAL or TRAINING, while it's {_globals.GLOBALS.training_mode} now"
+                training_mode = 1 if _globals.GLOBALS.training_mode == torch.onnx.TrainingMode.TRAINING else 0
         else:
             training_mode = symbolic_helper._training_mode
         cconv = n.cconv()

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_autograd.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_autograd.py
@@ -3,6 +3,7 @@
 
 # pylint: disable=missing-docstring
 # pylint: disable=C0103
+# pylint: disable=W0212
 
 import pytest
 import torch
@@ -1244,7 +1245,9 @@ def test_pythonop_training_mode():
         @staticmethod
         def backward(ctx, grad_output):
             x = ctx.saved_tensors
-            return None
+            tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+            ff = 0.5 * x * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)) + 0.5 * (1 + tanh_out)
+            return ff * grad_output
 
     class TestModel(torch.nn.Module):
         def __init__(self, output_size):


### PR DESCRIPTION
Customer reported this issue: they see many warnings when doing hte evaluation using ORTModule.

![image](https://user-images.githubusercontent.com/10530022/199371757-5fed7d05-a951-4f1b-8f88-049c5ab89886.png)

After investigation, we found the `training_mode` is exported to a wrong value in evaluation mode, it's value should be 0, but we found it is 1. 

Fix: 
fix pythonop training mode

if training_mode's type is torch._C._onnx.TrainingMode, then not matter it is EVAL or TRAINING, "if training_mode" will always be true



