### PR TITLE
Add a build job for VC++ static analysis for the CPU EP

### DIFF
--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -508,7 +508,7 @@ class WindowsEnv : public Env {
                                             0,
                                             static_cast<DWORD>(mapped_offset),
                                             mapped_length);
-
+    GSL_SUPPRESS(r .11)
     mapped_memory =
         MappedMemoryPtr{reinterpret_cast<char*>(mapped_base) + offset_to_page,
                         OrtCallbackInvoker{OrtCallback{UnmapFile, new UnmapFileParam{mapped_base, mapped_length}}}};

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1989,7 +1989,6 @@ ORT_API_STATUS_IMPL(OrtApis::CreateOpaqueValue, _In_z_ const char* domain_name, 
               "Specified domain and type names combination does not refer to a registered opaque type");
   const auto* non_tensor_base = ml_type->AsNonTensorType();
   ORT_ENFORCE(non_tensor_base != nullptr, "Opaque type is not a non_tensor type!!!");
-  GSL_SUPPRESS(r .11)
   std::unique_ptr<OrtValue> ort_val = std::make_unique<OrtValue>();
   non_tensor_base->FromDataContainer(data_container, data_container_size, *ort_val);
   *out = ort_val.release();

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -1990,7 +1990,7 @@ ORT_API_STATUS_IMPL(OrtApis::CreateOpaqueValue, _In_z_ const char* domain_name, 
   const auto* non_tensor_base = ml_type->AsNonTensorType();
   ORT_ENFORCE(non_tensor_base != nullptr, "Opaque type is not a non_tensor type!!!");
   GSL_SUPPRESS(r .11)
-  std::unique_ptr<OrtValue> ort_val(new OrtValue);
+  std::unique_ptr<OrtValue> ort_val = std::make_unique<OrtValue>();
   non_tensor_base->FromDataContainer(data_container, data_container_size, *ort_val);
   *out = ort_val.release();
   API_IMPL_END
@@ -2012,6 +2012,7 @@ ORT_API_STATUS_IMPL(OrtApis::GetOpaqueValue, _In_ const char* domain_name, _In_ 
   return nullptr;
 }
 
+GSL_SUPPRESS(r .11)
 ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char*** out_ptr,
                     _In_ int* providers_length) {
   API_IMPL_BEGIN
@@ -2021,11 +2022,9 @@ ORT_API_STATUS_IMPL(OrtApis::GetAvailableProviders, _Outptr_ char*** out_ptr,
   constexpr size_t MAX_LEN = 30;
   const auto& available_providers = GetAvailableExecutionProviderNames();
   const int available_count = narrow<int>(available_providers.size());
-  GSL_SUPPRESS(r .11)
   char** const out = new char*[available_count];
   if (out) {
     for (int i = 0; i < available_count; i++) {
-      GSL_SUPPRESS(r .11)
       out[i] = new char[MAX_LEN + 1];
 #ifdef _MSC_VER
       strncpy_s(out[i], MAX_LEN, available_providers[i].c_str(), MAX_LEN);
@@ -2195,8 +2194,7 @@ ORT_API(void, OrtApis::ReleaseArenaCfg, _Frees_ptr_opt_ OrtArenaCfg* ptr) {
 
 ORT_API_STATUS_IMPL(OrtApis::CreatePrepackedWeightsContainer, _Outptr_ OrtPrepackedWeightsContainer** out) {
   API_IMPL_BEGIN
-  GSL_SUPPRESS(r .11)
-  std::unique_ptr<PrepackedWeightsContainer> container(new PrepackedWeightsContainer());
+  std::unique_ptr<PrepackedWeightsContainer> container = std::make_unique<PrepackedWeightsContainer>();
   *out = reinterpret_cast<OrtPrepackedWeightsContainer*>(container.release());
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/test/framework/tunable_op_test.cc
+++ b/onnxruntime/test/framework/tunable_op_test.cc
@@ -426,10 +426,9 @@ class TunableVecAddHandleInplaceUpdate : public TunableOp<VecAddParams> {
   const VecAddParams* PreTuning(const VecAddParams* params) override {
     if (params->beta != 0) {
       is_proxy_params_used = true;
-      GSL_SUPPRESS(i .11)
-      VecAddParams* proxy = new VecAddParams(*params);
+      std::unique_ptr<VecAddParams> proxy = std::make_unique<VecAddParams>(*params);
       proxy->c = new int[params->num_elem];
-      return proxy;
+      return proxy.release();
     }
     is_proxy_params_used = false;
     return params;

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -180,3 +180,42 @@ stages:
         ORT_EP_NAME: CPU
         GenerateDocumentation: false
         MachinePool: 'onnxruntime-Win2019-CPU-training'
+
+- stage: sdl
+  dependsOn: []
+  jobs:
+    - job: Prefast
+      timeoutInMinutes: 120
+      workspace:
+        clean: all
+      variables:
+        skipComponentGovernanceDetection: true
+      pool: onnxruntime-win-cpu-2022
+      steps:
+       - task: UsePythonVersion@0
+         displayName: 'Use Python 3.x'
+
+       - task: SDLNativeRules@3
+         displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+         inputs:
+           publishXML: true
+           setupCommandlines: 'python $(Build.SourcesDirectory)\tools\ci_build\build.py --config Debug --build_dir $(Build.SourcesDirectory)\b --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_shared_lib --cmake_extra_defines onnxruntime_ENABLE_STATIC_ANALYSIS=ON'
+           msBuildCommandline: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64\MSBuild.exe" "$(Build.SourcesDirectory)\b\Debug\onnxruntime.sln" /p:RunCodeAnalysis=true /p:platform=x64 /p:configuration=Debug /p:VisualStudioVersion="17.0" /m /p:PreferredToolArchitecture=x64'
+           excludedPaths: '$(Build.SourcesDirectory)\b#$(Build.SourcesDirectory)\cmake#C:\program files'
+           rulesetName: Custom
+           customRuleset: '$(Build.SourcesDirectory)\cmake\Sdl.ruleset'
+
+       - task: SdtReport@2
+         displayName: 'Guardian Export'
+         inputs:
+           GdnExportPolicyMinSev: Warning
+           GdnExportGdnToolSDLNativeRulesSeverity: Note
+
+       - task: PublishSecurityAnalysisLogs@3
+         displayName: 'Publish Guardian Artifacts'
+
+       - task: PostAnalysis@2
+         displayName: 'Guardian Break'
+         inputs:
+           GdnBreakPolicyMinSev: Warning
+           GdnBreakGdnToolSDLNativeRulesSeverity: Note


### PR DESCRIPTION
Add a build job for VC++ static analysis for the CPU EP. The build job takes about 50 minutes and runs in parallel with the others. 