### PR TITLE
Fix error in Document generation CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
@@ -267,8 +267,9 @@ jobs:
         condition: succeededOrFailed()
 
   - ${{ if eq(parameters.GenerateDocumentation, true) }}:
-    - script:
-      python -m pip install -q --upgrade protobuf
+    - script: python -m pip install -q --upgrade protobuf
+      displayName: Upgrade Protobuf
+
     - task: PythonScript@0
       displayName: 'Generate documentation'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
@@ -267,6 +267,8 @@ jobs:
         condition: succeededOrFailed()
 
   - ${{ if eq(parameters.GenerateDocumentation, true) }}:
+    - script:
+      python -m pip install -q --upgrade protobuf
     - task: PythonScript@0
       displayName: 'Generate documentation'
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
@@ -267,7 +267,9 @@ jobs:
         condition: succeededOrFailed()
 
   - ${{ if eq(parameters.GenerateDocumentation, true) }}:
-    - script: python -m pip install -q --upgrade protobuf
+    - script: |
+        python -m pip install --upgrade pip
+        python -m pip install -q --upgrade protobuf
       displayName: Upgrade Protobuf
 
     - task: PythonScript@0


### PR DESCRIPTION
### Description
Upgrade the protobuf to the latest version in Document Generation CI


### Motivation and Context
Recently, the lastest master build for generate documentation have come across this exception frequently.
`ImportError: cannot import name 'builder' from 'google.protobuf.internal' (C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\google\protobuf\internal\__init__.py)`

### Ref:
The reason is that the Python classes are simplified since Protobuf v3.20.0. Straight from the [release notes](https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0) it says:
`Protobuf python generated codes are simplified. Descriptors and message classes' definitions are now dynamic created in internal/builder.py. Insertion Points for messages classes are discarded.`
https://stackoverflow.com/questions/71759248/importerror-cannot-import-name-builder-from-google-protobuf-internal

