### PR TITLE
make some model tests run parallel

### DIFF
--- a/onnxruntime/test/util/include/test_allocator.h
+++ b/onnxruntime/test/util/include/test_allocator.h
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+#pragma once
 #include <atomic>
 #include <stdexcept>
 #include "core/session/onnxruntime_c_api.h"


### PR DESCRIPTION
### Description
make some model tests run parallel



### Motivation and Context
Now the model test is running sequentially, meaning the datasets of the test will be run one by one. 
This PR will make some models run parallel. If they have multiple datasets, these datasets will be run simultaneously by multiple threads.


