### PR TITLE
[CANN] Add the ability to run graph

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1535,6 +1535,7 @@ endif()
 
 if (onnxruntime_USE_CANN)
   add_definitions(-DUSE_CANN=1)
+
   file(GLOB_RECURSE onnxruntime_providers_cann_cc_srcs CONFIGURE_DEPENDS
     "${ONNXRUNTIME_ROOT}/core/providers/cann/*.h"
     "${ONNXRUNTIME_ROOT}/core/providers/cann/*.cc"
@@ -1550,12 +1551,13 @@ if (onnxruntime_USE_CANN)
   set(onnxruntime_providers_cann_src ${onnxruntime_providers_cann_cc_srcs} ${onnxruntime_providers_cann_shared_srcs})
 
   onnxruntime_add_shared_library_module(onnxruntime_providers_cann ${onnxruntime_providers_cann_src})
-  onnxruntime_add_include_to_target(onnxruntime_providers_cann onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
+  onnxruntime_add_include_to_target(onnxruntime_providers_cann onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers Boost::mp11 safeint_interface)
 
   add_dependencies(onnxruntime_providers_cann onnxruntime_providers_shared ${onnxruntime_EXTERNAL_DEPENDENCIES})
-  target_link_libraries(onnxruntime_providers_cann PRIVATE ascendcl acl_op_compiler nsync_cpp ${ABSEIL_LIBS} onnxruntime_providers_shared)
+  target_link_libraries(onnxruntime_providers_cann PRIVATE ascendcl acl_op_compiler fmk_onnx_parser nsync_cpp ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED})
   target_link_directories(onnxruntime_providers_cann PRIVATE ${onnxruntime_CANN_HOME}/lib64)
   target_include_directories(onnxruntime_providers_cann PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} ${eigen_INCLUDE_DIRS} ${onnxruntime_CANN_HOME} ${onnxruntime_CANN_HOME}/include)
+
   set_target_properties(onnxruntime_providers_cann PROPERTIES LINKER_LANGUAGE CXX)
   set_target_properties(onnxruntime_providers_cann PROPERTIES FOLDER "ONNXRuntime")
 

--- a/include/onnxruntime/core/providers/cann/cann_provider_options.h
+++ b/include/onnxruntime/core/providers/cann/cann_provider_options.h
@@ -9,10 +9,11 @@
 
 struct OrtCANNProviderOptions {
   int device_id;                                           // CANN device id
-  int max_opqueue_num;                                     // CANN operator cache information aging configuration
   size_t npu_mem_limit;                                    // BFC Arena memory limit for CANN
   onnxruntime::ArenaExtendStrategy arena_extend_strategy;  // Strategy used to grow the memory arena
   int do_copy_in_default_stream;                           // Flag indicating if copying needs to take place on the
                                                            // same stream as the compute stream in the CANN EP
+  int enable_cann_graph;                                   // Flag indicating if prioritizing the use of
+                                                           // CANN's graph-running capabilities
   OrtArenaCfg* default_memory_arena_cfg;                   // CANN memory arena configuration parameters
 };

--- a/onnxruntime/core/providers/cann/cann_call.cc
+++ b/onnxruntime/core/providers/cann/cann_call.cc
@@ -91,8 +91,28 @@ const char* CannErrString<aclError>(aclError e) {
     CASE_ENUM_TO_STR(ACL_ERROR_RT_FAILURE);
     CASE_ENUM_TO_STR(ACL_ERROR_DRV_FAILURE);
     CASE_ENUM_TO_STR(ACL_ERROR_PROFILING_FAILURE);
+
     default:
       return "(look for ACL_ERROR_xxx in acl.h)";
+  }
+}
+
+template <>
+const char* CannErrString<ge::graphStatus>(ge::graphStatus e) {
+  using namespace ge;
+
+  switch (e) {
+    CASE_ENUM_TO_STR(GRAPH_FAILED);
+    CASE_ENUM_TO_STR(GRAPH_SUCCESS);
+    CASE_ENUM_TO_STR(GRAPH_NOT_CHANGED);
+    CASE_ENUM_TO_STR(GRAPH_PARAM_INVALID);
+    CASE_ENUM_TO_STR(GRAPH_NODE_WITHOUT_CONST_INPUT);
+    CASE_ENUM_TO_STR(GRAPH_NODE_NEED_REPASS);
+    CASE_ENUM_TO_STR(GRAPH_INVALID_IR_DEF);
+    CASE_ENUM_TO_STR(OP_WITHOUT_IR_DATATYPE_INFER_RULE);
+
+    default:
+      return "(look for graphStatus in ge_error_codes.h)";
   }
 }
 
@@ -132,5 +152,10 @@ template bool CannCall<aclError, false>(aclError retCode, const char* exprString
                                         aclError successCode, const char* msg);
 template bool CannCall<aclError, true>(aclError retCode, const char* exprString, const char* libName,
                                        aclError successCode, const char* msg);
