### PR TITLE
Change GSL download to use HTTPS URL.

### DIFF
--- a/cmake/external/gsl.cmake
+++ b/cmake/external/gsl.cmake
@@ -5,9 +5,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     GSL
-    GIT_REPOSITORY https://github.com/microsoft/gsl
-    GIT_TAG a3534567187d2edc428efd3f13466ff75fe5805c  # v4.0.0
-    GIT_SHALLOW ON
+    URL https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip
+    URL_HASH SHA1=cf368104cd22a87b4dd0c80228919bb2df3e2a14
     )
 
 FetchContent_MakeAvailable(GSL)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Change GSL download to use HTTPS URL.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The git download doesn't work in some environments.
