### PR TITLE
[ROCm] Sort kernel explorer profile result

### DIFF
--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
@@ -67,7 +67,7 @@ def test_fast_gelu(x_size, bias_size, dtype):
 
 
 @dataclass
-class FastGeluStatus(ke.BandWidthStatus):
+class FastGeluStatus(ke.BandwidthStatus):
     batch_size: int
     seq_len: int
     hidden_size: int

--- a/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/fast_gelu_test.py
@@ -67,7 +67,7 @@ def test_fast_gelu(x_size, bias_size, dtype):
 
 
 @dataclass
-class FastGeluStatus(ke.BandwidthStatus):
+class FastGeluMetric(ke.BandwidthMetric):
     batch_size: int
     seq_len: int
     hidden_size: int
@@ -98,7 +98,7 @@ def profile_fast_gelu_func(batch_size, seq_len, hidden_size, dtype, func):
         duration_ms = my_op.Profile()
     total_bytes = (x.size * 2 + bias.size) * dtype_to_bytes(dtype)
 
-    ke.report(FastGeluStatus(func, dtype, duration_ms, total_bytes, batch_size, seq_len, hidden_size))
+    ke.report(FastGeluMetric(func, dtype, duration_ms, total_bytes, batch_size, seq_len, hidden_size))
 
 
 def profile_with_args(batch_size, seq_len, hidden_size, dtype, sort):

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -101,16 +101,12 @@ def test_gemm_tunable_bert_cases(dtype, size, transab):
 
 
 @dataclass
-class GemmStatus(ke.InstanceStatus):
+class GemmStatus(ke.ComputeStatus):
     transa: bool
     transb: bool
     m: int
     n: int
     k: int
-
-    @property
-    def tflops(self):
-        return (self.m * self.k * self.n * 2) / (self.duration * 1e-6) / 1e12
 
     def report(self):
         prefix = f"{self.name:<50} {self.dtype} {transab_to_suffix((self.transa, self.transb))} "
