### PR TITLE
Use onnxruntime_fetchcontent_makeavailable cmake function for TRT

### DIFF
--- a/cgmanifests/generate_cgmanifest.py
+++ b/cgmanifests/generate_cgmanifest.py
@@ -59,6 +59,7 @@ def add_github_dep(name, parsed_url):
         if dep not in git_deps:
             git_deps[dep] = name
     else:
+        # TODO: support urls like: https://github.com/onnx/onnx-tensorrt/archive/refs/tags/release/7.1.zip
         if len(segments) == 5:
             tag = PurePosixPath(segments[4]).stem
             if tag.endswith(".tar"):
@@ -72,6 +73,7 @@ def add_github_dep(name, parsed_url):
             return
         # Make a REST call to convert to tag to a git commit
         url = "https://api.github.com/repos/%s/%s/git/refs/tags/%s" % (org_name, repo_name, tag)
+        print("requesting %s ..." % url)
         res = requests.get(url, auth=(args.username, args.token))
         response_json = res.json()
         tag_object = response_json["object"]
@@ -148,7 +150,6 @@ proc = subprocess.run(
         "submodule",
         "foreach",
         "--quiet",
-        "--recursive",
         "'{}' '{}' $toplevel/$sm_path".format(
             normalize_path_separators(sys.executable),
             normalize_path_separators(os.path.join(SCRIPT_DIR, "print_submodule_info.py")),

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -635,8 +635,10 @@ if (onnxruntime_USE_TENSORRT)
     FetchContent_Declare(
       onnx_tensorrt
       URL ${DEP_URL_onnx_tensorrt}
-        URL_HASH SHA1=${DEP_SHA1_onnx_tensorrt}
+      URL_HASH SHA1=${DEP_SHA1_onnx_tensorrt}
     )
+    # The onnx_tensorrt repo contains a test program, getSupportedAPITest, which doesn't support Windows. It uses
+    # unistd.h. So we must exclude it from our build. onnxruntime_fetchcontent_makeavailable is for the purpose.
     onnxruntime_fetchcontent_makeavailable(onnx_tensorrt)
     include_directories(${onnx_tensorrt_SOURCE_DIR})
     set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -635,10 +635,10 @@ if (onnxruntime_USE_TENSORRT)
     FetchContent_Declare(
       onnx_tensorrt
       URL ${DEP_URL_onnx_tensorrt}
-	    URL_HASH SHA1=${DEP_SHA1_onnx_tensorrt}
+        URL_HASH SHA1=${DEP_SHA1_onnx_tensorrt}
     )
-    FetchContent_MakeAvailable(onnx_tensorrt)
-	include_directories(${onnx_tensorrt_SOURCE_DIR})
+    onnxruntime_fetchcontent_makeavailable(onnx_tensorrt)
+    include_directories(${onnx_tensorrt_SOURCE_DIR})
     set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
     if ( CMAKE_COMPILER_IS_GNUCC )
       set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
@@ -1479,7 +1479,7 @@ if (onnxruntime_USE_TVM)
     # wd4100: identifier' : unreferenced formal parameter
     # wd4127: conditional expression is constant
     # wd4244: conversion from 'int' to 'char', possible loss of data
-	# TODO: 4244 should not be disabled
+    # TODO: 4244 should not be disabled
     target_compile_options(onnxruntime_providers_tvm PRIVATE "/wd4100" "/wd4127" "/wd4244")
   else()
     target_compile_options(onnxruntime_providers_tvm PRIVATE "-Wno-error=type-limits")


### PR DESCRIPTION
### Description
Use onnxruntime_fetchcontent_makeavailable cmake function for TRT. See the comment for the reason.


### Motivation and Context
To support a newer TRT version. Previously they have a "BUILD_EXE" build option to allow us to exclude such things from build. But in https://github.com/onnx/onnx-tensorrt/pull/879 they deleted the build option. It wouldn't be a problem if we continue to use git submodules as before, because cmake's add_subdirectories function has an "EXCLUDE_FROM_ALL" keyword.  However, cmake's FetchContent module doesn't. That's why I needed to create our own version of the macro. 