### PR TITLE
[DML EP] Add mixed datatype support for DML's LayerNorm contrib op

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -607,27 +607,6 @@ namespace Dml
             ));
     }
 
-    ComPtr<IDMLCompiledOperator> DmlOperator::InitializeCast(TensorDesc& inputDesc, TensorDesc& outputDesc)
-    {
-        assert(inputDesc.GetSizes() == outputDesc.GetSizes());
-        const auto dmlInputDesc = inputDesc.GetDmlDesc();
-        const auto dmlOutputDesc = outputDesc.GetDmlDesc();
-
-        DML_CAST_OPERATOR_DESC castDesc = {};
-        castDesc.InputTensor = &dmlInputDesc;
-        castDesc.OutputTensor = &dmlOutputDesc;
-
-        DML_OPERATOR_DESC opDesc = { DML_OPERATOR_CAST, &castDesc };
-
-        ComPtr<IDMLOperator> dmlOperator;
-        ORT_THROW_IF_FAILED(m_dmlDevice->CreateOperator(&opDesc, IID_PPV_ARGS(&dmlOperator)));
-
-        ComPtr<IDMLCompiledOperator> dmlCompiledOperator;
-        ORT_THROW_IF_FAILED(m_dmlDevice->CompileOperator(dmlOperator.Get(), GetExecutionFlags(), IID_PPV_ARGS(&dmlCompiledOperator)));
-
-        return dmlCompiledOperator;
-    }
-
     TensorDesc DmlOperator::CreateTensorDescFromInput(
         const MLOperatorKernelCreationContext& kernelInfo,
         uint32_t index,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -607,6 +607,27 @@ namespace Dml
             ));
     }
 
+    ComPtr<IDMLCompiledOperator> DmlOperator::InitializeCast(TensorDesc& inputDesc, TensorDesc& outputDesc)
+    {
+        assert(inputDesc.GetSizes() == outputDesc.GetSizes());
+        const auto dmlInputDesc = inputDesc.GetDmlDesc();
+        const auto dmlOutputDesc = outputDesc.GetDmlDesc();
+
+        DML_CAST_OPERATOR_DESC castDesc = {};
+        castDesc.InputTensor = &dmlInputDesc;
+        castDesc.OutputTensor = &dmlOutputDesc;
+
+        DML_OPERATOR_DESC opDesc = { DML_OPERATOR_CAST, &castDesc };
+
+        ComPtr<IDMLOperator> dmlOperator;
+        ORT_THROW_IF_FAILED(m_dmlDevice->CreateOperator(&opDesc, IID_PPV_ARGS(&dmlOperator)));
+
+        ComPtr<IDMLCompiledOperator> dmlCompiledOperator;
+        ORT_THROW_IF_FAILED(m_dmlDevice->CompileOperator(dmlOperator.Get(), GetExecutionFlags(), IID_PPV_ARGS(&dmlCompiledOperator)));
+
+        return dmlCompiledOperator;
+    }
+
     TensorDesc DmlOperator::CreateTensorDescFromInput(
         const MLOperatorKernelCreationContext& kernelInfo,
         uint32_t index,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
@@ -64,8 +64,8 @@ namespace Dml
             );
 
         // This method only works with DML_GRAPH.
-        // To make it work without DML_GRAPH, we need to add new functionality 
-        // in DMLX i.e. DMLX should also give access to DML_OPERATOR_DESC 
+        // To make it work without DML_GRAPH, we need to add new functionality
+        // in DMLX i.e. DMLX should also give access to DML_OPERATOR_DESC
         // rather than IDMLOperator.
         void SetDmlOperatorGraphDesc(
             const MLOperatorGraphDesc&& operatorGraphDesc,
@@ -103,8 +103,9 @@ namespace Dml
         // It returns nullptr if there is no work to do (0 bytes).
         //
         ComPtr<IDMLCompiledOperator> InitializeZeroInt64Tensor(uint64_t tensorSizeInBytes);
-
         void ExecuteZeroInt64Tensor(IDMLCompiledOperator* compiledOperator, IMLOperatorTensor* tensor);
+
+        ComPtr<IDMLCompiledOperator> InitializeCast(TensorDesc& inputDesc, TensorDesc& outputDesc);
 
         TensorDesc CreateTensorDescFromInput(
             const MLOperatorKernelCreationContext& kernelInfo,
@@ -140,7 +141,7 @@ namespace Dml
                                    _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlInputEdges,
                                    _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlOutputEdges,
                                    _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges);
-        
+
     };
 
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.h
@@ -105,8 +105,6 @@ namespace Dml
         ComPtr<IDMLCompiledOperator> InitializeZeroInt64Tensor(uint64_t tensorSizeInBytes);
         void ExecuteZeroInt64Tensor(IDMLCompiledOperator* compiledOperator, IMLOperatorTensor* tensor);
 
