### PR TITLE
Patch  eval_squad.py script for Python < 3.8 and multiple Execution Providers

### DIFF
--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -218,7 +218,7 @@ def main():
             squad_v2_format=True,
         )
 
-        result["provider"] = args.provider if use_gpu else "CPUExecutionProvider"
+        result["provider"] = args.provider
         result["disable_fused_attention"] = disable_fused_attention
         result["pretrained_model_name"] = pretrained_model_name
         result["onnx_path"] = onnx_path

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -198,7 +198,7 @@ def main():
         tokenizer.doc_stride = min(sequence_length // 2, 128)
 
         use_gpu = False
-        if args.provider is not "CPUExecutionProvider":
+        if args.provider != "CPUExecutionProvider":
             use_gpu = True
 
         ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, use_gpu, args.provider)

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -44,9 +44,7 @@ def get_package_version(package_name: str):
         return None
 
 
-def load_onnx_model(
-    model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"
-):
+def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, provider="CUDAExecutionProvider"):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
 

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -14,6 +14,7 @@
 import argparse
 import csv
 import os
+
 try:
     from importlib.metadata import PackageNotFoundError, version
 except ImportError:

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -14,7 +14,11 @@
 import argparse
 import csv
 import os
-from importlib.metadata import PackageNotFoundError, version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version
+
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -44,7 +44,9 @@ def get_package_version(package_name: str):
         return None
 
 
-def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, provider="CUDAExecutionProvider"):
+def load_onnx_model(
+    model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, provider="CUDAExecutionProvider"
+):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
 
@@ -260,7 +262,12 @@ def parse_arguments(argv=None):
     )
 
     parser.add_argument("--use_gpu", required=False, action="store_true", help="Allow GPU RUN.")
-    parser.add_argument("--provider", required=False, default="CUDAExcecutionProvider", help="Select which Execution Provider to use for runs.")
+    parser.add_argument(
+        "--provider",
+        required=False,
+        default="CUDAExcecutionProvider",
+        help="Select which Execution Provider to use for runs.",
+    )
 
 
     args = parser.parse_args(argv)

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -198,7 +198,7 @@ def main():
         tokenizer.doc_stride = min(sequence_length // 2, 128)
 
         use_gpu = False
-        if args.provider is not ("CPUExecutionProvider" or None):
+        if args.provider is not "CPUExecutionProvider":
             use_gpu = True
 
         ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, use_gpu, args.provider)

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -45,7 +45,7 @@ def get_package_version(package_name: str):
 
 
 def load_onnx_model(
-    model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, provider="CUDAExecutionProvider"
+    model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = False, provider="CUDAExecutionProvider"
 ):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
@@ -197,7 +197,11 @@ def main():
         tokenizer.model_max_length = sequence_length
         tokenizer.doc_stride = min(sequence_length // 2, 128)
 
-        ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, args.use_gpu, args.provider)
+        use_gpu = False
+        if args.provider is not ("CPUExecutionProvider" or None):
+            use_gpu = True
+
+        ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, use_gpu, args.provider)
         print(ort_model.config)
         if sequence_length > ort_model.config.max_position_embeddings:
             raise RuntimeError("sequence length should not be larger than {ort_model.config.max_position_embeddings}")
@@ -214,7 +218,7 @@ def main():
             squad_v2_format=True,
         )
 
-        result["provider"] = args.provider if args.use_gpu else "CPUExecutionProvider"
+        result["provider"] = args.provider if use_gpu else "CPUExecutionProvider"
         result["disable_fused_attention"] = disable_fused_attention
         result["pretrained_model_name"] = pretrained_model_name
         result["onnx_path"] = onnx_path
@@ -261,7 +265,6 @@ def parse_arguments(argv=None):
         help="Optional onnx model path. If not specified, optimum will be used to export onnx model for testing.",
     )
 
-    parser.add_argument("--use_gpu", required=False, action="store_true", help="Allow GPU RUN.")
     parser.add_argument(
         "--provider",
         required=False,
@@ -269,13 +272,7 @@ def parse_arguments(argv=None):
         help="Select which Execution Provider to use for runs.",
     )
 
-
     args = parser.parse_args(argv)
-
-    if args.provider is not None:
-        args.use_gpu = True
-    else:
-        args.use_gpu = False
 
     return args
 


### PR DESCRIPTION
Need this for benchmarks to function correctly with older containers

### Description
<!-- Describe your changes. -->
This fixes import errors when attempting to run eval_squad.py to evaluate bert distilled models

This arose when testing MIGraphX with the newest set of model accuracy scripts. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Adds a change to the previously merged #12947  which fails when using Python version < 3.8 to run this script. 


