### PR TITLE
Improve coverage of fused MHA in Attention

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu
@@ -78,9 +78,9 @@ size_t GetAttentionWorkspaceSize(
                           ((sequence_length * kv_sequence_length) * qk_head_size + kv_sequence_length * v_head_size);
 
   if (fused_runner != nullptr) {
-    // Offsets without padding is B + 1. When we add padding, the size need to increase to 2B + 1.
-    size_t sequenceOffsetBytes = sizeof(int) * (batch_size + 1);
-    return qkv_size + reinterpret_cast<MHARunner*>(fused_runner)->getWorkspaceSize() + sequenceOffsetBytes;
+    // There are batch_size + 1 offsets Without padding (or padding removed), and 2 * batch_size + 1 with padding.
+    size_t sequenceOffsetBytes = sizeof(int) * (2 * batch_size + 1);
+    return qkv_size + reinterpret_cast<FusedMHARunnerFP16v2*>(fused_runner)->getWorkspaceSize() + sequenceOffsetBytes;
   }
 
   return qkv_size + 2 * GetAttentionScratchSize(element_size, batch_size, num_heads, sequence_length,
@@ -180,11 +180,15 @@ Status QkvToContext(
   T* temp_output = scratch1;
   if (use_fused_kernel) {
     int* sequence_offset = reinterpret_cast<int*>(qkv + elements_q + elements_k + elements_v);
-    LaunchTrtSequenceOffset(sequence_offset, data.mask_index, batch_size, stream);
+    LaunchTrtSequenceOffset(sequence_offset, data.mask_index, batch_size, sequence_length, stream);
     CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
     FusedMHARunnerFP16v2* fused_fp16_runner = reinterpret_cast<FusedMHARunnerFP16v2*>(fused_runner);
-    fused_fp16_runner->setup(sequence_length, batch_size);
+
+    const int S = fused_fp16_runner->getSFromMaxSeqLen(sequence_length);
+    // B = 2 * batch_size when there is padding in input, and B = batch_size when padding is removed.
+    const int B = 2 * batch_size;
+    fused_fp16_runner->setup(S, B);
 
     fused_fp16_runner->run(qkv, nullptr, sequence_offset, data.output, nullptr, stream);
 

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
@@ -150,6 +150,24 @@ void FusedMHARunnerFP16v2::run(const void* qkvPtr, const void* maskPtr, const vo
   return pimpl->run(qkvPtr, maskPtr, seqLens, output, workspace, stream);
 }
 
+int FusedMHARunnerFP16v2::getSFromMaxSeqLen(const int max_seq_len) const {
+  int S = 1024;
+  if (max_seq_len <= 64) {
+    S = 64;
+  } else if (max_seq_len <= 96) {
+    S = 96;
+  } else if (max_seq_len <= 128) {
+    S = 128;
+  } else if (max_seq_len <= 256) {
+    S = 256;
+  } else if (max_seq_len <= 384) {
+    S = 384;
+  } else if (max_seq_len <= 512) {
+    S = 512;
+  }
+  return S;
+}
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h
@@ -66,6 +66,8 @@ class MHARunner {
 
   virtual bool isValid(int32_t s) const = 0;
 
+  virtual int getSFromMaxSeqLen(const int max_seq_len) const = 0;
+
  protected:
   int32_t mS;
   int32_t mB;
@@ -95,6 +97,8 @@ class FusedMHARunnerFP16v2 : public MHARunner {
   size_t getWorkspaceSize() const override;
 
   bool isValid(int32_t s) const override;
+
+  virtual int getSFromMaxSeqLen(const int max_seq_len) const override;
 
  private:
   int32_t mSm;

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -39,7 +39,7 @@ def get_package_version(package_name: str):
         return None
 
 
-def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True):
+def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, use_gpu: bool = True, use_io_binding: bool = False):
     """Load onnx model given pretrained model name and optional ONNX model path. If onnx_path is None,
     the default onnx model from optimum will be used.
 
@@ -58,14 +58,17 @@ def load_onnx_model(model_id: str, onnx_path: Optional[str] = None, use_gpu: boo
         model.latest_model_name = Path(onnx_path).name
 
         if use_gpu:
-            model.device = torch.device("cuda")
+            model.device = torch.device("cuda:0")
             model.model = ORTModel.load_model(onnx_path, "CUDAExecutionProvider")
         else:
+            model.device = torch.device("cpu")
             model.model = ORTModel.load_model(onnx_path)
     else:
         onnx_path = os.path.join(model.model_save_dir.as_posix(), model.latest_model_name)
         if use_gpu:
             model.to("cuda")
+
+    model.use_io_binding = use_io_binding
 
     return model, onnx_path
 
@@ -85,6 +88,7 @@ def output_details(results: List[Dict[str, Any]], csv_filename: str):
             "disable_fused_attention",
             "batch_size",
             "sequence_length",
+            "use_io_binding",
             "exact",
             "f1",
             "total",
@@ -119,7 +123,13 @@ def output_summary(results: List[Dict[str, Any]], csv_filename: str, metric_name
         metric_name (str): the metric to summarize
     """
     with open(csv_filename, mode="a", newline="", encoding="ascii") as csv_file:
-        header_names = ["pretrained_model_name", "onnx_path", "provider", "disable_fused_attention"]
+        header_names = [
+            "pretrained_model_name",
+            "onnx_path",
+            "provider",
+            "disable_fused_attention",
+            "use_io_binding",
+        ]
 
         model_list = list(set([result["onnx_path"] for result in results]))
         model_list.sort()
@@ -190,19 +200,21 @@ def main():
         tokenizer.model_max_length = sequence_length
         tokenizer.doc_stride = min(sequence_length // 2, 128)
 
-        ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, args.use_gpu)
+        ort_model, onnx_path = load_onnx_model(pretrained_model_name, args.onnx, args.use_gpu, args.use_io_binding)
         print(ort_model.config)
         if sequence_length > ort_model.config.max_position_embeddings:
             raise RuntimeError("sequence length should not be larger than {ort_model.config.max_position_embeddings}")
 
-        qa_pipeline = pipeline("question-answering", model=ort_model, tokenizer=tokenizer, question_first=True)
+        qa_pipeline = pipeline(
+            "question-answering", model=ort_model, tokenizer=tokenizer, question_first=True, batch_size=args.batch_size
+        )
 
         task_evaluator = evaluator("question-answering")
-        data = load_dataset("squad", split=f"validation[:{args.total}]" if args.total > 0 else "validation")
+        squad_dataset = load_dataset("squad", split=f"validation[:{args.total}]" if args.total > 0 else "validation")
 
         result = task_evaluator.compute(
             model_or_pipeline=qa_pipeline,
-            data=data,
+            data=squad_dataset,
             metric="squad_v2",
             squad_v2_format=True,
         )
@@ -211,8 +223,9 @@ def main():
         result["disable_fused_attention"] = disable_fused_attention
         result["pretrained_model_name"] = pretrained_model_name
         result["onnx_path"] = onnx_path
-        result["batch_size"] = 1
+        result["batch_size"] = args.batch_size
         result["sequence_length"] = sequence_length
+        result["use_io_binding"] = args.use_io_binding
         print(result)
 
         all_results.append(result)
@@ -244,6 +257,14 @@ def parse_arguments(argv=None):
         help="Sequence lengths for onnx model inputs. It could have multiple values.",
     )
 
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=1,
+        help="batch size for inference.",
+    )
+
     parser.add_argument("-t", "--total", type=int, default=0, help="Total samples to test. 0 means all samples.")
 
     parser.add_argument(
@@ -256,6 +277,9 @@ def parse_arguments(argv=None):
 
     parser.add_argument("--use_gpu", required=False, action="store_true", help="Use CUDA execution provider.")
     parser.set_defaults(use_gpu=False)
+
+    parser.add_argument("--use_io_binding", required=False, action="store_true", help="Use IO Binding for GPU.")
+    parser.set_defaults(use_io_binding=False)
 
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Description

Previously, fused attention was applied to limited sequence lengths (64, 96, 128, 256, 384, 512). This will expand support all sequence lengths <= 384 for V100 and T4, or 512 for A100.

Previously, fused attention only works for batch_size=1. After this change, fused MHA has no limit on batch_size.

## Accuracy Tests on SQuAD

Using optimized fp16 onnx model of distilbert-base-cased-distilled-squad, we test the CUDA EP with IO Binding using eval_squad.py:

disable_fused_attention | batch_size | sequence_length | exact | f1 | samples_per_second | latency_in_ms
-- | -- | -- | -- | -- | -- | --
TRUE | 1 | 384 | 79.6 | 86.8 | 283.5 | 3.5
TRUE | 2 | 384 | 79.6 | 86.8 | 308.3 | 3.2
FALSE | 1 | 384 | 79.6 | 86.8 | 313.2 | 3.2
FALSE | 2 | 384 | 79.6 | 86.8 | 340.9 | 2.9
TRUE | 1 | 300 | 79.3 | 86.6 | 278.5 | 3.6
TRUE | 2 | 300 | 79.4 | 86.6 | 301.8 | 3.3
FALSE | 1 | 300 | 79.4 | 86.6 | 305.8 | 3.3
FALSE | 2 | 300 | 79.4 | 86.6 | 335.9 | 3.0

It shows that with/without fused attention could achieve same accuracy. 

Note that latency number here is just for reference (eval_squad.py has not been optimized for speed). We can see that it is about 10% faster with fused attention than without fused attention.

version of package used:  onnx 1.12.0, torch 1.13.0, transformers 4.24.0, optimum 1.5.0, datasets 2.7.0, evaluate 0.3.0

## Performance Test of base-based-cased on T4 GPU
```
sudo nvidia-smi -rgc
export ORT_DISABLE_FUSED_ATTENTION=0
python benchmark.py -m bert-base-cased -e onnxruntime -g -p fp16 -o by_script -i 3 -t 1000 -b 1 8  -s 8 16 32 64 80 96 120 128 --use_mask_index --overwrite
```

Disable_Fused_Attention | b1_s8 | b1_s16 | b1_s32 | b1_s64 | b1_s80 | b1_s96 | b1_s120 | b1_s128 | b8_s8 | b8_s16 | b8_s32 | b8_s64 | b8_s80 | b8_s96 | b8_s120 | b8_s128
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
FALSE | 1.32 | 1.28 | 1.33 | 1.51 | 1.71 | 1.79 | 1.99 | 2.04 | 1.56 | 1.99 | 2.85 | 4.88 | 6.03 | 7.03 | 9.2 | 9.34
TRUE | 1.37 | 1.34 | 1.44 | 1.68 | 1.89 | 1.99 | 2.15 | 2.21 | 1.63 | 2.31 | 3.19 | 5.48 | 6.98 | 8.14 | 10.54 | 10.66
Latency Reduction  | 3.6% | 4.5% | 7.6% | 10.1% | 9.5% | 10.1% | 7.4% | 7.7% | 4.3% | 13.9% | 10.7% | 10.9% | 13.6% | 13.6% | 12.7% | 12.4%

Perf gain is observed in all sequence lengths tested.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


