### PR TITLE
[DML EP] Disable DML Graph Fusion for lower graph optimization level OR setOptimizedFilePath true

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
@@ -20,7 +20,15 @@ public:
         PoolingHelperBase(kernelInfo, kernelInfo.GetTensorShapeDescription(), useGlobalPooling),
         m_function(function)
     {
-        DmlOperator::Initialize(kernelInfo);
+        if (function == DML_OPERATOR_MAX_POOLING2)
+        {
+            auto kernelOutputIndices = std::vector<std::optional<uint32_t>> { 0, 1};
+            DmlOperator::Initialize(kernelInfo, std::nullopt, kernelOutputIndices);
+        }
+        else
+        {
+            DmlOperator::Initialize(kernelInfo);
+        }
 
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
@@ -20,16 +20,21 @@ public:
         PoolingHelperBase(kernelInfo, kernelInfo.GetTensorShapeDescription(), useGlobalPooling),
         m_function(function)
     {
-        if (function == DML_OPERATOR_MAX_POOLING2)
-        {
-            auto kernelOutputIndices = std::vector<std::optional<uint32_t>> { 0, 1};
-            DmlOperator::Initialize(kernelInfo, std::nullopt, kernelOutputIndices);
-        }
-        else
-        {
-            DmlOperator::Initialize(kernelInfo);
-        }
+        const bool hasDilations =
+            std::any_of(
+                m_kernel.dilations,
+                m_kernel.dilations + m_kernel.spatialDimensionCount,
+                [](auto d) {return d != 1; }
+            );
+        const bool hasOutputIndices = (kernelInfo.GetOutputCount() > 1 && kernelInfo.IsOutputValid(1));
+        std::vector<std::optional<uint32_t>> kernelOutputIndices = {0};
 
+        if (function == DML_OPERATOR_MAX_POOLING2 && (hasOutputIndices || hasDilations))
+        {
+            kernelOutputIndices.emplace_back(1);
+        }
+        DmlOperator::Initialize(kernelInfo, std::nullopt, kernelOutputIndices);
+        
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
         ML_CHECK_VALID_ARGUMENT(inputDescs.size() >= 1, "MaxPool input count must be >=1.");
@@ -40,13 +45,6 @@ public:
         // The below attributes are temporarily not supported:
         int storageOrder = kernelInfo.GetOptionalAttribute<int>(AttrName::StorageOrder, 0);
         ORT_THROW_HR_IF(E_NOTIMPL, storageOrder != 0);
-
-        const bool hasDilations =
-            std::any_of(
-                m_kernel.dilations,
-                m_kernel.dilations + m_kernel.spatialDimensionCount,
-                [](auto d) {return d != 1; }
-            );
 
         // DML requires that DimensionCount be equal to Input.DimCount - 2 for Pooling
         uint32_t expectedSpatialDimCount = m_inputTensorDescs[0].GetDimensionCount() - 2;
@@ -112,7 +110,6 @@ public:
             case DML_OPERATOR_MAX_POOLING1:
             case DML_OPERATOR_MAX_POOLING2:
             {
-                bool hasOutputIndices = (outputDescs.size() > 1 && outputDescs[1].Desc != nullptr);
                 if (hasOutputIndices || hasDilations)
                 {
                     DML_MAX_POOLING2_OPERATOR_DESC desc = {};

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1415,7 +1415,7 @@ common::Status InferenceSession::Initialize() {
         }
 
         // This transformer applies DML-specific fusions that go beyond what ORT offers by default
-        bool dml_operator_fusion_enabled = session_options_.graph_optimization_level > TransformerLevel::Level1;
+        bool dml_operator_fusion_enabled = session_options_.graph_optimization_level >= TransformerLevel::Level2;
         if (dml_operator_fusion_enabled) {
           std::unique_ptr<onnxruntime::GraphTransformer> dmlOperatorFusionTransformer = std::make_unique<Dml::GraphTransformer>("DmlOperatorFusionTransformer");
           if (dmlOperatorFusionTransformer == nullptr) {

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1405,7 +1405,6 @@ common::Status InferenceSession::Initialize() {
       if (execution_providers_.Get(kDmlExecutionProvider)) {
         bool dml_graph_fusion_enabled = session_options_.optimized_model_filepath.empty() &&
                                         session_options_.graph_optimization_level >= TransformerLevel::Level3;
-        
         if (dml_graph_fusion_enabled) {
           std::unique_ptr<onnxruntime::GraphTransformer> dmlGraphFusionTransformer = std::make_unique<Dml::DmlGraphFusionTransformer>("DmlGraphFusionTransformer",
                                                                                                                                       execution_providers_.Get(kDmlExecutionProvider));


### PR DESCRIPTION
### Description
DML EP won't fuse the ONNX Graph if ORT Graph optimization level is <= 1 or `SessionOption::SetOptimizedFilePath` is passed.

This is the successor of https://github.com/microsoft/onnxruntime/pull/11346.

### Motivation and Context
- **Why is this change required? What problem does it solve?**  
    Requested by few a users (issues below) and also helps in debugging. 
- **If it fixes an open issue, please link to the issue here:**
  - https://github.com/microsoft/onnxruntime/issues/13535
  - https://github.com/microsoft/onnxruntime/issues/8440