+
+template bool CannCall<ge::graphStatus, false>(ge::graphStatus retCode, const char* exprString, const char* libName,
+                                               ge::graphStatus successCode, const char* msg);
+template bool CannCall<ge::graphStatus, true>(ge::graphStatus retCode, const char* exprString, const char* libName,
+                                              ge::graphStatus successCode, const char* msg);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_call.h
+++ b/onnxruntime/core/providers/cann/cann_call.h
@@ -15,4 +15,7 @@ bool CannCall(ERRTYPE retCode, const char* exprString, const char* libName, ERRT
 #define CANN_CALL(expr) (CannCall<aclError, false>((expr), #expr, "CANN", ACL_SUCCESS))
 #define CANN_CALL_THROW(expr) (CannCall<aclError, true>((expr), #expr, "CANN", ACL_SUCCESS))
 
+#define CANN_GRAPH_CALL(expr) (CannCall<ge::graphStatus, false>((expr), #expr, "CANNGRAPH", ge::GRAPH_SUCCESS))
+#define CANN_GRAPH_CALL_THROW(expr) (CannCall<ge::graphStatus, true>((expr), #expr, "CANNGRAPH", ge::GRAPH_SUCCESS))
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_common.h
+++ b/onnxruntime/core/providers/cann/cann_common.h
@@ -16,6 +16,11 @@ namespace cann {
                           ? common::Status::OK() \
                           : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CANN error executing ", #expr))
 
+#define CANN_GRAPH_RETURN_IF_ERROR(expr)         \
+  ORT_RETURN_IF_ERROR(CANN_GRAPH_CALL(expr)      \
+                          ? common::Status::OK() \
+                          : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CANN Graph error executing ", #expr))
+
 template <typename ElemType>
 struct Constants {
   static const ElemType Zero;

--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -3,7 +3,15 @@
 // Licensed under the MIT License.
 
 #include <utility>
+#include <fstream>
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <unordered_set>
+
 #include "core/providers/shared_library/provider_api.h"
+#define ORT_API_MANUAL_INIT
+#include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/cann/cann_execution_provider.h"
 #include "core/providers/cann/cann_inc.h"
 #include "core/providers/cann/cann_call.h"
@@ -12,9 +20,16 @@
 #include "core/providers/cann/cann_fwd.h"
 #include "core/providers/cann/npu_data_transfer.h"
 
+using onnxruntime::cann::BuildONNXModel;
+using onnxruntime::cann::CannModelPreparation;
+using onnxruntime::cann::ParserONNXModel;
+using onnxruntime::cann::SupportONNXModel;
 using onnxruntime::common::Status;
 
 namespace onnxruntime {
+
+// Models can only be parsed and built serially in the same process
+OrtMutex g_mutex;
 
 class Memcpy final : public OpKernel {
  public:
@@ -994,9 +1009,14 @@ Status RegisterCANNKernels(KernelRegistry& kernel_registry) {
 }  // namespace cann
 
 CANNExecutionProvider::CANNExecutionProvider(const CANNExecutionProviderInfo& info)
-    : IExecutionProvider{onnxruntime::kCannExecutionProvider}, info_{info} {
+    : IExecutionProvider{onnxruntime::kCannExecutionProvider, true}, info_{info} {
+  InitProviderOrtApi();
+
   CANN_CALL_THROW(aclrtSetDevice(info_.device_id));
   CANN_CALL_THROW(aclrtCreateStream(&stream_));
+
+  soc_name_ = aclrtGetSocName();
+  ORT_ENFORCE(soc_name_ != nullptr, "aclrtGetSocName return nullptr");
 }
 
 CANNExecutionProvider::~CANNExecutionProvider() {
@@ -1021,10 +1041,10 @@ Status CANNExecutionProvider::OnRunEnd(bool sync_stream) {
 static std::shared_ptr<KernelRegistry> s_kernel_registry;
 
 void InitializeRegistry() {
+  CANN_CALL_THROW(aclInit(nullptr));
+
   s_kernel_registry = KernelRegistry::Create();
   ORT_THROW_IF_ERROR(cann::RegisterCANNKernels(*s_kernel_registry));
-
-  CANN_CALL_THROW(aclInit(nullptr));
 }
 
 void DeleteRegistry() {
@@ -1042,42 +1062,360 @@ std::unique_ptr<onnxruntime::IDataTransfer> CANNExecutionProvider::GetDataTransf
                                                         info_.do_copy_in_default_stream);
 }
 
-std::vector<std::unique_ptr<ComputeCapability>>
-CANNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
-                                     const IKernelLookup& kernel_lookup) const {
-  InlinedVector<NodeIndex> candidates;
-  for (auto& node_index : graph.GetNodesInTopologicalOrder()) {
-    const auto* p_node = graph.GetNode(node_index);
-    if (p_node == nullptr)
-      continue;
-
-    const auto& node = *p_node;
-    if (!node.GetExecutionProviderType().empty()) {
-      continue;
-    }
-
-    const KernelCreateInfo* cann_kernel_def = kernel_lookup.LookUpKernel(node);
-    if (cann_kernel_def == nullptr) {
-      LOGS_DEFAULT(INFO) << "CANN kernel not found in registries for Op type: " << node.OpType()
-                         << " node name: " << node.Name();
-      continue;
-    }
-
-    candidates.push_back(node.Index());
+std::unique_ptr<IndexedSubGraph> CANNExecutionProvider::GetSubGraph(
+    const std::vector<std::size_t>& graph_nodes_index,
+    const GraphViewer& graph_viewer) const {
+  std::unordered_set<size_t> node_set;
+  node_set.reserve(graph_nodes_index.size());
+  for (const auto& index : graph_nodes_index) {
+    node_set.insert(index);
   }
 
-  auto cpu_nodes = GetCpuPreferredNodes(graph, kernel_lookup, candidates);
-  std::vector<std::unique_ptr<ComputeCapability>> result;
-  for (auto& node_index : candidates) {
-    if (cpu_nodes.count(node_index) > 0)
-      continue;
+  // Get parent graph output names
+  std::vector<std::string> graph_output_names;
+  for (const auto* output_arg : graph_viewer.GetOutputs()) {
+    graph_output_names.push_back(output_arg->Name());
+  }
 
-    auto sub_graph = IndexedSubGraph::Create();
-    sub_graph->Nodes().push_back(node_index);
-    result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+  // Find inputs and outputs of the subgraph
+  std::unique_ptr<IndexedSubGraph> sub_graph = onnxruntime::IndexedSubGraph::Create();
+  std::unordered_map<const NodeArg*, int> fused_inputs, fused_outputs, fused_outputs_to_add, graph_outputs_to_add;
+  std::unordered_set<const NodeArg*> erased;
+  int input_order = 0;
+  int output_order = 0;
+
+  for (const auto& index : graph_nodes_index) {
+    sub_graph->Nodes().push_back(index);
+    const auto& node = graph_viewer.GetNode(index);
+    for (const auto& input : node->InputDefs()) {
+      const auto& it = fused_outputs.find(input);
+      if (it != fused_outputs.end()) {
+        fused_outputs.erase(it);
+        erased.insert(input);
+      } else if (erased.find(input) == erased.end() && !graph_viewer.GetAllInitializedTensors().count(input->Name())) {
+        // Only when input is neither in output list nor erased list, add the input to input list
+        fused_inputs[input] = input_order++;
+      }
+    }
+
+    for (const auto& input : node->ImplicitInputDefs()) {
+      const auto& it = fused_outputs.find(input);
+      if (it != fused_outputs.end()) {
+        fused_outputs.erase(it);
+        erased.insert(input);
+      } else if (erased.find(input) == erased.end() && !graph_viewer.GetAllInitializedTensors().count(input->Name())) {
+        // Only when input is neither in output list nor erased list, add the input to input list
+        fused_inputs[input] = input_order++;
+      }
+    }
+
+    // For output searching, there are two special cases,
+    // One is, if node's OutputEdges are more than its outputs, meaning certain output is used more than once,
+    // if the output is connected to nodes that don't belong to the subgraph, the output need to be added
+    // to the output list
+    // The other one is, if subgraph's node output is parent graph's output. the node output should
+    // be also added to the subgraph's output list
+    if (node->GetOutputEdgesCount() > node->OutputDefs().size()) {
+      for (auto it = node->OutputEdgesBegin(), end = node->OutputEdgesEnd(); it != end; ++it) {
+        const auto& node_idx = it->GetNode().Index();
+        const auto& output = (it->GetNode()).InputDefs()[it->GetDstArgIndex()];
+        if (node_set.find(node_idx) != node_set.end()) {
+          const auto& iter = fused_inputs.find(output);
+          if (iter != fused_inputs.end()) {
+            fused_inputs.erase(iter);
+            erased.insert(output);
+          } else if (erased.find(output) == erased.end()) {
+            auto it = std::find(graph_output_names.begin(), graph_output_names.end(), output->Name());
+            if (it != graph_output_names.end()) {
+              graph_outputs_to_add[output] = output_order;
+            }
+            fused_outputs[output] = output_order++;
+          }
+        } else {
+          fused_outputs_to_add[output] = output_order++;
+        }
+      }
+    } else {
+      for (const auto& output : node->OutputDefs()) {
+        const auto& it = fused_inputs.find(output);
+        if (it != fused_inputs.end()) {
+          fused_inputs.erase(it);
+          erased.insert(output);
+        } else {
+          // Only when output is neither in input list nor erased list, add the output to output list
+          if (erased.find(output) == erased.end()) {
+            auto it = std::find(graph_output_names.begin(), graph_output_names.end(), output->Name());
+            if (it != graph_output_names.end()) {
+              graph_outputs_to_add[output] = output_order;
+            }
+            fused_outputs[output] = output_order++;
+          }
+        }
+      }
+    }
+  }
+
+  fused_outputs.insert(fused_outputs_to_add.begin(), fused_outputs_to_add.end());
+  fused_outputs.insert(graph_outputs_to_add.begin(), graph_outputs_to_add.end());
+
+  // Sort inputs and outputs by the order they were added
+  std::multimap<int, const NodeArg*> inputs, outputs;
+  for (auto it = fused_inputs.begin(), end = fused_inputs.end(); it != end; ++it) {
+    inputs.insert(std::pair<int, const NodeArg*>(it->second, it->first));
+  }
+
+  for (auto it = fused_outputs.begin(), end = fused_outputs.end(); it != end; ++it) {
+    outputs.insert(std::pair<int, const NodeArg*>(it->second, it->first));
+  }
+
+  // It is possible that an output of an node is put bebind the output of an later
+  // node in the graph output list. So we should sort the output name according
+  // to the graph output names
+  std::vector<std::string> output_names;
+  std::unordered_set<std::string> graph_out_names;
+  for (const auto& output : outputs) {
+    if (output.second->Exists()) {
+      auto name = output.second->Name();
+      if (std::find(graph_output_names.begin(), graph_output_names.end(), name) == graph_output_names.end()) {
+        output_names.push_back(name);
+      } else {
+        graph_out_names.insert(name);
+      }
+    }
+  }
+
+  for (auto& name : graph_output_names) {
+    if (std::find(graph_out_names.begin(), graph_out_names.end(), name) != graph_out_names.end())
+      output_names.push_back(name);
+  }
+
+  // Generate unique kernel name for CANN subgraph
+  HashValue model_hash = 0;
+  int id = GenerateMetaDefId(graph_viewer, model_hash);
+  auto meta_def = IndexedSubGraph_MetaDef::Create();
+  meta_def->name() = graph_viewer.Name() + "_" + std::to_string(model_hash) + "_" + std::to_string(id);
+
+  // Assign inputs and outputs to subgraph's meta_def
+  for (const auto& input : inputs) {
+    if (input.second->Exists()) {
+      meta_def->inputs().push_back(input.second->Name());
+    }
+  }
+
+  for (const auto& output : output_names) {
+    meta_def->outputs().push_back(output);
+  }
+
+  meta_def->domain() = kMSDomain;
+  meta_def->since_version() = 1;
+  sub_graph->SetMetaDef(std::move(meta_def));
+
+  return sub_graph;
+}
+
+std::vector<std::vector<NodeIndex>>
+GetSubGraphPartition(const std::vector<NodeIndex>& topological_order, const std::vector<NodeIndex>& unsupported_nodes) {
+  std::vector<std::vector<NodeIndex>> partitions;
+
+  if (topological_order.size() == unsupported_nodes.size())
+    return partitions;
+
+  auto prev = topological_order.begin();
+  for (const auto& node : unsupported_nodes) {
+    auto next = std::find(prev, topological_order.end(), node);
+    std::vector<NodeIndex> partition{prev, next};
+    if (!partition.empty()) {
+      partitions.push_back(std::move(partition));
+    }
+
+    prev = ++next;
+  }
+
+  std::vector<NodeIndex> partition{prev, topological_order.end()};
+  if (!partition.empty()) {
+    partitions.push_back(std::move(partition));
+  }
+
+  return partitions;
+}
+
+std::vector<std::unique_ptr<ComputeCapability>>
+CANNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer,
+                                     const IKernelLookup& kernel_lookup) const {
+  std::vector<std::unique_ptr<ComputeCapability>> result;
+
+  // TODO(FFFrog): Feature Enhancement
+  // After the subgraph is divided, the remaining single operators should first fall back to
+  // the single operator operation mode of CANN
+  if (info_.enable_cann_graph) {
+    std::vector<NodeIndex>&& unsupported_nodes = SupportONNXModel(graph_viewer);
+
+    if (unsupported_nodes.empty()) {
+      auto sub_graph = GetSubGraph(graph_viewer.GetNodesInTopologicalOrder(), graph_viewer);
+      result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+    } else {
+      auto partitions = GetSubGraphPartition(graph_viewer.GetNodesInTopologicalOrder(), unsupported_nodes);
+
+      for (const auto& partition : partitions) {
+        auto sub_graph = GetSubGraph(partition, graph_viewer);
+        result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+      }
+    }
+  } else {
+    InlinedVector<NodeIndex> candidates;
+
+    for (auto& node_index : graph_viewer.GetNodesInTopologicalOrder()) {
+      const auto* p_node = graph_viewer.GetNode(node_index);
+      if (p_node == nullptr)
+        continue;
+
+      const auto& node = *p_node;
+      if (!node.GetExecutionProviderType().empty()) {
+        continue;
+      }
+
+      const KernelCreateInfo* cann_kernel_def = kernel_lookup.LookUpKernel(node);
+      if (cann_kernel_def == nullptr) {
+        LOGS_DEFAULT(INFO) << "CANN kernel not found in registries for Op type: " << node.OpType()
+                           << " node name: " << node.Name();
+        continue;
+      }
+
+      candidates.push_back(node.Index());
+    }
+
+    auto cpu_nodes = GetCpuPreferredNodes(graph_viewer, kernel_lookup, candidates);
+    for (auto& node_index : candidates) {
+      if (cpu_nodes.count(node_index) > 0)
+        continue;
+
+      auto sub_graph = IndexedSubGraph::Create();
+      sub_graph->Nodes().push_back(node_index);
+      result.push_back(ComputeCapability::Create(std::move(sub_graph)));
+    }
   }
 
   return result;
+}
+
+Status CANNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
+                                      std::vector<NodeComputeInfo>& node_compute_funcs) {
+  for (const auto& fused_node_graph : fused_nodes_and_graphs) {
+    const GraphViewer& graph_body_viewer = fused_node_graph.filtered_graph;
+    const Node& fused_node = fused_node_graph.fused_node;
+
+    const std::string node_name = fused_node.Name();
+
+    std::unordered_map<size_t, std::string> names2index;
+    const auto& input_defs = fused_node.InputDefs();
+    names2index.reserve(input_defs.size());
+    for (size_t i = 0, end = input_defs.size(); i < end; ++i) {
+      names2index[i] = input_defs[i]->Name();
+    }
+    names_[node_name] = names2index;
+
+    std::string string_model;
+    auto model = graph_body_viewer.CreateModel(*GetLogger(), true);
+    auto model_proto = model->ToProto();
+    graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true);
+    model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+    model_proto->SerializeToString(string_model);
+    models_[node_name] = string_model;
+
+    NodeComputeInfo compute_info;
+    compute_info.create_state_func = [=](ComputeContext* context, FunctionState* state) {
+      std::unique_ptr<CannFuncState> p = std::make_unique<CannFuncState>();
+      *p = {context->allocate_func, context->release_func, context->allocator_handle, context->node_name};
+      *state = p.release();
+      return 0;
+    };
+
+    compute_info.release_state_func = [](FunctionState state) {
+      if (state)
+        delete static_cast<CannFuncState*>(state);
+    };
+
+    compute_info.compute_func = [this](FunctionState state, const OrtApi* /* api */, OrtKernelContext* context) {
+      Ort::KernelContext ctx(context);
+
+      CannFuncState* cann_state = reinterpret_cast<CannFuncState*>(state);
+      std::string& string_model = models_[cann_state->node_name];
+      std::unordered_map<size_t, std::string>& names2index = names_[cann_state->node_name];
+
+      std::string input_shape = [&ctx, &names2index]() -> std::string {
+        std::string res;
+        for (size_t i = 0; i < ctx.GetInputCount(); i++) {
+          auto&& shape = ctx.GetInput(i).GetTensorTypeAndShapeInfo().GetShape();
+          auto name = names2index[i];
+
+          std::string s = name + ":";
+          for (auto& d : shape) {
+            s += std::to_string(d) + ",";
+          }
+          s[s.length() - 1] = ';';
+          res += s;
+        }
+
+        return res.substr(0, res.length() - 1);
+      }();
+
+      // Since the name of the input tensor of the sub-graph may exceed the maximum length required by Linux,
+      // and may also contain various special characters, such as "/". So, it is reasonable to convert it to HashValue.
+      HashValue hash;
+      cann::GenerateHashValue(input_shape, hash);
+      std::string filename = cann_state->node_name + "_" + std::to_string(hash);
+      std::string filename_with_suffix = filename + ".om";
+
+      uint32_t modelID;
+      {
+        std::lock_guard<OrtMutex> lock(g_mutex);
+
+        if (cann::FileExist(filename_with_suffix)) {
+          CANN_RETURN_IF_ERROR(aclmdlLoadFromFile(filename_with_suffix.c_str(), &modelID));
+        } else {
+          ge::Graph graph{cann_state->node_name.c_str()};
+          ORT_RETURN_IF_ERROR(ParserONNXModel(string_model, graph));
+
+          ge::ModelBufferData model;
+          ORT_RETURN_IF_ERROR(BuildONNXModel(graph, input_shape, soc_name_, filename, model));
+
+          CANN_RETURN_IF_ERROR(aclmdlLoadFromMem(model.data.get(), model.length, &modelID));
+        }
+      }
+
+      CannModelPreparation prepare(modelID);
+
+      ORT_TRY {
+        for (size_t i = 0; i < aclmdlGetNumInputs(prepare.modelDesc_); i++) {
+          auto input = ctx.GetInput(i);
+          CANN_MODEL_PREPARE_INPUTBUFFER(prepare,
+                                         const_cast<void*>(input.GetTensorRawData()),
+                                         aclmdlGetInputSizeByIndex(prepare.modelDesc_, i));
+        }
+
+        for (size_t i = 0; i < aclmdlGetNumOutputs(prepare.modelDesc_); i++) {
+          aclmdlIODims dims;
+          CANN_CALL_THROW(aclmdlGetOutputDims(prepare.modelDesc_, i, &dims));
+          std::vector<int64_t> vec{dims.dims, dims.dims + dims.dimCount};
+          auto output = ctx.GetOutput(i, vec);
+          CANN_MODEL_PREPARE_OUTPUTBUFFER(prepare,
+                                          const_cast<void*>(output.GetTensorRawData()),
+                                          aclmdlGetOutputSizeByIndex(prepare.modelDesc_, i));
+        }
+      }
+      ORT_CATCH(const std::exception& e) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what());
+      }
+
+      CANN_RETURN_IF_ERROR(aclmdlExecuteAsync(modelID, prepare.inputSet_, prepare.outputSet_, stream_));
+
+      return Status::OK();
+    };
+
+    node_compute_funcs.push_back(compute_info);
+  }
+
+  return Status::OK();
 }
 
 AllocatorPtr CANNExecutionProvider::GetAllocator(int id, OrtMemType mem_type) const {

--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -21,9 +21,9 @@
 #include "core/providers/cann/npu_data_transfer.h"
 
 using onnxruntime::cann::BuildONNXModel;
-using onnxruntime::cann::CannModelPreparation;
 using onnxruntime::cann::ParserONNXModel;
 using onnxruntime::cann::SupportONNXModel;
+using onnxruntime::cann::CannModelPreparation;
 using onnxruntime::common::Status;
 
 namespace onnxruntime {
@@ -1315,7 +1315,7 @@ Status CANNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fuse
     names_[node_name] = names2index;
 
     std::string string_model;
-    auto model = graph_body_viewer.CreateModel(*GetLogger(), true);
+    auto model = cann::CreateModel(graph_body_viewer, *GetLogger());
     auto model_proto = model->ToProto();
     graph_body_viewer.ToProto(*model_proto->mutable_graph(), true, true);
     model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);

--- a/onnxruntime/core/providers/cann/cann_execution_provider.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.h
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <memory>
-#include <set>
 #include <vector>
+#include <string>
+#include <unordered_map>
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/framework/allocatormgr.h"
@@ -16,8 +17,17 @@
 #include "core/providers/cann/cann_execution_provider_info.h"
 #include "core/providers/cann/cann_inc.h"
 #include "core/providers/cann/cann_utils.h"
+#include "core/providers/cann/cann_graph.h"
 
 namespace onnxruntime {
+
+// Information to construct kernel function state.
+struct CannFuncState {
+  AllocateFunc allocate_func = nullptr;
+  DestroyFunc release_func = nullptr;
+  AllocatorHandle allocate_handle = nullptr;
+  std::string node_name;
+};
 
 class CANNExecutionProvider : public IExecutionProvider {
  public:
@@ -59,9 +69,16 @@ class CANNExecutionProvider : public IExecutionProvider {
   std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
   std::unique_ptr<onnxruntime::IDataTransfer> GetDataTransfer() const override;
 
+  std::unique_ptr<IndexedSubGraph> GetSubGraph(
+      const std::vector<std::size_t>& graph_nodes_index,
+      const GraphViewer& graph_viewer) const;
+
   std::vector<std::unique_ptr<ComputeCapability>> GetCapability(
-      const onnxruntime::GraphViewer& graph,
+      const onnxruntime::GraphViewer& graph_viewer,
       const IKernelLookup& kernel_lookup) const override;
+
+  Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
+                 std::vector<NodeComputeInfo>& node_compute_funcs) override;
 
   ProviderOptions GetProviderOptions() const override {
     return CANNExecutionProviderInfo::ToProviderOptions(info_);
@@ -73,6 +90,10 @@ class CANNExecutionProvider : public IExecutionProvider {
  private:
   CANNExecutionProviderInfo info_;
   aclrtStream stream_ = nullptr;
+  const char* soc_name_ = nullptr;
+
+  std::unordered_map<std::string, std::string> models_;
+  std::unordered_map<std::string, std::unordered_map<std::size_t, std::string>> names_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider_info.cc
@@ -3,10 +3,10 @@
 // Licensed under the MIT License.
 
 #include <string>
+
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cann/cann_execution_provider_info.h"
 #include "core/providers/cann/cann_provider_options.h"
-
 #include "core/common/make_string.h"
 #include "core/common/parse_string.h"
 #include "core/framework/provider_options_utils.h"
@@ -19,17 +19,16 @@ namespace provider_option_names {
 constexpr const char* kDeviceId = "device_id";
 constexpr const char* kMemLimit = "npu_mem_limit";
 constexpr const char* kArenaExtendStrategy = "arena_extend_strategy";
-constexpr const char* kMaxOpqueueNum = "max_opqueue_num";
 constexpr const char* kDoCopyInDefaultStream = "do_copy_in_default_stream";
+constexpr const char* kEnableCannGraph = "enable_cann_graph";
 }  // namespace provider_option_names
 }  // namespace cann
 
 namespace {
-const DeleteOnUnloadPtr<EnumNameMapping<ArenaExtendStrategy>> arena_extend_strategy_mapping =
-    new EnumNameMapping<ArenaExtendStrategy>{
-        {ArenaExtendStrategy::kNextPowerOfTwo, "kNextPowerOfTwo"},
-        {ArenaExtendStrategy::kSameAsRequested, "kSameAsRequested"},
-    };
+const EnumNameMapping<ArenaExtendStrategy> arena_extend_strategy_mapping{
+    {ArenaExtendStrategy::kNextPowerOfTwo, "kNextPowerOfTwo"},
+    {ArenaExtendStrategy::kSameAsRequested, "kSameAsRequested"},
+};
 }  // namespace
 
 CANNExecutionProviderInfo CANNExecutionProviderInfo::FromProviderOptions(const ProviderOptions& options) {
@@ -50,12 +49,12 @@ CANNExecutionProviderInfo CANNExecutionProviderInfo::FromProviderOptions(const P
                     ", must be between 0 (inclusive) and ", num_devices, " (exclusive).");
                 return Status::OK();
               })
-          .AddAssignmentToReference(cann::provider_option_names::kMaxOpqueueNum, info.max_opqueue_num)
           .AddAssignmentToReference(cann::provider_option_names::kMemLimit, info.npu_mem_limit)
           .AddAssignmentToEnumReference(
               cann::provider_option_names::kArenaExtendStrategy,
-              *arena_extend_strategy_mapping, info.arena_extend_strategy)
+              arena_extend_strategy_mapping, info.arena_extend_strategy)
           .AddAssignmentToReference(cann::provider_option_names::kDoCopyInDefaultStream, info.do_copy_in_default_stream)
+          .AddAssignmentToReference(cann::provider_option_names::kEnableCannGraph, info.enable_cann_graph)
           .Parse(options));
   return info;
 }
@@ -65,10 +64,10 @@ ProviderOptions CANNExecutionProviderInfo::ToProviderOptions(const CANNExecution
       {cann::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
       {cann::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.npu_mem_limit)},
       {cann::provider_option_names::kArenaExtendStrategy,
-       EnumToName(*arena_extend_strategy_mapping, info.arena_extend_strategy)},
+       EnumToName(arena_extend_strategy_mapping, info.arena_extend_strategy)},
       {cann::provider_option_names::kDoCopyInDefaultStream,
        MakeStringWithClassicLocale(info.do_copy_in_default_stream)},
-      {cann::provider_option_names::kMaxOpqueueNum, MakeStringWithClassicLocale(info.max_opqueue_num)}};
+      {cann::provider_option_names::kEnableCannGraph, MakeStringWithClassicLocale(info.enable_cann_graph)}};
   return options;
 }
 
@@ -77,10 +76,10 @@ ProviderOptions CANNExecutionProviderInfo::ToProviderOptions(const OrtCANNProvid
       {cann::provider_option_names::kDeviceId, MakeStringWithClassicLocale(info.device_id)},
       {cann::provider_option_names::kMemLimit, MakeStringWithClassicLocale(info.npu_mem_limit)},
       {cann::provider_option_names::kArenaExtendStrategy,
-       EnumToName(*arena_extend_strategy_mapping, ArenaExtendStrategy(info.arena_extend_strategy))},
+       EnumToName(arena_extend_strategy_mapping, ArenaExtendStrategy(info.arena_extend_strategy))},
       {cann::provider_option_names::kDoCopyInDefaultStream,
        MakeStringWithClassicLocale(info.do_copy_in_default_stream)},
-      {cann::provider_option_names::kMaxOpqueueNum, MakeStringWithClassicLocale(info.max_opqueue_num)}};
+      {cann::provider_option_names::kEnableCannGraph, MakeStringWithClassicLocale(info.enable_cann_graph)}};
   return options;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_execution_provider_info.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider_info.h
