### PR TITLE
Add custom tolerance option for onnx_test_runner

### DIFF
--- a/onnxruntime/core/platform/path_lib.h
+++ b/onnxruntime/core/platform/path_lib.h
@@ -29,6 +29,9 @@ using PATH_CHAR_TYPE = ORTCHAR_T;
 template <typename T>
 long OrtStrtol(const T* nptr, T** endptr);
 
+template <typename T>
+double OrtStrtod(const T* nptr, T** endptr);
+
 /**
  * Convert a C string to ssize_t(or ptrdiff_t)
  * @return the converted integer value.
@@ -83,6 +86,16 @@ inline long OrtStrtol<char>(const char* nptr, char** endptr) {
 template <>
 inline long OrtStrtol<wchar_t>(const wchar_t* nptr, wchar_t** endptr) {
   return wcstol(nptr, endptr, 10);
+}
+
+template <>
+inline double OrtStrtod<char>(const char* nptr, char** endptr) {
+  return strtod(nptr, endptr);
+}
+
+template <>
+inline double OrtStrtod<wchar_t>(const wchar_t* nptr, wchar_t** endptr) {
+  return wcstod(nptr, endptr);
 }
 
 namespace onnxruntime {

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -45,7 +45,8 @@ void usage() {
       "\t-p: Pause after launch, can attach debugger and continue\n"
       "\t-x: Use parallel executor, default (without -x): sequential executor.\n"
       "\t-d [device_id]: Specifies the device id for multi-device (e.g. GPU). The value should > 0\n"
-      "\t-t: Specify custom absoulte and relative tolerance values for output value comparison. default: 1e-5\n"
+      "\t-t: Specify custom relative tolerance values for output value comparison. default: 1e-5\n"
+      "\t-a: Specify custom absolute tolerance values for output value comparison. default: 1e-5\n"
       "\t-i: Specify EP specific runtime options as key value pairs. Different runtime options available are: \n"
       "\t    [SNPE only] [runtime]: SNPE runtime, options: 'CPU', 'GPU', 'GPU_FLOAT16', 'DSP', 'AIP_FIXED_TF'. \n"
       "\t    [SNPE only] [priority]: execution priority, options: 'low', 'normal'. \n"
@@ -157,7 +158,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool pause = false;
   {
     int ch;
-    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:Mn:r:e:t:xvo:d:i:pz"))) != -1) {
+    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:Mn:r:e:t:a:xvo:d:i:pz"))) != -1) {
       switch (ch) {
         case 'A':
           enable_cpu_mem_arena = false;
@@ -230,8 +231,11 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           break;
         case 't':
           override_tolerance = true;
+          rtol = OrtStrtod<PATH_CHAR_TYPE>(optarg, nullptr);
+          break;
+        case 'a':
+          override_tolerance = true;
           atol = OrtStrtod<PATH_CHAR_TYPE>(optarg, nullptr);
-          rtol = atol;
           break;
         case 'x':
           execution_mode = ExecutionMode::ORT_PARALLEL;


### PR DESCRIPTION
Signed-off-by: Kevin Chen <kevinch@nvidia.com>

### Description
Add a `-t` option for `onnx_test_runner` to allow users to specify custom tolerance values when running ONNX models.


### Motivation and Context
For some backends, the default tolerance of 1-e5 is too tight to pass accuracy checks with ONNX model zoo reference values, especially if only one or two values are mismatched. Having a custom option will allow different backends to specify their own custom tolerance when running these models.

