### PR TITLE
[CANN] add more operators

### DIFF
--- a/onnxruntime/core/providers/cann/activation/activations.cc
+++ b/onnxruntime/core/providers/cann/activation/activations.cc
@@ -20,8 +20,8 @@ Status Activations::Prepare(OpKernelContext* ctx, CannPreparation& prepare) cons
     CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
     CANN_PREPARE_OUTPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
 
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
-    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
   }
   ORT_CATCH(const std::exception& e) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
@@ -87,6 +87,7 @@ Status Activations::Prepare(OpKernelContext* ctx, CannPreparation& prepare) cons
   REGISTER_ACTIVATION_TYPED(name, ver, int8_t)    \
   REGISTER_ACTIVATION_TYPED(name, ver, int16_t)   \
   REGISTER_ACTIVATION_TYPED(name, ver, int32_t)   \
+  REGISTER_ACTIVATION_TYPED(name, ver, int64_t)   \
   REGISTER_ACTIVATION_TYPED(name, ver, MLFloat16) \
   REGISTER_ACTIVATION_TYPED(name, ver, float)     \
   REGISTER_ACTIVATION_TYPED(name, ver, double)

--- a/onnxruntime/core/providers/cann/cann_common.cc
+++ b/onnxruntime/core/providers/cann/cann_common.cc
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/cann_common.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <>
+const MLFloat16 Constants<MLFloat16>::Zero = MLFloat16(static_cast<uint16_t>(0));
+template <>
+const MLFloat16 Constants<MLFloat16>::One = MLFloat16(static_cast<uint16_t>(0x3C00));
+
+template <>
+const float Constants<float>::Zero = 0;
+template <>
+const float Constants<float>::One = 1;
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_common.h
+++ b/onnxruntime/core/providers/cann/cann_common.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/cann_call.h"
+#include "core/framework/float16.h"
+
+namespace onnxruntime {
+namespace cann {
+
+#define CANN_RETURN_IF_ERROR(expr)               \
+  ORT_RETURN_IF_ERROR(CANN_CALL(expr)            \
+                          ? common::Status::OK() \
+                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CANN error executing ", #expr))
+
+template <typename ElemType>
+struct Constants {
+  static const ElemType Zero;
+  static const ElemType One;
+};
+
+template <typename T>
+class ToCannType {
+ public:
+  static T FromFloat(float f) {
+    return static_cast<T>(f);
+  }
+};
+
+template <>
+class ToCannType<MLFloat16> {
+ public:
+  static MLFloat16 FromFloat(float f) {
+    uint16_t h = math::floatToHalf(f);
+    return *reinterpret_cast<MLFloat16*>(&h);
+  }
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -110,11 +110,15 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Add);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, double, Add);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int64_t, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, double, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int64_t, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, float, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, double, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int32_t, Div);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, int64_t, Div);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 12, MLFloat16, Div);
@@ -138,26 +142,24 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, MLFloat16, Flatten);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 10, float, Flatten);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                      7, 8, MLFloat16, BatchNormalization);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                       7, 8, float, BatchNormalization);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                      9, 13, MLFloat16, BatchNormalization);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                       9, 13, float, BatchNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MLFloat16, GlobalAveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, float, GlobalAveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, double, GlobalAveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                       7, 9, MLFloat16, AveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 9, float, AveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 9, double, AveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 7, MLFloat16, MaxPool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 7, float, MaxPool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 7, double, MaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MLFloat16, GlobalMaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, float, GlobalMaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, double, GlobalMaxPool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, MLFloat16, Conv);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, float, Conv);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 10, double, Conv);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, 9, Dropout);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 12, Identity);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 8, MLFloat16, MatMul);
@@ -165,11 +167,89 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, MLFloat16, MatMul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, float, MatMul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int32_t, MatMul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, uint8_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, uint16_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, uint32_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, uint64_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, int8_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, int16_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, int32_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, int64_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, MLFloat16, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, float, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, double, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 8, bool, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, uint8_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, uint16_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, uint32_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, uint64_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int8_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int16_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int32_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, int64_t, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, MLFloat16, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, float, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, double, Cast);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, bool, Cast);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 4, Reshape);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 5, 12, Reshape);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, uint8_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, uint16_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, uint32_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, uint64_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, int8_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, int16_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, int32_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, int64_t, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, MLFloat16, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, float, Transpose);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, bool, Transpose);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Abs);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Abs);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, int32_t, Abs);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Abs);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Abs);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, int8_t, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, int32_t, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Neg);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Floor);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Floor);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Floor);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Floor);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Ceil);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Ceil);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Ceil);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Ceil);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Reciprocal);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Reciprocal);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                      6, 12, MLFloat16, Reciprocal);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Reciprocal);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Sqrt);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Sqrt);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Sqrt);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Sqrt);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Log);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, float, Log);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Log);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, float, Log);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 1, 5, MLFloat16, Exp);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 6, 12, MLFloat16, Exp);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, MLFloat16, Erf);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 9, 12, float, Erf);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, MLFloat16, Sin);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, float, Sin);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, MLFloat16, Cos);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 7, float, Cos);
 
 // op 10
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                       10, 10, MLFloat16, AveragePool);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 10, 10, float, AveragePool);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 10, 10, double, AveragePool);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 10, 11, Dropout);
 
 // op 11
@@ -186,12 +266,17 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, 12, float, Flatten);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, MLFloat16, AveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, float, AveragePool);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, double, AveragePool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, MLFloat16, Conv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, float, Conv);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, double, Conv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, MLFloat16, Round);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 11, float, Round);
 
 // op 12
-class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 12, 12, Dropout);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 12, 12,
+                                                      MLFloat16_MLFloat16, Dropout);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 12, 12,
+                                                      float_float, Dropout);
 
 // op 13
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Add);
@@ -200,11 +285,15 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Add);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Add);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int64_t, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Sub);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Sub);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int64_t, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, float, Mul);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, double, Mul);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int32_t, Div);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, int64_t, Div);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, MLFloat16, Div);
@@ -224,11 +313,46 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int64_t, Flatten);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Flatten);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Flatten);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, Dropout);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16_MLFloat16, Dropout);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float_float, Dropout);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, Identity);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, BFloat16, MatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, MatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, MatMul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, MatMul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint8_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint16_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint32_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, uint64_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int8_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int16_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int64_t, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, double, Cast);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, bool, Cast);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, 13, Reshape);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, Abs);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Abs);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Abs);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int8_t, Neg);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, int32_t, Neg);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Neg);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Neg);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Floor);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Floor);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Ceil);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Ceil);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Reciprocal);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Reciprocal);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Sqrt);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Sqrt);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Log);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Log);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Exp);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, MLFloat16, Erf);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, float, Erf);
 
 // op 14
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Add);
@@ -239,15 +363,28 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Add);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Add);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Add);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint16_t, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Sub);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Sub);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Sub);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Sub);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Sub);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint16_t, Mul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Mul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Mul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Mul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Mul);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Mul);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint8_t, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, uint16_t, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Div);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Div);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Div);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Div);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Div);
@@ -256,17 +393,16 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int8_t, Relu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int16_t, Relu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int32_t, Relu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, int64_t, Relu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, MLFloat16, Relu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, float, Relu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, double, Relu);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                      14, 14, MLFloat16, BatchNormalization);
-class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                       14, 14, float, BatchNormalization);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Identity);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Reshape);
 
 // op 15
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 15, MLFloat16, BatchNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 15, float, BatchNormalization);
 
 Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
@@ -287,15 +423,23 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, int32_t, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int64_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, MLFloat16, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, float, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, double, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, int32_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, int64_t, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, MLFloat16, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 12, double, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 12, int32_t, Div)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -341,25 +485,27 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             9, 10, float, Flatten)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                            7, 8, MLFloat16, BatchNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 8, float, BatchNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                            9, 13, MLFloat16, BatchNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             9, 13, float, BatchNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   1, MLFloat16, GlobalAveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   1, float, GlobalAveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, double, GlobalAveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 9, MLFloat16, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             7, 9, float, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            7, 9, double, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             1, 7, MLFloat16, MaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             1, 7, float, MaxPool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 7, double, MaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   1, MLFloat16, GlobalMaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -370,8 +516,6 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
                                                                             1, 10, MLFloat16, Conv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             1, 10, float, Conv)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                            1, 10, double, Conv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                       7, 9, Dropout)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -386,12 +530,166 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
                                                                             9, 12, float, MatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             9, 12, int32_t, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, uint8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, uint16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, uint32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, uint64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, int8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, int16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, int32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, int64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, MLFloat16, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, float, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, double, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 8, bool, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, uint8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, uint16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, uint32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, uint64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, int8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, int16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, int32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, int64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, MLFloat16, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, float, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, double, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, bool, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      1, 4, Reshape)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      5, 12, Reshape)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, uint8_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, uint16_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, uint32_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, uint64_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, int8_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, int16_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, int32_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, int64_t, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, MLFloat16, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, float, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  1, bool, Transpose)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, int32_t, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, int8_t, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, int32_t, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, float, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, float, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            1, 5, MLFloat16, Exp)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            6, 12, MLFloat16, Exp)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, MLFloat16, Erf)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            9, 12, float, Erf)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  7, MLFloat16, Sin)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  7, float, Sin)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  7, MLFloat16, Cos)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  7, float, Cos)>,
 
       // op 10
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             10, 10, MLFloat16, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             10, 10, float, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            10, 10, double, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                       10, 11, Dropout)>,
 
