### PR TITLE
Always build with XNNPACK EP in iOS CI build.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -1,8 +1,3 @@
-parameters:
-- name: BuildXnnpack
-  default: false
-  type: boolean
-
 jobs:
 - job: iOS_CI_CPU_on_Mac
   pool:
@@ -67,7 +62,6 @@ jobs:
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
   timeoutInMinutes: 150
-  condition: or(eq('${{parameters.BuildXnnpack}}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   steps:
     - script: |
         /bin/bash $(Build.SourcesDirectory)/tools/ci_build/github/apple/build_host_protoc.sh \

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: iOS_CI_CPU_on_Mac
+- job: iOS_CI_on_Mac
   pool:
     vmImage: 'macOS-11'
   variables:
@@ -7,73 +7,15 @@ jobs:
   timeoutInMinutes: 150
   steps:
     - script: |
-        $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/install_protobuf.sh -p $(Build.BinariesDirectory)/protobuf_install -d $(Build.SourcesDirectory)/cmake/deps.txt
-      displayName: Build Host Protoc
+        $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/install_protobuf.sh \
+          -p $(Build.BinariesDirectory)/protobuf_install -d $(Build.SourcesDirectory)/cmake/deps.txt
+      displayName: Install protobuf
 
     - script: |
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
           --skip_submodule_sync \
-          --build_dir $(Build.BinariesDirectory)/iOS_cpu \
-          --ios \
-          --ios_sysroot iphonesimulator  \
-          --osx_arch x86_64 \
-          --apple_deploy_target 11.0 \
-          --use_xcode \
-          --config RelWithDebInfo \
-          --build_apple_framework \
-          --path_to_protoc_exe $(Build.BinariesDirectory)/protobuf_install/bin/protoc \
-          --parallel
-      displayName: (CPU EP) Build onnxruntime for iOS x86_64 and run tests using simulator
-
-
-- job: iOS_CI_CoreML_on_Mac
-  pool:
-    vmImage: 'macOS-11'
-  variables:
-    MACOSX_DEPLOYMENT_TARGET: '10.14'
-  timeoutInMinutes: 150
-  steps:
-    - script: |
-        /bin/bash $(Build.SourcesDirectory)/tools/ci_build/github/apple/build_host_protoc.sh \
-          $(Build.SourcesDirectory) \
-          $(Build.BinariesDirectory)/protobuf \
-          $(Build.BinariesDirectory)/protobuf_install
-      displayName: Build Host Protoc
-
-    - script: |
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
-          --skip_submodule_sync \
-          --build_dir $(Build.BinariesDirectory)/iOS_coreml \
+          --build_dir $(Build.BinariesDirectory)/iOS \
           --use_coreml \
-          --ios \
-          --ios_sysroot iphonesimulator  \
-          --osx_arch x86_64 \
-          --apple_deploy_target 11.0 \
-          --use_xcode \
-          --config RelWithDebInfo \
-          --build_apple_framework \
-          --path_to_protoc_exe $(Build.BinariesDirectory)/protobuf_install/bin/protoc \
-          --parallel
-      displayName: (CoreML EP) Build onnxruntime for iOS x86_64 and run tests using simulator
-
-- job: iOS_CI_XNNPACK_on_Mac
-  pool:
-    vmImage: 'macOS-11'
-  variables:
-    MACOSX_DEPLOYMENT_TARGET: '10.14'
-  timeoutInMinutes: 150
-  steps:
-    - script: |
-        /bin/bash $(Build.SourcesDirectory)/tools/ci_build/github/apple/build_host_protoc.sh \
-          $(Build.SourcesDirectory) \
-          $(Build.BinariesDirectory)/protobuf \
-          $(Build.BinariesDirectory)/protobuf_install
-      displayName: Build Host Protoc
-
-    - script: |
-        python3 $(Build.SourcesDirectory)/tools/ci_build/build.py \
-          --skip_submodule_sync \
-          --build_dir $(Build.BinariesDirectory)/iOS_xnnpack \
           --use_xnnpack \
           --ios \
           --ios_sysroot iphonesimulator  \
@@ -84,4 +26,4 @@ jobs:
           --build_apple_framework \
           --path_to_protoc_exe $(Build.BinariesDirectory)/protobuf_install/bin/protoc \
           --parallel
-      displayName: (XNNPACK EP) Build onnxruntime for iOS x86_64 and run tests using simulator
+      displayName: (CPU, CoreML, XNNPACK EPs) Build onnxruntime for iOS x86_64 and run tests using simulator


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Always build with XNNPACK EP in iOS CI build.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Catch errors before code gets checked in.
