### PR TITLE
Fix hipify to avoid nccl_service.h: No such file or directory

### DIFF
--- a/cmake/onnxruntime_session.cmake
+++ b/cmake/onnxruntime_session.cmake
@@ -67,3 +67,7 @@ if (NOT onnxruntime_BUILD_SHARED_LIB)
             RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
             FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
+
+if (onnxruntime_USE_NCCL AND onnxruntime_USE_ROCM)
+  add_dependencies(onnxruntime_session generate_hipified_files)
+endif()


### PR DESCRIPTION
Fix various flaky build error due to onnxruntime_session missing dependencies on hipify generated files.

For example:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=824319&view=logs&j=48b14a85-ff1a-5ca4-53fa-8ea420d27feb&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=e882c4fa-e626-5790-579a-99f25f8389cd&l=2740