@@ -423,15 +721,21 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   11, float, AveragePool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, double, AveragePool)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   11, MLFloat16, Conv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   11, float, Conv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                  11, double, Conv)>,
+                                                                  11, MLFloat16, Round)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  11, float, Round)>,
 
       // op 12
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                      12, 12, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            12, 12, MLFloat16_MLFloat16, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            12, 12, float_float, Dropout)>,
 
       // op 13
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -447,15 +751,23 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, int32_t, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int64_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, MLFloat16, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, float, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, double, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, int32_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, int64_t, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, MLFloat16, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                            13, 13, double, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             13, 13, int32_t, Div)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -494,15 +806,86 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
                                                                   13, MLFloat16, Flatten)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   13, float, Flatten)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 13, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16_MLFloat16, Dropout)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float_float, Dropout)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                       13, 13, Identity)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, BFloat16, MatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   13, MLFloat16, MatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   13, float, MatMul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   13, int32_t, MatMul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, uint64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int8_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int16_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int32_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int64_t, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, double, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, bool, Cast)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                      13, 13, Reshape)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int32_t, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Abs)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int8_t, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, int32_t, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Neg)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Floor)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Ceil)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Reciprocal)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Sqrt)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Log)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Exp)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, MLFloat16, Erf)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  13, float, Erf)>,
 
       // op 14
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -522,13 +905,27 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, double, Add)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint8_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint16_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int8_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int16_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, int32_t, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int64_t, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, MLFloat16, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, float, Sub)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, double, Sub)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, uint8_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint16_t, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, int8_t, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -536,9 +933,21 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, int32_t, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int64_t, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, MLFloat16, Mul)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, float, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, double, Mul)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint8_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, uint16_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int8_t, Div)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int16_t, Div)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, int32_t, Div)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
@@ -556,20 +965,19 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, int32_t, Relu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
+                                                                  14, int64_t, Relu)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, MLFloat16, Relu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, float, Relu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   14, double, Relu)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                            14, 14, MLFloat16, BatchNormalization)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                             14, 14, float, BatchNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Identity)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain, 14, Reshape)>,
 
       // op 15
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
-                                                                  15, MLFloat16, BatchNormalization)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCannExecutionProvider, kOnnxDomain,
                                                                   15, float, BatchNormalization)>,
   };

--- a/onnxruntime/core/providers/cann/cann_fence.cc
+++ b/onnxruntime/core/providers/cann/cann_fence.cc
@@ -6,6 +6,7 @@
 #include "core/providers/cann/cann_call.h"
 #include "core/providers/cann/npu_data_transfer.h"
 #include "core/providers/cann/cann_fence.h"
+#include <iostream>
 
 namespace onnxruntime {
 
@@ -22,7 +23,6 @@ CANNFence::~CANNFence() {
 void CANNFence::BeforeUsingAsInput(onnxruntime::ProviderType provider_type, int async_queue_id) {
   if (provider_type == onnxruntime::kCannExecutionProvider) {
     CANN_CALL_THROW(aclrtStreamWaitEvent(data_transfer_->GetStream(async_queue_id), write_event_));
-    CANN_CALL_THROW(aclrtResetEvent(write_event_, data_transfer_->GetStream(async_queue_id)));
   } else {
     CANN_CALL_THROW(aclrtSynchronizeEvent(write_event_));
   }
@@ -32,9 +32,7 @@ void CANNFence::BeforeUsingAsOutput(onnxruntime::ProviderType provider_type, int
   if (provider_type == onnxruntime::kCannExecutionProvider) {
     aclrtStream stream = data_transfer_->GetStream(queue_id);
     CANN_CALL_THROW(aclrtStreamWaitEvent(stream, read_event_));
-    CANN_CALL_THROW(aclrtResetEvent(read_event_, stream));
     CANN_CALL_THROW(aclrtStreamWaitEvent(stream, write_event_));
-    CANN_CALL_THROW(aclrtResetEvent(write_event_, stream));
   } else {
     CANN_CALL_THROW(aclrtSynchronizeEvent(read_event_));
     CANN_CALL_THROW(aclrtSynchronizeEvent(write_event_));

--- a/onnxruntime/core/providers/cann/cann_inc.h
+++ b/onnxruntime/core/providers/cann/cann_inc.h
@@ -6,3 +6,4 @@
 
 #include <acl/acl.h>
 #include <acl/acl_op_compiler.h>
+#include <acl/ops/acl_cblas.h>

--- a/onnxruntime/core/providers/cann/cann_kernel.h
+++ b/onnxruntime/core/providers/cann/cann_kernel.h
@@ -35,12 +35,32 @@ class CannKernel : public OpKernel {
 
   virtual Status ComputeInternal(OpKernelContext* p_op_kernel_context) const = 0;
 
+  inline aclrtStream Stream() const { return static_cast<aclrtStream>(provider_->GetComputeStream()); }
+
   template <typename T>
   inline IAllocatorUniquePtr<T> GetScratchBuffer(size_t count_or_bytes) const {
     return provider_->GetScratchBuffer<T>(count_or_bytes);
   }
 
-  inline aclrtStream Stream() const { return static_cast<aclrtStream>(provider_->GetComputeStream()); }
+  template <typename T>
+  inline IAllocatorUniquePtr<T> GetScratchBufferOnCANNPinned(size_t count_or_bytes) const {
+    return provider_->GetScratchBufferOnCANNPinned<T>(count_or_bytes);
+  }
+
+  template <typename T>
+  inline Status Fill(Tensor* y, void* addr) const {
+    return provider_->Fill<T>(y, addr);
+  }
+
+  template <typename T>
+  inline Status Broadcast(const Tensor* x, Tensor* y, void* addr) const {
+    return provider_->Broadcast<T>(x, y, addr);
+  }
+
+ protected:
+  inline Status CopyTensor(const Tensor& src, Tensor& dst) const {
+    return Info().GetDataTransferManager().CopyTensor(src, dst);
+  }
 
  private:
   CANNExecutionProvider* provider_;

--- a/onnxruntime/core/providers/cann/cann_utils.cc
+++ b/onnxruntime/core/providers/cann/cann_utils.cc
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cann/cann_utils.h"
+#include <iostream>
 
 namespace onnxruntime {
 namespace cann {
@@ -31,6 +32,185 @@ GET_ACL_TYPE(MLFloat16, ACL_FLOAT16);
 GET_ACL_TYPE(BFloat16, ACL_BF16);
 GET_ACL_TYPE(double, ACL_DOUBLE);
 GET_ACL_TYPE(bool, ACL_BOOL);
+
+template <typename T>
+Status Fill(Tensor* y, void* addr, aclrtStream stream) {
+  int64_t one = 1;
+  int64_t dims = static_cast<int64_t>(y->Shape().NumDimensions());
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, ACL_INT64, 1, &dims, format);
+    CANN_CONST_INPUTDESC(prepare, 0, const_cast<int64_t*>(y->Shape().GetDims().data()), dims * sizeof(int64_t));
+    CANN_PREPARE_INPUTDESC(prepare, aclType, 1, &one, format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, dims, y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<int64_t*>(y->Shape().GetDims().data()), dims * sizeof(int64_t));
+    CANN_PREPARE_INPUTBUFFER(prepare, addr, sizeof(T));
+    CANN_PREPARE_OUTPUTBUFFER(prepare, y->MutableDataRaw(), y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("Fill",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              stream));
+
+  return Status::OK();
+}
+
+template Status Fill<uint8_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<uint16_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<uint32_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<uint64_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<int8_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<int16_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<int32_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<int64_t>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<MLFloat16>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<float>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<double>(Tensor* y, void* addr, aclrtStream stream);
+template Status Fill<bool>(Tensor* y, void* addr, aclrtStream stream);
+
+template <typename T>
+Status Broadcast(const Tensor* x, Tensor* y, void* addr, aclrtStream stream) {
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "shape", static_cast<int64_t>(y->Shape().NumDimensions()),
+                                           y->Shape().GetDims().data()));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, x->Shape().NumDimensions(), x->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, y->Shape().NumDimensions(), y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(x->DataRaw()), x->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, addr, y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("BroadcastToD",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              stream));
+
+  return Status::OK();
+}
+
+template Status Broadcast<uint8_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<uint16_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<uint32_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<uint64_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<int8_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<int16_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<int32_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<int64_t>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<MLFloat16>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<BFloat16>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<float>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<double>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+template Status Broadcast<bool>(const Tensor* x, Tensor* y, void* addr, aclrtStream stream);
+
+Status aclrtblasGemmEx(aclTransType transA,
+                       aclTransType transB,
+                       aclTransType transC,
+                       int m,
+                       int n,
+                       int k,
+                       const void* alpha,
+                       const void* matrixA,
+                       int lda,
+                       aclDataType dataTypeA,
+                       const void* matrixB,
+                       int ldb,
+                       aclDataType dataTypeB,
+                       const void* beta,
+                       void* matrixC,
+                       int ldc,
+                       aclDataType dataTypeC,
+                       aclComputeType type,
+                       aclrtStream stream) {
+  ORT_UNUSED_PARAMETER(transC);
+  ORT_UNUSED_PARAMETER(lda);
+  ORT_UNUSED_PARAMETER(ldb);
+  ORT_UNUSED_PARAMETER(ldc);
+  ORT_UNUSED_PARAMETER(type);
+
+  TensorShape A;
+  TensorShape B;
+  TensorShape C{m, n};
+  TensorShape shape{1};
+
+  A = transA ? TensorShape{k, m} : TensorShape{m, k};
+  B = transB ? TensorShape{n, k} : TensorShape{k, n};
+
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_a", transA));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_b", transB));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, dataTypeA, A.NumDimensions(), A.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, dataTypeB, B.NumDimensions(), B.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, dataTypeC, C.NumDimensions(), C.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, dataTypeC, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, dataTypeC, shape.NumDimensions(), shape.GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, dataTypeC, C.NumDimensions(), C.GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(matrixA), A.Size() * aclDataTypeSize(dataTypeA));
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(matrixB), B.Size() * aclDataTypeSize(dataTypeB));
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(matrixC), C.Size() * aclDataTypeSize(dataTypeC));
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(alpha), aclDataTypeSize(dataTypeC));
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(beta), aclDataTypeSize(dataTypeC));
+    CANN_PREPARE_OUTPUTBUFFER(prepare, const_cast<void*>(matrixC), C.Size() * aclDataTypeSize(dataTypeC));
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("GEMM",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              stream));
+
+  return Status::OK();
+}
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cann/math/binary_elementwise_ops.cc
@@ -3,10 +3,42 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cann/math/binary_elementwise_ops.h"
+#include <vector>
+#include <algorithm>
+#include <string>
 
 using onnxruntime::common::Status;
 namespace onnxruntime {
 namespace cann {
+
+Status ComputeOutputShape(const std::string& node_name, const TensorShape& lhs_shape,
+                          const TensorShape& rhs_shape, TensorShape& out_shape) {
+  size_t lhs_rank = lhs_shape.NumDimensions();
+  size_t rhs_rank = rhs_shape.NumDimensions();
+  size_t out_rank = std::max(lhs_rank, rhs_rank);
+
+  std::vector<int64_t> output_dims(out_rank, 0);
+  for (size_t i = 0; i < out_rank; ++i) {
+    int64_t lhs_dim = 1;
+    if (i < lhs_rank)
+      lhs_dim = lhs_shape[lhs_rank - 1 - i];
+    int64_t rhs_dim = 1;
+    if (i < rhs_rank)
+      rhs_dim = rhs_shape[rhs_rank - 1 - i];
+    int64_t max = std::max(lhs_dim, rhs_dim);
+    int64_t min = std::min(lhs_dim, rhs_dim);
+    int64_t out_dim = (min == 0 ? min : max);  // special case a dim value of 0.
+    if (lhs_dim != out_dim && lhs_dim != 1)
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, node_name, ": left operand cannot broadcast on dim ", lhs_rank - 1 - i,
+                             " LeftShape: ", lhs_shape.ToString(), ", RightShape: ", rhs_shape.ToString());
+    if (rhs_dim != out_dim && rhs_dim != 1)
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, node_name, ": right operand cannot broadcast on dim ", rhs_rank - 1 - i,
+                             " LeftShape: ", lhs_shape.ToString(), ", RightShape: ", rhs_shape.ToString());
+    output_dims[out_rank - 1 - i] = out_dim;
+  }
+  out_shape = TensorShape(output_dims);
+  return Status::OK();
+}
 
 template <typename T>
 Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
