### PR TITLE
Remove SafeInt dependency from Objective-C API.

### DIFF
--- a/cmake/onnxruntime_objectivec.cmake
+++ b/cmake/onnxruntime_objectivec.cmake
@@ -5,12 +5,6 @@ if(NOT APPLE)
     message(FATAL_ERROR "The Objective-C API must be built on an Apple platform.")
 endif()
 
-set(ONNXRUNTIME_OBJC_MIN_CMAKE_VERSION "3.18")
-
-if(CMAKE_VERSION VERSION_LESS ONNXRUNTIME_OBJC_MIN_CMAKE_VERSION)
-    message(FATAL_ERROR "The Objective-C API requires CMake ${ONNXRUNTIME_OBJC_MIN_CMAKE_VERSION}+.")
-endif()
-
 if(NOT onnxruntime_BUILD_SHARED_LIB)
     message(FATAL_ERROR "The Objective-C API requires onnxruntime_BUILD_SHARED_LIB to be enabled.")
 endif()
@@ -72,7 +66,6 @@ find_library(FOUNDATION_LIB Foundation REQUIRED)
 target_link_libraries(onnxruntime_objc
     PRIVATE
         onnxruntime
-        safeint_interface
         ${FOUNDATION_LIB})
 
 set_target_properties(onnxruntime_objc PROPERTIES
@@ -82,7 +75,6 @@ set_target_properties(onnxruntime_objc PROPERTIES
     FRAMEWORK_VERSION "A"
     PUBLIC_HEADER "${onnxruntime_objc_headers}"
     FOLDER "ONNXRuntime"
-    CXX_STANDARD 17 # TODO remove when everything else moves to 17
     )
 
 set_property(TARGET onnxruntime_objc APPEND PROPERTY COMPILE_OPTIONS "-fvisibility=default")

--- a/objectivec/src/ort_value.mm
+++ b/objectivec/src/ort_value.mm
@@ -5,8 +5,6 @@
 
 #include <optional>
 
-#include "safeint/SafeInt.hpp"
-
 #import "src/cxx_api.h"
 #import "src/error_utils.h"
 #import "src/ort_enums_internal.h"
@@ -44,6 +42,12 @@ ORTValueTypeInfo* CXXAPIToPublicValueTypeInfo(
   }
 
   return result;
+}
+
+// out = a * b
+// returns true iff the result does not overflow
+bool SafeMultiply(size_t a, size_t b, size_t& out) {
+  return !__builtin_mul_overflow(a, b, &out);
 }
 
 }  // namespace

--- a/tools/ci_build/github/apple/objectivec/assemble_objc_pod_package.py
+++ b/tools/ci_build/github/apple/objectivec/assemble_objc_pod_package.py
@@ -27,7 +27,6 @@ license_file = "LICENSE"
 # include directories for compiling the pod itself
 include_dirs = [
     "objectivec",
-    "cmake/external/SafeInt",
 ]
 
 # pod source files
@@ -36,7 +35,6 @@ source_files = [
     "objectivec/src/*.h",
     "objectivec/src/*.m",
     "objectivec/src/*.mm",
-    "cmake/external/SafeInt/safeint/SafeInt.hpp",
 ]
 
 # pod public header files


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove SafeInt dependency from Objective-C API.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Simplify Objective-C API build and packaging process.