### PR TITLE
exclude multi-stream logics from planner for minimal build

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -990,6 +990,7 @@ class PlannerImpl {
     return true;
   }
 
+#ifndef ORT_MINIMAL_BUILD
   // assume we already have a baseline reuse plan (no memory reuse at all)
   // this funciton will optimize the plan by building a reuse plan with stream safety.
   Status OptimizeReusePlanForMultiStream() {
@@ -1293,6 +1294,7 @@ class PlannerImpl {
     }
     return Status::OK();
   }
+#endif
 
   Status ComputeReusePlan() {
     gsl::not_null<const ISequentialPlannerContext*> backup_context = context_;
@@ -1324,7 +1326,11 @@ class PlannerImpl {
 #endif
     if (IsSingleStream())
       return Status::OK();
+
+#ifndef ORT_MINIMAL_BUILD
     ORT_RETURN_IF_ERROR(OptimizeReusePlanForMultiStream());
+#endif
+
     // restore context
     context_ = backup_context;
 
@@ -1702,6 +1708,41 @@ class PlannerImpl {
     return Status::OK();
   }
 
+#ifdef ORT_MINIMAL_BUILD
+
+  void PartitionIntoStreams(const logging::Logger& /*logger*/, const ExecutionProviders& /*execution_providers*/,
+                            const std::string& /*partition_config_file*/) {
+    stream_nodes_.push_back({});
+    node_stream_map_.resize(SafeInt<size_t>(graph_viewer_.MaxNodeIndex()) + 1);
+    for (auto node_index : graph_viewer_.GetNodesInTopologicalOrder()) {
+      stream_nodes_[0].push_back(node_index);
+      node_stream_map_[node_index] = 0;
+    }
+    num_logic_streams_ = 1;
+  }
+
+  Status BuildExecutionPlan(const ExecutionProviders& execution_providers,
+                            const IStreamCommandHandleRegistry& /*stream_handle_registry*/) {
+    // 1. create logic stream instance
+    auto& execution_plan = plan_.execution_plan;
+    ORT_ENFORCE(num_logic_streams_ == 1 && !stream_nodes_[0].empty());
+    auto first_node_index = stream_nodes_[0][0];
+    auto* node = graph_viewer_.GetNode(first_node_index);
+    onnxruntime::ProviderType exec_provider_name = node->GetExecutionProviderType();
+    const IExecutionProvider* ep = execution_providers.Get(exec_provider_name);
+    ORT_ENFORCE(ep);
+    auto& node_device_mem_location = ep->GetAllocator(ep->GetDeviceId(), OrtMemType::OrtMemTypeDefault)->Info();
+    execution_plan.emplace_back(std::make_unique<SequentialExecutionPlan::LogicStream>(node_device_mem_location.device));
+    // 2. add steps to the execution plan
+    for (auto node_index : stream_nodes_[0]) {
+      execution_plan[0]->steps_.emplace_back(std::make_unique<LaunchKernelStep>(node_index));
+      std::cout << "SINGLE STREAM" << std::endl;
+    }
+    return Status::OK();
+  }
+
+#else
+
   void PartitionIntoStreams(const logging::Logger& logger, const ExecutionProviders& execution_providers,
                             const std::string& partition_config_file) {
     auto partitioner = IGraphPartitioner::CreateGraphPartitioner(logger, partition_config_file);
@@ -2015,6 +2056,7 @@ class PlannerImpl {
 
     return Status::OK();
   }
+#endif
 
   static bool
   IsNonTensor(const onnxruntime::NodeArg& nodearg) {
@@ -2147,7 +2189,9 @@ Status SequentialPlanner::CreatePlan(
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// TODO: update the keyword in the config file
+
+#if !defined(ORT_MINIMAL_BUILD)
+
 InlinedHashMap<std::string, IGraphPartitioner::GraphPartitioningStrategy> IGraphPartitioner::name_type_map = {{std::string{"DeviceBasedPartitioner"}, GraphPartitioningStrategy::DeviceBasedPartition}};
 
 class DeviceBasedPartitioner : public IGraphPartitioner {
@@ -2370,5 +2414,6 @@ std::unique_ptr<IGraphPartitioner> IGraphPartitioner::CreateGraphPartitioner(con
 
   return graph_partitioner;
 }
+#endif
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -1736,7 +1736,6 @@ class PlannerImpl {
     // 2. add steps to the execution plan
     for (auto node_index : stream_nodes_[0]) {
       execution_plan[0]->steps_.emplace_back(std::make_unique<LaunchKernelStep>(node_index));
-      std::cout << "SINGLE STREAM" << std::endl;
     }
     return Status::OK();
   }

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -990,7 +990,7 @@ class PlannerImpl {
     return true;
   }
 
-#ifndef ORT_MINIMAL_BUILD
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
   // assume we already have a baseline reuse plan (no memory reuse at all)
   // this funciton will optimize the plan by building a reuse plan with stream safety.
   Status OptimizeReusePlanForMultiStream() {
@@ -1327,7 +1327,7 @@ class PlannerImpl {
     if (IsSingleStream())
       return Status::OK();
 
-#ifndef ORT_MINIMAL_BUILD
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
     ORT_RETURN_IF_ERROR(OptimizeReusePlanForMultiStream());
 #endif
 
@@ -1708,7 +1708,7 @@ class PlannerImpl {
     return Status::OK();
   }
 
-#ifdef ORT_MINIMAL_BUILD
+#if defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
   void PartitionIntoStreams(const logging::Logger& /*logger*/, const ExecutionProviders& /*execution_providers*/,
                             const std::string& /*partition_config_file*/) {
@@ -2190,7 +2190,7 @@ Status SequentialPlanner::CreatePlan(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
 
 InlinedHashMap<std::string, IGraphPartitioner::GraphPartitioningStrategy> IGraphPartitioner::name_type_map = {{std::string{"DeviceBasedPartitioner"}, GraphPartitioningStrategy::DeviceBasedPartition}};
 

--- a/onnxruntime/core/framework/allocation_planner.h
+++ b/onnxruntime/core/framework/allocation_planner.h
@@ -72,7 +72,7 @@ class SequentialPlannerContext : public ISequentialPlannerContext {
   bool enable_memory_reuse_ = true;
 };
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
 // Given a graph with node placement information, partition the nodes into multiple sequence.
 // Each sequence can be executed in-dependently. The nodes in each sequence are executed in order,
 // but we can't assume any execution order between sequences, unless there is a data dependency.

--- a/onnxruntime/core/framework/allocation_planner.h
+++ b/onnxruntime/core/framework/allocation_planner.h
@@ -72,6 +72,7 @@ class SequentialPlannerContext : public ISequentialPlannerContext {
   bool enable_memory_reuse_ = true;
 };
 
+#if !defined(ORT_MINIMAL_BUILD)
 // Given a graph with node placement information, partition the nodes into multiple sequence.
 // Each sequence can be executed in-dependently. The nodes in each sequence are executed in order,
 // but we can't assume any execution order between sequences, unless there is a data dependency.
@@ -105,6 +106,7 @@ class IGraphPartitioner {
   std::string configuration_file_{};
   int devices_ = 0;
 };
+#endif
 
 class SequentialPlanner {
  public:


### PR DESCRIPTION
Exclude multi-stream logics from minimal build.
With the change, allocation_planner.obj size was reduced from 51.2k to 8.8k.

- [binary size](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=822718&view=results)
- [linux minimal build](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=822719&view=results)
- [ios](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=822720&view=results)
- [android](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=822721&view=results)
- [coreml](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=822722&view=results)
