### PR TITLE
[DO NOT REVIEW] Optimize CPU and CUDA Slice kernels for Identity-like usage 

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/slice.cc
+++ b/onnxruntime/core/providers/cpu/tensor/slice.cc
@@ -241,10 +241,10 @@ static Status SliceImpl(OpKernelContext* ctx,
     return Status::OK();
   }
 
-  // If the Slice operation is Identity-like, just copy
-  // the input buffer into the output buffer and return
-  // without invoking any of the Slice kernel's machinery
-  if (output_shape == input_tensor.Shape()) {
+  // If the Slice operation is Identity-like (no reversing involved), 
+  // just copy the input buffer into the output buffer and return
+  // without invoking any of the Slice kernel's machinery.
+  if ((output_shape == input_tensor.Shape()) && compute_metadata.all_steps_are_positive) {
     // CopyCpuTensor() will only make the copy if the
     // data pointers of the source and destination
     // tensors are different.

--- a/onnxruntime/core/providers/cpu/tensor/slice.cc
+++ b/onnxruntime/core/providers/cpu/tensor/slice.cc
@@ -245,7 +245,7 @@ static Status SliceImpl(OpKernelContext* ctx,
   // the input buffer into the output buffer and return
   // without invoking any of the Slice kernel's machinery
   if (output_shape == input_tensor.Shape()) {
-    // CopyCpuTensor will only make the copy of the
+    // CopyCpuTensor() will only make the copy if the
     // data pointers of the source and destination
     // tensors are different.
     CopyCpuTensor(&input_tensor, &output_tensor);

--- a/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_compute_metadata.h
@@ -31,6 +31,7 @@ struct PrepareForComputeMetadata {
   TensorShapeVector* p_flattened_input_dims_ = &flattened_input_dims_;
   TensorShapeVector flattened_output_dims_;
   TensorShapeVector* p_flattened_output_dims_ = &flattened_output_dims_;
+  bool all_steps_are_positive = true;
 };
 
 }  // namespace SliceOp

--- a/onnxruntime/core/providers/cpu/tensor/slice_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/slice_helper.h
@@ -111,6 +111,10 @@ inline Status PrepareForComputeHelper(const gsl::span<const int64_t>& raw_starts
     if (step == 0)
       return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "'step' value cannot be 0");
 
+    if (step < 1) {
+        compute_metadata.all_steps_are_positive = false;
+    }
+
     if (dim_value == 0) {
       // shape with empty dim. only output_dims_ matters but set everything for completeness
       compute_metadata.steps_[onnxruntime::narrow<size_t>(axis)] = step;

--- a/onnxruntime/core/providers/cuda/tensor/slice.cc
+++ b/onnxruntime/core/providers/cuda/tensor/slice.cc
@@ -97,7 +97,10 @@ static Status SliceImpCore(cudaStream_t stream,
 
   // If the Slice operation is Identity-like, just copy
   // the input buffer into the output buffer and return
-  // without invoking any of the Slice kernel's machinery
+  // without invoking any of the Slice kernel's machinery.
+
+  // Currently, we do not support string tensors- so it is safe
+  // to have the following logic.
   if (input_shape == output_shape) {
     if (input_data != output_data) {
       CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output_data, input_data, output_shape.Size() * element_size,
@@ -240,11 +243,6 @@ Status Slice<dynamic>::CallSliceImp(size_t element_size, size_t dimension_count,
                                     const TensorShape& output_shape) const {
   const auto* input_tensor = ctx->Input<Tensor>(0);
   auto* output_tensor = ctx->Output(0, output_shape);
-
-  // Sanity check - ensure that we don't accidentally just enable support
-  // for string type for this kernel.
-  // We have logic in `SliceImpCore()` that can't handle string types just yet.
-  ORT_ENFORCE(!input_tensor->IsDataTypeString());
 
   return SliceImpCore(Stream(),
                       input_tensor->DataRaw(),

--- a/onnxruntime/core/providers/cuda/tensor/slice.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice.h
@@ -36,7 +36,7 @@ class Slice : public CudaKernel, public SliceBase {
   virtual Status CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                               const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,
                               const TArray<fast_divmod>& output_strides, OpKernelContext* ctx,
-                              const TensorShape& output_shape) const;
+                              const TensorShape& output_shape, bool ) const;
 };
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/slice_op.test.cc
@@ -780,6 +780,7 @@ class IdentitySliceIdentityOpTester : public OpTester {
       outputs = {&matmul_out};
 
       auto& matmul_node = graph.AddNode("matmul-0", "MatMul", "MatMul", inputs, outputs);
+      ORT_UNUSED_PARAMETER(matmul_node);   // Silence warning about unused var
     }
 
     // add Slice node
@@ -791,6 +792,7 @@ class IdentitySliceIdentityOpTester : public OpTester {
       outputs = {&slice_out};
 
       auto& split_node = graph.AddNode("slice", "Slice", "Identity Slicing", inputs, outputs);
+      ORT_UNUSED_PARAMETER(split_node);   // Silence warning about unused var
     }
 
     // add Identity node so that Slice output does not flow into graph output
@@ -799,6 +801,7 @@ class IdentitySliceIdentityOpTester : public OpTester {
       outputs = {graph_output_defs[0]};
 
       auto& identity_node = graph.AddNode("identity-0", "Identity", "Identity", inputs, outputs);
+      ORT_UNUSED_PARAMETER(identity_node);  // Silence warning about unused var
     }
   }
 };


### PR DESCRIPTION
### Description
Sometimes, the Slice kernel has nothing to do except do a copy of the input tensor. We want to be able to re-use the input buffer for that case (using the MayInPlace(0,0) hint to the allocation planner). Even if we are not able to re-use the input buffer for the output, we want to skip Slice kernel's machinery and just do a memcpy instead.

### Motivation and Context
Pre-cursor optimization to a change that will modify the GPT-2 subgraph for BeamSearch/GreedySearch that will have one such Slice that will just be Identity-like in its usage on most decoding runs. In any case, this is a generic optimization that can be applied for any other model too.


