### PR TITLE
[oneDNN] Implemented Concat Op

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -1096,69 +1096,77 @@ bool DnnlConcatNodeCapability::AreAllInputsOfSameType(const Node* node) const {
   // All inputs must be of the same type
   const auto node_inputs = node->InputDefs();
   if (!node_inputs.empty() && node_inputs[0]->TypeAsProto() != nullptr) {
-    const auto node_datatype = node_inputs[0]->TypeAsProto()->tensor_type().elem_type();
-    // Ensure that any other inputs have the same datatype as the first
+    const auto ref_datatype = node_inputs[0]->TypeAsProto()->tensor_type().elem_type();
+    // Ensure that other inputs have the same datatype as the first
     for (size_t i=1; i<node_inputs.size(); ++i) {
-      if (node_inputs[i]->TypeAsProto() != nullptr && 
-          node_inputs[i]->TypeAsProto()->tensor_type().elem_type() != node_datatype) {
+      if (node_inputs[i]->TypeAsProto() != nullptr &&
+          node_inputs[i]->TypeAsProto()->tensor_type().elem_type() != ref_datatype) {
         return false;
       }
     }
   }
   return true;
-}  
+}
 
 bool DnnlConcatNodeCapability::AreAxisAndDimensionsSupported(const Node* node) const {
-  const auto& attributes = node->GetAttributes();
+  auto& attributes = node->GetAttributes();
   auto axis_attr = attributes.find("axis");
   if (axis_attr != attributes.end()) {
     if (axis_attr->second().type() != ::ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT) {
       // Axis must be an integer
-      return false;
+        return false;
     }
-  } else {
-    // Axis is required.
+  }
+  else {
+    // Axis is required
     return false;
-  }    
+  }
 
+  int64_t signed_axis = axis_attr->second().i();
+
+  // Veriy input dimensions
   const auto& node_inputs = node->InputDefs();
