### PR TITLE
Decouple strided tensor support from ENABLE_TRAINING

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1224,6 +1224,7 @@ endif()
 if (onnxruntime_ENABLE_TRAINING)
   add_compile_definitions(ENABLE_TRAINING)
   add_compile_definitions(ENABLE_TRAINING_OPS)
+  add_compile_definitions(ENABLE_STRIDED_TENSORS)
 
   if (UNIX)
     if (EXISTS "${onnxruntime_MPI_HOME}")

--- a/include/onnxruntime/core/framework/kernel_def_builder.h
+++ b/include/onnxruntime/core/framework/kernel_def_builder.h
@@ -85,7 +85,7 @@ class KernelDef {
 
   bool HasExternalOutputs() const { return external_outputs_; }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   const std::vector<int>& MayStridedInput() const { return may_strided_inputs_; }
   const std::vector<std::pair<int, int>>& MayStridedOutput() const { return may_strided_output_map_; }
 #endif
@@ -143,7 +143,7 @@ class KernelDef {
   // Whether the outputs are from external.
   bool external_outputs_ = false;
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   // An element i means i-th input can be strided tensor.
   std::vector<int> may_strided_inputs_;
 
@@ -261,7 +261,7 @@ class KernelDefBuilder {
     return *this;
   }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   /**
      Specify that the input_index-th input can be strided tensor.
    */

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -248,7 +248,7 @@ class Tensor final {
   */
   size_t SizeInBytes() const;
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   /**
    * Get the strides of the tensor.
    */
@@ -276,7 +276,7 @@ class Tensor final {
 
   void ReleaseBuffer();
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   bool CheckIsContiguous() const;
 #endif
 
@@ -289,7 +289,7 @@ class Tensor final {
   AllocatorPtr buffer_deleter_;
 
   TensorShape shape_;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   mutable TensorShapeVector strides_;
   bool is_contiguous_ = true;
 #endif

--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -363,7 +363,7 @@ class PlannerImpl {
       }
     }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
     // If any output of the kernel can support strided tensor, and all its consumers' inputs also support
     // strided tensors at the corresponding position, this output will generate a strided tensor
     // and share the data from the corresponding input specified in MayStridedOutputsMap.
@@ -1018,11 +1018,11 @@ class PlannerImpl {
           // and optional types if the kernel has marked certain inputs as
           // possible candidates for re-use
           Reuse(reused, current, AllocKind::kReuse);
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
           if (is_strided_tensor) AllocPlan(current).is_strided_tensor = true;
 #else
           ORT_ENFORCE(!is_strided_tensor, "Strided tensor is not supported in non-training build for now.");
-#endif  // ENABLE_TRAINING
+#endif  // ENABLE_STRIDED_TENSORS
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
           InplaceReuse(reused, current);
 #endif

--- a/onnxruntime/core/framework/data_transfer.cc
+++ b/onnxruntime/core/framework/data_transfer.cc
@@ -7,7 +7,7 @@
 #include "core/framework/sparse_tensor.h"
 #endif
 #include "core/framework/ortdevice.h"
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 #include "core/framework/copy.h"
 #include "core/session/environment.h"
 #include "core/common/logging/logging.h"

--- a/onnxruntime/core/framework/data_transfer.cc
+++ b/onnxruntime/core/framework/data_transfer.cc
@@ -50,7 +50,7 @@ common::Status CPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int /
     return Status::OK();
   }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   if (!src.IsContiguous() || !dst.IsContiguous()) {
     auto dst_stride_vec = dst.Strides();
     auto src_stride_vec = src.Strides();
@@ -71,7 +71,7 @@ common::Status CPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst, int /
     }
 
     return Status::OK();
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   }
 #endif
 }

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -580,9 +580,9 @@ Status ExecutionFrame::AllocateMLValueTensorPreAllocateBuffer(OrtValue& ort_valu
 
   // Training starts to support strided tensor that the shape size may be larger (like Expand), smaller (like Split) or
   // equal (like Transpose) to the shared tensor's shape size, so below check is no longer valid.
-#ifndef ENABLE_TRAINING
+#ifndef ENABLE_STRIDED_TENSORS
   ORT_ENFORCE(!is_strided_tensor);
-#endif  // ENABLE_TRAINING
+#endif  // ENABLE_STRIDED_TENSORS
   if (!is_strided_tensor) {
     auto buffer_num_elements = reuse_tensor->Shape().Size();
     auto required_num_elements = shape.Size();
@@ -733,9 +733,9 @@ Status ExecutionFrame::AllocateAsPerAllocationPlan(OrtValue& ort_value, int ort_
         ORT_RETURN_IF_ERROR(AllocateReusedOrtValueIfNotAllocatedHelper(reuse_mlvalue_index, shape));
 
         bool is_strided_tensor = false;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
         is_strided_tensor = per_alloc_plan.is_strided_tensor;
-#endif  // ENABLE_TRAINING
+#endif  // ENABLE_STRIDED_TENSORS
         ORT_RETURN_IF_ERROR(
             AllocateMLValueTensorPreAllocateBuffer(ort_value, reuse_mlvalue_index, ml_data_type, alloc_info, *shape,
                                                    per_alloc_plan.create_fence_if_async, is_strided_tensor));

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -179,7 +179,7 @@ KernelDefBuilder& KernelDefBuilder::VariadicAlias(int input_offset, int output_o
   return *this;
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 KernelDefBuilder& KernelDefBuilder::MayStridedInput(int input_index) {
   kernel_def_->may_strided_inputs_.emplace_back(input_index);
   return *this;

--- a/onnxruntime/core/framework/sequential_execution_plan.h
+++ b/onnxruntime/core/framework/sequential_execution_plan.h
@@ -41,7 +41,7 @@ struct AllocPlanPerValue {
   IntervalT allocate_interval{0, 0};
   OrtValueIndex inplace_reuse{-1}; //No in-place reuse
 #endif
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   // is_strided_tensor indicates if this OrtValue is strided tensor.
   // If alloc_kind is kReuse, it reuses one of the node inputs (like Expand),
   // if alloc_kind is kAllocate, it will only allocate required buffer size (like ConstantOfShape).

--- a/onnxruntime/core/framework/tensor.cc
+++ b/onnxruntime/core/framework/tensor.cc
@@ -12,7 +12,7 @@
 
 namespace onnxruntime {
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 namespace {
 int64_t GetSizeFromStrides(const TensorShape& shape, gsl::span<const int64_t> strides) {
   SafeInt<int64_t> size = 1;
@@ -39,7 +39,7 @@ Tensor::Tensor(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAll
                gsl::span<const int64_t> strides)
     : alloc_info_(allocator->Info()) {
   ORT_ENFORCE(p_type != nullptr);
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   int64_t shape_size = 1;
   if (shape.NumDimensions() > 0 && !strides.empty()) {
     ORT_ENFORCE(shape.NumDimensions() == strides.size(), "Length of strides doesn't match with tensor dimension size.");
@@ -87,7 +87,7 @@ void Tensor::InitOrtValue(MLDataType p_type, const TensorShape& shape, void* p_d
 }
 
 size_t Tensor::SizeInBytes() const {
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   int64_t size = IsContiguous() ? shape_.Size() : GetSizeFromStrides(shape_, strides_);
 #else
   int64_t size = shape_.Size();
@@ -117,7 +117,7 @@ void Tensor::Init(MLDataType p_type, const TensorShape& shape, void* p_raw_data,
     utils::ConstructStrings(p_data_, shape_size);
   }
   byte_offset_ = offset;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   if (shape.NumDimensions() > 0 && !strides.empty()) {
     ORT_ENFORCE(shape.NumDimensions() == strides.size(), "Length of strides doesn't match with tensor dimension size.");
     strides_.assign(strides.begin(), strides.end());
@@ -175,7 +175,7 @@ void Tensor::ReleaseBuffer() {
   }
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 bool Tensor::CheckIsContiguous() const {
   if (strides_.empty()) {
     return true;

--- a/onnxruntime/core/providers/cuda/tensor/expand.cc
+++ b/onnxruntime/core/providers/cuda/tensor/expand.cc
@@ -58,7 +58,7 @@ static void CalcEffectiveDims(TensorShapeVector& x_dims, TensorShapeVector& y_di
   }
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 TensorShapeVector ComputeOutputStrides(const TensorShape& input_shapes, const gsl::span<const int64_t>& input_strides,
                                        const TensorShape& output_shapes) {
   const size_t rank = output_shapes.NumDimensions();
@@ -101,7 +101,7 @@ Status Expand::ComputeInternal(OpKernelContext* ctx) const {
     return Status::OK();
   }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   // Strided output.
   if (input_data_tensor.DataRaw() == output_tensor.DataRaw()) {
     gsl::span<const int64_t> input_strides = input_data_tensor.Strides();
@@ -142,7 +142,7 @@ Status Expand::ComputeInternal(OpKernelContext* ctx) const {
       input_strides);
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 #define CREATE_EXPAND_KERNEL_DEF (*KernelDefBuilder::Create()).MayStridedOutput(0, 0)
 #else
 #define CREATE_EXPAND_KERNEL_DEF (*KernelDefBuilder::Create())

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
@@ -12,7 +12,7 @@ namespace cuda {
 // Ideally both input and indices can support strided tensor, for training case, the indices is the input for both
 // GatherElements and GatherElementsGrad, indices supporting strided tensor is more useful for saving memory.
 // So we only mark indices as MayStridedInput for now. Will do this for input once needed.
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 #define CREATE_GATHER_ELEMENTS_KERNEL_DEF (*KernelDefBuilder::Create()).MayStridedInput(1)
 #else
 #define CREATE_GATHER_ELEMENTS_KERNEL_DEF (*KernelDefBuilder::Create())
@@ -175,7 +175,7 @@ Status GatherElements::ComputeInternal(OpKernelContext* context) const {
   TensorShapeVector indices_shape_vec = indices_shape.AsShapeVector();
   TensorShapeVector* p_indices_strides_vec = nullptr;
   TensorShapeVector indices_strides_vec;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   if (!indices_tensor->IsContiguous()) {
     indices_strides_vec = ToShapeVector(indices_tensor->Strides());
     p_indices_strides_vec = &indices_strides_vec;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -498,7 +498,7 @@ struct ProviderHost {
   virtual void KernelDefBuilder__VariadicAlias(KernelDefBuilder* p, int input_offset, int output_offset) = 0;
   virtual void KernelDefBuilder__ExternalOutputs(KernelDefBuilder* p) = 0;
   virtual void KernelDefBuilder__AllocateInputsContiguously(KernelDefBuilder* p) = 0;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   virtual void KernelDefBuilder__MayStridedInput(KernelDefBuilder* p, int input_index) = 0;
   virtual void KernelDefBuilder__MayStridedOutput(KernelDefBuilder* p, int input_index, int output_index) = 0;
 #endif
@@ -824,7 +824,7 @@ struct ProviderHost {
   virtual const OrtMemoryInfo& Tensor__Location(const Tensor* p) = 0;
   virtual int32_t Tensor__GetElementType(const Tensor* p) = 0;
   virtual MLDataType Tensor__DataType(const Tensor* p) = 0;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   virtual gsl::span<const int64_t> Tensor__Strides(const Tensor* p) = 0;
   virtual bool Tensor__IsContiguous(const Tensor* p) = 0;
   virtual void Tensor__SetShapeAndStrides(Tensor* p, const TensorShape& new_shape,

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -487,7 +487,7 @@ struct KernelDefBuilder final {
     return *this;
   }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   KernelDefBuilder& MayStridedInput(int input_index) {
     g_host->KernelDefBuilder__MayStridedInput(this, input_index);
     return *this;
@@ -947,7 +947,7 @@ struct Tensor final {
   MLDataType DataType() const { return g_host->Tensor__DataType(this); }
   bool IsDataTypeString() const { return g_host->Tensor__IsDataTypeString(this); }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   gsl::span<const int64_t> Strides() const noexcept { return g_host->Tensor__Strides(this); }
   bool IsContiguous() const { return g_host->Tensor__IsContiguous(this); }
   void SetShapeAndStrides(const TensorShape& new_shape, gsl::span<const int64_t> new_strides) {

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -585,7 +585,7 @@ struct ProviderHostImpl : ProviderHost {
   void KernelDefBuilder__VariadicAlias(KernelDefBuilder* p, int input_offset, int output_offset) override { p->VariadicAlias(input_offset, output_offset); }
   void KernelDefBuilder__ExternalOutputs(KernelDefBuilder* p) override { p->ExternalOutputs(); }
   void KernelDefBuilder__AllocateInputsContiguously(KernelDefBuilder* p) override { p->AllocateInputsContiguously(); }
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   void KernelDefBuilder__MayStridedInput(KernelDefBuilder* p, int input_index) override { p->MayStridedInput(input_index); }
   void KernelDefBuilder__MayStridedOutput(KernelDefBuilder* p, int input_index, int output_index) override { p->MayStridedOutput(input_index, output_index); }
 #endif
@@ -947,7 +947,7 @@ struct ProviderHostImpl : ProviderHost {
   const OrtMemoryInfo& Tensor__Location(const Tensor* p) override { return p->Location(); }
   int32_t Tensor__GetElementType(const Tensor* p) override { return p->GetElementType(); }
   MLDataType Tensor__DataType(const Tensor* p) override { return p->DataType(); }
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   gsl::span<const int64_t> Tensor__Strides(const Tensor* p) override { return p->Strides(); }
   bool Tensor__IsContiguous(const Tensor* p) override { return p->IsContiguous(); }
   void Tensor__SetShapeAndStrides(Tensor* p, const TensorShape& new_shape,

--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -166,7 +166,7 @@ class PlannerTest : public ::testing::Test {
   std::unique_ptr<::onnxruntime::KernelDef> std_kernel_;               // a unary kernel with no-aliasing and no-in-place
   std::unique_ptr<::onnxruntime::KernelDef> in_place_kernel_;          // a unary kernel with in-place
   std::unique_ptr<::onnxruntime::KernelDef> external_outputs_kernel_;  // an unary kernel with external outputs
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   std::unique_ptr<::onnxruntime::KernelDef> may_strided_input_kernel_;   // an uinary kernel with may_strided_input
   std::unique_ptr<::onnxruntime::KernelDef> may_strided_output_kernel_;  // an unary kernel with may_strided_output
 #endif
@@ -194,7 +194,7 @@ class PlannerTest : public ::testing::Test {
         KernelDefBuilder().SetName("Relu").Provider(kCpuExecutionProvider).SinceVersion(1, 10).MayInplace(0, 0).Build();
     external_outputs_kernel_ =
         KernelDefBuilder().SetName("Tanh").Provider(kCpuExecutionProvider).SinceVersion(1, 10).ExternalOutputs().Build();
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
     may_strided_input_kernel_ = KernelDefBuilder()
                                     .SetName("Abs")
                                     .Provider(kCpuExecutionProvider)
@@ -243,7 +243,7 @@ class PlannerTest : public ::testing::Test {
     return AddNode(*external_outputs_kernel_, input, output);
   }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   onnxruntime::Node* AddMayStridedInputNode(std::string& input, std::string& output) {
     return AddNode(*may_strided_input_kernel_, input, output);
   }
@@ -480,7 +480,7 @@ TEST_F(PlannerTest, ExternalOutputsTest) {
   CheckFreed(2, {X3});
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 TEST_F(PlannerTest, MayStridedTest1) {
   // tensor variables:
   std::string X1("X1"), X2("X2"), X3("X3");

--- a/onnxruntime/test/framework/tensor_test.cc
+++ b/onnxruntime/test/framework/tensor_test.cc
@@ -210,7 +210,7 @@ TEST(TensorTest, SizeOverflow) {
   EXPECT_THROW(t.SizeInBytes(), OnnxRuntimeException);
 }
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 TEST(TensorTest, Strided) {
   TensorShape shape({2, 3, 4});
   auto alloc = TestCPUExecutionProvider()->GetAllocator(0, OrtMemTypeDefault);

--- a/onnxruntime/test/providers/cpu/tensor/expand_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/expand_test.cc
@@ -5,7 +5,7 @@
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 #include "test/providers/kernel_compute_test_utils.h"
 #endif
 
@@ -187,7 +187,7 @@ TEST(ExpandOpTest, Expand_scalar_int32) {
   test.Run();
 }
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 TEST(ExpandOpTest, Strided) {
 #ifdef USE_CUDA
   const char* provider = kCudaExecutionProvider;

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -9,7 +9,7 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 #include "test/providers/kernel_compute_test_utils.h"
 #endif
 
@@ -210,7 +210,7 @@ void RunTestWrapper<std::string>() {
   test8.Run();
 }
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 template <typename T, typename TIndex>
 void RunKernelComputeTest(std::initializer_list<int64_t> input_dims, std::initializer_list<int64_t> indices_dims,
                           std::initializer_list<int64_t> indices_strides = {}, bool has_axis = false,
@@ -405,7 +405,7 @@ TEST(GatherElementsOpTest, BigIndices) {
   test1.Run();
 }
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 TEST(GatherElementsOpTest, Strided_float) { RunKernelComputeTestWrapper<float>(); }
 
 TEST(GatherElementsOpTest, Strided_double) { RunKernelComputeTestWrapper<double>(); }

--- a/orttraining/orttraining/test/training_ops/cuda/gather_elements_grad_test.cc
+++ b/orttraining/orttraining/test/training_ops/cuda/gather_elements_grad_test.cc
@@ -8,7 +8,7 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 #include "test/providers/kernel_compute_test_utils.h"
 #endif
 
@@ -135,7 +135,7 @@ void RunTestWrapper() {
   RunTest<T, int64_t>({2, 1, 1, 2, 3, 2, 3}, {2, 1, 1, 2, 3, 2, 2}, true, -5LL);
 }
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 template <typename T, typename TIndex>
 void RunKernelComputeTest(std::initializer_list<int64_t> input_dims, std::initializer_list<int64_t> indices_dims,
                           std::initializer_list<int64_t> indices_strides = {}, bool has_axis = false,
@@ -197,7 +197,7 @@ TEST(GatherElementsGrad, IndicesUpdatesDontMatch) {
   test.Run(onnxruntime::test::OpTester::ExpectResult::kExpectFailure, "");
 }
 
-#if defined(ENABLE_TRAINING) && (defined(USE_CUDA) || defined(USE_ROCM))
+#if defined(ENABLE_STRIDED_TENSORS) && (defined(USE_CUDA) || defined(USE_ROCM))
 TEST(GatherElementsGrad, Strided_float) { RunKernelComputeTestWrapper<float>(); }
 
 TEST(GatherElementsGrad, Strided_double) { RunKernelComputeTestWrapper<double>(); }

--- a/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/gather_elements_grad.cc
@@ -12,7 +12,7 @@
 namespace onnxruntime {
 namespace cuda {
 
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
 #define CREATE_GATHER_ELEMENTS_GRAD_KERNEL_DEF (*KernelDefBuilder::Create()).MayStridedInput(2)
 #else
 #define CREATE_GATHER_ELEMENTS_GRAD_KERNEL_DEF (*KernelDefBuilder::Create())
@@ -85,7 +85,7 @@ Status GatherElementsGrad::ComputeInternal(OpKernelContext* context) const {
   TensorShapeVector indices_shape_vec = indices_shape.AsShapeVector();
   TensorShapeVector* p_indices_strides_vec = nullptr;
   TensorShapeVector indices_strids_vec;
-#ifdef ENABLE_TRAINING
+#ifdef ENABLE_STRIDED_TENSORS
   if (!indices_tensor->IsContiguous()) {
     indices_strids_vec = ToShapeVector(indices_tensor->Strides());
     p_indices_strides_vec = &indices_strids_vec;


### PR DESCRIPTION
### Description
Decouple strided tensor support from ENABLE_TRAINING

### Motivation and Context
This is step 1 for creating a dedicated build for on device training. Intention is

1. We can set ENABLE_STRIDED_TENSORS in cmake when either ENABLE_TRAINING or  ENABLE_TRAINING_ON_DEVICE is selected, this way we dont have to use if defined(ENABLE_TRAINING) || defined(ENABLE_TRAINING_ON_DEVICE ) everywhere in the code.

2. This also paves the way to easily enable strided tensor support for inference in future (if required).



