### PR TITLE
[oneDNN ep] QAttention BF16 and GPU support added

### DIFF
--- a/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
+++ b/onnxruntime/core/providers/dnnl/dnnl_node_capability.cc
@@ -923,13 +923,6 @@ bool DnnlQAttentionNodeCapability::Supported(const Node* node, const GraphViewer
     return false;
   }
 
-  // qattention is disabled on gpu due to the following onednn bugs
-  // 1. flipped zero points in int8 matmul
-  // 2. unsupported runtime input source0 scaling in binary
-  // 3. f32 matmul on submemory gives wrong result
-  if (dnnl_engine_get_count(dnnl_engine_kind_t::dnnl_gpu)) {
-    return false;
-  }
   return true;
 }
 

--- a/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.h
+++ b/onnxruntime/core/providers/dnnl/subgraph/dnnl_qattention.h
@@ -2,8 +2,10 @@
 // Licensed under the MIT License
 
 #pragma once
+#include <cmath>
 #include "dnnl_subgraph.h"
 #include "dnnl_subgraph_primitive.h"
+#include "dnnl_util.h"
 
 namespace onnxruntime {
 namespace ort_dnnl {
@@ -33,6 +35,9 @@ class DnnlQAttention {
  private:
   dnnl::memory ComputeTotalScale(DnnlSubgraphPrimitive& sp, DnnlNode& node);
   dnnl::memory::dim GetNumHeads(DnnlNode& node);
+  dnnl::memory CopySubMemory(DnnlSubgraphPrimitive& sp, dnnl::memory& src_mem, dnnl::memory::dims sub_mem_dims, dnnl::memory::dims sub_mem_offset);
+  dnnl::memory CastMemory(DnnlSubgraphPrimitive& sp, dnnl::memory& src_mem, dnnl::memory::data_type dst_datatype);
+  dnnl::memory CastAndTransformMemory(DnnlSubgraphPrimitive& sp, dnnl::memory& src_mem, dnnl::memory::data_type dst_datatype, dnnl::memory::dims dst_strides);
 };
 
 }  // namespace ort_dnnl


### PR DESCRIPTION
### Description
QAttention performance improvement when hardware supports amx and avx-bf16 execution.

### Motivation and Context

- Streamlined the code to dynamically switch between BF16 and FP32 execution as and when supported by hardware

- Split QKV memory into three different memories for Q, K, and V. This helps to run QAttention on GPU and take advantage of parallel processing.

- This change has shown a significant amount of performance gain for QAttention operator on hardware like Sapphire Rapids which supports amx and avx-bf16.