### PR TITLE
CloudEP

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -200,6 +200,8 @@ option(onnxruntime_ENABLE_ATEN "Enable ATen fallback" OFF)
 
 option(onnxruntime_BUILD_KERNEL_EXPLORER "Build Kernel Explorer for testing and profiling GPU kernels" OFF)
 
+option(onnxruntime_USE_CLOUD "Build with hybrid-inferencing support" OFF)
+
 if (onnxruntime_USE_CUDA)
   set(onnxruntime_DISABLE_RTTI OFF)
 endif()
@@ -1262,6 +1264,11 @@ if (onnxruntime_USE_CANN)
     list(APPEND ORT_PROVIDER_FLAGS  -DUSE_CANN=1)
     list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_CANN=1)
     list(APPEND ONNXRUNTIME_PROVIDER_NAMES cann)
+endif()
+if (onnxruntime_USE_CLOUD)
+    list(APPEND ORT_PROVIDER_FLAGS  -DUSE_CLOUD=1)
+    list(APPEND ORT_PROVIDER_CMAKE_FLAGS -Donnxruntime_USE_CLOUD=1)
+    list(APPEND ONNXRUNTIME_PROVIDER_NAMES cloud)
 endif()
 
 function(onnxruntime_set_compile_flags target_name)

--- a/cmake/onnxruntime_framework.cmake
+++ b/cmake/onnxruntime_framework.cmake
@@ -36,6 +36,99 @@ endif()
 source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_framework_srcs})
 
 onnxruntime_add_static_library(onnxruntime_framework ${onnxruntime_framework_srcs})
+
+if (onnxruntime_USE_CLOUD)
+
+  include(ExternalProject)
+
+  if (WIN32)
+
+    function(get_vcpkg)
+      ExternalProject_Add(vcpkg
+        GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
+        PREFIX vcpkg
+        CONFIGURE_COMMAND ""
+        INSTALL_COMMAND ""
+        UPDATE_COMMAND ""
+        BUILD_COMMAND "<SOURCE_DIR>/bootstrap-vcpkg.bat")
+
+      ExternalProject_Get_Property(vcpkg SOURCE_DIR)
+      set(VCPKG_SRC ${SOURCE_DIR} PARENT_SCOPE)
+      set(VCPKG_DEPENDENCIES "vcpkg" PARENT_SCOPE)
+    endfunction()
+
+    function(vcpkg_install PACKAGE_NAME)
+      add_custom_command(
+        OUTPUT ${VCPKG_SRC}/packages/${PACKAGE_NAME}_x64-windows/BUILD_INFO
+        COMMAND ${VCPKG_SRC}/vcpkg install ${PACKAGE_NAME}:x64-windows
+        WORKING_DIRECTORY ${VCPKG_SRC}
+        DEPENDS vcpkg)
+
+      add_custom_target(get${PACKAGE_NAME}
+        ALL
+        DEPENDS ${VCPKG_SRC}/packages/${PACKAGE_NAME}_x64-windows/BUILD_INFO)
+
+      list(APPEND VCPKG_DEPENDENCIES "get${PACKAGE_NAME}")
+      set(VCPKG_DEPENDENCIES ${VCPKG_DEPENDENCIES} PARENT_SCOPE)
+    endfunction()
+
+    get_vcpkg()
+    vcpkg_install(openssl)
+    vcpkg_install(openssl-windows)
+    vcpkg_install(rapidjson)
+    vcpkg_install(re2)
+    vcpkg_install(boost-interprocess)
+    vcpkg_install(boost-stacktrace)
+    vcpkg_install(zlib)
+    vcpkg_install(pthread)
+    vcpkg_install(b64)
+
+    ExternalProject_Add(triton
+                        GIT_REPOSITORY https://github.com/triton-inference-server/client.git
+                        GIT_TAG main
+                        PREFIX triton
+                        CMAKE_ARGS -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=${VCPKG_SRC}/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=binary -DTRITON_ENABLE_CC_HTTP=ON
+                        INSTALL_COMMAND ""
+                        UPDATE_COMMAND "")
+
+  else()
+
+    ExternalProject_Add(triton
+                        GIT_REPOSITORY https://github.com/RandySheriffH/triton_client.git
+                        GIT_TAG buildfree
+                        PREFIX triton
+                        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=binary -DTRITON_ENABLE_CC_HTTP=ON
+                        INSTALL_COMMAND ""
+                        UPDATE_COMMAND "")
+
+  endif() #if (WIN32)
+
+  ExternalProject_Get_Property(triton SOURCE_DIR)
+  set(TRITON_SRC ${SOURCE_DIR})
+
+  ExternalProject_Get_Property(triton BINARY_DIR)
+  set(TRITON_BIN ${BINARY_DIR}/binary)
+  set(TRITON_THIRD_PARTY ${BINARY_DIR}/third-party)
+
+  add_dependencies(onnxruntime_framework triton)
+  target_include_directories(onnxruntime_framework PRIVATE ${TRITON_BIN}/include)
+  link_directories(${TRITON_BIN}/lib ${TRITON_THIRD_PARTY}/curl/lib)
+
+  if (WIN32)
+
+    target_link_libraries(onnxruntime_framework PRIVATE libcurl httpclient_static ws2_32 crypt32 Wldap32)
+
+  else()
+
+    find_package(ZLIB REQUIRED)
+    find_package(OpenSSL REQUIRED)
+    message(WARNING "SSL LIBS: " ${OPENSSL_LIBRARIES})
+    target_link_libraries(onnxruntime_framework PRIVATE httpclient_static curl ZLIB::ZLIB ${OPENSSL_LIBRARIES})
+
+  endif() #if (WIN32)
+
+endif() #if (onnxruntime_USE_CLOUD)
+
 if(onnxruntime_ENABLE_INSTRUMENT)
   target_compile_definitions(onnxruntime_framework PRIVATE ONNXRUNTIME_ENABLE_INSTRUMENT)
 endif()

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -147,6 +147,9 @@ endif()
 if (onnxruntime_USE_CANN)
   set(PROVIDERS_CANN onnxruntime_providers_cann)
 endif()
