### PR TITLE
Make natvis files work better

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1404,6 +1404,7 @@ function(onnxruntime_add_include_to_target dst_target)
     foreach(src_target ${ARGN})
         target_include_directories(${dst_target} PRIVATE $<TARGET_PROPERTY:${src_target},INTERFACE_INCLUDE_DIRECTORIES>)
         target_compile_definitions(${dst_target} PRIVATE $<TARGET_PROPERTY:${src_target},INTERFACE_COMPILE_DEFINITIONS>)
+        target_sources(${dst_target} PRIVATE $<TARGET_PROPERTY:${src_target},INTERFACE_SOURCES>)
     endforeach()
 endfunction()
 


### PR DESCRIPTION
### Description
After this change, you will see GSL.natvis and wil.nativs files will be added to every onnxruntime_xxx project. 

Like this:
![image](https://user-images.githubusercontent.com/856316/202081013-314145a8-7a0f-4f45-bf85-f9ed0e247c63.png)

This is because in onnxruntime_common.cmake we have:

```cmake
    if (MSVC)
    set(ABSEIL_NATVIS_FILE "abseil-cpp.natvis")
    target_sources(
        onnxruntime_common
        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/${ABSEIL_NATVIS_FILE}>)
  endif()
```
It sets a property, INTERFACE_SOURCES, on the target "onnxruntime_common". 

Then if anyone else uses:
```
target_link_libraries(mytarget PRIVATE onnxruntime_common)
```
The nativis file will be added to `mytarget`.

However, in this project we don't use such things for the targets that are static libraries. For example, onnxruntime_graph is a static library.

Instead, we use the `onnxruntime_add_include_to_target ` function to explicitly control what we want to propagate . The function was written before we started to have nativis files. So it doesn't pass a source file from one static library to another. Now we have the need. Probably only for Windows. 

### Motivation and Context

Add natvis  files to every project.


