### PR TITLE
fixing link of `c_cxx/fns_candy_style_transfer`

### DIFF
--- a/docs/execution-providers/DirectML-ExecutionProvider.md
+++ b/docs/execution-providers/DirectML-ExecutionProvider.md
@@ -122,7 +122,7 @@ However, if a model input contains a free dimension (such as for batch size), ad
 
 ## Samples
 
-A complete sample of onnxruntime using the DirectML execution provider can be found under [samples/c_cxx/fns_candy_style_transfer](https://github.com/microsoft/onnxruntime/tree/master/samples//c_cxx/fns_candy_style_transfer)
+A complete sample of onnxruntime using the DirectML execution provider can be found under [samples/c_cxx/fns_candy_style_transfer](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/c_cxx/fns_candy_style_transfer)
 
 
 ## Additional Resources


### PR DESCRIPTION
### Description
Updating an invalid link : 

The link for `samples/c_cxx/fns_candy_style_transfer` was invalid. The files now seems to be present in the `onnxruntime-inference-examples` repo - https://github.com/microsoft/onnxruntime-inference-examples/tree/main/c_cxx/fns_candy_style_transfer

### Motivation and Context
Fixing a non-working link. 