-        ComPtr<IDMLCompiledOperator> InitializeCast(TensorDesc& inputDesc, TensorDesc& outputDesc);
-
         TensorDesc CreateTensorDescFromInput(
             const MLOperatorKernelCreationContext& kernelInfo,
             uint32_t index,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 #include "precomp.h"
+#include "core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h"
+#include "core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h"
+
+using Windows::AI::MachineLearning::Adapter::TensorWrapper;
 
 namespace Dml
 {
@@ -18,7 +22,7 @@ public:
         // because DML MVN1 has a validation which requires all 3 needs to have same dimension count
         // due to historical artifact.
         DmlOperator::Initialize(
-            kernelCreationContext, 
+            kernelCreationContext,
             kernelInputIndices,
             std::nullopt,
             std::nullopt,
@@ -33,14 +37,54 @@ public:
         std::vector<uint32_t> onnxAxes(inputDimCount - onnxAxis);
         std::iota(onnxAxes.begin(), onnxAxes.end(), onnxAxis);
 
-        std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
-        std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
+        m_castedInputDescs.insert(m_castedInputDescs.end(), m_inputTensorDescs.begin(), m_inputTensorDescs.end());
+        m_inputCastOps.resize(m_inputTensorDescs.size());
+        m_castedOutputTensorDesc = m_outputTensorDescs[0];
+
+        auto inputDataType = m_inputTensorDescs[0].GetDmlDataType();
+        assert(inputDataType == DML_TENSOR_DATA_TYPE_FLOAT16 || inputDataType == DML_TENSOR_DATA_TYPE_FLOAT32);
+
+        auto scaleDataType = m_inputTensorDescs[1].GetDmlDataType();
+        assert(scaleDataType == DML_TENSOR_DATA_TYPE_FLOAT16 || scaleDataType == DML_TENSOR_DATA_TYPE_FLOAT32);
+
+        // Scale and Bias always have the same data type
+        assert(m_inputTensorDescs[2].GetDmlDataType() == DML_TENSOR_TYPE_INVALID || m_inputTensorDescs[2].GetDmlDataType() == scaleDataType);
+
+        // Cast all tensors to the highest common precision
+        if (inputDataType == DML_TENSOR_DATA_TYPE_FLOAT16 && scaleDataType == DML_TENSOR_DATA_TYPE_FLOAT32)
+        {
+            m_castedInputDescs[0] = TensorDesc(DML_TENSOR_DATA_TYPE_FLOAT32, m_inputTensorDescs[0].GetSizes());
+            m_inputCastOps[0] = InitializeCast(m_inputTensorDescs[0], m_castedInputDescs[0]);
+        }
+        else if (inputDataType == DML_TENSOR_DATA_TYPE_FLOAT32 && scaleDataType == DML_TENSOR_DATA_TYPE_FLOAT16)
+        {
+            m_castedInputDescs[1] = TensorDesc(DML_TENSOR_DATA_TYPE_FLOAT32, m_inputTensorDescs[1].GetSizes());
+            m_inputCastOps[1] = InitializeCast(m_inputTensorDescs[1], m_castedInputDescs[1]);
+
+            if (m_inputTensorDescs[2].GetDmlDataType() != DML_TENSOR_TYPE_INVALID)
+            {
+                m_castedInputDescs[2] = TensorDesc(DML_TENSOR_DATA_TYPE_FLOAT32, m_inputTensorDescs[2].GetSizes());
+                m_inputCastOps[2] = InitializeCast(m_inputTensorDescs[2], m_castedInputDescs[2]);
+            }
+        }
+
+        if (m_castedInputDescs[0].GetDmlDataType() != m_outputTensorDescs[0].GetDmlDataType())
+        {
+            // After the operator has been executed, we need to cast the "casted" output tensor to the original output tensor that TF expects
+            m_castedOutputTensorDesc = TensorDesc(m_castedInputDescs[0].GetDmlDataType(), m_outputTensorDescs[0].GetSizes());
+            m_outputCast = InitializeCast(m_castedOutputTensorDesc, m_outputTensorDescs[0]);
+        }
+
+        auto inputDesc = m_castedInputDescs[0].GetDmlDesc();
+        auto scaleDesc = m_castedInputDescs[1].GetDmlDesc();
+        auto biasDesc = m_castedInputDescs[2].GetDmlDesc();
+        auto outputDesc = m_castedOutputTensorDesc.GetDmlDesc();
 
         DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC operatorDesc = {};
-        operatorDesc.InputTensor = &inputDescs[0];
-        operatorDesc.ScaleTensor = &inputDescs[1];
-        operatorDesc.BiasTensor = inputDescs[2].Desc != nullptr ? &inputDescs[2] : nullptr;
-        operatorDesc.OutputTensor = outputDescs.data();
+        operatorDesc.InputTensor = &inputDesc;
+        operatorDesc.ScaleTensor = &scaleDesc;
+        operatorDesc.BiasTensor = biasDesc.Desc != nullptr ? &biasDesc : nullptr;
+        operatorDesc.OutputTensor = &outputDesc;
         operatorDesc.Axes = onnxAxes.data();
         operatorDesc.AxisCount = gsl::narrow_cast<uint32_t>(onnxAxes.size());
         operatorDesc.NormalizeVariance = true;
@@ -50,6 +94,101 @@ public:
         DML_OPERATOR_DESC opDesc = { DML_OPERATOR_MEAN_VARIANCE_NORMALIZATION1, &operatorDesc };
         SetDmlOperatorDesc(opDesc, kernelCreationContext);
     }
+
+    void Compute(const MLOperatorKernelContext& kernelContext) override
+    {
+        ExecutionProviderImpl* executionProvider = static_cast<ExecutionProviderImpl*>(m_executionProvider.Get());
+        std::vector<IMLOperatorTensor*> originalInputTensors = GetInputTensorsForExecute(kernelContext);
+        std::vector<IMLOperatorTensor*> originalOutputTensors = GetOutputTensorsForExecute(kernelContext);
+
+        std::array<onnxruntime::Tensor, 3> inputOrtTensors;
+        std::array<onnxruntime::Tensor, 1> outputOrtTensors;
+        std::array<ComPtr<IMLOperatorTensor>, 3> castedInputTensorWrappers;
+        std::array<ComPtr<IMLOperatorTensor>, 1> castedOutputTensorWrappers;
+        std::array<IMLOperatorTensor*, 3> castedInputTensors;
+        std::array<IMLOperatorTensor*, 1> castedOutputTensors;
+
+        assert(m_castedInputDescs.size() == m_inputCastOps.size());
+        for (size_t i = 0; i < m_castedInputDescs.size(); ++i)
+        {
+            const TensorDesc& inputDesc = m_castedInputDescs[i];
+
+            if (m_inputCastOps[i])
+            {
+                std::vector<int64_t> inputSizes(inputDesc.GetSizes().size());
+                for (size_t i = 0; i < inputSizes.size(); ++i)
+                {
+                    inputSizes[i] = inputDesc.GetSizes()[i];
+                }
+
+                auto dataType = Windows::AI::MachineLearning::Adapter::ToTensorDataType(GetMlDataTypeFromDmlDataType(inputDesc.GetDmlDataType()));
+                inputOrtTensors[i] = onnxruntime::Tensor(dataType, onnxruntime::TensorShape(inputSizes), executionProvider->GetGpuAllocator());
+                castedInputTensorWrappers[i] = wil::MakeOrThrow<TensorWrapper>(
+                    &inputOrtTensors[i],
+                    true,
+                    executionProvider,
+                    true);
+
+                castedInputTensors[i] = castedInputTensorWrappers[i].Get();
+
+                IMLOperatorTensor* inputTensors[] = {originalInputTensors[i]};
+                IMLOperatorTensor* outputTensors[] = {castedInputTensorWrappers[i].Get()};
+                ORT_THROW_IF_FAILED(m_executionProvider->ExecuteOperator(
+                    m_inputCastOps[i].Get(),
+                    nullptr,
+                    inputTensors,
+                    outputTensors));
+            }
+            else
+            {
+                castedInputTensors[i] = originalInputTensors[i];
+            }
+        }
+
+        if (m_outputCast)
+        {
+            std::vector<int64_t> outputSizes(m_castedOutputTensorDesc.GetSizes().size());
+            for (size_t i = 0; i < outputSizes.size(); ++i)
+            {
+                outputSizes[i] = m_castedOutputTensorDesc.GetSizes()[i];
+            }
+
+            auto dataType = Windows::AI::MachineLearning::Adapter::ToTensorDataType(GetMlDataTypeFromDmlDataType(m_castedOutputTensorDesc.GetDmlDataType()));
+            outputOrtTensors[0] = onnxruntime::Tensor(dataType, onnxruntime::TensorShape(outputSizes), executionProvider->GetGpuAllocator());
+            castedOutputTensorWrappers[0] = wil::MakeOrThrow<TensorWrapper>(
+                &outputOrtTensors[0],
+                true,
+                executionProvider,
+                true);
+            castedOutputTensors[0] = castedOutputTensorWrappers[0].Get();
+        }
+        else
+        {
+            castedOutputTensors[0] = originalOutputTensors[0];
+        }
+
+        ORT_THROW_IF_FAILED(m_executionProvider->ExecuteOperator(
+            m_compiledOperator.Get(),
+            m_persistentResourceBinding ? &*m_persistentResourceBinding : nullptr,
+            castedInputTensors,
+            castedOutputTensors));
+
+        // Finally, we can cast the tensor back to the original desired data type
+        if (m_outputCast)
+        {
+            ORT_THROW_IF_FAILED(m_executionProvider->ExecuteOperator(
+                m_outputCast.Get(),
+                nullptr,
+                castedOutputTensors,
+                originalOutputTensors));
+        }
+    }
+
+private:
+    std::vector<TensorDesc> m_castedInputDescs;
+    std::vector<ComPtr<IDMLCompiledOperator>> m_inputCastOps;
+    TensorDesc m_castedOutputTensorDesc;
+    ComPtr<IDMLCompiledOperator> m_outputCast;
 };
 
 void CALLBACK QueryLayerNormalization(IMLOperatorSupportQueryContextPrivate* context, /*out*/ bool* isSupported)
@@ -57,9 +196,9 @@ void CALLBACK QueryLayerNormalization(IMLOperatorSupportQueryContextPrivate* con
     *isSupported = false;
 
     // Mean and InvStdDev are not supported outputs.
-    // If only Scale tensor is present then fall back to CPU. This is temporary until 
+    // If only Scale tensor is present then fall back to CPU. This is temporary until
     // DML1.9.2 or DML1.10 gets released.
-    if (context->GetInputCount() < 3 || context->GetOutputCount() > 1) 
+    if (context->GetInputCount() < 3 || context->GetOutputCount() > 1)
     {
         return;
     }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 #include "precomp.h"
-#include "core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h"
-#include "core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h"
-
-using Windows::AI::MachineLearning::Adapter::TensorWrapper;
 
 namespace Dml
 {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
@@ -281,6 +281,7 @@ constexpr static std::array<const char*, 1> typeNameListDefault = {"T"};
 constexpr static std::array<const char*, 2> typeNameListAttention = {"T", "M"};
 constexpr static std::array<const char*, 2> typeNameListTwo = { "T1", "T2" };
 constexpr static std::array<const char*, 2> typeNameListLayerNorm = { "T", "U" };
+constexpr static std::array<const char*, 3> typeNameListLayerNormContrib = { "T", "U", "V" };
 constexpr static std::array<const char*, 3> typeNameListThree = { "T1", "T2", "T3" };
 constexpr static std::array<const char*, 4> typeNameListFour = { "T1", "T2", "T3", "T4" };
 constexpr static std::array<const char*, 2> typeNameListTopK = { "T", "I" };
@@ -338,6 +339,7 @@ constexpr static std::array<SupportedTensorDataTypes, 3> supportedTypeListIntege
 constexpr static std::array<SupportedTensorDataTypes, 1> supportedTypeListInteger8 = {SupportedTensorDataTypes::Int8|SupportedTensorDataTypes::UInt8 };
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListRoiAlign = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Int32|SupportedTensorDataTypes::Int64 };
 constexpr static std::array<SupportedTensorDataTypes, 1> supportedTypeListArgMinMax = {SupportedTensorDataTypes::Float16to32|SupportedTensorDataTypes::Ints8to64};
+constexpr static std::array<SupportedTensorDataTypes, 3> supportedTypeListLayerNormalizationContrib = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float16to32};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListLayerNormalization = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float32};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListShape = {SupportedTensorDataTypes::All, SupportedTensorDataTypes::Int64};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListSize = {SupportedTensorDataTypes::All, SupportedTensorDataTypes::Int64};
@@ -422,7 +424,6 @@ constexpr static OperatorRegistrationInformation operatorRegistrationInformation
     {REG_INFO(      9,  BatchNormalization,                 typeNameListDefault,            supportedTypeListFloat16to32,           DmlGraphSupport::Supported)},  // v9 just removes 'spatial' attribute.
     {REG_INFO(     14,  BatchNormalization,                 typeNameListDefault,            supportedTypeListFloat16to32,           DmlGraphSupport::Supported, requiredConstantCpuInputs(), std::nullopt, QueryBatchNormalization)},  // v14 adds training_mode attribute
     {REG_INFO(     15,  BatchNormalization,                 typeNameListDefault,            supportedTypeListFloat16to32,           DmlGraphSupport::Supported, requiredConstantCpuInputs(), std::nullopt, QueryBatchNormalization)},  // v15 adds differing types for scale and bias vs input.
