### PR TITLE
Bug Fix - WASM build break

### DIFF
--- a/onnxruntime/test/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc
+++ b/onnxruntime/test/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc
@@ -29,7 +29,7 @@ void VerifyTensorProtoFileData(const PathString& tensor_proto_path, gsl::span<co
   actual_data.resize(expected_data.size());
   ASSERT_STATUS_OK(utils::UnpackTensor(tensor_proto, Path{}, actual_data.data(), actual_data.size()));
 
-  ASSERT_EQ(gsl::make_span(static_cast<gsl::span<const T>>(actual_data)), expected_data);
+  ASSERT_EQ(gsl::span<const T>(actual_data), expected_data);
 }
 }  // namespace
 

--- a/onnxruntime/test/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc
+++ b/onnxruntime/test/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc
@@ -29,7 +29,7 @@ void VerifyTensorProtoFileData(const PathString& tensor_proto_path, gsl::span<co
   actual_data.resize(expected_data.size());
   ASSERT_STATUS_OK(utils::UnpackTensor(tensor_proto, Path{}, actual_data.data(), actual_data.size()));
 
-  ASSERT_EQ(gsl::make_span(actual_data), expected_data);
+  ASSERT_EQ(gsl::make_span(static_cast<gsl::span<const T>>(actual_data)), expected_data);
 }
 }  // namespace
 


### PR DESCRIPTION
### Description
When using the build flag "--cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1" with WASM it results with a build break. Since we are comparing a const vs. non-const T type, this added casting resolves the issue.


