### PR TITLE
Add Missing Test File

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.cc
@@ -200,7 +200,7 @@ struct ProviderInfo_CUDA_Impl : ProviderInfo_CUDA {
 
     // TODO(wechi): brings disabled tests in onnxruntime/test/providers/cuda/*
     // back alive here.
-    return false;
+    return true;
   }
 #endif
 } g_info;

--- a/onnxruntime/test/providers/cuda/cuda_provider_test.cc
+++ b/onnxruntime/test/providers/cuda/cuda_provider_test.cc
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef NDEBUG
+#include "gtest/gtest.h"
+#include "core/common/status.h"
+#include "core/providers/cuda/cuda_provider_factory.h"
+#include <iostream>
+namespace onnxruntime {
+
+ProviderInfo_CUDA& GetProviderInfo_CUDA();
+
+namespace test {
+namespace cuda {
+TEST(CUDAEPTEST, ALL) {
+  onnxruntime::ProviderInfo_CUDA& ep = onnxruntime::GetProviderInfo_CUDA();
+  ep.TestAll();
+}
+
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/test/providers/cuda/cuda_provider_test.cc
+++ b/onnxruntime/test/providers/cuda/cuda_provider_test.cc
@@ -14,7 +14,7 @@ namespace test {
 namespace cuda {
 TEST(CUDAEPTEST, ALL) {
   onnxruntime::ProviderInfo_CUDA& ep = onnxruntime::GetProviderInfo_CUDA();
-  ep.TestAll();
+  ASSERT_TRUE(ep.TestAll());
 }
 
 }  // namespace test


### PR DESCRIPTION
I built a new test infra for CUDA EP in #13016 but forgot adding the test to onnxruntime_test_all. Here is the missing file. Now, the `TestAll` function is really called in CI.

