### PR TITLE
Remove protobuf pin from training requirements

### DIFF
--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -4,6 +4,6 @@ h5py
 numpy >= 1.16.6
 onnx
 packaging
-protobuf >= 3.20.0, <= 3.21.0
+protobuf
 sympy
 setuptools>=41.4.0


### PR DESCRIPTION
### Description
In an earlier pull request #13596, I pinned the protobuf version to `>= 3.20.0, <= 3.21.0` with the intention of fixing a build pipeline.

But the change did not fix the broken pipeline as can be seen from this [run](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=812184&view=logs&j=5076e696-f193-5f12-2d8a-703dda41a79b&t=36d14095-574e-5e72-7b20-ff4ffba088b5&s=959c6b43-5937-53e5-5f36-e53cb0249117)

Moreover, this change had an inadvertent effect on the ACPT nightly pipelines which require protobuf version 3.19.x to meet dependency requirements from other packages.

Moving forward, will keep the `onnxruntime-training` and `onnxruntime` requirements for protobuf the same.