### PR TITLE
ignore dirty state of submodule XNNPACK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,3 +78,4 @@
 [submodule "cmake/external/XNNPACK"]
 	path = cmake/external/XNNPACK
 	url = https://github.com/google/XNNPACK.git
+	ignore = dirty


### PR DESCRIPTION
### Description
ignore dirty state of submodule XNNPACK



### Motivation and Context
ONNX Runtime WebAssembly build will apply a patch to XNNPACK so it is considered 'dirty' state in the submodule. We want to ignore this when checking the workspace using `git status`.