@@ -147,8 +143,9 @@ def profile_gemm_func(f, transa: bool, transb: bool, dtype: str, m: int, n: int,
         duration_ms = -1
         if my_gemm.SelectOp(impl):
             duration_ms = my_gemm.Profile()
+        FLOPs = m * k * n * 2
 
-        ke.report(GemmStatus(impl, dtype, duration_ms, transa, transb, m, n, k))
+        ke.report(GemmStatus(impl, dtype, duration_ms, FLOPs, transa, transb, m, n, k))
 
 
 def profile_with_args(transa, transb, dtype, m, n, k, sort):

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -9,7 +9,7 @@ from itertools import product
 import kernel_explorer as ke
 import numpy as np
 import pytest
-from utils import get_gemm_basic_sizes, get_gemm_bert_sizes, get_gemm_bound, transab_to_suffix
+from utils import get_gemm_basic_sizes, get_gemm_bert_sizes, get_gemm_bound, sort_profile_results, transab_to_suffix
 
 
 def dtype_to_suffix(dtype):
@@ -99,7 +99,20 @@ def test_gemm_tunable_bert_cases(dtype, size, transab):
     _test_gemm(getattr(ke, wrapper_name), dtype, *size, *transab)
 
 
-def profile_gemm_func(f, transa: bool, transb: bool, dtype: str, m: int, n: int, k: int):
+def print_results(transa, transb, dtype, m, n, k, profile_results):
+    for result in profile_results:
+        if result["tflops"] > 0:
+            print(
+                f"{result['func']:<50} {dtype} {transab_to_suffix((transa, transb))}",
+                f"m={m:<4} n={n:<4} k={k:<4} {result['duration']:>8.4f} us {result['tflops']:>5.2f} tflops",
+            )
+        else:
+            print(
+                f"{result['func']:<50} {dtype} {transab_to_suffix((transa, transb))} m={m:<4} n={n:<4} k={k:<4} not supported"
+            )
+
+
+def profile_gemm_func(f, transa: bool, transb: bool, dtype: str, m: int, n: int, k: int, enable_sort=True):
     a_shape = (k, m) if transa else (m, k)
     b_shape = (n, k) if transb else (k, n)
 
@@ -119,26 +132,36 @@ def profile_gemm_func(f, transa: bool, transb: bool, dtype: str, m: int, n: int,
     alpha = 1.0
     beta = 0.0
     my_gemm = f(opa, opb, m, n, k, alpha, dev_a, lda, dev_b, ldb, beta, dev_c, n)
+    profile_results = []
     for impl in my_gemm.ListOps():
-        if not my_gemm.SelectOp(impl):
-            print(f"{impl:<50} {dtype} {transab_to_suffix((transa, transb))} m={m:<4} n={n:<4} k={k:<4} not supported")
-            sys.stdout.flush()
-            continue
-        time_ms = my_gemm.Profile()
-        time_us = time_ms * 1000
-        tflops = (m * k * n * 2) / (time_ms * 1e-3) / 1e12
-        print(
-            f"{impl:<50} {dtype} {transab_to_suffix((transa, transb))}",
-            f"m={m:<4} n={n:<4} k={k:<4} {time_us:>8.4f} us {tflops:>5.2f} tflops",
-        )
+        profile_result = {"func": impl, "duration": -1, "tflops": -1}
+        if my_gemm.SelectOp(impl):
+            time_ms = my_gemm.Profile()
+            time_us = time_ms * 1000
+            tflops = (m * k * n * 2) / (time_ms * 1e-3) / 1e12
+            profile_result["duration"] = time_us
+            profile_result["tflops"] = tflops
+
+        if enable_sort:
+            profile_results.append(profile_result)
+        else:
+            print_results(transa, transb, dtype, m, n, k, [profile_result])
+
+    if enable_sort:
+        sorted_profile_results = sort_profile_results(profile_results, sort_item="tflops", reverse=True)
+        print_results(transa, transb, dtype, m, n, k, sorted_profile_results)
 
 
-def profile_with_args(transa, transb, dtype, m, n, k):
+def profile_with_args(transa, transb, dtype, m, n, k, enable_sort=True):
     dtype_suffix = "_" + dtype_to_suffix(dtype)
-    profile_gemm_func(getattr(ke, "RocblasGemm" + dtype_suffix), transa, transb, dtype, m, n, k)
+    profile_gemm_func(getattr(ke, "RocblasGemm" + dtype_suffix), transa, transb, dtype, m, n, k, enable_sort)
     transab_suffix = "_" + transab_to_suffix((transa, transb))
-    profile_gemm_func(getattr(ke, "CKGemm" + dtype_suffix + transab_suffix), transa, transb, dtype, m, n, k)
-    profile_gemm_func(getattr(ke, "GemmTunable" + dtype_suffix + transab_suffix), transa, transb, dtype, m, n, k)
+    profile_gemm_func(
+        getattr(ke, "CKGemm" + dtype_suffix + transab_suffix), transa, transb, dtype, m, n, k, enable_sort
+    )
+    profile_gemm_func(
+        getattr(ke, "GemmTunable" + dtype_suffix + transab_suffix), transa, transb, dtype, m, n, k, enable_sort
+    )
 
 
 def profile():
@@ -160,8 +183,10 @@ if __name__ == "__main__":
     group.add_argument("m", type=int)
     group.add_argument("n", type=int)
     group.add_argument("k", type=int)
+    group.add_argument("--enable_sort", action="store_true")
+
     if len(sys.argv) == 1:
         profile()
     else:
         args = parser.parse_args()
-        profile_with_args(args.transa == "T", args.transb == "T", args.dtype, args.m, args.n, args.k)
+        profile_with_args(args.transa == "T", args.transb == "T", args.dtype, args.m, args.n, args.k, args.enable_sort)

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -101,7 +101,7 @@ class ComputeStatus(InstanceStatus):
 
 
 @dataclass
-class BandWidthStatus(InstanceStatus):
+class BandwidthStatus(InstanceStatus):
     bytes: int
 
     @property

--- a/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/kernel_explorer.py
@@ -88,7 +88,25 @@ class InstanceStatus:
 
     @abstractmethod
     def report(self) -> str:
-        return self.name
+        ...
+
+
+@dataclass
+class ComputeStatus(InstanceStatus):
+    FLOPs: int
+
+    @property
+    def tflops(self):
+        return self.FLOPs * 1e6 / self.duration / 1e12
+
+
+@dataclass
+class BandWidthStatus(InstanceStatus):
+    bytes: int
+
+    @property
+    def gbps(self):
+        return self.bytes * 1e6 / self.duration / 1e9
 
 
 class InstanceBenchmarkReporter:

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -85,7 +85,7 @@ def test_skip_layer_norm(bert_sizes, dtype):
 
 
 @dataclass
-class SkipLayerNormStatus(ke.BandWidthStatus):
+class SkipLayerNormStatus(ke.BandwidthStatus):
     batch_size: int
     seq_len: int
     hidden_size: int

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -85,7 +85,7 @@ def test_skip_layer_norm(bert_sizes, dtype):
 
 
 @dataclass
-class SkipLayerNormStatus(ke.BandwidthStatus):
+class SkipLayerNormMetric(ke.BandwidthMetric):
     batch_size: int
     seq_len: int
     hidden_size: int
@@ -121,7 +121,7 @@ def profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func):
         duration_ms = my_op.Profile()
     total_bytes = (input_x.size * 3 + bias.size * 3) * dtype_to_bytes(dtype)
 
-    ke.report(SkipLayerNormStatus(func, dtype, duration_ms, total_bytes, batch_size, seq_len, hidden_size))
+    ke.report(SkipLayerNormMetric(func, dtype, duration_ms, total_bytes, batch_size, seq_len, hidden_size))
 
 
 def profile_with_args(batch_size, seq_len, hidden_size, dtype, sort=True):

--- a/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/skip_layer_norm_test.py
@@ -5,12 +5,13 @@
 
 import re
 import sys
+from dataclasses import dataclass
 from itertools import product
 
 import kernel_explorer as ke
 import numpy as np
 import pytest
-from utils import sort_profile_results
+from utils import dtype_to_bytes
 
 
 def get_bert_sizes_test():
@@ -63,9 +64,7 @@ def run_skip_layer_norm(batch_size: int, seq_len: int, hidden_size: int, dtype: 
     beta_d = ke.DeviceArray(beta)
     y_d = ke.DeviceArray(output_y)
     f = getattr(ke, func)
-    my_op = f(
-        y_d, input_d, skip_d, gamma_d, beta_d, bias_d, epsilon, hidden_size, batch_size * seq_len * hidden_size
-    )
+    my_op = f(y_d, input_d, skip_d, gamma_d, beta_d, bias_d, epsilon, hidden_size, batch_size * seq_len * hidden_size)
     if my_op.IsSupported():
         my_op.Run()
 
@@ -85,6 +84,25 @@ def test_skip_layer_norm(bert_sizes, dtype):
         run_skip_layer_norm(*bert_sizes, dtype, func)
 
 
+@dataclass
+class SkipLayerNormStatus(ke.InstanceStatus):
+    batch_size: int
+    seq_len: int
+    hidden_size: int
+
+    @property
+    def gbps(self):
+        x_size = self.batch_size * self.seq_len * self.hidden_size
+        bias_size = self.hidden_size
+        return (x_size * 3 + bias_size * 3) * dtype_to_bytes(self.dtype) * 1e3 / self.duration / 1e6
+
+    def report(self):
+        prefix = f"{self.name:<50} {self.dtype}  batch_size={self.batch_size:<4} seq_len={self.seq_len:<4} hidden_size={self.hidden_size:<4} "
+        if self.duration > 0:
+            return prefix + f"{self.duration:.2f} us, {self.gbps:.2f} GB/s"
+        return prefix + "not supported or redundant"
+
+
 def profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func):
     np.random.seed(0)
     input_x = np.random.rand(batch_size, seq_len, hidden_size).astype(dtype)
@@ -102,51 +120,26 @@ def profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func):
     bias_d = ke.DeviceArray(bias)
     y_d = ke.DeviceArray(output_y)
     f = getattr(ke, func)
-    my_op = f(
-        y_d, input_d, skip_d, gamma_d, beta_d, bias_d, epsilon, hidden_size, batch_size * seq_len * hidden_size
-    )
+    my_op = f(y_d, input_d, skip_d, gamma_d, beta_d, bias_d, epsilon, hidden_size, batch_size * seq_len * hidden_size)
+
+    duration_ms = -1
     if my_op.IsSupported():
-        duration = my_op.Profile()
-        gbytes_per_seconds = (input_x.size * 3 + bias.size * 3) * input_x.itemsize * 1e3 / duration / 1e9
-        duration = duration * 1000
-        return {"func": func, "duration": duration, "GBps": gbytes_per_seconds}
+        duration_ms = my_op.Profile()
 
-    return {"func": func, "duration": -1, "GBps": -1}
+    ke.report(SkipLayerNormStatus(func, dtype, duration_ms, batch_size, seq_len, hidden_size))
 
 
-def print_results(batch_size, seq_len, hidden_size, dtype, profile_results):
-    for result in profile_results:
-        if result["GBps"] > 0:
-            print(
-                f"{result['func']:<50} {dtype}  batch_size={batch_size:<4} seq_len={seq_len:<4} hidden_size={hidden_size:<4}",
-                f"{result['duration']:.2f} us",
-                f"{result['GBps']:.2f} GB/s",
-            )
-        else:
-            print(
-                f"{result['func']:<50} {dtype}  batch_size={batch_size:<4} seq_len={seq_len:<4} hidden_size={hidden_size:<4} not supported or redundant"
-            )
-
-
-def profile_with_args(batch_size, seq_len, hidden_size, dtype, enable_sort=True):
-    if enable_sort:
-        profile_results = []
+def profile_with_args(batch_size, seq_len, hidden_size, dtype, sort=True):
+    with ke.benchmark(sort):
         for func in dtype_to_funcs(dtype):
-            profile_result = profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func)
-            profile_results.append(profile_result)
-        sorted_profile_results = sort_profile_results(profile_results, sort_item="GBps", reverse=True)
-        print_results(batch_size, seq_len, hidden_size, dtype, sorted_profile_results)
-    else:
-        for func in dtype_to_funcs(dtype):
-            profile_result = profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func)
-            print_results(batch_size, seq_len, hidden_size, dtype, [profile_result])
-    print()
+            profile_skip_layer_norm_func(batch_size, seq_len, hidden_size, dtype, func)
 
 
 def profile():
     for dtype in dtypes:
         for bert_size in get_bert_sizes_profile():
             profile_with_args(*bert_size, dtype)
+            print()
 
 
 if __name__ == "__main__":
@@ -158,10 +151,10 @@ if __name__ == "__main__":
     group.add_argument("seq_len", type=int)
     group.add_argument("hidden_size", type=int)
     group.add_argument("dtype", choices=dtypes)
-    group.add_argument("--enable_sort", action="store_true")
+    group.add_argument("--sort", action="store_true")
 
     if len(sys.argv) == 1:
         profile()
     else:
         args = parser.parse_args()
-        profile_with_args(args.batch_size, args.seq_len, args.hidden_size, args.dtype, args.enable_sort)
+        profile_with_args(args.batch_size, args.seq_len, args.hidden_size, args.dtype, args.sort)

--- a/onnxruntime/python/tools/kernel_explorer/kernels/utils.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/utils.py
@@ -66,3 +66,14 @@ def get_gemm_basic_sizes(full=True):
     # ck has various impls to be tested, use the full basic cases will result too many cases to test.
     # So we use a reduced combination here.
     return list(product([1, 4, 127, 133], [3, 16, 128], [3, 129, 1024]))
+
+
+def sort_profile_results(profile_results, sort_item, reverse=False):
+    sorted_profile_result = sorted(profile_results, key=lambda x: x[sort_item], reverse=reverse)
+    tunable_id = 0
+    for impl_id, result in enumerate(sorted_profile_result):
+        if "Tunable" in result["func"]:
+            tunable_id = impl_id
+            break
+    sorted_profile_result.insert(0, sorted_profile_result.pop(tunable_id))
+    return sorted_profile_result

--- a/onnxruntime/python/tools/kernel_explorer/kernels/utils.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/utils.py
@@ -8,6 +8,15 @@ from itertools import product
 import numpy as np
 
 
+def dtype_to_bytes(dtype):
+    type_map = {
+        "float16": 2,
+        "float32": 4,
+        "float64": 8,
+    }
+    return type_map[dtype]
+
+
 def transab_to_suffix(transab):
     return {
         (True, True): "TT",
@@ -66,14 +75,3 @@ def get_gemm_basic_sizes(full=True):
     # ck has various impls to be tested, use the full basic cases will result too many cases to test.
     # So we use a reduced combination here.
     return list(product([1, 4, 127, 133], [3, 16, 128], [3, 129, 1024]))
-
-
-def sort_profile_results(profile_results, sort_item, reverse=False):
-    sorted_profile_result = sorted(profile_results, key=lambda x: x[sort_item], reverse=reverse)
-    tunable_id = 0
-    for impl_id, result in enumerate(sorted_profile_result):
-        if "Tunable" in result["func"]:
-            tunable_id = impl_id
-            break
-    sorted_profile_result.insert(0, sorted_profile_result.pop(tunable_id))
-    return sorted_profile_result

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
@@ -50,12 +50,8 @@ def test_vector_add(size, dtype):
 
 
 @dataclass
-class VectorAddStatus(ke.InstanceStatus):
+class VectorAddStatus(ke.BandWidthStatus):
     size: int
-
-    @property
-    def gbps(self):
-        return self.size * 3 * (dtype_to_bytes(self.dtype)) * 1e3 / self.duration / 1e6
 
     def report(self):
         return f"{self.name :<50} {self.dtype} size={self.size:<4}, {self.duration:.2f} us, {self.gbps:.2f} GB/s"
@@ -73,8 +69,9 @@ def profile_vector_add_func(size, dtype, func):
     f = getattr(ke, func)
     my_op = f(x_d, y_d, z_d, size)
     duration_ms = my_op.Profile()
+    total_bytes = size * 3 * (dtype_to_bytes(dtype))
 
-    ke.report(VectorAddStatus(func, dtype, duration_ms, size))
+    ke.report(VectorAddStatus(func, dtype, duration_ms, total_bytes, size))
 
 
 def profile_with_args(size, dtype, sort):

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
@@ -50,7 +50,7 @@ def test_vector_add(size, dtype):
 
 
 @dataclass
-class VectorAddStatus(ke.BandwidthStatus):
+class VectorAddMetric(ke.BandwidthMetric):
     size: int
 
     def report(self):
@@ -71,7 +71,7 @@ def profile_vector_add_func(size, dtype, func):
     duration_ms = my_op.Profile()
     total_bytes = size * 3 * (dtype_to_bytes(dtype))
 
-    ke.report(VectorAddStatus(func, dtype, duration_ms, total_bytes, size))
+    ke.report(VectorAddMetric(func, dtype, duration_ms, total_bytes, size))
 
 
 def profile_with_args(size, dtype, sort):

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add_test.py
@@ -50,7 +50,7 @@ def test_vector_add(size, dtype):
 
 
 @dataclass
-class VectorAddStatus(ke.BandWidthStatus):
+class VectorAddStatus(ke.BandwidthStatus):
     size: int
 
     def report(self):


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Sort kernel explorer profile result, the instance is sorted according to the performance.
1. Set sort kernel as an optional config when we pass parameters through commandline.
    `python gemm_test.py N N float16 M N K` disable sort by default, add `--sort` to enable sort.
2. 'python gemm_test.py' enable sort by default.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


