### PR TITLE
Upgrade cmake version to 3.24

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -429,10 +429,10 @@
          "component": {
             "type": "git",
             "git": {
-               "commitHash": "aaa5eab410c2e3fe41ebf7a2316be9c51572dbd2",
+               "commitHash": "c974557598645360fbabac71352b083117e3cc17",
                "repositoryUrl": "https://gitlab.kitware.com/cmake/cmake"
             },
-            "comments": "CMake 3.18.2. For building our CI build docker image"
+            "comments": "CMake 3.24.3. For building our CI build docker image"
          }
       },
       {

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,15 +2,13 @@
 # Licensed under the MIT License.
 
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.24)
 cmake_policy(SET CMP0069 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 
 cmake_policy(SET CMP0092 NEW)
 cmake_policy(SET CMP0091 NEW)
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20")
-  cmake_policy(SET CMP0117 NEW)
-endif()
+cmake_policy(SET CMP0117 NEW)
 # Don't let cmake set a default value for CMAKE_CUDA_ARCHITECTURES
 cmake_policy(SET CMP0104 OLD)
 

--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -11,7 +11,7 @@ MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 

--- a/dockerfiles/Dockerfile.migraphx
+++ b/dockerfiles/Dockerfile.migraphx
@@ -27,14 +27,14 @@ RUN apt-get update &&\
     apt-get install -y sudo git bash build-essential rocm-dev libpython3.6-dev python3-pip miopen-hip \
     rocblas half aria2 libnuma-dev
 
-RUN aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz \
-https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz &&\
-tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr
+RUN aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz \
+https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz &&\
+tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Install rbuild
 RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz numpy yapf==0.28.0
 
-ENV PATH /opt/miniconda/bin:/code/cmake-3.21.0-linux-x86_64/bin:${PATH}
+ENV PATH /opt/miniconda/bin:/code/cmake-3.24.3-linux-x86_64/bin:${PATH}
 
 # Install MIGraphX from source
 RUN mkdir -p /migraphx

--- a/dockerfiles/Dockerfile.openvino-centos7
+++ b/dockerfiles/Dockerfile.openvino-centos7
@@ -31,9 +31,9 @@ RUN yum update -y && \
     yum clean packages &&  yum clean all && rm -rf /var/cache/yum && \
 # Install cmake
     cd $MY_ROOT && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6.tar.gz && \
-    tar -zxvf cmake-3.18.6.tar.gz && rm -rf cmake-3.18.6.tar.gz && \
-    cd cmake-3.18.6 && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3.tar.gz && \
+    tar -zxvf cmake-3.24.3.tar.gz && rm -rf cmake-3.24.3.tar.gz && \
+    cd cmake-3.24.3 && \
     ./bootstrap && \
     make && \
     make install && \

--- a/dockerfiles/Dockerfile.source
+++ b/dockerfiles/Dockerfile.source
@@ -9,7 +9,7 @@ MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
 # Prepare onnxruntime repository & build onnxruntime
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 

--- a/dockerfiles/Dockerfile.tensorrt
+++ b/dockerfiles/Dockerfile.tensorrt
@@ -17,7 +17,7 @@ RUN apt-get update &&\
 RUN unattended-upgrade
 
 WORKDIR /code
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.21.0-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.24.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 
 # Prepare onnxruntime repository & build onnxruntime with TensorRT
 RUN git clone --single-branch --branch ${ONNXRUNTIME_BRANCH} --recursive ${ONNXRUNTIME_REPO} onnxruntime &&\

--- a/dockerfiles/Dockerfile.vitisai
+++ b/dockerfiles/Dockerfile.vitisai
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH /code/cmake-3.21.0-linux-x86_64/bin:$PATH
+ENV PATH /code/cmake-3.24.3-linux-x86_64/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/xilinx/xrt/lib:$LD_LIBRARY_PATH
 
 WORKDIR /code
@@ -41,4 +41,4 @@ RUN . $VAI_ROOT/conda/etc/profile.d/conda.sh &&\
     /bin/sh ./build.sh --config RelWithDebInfo --enable_pybind --build_wheel --use_vitisai --parallel --update --build --build_shared_lib &&\
     pip install /code/onnxruntime/build/Linux/RelWithDebInfo/dist/*-linux_x86_64.whl &&\
     cd .. &&\
-    rm -rf onnxruntime cmake-3.21.0-linux-x86_64
+    rm -rf onnxruntime cmake-3.24.3-linux-x86_64

--- a/dockerfiles/scripts/install_centos_arm64.sh
+++ b/dockerfiles/scripts/install_centos_arm64.sh
@@ -7,13 +7,13 @@ fi
 yum install -y devtoolset-10-binutils devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-gcc aria2 python3-pip python3-wheel git python3-devel
 ARCH=`uname -m`
 if [ "$ARCH" = "aarch64" ]; then
-    aria2c -q -d /tmp -o cmake-3.21.1-linux-aarch64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-aarch64.tar.gz && tar -zxf /tmp/cmake-3.21.1-linux-aarch64.tar.gz --strip=1 -C /usr
+    aria2c -q -d /tmp -o cmake-3.24.3-linux-aarch64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-aarch64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-aarch64.tar.gz --strip=1 -C /usr
 else
-    aria2c -q -d /tmp https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1.tar.gz
+    aria2c -q -d /tmp https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3.tar.gz
     cd /tmp
     mkdir cmake
     cd cmake
-    tar --strip=1 -zxvf /tmp/cmake-3.21.1.tar.gz
+    tar --strip=1 -zxvf /tmp/cmake-3.24.3.tar.gz
     ./configure --prefix=/usr --parallel=$(nproc)
     make -j$(nproc)
     make install

--- a/dockerfiles/scripts/install_common_deps.sh
+++ b/dockerfiles/scripts/install_common_deps.sh
@@ -21,6 +21,6 @@ pip install "wheel>=0.35.1"
 rm -rf /opt/miniconda/pkgs
 
 # Dependencies: cmake
-wget --quiet https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz
-tar zxf cmake-3.21.0-linux-x86_64.tar.gz
-rm -rf cmake-3.21.0-linux-x86_64.tar.gz
+wget --quiet https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz
+tar zxf cmake-3.24.3-linux-x86_64.tar.gz
+rm -rf cmake-3.24.3-linux-x86_64.tar.gz

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5.2.3
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5.2.3
@@ -19,7 +19,7 @@ LABEL maintainer="The ManyLinux project"
 RUN yum install -y hipify-clang
 
 # CMake
-ENV CMAKE_VERSION=3.24.2
+ENV CMAKE_VERSION=3.24.3
 RUN cd /usr/local && \
     wget -q -O - https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar zxf -
 ENV PATH=/usr/local/cmake-${CMAKE_VERSION}-linux-x86_64/bin:${PATH}

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5.3
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm5.3
@@ -19,7 +19,7 @@ LABEL maintainer="The ManyLinux project"
 RUN yum install -y hipify-clang
 
 # CMake
-ENV CMAKE_VERSION=3.24.2
+ENV CMAKE_VERSION=3.24.3
 RUN cd /usr/local && \
     wget -q -O - https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar zxf -
 ENV PATH=/usr/local/cmake-${CMAKE_VERSION}-linux-x86_64/bin:${PATH}

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_4_tensorrt8_0
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_4_tensorrt8_0
@@ -12,7 +12,7 @@ ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=main
 ARG CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.21.0-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.24.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 ENV LD_LIBRARY_PATH /opt/miniconda/lib:$LD_LIBRARY_PATH
 
 RUN apt-get update &&\

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_4_tensorrt8_2
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_4_tensorrt8_2
@@ -13,7 +13,7 @@ ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=main
 ARG CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.21.0-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.24.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 ENV LD_LIBRARY_PATH /opt/miniconda/lib:$LD_LIBRARY_PATH
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_6_tensorrt8_4
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_cuda11_6_tensorrt8_4
@@ -12,7 +12,7 @@ ARG ONNXRUNTIME_REPO=https://github.com/Microsoft/onnxruntime
 ARG ONNXRUNTIME_BRANCH=main
 ARG CMAKE_CUDA_ARCHITECTURES=37;50;52;60;61;70;75;80
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:/code/cmake-3.21.0-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/src/tensorrt/bin:/code/cmake-3.24.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_openvino
@@ -36,8 +36,8 @@ RUN wget "https://github.com/intel/compute-runtime/releases/download/21.48.21782
     sudo dpkg -i *.deb && rm -rf *.deb
 
 RUN mkdir -p /opt/cmake/bin && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && \
-    tar -xf cmake-3.21.0-linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.21.0-linux-x86_64.tar.gz && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && \
+    tar -xf cmake-3.24.3-linux-x86_64.tar.gz --strip 1 -C /opt/cmake && rm -rf /cmake-3.24.3-linux-x86_64.tar.gz && \
     ln -sf /opt/cmake/bin/* /usr/bin
 
 ARG BUILD_UID=1000

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt_bin
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt_bin
@@ -21,7 +21,7 @@ ARG TAR_CUDNN_VERSION
 # Directory containing TensorRT tar.gz installation package
 ARG TRT_BINS_DIR=.
 
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.21.0-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:/code/cmake-3.24.3-linux-x86_64/bin:/opt/miniconda/bin:${PATH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/scripts/install_deps.sh
@@ -39,8 +39,8 @@ mkdir -p /tmp/src
 cd /tmp/src
 
 echo "Installing cmake"
-GetFile https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-`uname -m`.tar.gz /tmp/src/cmake-3.23.2-linux-`uname -m`.tar.gz
-tar -zxf /tmp/src/cmake-3.23.2-linux-`uname -m`.tar.gz --strip=1 -C /usr
+GetFile https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-`uname -m`.tar.gz /tmp/src/cmake-3.24.3-linux-`uname -m`.tar.gz
+tar -zxf /tmp/src/cmake-3.24.3-linux-`uname -m`.tar.gz --strip=1 -C /usr
 
 echo "Installing Ninja"
 GetFile https://github.com/ninja-build/ninja/archive/v1.10.0.tar.gz /tmp/src/ninja-linux.tar.gz

--- a/tools/ci_build/github/linux/docker/inference/x64/default/cpu/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/inference/x64/default/cpu/scripts/install_deps.sh
@@ -39,8 +39,8 @@ mkdir -p /tmp/src
 cd /tmp/src
 
 echo "Installing cmake"
-GetFile https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-`uname -m`.tar.gz /tmp/src/cmake-3.23.2-linux-`uname -m`.tar.gz
-tar -zxf /tmp/src/cmake-3.23.2-linux-`uname -m`.tar.gz --strip=1 -C /usr
+GetFile https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-`uname -m`.tar.gz /tmp/src/cmake-3.24.3-linux-`uname -m`.tar.gz
+tar -zxf /tmp/src/cmake-3.24.3-linux-`uname -m`.tar.gz --strip=1 -C /usr
 
 echo "Installing Ninja"
 GetFile https://github.com/ninja-build/ninja/archive/v1.10.0.tar.gz /tmp/src/ninja-linux.tar.gz

--- a/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/install_os_deps.sh
@@ -71,17 +71,17 @@ if [[ $SYS_LONG_BIT = "64" && "$GLIBC_VERSION" -gt "9" ]]; then
   tar --strip 1 -xf /tmp/azcopy/azcopy.tar.gz -C /tmp/azcopy
   cp /tmp/azcopy/azcopy /usr/bin
   echo "Installing cmake"
-  GetFile https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz /tmp/src/cmake-3.18.2-Linux-x86_64.tar.gz
-  tar -zxf /tmp/src/cmake-3.18.2-Linux-x86_64.tar.gz --strip=1 -C /usr
+  GetFile https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-Linux-x86_64.tar.gz /tmp/src/cmake-3.24.3-Linux-x86_64.tar.gz
+  tar -zxf /tmp/src/cmake-3.24.3-Linux-x86_64.tar.gz --strip=1 -C /usr
   echo "Installing Node.js"
   GetFile https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.xz /tmp/src/node-v16.14.2-linux-x64.tar.xz
   tar -xf /tmp/src/node-v16.14.2-linux-x64.tar.xz --strip=1 -C /usr
 else
   echo "Installing cmake"
-  GetFile https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz /tmp/src/cmake-3.18.2.tar.gz
-  tar -xf /tmp/src/cmake-3.18.2.tar.gz -C /tmp/src
+  GetFile https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3.tar.gz /tmp/src/cmake-3.24.3.tar.gz
+  tar -xf /tmp/src/cmake-3.24.3.tar.gz -C /tmp/src
   pushd .
-  cd /tmp/src/cmake-3.18.2
+  cd /tmp/src/cmake-3.24.3
   ./bootstrap --prefix=/usr --parallel=$(getconf _NPROCESSORS_ONLN) --system-bzip2 --system-curl --system-zlib --system-expat
   make -j$(getconf _NPROCESSORS_ONLN)
   make install


### PR DESCRIPTION
### Description
Upgrade cmake version to 3.24 because I need to use a new feature that is only provided in that version and later.  Starting from cmake 3.24, the [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html#module:FetchContent) module and the [find_package()](https://cmake.org/cmake/help/latest/command/find_package.html#command:find_package) command now support integration capabilities, which means calls to "FetchContent" can be implicitly redirected to "find_package", and vice versa.  Users can use a cmake variable to control the behavior. So, we don't need to provide such a build option. We can delete our "onnxruntime_PREFER_SYSTEM_LIB" build option and let cmake handle it.  And it would be easier for who wants to use vcpkg. 


### Motivation and Context

Provide a unified package management method, and get aligned with the community.  This change is split from #13523 for easier review. 

