### PR TITLE
Add DML support to the transformers benchmark.py script

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -118,9 +118,10 @@ def run_onnxruntime(
         use_gpu
         and ("CUDAExecutionProvider" not in onnxruntime.get_available_providers())
         and ("ROCMExecutionProvider" not in onnxruntime.get_available_providers())
+        and ("DmlExecutionProvider" not in onnxruntime.get_available_providers())
     ):
         logger.error(
-            "Please install onnxruntime-gpu package instead of onnxruntime, and use a machine with GPU for testing gpu performance."
+            "Please install onnxruntime-gpu or onnxruntime-directml package instead of onnxruntime, and use a machine with GPU for testing gpu performance."
         )
         return results
 


### PR DESCRIPTION
### Description
Add DML support to the transformers benchmark.py script



### Motivation and Context
Before this change, running the `benchmark.py` script when the `onnxruntime-directml` package is installed resulted in an error because it expects a CUDA or ROCM framework.


