### PR TITLE
skip quantized model C# tests on GPU

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -451,13 +451,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 //var modelRoot = new DirectoryInfo(Path.Combine(modelsDir, opsetDir.Name));
                 foreach (var modelDir in opsetDir.EnumerateDirectories())
                 {
-#if USE_CUDA
-                    if (!skipModels.ContainsKey(modelDir.Name))
-#else
-                    if (!(skipModels.ContainsKey(modelDir.Name) || 
+                    if (!(skipModels.ContainsKey(modelDir.Name) ||
                           modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
                           modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase)))
-#endif
                     {
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };
                     }
@@ -475,13 +471,9 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 foreach (var modelDir in opsetDir.EnumerateDirectories())
                 {
-#if USE_CUDA
-                    if (skipModels.ContainsKey(modelDir.Name))
-#else
                     if (skipModels.ContainsKey(modelDir.Name) ||
                         modelDir.Name.Contains("int8", StringComparison.OrdinalIgnoreCase) ||
                         modelDir.Name.Contains("qdq", StringComparison.OrdinalIgnoreCase))
-#endif
                     {
                         //Console.WriteLine("Model {0} is skipped due to the error: {1}", modelDir.FullName, skipModels[modelDir.Name]);
                         yield return new object[] { modelDir.Parent.FullName, modelDir.Name };


### PR DESCRIPTION
### Description
Skip quantized model C# tests on GPU too.

### Motivation and Context
It looks the current test result isn't reasonable.
https://github.com/onnx/models/issues/581

Once we update the image, the quantized model [test data will be generated with VNNI](https://github.com/onnx/models/commit/ba629906dd91872def671e70177c5544e0ea9e02), the CI would be broken.