@@ -14,10 +14,10 @@
 namespace onnxruntime {
 struct CANNExecutionProviderInfo {
   OrtDevice::DeviceId device_id{0};
-  int max_opqueue_num{10000};
   size_t npu_mem_limit{std::numeric_limits<size_t>::max()};
   ArenaExtendStrategy arena_extend_strategy{ArenaExtendStrategy::kNextPowerOfTwo};
   bool do_copy_in_default_stream{true};
+  bool enable_cann_graph{true};
   OrtArenaCfg* default_memory_arena_cfg{nullptr};
 
   static CANNExecutionProviderInfo FromProviderOptions(const ProviderOptions& options);

--- a/onnxruntime/core/providers/cann/cann_graph.cc
+++ b/onnxruntime/core/providers/cann/cann_graph.cc
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#include <map>
+#include <set>
+
+#include "core/providers/cann/cann_graph.h"
+
+namespace onnxruntime {
+namespace cann {
+
+/**
+ * This function will been changed with the evolution of ONNX and CANN
+ * and will be replaced by the corresponding API provided by CANN in the future, probably.
+ **/
+std::vector<NodeIndex> SupportONNXModel(const GraphViewer& graph_viewer) {
+  static std::set<std::string> cann_supported_ops = {
+      "Abs", "Acos", "Acosh", "Add",
+      "And", "ArgMax", "ArgMin", "Asin",
+      "Asinh", "Atan", "Atanh", "AveragePool",
+      "BatchNormalization", "BitShift", "Cast", "Ceil",
+      "Celu", "Clip", "Compress", "Concat",
+      "Constant", "ConstantOfShape", "Conv", "ConvTranspose",
+      "Cos", "Cosh", "CumSum", "DepthToSpace",
+      "Det", "Div", "Dropout", "Elu",
+      "Equal", "Erf", "Exp", "Expand",
+      "EyeLike", "Flatten", "Floor", "Gather",
+      "GatherElements", "GatherND", "Gemm", "GlobalAveragePool",
+      "GlobalLpPool", "GlobalMaxPool", "Greater", "GreaterOrEqual",
+      "Hardmax", "HardSigmoid", "HardSwish", "Identity",
+      "If", "InstanceNormalization", "LeakyRelu", "Less",
+      "LessOrEqual", "Log", "LogSoftmax", "LpNormalization",
+      "LpPool", "LRN", "LSTM", "MatMul",
+      "Max", "MaxPool", "MaxRoiPool", "MaxUnpool",
+      "Mean", "MeanVarianceNormalization", "Min", "Mod",
+      "Mul", "Multinomial", "Neg", "NonMaxSuppression",
+      "NonZero", "Not", "OneHot", "Or",
+      "Pad", "Pow", "PRelu", "RandomNormalLike",
+      "RandomUniform", "RandomUniformLike", "Range", "Reciprocal",
+      "ReduceL1", "ReduceL2", "ReduceLogSum", "ReduceLogSumExp",
+      "ReduceMax", "ReduceMean", "ReduceMin", "ReduceProd",
+      "ReduceSum", "ReduceSumSquare", "Relu", "Reshape",
+      "Resize", "ReverseSequence", "RoiAlign", "Round",
+      "Scatter", "ScatterElements", "ScatterND", "Selu",
+      "Shape", "Shrink", "Sigmoid", "Sign",
+      "Sin", "Sinh", "Size", "Slice",
+      "Softmax", "SoftmaxCrossEntropyLoss", "Softplus", "Softsign",
+      "SpaceToDepth", "Split", "Sqrt", "Squeeze",
+      "Sub", "Sum", "Tanh", "TfIdfVectorizer",
+      "ThresholdedRelu", "Tile", "TopK", "Transpose",
+      "Unsqueeze", "Where", "Xor"};
+
+  std::vector<NodeIndex> unsupported_nodes;
+
+  int domain_version = graph_viewer.DomainToVersionMap().at(kOnnxDomain);
+  if (domain_version < 8 || domain_version > 15) {
+    return graph_viewer.GetNodesInTopologicalOrder();
+  }
+
+  // When the ONNX model is converted into an OM model, the Constant node will be automatically removed,
+  // Therefore, the Constant nodes must be run on single operator inference mode.
+  for (const auto& index : graph_viewer.GetNodesInTopologicalOrder()) {
+    const auto& node = graph_viewer.GetNode(index);
+
+    if (!cann_supported_ops.count(node->OpType())) {
+      unsupported_nodes.push_back(index);
+      continue;
+    }
+
+    bool is_all_constant = true;
+    for (const auto& input : node->InputDefs()) {
+      if (!graph_viewer.GetAllInitializedTensors().count(input->Name())) {
+        is_all_constant = false;
+        break;
+      }
+    }
+    if (is_all_constant) {
+      unsupported_nodes.push_back(index);
+    }
+  }
+
+  return unsupported_nodes;
+}
+
+Status ParserONNXModel(std::string string_model, ge::Graph& graph) {
+  std::map<ge::AscendString, ge::AscendString> parser_params;
+  CANN_GRAPH_RETURN_IF_ERROR(ge::aclgrphParseONNXFromMem(string_model.data(),
+                                                         string_model.size(),
+                                                         parser_params,
+                                                         graph));
+
+  return Status::OK();
+}
+
+Status BuildONNXModel(ge::Graph& graph, std::string input_shape, const char* soc_name, std::string file_name,
+                      ge::ModelBufferData& model) {
+  std::map<ge::AscendString, ge::AscendString> options;
+
+  options.emplace(ge::ir_option::SOC_VERSION, soc_name);
+  CANN_GRAPH_RETURN_IF_ERROR(ge::aclgrphBuildInitialize(options));
+
+  options.clear();
+  options.emplace(ge::ir_option::INPUT_SHAPE, input_shape.c_str());
+  CANN_GRAPH_RETURN_IF_ERROR(ge::aclgrphBuildModel(graph, options, model));
+
+  CANN_GRAPH_RETURN_IF_ERROR(ge::aclgrphSaveModel(file_name.c_str(), model));
+
+  ge::aclgrphBuildFinalize();
+
+  return Status::OK();
+}
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_graph.h
+++ b/onnxruntime/core/providers/cann/cann_graph.h
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Huawei. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <vector>
+#include <utility>
+#include <iomanip>
+#include <string>
+
+#include "core/providers/cann/cann_common.h"
+#include "core/providers/cann/cann_inc.h"
+#include "core/providers/cann/cann_utils.h"
+
+namespace onnxruntime {
+namespace cann {
+
+struct CannModelPreparation {
+  explicit CannModelPreparation(uint32_t modelID) {
+    modelDesc_ = aclmdlCreateDesc();
+    CANN_CALL_THROW(aclmdlGetDesc(modelDesc_, modelID));
+
+    inputSet_ = aclmdlCreateDataset();
+    outputSet_ = aclmdlCreateDataset();
+  }
+
+  virtual ~CannModelPreparation() {
+    CANN_CALL_THROW(aclmdlDestroyDesc(modelDesc_));
+
+    CANN_CALL_THROW(aclmdlDestroyDataset(inputSet_));
+    CANN_CALL_THROW(aclmdlDestroyDataset(outputSet_));
+
+    for (auto buf : inputBuffers_) {
+      CANN_CALL_THROW(aclDestroyDataBuffer(buf));
+    }
+
+    for (auto buf : outputBuffers_) {
+      CANN_CALL_THROW(aclDestroyDataBuffer(buf));
+    }
+  }
+
+  std::vector<aclDataBuffer*> inputBuffers_;
+  std::vector<aclDataBuffer*> outputBuffers_;
+  aclmdlDataset* inputSet_;
+  aclmdlDataset* outputSet_;
+  aclmdlDesc* modelDesc_;
+};
+
+#define CANN_MODEL_PREPARE_INPUTBUFFER(var, ...)    \
+  do {                                              \
+    auto _rPtr = aclCreateDataBuffer(__VA_ARGS__);  \
+    if (_rPtr == nullptr) {                         \
+      ORT_THROW("aclCreateDataBuffer run failed");  \
+    } else {                                        \
+      var.inputBuffers_.push_back(_rPtr);           \
+      aclmdlAddDatasetBuffer(var.inputSet_, _rPtr); \
+    }                                               \
+  } while (0)
+
+#define CANN_MODEL_PREPARE_OUTPUTBUFFER(var, ...)    \
+  do {                                               \
+    auto _rPtr = aclCreateDataBuffer(__VA_ARGS__);   \
+    if (_rPtr == nullptr) {                          \
+      ORT_THROW("aclCreateDataBuffer run failed");   \
+    } else {                                         \
+      var.outputBuffers_.push_back(_rPtr);           \
+      aclmdlAddDatasetBuffer(var.outputSet_, _rPtr); \
+    }                                                \
+  } while (0)
+
+std::vector<NodeIndex> SupportONNXModel(const GraphViewer& graph_viewer);
+Status ParserONNXModel(std::string string_model, ge::Graph& graph);
+Status BuildONNXModel(ge::Graph& graph, std::string input_shape, const char* soc_name, std::string file_name,
+                      ge::ModelBufferData& model);
+
+}  // namespace cann
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_inc.h
+++ b/onnxruntime/core/providers/cann/cann_inc.h
@@ -7,3 +7,6 @@
 #include <acl/acl.h>
 #include <acl/acl_op_compiler.h>
 #include <acl/ops/acl_cblas.h>
+#include <ge/ge_ir_build.h>
+#include <ge/ge_api_types.h>
+#include <parser/onnx_parser.h>

--- a/onnxruntime/core/providers/cann/cann_provider_factory.cc
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.cc
@@ -51,10 +51,10 @@ struct CANN_Provider : Provider {
 
     CANNExecutionProviderInfo info{};
     info.device_id = static_cast<OrtDevice::DeviceId>(params->device_id);
-    info.max_opqueue_num = params->max_opqueue_num;
     info.npu_mem_limit = params->npu_mem_limit;
     info.arena_extend_strategy = params->arena_extend_strategy;
     info.do_copy_in_default_stream = params->do_copy_in_default_stream != 0;
+    info.enable_cann_graph = params->enable_cann_graph != 0;
     info.default_memory_arena_cfg = params->default_memory_arena_cfg;
 
     return std::make_shared<CANNProviderFactory>(info);
@@ -65,10 +65,10 @@ struct CANN_Provider : Provider {
     auto& cann_options = *reinterpret_cast<OrtCANNProviderOptions*>(provider_options);
 
     cann_options.device_id = internal_options.device_id;
-    cann_options.max_opqueue_num = internal_options.max_opqueue_num;
     cann_options.npu_mem_limit = internal_options.npu_mem_limit;
     cann_options.arena_extend_strategy = internal_options.arena_extend_strategy;
     cann_options.do_copy_in_default_stream = internal_options.do_copy_in_default_stream;
+    cann_options.enable_cann_graph = internal_options.enable_cann_graph;
     cann_options.default_memory_arena_cfg = internal_options.default_memory_arena_cfg;
   }
 

--- a/onnxruntime/core/providers/cann/cann_utils.cc
+++ b/onnxruntime/core/providers/cann/cann_utils.cc
@@ -2,8 +2,9 @@
 // Copyright (c) Huawei. All rights reserved.
 // Licensed under the MIT License.
 
+#include <unistd.h>
+
 #include "core/providers/cann/cann_utils.h"
-#include <iostream>
 
 namespace onnxruntime {
 namespace cann {
@@ -210,6 +211,16 @@ Status aclrtblasGemmEx(aclTransType transA,
                                               stream));
 
   return Status::OK();
+}
+
+bool FileExist(const std::string& file_name) {
+  return (access(file_name.c_str(), F_OK) != -1);
+}
+
+void GenerateHashValue(const std::string string, HashValue& hash_value) {
+  uint32_t hash[4] = {0, 0, 0, 0};
+  MurmurHash3::x86_128(string.data(), gsl::narrow_cast<int32_t>(string.size()), hash[0], &hash);
+  hash_value = hash[0] | (uint64_t(hash[1]) << 32);
 }
 
 }  // namespace cann

--- a/onnxruntime/core/providers/cann/cann_utils.h
+++ b/onnxruntime/core/providers/cann/cann_utils.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <iomanip>
 #include <string>
+#include <memory>
 
 #include "core/framework/murmurhash3.h"
 #include "core/providers/cann/cann_common.h"
@@ -123,6 +124,7 @@ Status aclrtblasGemmEx(aclTransType transA,
 
 bool FileExist(const std::string& file_name);
 void GenerateHashValue(const std::string string, HashValue& hash_value);
+std::unique_ptr<Model> CreateModel(const GraphViewer& graph_viewer, const logging::Logger& logger);
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cann/cann_utils.h
+++ b/onnxruntime/core/providers/cann/cann_utils.h
@@ -7,6 +7,9 @@
 #include <vector>
 #include <utility>
 #include <iomanip>
+#include <string>
+
+#include "core/framework/murmurhash3.h"
 #include "core/providers/cann/cann_common.h"
 #include "core/providers/cann/cann_inc.h"
 
@@ -16,6 +19,7 @@ namespace cann {
 struct CannPreparation {
   CannPreparation() {
     opAttr_ = aclopCreateAttr();
+    ORT_ENFORCE(opAttr_ != nullptr, "aclopCreateAttr run failed");
   }
 
   virtual ~CannPreparation() {
@@ -28,11 +32,11 @@ struct CannPreparation {
     }
 
     for (auto buf : inputBuffers_) {
-      aclDestroyDataBuffer(buf);
+      CANN_CALL_THROW(aclDestroyDataBuffer(buf));
     }
 
     for (auto buf : outputBuffers_) {
-      aclDestroyDataBuffer(buf);
+      CANN_CALL_THROW(aclDestroyDataBuffer(buf));
     }
 
     aclopDestroyAttr(opAttr_);
@@ -116,6 +120,9 @@ Status aclrtblasGemmEx(aclTransType transA,
                        aclDataType dataTypeC,
                        aclComputeType type,
                        aclrtStream stream);
+
+bool FileExist(const std::string& file_name);
+void GenerateHashValue(const std::string string, HashValue& hash_value);
 
 }  // namespace cann
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -677,5 +677,11 @@ RandomGenerator& RandomGenerator::Default() { return g_host->RandomGenerator__De
 void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
   return g_host->MurmurHash3__x86_128(key, len, seed, out);
 }
+
+namespace cann {
+std::unique_ptr<Model> CreateModel(const GraphViewer& graph_viewer, const logging::Logger& logger) {
+  return g_host->cann__CreateModel(graph_viewer, logger);
+}
+}  // namespace cann
 #endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -9,6 +9,7 @@
 #include "core/providers/shared/common.h"
 
 #include "core/common/inlined_containers.h"
+#include "core/framework/murmurhash3.h"
 #include "core/framework/random_generator.h"
 #include "core/providers/cpu/controlflow/if.h"
 #include "core/providers/cpu/controlflow/loop.h"
@@ -673,5 +674,8 @@ void RefCountTracker::DumpDetails(const std::string& phase_name) const {
 
 #if defined(USE_CANN)
 RandomGenerator& RandomGenerator::Default() { return g_host->RandomGenerator__Default(); }
+void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
+  return g_host->MurmurHash3__x86_128(key, len, seed, out);
+}
 #endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -674,7 +674,7 @@ struct ProviderHost {
 
   // GraphViewer
   virtual void GraphViewer__operator_delete(GraphViewer* p) = 0;
-  virtual std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* p, const logging::Logger& logger) = 0;
+  virtual std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* p, const logging::Logger& logger, bool is_domain_onnx_only) = 0;
 
   virtual const std::string& GraphViewer__Name(const GraphViewer* p) noexcept = 0;
   virtual const Path& GraphViewer__ModelPath(const GraphViewer* p) noexcept = 0;
@@ -875,6 +875,7 @@ struct ProviderHost {
 
 #if defined(USE_CANN)
   virtual RandomGenerator& RandomGenerator__Default() = 0;
+  virtual void MurmurHash3__x86_128(const void* key, int len, uint32_t seed, void* out) = 0;
 #endif
 
   virtual ProviderHostCPU& GetProviderHostCPU() = 0;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -674,7 +674,7 @@ struct ProviderHost {
 
   // GraphViewer
   virtual void GraphViewer__operator_delete(GraphViewer* p) = 0;
-  virtual std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* p, const logging::Logger& logger, bool is_domain_onnx_only) = 0;
+  virtual std::unique_ptr<Model> GraphViewer__CreateModel(const GraphViewer* p, const logging::Logger& logger) = 0;
 
   virtual const std::string& GraphViewer__Name(const GraphViewer* p) noexcept = 0;
   virtual const Path& GraphViewer__ModelPath(const GraphViewer* p) noexcept = 0;
@@ -876,6 +876,7 @@ struct ProviderHost {
 #if defined(USE_CANN)
   virtual RandomGenerator& RandomGenerator__Default() = 0;
   virtual void MurmurHash3__x86_128(const void* key, int len, uint32_t seed, void* out) = 0;
+  virtual std::unique_ptr<Model> cann__CreateModel(const GraphViewer& graph_viewer, const logging::Logger& logger) = 0;
 #endif
 
   virtual ProviderHostCPU& GetProviderHostCPU() = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -709,7 +709,7 @@ struct Graph final {
 struct GraphViewer final {
   static void operator delete(void* p) { g_host->GraphViewer__operator_delete(reinterpret_cast<GraphViewer*>(p)); }
 
-  std::unique_ptr<Model> CreateModel(const logging::Logger& logger) const { return g_host->GraphViewer__CreateModel(this, logger); }
+  std::unique_ptr<Model> CreateModel(const logging::Logger& logger, bool is_onnx_domain_only = false) const { return g_host->GraphViewer__CreateModel(this, logger, is_onnx_domain_only); }
 
   const std::string& Name() const noexcept { return g_host->GraphViewer__Name(this); }
   const Path& ModelPath() const noexcept { return g_host->GraphViewer__ModelPath(this); }

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -709,7 +709,7 @@ struct Graph final {
 struct GraphViewer final {
   static void operator delete(void* p) { g_host->GraphViewer__operator_delete(reinterpret_cast<GraphViewer*>(p)); }
 
-  std::unique_ptr<Model> CreateModel(const logging::Logger& logger, bool is_onnx_domain_only = false) const { return g_host->GraphViewer__CreateModel(this, logger, is_onnx_domain_only); }
+  std::unique_ptr<Model> CreateModel(const logging::Logger& logger) const { return g_host->GraphViewer__CreateModel(this, logger); }
 
   const std::string& Name() const noexcept { return g_host->GraphViewer__Name(this); }
   const Path& ModelPath() const noexcept { return g_host->GraphViewer__ModelPath(this); }

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,7 @@ try:
                 to_preload = []
                 to_preload_cuda = []
                 to_preload_tensorrt = []
+                to_preload_cann = []
                 cuda_dependencies = []
                 args = ["patchelf", "--debug"]
                 for line in result.stdout.split("\n"):
@@ -258,6 +259,26 @@ try:
                     if len(args) > 3:
                         subprocess.run(args, check=True, stdout=subprocess.PIPE)
 
+                dest = "onnxruntime/capi/libonnxruntime_providers_cann.so"
+                if path.isfile(dest):
+                    result = subprocess.run(
+                        ["patchelf", "--print-needed", dest],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        universal_newlines=True,
+                    )
+                    cann_dependencies = ["libascendcl.so", "libacl_op_compiler.so", "libfmk_onnx_parser.so"]
+                    args = ["patchelf", "--debug"]
+                    for line in result.stdout.split("\n"):
+                        for dependency in cann_dependencies:
+                            if dependency in line:
+                                if dependency not in to_preload:
+                                    to_preload_cann.append(line)
+                                args.extend(["--remove-needed", line])
+                    args.append(dest)
+                    if len(args) > 3:
+                        subprocess.run(args, check=True, stdout=subprocess.PIPE)
+
                 dest = "onnxruntime/capi/libonnxruntime_providers_openvino.so"
                 if path.isfile(dest):
                     subprocess.run(
@@ -270,6 +291,7 @@ try:
                 self._rewrite_ld_preload(to_preload)
                 self._rewrite_ld_preload_cuda(to_preload_cuda)
                 self._rewrite_ld_preload_tensorrt(to_preload_tensorrt)
+                self._rewrite_ld_preload(to_preload_cann)
             _bdist_wheel.run(self)
             if is_manylinux and not disable_auditwheel_repair and not is_openvino:
                 assert self.dist_dir is not None
@@ -299,6 +321,7 @@ class InstallCommand(InstallCommandBase):
 providers_cuda_or_rocm = "libonnxruntime_providers_" + ("rocm.so" if is_rocm else "cuda.so")
 providers_tensorrt_or_migraphx = "libonnxruntime_providers_" + ("migraphx.so" if is_rocm else "tensorrt.so")
 providers_openvino = "libonnxruntime_providers_openvino.so"
+providers_cann = "libonnxruntime_providers_cann.so"
 
 # Additional binaries
 dl_libs = []
@@ -316,12 +339,14 @@ if platform.system() == "Linux":
     dl_libs = ["libonnxruntime_providers_shared.so"]
     dl_libs.append(providers_cuda_or_rocm)
     dl_libs.append(providers_tensorrt_or_migraphx)
+    dl_libs.append(providers_cann)
     # DNNL, TensorRT & OpenVINO EPs are built as shared libs
     libs.extend(["libonnxruntime_providers_shared.so"])
     libs.extend(["libonnxruntime_providers_dnnl.so"])
     libs.extend(["libonnxruntime_providers_openvino.so"])
     libs.append(providers_cuda_or_rocm)
     libs.append(providers_tensorrt_or_migraphx)
+    libs.append(providers_cann)
     if nightly_build:
         libs.extend(["libonnxruntime_pywrapper.so"])
 elif platform.system() == "Darwin":

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1964,9 +1964,9 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                 onnx_test = False
 
             if onnx_test:
-                # Disable python onnx tests for TensorRT because many tests are
+                # Disable python onnx tests for TensorRT and CANN EP, because many tests are
                 # not supported yet.
-                if args.use_tensorrt:
+                if args.use_tensorrt or args.use_cann:
                     return
 
                 run_subprocess(
@@ -2009,11 +2009,6 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                 )
 
                 if not args.skip_onnx_tests:
-                    # Disable python onnx tests for CANN EP, because many tests are
-                    # not supported yet.
-                    if args.use_cann:
-                        return
-
                     run_subprocess([os.path.join(cwd, "onnx_test_runner"), "test_models"], cwd=cwd)
                     if config != "Debug":
                         run_subprocess([sys.executable, "onnx_backend_test_series.py"], cwd=cwd, dll_path=dll_path)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2009,6 +2009,11 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                 )
 
                 if not args.skip_onnx_tests:
+                    # Disable python onnx tests for CANN EP, because many tests are
+                    # not supported yet.
+                    if args.use_cann:
+                        return
+
                     run_subprocess([os.path.join(cwd, "onnx_test_runner"), "test_models"], cwd=cwd)
                     if config != "Debug":
                         run_subprocess([sys.executable, "onnx_backend_test_series.py"], cwd=cwd, dll_path=dll_path)


### PR DESCRIPTION
### Description
Add the ability to run graph

### Motivation and Context
A brief description is as follows:
1) If the whole graph is supported, then will be processed by the graph engine, directly.
2) If the whole graph is not supported, the whole graph will be divided into subgraphs and single operators; The sub-graphs will be run on graph engine, and the single operators will fallback to the traditional mode.
