### PR TITLE
Enable parallel output reordering in MlasReorderOutputNchw()

### DIFF
--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -144,7 +144,7 @@ Status ReorderOutput::Compute(OpKernelContext* context) const {
   if (channels_last_) {
     MlasReorderOutputNhwc(Y_shape.data(), x_data, y_data);
   } else {
-    MlasReorderOutputNchw(Y_shape.data(), x_data, y_data);
+    MlasReorderOutputNchw(Y_shape.data(), x_data, y_data, context->GetOperatorThreadPool());
   }
 
   return Status::OK();

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1085,7 +1085,8 @@ MLASCALL
 MlasReorderOutputNchw(
     const int64_t* OutputShape,
     const float* S,
-    float* D
+    float* D,
+    MLAS_THREADPOOL* ThreadPool
     );
 
 void

--- a/onnxruntime/test/mlas/unittest/test_conv2d_nchwc.h
+++ b/onnxruntime/test/mlas/unittest/test_conv2d_nchwc.h
@@ -137,7 +137,7 @@ class MlasNchwcConv2DTest : public MlasConv2DTest<Threaded> {
     // Reorder the output buffer.
     //
 
-    MlasReorderOutputNchw(OutputShape, NchwcOutput, Output);
+    MlasReorderOutputNchw(OutputShape, NchwcOutput, Output, MlasConv2DTest<Threaded>::threadpool_);
   }
 
   const size_t BlockSize = MlasNchwcGetBlockSize();

--- a/onnxruntime/test/mlas/unittest/test_pool2d_nchwc.h
+++ b/onnxruntime/test/mlas/unittest/test_pool2d_nchwc.h
@@ -49,7 +49,7 @@ class MlasNchwcPool2DTest : public MlasPool2DTest<PoolingKind, Threaded> {
                   NchwcOutput,
                   nullptr);
 
-    MlasReorderOutputNchw(OutputShape, NchwcOutput, Output);
+    MlasReorderOutputNchw(OutputShape, NchwcOutput, Output, nullptr);
   }
 
   MatrixGuardBuffer<float> BufferNchwcInput;

--- a/onnxruntime/test/mlas/unittest/test_reorder_output.cpp
+++ b/onnxruntime/test/mlas/unittest/test_reorder_output.cpp
@@ -27,7 +27,7 @@ class MlasReorderOutputTest : public MlasTestBase {
     std::fill_n(Output, OutputBufferElements, -0.5f);
     std::fill_n(OutputReference, OutputBufferElements, -0.5f);
 
-    MlasReorderOutputNchw(NchwOutputShape, Input, Output);
+    MlasReorderOutputNchw(NchwOutputShape, Input, Output, GetMlasThreadPool());
     ReferenceReorderOutput(BatchCount, Channels, Height, Width, Input, OutputReference, false);
     ASSERT_EQ(memcmp(Output, OutputReference, OutputBufferElements * sizeof(float)), 0)
         << " [Nchw] batch=" << BatchCount << ", channels=" << Channels


### PR DESCRIPTION
### Description
This PR speeds-up the output reordering operation (as implemented in [MlasReorderOutputNchw](https://github.com/microsoft/onnxruntime/blob/9954454c65086c49b7c00f83b23ada76975f3546/onnxruntime/core/mlas/lib/reorder.cpp#L400)) by replacing the sequential implementation with a parallelized one. The parallelization is achieved through the use of the existing [TryBatchParallelFor](https://github.com/microsoft/onnxruntime/blob/9954454c65086c49b7c00f83b23ada76975f3546/include/onnxruntime/core/platform/threadpool.h#L284) construct.

### Motivation and Context
The output reordering operation is frequently executed in image processing models.
Its implementation can be easily parallelized and therefore sped up when executed on a multi-core machine. 
The amount of speedup achieved by this PR varies and depends on the actual input. 

The table below summarizes the results of some of the experiments I have conducted on a 16-core VM running on an AMD EPYC 7742 64-core processor. The experiment is based on the existing [unit test](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/test/mlas/unittest/test_reorder_output.cpp) for the output reordering operation.  The first column represents the shape of the output as BatchCount:Channels:Height:Width, and the numbers in other columns represent the latency (in us, on average out of 100 runs) for the tested variants. Specifically, I compare the (sequential) baseline (in second column) with the (parallelized) variants with a varying number of worker threads (as specified in [the constructor to the threadpool object](https://github.com/microsoft/onnxruntime/blob/9954454c65086c49b7c00f83b23ada76975f3546/onnxruntime/test/mlas/unittest/test_main.cpp#L12)). The numbers in () represent the speedup over the baseline.

|   Input             |      baseline    |             1          |                  2     |                        4|                             8  |                             16|
| ------------- | ------------- |---------------|---------------|---------------|---------------|---------------|
1:1:112:112 | 21.3 | 22.9 (x0.93) | 22.7 (x0.94) | 23.1 (x0.92) | 22.7 (x0.94) | 23.4 (x0.91) |
1:128:160:84 | 536.2 | 714.0 (x0.75) | 399.8 (x1.34) | 324.7 (x1.65) | 372.7 (x1.44) | 362.6 (x1.48) |
13:240:4:314 | 1525.1 | 1855.6 (x0.82) | 1089.8 (x1.40) | 577.6 (x2.64) | 538.0 (x2.83) | 535.2 (x2.85) |
13:96:4:314 | 480.5 | 678.7 (x0.71) | 417.5 (x1.15) | 376.4 (x1.28) | 405.3 (x1.19) | 458.7 (x1.05) |
1:64:320:168 | 1239.2 | 1504.8 (x0.82) | 877.4 (x1.41) | 454.0 (x2.73) | 451.0 (x2.75) | 436.3 (x2.84) |
30:240:4:140 | 1764.4 | 2194.3 (x0.80) | 1179.7 (x1.50) | 667.5 (x2.64) | 592.8 (x2.98) | 596.2 (x2.96) |
30:336:4:140 | 2490.0 | 3079.9 (x0.81) | 1672.1 (x1.49) | 940.0 (x2.65) | 841.4 (x2.96) | 798.0 (x3.12) |

The initial drop between the baseline and the variant using just one single thread can be attributed to the overhead of invoking the reordering loop as a functor in TryBatchParallelFor. That overhead is compensated by the speedup of parallel processing when the number of worker threads is increased.