### PR TITLE
Update fusion for distilbert accuracy test on SQuAD

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_embedlayer.py
+++ b/onnxruntime/python/tools/transformers/fusion_embedlayer.py
@@ -219,7 +219,7 @@ class FusionEmbedLayerNoMask(Fusion):
     def match_position_embedding_bert(self, position_embedding_gather, input_ids, output_name_to_node):
         """  Match position embedding path from input_ids to Gather for BERT.
 
-        BERT Embedding Layer Pattern:       
+        BERT Embedding Layer Pattern:
                                     (input_ids)
                                    /         \
                                  /          Shape
@@ -232,7 +232,7 @@ class FusionEmbedLayerNoMask(Fusion):
                            \        |           |
                             \     Gather      Slice (data[1,512], starts=0, ends=*, axes=1, steps=1)
                               \    /            |
-                                Add          Gather 
+                                Add          Gather
                                    \       /
                                       Add
                                        |
@@ -682,8 +682,27 @@ class FusionEmbedLayerNoMask(Fusion):
 
 
 class FusionEmbedLayerNormalization(FusionEmbedLayerNoMask):
-    def __init__(self, model: OnnxModel):
+    def __init__(self, model: OnnxModel, use_mask_index=False):
         super().__init__(model, "with mask")
+        self.use_mask_index = use_mask_index
+
+    def replace_mask(self, mask_int32, attention_nodes):
+        # Inputs of EmbedLayerNorm: input_ids, segment_ids (optional), word_embedding, position_embedding,
+        #           segment_embedding (optional), gamma, beta, mask (optional), position_ids (optional)
+        embed_node = self.embed_node
+        if len(embed_node.input) == 7:
+            embed_node.input.append(mask_int32)
+            logger.debug("append mask to %s", embed_node.name)
+        elif len(embed_node.input) > 7 and embed_node.input[7] == "":
+            embed_node.input[7] = mask_int32
+            logger.debug("replace mask in %s", embed_node.name)
+        else:
+            logger.debug("skip mask in %s", embed_node.name)
+            return
+
+        for attention_node in attention_nodes:
+            logger.debug("update mask_index in %s", attention_node.name)
+            attention_node.input[3] = embed_node.output[1]
 
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
         # Reset attention and embed_node so that we know fusion is successful when they are not None.
@@ -691,13 +710,32 @@ class FusionEmbedLayerNormalization(FusionEmbedLayerNoMask):
         self.embed_node = None
         super().fuse(node, input_name_to_nodes, output_name_to_node)
 
-        if self.attention and self.embed_node:
-            mask_index = self.attention.input[3]
-            if mask_index in output_name_to_node:
-                node = output_name_to_node[mask_index]
-                if node.op_type == "ReduceSum":
-                    embed_node = self.embed_node
-                    mask_input_name = node.input[0]
-                    self.nodes_to_remove.extend([node])
-                    embed_node.input.append(mask_input_name)
-                    embed_node.output[1] = mask_index
+        if self.embed_node is None:
+            return
+
+        if not self.use_mask_index:
+            logger.debug("--use_mask_index is not set: EmbedLayerNormalization will not have mask")
+            self.increase_counter("EmbedLayerNormalization(no mask)")
+            return
+
+        if self.attention is None:
+            logger.debug("EmbedLayerNormalization will not have mask since attention node is not found")
+            self.increase_counter("EmbedLayerNormalization(no mask)")
+            return
+
+        mask_int32 = self.attention.input[3]
+        children_nodes = input_name_to_nodes[mask_int32]
+        if mask_int32 not in output_name_to_node:
+            logger.debug("EmbedLayerNormalization will not have mask since %s is not a node output", mask_int32)
+            self.increase_counter("EmbedLayerNormalization(no mask)")
+            return
+
+        node = output_name_to_node[mask_int32]
+        if node.op_type in ["ReduceSum", "Cast"]:
+            attention_nodes = [node for node in children_nodes if node.op_type == "Attention"]
+            if node.op_type == "ReduceSum":
+                mask_int32 = node.input[0]
+                if len(children_nodes) == len(attention_nodes):
+                    self.nodes_to_remove.append(node)
+            self.replace_mask(mask_int32, attention_nodes)
+            self.increase_counter("EmbedLayerNormalization(with mask)")

--- a/onnxruntime/python/tools/transformers/fusion_shape.py
+++ b/onnxruntime/python/tools/transformers/fusion_shape.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Union
 
 from fusion_base import Fusion
 from fusion_utils import FusionUtils
+from numpy import ndarray
 from onnx import NodeProto, TensorProto
 from onnx_model import OnnxModel
 
@@ -58,7 +59,7 @@ class FusionShape(Fusion):
                 |                |
             Unsqueeze(axes=0)   Unsqueeze(axes=0)
                    \          /
-                      Concat 
+                      Concat
                         |
 
         into  (2d_input) --> Shape -->
@@ -99,12 +100,11 @@ class FusionShape(Fusion):
                     return
 
             value = self.model.get_constant_value(gather.input[1])
-            from numpy import array_equal, ndarray
 
             if not (isinstance(value, ndarray) and value.size == 1 and value.item() == i):
                 return
 
         if self.model.find_graph_output(concat_node.output[0]) is None:
             self.model.replace_input_of_all_nodes(concat_node.output[0], shape_output)
-            self.fused_count += 1
+            self.increase_counter("Reshape")
             self.prune_graph = True

--- a/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
+++ b/onnxruntime/python/tools/transformers/models/bert/eval_squad.py
@@ -7,9 +7,10 @@
 # Example to evaluate raw and optimized model for CUDA in Linux:
 #   pip3 install datasets evaluate optimum transformers onnxruntime-gpu
 #   python3 eval_squad.py -m distilbert-base-cased-distilled-squad --use_gpu
-#   python3 -m onnxruntime.transformers.optimizer --output optimized.onnx --num_heads 12 --hidden_size 768 \
-#           --input /home/$USER/.cache/huggingface/hub/distilbert-base-cased-distilled-squad/model.onnx
-#   python3 eval_squad.py -m distilbert-base-cased-distilled-squad --use_gpu --onnx optimized.onnx
+#   python3 -m onnxruntime.transformers.optimizer --output optimized_fp16.onnx --num_heads 12 --hidden_size 768 \
+#           --input /home/$USER/.cache/huggingface/hub/distilbert-base-cased-distilled-squad/model.onnx \
+#           --use_mask_index --float16
+#   python3 eval_squad.py -m distilbert-base-cased-distilled-squad --use_gpu --onnx optimized_fp16.onnx -b 16
 
 import argparse
 import csv

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -438,20 +438,18 @@ class BertOnnxModel(OnnxModel):
         ops = [
             "EmbedLayerNormalization",
             "Attention",
-            "QOrderedAttention",
             "Gelu",
-            "QOrderedGelu",
             "FastGelu",
             "BiasGelu",
             "GemmFastGelu",
             "LayerNormalization",
-            "QOrderedLayerNormalization",
             "SkipLayerNormalization",
-            "QOrderedMatMul",
         ]
-        for op in ops:
+        q_ops = ["QOrderedAttention", "QOrderedGelu", "QOrderedLayerNormalization", "QOrderedMatMul"]
+        for op in ops + q_ops:
             nodes = self.get_nodes_by_op_type(op)
             op_count[op] = len(nodes)
+
         logger.info(f"Optimized operators:{op_count}")
         return op_count
 

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -67,7 +67,7 @@ class TestModelOptimization(unittest.TestCase):
 
                 self.assertEqual(len(onnx_model.get_nodes_by_op_type(op_type)), count)
 
-    # add test function for huggingface pytorch model
+    # test huggingface pytorch model
     def _test_optimizer_on_huggingface_model(
         self,
         model_name,
@@ -75,7 +75,7 @@ class TestModelOptimization(unittest.TestCase):
         inputs_count=1,
         validate_model=True,
     ):
-        # Remove cached model so that CI machine will have space
+        # Remove cached model so that CI machine has enough space. Do not remove cache models in dev machine.
         if not find_transformers_source():
             shutil.rmtree("./cache_models", ignore_errors=True)
         shutil.rmtree("./onnx_models", ignore_errors=True)
@@ -291,7 +291,7 @@ class TestTensorflowModelOptimization(unittest.TestCase):
             self.skipTest("skip TestBertOptimizationTF since tf2onnx not installed")
 
     def _test_optimizer_on_tf_model(self, model_name, expected_fusion_result_list, inputs_count, validate_model=True):
-        # Remove cached model so that CI mach0ne will have space
+        # Remove cached model so that CI machine has enough space. Do not remove cache models in dev machine.
         if not find_transformers_source():
             shutil.rmtree("./cache_models", ignore_errors=True)
         shutil.rmtree("./onnx_models", ignore_errors=True)


### PR DESCRIPTION
### Description
(1) Embed layer fusion to work with --use_mask_index.
(2) Parse num_heads and hidden_size from a pattern of Concat shape node.
(3) Fix a typo (CUDAExcecutionProvider=> CUDAExecutionProvider) in eval_squad.py
(4) Update example comments in eval_squad.py to use fp16 optimized model.
(5) Update tests in test_optimizer.py

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


