### PR TITLE
Ensure graph resolve occurs after free dimension is overridden

### DIFF
--- a/onnxruntime/core/optimizer/free_dim_override_transformer.cc
+++ b/onnxruntime/core/optimizer/free_dim_override_transformer.cc
@@ -100,6 +100,8 @@ Status FreeDimensionOverrideTransformer::ApplyImpl(Graph& graph, bool& modified,
       auto* mutable_graph_input = graph.GetNodeArg(graph_input->Name());
       assert(mutable_graph_input != nullptr);
       mutable_graph_input->SetShape(new_shape);
+
+      graph.SetGraphResolveNeeded();
       modified = true;
     }
   }


### PR DESCRIPTION
### Description
This ensures that the graph is re-resolved after a free dimension shape is overridden according to session options.

### Motivation and Context
This ensures that shape inference occurs, which is necessary to apply the optimation and ensure it the session is compatible with bound shapes.   This bug seems to only have affected a small fraction of models.

