### PR TITLE
Update protobuf version to 3.18.3 in tools/ci_build/github/linux/docker/scripts/requirements.txt.

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -8,5 +8,5 @@ onnx==1.12.0
 argparse
 sympy==1.10.1
 flatbuffers
-protobuf==3.18.1
+protobuf==3.18.3
 packaging


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update protobuf version to 3.18.3 in tools/ci_build/github/linux/docker/scripts/requirements.txt.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address component governance alert.