+if (onnxruntime_USE_CLOUD)
+  set(PROVIDERS_CLOUD onnxruntime_providers_cloud)
+endif()
 
 source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_common_srcs} ${onnxruntime_providers_srcs})
 
@@ -1550,6 +1553,28 @@ if (onnxruntime_USE_CANN)
           ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
           LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
           RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+if (onnxruntime_USE_CLOUD)
+
+  file(GLOB_RECURSE onnxruntime_providers_cloud_src CONFIGURE_DEPENDS
+    "${ONNXRUNTIME_ROOT}/core/providers/cloud/*.h"
+    "${ONNXRUNTIME_ROOT}/core/providers/cloud/*.cc"
+  )
+  source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_cloud_src})
+  onnxruntime_add_static_library(onnxruntime_providers_cloud ${onnxruntime_providers_cloud_src})
+  add_dependencies(onnxruntime_providers_cloud ${onnxruntime_EXTERNAL_DEPENDENCIES})
+  target_include_directories(onnxruntime_providers_cloud PRIVATE external/curl/include)
+  onnxruntime_add_include_to_target(onnxruntime_providers_cloud onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers)
+  target_link_libraries(onnxruntime_providers_cloud PRIVATE onnx onnxruntime_common onnxruntime_framework)
+  set_target_properties(onnxruntime_providers_cloud PROPERTIES FOLDER "ONNXRuntime")
+  set_target_properties(onnxruntime_providers_cloud PROPERTIES LINKER_LANGUAGE CXX)
+
+  install(TARGETS onnxruntime_providers_cloud
+          ARCHIVE   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
+          FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if (NOT onnxruntime_BUILD_SHARED_LIB)

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -210,7 +210,7 @@ target_link_libraries(onnxruntime_pybind11_state PRIVATE
     ${PROVIDERS_DML}
     ${PROVIDERS_ACL}
     ${PROVIDERS_ARMNN}
-    ${PROVIDERS_XNNPACK}
+	${PROVIDERS_CLOUD}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -510,6 +510,7 @@ set(ONNXRUNTIME_TEST_LIBS
     ${PROVIDERS_COREML}
     # ${PROVIDERS_TVM}
     ${PROVIDERS_XNNPACK}
+	${PROVIDERS_CLOUD}
     onnxruntime_optimizer
     onnxruntime_providers
     onnxruntime_util
@@ -584,6 +585,13 @@ if(onnxruntime_USE_XNNPACK)
   list(APPEND onnxruntime_test_framework_libs onnxruntime_providers_xnnpack)
   list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_xnnpack)
   list(APPEND onnxruntime_test_providers_libs onnxruntime_providers_xnnpack)
+endif()
+
+if(onnxruntime_USE_CLOUD)
+  list(APPEND onnxruntime_test_framework_src_patterns  ${TEST_SRC_DIR}/providers/cloud/*)
+  list(APPEND onnxruntime_test_framework_libs onnxruntime_providers_cloud)
+  list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_cloud)
+  list(APPEND onnxruntime_test_providers_libs onnxruntime_providers_cloud)
 endif()
 
 if(WIN32)

--- a/include/onnxruntime/core/graph/constants.h
+++ b/include/onnxruntime/core/graph/constants.h
@@ -41,6 +41,7 @@ constexpr const char* kSnpeExecutionProvider = "SNPEExecutionProvider";
 constexpr const char* kTvmExecutionProvider = "TvmExecutionProvider";
 constexpr const char* kXnnpackExecutionProvider = "XnnpackExecutionProvider";
 constexpr const char* kCannExecutionProvider = "CANNExecutionProvider";
+constexpr const char* kCloudExecutionProvider = "CloudExecutionProvider";
 
 constexpr const char* kExecutionProviderSharedLibraryPath = "shared_lib_path";
 constexpr const char* kExecutionProviderSharedLibraryEntry = "provider_factory_entry_point";

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -308,6 +308,7 @@ typedef enum GraphOptimizationLevel {
 typedef enum ExecutionMode {
   ORT_SEQUENTIAL = 0,
   ORT_PARALLEL = 1,
+  ORT_CLOUD = 2,
 } ExecutionMode;
 
 /** \brief Language projection identifiers

--- a/onnxruntime/core/framework/cloud_executor.cc
+++ b/onnxruntime/core/framework/cloud_executor.cc
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/cloud_executor.h"
+#include "core/framework/cloud_invoker.h"
+#include "core/framework/session_state.h"
+
+namespace onnxruntime {
+
+#ifdef USE_CLOUD
+
+common::Status CloudExecutor::Execute(const SessionState& session_state, gsl::span<const int>,
+                                      gsl::span<const OrtValue> feeds, gsl::span<const int>,
+                                      std::vector<OrtValue>& fetches,
+                                      const std::unordered_map<size_t, CustomAllocator>&,
+                                      const logging::Logger&) {
+  CloudEndPointInvoker* invoker = session_state.GetCloudInvoker();
+  if (invoker) {
+    if (invoker->GetStaus().IsOK()) {
+      invoker->Send(feeds, fetches);
+      return invoker->GetStaus();
+    }
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get cloud endpoint invoker");
+  }
+  const auto& invoker_status = invoker->GetStaus();
+  if (!invoker_status.IsOK()) return invoker_status;
+  return onnxruntime::Status::OK();
+}
+
+#else
+
+common::Status CloudExecutor::Execute(const SessionState&, gsl::span<const int>,
+                                      gsl::span<const OrtValue>, gsl::span<const int>,
+                                      std::vector<OrtValue>&,
+                                      const std::unordered_map<size_t, CustomAllocator>&,
+                                      const logging::Logger&) {
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "CloudExecutor::Execute not implemented");
+}
+
+#endif
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/cloud_executor.h
+++ b/onnxruntime/core/framework/cloud_executor.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/framework/iexecutor.h"
+
+namespace onnxruntime {
+
+class CloudExecutor : public onnxruntime::IExecutor {
+ public:
+  CloudExecutor() = default;
+  ~CloudExecutor() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CloudExecutor);
+
+  common::Status Execute(const SessionState& session_state, gsl::span<const int> feed_mlvalue_idxs,
+                         gsl::span<const OrtValue> feeds, gsl::span<const int> fetch_mlvalue_idxs,
+                         std::vector<OrtValue>& fetches,
+                         const std::unordered_map<size_t, CustomAllocator>& fetch_allocators,
+                         const logging::Logger& logger) override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/cloud_invoker.cc
+++ b/onnxruntime/core/framework/cloud_invoker.cc
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef USE_CLOUD
+
+#include "http_client.h"
+#include "core/common/common.h"
+#include "core/framework/cloud_invoker.h"
+#include "core/framework/ort_value.h"
+
+namespace onnxruntime {
+
+namespace tc = triton::client;
+
+class TritonInvokder : public CloudEndPointInvoker {
+ public:
+  TritonInvokder(const CloudEndPointConfig& config);
+  void Send(gsl::span<const OrtValue> ort_inputs, std::vector<OrtValue>& ort_outputs) const noexcept override;
+
+ private:
+  static std::string MapDataType(int32_t ort_data_type);
+  std::string uri_;
+  std::string key_;  // access token for bearer authentication
+  std::string model_name_;
+  std::string model_ver_;
+  bool verbose_ = false;
+  onnxruntime::InlinedVector<std::string> input_names_;
+  onnxruntime::InlinedVector<std::string> output_names_;
+  std::shared_ptr<CPUAllocator> cpu_allocator_;
+  std::unique_ptr<triton::client::InferenceServerHttpClient> triton_client_;
+  tc::Headers http_headers_;
+};
+
+std::string TritonInvokder::MapDataType(int32_t ort_data_type) {
+  std::string triton_data_type;
+  switch (ort_data_type) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      triton_data_type = "FP32";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+      triton_data_type = "UINT8";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8:
+      triton_data_type = "INT8";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT16:
+      triton_data_type = "UINT16";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16:
+      triton_data_type = "INT16";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      triton_data_type = "INT32";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      triton_data_type = "INT64";
+      break;
+    //todo - do we need to support string?
+    //case ONNX_NAMESPACE::TensorProto_DataType_STRING:
+    //  triton_data_type = "BYTES";
+    //  break;
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+      triton_data_type = "BOOL";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      triton_data_type = "FP16";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      triton_data_type = "FP64";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
+      triton_data_type = "UINT32";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      triton_data_type = "UINT64";
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
+      triton_data_type = "BF16";
+      break;
+    default:
+      break;
+  }
+  return triton_data_type;
+}
+
+TritonInvokder::TritonInvokder(const CloudEndPointConfig& config) : CloudEndPointInvoker(config) {
+  if (ReadConfig("uri", uri_) &&
+      ReadConfig("key", key_) &&
+      ReadConfig("model_name", model_name_) &&
+      ReadConfig("model_ver", model_ver_) &&
+      ReadConfig("input_names", input_names_) &&
+      ReadConfig("output_names", output_names_) &&
+      ReadConfig("verbose", verbose_, false)) {
+    if (tc::InferenceServerHttpClient::Create(&triton_client_, uri_, verbose_).IsOk()) {
+      cpu_allocator_ = std::make_shared<CPUAllocator>();
+    } else {
+      status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to initialize triton client");
+    }
+  }
+  http_headers_["Authorization"] = std::string{"Bearer "} + key_;
+}
+
+void TritonInvokder::Send(gsl::span<const OrtValue> ort_inputs, std::vector<OrtValue>& ort_outputs) const noexcept {
+  if (!status_.IsOK()) return;
+
+  if (ort_inputs.size() != input_names_.size()) {
+    status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                              "Number of inputs mismatch with number of input names for triton invoker: ",
+                              ort_inputs.size(), " != ", input_names_.size());
+    return;
+  }
+
+  auto tensor_type = DataTypeImpl::GetType<Tensor>();
+  std::vector<std::unique_ptr<tc::InferInput>> triton_inputs_uptr;
+  std::vector<tc::InferInput*> triton_inputs;
+  std::vector<std::unique_ptr<const tc::InferRequestedOutput>> triton_outputs_uptr;
+  std::vector<const tc::InferRequestedOutput*> triton_outputs;
+
+  try {
+    //assemble triton inputs
+    auto iter = input_names_.begin();
+    for (int i = 0; i < static_cast<int>(ort_inputs.size()); i++) {
+      const OrtValue& ort_input = ort_inputs[i];
+      if (!ort_input.IsTensor()) {
+        //todo - do we need to support tensor sequence and sparse tensor?
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Triton client only accept tensor(s) as input");
+        return;
+      }
+      const auto& input_tensor = ort_input.Get<Tensor>();
+      const auto& ort_input_shape = input_tensor.Shape();
+      std::vector<int64_t> dims;
+      dims.reserve(ort_input_shape.NumDimensions());
+      for (auto dim : ort_input_shape.GetDims()) {
+        dims.push_back(dim);
+      }
+      tc::InferInput* triton_input{};
+      std::string triton_data_type = MapDataType(input_tensor.GetElementType());
+      if (triton_data_type.empty()) {
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Triton client does not support data type: ",
+                                  ONNX_NAMESPACE::TensorProto_DataType_Name(input_tensor.GetElementType()));
+        return;
+      }
+      if (!tc::InferInput::Create(&triton_input, *iter, dims, MapDataType(input_tensor.GetElementType())).IsOk()) {
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to create triton input for ", *iter);
+        return;
+      }
+      triton_inputs_uptr.emplace_back(triton_input);
+      triton_inputs.push_back(triton_input);
+      triton_input->AppendRaw(static_cast<const uint8_t*>(input_tensor.DataRaw()), input_tensor.SizeInBytes());
+      ++iter;
+    }  //for
+
+    iter = output_names_.begin();
+    while (iter != output_names_.end()) {
+      tc::InferRequestedOutput* triton_output;
+      if (!tc::InferRequestedOutput::Create(&triton_output, *iter).IsOk()) {
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to create triton output for ", *iter);
+        return;
+      }
+      triton_outputs_uptr.emplace_back(triton_output);
+      triton_outputs.push_back(triton_output);
+      ++iter;
+    }
+
+    tc::InferResult* results;
+    tc::InferOptions options(model_name_);
+    options.model_version_ = model_ver_;
+    options.client_timeout_ = 0;
+
+    auto request_compression_algorithm = tc::InferenceServerHttpClient::CompressionType::NONE;
+    auto response_compression_algorithm = tc::InferenceServerHttpClient::CompressionType::NONE;
+
+    if (!triton_client_->Infer(&results, options, triton_inputs, triton_outputs,
+                               http_headers_, tc::Parameters(), request_compression_algorithm, response_compression_algorithm)
+             .IsOk()) {
+      status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to infer inputs by triton client");
+      return;
+    }
+
+    if (ort_outputs.empty()) {
+      ort_outputs.resize(output_names_.size());
+    }
+    int output_index = 0;
+    std::unique_ptr<tc::InferResult> results_ptr;
+    results_ptr.reset(results);
+    iter = output_names_.begin();
+    while (iter != output_names_.end()) {
+      std::vector<int64_t> dims;
+      if (!results_ptr->Shape(*iter, &dims).IsOk()) {
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get shape for output: ", *iter);
+        return;
+      }
+
+      int32_t* output0_data;
+      size_t output0_byte_size;
+      if (!results_ptr->RawData(*iter, (const uint8_t**)&output0_data, &output0_byte_size).IsOk()) {
+        status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get raw data for output", *iter);
+        return;
+      }
+
+      TensorShape tensor_shape(dims);
+      auto output_tensor = std::make_unique<Tensor>(onnxruntime::DataTypeImpl::GetType<float>(), tensor_shape, cpu_allocator_);
+      //todo - can we skip memcpy?
+      memcpy(output_tensor->MutableDataRaw(), output0_data, output0_byte_size);
+      ort_outputs[output_index].Init(output_tensor.get(), tensor_type, tensor_type->GetDeleteFunc());
+      output_tensor.release();
+      ++iter;
+      ++output_index;
+    }
+  } catch (const std::exception& ex) {
+    status_ = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Caught exception in TritonInvokder::Send", ex.what());
+  }
+}
+
+bool CloudEndPointInvoker::ReadConfig(const char* config_name, bool& config_val, bool required) {
+  if (config_.count(config_name)) {
+    config_val = config_[config_name] == "true" || config_[config_name] == "True" || config_[config_name] == "TRUE" || config_[config_name] == "1";
+  } else if (required) {
+    status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Triton invoker failed to initialize due to missing config: ", config_name);
+  }
+  return status_.IsOK();
+}
+
+bool CloudEndPointInvoker::ReadConfig(const char* config_name, std::string& config_val, bool required) {
+  if (config_.count(config_name)) {
+    config_val = config_[config_name];
+  } else if (required) {
+    status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Triton invoker failed to initialize due to missing config: ", config_name);
+  }
+  return status_.IsOK();
+}
+
+bool CloudEndPointInvoker::ReadConfig(const char* config_name, onnxruntime::InlinedVector<std::string>& config_vals, bool required) {
+  if (config_.count(config_name)) {
+    std::stringstream ss;
+    ss << config_[config_name];
+    std::string tmp;
+    while (std::getline(ss, tmp, ',')) {
+      config_vals.push_back(std::move(tmp));
+    }
+  } else if (required) {
+    status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Triton invoker failed to initialize due to missing config: ", config_name);
+  }
+  return status_.IsOK();
+}
+
+std::unique_ptr<CloudEndPointInvoker> CloudEndPointInvoker::CreateInvoker(const CloudEndPointConfig& config) {
+  static const std::string endpoint_type = "endpoint_type";
+  static const std::string triton_type = "triton";
+  if (config.count(endpoint_type)) {
+    if (config.at(endpoint_type) == triton_type) {
+      return std::make_unique<TritonInvokder>(config);
+    }
+  }
+  return {};
+}
+
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/framework/cloud_invoker.h
+++ b/onnxruntime/core/framework/cloud_invoker.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include "gsl/gsl"
+#include "core/framework/tensor.h"
+#include "core/common/inlined_containers.h"
+
+namespace onnxruntime {
+
+using CloudEndPointConfig = std::unordered_map<std::string, std::string>;
+using TensorPtr = std::unique_ptr<onnxruntime::Tensor>;
+using TensorPtrArray = onnxruntime::InlinedVector<TensorPtr>;
+using ConstTensorPtrArray = gsl::span<onnxruntime::Tensor* const>;
+
+#ifdef USE_CLOUD
+
+class CloudEndPointInvoker {
+ public:
+  CloudEndPointInvoker(const CloudEndPointConfig& config) : config_(config) {}
+  virtual ~CloudEndPointInvoker() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CloudEndPointInvoker);
+
+  static std::unique_ptr<CloudEndPointInvoker> CreateInvoker(const CloudEndPointConfig& config);
+  virtual void Send(gsl::span<const OrtValue> ort_inputs, std::vector<OrtValue>& ort_outputs) const noexcept = 0;
+  const onnxruntime::Status& GetStaus() const { return status_; }
+
+ protected:
+  bool ReadConfig(const char* config_name, bool& config_val, bool required = true);
+  bool ReadConfig(const char* config_name, std::string& config_val, bool required = true);
+  bool ReadConfig(const char* config_name, onnxruntime::InlinedVector<std::string>& config_vals, bool required = true);
+
+  CloudEndPointConfig config_;
+  mutable onnxruntime::Status status_ = onnxruntime::Status::OK();
+};
+
+#else
+
+class CloudEndPointInvoker {
+ public:
+  CloudEndPointInvoker() = delete;
+  ~CloudEndPointInvoker() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CloudEndPointInvoker);
+  static std::unique_ptr<CloudEndPointInvoker> CreateInvoker(const CloudEndPointConfig&) {
+    return {};
+  }
+  void Send(gsl::span<const OrtValue>, std::vector<OrtValue>&){};
+  const onnxruntime::Status& GetStaus() const {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED);
+  }
+};
+
+#endif
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -37,6 +37,8 @@
 #include "core/framework/memory_info.h"
 #endif
 
+#include "core/framework/cloud_invoker.h"
+
 namespace flatbuffers {
 class FlatBufferBuilder;
 template <typename T>
@@ -339,6 +341,14 @@ class SessionState {
   }
 #endif
 
+  CloudEndPointInvoker* GetCloudInvoker() const {
+    return cloud_invoker_.get();
+  }
+
+  void SetCloudInvoker(const CloudEndPointConfig& config) {
+    cloud_invoker_ = CloudEndPointInvoker::CreateInvoker(config);
+  }
+
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SessionState);
 
@@ -542,6 +552,8 @@ class SessionState {
   // Counter for number of times the session graph has been executed
   size_t graph_executions_counter_ = 0;
 #endif
+
+  std::unique_ptr<CloudEndPointInvoker> cloud_invoker_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cloud/cloud_execution_provider.cc
+++ b/onnxruntime/core/providers/cloud/cloud_execution_provider.cc
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cloud/cloud_execution_provider.h"
+#include "core/graph/constants.h"
+
+namespace onnxruntime {
+
+CloudExecutionProvider::CloudExecutionProvider(const std::unordered_map<std::string, std::string>& config) : IExecutionProvider{onnxruntime::kCloudExecutionProvider},
+                                                                                                             config_(config) {
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cloud/cloud_execution_provider.h
+++ b/onnxruntime/core/providers/cloud/cloud_execution_provider.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/execution_provider.h"
+
+namespace onnxruntime {
+
+class CloudExecutionProvider : public IExecutionProvider {
+ public:
+  explicit CloudExecutionProvider(const std::unordered_map<std::string, std::string>& config);
+  ~CloudExecutionProvider() = default;
+  const std::unordered_map<std::string, std::string>& GetConfig() const { return config_; }
+
+ private:
+  std::unordered_map<std::string, std::string> config_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cloud/cloud_provider_factory_creator.cc
+++ b/onnxruntime/core/providers/cloud/cloud_provider_factory_creator.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include <unordered_map>
+#include "core/providers/cloud/cloud_provider_factory_creator.h"
+#include "core/providers/cloud/cloud_execution_provider.h"
+
+namespace onnxruntime {
+
+struct CloudProviderFactory : public IExecutionProviderFactory {
+  CloudProviderFactory(const std::unordered_map<std::string, std::string>& config) : config_(config) {}
+
+  std::unique_ptr<IExecutionProvider> CreateProvider() override {
+    return std::make_unique<CloudExecutionProvider>(config_);
+  };
+
+  std::unordered_map<std::string, std::string> config_;
+};
+
+std::shared_ptr<IExecutionProviderFactory> CloudProviderFactoryCreator::Create(const std::unordered_map<std::string, std::string>& config) {
+  return std::make_shared<CloudProviderFactory>(config);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cloud/cloud_provider_factory_creator.h
+++ b/onnxruntime/core/providers/cloud/cloud_provider_factory_creator.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include "core/providers/providers.h"
+
+namespace onnxruntime {
+
+struct CloudProviderFactoryCreator {
+  static std::shared_ptr<IExecutionProviderFactory> Create(const std::unordered_map<std::string, std::string>& config);
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/get_execution_providers.cc
+++ b/onnxruntime/core/providers/get_execution_providers.cc
@@ -145,6 +145,14 @@ constexpr ProviderInfo kProvidersInPriorityOrder[] =
             false,
 #endif
         },
+        {
+            kCloudExecutionProvider,
+#ifdef USE_CLOUD
+            true,
+#else
+            false,
+#endif
+        },
         {kCpuExecutionProvider, true},  // kCpuExecutionProvider is always last
 };
 }  // namespace

--- a/onnxruntime/core/providers/provider_factory_creators.h
+++ b/onnxruntime/core/providers/provider_factory_creators.h
@@ -81,3 +81,7 @@
 #if defined(USE_CANN)
 #include "core/providers/cann/cann_provider_factory_creator.h"
 #endif
+
+#if defined(USE_CLOUD)
+#include "core/providers/cloud/cloud_provider_factory_creator.h"
+#endif

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -238,6 +238,7 @@ constexpr const char* kOpenVINOExecutionProvider = "OpenVINOExecutionProvider";
 constexpr const char* kRocmExecutionProvider = "ROCMExecutionProvider";
 constexpr const char* kTensorrtExecutionProvider = "TensorrtExecutionProvider";
 constexpr const char* kMIGraphXExecutionProvider = "MIGraphXExecutionProvider";
+constexpr const char* kCloudExecutionProvider = "CloudExecutionProvider";
 
 template <typename T>
 using IAllocatorUniquePtr = std::unique_ptr<T, std::function<void(T*)> >;

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -644,6 +644,16 @@ class InferenceSession {
                                 SessionState& session_state,
                                 bool saving_model_in_ort_format) ORT_MUST_USE_RESULT;
 
+  ExecutionMode GetExecutionMode(const RunOptions& run_options) const {
+    if (run_options.config_options.configurations.count("use_cloud") &&
+        run_options.config_options.configurations.at("use_cloud") != "0") {
+      //override session execution mode with run option
+      return ExecutionMode::ORT_CLOUD;
+    } else {
+      return session_options_.execution_mode;
+    }
+  }
+
   onnxruntime::GraphTransformerManager graph_transformation_mgr_;
 
   InsertCastTransformer insert_cast_transformer_;

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -78,10 +78,16 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
 #else
     status = create_not_supported_status();
 #endif
+  } else if (strcmp(provider_name, "CLOUD") == 0) {
+#if defined(USE_CLOUD)
+    options->provider_factories.push_back(CloudProviderFactoryCreator::Create(provider_options));
+#else
+    status = create_not_supported_status();
+#endif
   } else {
     ORT_UNUSED_PARAMETER(options);
     status = OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                                   "Unknown provider name. Currently supported values are 'SNPE' and 'XNNPACK'");
+                                   "Unknown provider name. Currently supported values are 'SNPE', 'XNNPACK', and 'CLOUD'");
   }
 
   return status;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -775,6 +775,10 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
       ORT_THROW("create CANN ExecutionProvider fail");
     }
 #endif
+  } else if (type == kCloudExecutionProvider) {
+#ifdef USE_CLOUD
+    return onnxruntime::CloudProviderFactoryCreator::Create({})->CreateProvider();
+#endif
   } else {
     // check whether it is a dynamic load EP:
     const auto it = provider_options_map.find(type);

--- a/onnxruntime/test/providers/cloud/cloud_basic_test.cc
+++ b/onnxruntime/test/providers/cloud/cloud_basic_test.cc
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/inference_session.h"
+#include "test/util/include/inference_session_wrapper.h"
+#include "test/util/include/test_allocator.h"
+#include "gtest/gtest.h"
+
+// defined in test_main.cc
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+
+TEST(CloudEP, TestSessionCreation) {
+  const auto* ort_model_path = ORT_TSTR("testdata/mul_1.onnx");
+  Ort::SessionOptions so;
+  so.AddConfigEntry("endpoint_type", "triton");
+  onnxruntime::ProviderOptions options;
+  so.AppendExecutionProvider("CLOUD", options);
+  EXPECT_NO_THROW((Ort::Session{*ort_env, ort_model_path, so}));
+}
+
+TEST(CloudEP, TestSessionRunMissingConfig) {
+  const auto* ort_model_path = ORT_TSTR("testdata/mul_1.onnx");
+  Ort::SessionOptions so;
+  onnxruntime::ProviderOptions options;
+  so.AppendExecutionProvider("CLOUD", options);
+  Ort::Session sess(*ort_env, ort_model_path, so);
+
+  float raw_inputs[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  std::vector<int64_t> input_dims = {3, 2};
+  std::vector<Ort::Value> input_values;
+  const char* input_names[] = {"X"};
+  const char* output_names[] = {"Y"};
+  auto default_allocator = std::make_unique<MockedOrtAllocator>();
+
+  Ort::RunOptions run_options;
+  run_options.AddConfigEntry("use_cloud", "1");
+
+  input_values.emplace_back(Ort::Value::CreateTensor<float>(default_allocator->Info(), raw_inputs, 6, input_dims.data(), 2));
+  EXPECT_THROW(sess.Run(run_options, input_names, input_values.data(), 1UL, output_names, 1UL), Ort::Exception);
+}
+
+TEST(CloudEP, TestSessionRunMissingEP) {
+  const auto* ort_model_path = ORT_TSTR("testdata/mul_1.onnx");
+  Ort::SessionOptions so;
+  so.AddConfigEntry("endpoint_type", "triton");
+  Ort::Session sess(*ort_env, ort_model_path, so);
+
+  float raw_inputs[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  std::vector<int64_t> input_dims = {3, 2};
+  std::vector<Ort::Value> input_values;
+  const char* input_names[] = {"X"};
+  const char* output_names[] = {"Y"};
+  auto default_allocator = std::make_unique<MockedOrtAllocator>();
+
+  Ort::RunOptions run_options;
+  run_options.AddConfigEntry("use_cloud", "1");
+
+  input_values.emplace_back(Ort::Value::CreateTensor<float>(default_allocator->Info(), raw_inputs, 6, input_dims.data(), 2));
+  EXPECT_THROW(sess.Run(run_options, input_names, input_values.data(), 1UL, output_names, 1UL), Ort::Exception);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -665,6 +665,7 @@ def parse_arguments():
     )
 
     parser.add_argument("--use_xnnpack", action="store_true", help="Enable xnnpack EP.")
+    parser.add_argument("--use_cloud", action="store_true", help="Enable cloud EP.")
 
     args = parser.parse_args()
     if args.android_sdk_path:
@@ -1234,6 +1235,9 @@ def generate_build_tree(
         cmake_args += ["-Donnxruntime_PREBUILT_PYTORCH_PATH=%s" % os.path.dirname(torch.__file__)]
         cmake_args += ["-D_GLIBCXX_USE_CXX11_ABI=" + str(int(torch._C._GLIBCXX_USE_CXX11_ABI))]
 
+    if args.use_cloud:
+        add_default_definition(cmake_extra_defines, "onnxruntime_USE_CLOUD", "ON")
+        
     cmake_args += ["-D{}".format(define) for define in cmake_extra_defines]
 
     cmake_args += cmake_extra_args


### PR DESCRIPTION
Implement CloudEP for hybrid inferencing.
The PR introduces zero new API, customers could configure session and run options to do inferencing with Azure [triton endpoint.](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-deploy-with-triton?tabs=azure-cli%2Cendpoint)
Sample configuration be like (python):

```
sess_opt.add_session_config_entry('cloud_ep.endpoint_type', 'triton');
sess_opt.add_session_config_entry('cloud.uri', 'https://mymodel.com');
sess_opt.add_session_config_entry('cloud.key', 'abcdefghijk...'); // use name like "auth_token", move to run option
sess_opt.add_session_config_entry('cloud.model_name', 'detection2'); //if missing use file name
sess_opt.add_session_config_entry('cloud.model_ver', '7'); //should be optional
sess_opt.add_session_config_entry('cloud.input_names', 'input'); // rid this
sess_opt.add_session_config_entry('cloud.output_names', 'bbox,class,landmarks,confidence'); // rid this
sess_opt.add_session_config_entry('cloud.verbose', 'true'); // use ort log configure
...
run_opt.add_run_config_entry('use_cloud', '1') # 0 for local inferencing, 1 for AML endpoint.
...
sess.run(None, {'input':input_}, run_opt)
```

todos:

1. Documentation;
2. Setup packaging pipeline where testing could be performed with an existing AML endpoint.

