### PR TITLE
Remove torch and valgrind from inference pipelines

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
@@ -98,20 +98,7 @@ export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
 for PYTHON_EXE in "${PYTHON_EXES[@]}"
 do
   ${PYTHON_EXE} -m pip install -r ${0/%install_deps\.sh/requirements\.txt}
-  if ! [[ ${PYTHON_EXE} = "/opt/python/cp310-cp310/bin/python3.10" ]]; then
-    ${PYTHON_EXE} -m pip install -r ${0/%install_deps\.sh/..\/training\/ortmodule\/stage1\/requirements_torch_cpu\/requirements.txt}
-  else
-    ${PYTHON_EXE} -m pip install torch==1.12.1
-  fi
 done
-
-cd /tmp/src
-GetFile 'https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2' /tmp/src/valgrind-3.16.1.tar.bz2
-tar -jxvf valgrind-3.16.1.tar.bz2
-cd valgrind-3.16.1
-./configure --prefix=/usr --libdir=/usr/lib64 --enable-only64bit --enable-tls
-make -j$(getconf _NPROCESSORS_ONLN)
-make install
 
 cd /
 rm -rf /tmp/src


### PR DESCRIPTION
### Description

Pytorch was added to inference pipelines in PR #8027. But, actually these pipelines do not use PyTorch. PyTorch is huge, here we need to install it for 4 different Python versions. If we remove PyTorch, we will significantly reduce the image size. And, now downloading a pytorch package often takes more than 1 hour. If we do it 4 times, it may take 4 hours. 

Valgrind was added by me long time back, and it was not used too. Now we run Linux tests outside of docker containers. So, when we have the need, we could install it through apt-get on Ubuntu instead of doing it in the CentOS container.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