@@ -15,16 +47,34 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
 
   const Tensor* A = ctx->Input<Tensor>(0);
   const Tensor* B = ctx->Input<Tensor>(1);
-  Tensor* C = ctx->Output(0, A->Shape());
+
+  TensorShape output_shape;
+  ORT_RETURN_IF_ERROR(ComputeOutputShape(Node().Name(), A->Shape(), B->Shape(), output_shape));
+  Tensor* C = ctx->Output(0, output_shape);
+
+  void* A_data = const_cast<void*>(A->DataRaw());
+  void* B_data = const_cast<void*>(B->DataRaw());
+
+  if (A->Shape() != C->Shape()) {
+    IAllocatorUniquePtr<void> pA = GetScratchBuffer<void>(C->SizeInBytes());
+    ORT_RETURN_IF_ERROR(Broadcast<T>(A, C, pA.get()));
+    A_data = pA.get();
+  }
+
+  if (B->Shape() != C->Shape()) {
+    IAllocatorUniquePtr<void> pB = GetScratchBuffer<void>(C->SizeInBytes());
+    ORT_RETURN_IF_ERROR(Broadcast<T>(B, C, pB.get()));
+    B_data = pB.get();
+  }
 
   ORT_TRY {
-    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
-    CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
-    CANN_PREPARE_OUTPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, C->Shape().NumDimensions(), C->Shape().GetDims().data(), format);
+    CANN_PREPARE_INPUTDESC(prepare, aclType, C->Shape().NumDimensions(), C->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, C->Shape().NumDimensions(), C->Shape().GetDims().data(), format);
 
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(A->template Data<T>()), A->SizeInBytes());
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
-    CANN_PREPARE_OUTPUTBUFFER(prepare, C->template MutableData<T>(), C->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, A_data, C->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, B_data, C->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, C->MutableDataRaw(), C->SizeInBytes());
   }
   ORT_CATCH(const std::exception& e) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
@@ -53,7 +103,7 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
     return Status::OK();                                                       \
   }
 
-#define REGISTER_ELEMENTWISE_TYPED_KERNEL(x, class_name, ver, T)                           \
+#define REGISTER_ELEMENTWISE_TYPED_KERNEL(x, ver, T)                                       \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
       x,                                                                                   \
       kOnnxDomain,                                                                         \
@@ -61,7 +111,7 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
       T,                                                                                   \
       kCannExecutionProvider,                                                              \
       (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
-      class_name<T>);
+      x<T>);
 
 #define REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(x, startver, endver, T)                \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
@@ -77,9 +127,23 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
 #define REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, T) \
   REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(name, startver, endver, T)
 
-#define REGISTER_ELEMENTWISE_TYPED(name, ver, T)        \
-  REGISTER_ELEMENTWISE_TYPED_KERNEL(name, name, ver, T) \
+#define REGISTER_ELEMENTWISE_TYPED(name, ver, T)  \
+  REGISTER_ELEMENTWISE_TYPED_KERNEL(name, ver, T) \
   REGISTER_ELEMENTWISE_TYPED_COMPUTE(name, T)
+
+// B: uint8_t
+// W: uint16_t
+// U: uint32_t
+// Z: uint64_t
+// C: int8_t
+// S: int16_t
+// I: int32_t
+// L: int64_t
+// H: float16
+// X: bfloat16
+// F: float
+// D: double
+// O: bool
 
 #define REGISTER_ELEMENTWISE_VERSIONED_ILHFD(name, startver, endver)      \
   REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int32_t)   \
@@ -87,11 +151,6 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
   REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, MLFloat16) \
   REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, float)     \
   REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, double)
-
-#define REGISTER_ELEMENTWISE_VERSIONED_IHF(name, startver, endver)        \
-  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int32_t)   \
-  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, MLFloat16) \
-  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, float)
 
 #define REGISTER_ELEMENTWISE_BCSILHFD(name, ver)   \
   REGISTER_ELEMENTWISE_TYPED(name, ver, uint8_t)   \
@@ -103,20 +162,11 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
   REGISTER_ELEMENTWISE_TYPED(name, ver, float)     \
   REGISTER_ELEMENTWISE_TYPED(name, ver, double)
 
-#define REGISTER_ELEMENTWISE_IHF(name, ver)        \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, float)
-
-#define REGISTER_ELEMENTWISE_BCSIHF(name, ver)     \
+#define REGISTER_ELEMENTWISE_BWCSILHFD(name, ver)  \
   REGISTER_ELEMENTWISE_TYPED(name, ver, uint8_t)   \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, uint16_t)  \
   REGISTER_ELEMENTWISE_TYPED(name, ver, int8_t)    \
   REGISTER_ELEMENTWISE_TYPED(name, ver, int16_t)   \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
-  REGISTER_ELEMENTWISE_TYPED(name, ver, float)
-
-#define REGISTER_ELEMENTWISE_ILHFD(name, ver)      \
   REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)   \
   REGISTER_ELEMENTWISE_TYPED(name, ver, int64_t)   \
   REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16) \
@@ -124,19 +174,19 @@ Status BinaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare
   REGISTER_ELEMENTWISE_TYPED(name, ver, double)
 
 REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Add, 7, 12)
-REGISTER_ELEMENTWISE_VERSIONED_IHF(Sub, 7, 12)
-REGISTER_ELEMENTWISE_VERSIONED_IHF(Mul, 7, 12)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Sub, 7, 12)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Mul, 7, 12)
 REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Div, 7, 12)
 
 REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Add, 13, 13)
-REGISTER_ELEMENTWISE_VERSIONED_IHF(Sub, 13, 13)
-REGISTER_ELEMENTWISE_VERSIONED_IHF(Mul, 13, 13)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Sub, 13, 13)
+REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Mul, 13, 13)
 REGISTER_ELEMENTWISE_VERSIONED_ILHFD(Div, 13, 13)
 
 REGISTER_ELEMENTWISE_BCSILHFD(Add, 14)
-REGISTER_ELEMENTWISE_IHF(Sub, 14)
-REGISTER_ELEMENTWISE_BCSIHF(Mul, 14)
-REGISTER_ELEMENTWISE_ILHFD(Div, 14)
+REGISTER_ELEMENTWISE_BWCSILHFD(Sub, 14)
+REGISTER_ELEMENTWISE_BWCSILHFD(Mul, 14)
+REGISTER_ELEMENTWISE_BWCSILHFD(Div, 14)
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/gemm.h
+++ b/onnxruntime/core/providers/cann/math/gemm.h
@@ -26,7 +26,6 @@ class Gemm final : public CannKernel {
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
-  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
 
  private:
   bool trans_A_;

--- a/onnxruntime/core/providers/cann/math/matmul.cc
+++ b/onnxruntime/core/providers/cann/math/matmul.cc
@@ -13,17 +13,8 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor* A = ctx->Input<Tensor>(0);
   const Tensor* B = ctx->Input<Tensor>(1);
 
-  bool transa = trans_A_;
-  bool transb = trans_B_;
-  if (A->Shape().NumDimensions() == 1) {
-    transa = false;
-  }
-  if (B->Shape().NumDimensions() == 1) {
-    transb = false;
-  }
-
   MatMulComputeHelper helper;
-  ORT_RETURN_IF_ERROR(helper.Compute(A->Shape(), B->Shape(), transa, transb, trans_batch_a_, trans_batch_b_, false));
+  ORT_RETURN_IF_ERROR(helper.Compute(A->Shape(), B->Shape()));
 
   Tensor* Y = ctx->Output(0, helper.OutputShape());
   if (Y->Shape().Size() == 0)
@@ -34,25 +25,23 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   CannPreparation prepare;
 
-  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_x1", transa));
-  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "transpose_x2", transb));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "adj_x1", 0));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "adj_x2", 0));
 
   ORT_TRY {
     CANN_PREPARE_INPUTDESC(prepare, aclType, A->Shape().NumDimensions(), A->Shape().GetDims().data(), format);
     CANN_PREPARE_INPUTDESC(prepare, aclType, B->Shape().NumDimensions(), B->Shape().GetDims().data(), format);
-    CANN_PREPARE_INPUTDESC(prepare, ACL_DT_UNDEFINED, 0, nullptr, ACL_FORMAT_UNDEFINED);
     CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
 
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(A->template Data<T>()), A->SizeInBytes());
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(B->template Data<T>()), B->SizeInBytes());
-    CANN_PREPARE_INPUTBUFFER(prepare, nullptr, 0);
-    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(A->DataRaw()), A->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(B->DataRaw()), B->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
   }
   ORT_CATCH(const std::exception& e) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
   }
 
