### PR TITLE
[DML EP] Attention Kernel bug fix

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorAttention.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorAttention.cpp
@@ -146,7 +146,7 @@ public:
         valueSlicedOperatorDesc.InputWindowStrides = strides.data();
         const DML_OPERATOR_DESC valueSlicedDesc = { DML_OPERATOR_SLICE1, &valueSlicedOperatorDesc};
 
-        TensorDesc castedMaskIndexTensorDesc = TensorDesc::ConstructDefaultTensorDesc(MLOperatorTensorDataType::Float, desiredMaskIndexShape);
+        TensorDesc castedMaskIndexTensorDesc = TensorDesc::ConstructDefaultTensorDesc(dataType, desiredMaskIndexShape);
         DML_TENSOR_DESC namedCastedMaskIndexTensorDesc = castedMaskIndexTensorDesc.GetDmlDesc();
 
         DML_CAST_OPERATOR_DESC castMaskIndexOperatorDesc = {};

--- a/winml/test/scenario/cppwinrt/CustomOps.cpp
+++ b/winml/test/scenario/cppwinrt/CustomOps.cpp
@@ -8,7 +8,6 @@
 #include "filehelpers.h"
 #include <fstream>
 #include <MemoryBuffer.h>
-#include <gsl/gsl>
 #include "CustomOperatorProvider.h"
 #include "CustomOps.h"
 


### PR DESCRIPTION
### Description
- Use same data type as input for mask_index tensor which is used as DML GEMM API's C parameter. 
- Remove gsl header include as it is already gets included transitively. 



### Motivation and Context
- Why is this change required? What problem does it solve?
Bug found in internal conformance testing.
- If it fixes an open issue, please link to the issue here.
N/A


