### PR TITLE
Fix compile error with protobuf RepeatedIterator

### DIFF
--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -98,7 +98,7 @@ static void UnpackTensorWithRawData(const void* raw_data, size_t raw_data_length
                         OrtErrorCode::ORT_FAIL);                                                          \
     auto& data = tensor.field_name();                                                                     \
     for (auto data_iter = data.cbegin(); data_iter != data.cend(); ++data_iter)                           \
-      *p_data++ = *reinterpret_cast<const T*>(data_iter);                                                 \
+      *p_data++ = *(data_iter);                                                                           \
     return;                                                                                               \
   }
 

--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -98,7 +98,7 @@ static void UnpackTensorWithRawData(const void* raw_data, size_t raw_data_length
                         OrtErrorCode::ORT_FAIL);                                                          \
     auto& data = tensor.field_name();                                                                     \
     for (auto data_iter = data.cbegin(); data_iter != data.cend(); ++data_iter)                           \
-      *p_data++ = gsl::narrow<T>(*data_iter);                                                             \
+      *p_data++ = onnxruntime::narrow<T>(*data_iter);                                                     \
     return;                                                                                               \
   }
 

--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -98,7 +98,7 @@ static void UnpackTensorWithRawData(const void* raw_data, size_t raw_data_length
                         OrtErrorCode::ORT_FAIL);                                                          \
     auto& data = tensor.field_name();                                                                     \
     for (auto data_iter = data.cbegin(); data_iter != data.cend(); ++data_iter)                           \
-      *p_data++ = (T)(*data_iter);                                                                        \
+      *p_data++ = gsl::narrow<T>(*data_iter);                                                             \
     return;                                                                                               \
   }
 

--- a/onnxruntime/test/onnx/tensorprotoutils.cc
+++ b/onnxruntime/test/onnx/tensorprotoutils.cc
@@ -98,7 +98,7 @@ static void UnpackTensorWithRawData(const void* raw_data, size_t raw_data_length
                         OrtErrorCode::ORT_FAIL);                                                          \
     auto& data = tensor.field_name();                                                                     \
     for (auto data_iter = data.cbegin(); data_iter != data.cend(); ++data_iter)                           \
-      *p_data++ = *(data_iter);                                                                           \
+      *p_data++ = (T)(*data_iter);                                                                        \
     return;                                                                                               \
   }
 

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -183,7 +183,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
         ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
         ind_span = ReinterpretAsSpan<const int64_t>(gsl::make_span(unpack_buffer));
       } else {
-        ind_span = gsl::make_span(indices_proto.int64_data().cbegin(), indices_proto.int64_data().cend());
+        ind_span = gsl::make_span(&(*indices_proto.int64_data().cbegin()), &(*indices_proto.int64_data().cend()));
       }
       break;
     }

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -183,7 +183,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
         ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
         ind_span = ReinterpretAsSpan<const int64_t>(gsl::make_span(unpack_buffer));
       } else {
-        ind_span = gsl::make_span(indices_proto.int64_data().data(), (std::size_t)indices_proto.int64_data_size());
+        ind_span = gsl::make_span(indices_proto.int64_data().data(), indices_proto.int64_data_size());
       }
       break;
     }

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -183,7 +183,7 @@ void SparseIndicesChecker(const ONNX_NAMESPACE::TensorProto& indices_proto, gsl:
         ASSERT_STATUS_OK(utils::UnpackInitializerData(indices_proto, model_path, unpack_buffer));
         ind_span = ReinterpretAsSpan<const int64_t>(gsl::make_span(unpack_buffer));
       } else {
-        ind_span = gsl::make_span(&(*indices_proto.int64_data().cbegin()), &(*indices_proto.int64_data().cend()));
+        ind_span = gsl::make_span(indices_proto.int64_data().data(), (std::size_t)indices_proto.int64_data_size());
       }
       break;
     }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
There are some compile errors with google::protobuf::internal::RepeatedIterator.
replace reinterpret_cast with &(*iter), which iter is RepeatedIterator type.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
My protobuf version is:
- libprotoc 3.21.5
- g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0

when I use build command:
```
./build.sh --use_cuda --cudnn_home /usr --cuda_home /usr/local/cuda --config Debug --build_shared_lib --parallel 
```

There are some compile errors like this:

- error 1
onnxruntime/test/util/test_utils.cc:186:105: error: no matching function for call to ‘make_span(google::protobuf::RepeatedField<long int>::const_iterator, google::protobuf::RepeatedField<long int>::const_iterator)’
  186 |         ind_span = gsl::make_span(indices_proto.int64_data().cbegin(), indices_proto.int64_data().cend());

- error 2
onnxruntime/test/onnx/tensorprotoutils.cc:101:56: error: invalid cast from type ‘google::protobuf::internal::RepeatedIterator<const long unsigned int>’ to type ‘const uint32_t*’ {aka ‘const unsigned int*’}
  101 |       *p_data++ = *reinterpret_cast<const T*>(data_iter);