### PR TITLE
[DML EP] Add an implementation for NonZero

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -69,6 +69,8 @@ Do not modify directly.*
   * <a href="#com.microsoft.QuickGelu">com.microsoft.QuickGelu</a>
   * <a href="#com.microsoft.Range">com.microsoft.Range</a>
   * <a href="#com.microsoft.ReduceSumInteger">com.microsoft.ReduceSumInteger</a>
+  * <a href="#com.microsoft.RemovePadding">com.microsoft.RemovePadding</a>
+  * <a href="#com.microsoft.RestorePadding">com.microsoft.RestorePadding</a>
   * <a href="#com.microsoft.Rfft">com.microsoft.Rfft</a>
   * <a href="#com.microsoft.SampleOp">com.microsoft.SampleOp</a>
   * <a href="#com.microsoft.SkipLayerNormalization">com.microsoft.SkipLayerNormalization</a>
@@ -404,6 +406,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>no repeat ngrams size</dd>
 <dt><tt>pad_token_id</tt> : int (required)</dt>
 <dd>The id of the padding token</dd>
+<dt><tt>vocab_size</tt> : int</dt>
+<dd>Size of the vocabulary. If not provided, it will be inferred from the decoder subgraph's output shape</dd>
 </dl>
 
 #### Inputs (5 - 10)
@@ -1311,7 +1315,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>mask</tt> (optional) : T1</dt>
 <dd>2D attention mask with shape (batch_size, sequence_length)</dd>
 <dt><tt>position_ids</tt> (optional) : T1</dt>
-<dd>2D position ids with shape (batch_size, sequence_length)</dd>
+<dd>2D position ids with shape (batch_size, sequence_length) or (1, sequence_length)</dd>
 </dl>
 
 #### Outputs (2 - 3)
@@ -3590,6 +3594,89 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>Constrain input type to 8-bit integer tensor.</dd>
 <dt><tt>T2</tt> : tensor(int32), tensor(uint32)</dt>
 <dd>Constrain output data type to 32-bit integer tensor.T2 must be tensor(uint32) when T1 is tensor(uint8),or must be tensor(int32) when T1 is tensor(int8).</dd>
+</dl>
+
+
+### <a name="com.microsoft.RemovePadding"></a><a name="com.microsoft.removepadding">**com.microsoft.RemovePadding**</a>
+
+  Compress transformer input by removing paddings. It assumes padding is on the right side of sequence.
+  
+  The input has padding with shape (batch_size, sequence_length, hidden_size). This will generate two outputs:
+  output has shape (total_tokens, hidden_size); token_offset with shape (batch_size, sequence_length).
+  
+  token_offset has offsets of all non-padding tokens first, then offset of all padding tokens. It is
+  a list of batch_size * sequence_length elements, which is reshaped to 2D for convenience of shape inference.
+
+#### Version
+
+This version of the operator has been available since version 1 of the 'com.microsoft' operator set.
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T</dt>
+<dd>Input tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+<dt><tt>sequence_token_count</tt> : M</dt>
+<dd>Number of non-padding tokens in each sequence with shape (batch_size).</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T</dt>
+<dd>output tensor with shape (total_tokens, hidden_size)</dd>
+<dt><tt>token_offset</tt> : M</dt>
+<dd>Offset of non-padding tokens, and those of padding tokens. Its shape is (batch_size, sequence_length)</dd>
+<dt><tt>cumulated_seq_len</tt> : M</dt>
+<dd>Cumulated sequence lengths. Its shape is (batch_size + 1)</dd>
+<dt><tt>max_seq_len</tt> : M</dt>
+<dd>Max sequence length without padding. Its shape is (1)</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float), tensor(float16)</dt>
+<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>M</tt> : tensor(int32)</dt>
+<dd>Constrain sequence_token_count and token_offset to integer types</dd>
+</dl>
+
+
+### <a name="com.microsoft.RestorePadding"></a><a name="com.microsoft.restorepadding">**com.microsoft.RestorePadding**</a>
+
+  Restore paddings and fill padding with zeros.
+  
+  The input has padding with shape (total_tokens, hidden_size) and token_offset with shape (batch_size, sequence_length).
+  The output has shape (batch_size, sequence_length, hidden_size).
+
+#### Version
+
+This version of the operator has been available since version 1 of the 'com.microsoft' operator set.
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T</dt>
+<dd>Input tensor with shape (total_tokens, hidden_size)</dd>
+<dt><tt>token_offset</tt> : M</dt>
+<dd>Offset of non-padding tokens and paddings. Its shape is (batch_size, sequence_length)</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T</dt>
+<dd>output tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float), tensor(float16)</dt>
+<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>M</tt> : tensor(int32)</dt>
+<dd>Constrain token_offset to integer types</dd>
 </dl>
 
 

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -793,6 +793,8 @@ Do not modify directly.*
 |QuantizeLinear|*in* x:**T1**<br> *in* y_scale:**T1**<br> *in* y_zero_point:**T2**<br> *out* y:**T2**|1+|**T1** = tensor(float16)<br/> **T2** = tensor(int8), tensor(uint8)|
 |QuantizeWithOrder|*in* input:**F**<br> *in* scale_input:**S**<br> *out* output:**Q**|1+|**F** = tensor(float), tensor(float16)<br/> **Q** = tensor(int8)<br/> **S** = tensor(float)|
 |QuickGelu|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