-  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("MatMul",
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("BatchMatMul",
                                               prepare.inputDesc_.size(),
                                               prepare.inputDesc_.data(),
                                               prepare.inputBuffers_.data(),
@@ -68,11 +57,11 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   return Status::OK();
 }
 
-#define REGISTER_MATMUL_TYPED_KERNEL(T, startver)                                          \
+#define REGISTER_MATMUL_TYPED_KERNEL(T, ver)                                               \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
       MatMul,                                                                              \
       kOnnxDomain,                                                                         \
-      startver,                                                                            \
+      ver,                                                                                 \
       T,                                                                                   \
       kCannExecutionProvider,                                                              \
       (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
@@ -98,6 +87,7 @@ REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(float, 9, 12)
 REGISTER_MATMUL_VERSIONED_TYPED_KERNEL(int32_t, 9, 12)
 
 REGISTER_MATMUL_TYPED_KERNEL(MLFloat16, 13)
+REGISTER_MATMUL_TYPED_KERNEL(BFloat16, 13)
 REGISTER_MATMUL_TYPED_KERNEL(float, 13)
 REGISTER_MATMUL_TYPED_KERNEL(int32_t, 13)
 

--- a/onnxruntime/core/providers/cann/math/matmul.h
+++ b/onnxruntime/core/providers/cann/math/matmul.h
@@ -13,21 +13,9 @@ template <typename T>
 class MatMul final : public CannKernel {
  public:
   MatMul(const OpKernelInfo& info)
-      : CannKernel(info),
-        alpha_{info.GetAttrOrDefault<float>("alpha", 1.0f)},
-        trans_A_{info.GetAttrOrDefault<int64_t>("transA", 0) != 0},
-        trans_B_{info.GetAttrOrDefault<int64_t>("transB", 0) != 0},
-        trans_batch_a_{info.GetAttrOrDefault<int64_t>("transBatchA", 0) != 0},
-        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0} {}
+      : CannKernel(info) {}
 
   Status ComputeInternal(OpKernelContext* context) const override;
-
- private:
-  const float alpha_;
-  const bool trans_A_;
-  const bool trans_B_;
-  const bool trans_batch_a_;
-  const bool trans_batch_b_;
 };
 
 }  // namespace cann

--- a/onnxruntime/core/providers/cann/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/cann/math/unary_elementwise_ops.cc
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/math/unary_elementwise_ops.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status UnaryElementwise::Prepare(OpKernelContext* ctx, CannPreparation& prepare) const {
+  const Tensor* X = ctx->Input<Tensor>(0);
+  Tensor* Y = ctx->Output(0, X->Shape());
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  if (op_name_ == "Log" || op_name_ == "Exp") {
+    CANN_RETURN_IF_ERROR(aclopSetAttrFloat(prepare.opAttr_, "base", -1.0f));
+    CANN_RETURN_IF_ERROR(aclopSetAttrFloat(prepare.opAttr_, "scale", 1.0f));
+    CANN_RETURN_IF_ERROR(aclopSetAttrFloat(prepare.opAttr_, "shift", 0.0f));
+  }
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  return Status::OK();
+}
+
+#define REGISTER_ELEMENTWISE_TYPED_COMPUTE(x, T)                               \
+  template <>                                                                  \
+  Status x<T>::ComputeInternal(OpKernelContext* context) const {               \
+    CannPreparation prepare;                                                   \
+    ORT_RETURN_IF_ERROR(Prepare<T>(context, prepare));                         \
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute(#x,                            \
+                                                prepare.inputDesc_.size(),     \
+                                                prepare.inputDesc_.data(),     \
+                                                prepare.inputBuffers_.data(),  \
+                                                prepare.outputDesc_.size(),    \
+                                                prepare.outputDesc_.data(),    \
+                                                prepare.outputBuffers_.data(), \
+                                                prepare.opAttr_,               \
+                                                ACL_ENGINE_SYS,                \
+                                                ACL_COMPILE_SYS,               \
+                                                NULL,                          \
+                                                Stream()));                    \
+    return Status::OK();                                                       \
+  }
+
+#define REGISTER_ELEMENTWISE_TYPED_KERNEL(x, ver, T)                                       \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      x<T>);
+
+#define REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(x, startver, endver, T)                \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                                 \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      startver,                                                                            \
+      endver,                                                                              \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      x<T>);
+
+#define REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, T) \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED_KERNEL(name, startver, endver, T)
+
+#define REGISTER_ELEMENTWISE_TYPED(name, ver, T)  \
+  REGISTER_ELEMENTWISE_TYPED_KERNEL(name, ver, T) \
+  REGISTER_ELEMENTWISE_TYPED_COMPUTE(name, T)
+
+// B: uint8_t
+// W: uint16_t
+// U: uint32_t
+// Z: uint64_t
+// C: int8_t
+// S: int16_t
+// I: int32_t
+// L: int64_t
+// H: float16
+// X: bfloat16
+// F: float
+// D: double
+// O: bool
+
+#define REGISTER_ELEMENTWISE_VERSIONED_H(name, startver, endver) \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, MLFloat16)
+
+#define REGISTER_ELEMENTWISE_VERSIONED_HF(name, startver, endver) \
+  REGISTER_ELEMENTWISE_VERSIONED_H(name, startver, endver)        \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, float)
+
+#define REGISTER_ELEMENTWISE_VERSIONED_IHF(name, startver, endver) \
+  REGISTER_ELEMENTWISE_VERSIONED_HF(name, startver, endver)        \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int32_t)
+
+#define REGISTER_ELEMENTWISE_VERSIONED_CIHF(name, startver, endver) \
+  REGISTER_ELEMENTWISE_VERSIONED_IHF(name, startver, endver)        \
+  REGISTER_ELEMENTWISE_VERSIONED_TYPED(name, startver, endver, int8_t)
+
+#define REGISTER_ELEMENTWISE_H(name, ver) \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, MLFloat16)
+
+#define REGISTER_ELEMENTWISE_HF(name, ver) \
+  REGISTER_ELEMENTWISE_H(name, ver)        \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, float)
+
+#define REGISTER_ELEMENTWISE_IHF(name, ver) \
+  REGISTER_ELEMENTWISE_HF(name, ver)        \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int32_t)
+
+#define REGISTER_ELEMENTWISE_CIHF(name, ver) \
+  REGISTER_ELEMENTWISE_IHF(name, ver)        \
+  REGISTER_ELEMENTWISE_TYPED(name, ver, int8_t)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Abs, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_IHF(Abs, 6, 12)
+REGISTER_ELEMENTWISE_IHF(Abs, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Neg, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_CIHF(Neg, 6, 12)
+REGISTER_ELEMENTWISE_CIHF(Neg, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Floor, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_HF(Floor, 6, 12)
+REGISTER_ELEMENTWISE_HF(Floor, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Ceil, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_HF(Ceil, 6, 12)
+REGISTER_ELEMENTWISE_HF(Ceil, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Reciprocal, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_HF(Reciprocal, 6, 12)
+REGISTER_ELEMENTWISE_HF(Reciprocal, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Sqrt, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_HF(Sqrt, 6, 12)
+REGISTER_ELEMENTWISE_HF(Sqrt, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Log, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_HF(Log, 6, 12)
+REGISTER_ELEMENTWISE_HF(Log, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_H(Exp, 1, 5)
+REGISTER_ELEMENTWISE_VERSIONED_H(Exp, 6, 12)
+REGISTER_ELEMENTWISE_H(Exp, 13)
+
+REGISTER_ELEMENTWISE_VERSIONED_HF(Erf, 9, 12)
+REGISTER_ELEMENTWISE_HF(Erf, 13)
+
+REGISTER_ELEMENTWISE_HF(Round, 11)
+
+REGISTER_ELEMENTWISE_HF(Sin, 7)
+
+REGISTER_ELEMENTWISE_HF(Cos, 7)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/math/unary_elementwise_ops.h
+++ b/onnxruntime/core/providers/cann/math/unary_elementwise_ops.h
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include "core/providers/cann/cann_kernel.h"
+
+namespace onnxruntime {
+namespace cann {
+
+class UnaryElementwise : public CannKernel {
+ protected:
+  explicit UnaryElementwise(const OpKernelInfo& info) : CannKernel(info) {
+    op_name_ = Info().GetKernelDef().OpName();
+  }
+  Status ComputeInternal(OpKernelContext*) const override {
+    return Status(common::ONNXRUNTIME, common::FAIL);  // should not reach here
+  }
+  template <typename T>
+  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
+
+ private:
+  std::string op_name_;
+};
+
+template <typename T>
+class Abs final : public UnaryElementwise {
+ public:
+  Abs(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Neg final : public UnaryElementwise {
+ public:
+  Neg(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Floor final : public UnaryElementwise {
+ public:
+  Floor(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Ceil final : public UnaryElementwise {
+ public:
+  Ceil(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Reciprocal final : public UnaryElementwise {
+ public:
+  Reciprocal(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Sqrt final : public UnaryElementwise {
+ public:
+  Sqrt(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Log final : public UnaryElementwise {
+ public:
+  Log(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Exp final : public UnaryElementwise {
+ public:
+  Exp(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Erf final : public UnaryElementwise {
+ public:
+  Erf(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Round final : public UnaryElementwise {
+ public:
+  Round(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Sin final : public UnaryElementwise {
+ public:
+  Sin(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+template <typename T>
+class Cos final : public UnaryElementwise {
+ public:
+  Cos(const OpKernelInfo& info) : UnaryElementwise(info) {}
+  Status ComputeInternal(OpKernelContext* context) const override;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/average_pool.cc
+++ b/onnxruntime/core/providers/cann/nn/average_pool.cc
@@ -2,67 +2,80 @@
 // Copyright (c) Huawei. All rights reserved.
 // Licensed under the MIT License.
 
+#include <unordered_map>
 #include "core/providers/shared_library/provider_api.h"
-#include "core/providers/cann/nn/pool.h"
+#include "core/providers/cann/nn/average_pool.h"
 
 using onnxruntime::common::Status;
 namespace onnxruntime {
 namespace cann {
 
 template <typename T>
-Status Pool<T>::ComputeInternal(OpKernelContext* context) const {
+Status AveragePool<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
-  const TensorShape& x_shape = X->Shape();
-  const auto x_dims = x_shape.GetDims();
+  const TensorShape& X_shape = X->Shape();
+  const auto X_dims = X_shape.GetDims();
 
-  if (x_shape.NumDimensions() < 3) {
+  if (X_shape.NumDimensions() < 3) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input dimension cannot be less than 3.");
   }
 
   auto kernel_shape = pool_attrs_.kernel_shape;
-  auto pads = pool_attrs_.pads;
   auto strides = pool_attrs_.strides;
+  auto pads = pool_attrs_.pads;
 
   if (pool_attrs_.global_pooling) {
-    kernel_shape.assign(x_dims.begin() + 2, x_dims.end());
-    pads.assign(kernel_shape.size(), 0);
+    kernel_shape.assign(X_dims.begin() + 2, X_dims.end());
     strides.assign(kernel_shape.size(), 1);
+    pads.assign(kernel_shape.size() * 2, 0);
   }
 
-  auto y_dims = pool_attrs_.SetOutputSize(x_shape, x_shape[1], &pads);
-  TensorShape y_shape(y_dims);
-  Tensor* Y = context->Output(0, y_shape);
-  if (y_shape.Size() == 0)
+  kernel_shape.insert(kernel_shape.begin(), {1, 1});
+  strides.insert(strides.begin(), {1, 1});
+
+  auto Y_dims = pool_attrs_.SetOutputSize(X_shape, X_shape[1], &pads);
+  TensorShape Y_shape(Y_dims);
+  Tensor* Y = context->Output(0, Y_shape);
+  if (Y_shape.Size() == 0)
     return Status::OK();
+
+  std::unordered_map<AutoPadType, const char*> padding_mode = {
+      {AutoPadType::NOTSET, "CALCULATED"},
+      {AutoPadType::SAME_UPPER, "SAME"},
+      {AutoPadType::SAME_LOWER, "SAME"},
+      {AutoPadType::VALID, "VALID"}};
 
   const aclDataType aclType = getACLType<T>();
   aclFormat format = ACL_FORMAT_ND;
 
   CannPreparation prepare;
 
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "ksize", kernel_shape.size(), kernel_shape.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "strides", strides.size(), strides.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "data_format", "NCHW"));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "pads", pads.size(), pads.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "ceil_mode", pool_attrs_.ceil_mode));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "exclusive", pool_attrs_.count_include_pad));
   if (!pool_attrs_.global_pooling) {
-    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "auto_pad", static_cast<int64_t>(pool_attrs_.auto_pad)));
-    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "kernel_shape", pool_attrs_.kernel_shape.size(),
-                                             pool_attrs_.kernel_shape.data()));
-    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "strides", pool_attrs_.strides.size(),
-                                             pool_attrs_.strides.data()));
-    CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "pads", pool_attrs_.pads.size(),
-                                             pool_attrs_.pads.data()));
-    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "ceil_mode", pool_attrs_.ceil_mode));
+    CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "padding_mode", padding_mode[pool_attrs_.auto_pad]));
+    CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "global_pooling", false));
+  } else {
+    CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "padding_mode", "VALID"));
+    CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "global_pooling", true));
   }
 
   ORT_TRY {
     CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
     CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
 
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
-    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
   }
   ORT_CATCH(const std::exception& e) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
   }
 
-  CANN_RETURN_IF_ERROR(aclopCompileAndExecute(op_name_.c_str(),
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("AvgPoolV2",
                                               prepare.inputDesc_.size(),
                                               prepare.inputDesc_.data(),
                                               prepare.inputBuffers_.data(),
@@ -78,15 +91,15 @@ Status Pool<T>::ComputeInternal(OpKernelContext* context) const {
   return Status::OK();
 }
 
-#define REGISTER_POOL_TYPED_KERNEL(x, T, startver)                                         \
+#define REGISTER_POOL_TYPED_KERNEL(x, T, ver)                                              \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
       x,                                                                                   \
       kOnnxDomain,                                                                         \
-      startver,                                                                            \
+      ver,                                                                                 \
       T,                                                                                   \
       kCannExecutionProvider,                                                              \
       (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
-      Pool<T>);
+      AveragePool<T>);
 
 #define REGISTER_POOL_VERSIONED_TYPED_KERNEL(x, T, startver, endver) \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                           \
@@ -98,24 +111,21 @@ Status Pool<T>::ComputeInternal(OpKernelContext* context) const {
       kCannExecutionProvider,                                        \
       (*KernelDefBuilder::Create())                                  \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
-      Pool<T>);
+      AveragePool<T>);
 
-REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 7, 9)
 REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, MLFloat16, 7, 9)
-REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 10, 10)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 7, 9)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, double, 7, 9)
 REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, MLFloat16, 10, 10)
-REGISTER_POOL_TYPED_KERNEL(AveragePool, float, 11)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, float, 10, 10)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(AveragePool, double, 10, 10)
 REGISTER_POOL_TYPED_KERNEL(AveragePool, MLFloat16, 11)
+REGISTER_POOL_TYPED_KERNEL(AveragePool, float, 11)
+REGISTER_POOL_TYPED_KERNEL(AveragePool, double, 11)
 
-REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, float, 1)
 REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, MLFloat16, 1)
-
-REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, float, 1, 7)
-REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, MLFloat16, 1, 7)
-
-REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, float, 1)
-REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, double, 1)
-REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, MLFloat16, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, float, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalAveragePool, double, 1)
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/average_pool.h
+++ b/onnxruntime/core/providers/cann/nn/average_pool.h
@@ -5,26 +5,17 @@
 #pragma once
 
 #include "core/providers/cann/cann_kernel.h"
