### PR TITLE
Include algorithm selection exposed by ROCBLAS extensions API in GEMM autotuning

### DIFF
--- a/onnxruntime/core/framework/tunable.h
+++ b/onnxruntime/core/framework/tunable.h
@@ -250,10 +250,10 @@ protected:
   }
 
   std::vector<Op<ParamsT>> ops_;
-  // mapping from Signature to best impl
-  std::unordered_map<std::string, int> kernel_map_;
 
  private:
+  // mapping from Signature to best impl
+  std::unordered_map<std::string, int> kernel_map_;
   // the default impl to use when tuning is disabled
   int default_id_{0};
   bool tuning_{false};

--- a/onnxruntime/core/framework/tunable.h
+++ b/onnxruntime/core/framework/tunable.h
@@ -235,7 +235,7 @@ class TunableOp {
 #endif
   }
 
-protected:
+ protected:
   virtual int FindFastest(const ParamsT* params) {
     return FindFastestImpl(params, ops_);
   }

--- a/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
@@ -33,7 +33,7 @@ class RocblasHandleStreamGuard {
   hipStream_t original_stream_;
 };
 
-#if defined USE_ROCBLAS_EXTENSION_API
+#ifdef USE_ROCBLAS_EXTENSION_API
 
 template <typename T>
 constexpr rocblas_datatype RocBlasDataTypeFor(const T*) {
@@ -80,6 +80,11 @@ constexpr rocblas_datatype RocBlasComputeTypeFor<float>(const float*) {
 
 template <>
 constexpr rocblas_datatype RocBlasComputeTypeFor<half>(const half*) {
+  // Note that we're returning the _compute_ type for a given datatype.
+  // As of 12/2022, using compute type FP16 for 16-bit floats was much
+  // slower than using compute type FP32. So we use FP32 compute even for
+  // FP16 datatypes. This is how GEMM is implemented even in the function
+  // rocblasGemmHelper (see fpgeneric.h)
   return rocblas_datatype_f32_r;
 }
 
@@ -90,6 +95,11 @@ constexpr rocblas_datatype RocBlasComputeTypeFor<double>(const double*) {
 
 template <>
 constexpr rocblas_datatype RocBlasComputeTypeFor<BFloat16>(const BFloat16*) {
+  // Note that we're returning the _compute_ type for a given datatype.
+  // As of 12/2022, using compute type FP16 for 16-bit floats was much
+  // slower than using compute type FP32. So we use FP32 compute even for
+  // BF16 datatypes. This is how GEMM is implemented even in the function
+  // rocblasGemmHelper (see fpgeneric.h)
   return rocblas_datatype_f32_r;
 }
 
@@ -206,7 +216,7 @@ private:
   }
 };
 
-#endif /* #if defined USE_ROCBLAS_EXTENSION_API */
+#endif /* #ifdef USE_ROCBLAS_EXTENSION_API */
 
 template <typename T>
 Status RocBlasGemmOp(const GemmParams<T>* params) {

--- a/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
@@ -142,6 +142,7 @@ public:
   }
 
   Status IsSupported(const GemmParams<T>* params) {
+    ORT_UNUSED_PARAMETER(params);
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
@@ -8,8 +8,6 @@
 #include "core/providers/rocm/tunable/gemm_common.h"
 #include "core/providers/rocm/tunable/rocm_tunable.h"
 
-#include <memory>
-
 namespace onnxruntime {
 namespace rocm {
 namespace tunable {

--- a/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
@@ -104,9 +104,8 @@ constexpr rocblas_datatype RocBlasComputeTypeFor<BFloat16>(const BFloat16*) {
 }
 
 template <typename T>
-class IndexedRocBlasGemmOp
-{
-public:
+class IndexedRocBlasGemmOp {
+ public:
   IndexedRocBlasGemmOp()
       : index_(0) {}
   IndexedRocBlasGemmOp(int index)
@@ -115,37 +114,34 @@ public:
   Status operator()(const GemmParams<T>* params) {
     RocblasHandleStreamGuard guard(params->handle, params->stream);
     return ROCBLAS_CALL(
-      rocblas_gemm_ex(
-        params->handle,
-        params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-        params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-        params->n, params->m, params->k,
-        &(params->alpha),
-        params->b, RocBlasDataTypeFor(params->b), params->ldb,
-        params->a, RocBlasDataTypeFor(params->a), params->lda,
-        &(params->beta),
-        params->c, RocBlasDataTypeFor(params->c), params->ldc,
-        params->c, RocBlasDataTypeFor(params->c), params->ldc,
-        RocBlasComputeTypeFor(params->a),
-        rocblas_gemm_algo_standard,
-        index_,
-        rocblas_gemm_flags_none
-      )
-    );
+        rocblas_gemm_ex(
+            params->handle,
+            params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+            params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+            params->n, params->m, params->k,
+            &(params->alpha),
+            params->b, RocBlasDataTypeFor(params->b), params->ldb,
+            params->a, RocBlasDataTypeFor(params->a), params->lda,
+            &(params->beta),
+            params->c, RocBlasDataTypeFor(params->c), params->ldc,
+            params->c, RocBlasDataTypeFor(params->c), params->ldc,
+            RocBlasComputeTypeFor(params->a),
+            rocblas_gemm_algo_standard,
+            index_,
+            rocblas_gemm_flags_none));
   }
 
   Status IsSupported(const GemmParams<T>*) {
     return Status::OK();
   }
 
-private:
+ private:
   int index_;
 };
 
 template <typename T>
-class RocBlasGemmTunableOp : public tunable::TunableOp<GemmParams<T>>
-{
-public:
+class RocBlasGemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
+ public:
   RocBlasGemmTunableOp() {
     // Ensure that the default implementation is always present
     this->ops_.emplace_back(IndexedRocBlasGemmOp<T>{0});
@@ -156,7 +152,7 @@ public:
     return Status::OK();
   }
 
-protected:
+ protected:
   virtual int FindFastest(const GemmParams<T>* params) override {
     auto solution_indices = this->GetSolutions(params);
     std::vector<Op<GemmParams<T>>> candidates;
@@ -170,47 +166,45 @@ protected:
     return this->ops_.size() - 1;
   }
 
-private:
+ private:
   std::vector<int> GetSolutions(const GemmParams<T>* params) {
     int num_solutions = 0;
     // Get the number of candidate solutions
     ROCBLAS_CALL_THROW(rocblas_gemm_ex_get_solutions(
-      params->handle,
-      params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->n, params->m, params->k,
-      &(params->alpha),
-      params->b, RocBlasDataTypeFor(params->b), params->ldb,
-      params->a, RocBlasDataTypeFor(params->a), params->lda,
-      &(params->beta),
-      params->c, RocBlasDataTypeFor(params->c), params->ldc,
-      params->c, RocBlasDataTypeFor(params->c), params->ldc,
-      RocBlasComputeTypeFor(params->a),
-      rocblas_gemm_algo_standard,
-      rocblas_gemm_flags_none,
-      NULL,
-      &num_solutions
-    ));
+        params->handle,
+        params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+        params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+        params->n, params->m, params->k,
+        &(params->alpha),
+        params->b, RocBlasDataTypeFor(params->b), params->ldb,
+        params->a, RocBlasDataTypeFor(params->a), params->lda,
+        &(params->beta),
+        params->c, RocBlasDataTypeFor(params->c), params->ldc,
+        params->c, RocBlasDataTypeFor(params->c), params->ldc,
+        RocBlasComputeTypeFor(params->a),
+        rocblas_gemm_algo_standard,
+        rocblas_gemm_flags_none,
+        NULL,
+        &num_solutions));
 
     // Get the actual candidate solutions
     std::vector<int> solutions(num_solutions);
     ROCBLAS_CALL_THROW(rocblas_gemm_ex_get_solutions(
-      params->handle,
-      params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
-      params->n, params->m, params->k,
-      &(params->alpha),
-      params->b, RocBlasDataTypeFor(params->b), params->ldb,
-      params->a, RocBlasDataTypeFor(params->a), params->lda,
-      &(params->beta),
-      params->c, RocBlasDataTypeFor(params->c), params->ldc,
-      params->c, RocBlasDataTypeFor(params->c), params->ldc,
-      RocBlasComputeTypeFor(params->a),
-      rocblas_gemm_algo_standard,
-      rocblas_gemm_flags_none,
-      solutions.data(),
-      &num_solutions
-    ));
+        params->handle,
+        params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+        params->opa == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
+        params->n, params->m, params->k,
+        &(params->alpha),
+        params->b, RocBlasDataTypeFor(params->b), params->ldb,
+        params->a, RocBlasDataTypeFor(params->a), params->lda,
+        &(params->beta),
+        params->c, RocBlasDataTypeFor(params->c), params->ldc,
+        params->c, RocBlasDataTypeFor(params->c), params->ldc,
+        RocBlasComputeTypeFor(params->a),
+        rocblas_gemm_algo_standard,
+        rocblas_gemm_flags_none,
+        solutions.data(),
+        &num_solutions));
 
     return solutions;
   }

--- a/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
@@ -38,14 +38,9 @@ class GemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
   GemmTunableOp() {
     this->ops_.emplace_back(RocBlasGemmOp<T>);
 
-  #if defined USE_ROCBLAS_EXTENSION_API
-    this->ops_.emplace_back(
-      [this](const GemmParams<T>* params){
-        return rocblas_gemm_tunable_op_(params);
-      }
-    );
-    this->RegisterTunableSubOp(&rocblas_gemm_tunable_op_);
-  #endif
+  #ifdef USE_ROCBLAS_EXTENSION_API
+    this->RegisterNestedTunableOp(&rocblas_gemm_tunable_op_);
+  #endif /* #ifdef USE_ROCBLAS_EXTENSION_API */
 
     for (auto&& [_, op] : GetCKGemmTypeStringAndOps<T, ALayout, BLayout>()) {
       ORT_UNUSED_PARAMETER(_);

--- a/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
@@ -36,10 +36,9 @@ template <typename T, typename ALayout, typename BLayout>
 class GemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
  public:
   GemmTunableOp() {
+    this->ops_.emplace_back(RocBlasGemmOp<T>);
   #if defined USE_ROCBLAS_EXTENSION_API
     this->ops_.emplace_back(Op<GemmParams<T>>{RocBlasGemmTunableOp<T>{}});
-  #else
-    this->ops_.emplace_back(RocBlasGemmOp<T>);
   #endif
 
     for (auto&& [_, op] : GetCKGemmTypeStringAndOps<T, ALayout, BLayout>()) {

--- a/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
@@ -31,16 +31,15 @@ bool IsZero(half v) {
   return __half2float(v) == 0.0f;
 }
 
-
 template <typename T, typename ALayout, typename BLayout>
 class GemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
  public:
   GemmTunableOp() {
     this->ops_.emplace_back(RocBlasGemmOp<T>);
 
-  #ifdef USE_ROCBLAS_EXTENSION_API
+#ifdef USE_ROCBLAS_EXTENSION_API
     this->RegisterNestedTunableOp(&rocblas_gemm_tunable_op_);
-  #endif /* #ifdef USE_ROCBLAS_EXTENSION_API */
+#endif /* #ifdef USE_ROCBLAS_EXTENSION_API */
 
     for (auto&& [_, op] : GetCKGemmTypeStringAndOps<T, ALayout, BLayout>()) {
       ORT_UNUSED_PARAMETER(_);
@@ -73,7 +72,7 @@ class GemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
     }
   }
 
-private:
+ private:
 #ifdef USE_ROCBLAS_EXTENSION_API
   RocBlasGemmTunableOp<T> rocblas_gemm_tunable_op_;
 #endif

--- a/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_tunable.cuh
@@ -36,7 +36,12 @@ template <typename T, typename ALayout, typename BLayout>
 class GemmTunableOp : public tunable::TunableOp<GemmParams<T>> {
  public:
   GemmTunableOp() {
+  #if defined USE_ROCBLAS_EXTENSION_API
+    this->ops_.emplace_back(Op<GemmParams<T>>{RocBlasGemmTunableOp<T>{}});
+  #else
     this->ops_.emplace_back(RocBlasGemmOp<T>);
+  #endif
+
     for (auto&& [_, op] : GetCKGemmTypeStringAndOps<T, ALayout, BLayout>()) {
       ORT_UNUSED_PARAMETER(_);
       this->ops_.emplace_back(std::move(op));


### PR DESCRIPTION
### Description
Extend GEMM autotuning by including algorithms exposed by a ROCBLAS extension API.

### Motivation and Context
Based on our request, the ROCm team has implemented extension APIs in ROCBLAS that provides a list of application GEMM algorithms/implementations for a given input size, along with an API that actually performs the GEMM using the specified implementation/algorithm. We have observed that the ROCBLAS algorithm/implementation selection logic does not always pick the optimal. This PR uses the extension APIs to integrate the exposed ROCBLAS algorithms/implementations into the autotuning framework.

The feature is disabled by default (the ROCBlas extension APIs are slated to be released with ROCm 5.5, and are not yet generally available). To enable: build with `--cmake-extra-defines USE_ROCBLAS_EXTENSION_API=1 CMAKE_HIP_FLAGS=-DUSE_ROCBLAS_EXTENSION_API` and then enable tuning in the provider options.