+  auto ref_input_it = std::find_if(node_inputs.begin(), node_inputs.end(), 
+                      [](const auto input) {
+                        return input->Shape() != nullptr;
+                      });
+  if (ref_input_it != node_inputs.end()) {
+    const auto ref_input = *ref_input_it;
+    const auto ref_input_shape = ref_input->Shape();
+    const auto ref_input_rank = ref_input_shape->dim_size();
 
-  // Validate axis
-  int64_t signed_axis = axis_attr->second().i();  
-  const auto first_input_shape = node_inputs[0]->Shape();
-  if (first_input_shape != nullptr) {
-    const auto first_input_rank = first_input_shape->dim_size();      
-    // Axis must be b/w [-first_input_rank, first_input_rank-1]
-    if (signed_axis < 0 && signed_axis < -first_input_rank) {
-      return false;
-    }
-    if (signed_axis >= 0 && signed_axis >= first_input_rank) {
-      return false;
-    }
-
-    // Verify that dimensions of all other inputs match except on the axis.
-    const auto actual_axis = (signed_axis >= 0) ? signed_axis : signed_axis + first_input_rank;    
-    for (size_t i=1; i<node_inputs.size(); ++i) {
-      const auto& other_input_shape = node_inputs[i]->Shape();
-      if (other_input_shape == nullptr) {
-        // Unknown shape for other input
+    // DNNL only supports tensors of 6 or fewer dimensions on GPU  
+    if (dnnl_engine_get_count(dnnl_engine_kind_t::dnnl_gpu)) {
+      if(ref_input_rank > 6 ){
         return false;
       }
-      if (other_input_shape->dim_size() != first_input_rank) {
-        // Rank doesn't match first input.
+    }  
+
+    // Verify that input tensors match shapes except on the axis dimension.
+    const auto adjusted_axis = (signed_axis >= 0) ? signed_axis : signed_axis + ref_input_rank;
+    for (auto input : node_inputs) {
+      if (input == ref_input) {
+        continue;
+      }
+      
+      const auto input_shape = input->Shape();
+      if (input_shape == nullptr) {
+        continue;
+      }
+      if (input_shape->dim_size() != ref_input_rank) {
+        // Rank doesn't match reference input.
         return false;
       }
-      for (int d=0; d<first_input_rank; ++d) {
-        // The axis dim is not expected to match.
-        if (d == actual_axis) {
+      for (int d=0; d<ref_input_rank; ++d) {
+        if (d == adjusted_axis) {
           continue;
         }
-        const auto& first_input_dim = first_input_shape->dim(d);
-        const auto& other_input_dim = other_input_shape->dim(d);
-        if (first_input_dim.has_dim_value() && other_input_dim.has_dim_value()) {
-          if (first_input_dim.dim_value() != other_input_dim.dim_value()) {
+        const auto& ref_input_dim = ref_input_shape->dim(d);
+        const auto& input_dim = input_shape->dim(d);
+        if (ref_input_dim.has_dim_value() && input_dim.has_dim_value()) {
+          if (ref_input_dim.dim_value() != input_dim.dim_value()) {
             return false;
-          }        
+          }
         }
       }
     }

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -130,7 +130,7 @@ class DnnlDefaultMultiInputNodeCapability : public DnnlNodeCapability {
  * In general node_data consist of a tuple that has:
  * (INPUT_POS, <IsThisInputMandatory?(true or false)>, {list, of, supported, types})
  *
- * We always asume that the input 0 of the map corresponds to the node input with index 0,
+ * We always assume that the input 0 of the map corresponds to the node input with index 0,
  * so if a node has M mandatory inputs and O optional, the map should contain the first
  * N inputs followed by the other M optional.
  *

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -128,7 +128,7 @@ class DnnlDefaultMultiInputNodeCapability : public DnnlNodeCapability {
  * DnnlDefaultOptionalMultiInputNodeCapability(rules)
  *
  * In general node_data consist of a tuple that has:
- * (INPUT_POS, <IsThisInputMandatory?(true or false)>, {list, of, suppurted, types})
+ * (INPUT_POS, <IsThisInputMandatory?(true or false)>, {list, of, supported, types})
  *
  * We always asume that the input 0 of the map corresponds to the node input with index 0,
  * so if a node has M mandatory inputs and O optional, the map should contain the first
@@ -454,5 +454,20 @@ class DnnlSkipLayerNormalizationNodeCapability : public DnnlLayerNormalizationNo
                                                                                     type_float16}) {}
 };
 
+class DnnlConcatNodeCapability : public DnnlDefaultNodeCapability {
+ public:
+  DnnlConcatNodeCapability() : DnnlDefaultNodeCapability({type_float32,
+                                                           type_float16,
+                                                           type_bfloat16,
+                                                           type_int32,
+                                                           type_int8,
+                                                           type_uint8}) {}
+
+  bool Supported(const Node* node, const GraphViewer& graph_viewer) const override;
+
+ private:
+  bool AreAllInputsOfSameType(const Node* node) const;
+  bool AreAxisAndDimensionsSupported(const Node* node) const;
+};
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.h
@@ -97,7 +97,7 @@ class DnnlDefaultNodeCapability : public DnnlNodeCapability {
 * DnnlDefaultMultiInputNodeCapability({T1, T2});
 *
 * The number of inputs and the number of unordered_sets must match. For this reason
-* this capability class is not sutable for nodes that may have a varible number of
+* this capability class is not suitable for nodes that may have a variable number of
 * inputs.
 *
 * All types for all inputs must be specified.
@@ -239,7 +239,7 @@ class DnnlMatMulIntegerNodeCapability : public DnnlDefaultNodeCapability {
 };
 
 /**
- * Decide if aSum op is supported by DnnlExecutionProvider
+ * Decide if a Sum op is supported by DnnlExecutionProvider
  * OneDNN does not support Numpy-style broadcasting for 'Sum'
  */
 class DnnlSumNodeCapability : public DnnlDefaultNodeCapability {

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -12,7 +12,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("BatchNormalization", std::unique_ptr<DnnlNodeCapability>(new DnnlBatchNormalizationNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("BiasGelu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Cast", std::unique_ptr<DnnlNodeCapability>(new DnnlCastNodeCapability())));
-  dnnl_ops_map_.emplace(std::make_pair("Concat", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Concat", std::unique_ptr<DnnlNodeCapability>(new DnnlConcatNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Conv", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("DequantizeLinear", std::unique_ptr<DnnlNodeCapability>(new DnnlDequantizeLinearNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Div", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_op_manager.cc
@@ -12,6 +12,7 @@ DnnlOpManager::DnnlOpManager() {
   dnnl_ops_map_.emplace(std::make_pair("BatchNormalization", std::unique_ptr<DnnlNodeCapability>(new DnnlBatchNormalizationNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("BiasGelu", std::unique_ptr<DnnlNodeCapability>(new DnnlElementwiseCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Cast", std::unique_ptr<DnnlNodeCapability>(new DnnlCastNodeCapability())));
+  dnnl_ops_map_.emplace(std::make_pair("Concat", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Conv", std::unique_ptr<DnnlNodeCapability>(new DnnlDefaultNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("DequantizeLinear", std::unique_ptr<DnnlNodeCapability>(new DnnlDequantizeLinearNodeCapability())));
   dnnl_ops_map_.emplace(std::make_pair("Div", std::unique_ptr<DnnlNodeCapability>(new DnnlBinaryNodeCapability())));

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
@@ -31,7 +31,7 @@ void DnnlConcat::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   auto axis = GetAxis(node, input_rank != -1 ? input_rank : 0);
 
   // Create primitive descriptor
-  auto concat_pd = dnnl::concat::primitive_desc(axis, src_mds, dnnl_engine);
+  auto concat_pd = dnnl::concat::primitive_desc(static_cast<int>(axis), src_mds, dnnl_engine);
 
   // Create primitive memory objects
   std::vector<dnnl::memory> concat_src_mems;

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
@@ -58,7 +58,6 @@ int64_t DnnlConcat::GetAxis(DnnlNode& node, int64_t input_rank) {
   ORT_ENFORCE(axis_attr->second().type() == ::ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT,
     "Axis value is not an integer");
 
-  // We need to do sign comparisons so we have to cast
   int64_t signed_axis = axis_attr->second().i();  
   ORT_ENFORCE(((signed_axis < 0) && (signed_axis >= -input_rank)) || ((signed_axis >= 0) && (signed_axis <= (input_rank - 1))),
     "Axis value ", signed_axis, "is not between input rank ", -input_rank, " and ", input_rank - 1);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
@@ -1,0 +1,72 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#include "dnnl_concat.h"
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+DnnlConcat::DnnlConcat() {}
+
+void DnnlConcat::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
+  auto dnnl_engine = sp.GetEngine();
+
+  int64_t input_rank = -1;
+  std::vector<dnnl::memory::desc> src_mds;
+  for (size_t i = IN_DATA_0; i < node.InputCount(); ++i) {
+    const auto& input_tensor = node.Input(static_cast<int>(IN_DATA_0 + i));
+    if (input_rank == -1) {
+      // Tensor rank is assumed to be the same for all inputs          
+      input_rank = static_cast<int64_t>(input_tensor.Dim().size());
+    }
+    auto src_mem = sp.GetMemory(input_tensor);
+    src_mds.push_back(src_mem.get_desc());
+  }
+
+  auto axis = GetAxis(node, input_rank);
+
+  // Create primitive descriptor
+  auto concat_pd = dnnl::concat::primitive_desc(axis, src_mds, dnnl_engine);
+
+  // Create primitive memory objects
+  std::vector<dnnl::memory> concat_src_mems;
+  for (size_t i = 0; i < src_mds.size(); ++i) {
+    auto concat_src_mem = sp.GetMemoryAndReshape(node.Input(static_cast<int>(IN_DATA_0 + i)), concat_pd.src_desc(i), dnnl_engine);
+    concat_src_mems.push_back(concat_src_mem);
+  }
+  auto concat_dst_mem = dnnl::memory(concat_pd.dst_desc(), dnnl_engine);
+
+  // Create primitive arguments
+  std::unordered_map<int, dnnl::memory> concat_args;
+  for (int n = 0; n < static_cast<int>(concat_src_mems.size()); ++n)
+      concat_args.insert({DNNL_ARG_MULTIPLE_SRC + n, concat_src_mems[n]});
+  concat_args.insert({DNNL_ARG_DST, concat_dst_mem});  
+
+  // Create and execute primitive
+  auto concat_op = dnnl::concat(concat_pd);  
+
+  sp.AddPrimitive(concat_op, concat_args);
+  sp.SetMemory(node.Output(OUT_CONCAT), concat_dst_mem);  
+}
+
+int64_t DnnlConcat::GetAxis(DnnlNode& node, int64_t input_rank) {
+  auto axis_attr = node.Attributes().find("axis");
+  ORT_ENFORCE(axis_attr != node.Attributes().end(), 
+    "Axis attribute is not provided");
+  ORT_ENFORCE(axis_attr->second().type() == ::ONNX_NAMESPACE::AttributeProto_AttributeType::AttributeProto_AttributeType_INT,
+    "Axis value is not an integer");
+
+  // We need to do sign comparisons so we have to cast
+  int64_t signed_axis = axis_attr->second().i();  
+  ORT_ENFORCE(((signed_axis < 0) && (signed_axis >= -input_rank)) || ((signed_axis >= 0) && (signed_axis <= (input_rank - 1))),
+    "Axis value ", signed_axis, "is not between input rank ", -input_rank, " and ", input_rank - 1);
+
+  if (signed_axis < 0) {
+    signed_axis += input_rank;
+  }
+  return signed_axis;
+}
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.cc
@@ -36,7 +36,10 @@ void DnnlConcat::CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node) {
   // Create primitive memory objects
   std::vector<dnnl::memory> concat_src_mems;
   for (size_t i = 0; i < src_mds.size(); ++i) {
-    auto concat_src_mem = sp.GetMemoryAndReshape(node.Input(static_cast<int>(IN_DATA_0 + i)), concat_pd.src_desc(i), dnnl_engine);
+    auto concat_src_mem = sp.GetMemoryAndReshape(
+        node.Input(static_cast<int>(IN_DATA_0 + i)),
+        concat_pd.src_desc(static_cast<int>(i)),
+        dnnl_engine);
     concat_src_mems.push_back(concat_src_mem);
   }
   auto concat_dst_mem = dnnl::memory(concat_pd.dst_desc(), dnnl_engine);

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_concat.h
@@ -1,0 +1,32 @@
+// Copyright(C) 2021 Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+#include "dnnl_subgraph.h"
+#include "dnnl_subgraph_primitive.h"
+
+//class DnnlSubgraphPrimitive;
+//class DnnlNode;
+
+namespace onnxruntime {
+namespace ort_dnnl {
+
+class DnnlConcat {
+ public:
+  enum InputTensors : int {
+    IN_DATA_0 = 0,
+  };
+
+  enum OutputTensors : int {
+    OUT_CONCAT = 0,
+  };
+
+  DnnlConcat();
+  void CreatePrimitive(DnnlSubgraphPrimitive& sp, DnnlNode& node);
+
+ private:
+  int64_t GetAxis(DnnlNode& node, int64_t input_rank);
+};
+
+}  // namespace ort_dnnl
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_subgraph_primitive.cc
@@ -6,6 +6,7 @@
 #include "dnnl_batchnorm.h"
 #include "dnnl_binary.h"
 #include "dnnl_cast.h"
+#include "dnnl_concat.h"
 #include "dnnl_conv.h"
 #include "dnnl_dequantizelinear.h"
 #include "dnnl_dynamicquantizelinear.h"
@@ -177,6 +178,8 @@ void DnnlSubgraphPrimitive::AddKernels() {
       DnnlBinary().CreatePrimitive(*this, node);
     } else if (node.OpType() == "Cast") {
       DnnlCast().CreatePrimitive(*this, node);
+    } else if (node.OpType() == "Concat") {
+      DnnlConcat().CreatePrimitive(*this, node);      
     } else if (node.OpType() == "Conv" || node.OpType() == "ConvRelu") {
       DnnlConv().CreatePrimitive(*this, node);
     } else if (node.OpType() == "DequantizeLinear") {
@@ -558,8 +561,7 @@ dnnl::memory DnnlSubgraphPrimitive::GetMemoryAndReshape(const DnnlTensor& tensor
     auto mem_from_dims = mem_from.get_desc().dims();
     auto mem_to_dims = mem_to.get_desc().dims();
     if (Product(mem_from_dims) != Product(mem_to_dims)) {
-      LOGS_DEFAULT(ERROR) << mem_from_dims;
-      LOGS_DEFAULT(ERROR) << mem_to_dims;
+      LOGS_DEFAULT(ERROR) << tensor.Name() << ", Dims From: " << mem_from_dims << ", To: " << mem_to_dims;
       throw std::invalid_argument("not a valid reshape, inconsistent dim product");
     }
     //keep the same data type from mem_from but reshape the dims with mem_desc


### PR DESCRIPTION
### Description
This PR implements the **Concat Operator** for the **OneDNN Execution Provider**.

### Motivation and Context
- As part of evaluating ORT performance on ARM based targets such as Graviton3, we discovered that the OneDNN EP had some gaps on operator coverage.
- The Concat Operator is fairly common and used in models such as Yolov5, MobileNet, DistillBert and GPT2
- For Yolov5 specifically, this improves average inference time over 100 runs on Graviton3 from 180.2ms to 115.5ms when using OneDNN + ARM Compute Library.