+#include "core/providers/cpu/nn/pool_base.h"
 
 namespace onnxruntime {
 namespace cann {
 
 template <typename T>
-class BatchNorm final : public CannKernel {
+class AveragePool : public CannKernel, public PoolBase {
  public:
-  BatchNorm(const OpKernelInfo& info)
-      : CannKernel(info) {
-    epsilon_ = info.GetAttrOrDefault<float>("epsilon", 1e-5f);
-
-    is_training_mode_ = info.GetAttrOrDefault<int64_t>("training_mode", 0);
-    ORT_ENFORCE(!is_training_mode_, "only supports inference mode");
-  }
+  explicit AveragePool(const OpKernelInfo& info) : CannKernel(info), PoolBase(info) {}
 
   Status ComputeInternal(OpKernelContext* context) const override;
-
- private:
-  float epsilon_;
-  int64_t is_training_mode_;
 };
 
 }  // namespace cann

--- a/onnxruntime/core/providers/cann/nn/dropout.cc
+++ b/onnxruntime/core/providers/cann/nn/dropout.cc
@@ -9,126 +9,146 @@ namespace cann {
 
 namespace {
 
-template <typename T>
-struct GetRatioDataImpl {
-  void operator()(const Tensor* ratio, float& ratio_data) const {
-    ratio_data = static_cast<float>(*(ratio->Data<T>()));
-    ORT_ENFORCE(ratio_data >= 0.0f && ratio_data < 1.0f, "ratio_data is outside range [0, 1)");
+constexpr float default_ratio{0.5f};
+
+template <typename T2>
+float GetRatioOrDefault(const Tensor* ratio) {
+  if (ratio) {
+    ORT_ENFORCE(ratio->Shape().Size() == 1, "ratio input should have a single value.");
+    const float ratio_value = *ratio->Data<T2>();
+    ORT_ENFORCE(0.0f <= ratio_value && ratio_value < 1.0f, "ratio must be in the range [0, 1)");
+    return ratio_value;
   }
-};
 
-template <typename T>
-struct DropoutComputeImpl {
-  void operator()(const Tensor* X, Tensor* Y, float ratio_data, void* mask_data, aclrtStream stream) const {
-    const aclDataType aclType = getACLType<T>();
-    aclFormat format = ACL_FORMAT_ND;
-
-    TensorShape shape{1};
-    bool train_mode = true;
-
-    CannPreparation prepare;
-
-    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
-    CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
-    CANN_PREPARE_INPUTDESC(prepare, ACL_BOOL, shape.NumDimensions(), shape.GetDims().data(), format);
-    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
-    CANN_PREPARE_OUTPUTDESC(prepare, ACL_BOOL, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
-
-    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<T*>(X->template Data<T>()), X->SizeInBytes());
-    CANN_PREPARE_INPUTBUFFER(prepare, &ratio_data, sizeof(float));
-    CANN_PREPARE_INPUTBUFFER(prepare, &train_mode, sizeof(bool));
-    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->template MutableData<T>(), Y->SizeInBytes());
-    CANN_PREPARE_OUTPUTBUFFER(prepare, mask_data, X->Shape().Size());
-
-    CANN_CALL_THROW(aclopCompileAndExecute("Dropout",
-                                           prepare.inputDesc_.size(),
-                                           prepare.inputDesc_.data(),
-                                           prepare.inputBuffers_.data(),
-                                           prepare.outputDesc_.size(),
-                                           prepare.outputDesc_.data(),
-                                           prepare.outputBuffers_.data(),
-                                           prepare.opAttr_,
-                                           ACL_ENGINE_SYS,
-                                           ACL_COMPILE_SYS,
-                                           NULL,
-                                           stream));
-  }
-};
+  return default_ratio;
+}
 
 }  // namespace
 
-Status Dropout::ComputeInternal(OpKernelContext* context) const {
+template <typename T1, typename T2>
+Status Dropout<T1, T2>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* X = context->Input<Tensor>(0);
-  if (!X) return Status(common::ONNXRUNTIME, common::FAIL, "X Input is not available.");
-  const TensorShape& shape = X->Shape();
-  const int64_t N = shape.Size();
+  const TensorShape& X_shape = X->Shape();
 
-  auto Y = context->Output(0, shape);
-
-  Tensor* mask = context->Output(1, shape);
-  ORT_ENFORCE(!mask || mask->Shape().Size() == N);
-
-  float ratio_data = default_ratio_;
-  auto ratio = context->Input<Tensor>(1);
-  if (ratio) {
-    utils::MLTypeCallDispatcher<float, MLFloat16, double, BFloat16> t_disp(ratio->GetElementType());
-    t_disp.Invoke<GetRatioDataImpl>(ratio, ratio_data);
-  }
+  const Tensor* ratio = context->Input<Tensor>(1);
+  const float ratio_value = GetRatioOrDefault<T2>(ratio);
 
   const Tensor* training_mode = context->Input<Tensor>(2);
-  if (ratio_data == 0.f || !training_mode || !(*(training_mode->Data<bool>()))) {
+
+  auto Y = context->Output(0, X_shape);
+  auto mask = context->Output(1, X_shape);
+
+  if (ratio_value == 0.f || !training_mode || !(*(training_mode->Data<bool>()))) {
     const void* X_data = X->DataRaw();
     void* Y_data = Y->MutableDataRaw();
 
     if (Y_data != X_data) {
-      CANN_RETURN_IF_ERROR(aclrtMemcpyAsync(Y_data, Y->SizeInBytes(), X_data, X->SizeInBytes(),
+      CANN_RETURN_IF_ERROR(aclrtMemcpyAsync(Y_data, Y->SizeInBytes(), X_data, Y->SizeInBytes(),
                                             ACL_MEMCPY_DEVICE_TO_DEVICE, Stream()));
     }
 
     if (mask) {
       CANN_RETURN_IF_ERROR(aclrtMemsetAsync(mask->MutableData<bool>(), mask->SizeInBytes(), true,
-                                            N * sizeof(bool), Stream()));
+                                            mask->SizeInBytes(), Stream()));
+    }
+  } else {
+    IAllocatorUniquePtr<void> pmask{};
+    IAllocatorUniquePtr<void> pseed = GetScratchBuffer<void>(sizeof(float));
+
+    void* mask_data = nullptr;
+    if (mask) {
+      mask_data = mask->MutableDataRaw();
+    } else {
+      pmask = GetScratchBuffer<void>(X_shape.Size() * sizeof(bool));
+      mask_data = pmask.get();
     }
 
-    return Status::OK();
-  }
+    RandomGenerator& generator = generator_ != nullptr ? *generator_.get() : RandomGenerator::Default();
+    float seed = static_cast<float>(generator.NextSeed());
+    // TODO(FFFrog): use aclrtMemcpyAsyn to improve performance later.
+    CANN_RETURN_IF_ERROR(aclrtMemcpy(pseed.get(), sizeof(float), &seed, sizeof(float), ACL_MEMCPY_HOST_TO_DEVICE));
 
-  IAllocatorUniquePtr<void> temp_mask_buffer{};  // buffer to use if mask is not provided
-  void* const mask_data = [this, N, mask, &temp_mask_buffer]() {
-    if (mask) return mask->MutableDataRaw();
-    temp_mask_buffer =
-        GetScratchBuffer<void>(N * sizeof(bool));
-    return temp_mask_buffer.get();
-  }();
+    TensorShape shape{1};
 
-  ORT_TRY {
-    utils::MLTypeCallDispatcher<float, MLFloat16, double, BFloat16> t_disp(X->GetElementType());
-    t_disp.Invoke<DropoutComputeImpl>(X, Y, ratio_data, mask_data, Stream());
-  }
-  ORT_CATCH(const std::exception& e) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+    const aclDataType aclType = getACLType<T1>();
+    aclFormat format = ACL_FORMAT_ND;
+
+    CannPreparation prepare;
+
+    CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "p", static_cast<float>(ratio_value)));
+
+    ORT_TRY {
+      CANN_PREPARE_INPUTDESC(prepare, aclType, X_shape.NumDimensions(), X_shape.GetDims().data(), format);
+      CANN_PREPARE_INPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
+
+      CANN_PREPARE_OUTPUTDESC(prepare, aclType, X_shape.NumDimensions(), X_shape.GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_BOOL, X_shape.NumDimensions(), X_shape.GetDims().data(), format);
+      CANN_PREPARE_OUTPUTDESC(prepare, ACL_FLOAT, shape.NumDimensions(), shape.GetDims().data(), format);
+
+      CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+      CANN_PREPARE_INPUTBUFFER(prepare, pseed.get(), sizeof(float));
+
+      CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
+      CANN_PREPARE_OUTPUTBUFFER(prepare, mask_data, X_shape.Size() * sizeof(float));
+      CANN_PREPARE_OUTPUTBUFFER(prepare, pseed.get(), sizeof(float));
+    }
+    ORT_CATCH(const std::exception& e) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+    }
+
+    CANN_RETURN_IF_ERROR(aclopCompileAndExecute("DropoutV2",
+                                                prepare.inputDesc_.size(),
+                                                prepare.inputDesc_.data(),
+                                                prepare.inputBuffers_.data(),
+                                                prepare.outputDesc_.size(),
+                                                prepare.outputDesc_.data(),
+                                                prepare.outputBuffers_.data(),
+                                                prepare.opAttr_,
+                                                ACL_ENGINE_SYS,
+                                                ACL_COMPILE_SYS,
+                                                NULL,
+                                                Stream()));
   }
 
   return Status::OK();
 }
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(Dropout, kOnnxDomain, 12, 12, kCannExecutionProvider,
-                                  (*KernelDefBuilder::Create())
-                                      .TypeConstraint("T", DataTypeImpl::AllIEEEFloatTensorTypes())
-                                      .TypeConstraint("T1", DataTypeImpl::AllIEEEFloatTensorTypes())
-                                      .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>())
-                                      .InputMemoryType(OrtMemTypeCPUInput, 1)
-                                      .InputMemoryType(OrtMemTypeCPUInput, 2),
-                                  Dropout);
+#define REGISTER_DROPOUT_VERSIONED_TYPED_KERNEL(startver, endver, T1, T2) \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                                \
+      Dropout,                                                            \
+      kOnnxDomain,                                                        \
+      startver,                                                           \
+      endver,                                                             \
+      T1##_##T2,                                                          \
+      kCannExecutionProvider,                                             \
+      (*KernelDefBuilder::Create())                                       \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T1>())         \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T2>())        \
+          .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>())      \
+          .InputMemoryType(OrtMemTypeCPUInput, 1)                         \
+          .InputMemoryType(OrtMemTypeCPUInput, 2),                        \
+      Dropout<T1, T2>);
 
