### PR TITLE
[ROCm] float16.h should use __HIP__ not USE_ROCM

### DIFF
--- a/include/onnxruntime/core/framework/float16.h
+++ b/include/onnxruntime/core/framework/float16.h
@@ -41,11 +41,10 @@ inline bool operator<(const MLFloat16& left, const MLFloat16& right) { return le
 // BFloat16
 struct BFloat16 {
   uint16_t val{0};
-#if defined(USE_ROCM)
-  ORT_HOST_DEVICE BFloat16() = default;
-#else
-  BFloat16() = default;
+#if defined(__clang__) && defined(__HIP__)
+  ORT_HOST_DEVICE
 #endif
+  BFloat16() = default;
 
   struct FromBitsT {};
   static constexpr ORT_HOST_DEVICE FromBitsT FromBits() { return FromBitsT(); }
@@ -54,7 +53,7 @@ struct BFloat16 {
   inline ORT_HOST_DEVICE BFloat16(float v) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000 && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     val = __bfloat16_as_ushort(__float2bfloat16(v));
-#elif defined(USE_ROCM)
+#elif defined(__clang__) && defined(__HIP__)
     // We should be using memcpy in order to respect the strict aliasing rule but it fails in the HIP environment.
     if (v != v) {  // isnan
       val = UINT16_C(0x7FC0);
@@ -81,7 +80,7 @@ struct BFloat16 {
   inline ORT_HOST_DEVICE float ToFloat() const {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&val));
-#elif defined(USE_ROCM)
+#elif defined(__clang__) && defined(__HIP__)
     // We should be using memcpy in order to respect the strict aliasing rule but it fails in the HIP environment.
     float result = 0;
     uint32_t tmp = val;

--- a/include/onnxruntime/core/framework/float16.h
+++ b/include/onnxruntime/core/framework/float16.h
@@ -41,10 +41,11 @@ inline bool operator<(const MLFloat16& left, const MLFloat16& right) { return le
 // BFloat16
 struct BFloat16 {
   uint16_t val{0};
-#if defined(__clang__) && defined(__HIP__)
-  ORT_HOST_DEVICE
-#endif
+#if defined(__HIP__)
+  ORT_HOST_DEVICE BFloat16() = default;
+#else
   BFloat16() = default;
+#endif
 
   struct FromBitsT {};
   static constexpr ORT_HOST_DEVICE FromBitsT FromBits() { return FromBitsT(); }
@@ -53,7 +54,7 @@ struct BFloat16 {
   inline ORT_HOST_DEVICE BFloat16(float v) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000 && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
     val = __bfloat16_as_ushort(__float2bfloat16(v));
-#elif defined(__clang__) && defined(__HIP__)
+#elif defined(__HIP__)
     // We should be using memcpy in order to respect the strict aliasing rule but it fails in the HIP environment.
     if (v != v) {  // isnan
       val = UINT16_C(0x7FC0);
@@ -80,7 +81,7 @@ struct BFloat16 {
   inline ORT_HOST_DEVICE float ToFloat() const {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&val));
-#elif defined(__clang__) && defined(__HIP__)
+#elif defined(__HIP__)
     // We should be using memcpy in order to respect the strict aliasing rule but it fails in the HIP environment.
     float result = 0;
     uint32_t tmp = val;


### PR DESCRIPTION
The float16.h header is shared between the CPU and ROCm EPs. The USE_ROCM macro is defined universally, but for the float16.h header we only wish to detect the hip-clang compiler. Otherwise, the CPU EP fails to build because of -Werror -Wuninitialized caused by the USE_ROCM code additions, and the CPU EP should be using a different code path.