### PR TITLE
Add parameterized docker flag support for custom build android package script.

### DIFF
--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -136,7 +136,7 @@ def main():
         args.docker_path,
         "run",
         "--rm",
-        "-it",
+        "-i",
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -26,15 +26,6 @@ def parse_args():
         "working_dir", type=pathlib.Path, help="The directory used to store intermediate and output files."
     )
 
-    default_docker_interactive_mode_flag = "it"
-    parser.add_argument(
-        "--docker_interactive_mode_flag",
-        default=default_docker_interactive_mode_flag,
-        help="The docker run flag specifying whether to run in interactive mode. "
-             "If unspecified, docker would run in interactive mode. "
-             "Use 'i' for this argument if want to run in non-interactive mode. ",
-    )
-
     parser.add_argument(
         "--onnxruntime_branch_or_tag",
         help="The ONNX Runtime branch or tag to build. "
@@ -145,7 +136,6 @@ def main():
         args.docker_path,
         "run",
         "--rm",
-        f"-{args.docker_interactive_mode_flag}",
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -26,6 +26,16 @@ def parse_args():
         "working_dir", type=pathlib.Path, help="The directory used to store intermediate and output files."
     )
 
+    default_docker_psuedo_tty = True
+    parser.add_argument(
+        "--docker_psuedo_tty",
+        default=default_docker_psuedo_tty,
+        help="The docker run flag specifying whether to run in interactive mode. "
+             "If unspecified, docker would run in interactive mode using a psuedo TTY. "
+             "Specify 'False' for this argument if want to run in non-interactive mode. ",
+    )
+
+
     parser.add_argument(
         "--onnxruntime_branch_or_tag",
         help="The ONNX Runtime branch or tag to build. "
@@ -132,10 +142,17 @@ def main():
         else f"/workspace/onnxruntime/{DEFAULT_BUILD_SETTINGS_RELATIVE_PATH}"
     )
 
+    docker_psuedo_tty_flag = (
+        "-it"
+        if args.docker_psuedo_tty
+        else "-i"
+    )
+
     docker_run_cmd = [
         args.docker_path,
         "run",
         "--rm",
+        docker_psuedo_tty_flag,
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -27,15 +27,6 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--disable_docker_pseudo_tty",
-        action="store_false",
-        help="The docker run flag specifying whether to disable using a pseudo TTY when running docker in interactive mode. "
-             "If unspecified, docker would run in interactive mode using a Pseudo TTY. "
-             "Specify 'False' for this argument if want to run in non-interactive mode without a TTY. ",
-    )
-
-
-    parser.add_argument(
         "--onnxruntime_branch_or_tag",
         help="The ONNX Runtime branch or tag to build. "
         "Supports branches and tags starting from 1.11 (branch rel-1.11.0 or tag v1.11.0). "
@@ -141,17 +132,10 @@ def main():
         else f"/workspace/onnxruntime/{DEFAULT_BUILD_SETTINGS_RELATIVE_PATH}"
     )
 
-    docker_pseudo_tty_flag = (
-        "-it"
-        if args.disable_docker_pseudo_tty is True
-        else "-i"
-    )
-
     docker_run_cmd = [
         args.docker_path,
         "run",
         "--rm",
-        docker_pseudo_tty_flag,
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -28,7 +28,7 @@ def parse_args():
 
     default_docker_interactive_mode_flag = "it"
     parser.add_argument(
-        "docker_interactive_mode_flag",
+        "--docker_interactive_mode_flag",
         default=default_docker_interactive_mode_flag,
         help="The docker run flag specifying whether to run in interactive mode. "
              "If unspecified, docker would run in interactive mode. "

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -26,13 +26,12 @@ def parse_args():
         "working_dir", type=pathlib.Path, help="The directory used to store intermediate and output files."
     )
 
-    default_docker_psuedo_tty = True
     parser.add_argument(
-        "--docker_psuedo_tty",
-        default=default_docker_psuedo_tty,
-        help="The docker run flag specifying whether to run in interactive mode. "
-             "If unspecified, docker would run in interactive mode using a psuedo TTY. "
-             "Specify 'False' for this argument if want to run in non-interactive mode. ",
+        "--disable_docker_pseudo_tty",
+        action="store_false",
+        help="The docker run flag specifying whether to disable using a pseudo TTY when running docker in interactive mode. "
+             "If unspecified, docker would run in interactive mode using a Pseudo TTY. "
+             "Specify 'False' for this argument if want to run in non-interactive mode without a TTY. ",
     )
 
 
@@ -142,9 +141,9 @@ def main():
         else f"/workspace/onnxruntime/{DEFAULT_BUILD_SETTINGS_RELATIVE_PATH}"
     )
 
-    docker_psuedo_tty_flag = (
+    docker_pseudo_tty_flag = (
         "-it"
-        if args.docker_psuedo_tty
+        if args.disable_docker_pseudo_tty is True
         else "-i"
     )
 
@@ -152,7 +151,7 @@ def main():
         args.docker_path,
         "run",
         "--rm",
-        docker_psuedo_tty_flag,
+        docker_pseudo_tty_flag,
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -145,7 +145,7 @@ def main():
         args.docker_path,
         "run",
         "--rm",
-        "-{args.docker_interactive_mode_flag}",
+        f"-{args.docker_interactive_mode_flag}",
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",

--- a/tools/android_custom_build/build_custom_android_package.py
+++ b/tools/android_custom_build/build_custom_android_package.py
@@ -26,6 +26,15 @@ def parse_args():
         "working_dir", type=pathlib.Path, help="The directory used to store intermediate and output files."
     )
 
+    default_docker_interactive_mode_flag = "it"
+    parser.add_argument(
+        "docker_interactive_mode_flag",
+        default=default_docker_interactive_mode_flag,
+        help="The docker run flag specifying whether to run in interactive mode. "
+             "If unspecified, docker would run in interactive mode. "
+             "Use 'i' for this argument if want to run in non-interactive mode. ",
+    )
+
     parser.add_argument(
         "--onnxruntime_branch_or_tag",
         help="The ONNX Runtime branch or tag to build. "
@@ -136,7 +145,7 @@ def main():
         args.docker_path,
         "run",
         "--rm",
-        "-i",
+        "-{args.docker_interactive_mode_flag}",
         f"--volume={str(working_dir)}:/workspace/shared",
         args.docker_image_tag,
         "/usr/bin/env",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This change adds parameterized docker run flag support for custom build android package script. 
p.s. This Android custom build script isn't included in the release. it's intended for usage by a user wanting to do a custom build. This script is not included in the python package of this release.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Currently the suggested approach building custom Android ONNXRuntime library is based on the following script:
https://github.com/microsoft/onnxruntime/blob/main/tools/android_custom_build/build_custom_android_package.py

In this script, the docker run settings are set to require an interactive environment, with the flag "-it". Thus if running in a non-interactive environment, this would be an issue.

This change adds parameterized docker run flag support, so user can specify whether to run docker in an interactive/non-interactive environment. If the user doesn't specify the content of "--docker_interactive_mode_flag", the default behavior is the same as what has been set previously: Use flag "-it" to make it run in an interactive environment. If user wants to run this script non-interactively, they can specify with the command "--docker_interactive_mode_flag i" to make it run non-interactively.

The parameter is added along with description on how it would work, and suggested use cases.

Update: In the discussion under this PR, we decided to remove the `-it` flag in the end, as it is not necessary for working in a console (interactive envinironment) and works with building in non-interactive environment as well.