### PR TITLE
[rn] Add uint8 typedArray support for react native android

### DIFF
--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -110,7 +110,7 @@ public class TensorHelperTest {
 
   @Test
   public void createInputTensor_uint8() throws Exception {
-    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, new byte[] {Byte.MIN_VALUE, 2, Byte.MAX_VALUE});
+    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, new byte[] {Byte.MAX_VALUE, 2, Byte.MAX_VALUE});
 
     JavaOnlyMap inputTensorMap = new JavaOnlyMap();
 
@@ -120,7 +120,7 @@ public class TensorHelperTest {
     inputTensorMap.putString("type", TensorHelper.JsTensorTypeUnsignedByte);
 
     ByteBuffer dataByteBuffer = ByteBuffer.allocate(3);
-    dataByteBuffer.put(Byte.MIN_VALUE);
+    dataByteBuffer.put(Byte.MAX_VALUE);
     dataByteBuffer.put((byte)2);
     dataByteBuffer.put(Byte.MAX_VALUE);
     String dataEncoded = Base64.encodeToString(dataByteBuffer.array(), Base64.DEFAULT);

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -110,9 +110,8 @@ public class TensorHelperTest {
 
   @Test
   public void createInputTensor_uint8() throws Exception {
-    OnnxTensor outputTensor =
-        OnnxTensor.createTensor(ortEnvironment, ByteBuffer.wrap(new byte[] {Byte.MAX_VALUE, 2, Byte.MAX_VALUE}),
-                                new long[] {3}, OnnxJavaType.UINT8);
+    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, ByteBuffer.wrap(new byte[] {0, 2, byte(255)}),
+                                                      new long[] {3}, OnnxJavaType.UINT8);
 
     JavaOnlyMap inputTensorMap = new JavaOnlyMap();
 
@@ -123,9 +122,9 @@ public class TensorHelperTest {
     inputTensorMap.putString("type", TensorHelper.JsTensorTypeUnsignedByte);
 
     ByteBuffer dataByteBuffer = ByteBuffer.allocate(3);
-    dataByteBuffer.put(Byte.MAX_VALUE);
+    dataByteBuffer.put((byte)0);
     dataByteBuffer.put((byte)2);
-    dataByteBuffer.put(Byte.MAX_VALUE);
+    dataByteBuffer.put((byte)255);
     String dataEncoded = Base64.encodeToString(dataByteBuffer.array(), Base64.DEFAULT);
     inputTensorMap.putString("data", dataEncoded);
 

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -117,7 +117,7 @@ public class TensorHelperTest {
     JavaOnlyArray dims = new JavaOnlyArray();
     dims.pushInt(3);
     inputTensorMap.putArray("dims", dims);
-    inputTensorMap.putString("type", TensorHelper.JsTensorTypeByte);
+    inputTensorMap.putString("type", TensorHelper.JsTensorTypeUnsignedByte);
 
     ByteBuffer dataByteBuffer = ByteBuffer.allocate(3);
     dataByteBuffer.put(Byte.MIN_VALUE);

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -110,13 +110,16 @@ public class TensorHelperTest {
 
   @Test
   public void createInputTensor_uint8() throws Exception {
-    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, new byte[] {Byte.MAX_VALUE, 2, Byte.MAX_VALUE});
+    OnnxTensor outputTensor =
+        OnnxTensor.createTensor(ortEnvironment, ByteBuffer.wrap(new byte[] {Byte.MAX_VALUE, 2, Byte.MAX_VALUE}),
+                                new long[] {3}, OnnxJavaType.UINT8);
 
     JavaOnlyMap inputTensorMap = new JavaOnlyMap();
 
     JavaOnlyArray dims = new JavaOnlyArray();
     dims.pushInt(3);
     inputTensorMap.putArray("dims", dims);
+
     inputTensorMap.putString("type", TensorHelper.JsTensorTypeUnsignedByte);
 
     ByteBuffer dataByteBuffer = ByteBuffer.allocate(3);

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -109,6 +109,35 @@ public class TensorHelperTest {
   }
 
   @Test
+  public void createInputTensor_uint8() throws Exception {
+    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, new byte[] {Byte.MIN_VALUE, 2, Byte.MAX_VALUE});
+
+    JavaOnlyMap inputTensorMap = new JavaOnlyMap();
+
+    JavaOnlyArray dims = new JavaOnlyArray();
+    dims.pushInt(3);
+    inputTensorMap.putArray("dims", dims);
+    inputTensorMap.putString("type", TensorHelper.JsTensorTypeByte);
+
+    ByteBuffer dataByteBuffer = ByteBuffer.allocate(3);
+    dataByteBuffer.put(Byte.MIN_VALUE);
+    dataByteBuffer.put((byte)2);
+    dataByteBuffer.put(Byte.MAX_VALUE);
+    String dataEncoded = Base64.encodeToString(dataByteBuffer.array(), Base64.DEFAULT);
+    inputTensorMap.putString("data", dataEncoded);
+
+    OnnxTensor inputTensor = TensorHelper.createInputTensor(inputTensorMap, ortEnvironment);
+
+    Assert.assertEquals(inputTensor.getInfo().onnxType, TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+    Assert.assertEquals(outputTensor.getInfo().onnxType, TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+    Assert.assertEquals(inputTensor.toString(), outputTensor.toString());
+    Assert.assertArrayEquals(inputTensor.getByteBuffer().array(), outputTensor.getByteBuffer().array());
+
+    inputTensor.close();
+    outputTensor.close();
+  }
+
+  @Test
   public void createInputTensor_int32() throws Exception {
     OnnxTensor outputTensor =
         OnnxTensor.createTensor(ortEnvironment, new int[] {Integer.MIN_VALUE, 2, Integer.MAX_VALUE});

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/TensorHelperTest.java
@@ -110,7 +110,7 @@ public class TensorHelperTest {
 
   @Test
   public void createInputTensor_uint8() throws Exception {
-    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, ByteBuffer.wrap(new byte[] {0, 2, byte(255)}),
+    OnnxTensor outputTensor = OnnxTensor.createTensor(ortEnvironment, ByteBuffer.wrap(new byte[] {0, 2, (byte)255}),
                                                       new long[] {3}, OnnxJavaType.UINT8);
 
     JavaOnlyMap inputTensorMap = new JavaOnlyMap();

--- a/js/react_native/lib/backend.ts
+++ b/js/react_native/lib/backend.ts
@@ -10,12 +10,14 @@ import {binding, Binding} from './binding';
 type SupportedTypedArray = Exclude<Tensor.DataType, string[]>;
 
 const tensorTypeToTypedArray = (type: Tensor.Type):|Float32ArrayConstructor|Int8ArrayConstructor|Int16ArrayConstructor|
-    Int32ArrayConstructor|BigInt64ArrayConstructor|Float64ArrayConstructor => {
+    Int32ArrayConstructor|BigInt64ArrayConstructor|Float64ArrayConstructor|Uint8ArrayConstructor => {
       switch (type) {
         case 'float32':
           return Float32Array;
         case 'int8':
           return Int8Array;
+        case 'uint8':
+          return Uint8Array;
         case 'int16':
           return Int16Array;
         case 'int32':


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Add missing uint8 typedArray case
- Add createInputTensor_uint8 unit test in TensorHelperTest.java file


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Detected inferencesession.run() call error when running react native app with uint8array input ort tensor. Add missing support to fix.

