### PR TITLE
Revert "skip TestCUDAProviderOptions in End2EndTest (#13737)"

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh
@@ -34,7 +34,7 @@ if [ $RunTestCsharp = "true" ]; then
 
   if [ $PACKAGENAME = "Microsoft.ML.OnnxRuntime.Gpu" ]; then
     export TESTONGPU=ON
-    dotnet test -p:DefineConstants=USE_CUDA $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed --filter "DisplayName!=TestCUDAProviderOptions"
+    dotnet test -p:DefineConstants=USE_CUDA $BUILD_SOURCESDIRECTORY/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj --no-restore --verbosity detailed
     if [ $? -ne 0 ]; then
       echo "Failed to build or execute the end-to-end test"
       exit 1


### PR DESCRIPTION
This reverts commit 87d5703b14b0123b63a7ecdd0f69505fd30421c1.

### Motivation and Context
There was a bug in Linux CUDA installation.
The OS image is updated.
The TestCUDAProviderOptions could be reenabled.


