### PR TITLE
Misc minor bug fixes in transformer kernels

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_base.h
@@ -191,7 +191,7 @@ Status BeamSearchBase<T>::CheckInputs(const OpKernelContextInternal& context) {
                                             context.Input<Tensor>(0),     // input_ids
                                             context.Input<Tensor>(7),     // vocab_mask
                                             context.Input<Tensor>(8),     // prefix_vocab_mask
-                                            context.Input<Tensor>(10)));  // attention_mask
+                                            context.Input<Tensor>(9)));  // attention_mask
 
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -122,14 +122,14 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   cublasHandle_t cublas = CublasHandle();
   constexpr size_t element_size = sizeof(T);
 
-  IAllocatorUniquePtr<T> gemm_buffer;
+  IAllocatorUniquePtr<void> gemm_buffer;
   if (weights != nullptr) {
     // Use GEMM for fully connection.
     int m = batch_size * sequence_length;
     int n = (parameters.hidden_size + parameters.hidden_size + parameters.v_hidden_size);
     int k = parameters.input_hidden_size;
     size_t gemm_buffer_size = static_cast<size_t>(batch_size) * sequence_length * n * element_size;
-    gemm_buffer = GetScratchBuffer<T>(gemm_buffer_size);
+    gemm_buffer = GetScratchBuffer<void>(gemm_buffer_size);
 
     typedef typename ToCudaType<T>::MappedType CudaT;
     CudaT one = ToCudaType<T>::FromFloat(1.0f);


### PR DESCRIPTION
1) Fix off by one index bug in BeamSearch's input validation. The `attention_mask` is the 10th input (9th index). Even if test models had attention mask, the check didn't happen, as it will always be passed in as nullptr to the actual validation method which will in-turn skip the validation for it as receiving nullptr for the optional input would be taken as the optional input is not provided. 

2) In the Attention op, `gemm_buffer_size` already has element size cooked into it, so we don't need to template on element type for `GetSratchBuffer()` - this should reduce the amount of memory allocated for it by a factor of `element_size`
