### PR TITLE
Fix an error in the python packaging pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/py-linux.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-linux.yml
@@ -56,7 +56,7 @@ jobs:
               -e NIGHTLY_BUILD \
               -e BUILD_BUILDNUMBER \
               onnxruntimecpubuilpython${{ parameters.arch }} tools/ci_build/github/linux/build_linux_arm64_python_package.sh
-            rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11 $(Build.BinariesDirectory)/Release/models$(Build.BinariesDirectory)/Release/_deps $(Build.BinariesDirectory)/Release/CMakeFiles
+            rm -rf $(Build.BinariesDirectory)/Release/onnxruntime $(Build.BinariesDirectory)/Release/pybind11 $(Build.BinariesDirectory)/Release/models $(Build.BinariesDirectory)/Release/_deps $(Build.BinariesDirectory)/Release/CMakeFiles
             cd $(Build.BinariesDirectory)/Release
             find -executable -type f > $(Build.BinariesDirectory)/Release/perms.txt
 


### PR DESCRIPTION
### Description
It missed a space there.

### Motivation and Context
Right now the pipeline is failing because GSL was just converted from a submodule to a cmake external project. 


