### PR TITLE
[CUDA] Optimize Slice Kernel

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
@@ -27,6 +27,8 @@ struct PrepareForComputeMetadata {
   TensorShapeVector ends_;
   TensorShapeVector steps_;
   TensorShapeVector output_dims_;
+  TensorShapeVector flattened_input_dims_;
+  TensorShapeVector* p_flattened_input_dims_ = &flattened_input_dims_;
   TensorShapeVector flattened_output_dims_;
   TensorShapeVector* p_flattened_output_dims_ = &flattened_output_dims_;
 };

--- a/onnxruntime/core/providers/cuda/tensor/slice.cc
+++ b/onnxruntime/core/providers/cuda/tensor/slice.cc
@@ -103,40 +103,24 @@ static Status SliceImpCore(cudaStream_t stream,
 
 namespace SliceCuda {
 
-static Status ComputeSliceStrides(const TensorShape& input_shape,
-                                  TArray<int64_t>& input_strides,
+static Status ComputeSliceStrides(const TensorShape& input_shape, TArray<int64_t>& input_strides,
                                   TArray<fast_divmod>& output_strides,
                                   SliceOp::PrepareForComputeMetadata& compute_metadata) {
+  // If we were able to coalesce the input and output shapes, use the new shapes to compute the strides.
   const auto input_dimensions = input_shape.GetDims();
-  size_t dimension_count = input_dimensions.size();
-  // if we are able to flatten the output dims we updated 'starts' and 'steps' to match the smaller number of dims.
-  // update dimension_count to match.
-  if (compute_metadata.p_flattened_output_dims_) {
-    dimension_count = compute_metadata.p_flattened_output_dims_->size();
-  }
-
-  input_strides.SetSize(gsl::narrow_cast<int32_t>(dimension_count));
+  size_t rank = compute_metadata.p_flattened_input_dims_ ? compute_metadata.p_flattened_input_dims_->size()
+                                                         : input_dimensions.size();
+  input_strides.SetSize(gsl::narrow_cast<int32_t>(rank));
   const gsl::span<int64_t> input_strides_span = gsl::make_span(input_strides.Data(), input_strides.Size());
-  if (compute_metadata.p_flattened_output_dims_ != nullptr) {
-    // we were able to flatten the innermost dimensions as they're being copied in full to the output.
-    // do the same flattening to the innermost input dimensions in order to calculate pitches that match
-    // the flattened output dimensions.
-    int64_t aggregated_last_dim = 1;
-    for (size_t i = dimension_count - 1, end = input_dimensions.size(); i < end; ++i) {
-      aggregated_last_dim *= input_dimensions[i];
-    }
-
-    TensorShapeVector flattened_input_dims(input_dimensions.begin(), input_dimensions.end());
-    flattened_input_dims.resize(dimension_count);
-    flattened_input_dims.back() = aggregated_last_dim;
-    ORT_ENFORCE(TensorPitches::Calculate(input_strides_span, flattened_input_dims));
+  if (compute_metadata.p_flattened_input_dims_) {
+    ORT_ENFORCE(TensorPitches::Calculate(input_strides_span, compute_metadata.flattened_input_dims_));
   } else {
     ORT_ENFORCE(TensorPitches::Calculate(input_strides_span, input_dimensions));
   }
 
-  const auto output_dims = gsl::make_span(compute_metadata.p_flattened_output_dims_ != nullptr
-                                              ? compute_metadata.flattened_output_dims_
-                                              : compute_metadata.output_dims_);
+  const auto output_dims =
+      gsl::make_span(compute_metadata.p_flattened_output_dims_ != nullptr ? compute_metadata.flattened_output_dims_
+                                                                          : compute_metadata.output_dims_);
   TensorPitches original_output_strides(output_dims);
   output_strides.SetSize(gsl::narrow_cast<int32_t>(original_output_strides.size()));
   for (int32_t i = 0, limit = static_cast<int32_t>(original_output_strides.size()); i < limit; ++i) {

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
@@ -8,95 +8,92 @@
 namespace onnxruntime {
 namespace cuda {
 
-template <bool is_grad, int DIMS, int NumThreadsPerBlock, int NumElementsPerThread, typename T>
-__global__ void _SliceKernel(const TArray<int64_t> starts,
-                             const TArray<int64_t> steps,
-                             const TArray<int64_t> input_strides,
-                             const TArray<fast_divmod> output_strides,
-                             const T* input_data,
-                             T* output_data,
-                             const CUDA_LONG N) {
-  CUDA_LONG start = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + threadIdx.x;
-  CUDA_LONG input_indices[NumElementsPerThread];
+namespace {
+#ifdef USE_ROCM
+constexpr int kNumElementsPerThread = 2;
+constexpr int kNumThreadsPerBlock = 512;
+#else
+constexpr int kNumElementsPerThread = GridDim::maxElementsPerThread;
+constexpr int kNumThreadsPerBlock = GridDim::maxThreadsPerBlock;
+#endif
+}  // namespace
 
-  CUDA_LONG id = start;
+template <bool is_grad, int DIMS, typename T>
+__global__ void _SliceKernel(const TArray<int64_t> starts, const TArray<int64_t> steps,
+                             const TArray<int64_t> input_strides, const TArray<fast_divmod> output_strides,
+                             const T* input_data, T* output_data, const CUDA_LONG N) {
+  CUDA_LONG start = kNumElementsPerThread * kNumThreadsPerBlock * blockIdx.x + threadIdx.x;
+  T values[kNumElementsPerThread];
+  CUDA_LONG id;
+  if (is_grad) {
+    id = start;
 #pragma unroll
-  for (int i = 0; i < NumElementsPerThread; i++) {
+    for (int i = 0; i < kNumElementsPerThread; ++i) {
+      if (id < N) {
+        values[i] = input_data[id];
+        id += kNumThreadsPerBlock;
+      }
+    }
+  }
+
+  id = start;
+#pragma unroll
+  for (int i = 0; i < kNumElementsPerThread; ++i) {
     if (id < N) {
       CUDA_LONG input_index = 0;
       int div;
       int mod = id;
-      int value = id;
       int dim = 0;
 #pragma unroll
       for (; dim < DIMS - 1; ++dim) {
-        output_strides[dim].divmod(value, div, mod);
+        output_strides[dim].divmod(mod, div, mod);
         input_index += (starts[dim] + div * steps[dim]) * input_strides[dim];
-        value = mod;
       }
       input_index += starts[dim] + mod * steps[dim];
-      input_indices[i] = input_index;
-      id += NumThreadsPerBlock;
+      if (is_grad) {
+        output_data[input_index] = values[i];
+      } else {
+        values[i] = input_data[input_index];
+      }
+      id += kNumThreadsPerBlock;
     }
   }
 
-  if (is_grad) {
+  if (!is_grad) {
     id = start;
 #pragma unroll
-    for (int i = 0; i < NumElementsPerThread; i++) {
+    for (int i = 0; i < kNumElementsPerThread; ++i) {
       if (id < N) {
-        output_data[input_indices[i]] = input_data[id];
-        id += NumThreadsPerBlock;
-      }
-    }
-  } else {
-    id = start;
-#pragma unroll
-    for (int i = 0; i < NumElementsPerThread; i++) {
-      if (id < N) {
-        output_data[id] = input_data[input_indices[i]];
-        id += NumThreadsPerBlock;
+        output_data[id] = values[i];
+        id += kNumThreadsPerBlock;
       }
     }
   }
 }
 
-Status SliceImpl(cudaStream_t stream,
-                 const size_t element_size,
-                 const int32_t dimension_count,
-                 const TArray<int64_t>& starts,
-                 const TArray<int64_t>& steps,
-                 const TArray<int64_t>& input_strides,
-                 const TArray<fast_divmod>& output_strides,
-                 const void* input_data,
-                 void* output_data,
-                 const size_t N) {
-  return SliceImplEx<false>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides, input_data,
-                            output_data, N);
+Status SliceImpl(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
+                 const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
+                 const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data, const size_t N) {
+  return SliceImplEx<false>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides,
+                            input_data, output_data, N);
 }
 
-Status SliceImplGrad(cudaStream_t stream,
-                     const size_t element_size,
-                     const int32_t dimension_count,
-                     const TArray<int64_t>& starts,
-                     const TArray<int64_t>& steps,
-                     const TArray<int64_t>& input_strides,
-                     const TArray<fast_divmod>& output_strides,
-                     const void* input_data,
-                     void* output_data,
+#ifdef ENABLE_TRAINING
+Status SliceImplGrad(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
+                     const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
+                     const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data,
                      const size_t N) {
-  return SliceImplEx<true>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides, input_data,
-                           output_data, N);
+  return SliceImplEx<true>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides,
+                           input_data, output_data, N);
 }
+#endif  // ENABLE_TRAINING
 
-#define HANDLE_DIMS(ELEMENT_TYPE, DIMS)                                                     \
-  case DIMS: {                                                                              \
-    _SliceKernel<is_grad, DIMS, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread> \
-        <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(                                \
-            starts, steps, input_strides, output_strides,                                   \
-            reinterpret_cast<const ToCudaType<ELEMENT_TYPE>::MappedType*>(input_data),      \
-            reinterpret_cast<ToCudaType<ELEMENT_TYPE>::MappedType*>(output_data),           \
-            (CUDA_LONG)N);                                                                  \
+#define HANDLE_DIMS(ELEMENT_TYPE, DIMS)                                                           \
+  case DIMS: {                                                                                    \
+    _SliceKernel<is_grad, DIMS, ELEMENT_TYPE><<<blocksPerGrid, kNumThreadsPerBlock, 0, stream>>>( \
+        starts, steps, input_strides, output_strides,                                             \
+        reinterpret_cast<const ToCudaType<ELEMENT_TYPE>::MappedType*>(input_data),                \
+        reinterpret_cast<ToCudaType<ELEMENT_TYPE>::MappedType*>(output_data), (CUDA_LONG)N);      \
   } break
 
 #define HANDLE_ELEMENT_TYPE(ELEMENT_TYPE) \
@@ -114,17 +111,11 @@ Status SliceImplGrad(cudaStream_t stream,
   } break
 
 template <bool is_grad>
-Status SliceImplEx(cudaStream_t stream,
-                   const size_t element_size,
-                   const int32_t dimension_count,
-                   const TArray<int64_t>& starts,
-                   const TArray<int64_t>& steps,
-                   const TArray<int64_t>& input_strides,
-                   const TArray<fast_divmod>& output_strides,
-                   const void* input_data,
-                   void* output_data,
+Status SliceImplEx(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
+                   const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
+                   const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data,
                    const size_t N) {
-  int blocksPerGrid = static_cast<int>(CeilDiv(N, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  int blocksPerGrid = static_cast<int>(CeilDiv(N, kNumThreadsPerBlock * kNumElementsPerThread));
   switch (element_size) {
     HANDLE_ELEMENT_TYPE(int8_t);
     HANDLE_ELEMENT_TYPE(int16_t);

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.h
@@ -8,18 +8,6 @@
 namespace onnxruntime {
 namespace cuda {
 
-template <bool is_grad>
-Status SliceImplEx(cudaStream_t stream,
-                   const size_t element_size,
-                   const int32_t dimension_count,
-                   const TArray<int64_t>& starts,
-                   const TArray<int64_t>& steps,
-                   const TArray<int64_t>& input_strides,
-                   const TArray<fast_divmod>& output_strides,
-                   const void* input_data,
-                   void* output_data,
-                   const size_t N);
-
 Status SliceImpl(cudaStream_t stream,
                  const size_t element_size,
                  const int32_t dimension_count,

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.h
@@ -31,6 +31,7 @@ Status SliceImpl(cudaStream_t stream,
                  void* output_data,
                  const size_t N);
 
+#ifdef ENABLE_TRAINING
 Status SliceImplGrad(cudaStream_t stream,
                      const size_t element_size,
                      const int32_t dimension_count,
@@ -41,5 +42,7 @@ Status SliceImplGrad(cudaStream_t stream,
                      const void* input_data,
                      void* output_data,
                      const size_t N);
+#endif  // ENABLE_TRAINING
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -731,5 +731,21 @@ TEST(SliceTest, EmptyDim) {
                       {0, 6},
                       {});
 }
+
+TEST(SliceTest, CoalesceDims) {
+  RunSliceTest<float>({2, 2, 2, 2},
+                      {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, -1.f, -2.f, -3.f, -4.f, -5.f, -6.f, -7.f, -8.f}, {1, 1},
+                      {0, 2}, {0, 1}, {-1, 1}, {1, 1, 2, 2}, {-5.f, -6.f, -7.f, -8.f}, true);
+  RunSliceTest<float>({1, 2, 2, 2, 2},
+                      {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, -1.f, -2.f, -3.f, -4.f, -5.f, -6.f, -7.f, -8.f}, {1},
+                      {std::numeric_limits<int64_t>::max()}, {2}, {}, {1, 2, 1, 2, 2},
+                      {5.f, 6.f, 7.f, 8.f, -5.f, -6.f, -7.f, -8.f}, true);
+  RunSliceTest<float>({1, 2, 2, 2, 2},
+                      {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, -1.f, -2.f, -3.f, -4.f, -5.f, -6.f, -7.f, -8.f}, {1, 1},
+                      {std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()}, {1, 3}, {},
+                      {1, 1, 2, 1, 2}, {-3.f, -4.f, -7.f, -8.f}, true);
+  RunSliceTest<float>({1, 1, 1}, {1.f}, {0}, {std::numeric_limits<int64_t>::max()}, {1}, {}, {1, 1, 1}, {1.f}, true);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/orttraining/orttraining/test/training_ops/cpu/tensor/slice_grad_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/slice_grad_op_test.cc
@@ -56,5 +56,55 @@ TEST(SliceGradOpTest, SliceGrad_blockcopy_double) {
   test.Run();
 }
 
+TEST(SliceGradOpTest, CoalesceDims) {
+  {
+    OpTester test("SliceGrad", 1, onnxruntime::kMSDomain);
+    test.AddInput<float>("grad", {1, 1, 2, 2}, {1, 2, 3, 4});
+    test.AddInput<int64_t>("shape", {4}, {2, 2, 2, 2});
+    test.AddInput<int64_t>("starts", {2}, {1LL, 1LL});
+    test.AddInput<int64_t>("ends", {2}, {0LL, 2LL});
+    test.AddInput<int64_t>("axes", {2}, {0LL, 1LL});
+    test.AddInput<int64_t>("steps", {2}, {-1LL, 1LL});
+    test.AddOutput<float>("output", {2, 2, 2, 2}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4});
+    test.Run();
+  }
+
+  {
+    OpTester test("SliceGrad", 1, onnxruntime::kMSDomain);
+    test.AddInput<float>("grad", {1, 2, 1, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
+    test.AddInput<int64_t>("shape", {5}, {1, 2, 2, 2, 2});
+    test.AddInput<int64_t>("starts", {1}, {1LL});
+    test.AddInput<int64_t>("ends", {1}, {std::numeric_limits<int64_t>::max()});
+    test.AddInput<int64_t>("axes", {1}, {2LL});
+    test.AddInput<int64_t>("steps", {1}, {1LL});
+    test.AddOutput<float>("output", {1, 2, 2, 2, 2}, {0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8});
+    test.Run();
+  }
+
+  {
+    OpTester test("SliceGrad", 1, onnxruntime::kMSDomain);
+    test.AddInput<float>("grad", {1, 1, 2, 1, 2}, {1, 2, 3, 4});
+    test.AddInput<int64_t>("shape", {5}, {1, 2, 2, 2, 2});
+    test.AddInput<int64_t>("starts", {2}, {1LL, 1LL});
+    test.AddInput<int64_t>("ends", {2}, {std::numeric_limits<int64_t>::max(), 2});
+    test.AddInput<int64_t>("axes", {2}, {1LL, 3LL});
+    test.AddInput<int64_t>("steps", {2}, {1LL, 1LL});
+    test.AddOutput<float>("output", {1, 2, 2, 2, 2}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4});
+    test.Run();
+  }
+
+  {
+    OpTester test("SliceGrad", 1, onnxruntime::kMSDomain);
+    test.AddInput<float>("grad", {1, 1, 1}, {1});
+    test.AddInput<int64_t>("shape", {3}, {1, 1, 1});
+    test.AddInput<int64_t>("starts", {1}, {0LL});
+    test.AddInput<int64_t>("ends", {1}, {std::numeric_limits<int64_t>::max()});
+    test.AddInput<int64_t>("axes", {1}, {1LL});
+    test.AddInput<int64_t>("steps", {1}, {1LL});
+    test.AddOutput<float>("output", {1, 1, 1}, {1});
+    test.Run();
+  }
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.h
+++ b/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.h
@@ -22,7 +22,8 @@ class SliceGrad final : public OpKernel, public SliceBase {
   Status ComputeImpl(OpKernelContext* ctx,
                      Tensor& output_grad_tensor,
                      const gsl::span<const int64_t>& output_dims,
-                     TensorShapeVector* flattened_output_dims,
+                     TensorShapeVector* p_flattened_input_dims,
+                     TensorShapeVector* p_flattened_output_dims,
                      const gsl::span<const int64_t>& starts,
                      const gsl::span<const int64_t>& steps) const;
 };


### PR DESCRIPTION
The PR optimizes Slice CUDA kernel by two ways:
- Coalesce dimensions so less divmod during the kernel compute
- Split data load and write for better memory throughput

Below shows some perf results (cycles number from Nsight Compute) in V100 using real cases from Huggingface's XLNet model:

  | Old | New
-- | -- | --
[8,12,2048,1024], axis=2, start=1, end=2048 | 1838687| 1539846
[8,12,1024,2047], axis=3, start=0, end=1024 | 951383| 722203
