### PR TITLE
Fix aten::_to_copy in DORT

### DIFF
--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -268,10 +268,32 @@ def _replace_to_copy_with_to(fx_module: torch.fx.GraphModule) -> None:
             isinstance(node.target, torch._ops.OpOverload)
             and node.target.overloadpacket == torch.ops.aten._to_copy  # type: ignore
         ):
-            if len(node.args) == 1 and len(node.kwargs) == 1 and "dtype" in node.kwargs:
+            is_default_layout = True
+            is_on_same_device = True
+            is_cast = True
+            are_kwargs_supported = True
+            if "layout" in node.kwargs and node.kwargs["layout"] != torch.strided:
+                is_default_layout = False
+            if "device" in node.kwargs and node.kwargs["device"] != node.args[0].meta["val"].device:
+                is_on_same_device = False
+            if "dtype" not in node.kwargs:
+                is_cast = False
+            for kwarg in node.kwargs:
+                if kwarg not in ["layout", "device", "dtype"]:
+                    are_kwargs_supported = False
+
+            if len(node.args) == 1 and is_default_layout and is_on_same_device and is_cast and are_kwargs_supported:
+                # This aten::_to_copy looks like ONNX Cast, so other kwargs are ignored.
+                # This change could lead to invalid FX graph but it doesn't matter, as long as the downstream backend,
+                # ONNXRuntime, can execute the exported ONNX graph.
+                node.kwargs = {"dtype": node.kwargs["dtype"]}
+
                 node.target = torch.ops.aten.to.dtype  # type: ignore
             else:
-                raise RuntimeError("aten._to_copy must be replaced with other ONNX-supported aten ops.")
+                raise RuntimeError(
+                    f"aten._to_copy must be replaced with other ONNX-supported aten ops. \
+                         args={[arg.meta for arg in node.args]}, kwargs={node.kwargs}"
+                )
     fx_module.recompile()
 
 
@@ -481,8 +503,8 @@ class OrtBackend:
             onnx_model = _create_onnx_model(onnx_proto)
             # TODO(wechi): ORT session should provide a API to extract
             # input and output names from the underlying model.
-            input_names = tuple(list(input.name for input in onnx_model.graph.input))
-            output_names = tuple(list(output.name for output in onnx_model.graph.output))
+            input_names = tuple(input.name for input in onnx_model.graph.input)
+            output_names = tuple(output.name for output in onnx_model.graph.output)
             input_devices = _get_onnx_devices(args)
             # Cache devices for inputs and outputs. They are used to invoke
             # ORT session. Output devices indicate where (e.g., GPU or CPU)
@@ -534,6 +556,9 @@ class OrtBackend:
             partitioned_prim_graph_module = self._partitioner_cache[graph_module]
         else:
             prim_graph_module = make_fx(graph_module, decomposition_table=_ATEN2ATEN_DECOMP)(*args)
+            # TODO(wechi): this is required for removing aten::_to_copy in _replace_to_copy_with_to.
+            # We need input and output tensors' devices to decide if aten::_to_copy is just a Cast.
+            FakeTensorProp(prim_graph_module).propagate(*args)
             _replace_to_copy_with_to(prim_graph_module)
             partitioner = CapabilityBasedPartitioner(
                 prim_graph_module, self._supported_ops, allows_single_node_partition=False


### PR DESCRIPTION
`aten::_to_copy` is not exportable to ONNX. In DORT, so `_replace_to_copy_with_to` replaces `aten::_to_copy` with onnx-supported `aten::to`. This replacement logic becomes incorrect in latest PyTorch commit, and this PR is a fix.

Basically, we examine more key-word attributes passed to `aten::_to_copy` and if they lead to a type casting operator (i.e., mapped to ONNX's Cast), we replace that `aten::_to_copy` with `aten::to`. Unsupported attributes are removed (with a low risk of breaking FX graph's assumptions).