### PR TITLE
Update VerifyOutputs() to use SpanEq() instead of gsl::span comparison operators which may be disabled.

### DIFF
--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -43,7 +43,7 @@ static void VerifyOutputs(const std::vector<std::string>& output_names,
             << " mismatch for " << output_names[i];
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_INT8:
-        EXPECT_THAT(ltensor.DataAsSpan<int8_t>(), ::testing::ContainerEq(rtensor.DataAsSpan<int8_t>()))
+        EXPECT_TRUE(SpanEq(ltensor.DataAsSpan<int8_t>(), rtensor.DataAsSpan<int8_t>()))
             << " mismatch for " << output_names[i];
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update VerifyOutputs() to use SpanEq() instead of gsl::span comparison operators which may be disabled.

Note: The span comparison operators happen to be disabled in Windows builds with exceptions disabled.
https://github.com/microsoft/GSL/blob/a3534567187d2edc428efd3f13466ff75fe5805c/include/gsl/span_ext#L49-L51
https://github.com/microsoft/GSL/blob/a3534567187d2edc428efd3f13466ff75fe5805c/include/gsl/assert#L24-L25


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix #13893