-ONNX_OPERATOR_KERNEL_EX(Dropout, kOnnxDomain, 13, kCannExecutionProvider,
-                        (*KernelDefBuilder::Create())
-                            .TypeConstraint("T", BuildKernelDefConstraints<MLFloat16, float, double, BFloat16>())
-                            .TypeConstraint("T1", BuildKernelDefConstraints<MLFloat16, float, double>())
-                            .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>())
-                            .InputMemoryType(OrtMemTypeCPUInput, 1)
-                            .InputMemoryType(OrtMemTypeCPUInput, 2),
-                        Dropout);
+#define REGISTER_DROPOUT_TYPED_KERNEL(ver, T1, T2)                   \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                     \
+      Dropout,                                                       \
+      kOnnxDomain,                                                   \
+      ver,                                                           \
+      T1##_##T2,                                                     \
+      kCannExecutionProvider,                                        \
+      (*KernelDefBuilder::Create())                                  \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T1>())    \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T2>())   \
+          .TypeConstraint("T2", DataTypeImpl::GetTensorType<bool>()) \
+          .InputMemoryType(OrtMemTypeCPUInput, 1)                    \
+          .InputMemoryType(OrtMemTypeCPUInput, 2),                   \
+      Dropout<T1, T2>);
+
+REGISTER_DROPOUT_VERSIONED_TYPED_KERNEL(12, 12, MLFloat16, MLFloat16)
+REGISTER_DROPOUT_VERSIONED_TYPED_KERNEL(12, 12, float, float)
+
+REGISTER_DROPOUT_TYPED_KERNEL(13, MLFloat16, MLFloat16)
+REGISTER_DROPOUT_TYPED_KERNEL(13, float, float)
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/dropout.h
+++ b/onnxruntime/core/providers/cann/nn/dropout.h
@@ -4,25 +4,27 @@
 
 #pragma once
 
+#include <memory>
 #include "core/providers/cann/cann_kernel.h"
