### PR TITLE
Replace deprecated Python dependency sklearn with scikit-learn.

### DIFF
--- a/orttraining/tools/amdgpu/Dockerfile.rocm4.3.1.pytorch
+++ b/orttraining/tools/amdgpu/Dockerfile.rocm4.3.1.pytorch
@@ -1,6 +1,6 @@
 # docker build --network=host --file Dockerfile.rocm4.3.1.pytorch --tag ort:rocm4.3.1-pytorch .
 
-FROM rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0  
+FROM rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.9.0
 
 RUN apt-get -y install gpg-agent
 RUN wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
@@ -137,7 +137,7 @@ RUN git clone -b wezhan/tnlrv4 --recursive https://github.com/microsoft/onnxrunt
 
 RUN pip3 install --no-cache-dir GPUtil azureml azureml-core datasets tokenizers ninja cerberus sympy sacremoses sacrebleu
 
-RUN pip install transformers==2.10.0 sklearn tensorboardX
+RUN pip install transformers==2.10.0 scikit-learn tensorboardX
 RUN pip install --pre torch-ort -f https://download.onnxruntime.ai/torch_ort_nightly.html
 RUN python -m torch_ort.configure
 

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
@@ -1,3 +1,3 @@
-sklearn
+scikit-learn
 transformers==v4.4.2
 wget

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/torch_eager_cpu/requirements.txt
@@ -4,7 +4,7 @@ torch==1.12.0
 setuptools>=41.4.0
 cerberus
 h5py
-sklearn
+scikit-learn
 numpy
 pandas
 parameterized

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-sklearn
+scikit-learn
 numpy==1.21.6
 transformers==v4.4.2
 tensorboard>=2.2.0,<2.5.0

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -1,7 +1,7 @@
 --pre
 -f https://download.pytorch.org/whl/torch_stable.html
-# transformers requires sklearn
-sklearn
+# transformers requires scikit-learn
+scikit-learn
 numpy==1.21.6
 transformers==v2.10.0
 torch==1.10.0+cu113

--- a/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
@@ -33,7 +33,6 @@ RUN pip install \
       sacremoses \
       scipy \
       scikit-learn \
-      sklearn \
       tokenizers \
       sentencepiece \
       dill==0.3.4 \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Replace deprecated Python dependency sklearn with scikit-learn.
"sklearn" is now deprecated and "scikit-learn" is the suggested replacement.
https://pypi.org/project/sklearn/

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix CI build failure.