-    {REG_INFO(      7,  LayerNormalization,                 typeNameListLayerNorm,          supportedTypeListLayerNormalization,    DmlGraphSupport::Supported, requiredConstantCpuInputs(), std::nullopt, QueryLayerNormalization)},
     {REG_INFO_VER( 17,  LayerNormalization,                 typeNameListLayerNorm,          supportedTypeListLayerNormalization,    DmlGraphSupport::Supported, requiredConstantCpuInputs(), std::nullopt, QueryLayerNormalization)},
     {REG_INFO(      7,  LRN,                                typeNameListDefault,            supportedTypeListFloat16to32,           DmlGraphSupport::Supported)},
     {REG_INFO(     13,  LRN,                                typeNameListDefault,            supportedTypeListFloat16to32,           DmlGraphSupport::Supported)},
@@ -737,6 +738,7 @@ constexpr static OperatorRegistrationInformation operatorRegistrationInformation
     {REG_INFO(     10,  MatMulInteger,                      typeNameListThree,              supportedTypeListInteger,               DmlGraphSupport::Supported)},
     {REG_INFO(     10,  ConvInteger,                        typeNameListThree,              supportedTypeListInteger,               DmlGraphSupport::Supported)},
     {REG_INFO(     11,  DynamicQuantizeLinear,              typeNameListTwo,                supportedTypeListDynamicQuantizeLinear, DmlGraphSupport::Supported)},
