### PR TITLE
Fix Dockerfile.cuda: install missing package `python3-packaging`

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -11,7 +11,7 @@ MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-packaging python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.24.3-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.24.3-linux-x86_64.tar.gz --strip=1 -C /usr
 
 RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -41,7 +41,7 @@ git submodule update --init
   ```
 
 ## CUDA
-**Ubuntu 18.04, CUDA 10.2, CuDNN 8**
+**Ubuntu 20.04, CUDA 11.4, CuDNN 8**
 
 1. Update submodules
 ```


### PR DESCRIPTION
Signed-off-by: Jian Zeng <anonymousknight96@gmail.com>

### Description
<!-- Describe your changes. -->

Install the missing package `python3-packaging` in `Dockerfile.cuda`


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

When I was following the instructions described here https://github.com/microsoft/onnxruntime/tree/main/dockerfiles#cuda to build the image, an error occurred:
```
#0 671.6 2022-12-09 16:33:28,129 util.run [INFO] - Running subprocess in '/code/build/Linux/Release'
#0 671.6   /usr/bin/python3 /code/setup.py bdist_wheel --wheel_name_suffix=gpu
#0 671.6 Traceback (most recent call last):
#0 671.6   File "/code/setup.py", line 17, in <module>
#0 671.6     from packaging.tags import sys_tags
#0 671.6 ModuleNotFoundError: No module named 'packaging'
#0 671.6 Traceback (most recent call last):
#0 671.6   File "/code/tools/ci_build/build.py", line 2865, in <module>
#0 671.6     sys.exit(main())
#0 671.6   File "/code/tools/ci_build/build.py", line 2791, in main
#0 671.6     build_python_wheel(
#0 671.6   File "/code/tools/ci_build/build.py", line 2123, in build_python_wheel
#0 671.6     run_subprocess(args, cwd=cwd)
#0 671.6   File "/code/tools/ci_build/build.py", line 752, in run_subprocess
#0 671.6     return run(*args, cwd=cwd, capture_stdout=capture_stdout, shell=shell, env=my_env)
#0 671.6   File "/code/tools/python/util/run.py", line 49, in run
#0 671.6     completed_process = subprocess.run(
#0 671.6   File "/usr/lib/python3.8/subprocess.py", line 516, in run
#0 671.6     raise CalledProcessError(retcode, process.args,
#0 671.6 subprocess.CalledProcessError: Command '['/usr/bin/python3', '/code/setup.py', 'bdist_wheel', '--wheel_name_suffix=gpu']' returned non-zero exit status 1.
```

Please note the line `ModuleNotFoundError: No module named 'packaging'`.

Now the `packging` module is imported at https://github.com/microsoft/onnxruntime/blob/05dc1165a5e03d35cfe573c5a7d0dff7bcb22da5/setup.py#L16-L19, so we need to install `python3-packging` during build time.