### PR TITLE
Fix ES Lint issue

### DIFF
--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -115,7 +115,7 @@ export const initWasm = async(): Promise<void> => {
     // overwrite wasm filepaths
     if (env.wasm.wasmPaths === undefined) {
       if (scriptSrc && scriptSrc.indexOf('blob:') !== 0) {
-        env.wasm.wasmPaths = scriptSrc.substr(0, (scriptSrc).lastIndexOf('/') + 1);
+        env.wasm.wasmPaths = scriptSrc.substr(0, +(scriptSrc).lastIndexOf('/') + 1);
       }
     }
 

--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -115,7 +115,7 @@ export const initWasm = async(): Promise<void> => {
     // overwrite wasm filepaths
     if (env.wasm.wasmPaths === undefined) {
       if (scriptSrc && scriptSrc.indexOf('blob:') !== 0) {
-        env.wasm.wasmPaths = scriptSrc.substr(0, (scriptSrc as string).lastIndexOf('/') + 1);
+        env.wasm.wasmPaths = scriptSrc.substr(0, (scriptSrc).lastIndexOf('/') + 1);
       }
     }
 


### PR DESCRIPTION
Fixing an error -
118:51  error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion



