### PR TITLE
check GetApi() pointer before deferencing to prevent easy crashes

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -375,6 +375,7 @@ endif()
 set (ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR "${TEST_SRC_DIR}/shared_lib")
 set (ONNXRUNTIME_GLOBAL_THREAD_POOLS_TEST_SRC_DIR "${TEST_SRC_DIR}/global_thread_pools")
 set (ONNXRUNTIME_API_TESTS_WITHOUT_ENV_SRC_DIR "${TEST_SRC_DIR}/api_tests_without_env")
+set (ONNXRUNTIME_NO_GLOBAL_API_TEST_SRC_DIR "${TEST_SRC_DIR}/no_global_api")
 
 set (onnxruntime_shared_lib_test_SRC
           ${ONNXRUNTIME_SHARED_LIB_TEST_SRC_DIR}/test_fixture.h
@@ -404,6 +405,12 @@ set (onnxruntime_global_thread_pools_test_SRC
 
 set (onnxruntime_api_tests_without_env_SRC
           ${ONNXRUNTIME_API_TESTS_WITHOUT_ENV_SRC_DIR}/test_apis_without_env.cc)
+
+file(GLOB onnxruntime_no_global_api_test_SRC CONFIGURE_DEPENDS
+  "${ONNXRUNTIME_NO_GLOBAL_API_TEST_SRC_DIR}/*.h"
+  "${ONNXRUNTIME_NO_GLOBAL_API_TEST_SRC_DIR}/*.cc"
+  "${ONNXRUNTIME_NO_GLOBAL_API_TEST_SRC_DIR}/*.cpp"
+)
 
 # tests from lowest level library up.
 # the order of libraries should be maintained, with higher libraries being added first in the list
@@ -596,8 +603,8 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
   ${onnxruntime_test_framework_src_patterns}
   )
 
-#This is a small wrapper library that shouldn't use any onnxruntime internal symbols(except onnxruntime_common). 
-#Because it could dynamically link to onnxruntime. Otherwise you will have two copies of onnxruntime in the same 
+#This is a small wrapper library that shouldn't use any onnxruntime internal symbols(except onnxruntime_common).
+#Because it could dynamically link to onnxruntime. Otherwise you will have two copies of onnxruntime in the same
 #process and you won't know which one you are testing.
 onnxruntime_add_static_library(onnxruntime_test_utils ${onnxruntime_test_utils_src})
 if(MSVC)
@@ -1065,7 +1072,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
 
   if (onnxruntime_BUILD_SHARED_LIB)
     #It will dynamically link to onnxruntime. So please don't add onxruntime_graph/onxruntime_framework/... here.
-    #onnxruntime_common is kind of ok because it is thin, tiny and totally stateless. 
+    #onnxruntime_common is kind of ok because it is thin, tiny and totally stateless.
     set(onnxruntime_perf_test_libs
             onnx_test_runner_common onnxruntime_test_utils onnxruntime_common
             onnxruntime onnxruntime_flatbuffers onnx_test_data_proto
@@ -1158,7 +1165,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       )
     endif()
 
-  # A separate test is needed to test the APIs that don't rely on the env being created first.
+    # A separate test is needed to test the APIs that don't rely on the env being created first.
     if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|iOS")
       AddTest(DYN
               TARGET onnxruntime_api_tests_without_env
@@ -1166,6 +1173,17 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
               LIBS ${onnxruntime_shared_lib_test_LIBS}
               DEPENDS ${all_dependencies}
       )
+    endif()
+
+    # A separate test is needed to test APIs while `Global<void>::api_ == null`
+    if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|iOS")
+      AddTest(DYN
+              TARGET onnxruntime_no_global_api_test
+              SOURCES ${onnxruntime_no_global_api_test_SRC}
+              LIBS ${onnxruntime_shared_lib_test_LIBS}
+              DEPENDS ${all_dependencies}
+      )
+      target_compile_definitions(onnxruntime_no_global_api_test PRIVATE ORT_API_MANUAL_INIT _CRT_SECURE_NO_WARNINGS)
     endif()
   endif()
 
@@ -1239,8 +1257,8 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
   endif()
   if (CMAKE_SYSTEM_NAME STREQUAL "Android")
     target_link_libraries(onnxruntime_mlas_test PRIVATE ${android_shared_libs})
-  endif()  
-  
+  endif()
+
   if(WIN32)
     target_link_libraries(onnxruntime_mlas_test PRIVATE debug Dbghelp Advapi32)
   endif()

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -184,7 +184,7 @@ namespace detail {
 // This is used internally by the C++ API. This macro is to make it easy to generate overloaded methods for all of the various OrtRelease* functions for every Ort* type
 // This can't be done in the C API since C doesn't have function overloading.
 #define ORT_DEFINE_RELEASE(NAME) \
-  inline void OrtRelease(Ort##NAME* ptr) { GetApi().Release##NAME(ptr); }
+  inline void OrtRelease(Ort##NAME* ptr) { if (&GetApi()) GetApi().Release##NAME(ptr); }
 
 ORT_DEFINE_RELEASE(Allocator);
 ORT_DEFINE_RELEASE(MemoryInfo);
@@ -366,9 +366,9 @@ struct Env : detail::Base<OrtEnv> {
 
   Env& EnableTelemetryEvents();   ///< Wraps OrtApi::EnableTelemetryEvents
   Env& DisableTelemetryEvents();  ///< Wraps OrtApi::DisableTelemetryEvents
-  
-  Env& UpdateEnvWithCustomLogLevel(OrtLoggingLevel log_severity_level);  ///< Wraps OrtApi::UpdateEnvWithCustomLogLevel 
-  
+
+  Env& UpdateEnvWithCustomLogLevel(OrtLoggingLevel log_severity_level);  ///< Wraps OrtApi::UpdateEnvWithCustomLogLevel
+
   Env& CreateAndRegisterAllocator(const OrtMemoryInfo* mem_info, const OrtArenaCfg* arena_cfg);  ///< Wraps OrtApi::CreateAndRegisterAllocator
 };
 

--- a/onnxruntime/test/no_global_api/getapi_null_test.cc
+++ b/onnxruntime/test/no_global_api/getapi_null_test.cc
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation, Dale Phurrough. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/session/onnxruntime_cxx_api.h"
+#include "core/common/common.h"
+
+#include <cstdio>
+
+#include "gtest/gtest.h"
+
+#include "test/util/include/asserts.h"
+
+namespace onnxruntime {
+namespace test {
+
+class ConditionalOrt {
+  Ort::Env ort_env{nullptr};
+
+public:
+  ConditionalOrt() {
+    // create condition that will not be optimized-out by compiler to
+    // simulate consumers of Ort conditionally and at a time of their
+    // choosing the initialization of Ort API
+    // e.g. checking if dependent data files or delay-loaded DLLs exist
+    // before initializing or calling Ort APIs which require such dependencies
+    char *const tmpname = std::tmpnam(nullptr);
+
+    // condition test; intentionally failing to create test scenario
+    if (!tmpname) {
+      ort_env = Ort::Env{ORT_LOGGING_LEVEL_WARNING, "mylogid"};
+      ORT_THROW("std::tmpnam() failed");
+    }
+  }
+};
+
+TEST(PlatformGetApiTest, Null_Env) {
+#ifdef ORT_NO_EXCEPTIONS
+  ConditionalOrt my_onnx;
+#else
+  EXPECT_NO_THROW({
+    ConditionalOrt my_onnx;
+  });
+#endif
+}
+
+TEST(PlatformGetApiTest, Null_Session) {
+  Ort::Session session{nullptr};
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/no_global_api/test_main.cc
+++ b/onnxruntime/test/no_global_api/test_main.cc
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef USE_ONNXRUNTIME_DLL
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+#include <google/protobuf/message_lite.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#endif
+
+#include "gtest/gtest.h"
+
+// The global singleton for Ort's GetApi() will already exists if
+// gtest compiles multiple translation units into a single test EXE.
+// This pollutes the test environment needed for the no-global-api tests
+// because other TUs have already initialized `Global<void>::api_`.
+// Therefore...this main() and the other TUs are a separate test EXE and
+// their cmake defines ORT_API_MANUAL_INIT.
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int status = RUN_ALL_TESTS();
+
+#ifndef USE_ONNXRUNTIME_DLL
+  //make memory leak checker happy
+  ::google::protobuf::ShutdownProtobufLibrary();
+#endif
+  return status;
+}


### PR DESCRIPTION
### Description

* check GetApi() pointer before deferencing to prevent easy crashes

### Motivation and Context

Fixes #12736

I had to add an entirely new test EXE so that the global API pointer is not static initialized or initialized via `InitApi()` due to all the other test TUs being compiled in unpredictable order into a single EXE. For now, this new exe is within the SHARED cmake block. Please review that this is the correct location.

The first commit in this PR will expose the crashes. The 2nd comment fixes it.