### PR TITLE
Add Google Analytics to python apidocs

### DIFF
--- a/.github/workflows/publish-python-apidocs.yml
+++ b/.github/workflows/publish-python-apidocs.yml
@@ -2,7 +2,8 @@ name: Update Python API Docs
 on:
   push:
     branches:
-      - master
+      - main
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -60,7 +60,7 @@ graphviz_output_format = "svg"
 
 # -- Options for Google Analytics -------------------------------------------------
 
-googleanalytics_id = 'UA-156955408-1'
+googleanalytics_id = "UA-156955408-1"
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -34,7 +34,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.graphviz",
     "pyquickhelper.sphinxext.sphinx_runpython_extension",
-    "sphinxcontrib.googleanalytics"
+    "sphinxcontrib.googleanalytics",
 ]
 
 templates_path = ["_templates"]

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -34,7 +34,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.graphviz",
     "pyquickhelper.sphinxext.sphinx_runpython_extension",
-    'sphinxcontrib.googleanalytics'
+    "sphinxcontrib.googleanalytics"
 ]
 
 templates_path = ["_templates"]

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.graphviz",
     "pyquickhelper.sphinxext.sphinx_runpython_extension",
+    'sphinxcontrib.googleanalytics'
 ]
 
 templates_path = ["_templates"]
@@ -56,6 +57,10 @@ html_theme = "alabaster"
 html_logo = "ONNX_Runtime_icon.png"
 html_static_path = ["_static"]
 graphviz_output_format = "svg"
+
+# -- Options for Google Analytics -------------------------------------------------
+
+googleanalytics_id = 'UA-156955408-1'
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -5,6 +5,7 @@ skl2onnx
 sphinx
 sphinx-gallery
 sphinxcontrib.imagesvg
+sphinxcontrib.googleanalytics
 sphinx_rtd_theme
 pyquickhelper
 pandas


### PR DESCRIPTION
Changes staged here: https://natke.github.io/onnxruntime/docs/api/python/

You can see GA included in header

```
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8"/>
        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
        <meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/"/>
        <!-- Google tag (gtag.js) -->
        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156955408-1"></script>
        <script>
            window.dataLayer = window.dataLayer || [];
            function gtag() {
                dataLayer.push(arguments);
            }
            gtag('js', new Date());
            gtag('config', 'UA-156955408-1');
        </script>
```