+    {REG_INFO(      7,  LayerNormalization,                 typeNameListLayerNormContrib,   supportedTypeListLayerNormalizationContrib, DmlGraphSupport::Supported, requiredConstantCpuInputs(), std::nullopt, QueryLayerNormalization)},
 };
 
 template<typename T>

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
@@ -281,7 +281,7 @@ constexpr static std::array<const char*, 1> typeNameListDefault = {"T"};
 constexpr static std::array<const char*, 2> typeNameListAttention = {"T", "M"};
 constexpr static std::array<const char*, 2> typeNameListTwo = { "T1", "T2" };
 constexpr static std::array<const char*, 2> typeNameListLayerNorm = { "T", "U" };
-constexpr static std::array<const char*, 3> typeNameListLayerNormContrib = { "T", "U", "V" };
+constexpr static std::array<const char*, 2> typeNameListLayerNormContrib = { "T", "V" };
 constexpr static std::array<const char*, 3> typeNameListThree = { "T1", "T2", "T3" };
 constexpr static std::array<const char*, 4> typeNameListFour = { "T1", "T2", "T3", "T4" };
 constexpr static std::array<const char*, 2> typeNameListTopK = { "T", "I" };
@@ -339,7 +339,7 @@ constexpr static std::array<SupportedTensorDataTypes, 3> supportedTypeListIntege
 constexpr static std::array<SupportedTensorDataTypes, 1> supportedTypeListInteger8 = {SupportedTensorDataTypes::Int8|SupportedTensorDataTypes::UInt8 };
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListRoiAlign = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Int32|SupportedTensorDataTypes::Int64 };
 constexpr static std::array<SupportedTensorDataTypes, 1> supportedTypeListArgMinMax = {SupportedTensorDataTypes::Float16to32|SupportedTensorDataTypes::Ints8to64};