+#include "core/framework/random_generator.h"
 
 namespace onnxruntime {
 namespace cann {
 
+template <typename T1, typename T2>
 class Dropout final : public CannKernel {
  public:
   Dropout(const OpKernelInfo& info) : CannKernel(info) {
     int64_t seed = 0;
     if (info.GetAttr<int64_t>("seed", &seed).IsOK()) {
-      seed_ = seed;
+      generator_ = std::make_unique<RandomGenerator>(seed);
     }
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
 
  private:
-  int64_t seed_;
-  static constexpr float default_ratio_ = 0.5f;
+  mutable std::unique_ptr<RandomGenerator> generator_;
 };
 
 }  // namespace cann

--- a/onnxruntime/core/providers/cann/nn/max_pool.cc
+++ b/onnxruntime/core/providers/cann/nn/max_pool.cc
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <unordered_map>
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cann/nn/max_pool.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status MaxPool<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* X = context->Input<Tensor>(0);
+  const TensorShape& X_shape = X->Shape();
+  const auto X_dims = X_shape.GetDims();
+
+  if (X_shape.NumDimensions() < 3) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input dimension cannot be less than 3.");
+  }
+
+  auto kernel_shape = pool_attrs_.kernel_shape;
+  auto strides = pool_attrs_.strides;
+  auto pads = pool_attrs_.pads;
+
+  if (pool_attrs_.global_pooling) {
+    kernel_shape.assign(X_dims.begin() + 2, X_dims.end());
+    strides.assign(kernel_shape.size(), 1);
+    pads.assign(kernel_shape.size() * 2, 0);
+  }
+
+  kernel_shape.insert(kernel_shape.begin(), {1, 1});
+  strides.insert(strides.begin(), {1, 1});
+
+  auto Y_dims = pool_attrs_.SetOutputSize(X_shape, X_shape[1], &pads);
+  TensorShape Y_shape(Y_dims);
+  Tensor* Y = context->Output(0, Y_shape);
+  if (Y_shape.Size() == 0)
+    return Status::OK();
+
+  std::unordered_map<AutoPadType, const char*> padding_mode = {
+      {AutoPadType::NOTSET, "CALCULATED"},
+      {AutoPadType::SAME_UPPER, "SAME"},
+      {AutoPadType::SAME_LOWER, "SAME"},
+      {AutoPadType::VALID, "VALID"}};
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "ksize", kernel_shape.size(), kernel_shape.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "strides", strides.size(), strides.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "data_format", "NCHW"));
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_, "pads", pads.size(), pads.data()));
+  CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "ceil_mode", pool_attrs_.ceil_mode));
+  if (!pool_attrs_.global_pooling) {
+    CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "padding_mode", padding_mode[pool_attrs_.auto_pad]));
+    CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "global_pooling", false));
+  } else {
+    CANN_RETURN_IF_ERROR(aclopSetAttrString(prepare.opAttr_, "padding_mode", "VALID"));
+    CANN_RETURN_IF_ERROR(aclopSetAttrBool(prepare.opAttr_, "global_pooling", true));
+  }
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("MaxPoolV3",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+#define REGISTER_POOL_TYPED_KERNEL(x, T, ver)                                              \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      x,                                                                                   \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      MaxPool<T>);
+
+#define REGISTER_POOL_VERSIONED_TYPED_KERNEL(x, T, startver, endver) \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                           \
+      x,                                                             \
+      kOnnxDomain,                                                   \
+      startver,                                                      \
+      endver,                                                        \
+      T,                                                             \
+      kCannExecutionProvider,                                        \
+      (*KernelDefBuilder::Create())                                  \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()),    \
+      MaxPool<T>);
+
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, MLFloat16, 1, 7)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, float, 1, 7)
+REGISTER_POOL_VERSIONED_TYPED_KERNEL(MaxPool, double, 1, 7)
+
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, MLFloat16, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, float, 1)
+REGISTER_POOL_TYPED_KERNEL(GlobalMaxPool, double, 1)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/nn/max_pool.h
+++ b/onnxruntime/core/providers/cann/nn/max_pool.h
@@ -11,9 +11,9 @@ namespace onnxruntime {
 namespace cann {
 
 template <typename T>
-class Pool : public CannKernel, public PoolBase {
+class MaxPool : public CannKernel, public PoolBase {
  public:
-  explicit Pool(const OpKernelInfo& info) : CannKernel(info), PoolBase(info) {}
+  explicit MaxPool(const OpKernelInfo& info) : CannKernel(info), PoolBase(info) {}
 
   Status ComputeInternal(OpKernelContext* context) const override;
 };

--- a/onnxruntime/core/providers/cann/tensor/cast.cc
+++ b/onnxruntime/core/providers/cann/tensor/cast.cc
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <vector>
+#include "core/providers/cann/tensor/cast.h"
+
+using onnxruntime::common::Status;
+namespace onnxruntime {
+namespace cann {
+
+aclDataType getACLTypeByMap(ONNX_NAMESPACE::TensorProto_DataType type) {
+  switch (type) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      return ACL_FLOAT16;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      return ACL_FLOAT;
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      return ACL_DOUBLE;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8:
+      return ACL_INT8;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16:
+      return ACL_INT16;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      return ACL_INT32;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      return ACL_INT64;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+      return ACL_UINT8;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT16:
+      return ACL_UINT16;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
+      return ACL_UINT32;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      return ACL_UINT64;
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+      return ACL_BOOL;
+
+    default:
+      return ACL_DT_UNDEFINED;
+  }
+}
+
+template <typename T>
+Status Cast<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* X = context->Input<Tensor>(0);
+
+  Tensor* Y = context->Output(0, X->Shape());
+
+  aclFormat format = ACL_FORMAT_ND;
+  const aclDataType aclTypeX = getACLType<T>();
+  const aclDataType aclTypeY = getACLTypeByMap(to_);
+  ORT_ENFORCE(aclTypeY != ACL_DT_UNDEFINED, "unsupported type");
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrInt(prepare.opAttr_, "dst_type", aclTypeY));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclTypeX, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclTypeY, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("Cast",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+const std::vector<MLDataType> castOpTypeConstraints = {
+    DataTypeImpl::GetTensorType<MLFloat16>(),
+    DataTypeImpl::GetTensorType<float>(),
+    DataTypeImpl::GetTensorType<double>(),
+    DataTypeImpl::GetTensorType<int8_t>(),
+    DataTypeImpl::GetTensorType<int16_t>(),
+    DataTypeImpl::GetTensorType<int32_t>(),
+    DataTypeImpl::GetTensorType<int64_t>(),
+    DataTypeImpl::GetTensorType<uint8_t>(),
+    DataTypeImpl::GetTensorType<uint16_t>(),
+    DataTypeImpl::GetTensorType<uint32_t>(),
+    DataTypeImpl::GetTensorType<uint64_t>(),
+    DataTypeImpl::GetTensorType<bool>()};
+
+#define REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, T) \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
+      Cast,                                                       \
+      kOnnxDomain,                                                \
+      startver,                                                   \
+      endver,                                                     \
+      T,                                                          \
+      kCannExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
+          .TypeConstraint("T2", castOpTypeConstraints),           \
+      Cast<T>);
+
+#define REGISTER_CAST_TYPED_KERNEL(ver, T)                        \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      Cast,                                                       \
+      kOnnxDomain,                                                \
+      ver,                                                        \
+      T,                                                          \
+      kCannExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>()) \
+          .TypeConstraint("T2", castOpTypeConstraints),           \
+      Cast<T>);
+
+// B: uint8_t
+// W: uint16_t
+// U: uint32_t
+// Z: uint64_t
+// C: int8_t
+// S: int16_t
+// I: int32_t
+// L: int64_t
+// H: float16
+// X: bfloat16
+// F: float
+// D: double
+// O: bool
+
+#define REGISTER_CAST_VERSIONED_BWUZCSILHFDO(startver, endver)      \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, uint8_t)   \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, uint16_t)  \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, uint32_t)  \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, uint64_t)  \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, int8_t)    \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, int16_t)   \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, int32_t)   \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, int64_t)   \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, MLFloat16) \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, float)     \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, double)    \
+  REGISTER_CAST_VERSIONED_TYPED_KERNEL(startver, endver, bool)
+
+#define REGISTER_CAST_BWUZCSILHFDO(ver)      \
+  REGISTER_CAST_TYPED_KERNEL(ver, uint8_t)   \
+  REGISTER_CAST_TYPED_KERNEL(ver, uint16_t)  \
+  REGISTER_CAST_TYPED_KERNEL(ver, uint32_t)  \
+  REGISTER_CAST_TYPED_KERNEL(ver, uint64_t)  \
+  REGISTER_CAST_TYPED_KERNEL(ver, int8_t)    \
+  REGISTER_CAST_TYPED_KERNEL(ver, int16_t)   \
+  REGISTER_CAST_TYPED_KERNEL(ver, int32_t)   \
+  REGISTER_CAST_TYPED_KERNEL(ver, int64_t)   \
+  REGISTER_CAST_TYPED_KERNEL(ver, MLFloat16) \
+  REGISTER_CAST_TYPED_KERNEL(ver, float)     \
+  REGISTER_CAST_TYPED_KERNEL(ver, double)    \
+  REGISTER_CAST_TYPED_KERNEL(ver, bool)
+
+REGISTER_CAST_VERSIONED_BWUZCSILHFDO(6, 8)
+REGISTER_CAST_VERSIONED_BWUZCSILHFDO(9, 12)
+REGISTER_CAST_BWUZCSILHFDO(13)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/cast.h
+++ b/onnxruntime/core/providers/cann/tensor/cast.h
@@ -4,27 +4,26 @@
 
 #pragma once
 
+#include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cann/cann_kernel.h"
 
 namespace onnxruntime {
 namespace cann {
 
 template <typename T>
-class BatchNorm final : public CannKernel {
+class Cast final : public CannKernel {
  public:
-  BatchNorm(const OpKernelInfo& info)
-      : CannKernel(info) {
-    epsilon_ = info.GetAttrOrDefault<float>("epsilon", 1e-5f);
-
-    is_training_mode_ = info.GetAttrOrDefault<int64_t>("training_mode", 0);
-    ORT_ENFORCE(!is_training_mode_, "only supports inference mode");
+  Cast(const OpKernelInfo& info) : CannKernel(info) {
+    int64_t to;
+    Status status = info.GetAttr("to", &to);
+    ORT_ENFORCE(status.IsOK(), "Attribute to is not set.");
+    to_ = gsl::narrow_cast<ONNX_NAMESPACE::TensorProto_DataType>(to);
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
 
  private:
-  float epsilon_;
-  int64_t is_training_mode_;
+  ONNX_NAMESPACE::TensorProto_DataType to_;
 };
 
 }  // namespace cann

--- a/onnxruntime/core/providers/cann/tensor/flatten.h
+++ b/onnxruntime/core/providers/cann/tensor/flatten.h
@@ -2,6 +2,8 @@
 // Copyright (c) Huawei. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 #include "core/providers/cann/cann_kernel.h"
 
 namespace onnxruntime {
@@ -15,7 +17,6 @@ class Flatten final : public CannKernel {
   }
 
   Status ComputeInternal(OpKernelContext* context) const override;
-  Status Prepare(OpKernelContext* ctx, CannPreparation& prepare) const;
 
  private:
   int64_t axis_;

--- a/onnxruntime/core/providers/cann/tensor/reshape.cc
+++ b/onnxruntime/core/providers/cann/tensor/reshape.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/tensor/reshape.h"
+
+namespace onnxruntime {
+namespace cann {
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Reshape,
+    kOnnxDomain,
+    1,
+    4,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .Alias(0, 0)
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes()),
+    Reshape_1);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Reshape,
+    kOnnxDomain,
+    5, 12,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+        .Alias(0, 0)
+        .InputMemoryType(OrtMemTypeCPUInput, 1),
+    Reshape);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    Reshape,
+    kOnnxDomain,
+    13, 13,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+        .Alias(0, 0)
+        .InputMemoryType(OrtMemTypeCPUInput, 1),
+    Reshape);
+
+ONNX_OPERATOR_KERNEL_EX(
+    Reshape,
+    kOnnxDomain,
+    14,
+    kCannExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+        .Alias(0, 0)
+        .InputMemoryType(OrtMemTypeCPUInput, 1),
+    Reshape);
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/reshape.h
+++ b/onnxruntime/core/providers/cann/tensor/reshape.h
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cpu/tensor/reshape_helper.h"
+#include "core/providers/cann/cann_kernel.h"
+#include "gsl/gsl"
+
+namespace onnxruntime {
+namespace cann {
+
+class Reshape final : public CannKernel {
+ public:
+  Reshape(const OpKernelInfo& info) : CannKernel(info) {
+    allow_zero_ = (info.GetAttrOrDefault("allowzero", static_cast<int64_t>(0)) == 1);
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override {
+    const Tensor* shapeTensor = context->Input<Tensor>(1);
+    if (shapeTensor == nullptr)
+      return Status(common::ONNXRUNTIME, common::FAIL, "the 0th input is missing");
+    if (shapeTensor->Shape().NumDimensions() != 1)
+      return Status(common::ONNXRUNTIME, common::FAIL, "A shape tensor must be a vector tensor");
+
+    auto data_span = shapeTensor->template DataAsSpan<int64_t>();
+    TensorShapeVector shape(data_span.begin(), data_span.end());
+
+    const Tensor* X = context->Input<Tensor>(0);
+    if (X == nullptr)
+      return Status(common::ONNXRUNTIME, common::FAIL, "the 1th input is missing");
+    const TensorShape& X_shape = X->Shape();
+
+    ReshapeHelper helper(X_shape, shape, allow_zero_);
+
+    Tensor* Y = context->Output(0, TensorShape(shape));
+    const void* source = X->DataRaw();
+    void* target = Y->MutableDataRaw();
+    if (target != source) {
+      ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
+    }
+
+    return Status::OK();
+  }
+
+ private:
+  bool allow_zero_;
+};
+
+class Reshape_1 final : public CannKernel {
+ public:
+  Reshape_1(const OpKernelInfo& info) : CannKernel(info) {
+    Status status = info.GetAttrs("shape", shape_);
+    ORT_ENFORCE(status.IsOK(), "Attribute shape is not set.");
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override {
+    TensorShapeVector shape = shape_;
+    const Tensor* X = context->Input<Tensor>(0);
+    const TensorShape& X_shape = X->Shape();
+
+    ReshapeHelper helper(X_shape, shape);
+
+    Tensor* Y = context->Output(0, TensorShape(shape));
+    const void* source = X->DataRaw();
+    void* target = Y->MutableDataRaw();
+    if (target != source) {
+      ORT_RETURN_IF_ERROR(CopyTensor(*X, *Y));
+    }
+
+    return Status::OK();
+  }
+
+ private:
+  TensorShapeVector shape_;
+};
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cann/tensor/transpose.cc
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cann/tensor/transpose.h"
+
+namespace onnxruntime {
+namespace cann {
+
+template <typename T>
+Status Transpose<T>::ComputeInternal(OpKernelContext* ctx) const {
+  const Tensor* X = ctx->Input<Tensor>(0);
+
+  int32_t rank = gsl::narrow_cast<int32_t>(X->Shape().NumDimensions());
+
+  TensorShapeVector Y_dims(rank);
+  InlinedVector<size_t> default_perm(rank);
+  const InlinedVector<size_t>* perm = nullptr;
+  const auto& status = ComputeOutputShape(*X, Y_dims, default_perm, perm);
+  if (!status.IsOK())
+    return status;
+
+  TensorShape output_shape{Y_dims};
+  Tensor* Y = ctx->Output(0, output_shape);
+
+  const aclDataType aclType = getACLType<T>();
+  aclFormat format = ACL_FORMAT_ND;
+
+  CannPreparation prepare;
+
+  CANN_RETURN_IF_ERROR(aclopSetAttrListInt(prepare.opAttr_,
+                                           "perm",
+                                           perm->size(),
+                                           reinterpret_cast<const int64_t*>(perm->data())));
+
+  ORT_TRY {
+    CANN_PREPARE_INPUTDESC(prepare, aclType, X->Shape().NumDimensions(), X->Shape().GetDims().data(), format);
+    CANN_PREPARE_OUTPUTDESC(prepare, aclType, Y->Shape().NumDimensions(), Y->Shape().GetDims().data(), format);
+
+    CANN_PREPARE_INPUTBUFFER(prepare, const_cast<void*>(X->DataRaw()), X->SizeInBytes());
+    CANN_PREPARE_OUTPUTBUFFER(prepare, Y->MutableDataRaw(), Y->SizeInBytes());
+  }
+  ORT_CATCH(const std::exception& e) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+  }
+
+  CANN_RETURN_IF_ERROR(aclopCompileAndExecute("TransposeD",
+                                              prepare.inputDesc_.size(),
+                                              prepare.inputDesc_.data(),
+                                              prepare.inputBuffers_.data(),
+                                              prepare.outputDesc_.size(),
+                                              prepare.outputDesc_.data(),
+                                              prepare.outputBuffers_.data(),
+                                              prepare.opAttr_,
+                                              ACL_ENGINE_SYS,
+                                              ACL_COMPILE_SYS,
+                                              NULL,
+                                              Stream()));
+
+  return Status::OK();
+}
+
+#define REGISTER_TRANSPOSE_TYPED_KERNEL(T, ver)                                            \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                           \
+      Transpose,                                                                           \
+      kOnnxDomain,                                                                         \
+      ver,                                                                                 \
+      T,                                                                                   \
+      kCannExecutionProvider,                                                              \
+      (*KernelDefBuilder::Create()).TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      Transpose<T>);
+
+REGISTER_TRANSPOSE_TYPED_KERNEL(uint8_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(uint16_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(uint32_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(uint64_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(int8_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(int16_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(int32_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(int64_t, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(MLFloat16, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(float, 1)
+REGISTER_TRANSPOSE_TYPED_KERNEL(bool, 1)
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/tensor/transpose.h
+++ b/onnxruntime/core/providers/cann/tensor/transpose.h
@@ -4,24 +4,21 @@
 
 #pragma once
 
+#include "core/providers/shared_library/provider_api.h"
+#include "core/providers/cpu/tensor/transpose.h"
 #include "core/providers/cann/cann_kernel.h"
-#include "core/providers/cpu/nn/conv_attributes.h"
+#include "gsl/gsl"
 
 namespace onnxruntime {
 namespace cann {
 
 template <typename T>
-class Conv final : public CannKernel {
+class Transpose final : public CannKernel, public TransposeBase {
  public:
-  Conv(const OpKernelInfo& info) : CannKernel(info), conv_attrs_(info) {
-    auto pads_size = conv_attrs_.pads.size();
-    ORT_ENFORCE(pads_size % 2 == 0);
+  Transpose(const OpKernelInfo& info) : CannKernel(info), TransposeBase(info) {
   }
 
   Status ComputeInternal(OpKernelContext* ctx) const override;
-
- private:
-  ConvAttributes conv_attrs_;
 };
 
 }  // namespace cann

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -670,4 +670,8 @@ void RefCountTracker::DumpDetails(const std::string& phase_name) const {
 
 #endif
 #endif
+
+#if defined(USE_CANN)
+RandomGenerator& RandomGenerator::Default() { return g_host->RandomGenerator__Default(); }
+#endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -30,6 +30,7 @@ struct ProviderHost;
 struct ProviderHostCPU;
 
 class PhiloxGenerator;
+class RandomGenerator;
 
 #ifdef ENABLE_TRAINING_TORCH_INTEROP
 namespace contrib {
@@ -870,6 +871,10 @@ struct ProviderHost {
   virtual language_interop_ops::torch::RefCountTracker& GetRefCountTrackerInstance() = 0;
   virtual void RefCountTracker__DumpDetails(const language_interop_ops::torch::RefCountTracker* p, const std::string& phase_name) = 0;
 #endif
+#endif
+
+#if defined(USE_CANN)
+  virtual RandomGenerator& RandomGenerator__Default() = 0;
 #endif
 
   virtual ProviderHostCPU& GetProviderHostCPU() = 0;

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1007,6 +1007,10 @@ struct ProviderHostImpl : ProviderHost {
 #endif
 #endif
 
+#if defined(USE_CANN)
+  RandomGenerator& RandomGenerator__Default() override { return RandomGenerator::Default(); }
+#endif
+
   ProviderHostCPU& GetProviderHostCPU() override { return onnxruntime::GetProviderHostCPU(); }
 } provider_host_;
 #if defined(_MSC_VER) && !defined(__clang__)


### PR DESCRIPTION
### Description
Adding new operators and  enhances operators, also.

### Motivation and Context
The operators of CANN EP is modified as follows:

The list of enhanced operators is as follows:

- Add
- Sub
- Mul
- Div
- Gemm
- MatMul
- AveragePool
- GlobalAveragePool
- MaxPool
- GlobalMaxPool
- Dropout

The new operators are as follows:

- Abs
- Neg
- Floor
- Ceil
- Reciprocal
- Sqrt
- Log
- Exp
- Erf
- Round
- Sin
- Cos
- Cast
- Reshape
- Transpose

The remaining operators will be supported in the next PRs.


