### PR TITLE
set node schema when apply NHWC transformer

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -909,7 +909,8 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
         onnx_layout_transformation::WrapTransposesAroundNode(*api_graph, *node, {&input_perm}, {&output_perm});
       }
 
-      auto new_node_ref = onnx_layout_transformation::SwapNodeOpTypeAndDomain(*api_graph, *node, node->OpType(), kMSInternalNHWCDomain);
+      [[maybe_unused]] auto new_node_ref =
+        onnx_layout_transformation::SwapNodeOpTypeAndDomain(*api_graph, *node, node->OpType(), kMSInternalNHWCDomain);
 
 #if !defined(ORT_MINIMAL_BUILD)
       // Set the schema if one is available. This keeps the node equivalent with the state of the original ONNX
@@ -919,8 +920,6 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
       // add schema if available.
       // not guaranteed to be (compiling EP doesn't need schemas, not available in minimal build
       graph.SetOpSchemaFromRegistryForNode(new_node);
-#else
-      UNREFERENCED_PARAMETER(new_node_ref);
 #endif
       modified = true;
     }

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -909,7 +909,19 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
         onnx_layout_transformation::WrapTransposesAroundNode(*api_graph, *node, {&input_perm}, {&output_perm});
       }
 
-      onnx_layout_transformation::SwapNodeOpTypeAndDomain(*api_graph, *node, node->OpType(), kMSInternalNHWCDomain);
+      auto new_node_ref = onnx_layout_transformation::SwapNodeOpTypeAndDomain(*api_graph, *node, node->OpType(), kMSInternalNHWCDomain);
+
+#if !defined(ORT_MINIMAL_BUILD)
+      // Set the schema if one is available. This keeps the node equivalent with the state of the original ONNX
+      // node (if possible - some replacement nodes do not have a schema).
+      //
+      Node& new_node = NodeFromApiNode(*new_node_ref);
+      // add schema if available.
+      // not guaranteed to be (compiling EP doesn't need schemas, not available in minimal build
+      graph.SetOpSchemaFromRegistryForNode(new_node);
+#else
+      UNREFERENCED_PARAMETER(new_node_ref);
+#endif
       modified = true;
     }
   }


### PR DESCRIPTION
### Description
set node schema when apply NHWC transformer

### Motivation and Context
The implementation in `IExecutionProvider::GetCapability()` checks node schema to determine the capability of the current EP. If NHWC graph transformer created a new channel last `Conv` node to replace the channel first `Conv` node, we need to assign the schema to the replaced node.
