### PR TITLE
enable exception throwing for wasm

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -392,10 +392,9 @@ def parse_arguments():
         "--disable_wasm_exception_catching", action="store_true", help="Disable exception catching in WebAssembly."
     )
     parser.add_argument(
-        "--enable_wasm_exception_throwing_override",
+        "--disable_wasm_exception_throwing",
         action="store_true",
-        help="Enable exception throwing in WebAssembly, this will override default disabling exception throwing "
-        "behavior when disable exceptions.",
+        help="Disable exception throwing in WebAssembly."
     )
 
     parser.add_argument(
@@ -919,7 +918,7 @@ def generate_build_tree(
         "-Donnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_CATCHING="
         + ("OFF" if args.disable_wasm_exception_catching else "ON"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_THROWING="
-        + ("ON" if args.enable_wasm_exception_throwing_override else "OFF"),
+        + ("OFF" if args.disable_wasm_exception_throwing else "ON"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_THREADS=" + ("ON" if args.enable_wasm_threads else "OFF"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO=" + ("ON" if args.enable_wasm_debug_info else "OFF"),
         "-Donnxruntime_ENABLE_WEBASSEMBLY_PROFILING=" + ("ON" if args.enable_wasm_profiling else "OFF"),


### PR DESCRIPTION
enable exception throwing for wasm so in case of errors callers will receive a meaningful error message.
As far I can tell there is no impact on size and performance:

![image](https://user-images.githubusercontent.com/22941064/199094835-2ad40d2d-51f4-4bb3-96f6-0f312bccf8de.png)
