### PR TITLE
DML EP allow squeeze-13 axes to be empty

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -2040,7 +2040,10 @@ namespace OperatorHelper
     {
         if (opsetVersion >= 13) // Axes are a dynamic input parameter.
         {
-            ReadCpuLocalTensorIntoInt32(kernelInformation.GetConstantInputTensor(1), /*out*/ m_axes);
+            if (kernelInformation.IsInputValid(1))
+            {
+                ReadCpuLocalTensorIntoInt32(kernelInformation.GetConstantInputTensor(1), /*out*/ m_axes);
+            }
         }
         else // Axes were a constant attribute parameter.
         {


### PR DESCRIPTION
### Description
**Description**: [ONNX Squeeze-13](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Squeeze) treats empty `axes` as if all axes had been given. This works for [earlier Squeeze versions](https://github.com/microsoft/onnxruntime/pull/12649), but Squeeze-13 checks for axes as a dynamic input tensor, which means it needs to checked for existence before accessing.

### Motivation and Context
- *Why is this change required? What problem does it solve?* Fixes a customer model. Makes ORT DML EP consistent with spec.