### PR TITLE
Change protobuf pin in training requirements

### DIFF
--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -4,6 +4,6 @@ h5py
 numpy >= 1.16.6
 onnx
 packaging
-protobuf >= 3.12.2, <= 3.20.1
+protobuf >= 3.20.0, <= 3.21.0
 sympy
 setuptools>=41.4.0


### PR DESCRIPTION
protobuf 3.18.3 is incompatible with onnx 1.12.0

This causes some pipelines to use old version of protobuf which is not compatible with onnx 1.12.0.

Forcing re-install of protobuf.