-constexpr static std::array<SupportedTensorDataTypes, 3> supportedTypeListLayerNormalizationContrib = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float16to32};
+constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListLayerNormalizationContrib = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float16to32};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListLayerNormalization = {SupportedTensorDataTypes::Float16to32, SupportedTensorDataTypes::Float32};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListShape = {SupportedTensorDataTypes::All, SupportedTensorDataTypes::Int64};
 constexpr static std::array<SupportedTensorDataTypes, 2> supportedTypeListSize = {SupportedTensorDataTypes::All, SupportedTensorDataTypes::Int64};

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -94,6 +94,54 @@ TEST(LayerNormTest, LayerNorm_Scale) {
   test.Run();
 }
 
+TEST(LayerNormTest, LayerNorm_Scale_Float16Input) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because DML's LayerNorm doesn't support less than 3 inputs yet";
+  }
+
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{2, 2, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({-10.264f, 8.6453f, 43.1561f, -0.641239f, -8.2164f, 0.11412f, 41.3156f, 3.0458f}));
+  test.AddInput<float>("gamma", {2}, {-0.6953f, 5.1824f});
+  test.AddOutput<float>("output", dims, {0.6953f, 5.1824f, -0.6953f, -5.1824f, 0.6953f, 5.1824f, -0.6953f, -5.1824f});
+  test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Float16ScaleOutput) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because DML's LayerNorm doesn't support less than 3 inputs yet";
+  }
+
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{2, 2, 2};
+  test.AddInput<float>("x", dims, {-10.264f, 8.6453f, 43.1561f, -0.641239f, -8.2164f, 0.11412f, 41.3156f, 3.0458f});
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}));
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({0.6953f, 5.1824f, -0.6953f, -5.1824f, 0.6953f, 5.1824f, -0.6953f, -5.1824f}));
+  test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Float16InputScaleOutput) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because DML's LayerNorm doesn't support less than 3 inputs yet";
+  }
+
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{2, 2, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({-10.264f, 8.6453f, 43.1561f, -0.641239f, -8.2164f, 0.11412f, 41.3156f, 3.0458f}));
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}));
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({0.6953f, 5.1824f, -0.6953f, -5.1824f, 0.6953f, 5.1824f, -0.6953f, -5.1824f}));
+  test.Run();
+}
+
 TEST(LayerNormTest, LayerNorm_Scale_Bias) {
   OpTester test("LayerNormalization");
   test.AddAttribute<float>("epsilon", 1e-05f);
@@ -103,6 +151,42 @@ TEST(LayerNormTest, LayerNorm_Scale_Bias) {
   test.AddInput<float>("gamma", {2}, {-0.6953f, 5.1824f});
   test.AddInput<float>("bias", {2}, {0.6435f, -0.3964f});
   test.AddOutput<float>("output", dims, {-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f});
+  test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Bias_Float16Input) {
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{1, 3, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({1.2416f, 0.946123f, 13.1685f, 0.36423f, 21.145f, 0.03941f}));
+  test.AddInput<float>("gamma", {2}, {-0.6953f, 5.1824f});
+  test.AddInput<float>("bias", {2}, {0.6435f, -0.3964f});
+  test.AddOutput<float>("output", dims, {-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f});
+  test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Bias_Float16ScaleBiasOutput) {
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{1, 3, 2};
+  test.AddInput<float>("x", dims, {1.2416f, 0.946123f, 13.1685f, 0.36423f, 21.145f, 0.03941f});
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}));
+  test.AddInput<MLFloat16>("bias", {2}, ToFloat16({0.6435f, -0.3964f}));
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f}));
+  test.Run();
+}
+
+TEST(LayerNormTest, LayerNorm_Scale_Bias_Float16InputScaleBiasOutput) {
+  OpTester test("LayerNormalization");
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> dims{1, 3, 2};
+  test.AddInput<MLFloat16>("x", dims, ToFloat16({1.2416f, 0.946123f, 13.1685f, 0.36423f, 21.145f, 0.03941f}));
+  test.AddInput<MLFloat16>("gamma", {2}, ToFloat16({-0.6953f, 5.1824f}));
+  test.AddInput<MLFloat16>("bias", {2}, ToFloat16({0.6435f, -0.3964f}));
+  test.AddOutput<MLFloat16>("output", dims, ToFloat16({-0.0516f, -5.5776f, -0.0518f, -5.5788f, -0.0518f, -5.5788f}));
   test.Run();
 }
 


### PR DESCRIPTION
### Description
Add mixed datatype support for DML's LayerNorm contrib op.



### Motivation and Context
The fusion logic removes casts around LayerNorm in the graph because the contrib version of the op supports mixed datatypes.  Scale, Bias and Output's datatypes must match, but input's datatype can be different.


