### PR TITLE
TEST - Linux GPU pipe fail

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -3,7 +3,7 @@
 # transformers requires scikit-learn
 scikit-learn
 numpy==1.21.6
-transformers==v2.10.0
+transformers==v4.4.2
 torch==1.10.0+cu113
 torchvision==0.11.1+cu113
 torchtext==0.11.0


### PR DESCRIPTION
Linux ORT Linux CI pipe fails due to transformers package version.
Updating the transformers version to see it this resolves the pipe fail.