+|RemovePadding|*in* input:**T**<br> *in* sequence_token_count:**M**<br> *out* output:**T**<br> *out* token_offset:**M**<br> *out* cumulated_seq_len:**M**<br> *out* max_seq_len:**M**|1+|**T** = tensor(float), tensor(float16)|
+|RestorePadding|*in* input:**T**<br> *in* token_offset:**M**<br> *out* output:**T**|1+|**T** = tensor(float), tensor(float16)|
 |Rfft|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
 |SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**|1+|**T** = tensor(float), tensor(float16)|
 |TransposeMatMul|*in* A:**T**<br> *in* B:**T**<br> *out* Y:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
@@ -978,6 +980,8 @@ Do not modify directly.*
 |||7+|**T** = tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |Neg|*in* X:**T**<br> *out* Y:**T**|13+|**T** = tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8)|
 |||6+|**T** = tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8)|
+|NonZero|*in* X:**T**<br> *out* Y:**tensor(int64)**|13+|**T** = tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint8)|
+|||9+|**T** = tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint8)|
 |Not|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(bool)|
 |OneHot|*in* indices:**T1**<br> *in* depth:**T2**<br> *in* values:**T3**<br> *out* output:**T3**|11+|**T1** = tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)<br/> **T2** = tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T3** = tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |||9+|**T1** = tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)<br/> **T2** = tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T3** = tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "precomp.h"
+#include "core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h"
+#include "core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h"
+
+namespace Dml
+{
+
+class DmlOperatorNonZero: public DmlOperator
+{
+public:
+    DmlOperatorNonZero(const MLOperatorKernelCreationContext& kernelCreationContext)
+    :   DmlOperator(kernelCreationContext)
+    {
+        ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetInputCount() == 1);
+        ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetOutputCount() == 1);
+
+        std::vector<DimensionType> inputShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
+
+        // Scalars have a rank of 0, but DML only supports 1 and more, which is the same
+        if (inputShape.empty())
+        {
+            inputShape.push_back(1);
+        }
+
+        uint32_t numElements = ComputeElementCountFromDimensions(inputShape);
+
+        gsl::span<const uint32_t> inputShapes[1] = {inputShape};
+        DmlOperator::InitializeWithShapes(kernelCreationContext, std::nullopt, std::nullopt, inputShapes, std::nullopt, 1);
+
+        m_rank = static_cast<DimensionType>(inputShape.size());
+        std::vector<DimensionType> outputCountShape = {1};
+        std::vector<DimensionType> outputCoordinatesShape = {numElements, m_rank};
+
+        // TODO: Remove the doubled strides when DML supports native int64 for NonZero
+        // TensorFlow outputs {rank, numElements}, but DML outputs {numElements, rank}
+        std::vector<DimensionType> outputCoordinatesStrides = {2, numElements * 2};
+        m_intermediateTensorDescs = {
+            TensorDesc(DML_TENSOR_DATA_TYPE_UINT32, outputCountShape),
+            TensorDesc(DML_TENSOR_DATA_TYPE_UINT32, outputCoordinatesShape, outputCoordinatesStrides),
+        };
+
+        // If the input has no elements, bypass the DML execution
+        if (numElements == 0)
+        {
+            m_emptyInput = true;
+        }
+        else
+        {
+            m_emptyInput = false;
+            m_outputCountShape = {1};
+            m_outputCoordinatesShape = {static_cast<int64_t>(numElements), static_cast<int64_t>(m_rank)};
+
+            std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
+            std::vector<DML_TENSOR_DESC> intermediateDescs(m_intermediateTensorDescs.size());
+            for (size_t i = 0; i < intermediateDescs.size(); i++)
+            {
+                intermediateDescs[i] = m_intermediateTensorDescs[i].GetDmlDesc();
+            }
+
+            DML_NONZERO_COORDINATES_OPERATOR_DESC nonzeroCoordinatesDesc = {};
+            nonzeroCoordinatesDesc.InputTensor = &inputDescs[0];
+            nonzeroCoordinatesDesc.OutputCountTensor = &intermediateDescs[0];
+            nonzeroCoordinatesDesc.OutputCoordinatesTensor = &intermediateDescs[1];
+
+            // TODO: Remove this hack when DML supports native int64 for NonZero
+            // We use the int64/uint32 stride hack here, so zero out the data before writing to it
+            m_zeroOperator = InitializeZeroInt64Tensor(m_intermediateTensorDescs[1].GetBufferSizeInBytes());
+
+            DML_OPERATOR_DESC opDesc = { DML_OPERATOR_NONZERO_COORDINATES, &nonzeroCoordinatesDesc };
+            SetDmlOperatorDesc(opDesc, kernelCreationContext);
+        }
+    }
+
+    void Compute(const MLOperatorKernelContext& kernelContext)
+    {
+        ExecutionProviderImpl* executionProvider = static_cast<ExecutionProviderImpl*>(m_executionProvider.Get());
+
+        // Create the DML output tensor for the number of nonzero elements
+        onnxruntime::Tensor outputCountDml(onnxruntime::DataTypeImpl::GetType<uint32_t>(), m_outputCountShape, executionProvider->GetGpuAllocator());
+        Microsoft::WRL::ComPtr<IMLOperatorTensor> outputCountDmlWrapper = wil::MakeOrThrow<Windows::AI::MachineLearning::Adapter::TensorWrapper>(
+            &outputCountDml,
+            true,
+            executionProvider,
+            true);
+
+        // Create the DML output tensor for the coordinates (not cropped)
+        onnxruntime::Tensor intermediateCoordinatesDml(onnxruntime::DataTypeImpl::GetType<int64_t>(), m_outputCoordinatesShape, executionProvider->GetGpuAllocator());
+        Microsoft::WRL::ComPtr<IMLOperatorTensor> intermediateCoordinatesDmlWrapper = wil::MakeOrThrow<Windows::AI::MachineLearning::Adapter::TensorWrapper>(
+            &intermediateCoordinatesDml,
+            true,
+            executionProvider,
+            true);
+
+        std::vector<IMLOperatorTensor*> nonzeroCoordinatesInputTensors = GetInputTensors(kernelContext);
+        std::vector<IMLOperatorTensor*> nonzeroCoordinatesOutputTensors = {outputCountDmlWrapper.Get(), intermediateCoordinatesDmlWrapper.Get()};
+
+        uint32_t nonzeroElementCount = 0;
+
+        if (!m_emptyInput)
+        {
+            ORT_THROW_IF_FAILED(m_executionProvider->ExecuteOperator(
+                m_compiledOperator.Get(),
+                m_persistentResourceBinding ? &*m_persistentResourceBinding : nullptr,
+                gsl::make_span(nonzeroCoordinatesInputTensors),
+                gsl::make_span(nonzeroCoordinatesOutputTensors)));
+
+            // Copy the number of nonzero elements back to the CPU
+            onnxruntime::Tensor outputCountCpu(onnxruntime::DataTypeImpl::GetType<uint32_t>(), {1}, executionProvider->GetCpuInputAllocator());
+            Microsoft::WRL::ComPtr<IMLOperatorTensor> outputCountCpuWrapper = wil::MakeOrThrow<Windows::AI::MachineLearning::Adapter::TensorWrapper>(
+                &outputCountCpu,
+                false,
+                executionProvider,
+                true);
+            ORT_THROW_IF_FAILED(m_executionProvider->CopyTensor(
+                outputCountCpuWrapper.Get(),
+                nonzeroCoordinatesOutputTensors.front()));
+            nonzeroElementCount = outputCountCpu.Data<uint32_t>()[0];
+        }
+
+        // Create the final output tensor, which is cropped to the actual number of nonzero elements
+        std::vector<uint32_t> outputSizes({m_rank, nonzeroElementCount});
+        auto outputTensor = kernelContext.GetOutputTensor(0, outputSizes);
+
+        if (!m_emptyInput && nonzeroElementCount > 0)
+        {
+            // TODO: Remove this hack when DML supports native int64 for NonZero
+            ExecuteZeroInt64Tensor(m_zeroOperator.Get(), outputTensor.GetInterface().Get());
+
+            ComPtr<IDMLCompiledOperator> sliceOperator = InitializeSlice(m_intermediateTensorDescs[1], nonzeroElementCount);
+
+            // Finally, we crop the output to the actual number of nonzero elements, thus removing the padding
+            std::array<IMLOperatorTensor*, 1> sliceInputTensors = {nonzeroCoordinatesOutputTensors[1]};
+            std::array<IMLOperatorTensor*, 1> sliceOutputTensors = {outputTensor.GetInterface().Get()};
+
+            ORT_THROW_IF_FAILED(m_executionProvider->ExecuteOperator(
+                sliceOperator.Get(),
+                nullptr, // persistent resource binding
+                sliceInputTensors,
+                sliceOutputTensors));
+        }
+    }
+
+private:
+    ComPtr<IDMLCompiledOperator> InitializeSlice(TensorDesc& inputDesc, uint32_t nonzeroElementCount)
+    {
+        assert(inputDesc.GetSizes().size() == 2);
+
+        uint32_t rank = inputDesc.GetSizes().back();
+        std::array<uint32_t, 2> inputWindowOffsets = {0, 0};
+        std::array<int32_t, 2> inputWindowStrides = {1, 1};
+        std::array<uint32_t, 2> inputWindowSizes = {nonzeroElementCount, rank};
+
+        // TODO: Remove the doubled strides when DML supports native int64 for NonZero
+        std::array<uint32_t, 2> outputStrides = {2, nonzeroElementCount * 2};
+        TensorDesc outputDesc(inputDesc.GetDmlDataType(), inputWindowSizes, outputStrides);
+
+        const auto inputOpDesc = inputDesc.GetDmlDesc();
+        const auto outputOpDesc = outputDesc.GetDmlDesc();
+
+        DML_SLICE1_OPERATOR_DESC sliceDesc = {};
+        sliceDesc.DimensionCount = 2;
+        sliceDesc.InputWindowOffsets = inputWindowOffsets.data();
+        sliceDesc.InputWindowSizes = inputWindowSizes.data();
+        sliceDesc.InputWindowStrides = inputWindowStrides.data();
+        sliceDesc.InputTensor = &inputOpDesc;
+        sliceDesc.OutputTensor = &outputOpDesc;
+
+        DML_OPERATOR_DESC opDesc = { DML_OPERATOR_SLICE1, &sliceDesc };
+
+        ComPtr<IDMLOperator> dmlOperator;
+        ORT_THROW_IF_FAILED(m_dmlDevice->CreateOperator(&opDesc, IID_PPV_ARGS(&dmlOperator)));
+
+        ComPtr<IDMLCompiledOperator> dmlCompiledOperator;
+        ORT_THROW_IF_FAILED(m_dmlDevice->CompileOperator(dmlOperator.Get(), GetExecutionFlags(), IID_PPV_ARGS(&dmlCompiledOperator)));
+
+        return dmlCompiledOperator;
+    }
+
+    std::vector<TensorDesc> m_intermediateTensorDescs;
+    onnxruntime::TensorShape m_outputCountShape;
+    onnxruntime::TensorShape m_outputCoordinatesShape;
+    ComPtr<IDMLCompiledOperator> m_zeroOperator;
+    bool m_emptyInput = false;
+    uint32_t m_rank = 0;
+};
+
+DML_OP_DEFINE_CREATION_FUNCTION(NonZero, DmlOperatorNonZero);
+
+} // namespace Dml

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorVersions.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorVersions.h
@@ -157,7 +157,7 @@ namespace OperatorHelper
         static const int sc_sinceVer_Compress = 9;
         static const int sc_sinceVer_EyeLike = 9;
         static const int sc_sinceVer_Scatter = 9;
-        static const int sc_sinceVer_Nonzero = 9;
+        static const int sc_sinceVer_NonZero = 9;
         static const int sc_sinceVer_Shrink = 9;
         static const int sc_sinceVer_Greater = 9;
         static const int sc_sinceVer_Less = 9;
@@ -303,6 +303,7 @@ namespace OperatorHelper
         static const int sc_sinceVer_Mod = 13;
         static const int sc_sinceVer_Mul = 13;
         static const int sc_sinceVer_Neg = 13;
+        static const int sc_sinceVer_NonZero = 13;
         static const int sc_sinceVer_Pad = 13;
         static const int sc_sinceVer_Pow = 13;
         static const int sc_sinceVer_QuantizeLinear = 13;


### PR DESCRIPTION
### Description
Add the NonZero op for DML



### Motivation and Context
NonZero is used in a few transformer models, so having a DML implementation will stop large tensors from being transferred to the CPU and back to the GPU


