### PR TITLE
Bug Fix - ORT Web build script

### DIFF
--- a/js/scripts/build_web.py
+++ b/js/scripts/build_web.py
@@ -33,8 +33,8 @@ BUILDS = [
 
 JS_FILES = [
     {"dir": "wasm", "file_name": "ort-wasm.js"},
-    {"dir": "wasm_SIMD_threaded", "file_name": "ort-wasm-simd-threaded.worker.js"},
-    {"dir": "wasm_SIMD_threaded", "file_name": "ort-wasm-simd-threaded.js"},
+    {"dir": "wasm_threaded", "file_name": "ort-wasm-threaded.worker.js"},
+    {"dir": "wasm_threaded", "file_name": "ort-wasm-threaded.js"},
 ]
 
 NPM_BUILD_DIR = [


### PR DESCRIPTION
Copying the right files according to the build documentation. 
The bug originated to address a run break under some machines (needed threaded SIMD instead of only threaded), analysis ongoing.
