### PR TITLE
Add ability to set RunOptions config entries to C# API.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -333,6 +333,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtRunOptionsGetRunTag = (DOrtRunOptionsGetRunTag)Marshal.GetDelegateForFunctionPointer(api_.RunOptionsGetRunTag, typeof(DOrtRunOptionsGetRunTag));
             OrtRunOptionsSetTerminate = (DOrtRunOptionsSetTerminate)Marshal.GetDelegateForFunctionPointer(api_.RunOptionsSetTerminate, typeof(DOrtRunOptionsSetTerminate));
             OrtRunOptionsUnsetTerminate = (DOrtRunOptionsUnsetTerminate)Marshal.GetDelegateForFunctionPointer(api_.RunOptionsUnsetTerminate, typeof(DOrtRunOptionsUnsetTerminate));
+            OrtAddRunConfigEntry = (DOrtAddRunConfigEntry)Marshal.GetDelegateForFunctionPointer(api_.AddRunConfigEntry, typeof(DOrtAddRunConfigEntry));
 
             OrtCreateArenaCfg = (DOrtCreateArenaCfg)Marshal.GetDelegateForFunctionPointer(api_.CreateArenaCfg, typeof(DOrtCreateArenaCfg));
             OrtReleaseArenaCfg = (DOrtReleaseArenaCfg)Marshal.GetDelegateForFunctionPointer(api_.ReleaseArenaCfg, typeof(DOrtReleaseArenaCfg));
@@ -1058,9 +1059,22 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtRunOptionsUnsetTerminate(IntPtr /* OrtRunOptions* */ options);
         public static DOrtRunOptionsUnsetTerminate OrtRunOptionsUnsetTerminate;
 
-#endregion
 
-#region Allocator/MemoryInfo API
+        /// <summary>
+        /// Add run config entry
+        /// </summary>
+        /// <param name="options">Native RunOptions instance</param>
+        /// <param name="configKey">Config key</param>
+        /// <param name="configValue">Config value</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /*(OrtStatus*)*/ DOrtAddRunConfigEntry(IntPtr /* OrtRunOptions* */ options,
+                                                                      IntPtr /* const char* */configKey,
+                                                                      IntPtr /* const char* */ configValue);
+        public static DOrtAddRunConfigEntry OrtAddRunConfigEntry;
+
+        #endregion
+
+        #region Allocator/MemoryInfo API
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* (OrtStatus*)*/ DOrtCreateMemoryInfo(

--- a/csharp/src/Microsoft.ML.OnnxRuntime/RunOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/RunOptions.shared.cs
@@ -119,6 +119,24 @@ namespace Microsoft.ML.OnnxRuntime
         }
         private bool _terminate = false; //value set to default value of the C++ RunOptions
 
+        /// <summary>
+        /// Set a single run configuration entry as a pair of strings
+        /// If a configuration with same key exists, this will overwrite the configuration with the given configValue.
+        /// </summary>
+        /// <param name="configKey">config key name</param>
+        /// <param name="configValue">config key value</param>
+        public void AddRunConfigEntry(string configKey, string configValue)
+        {
+            using (var pinnedConfigKeyName = new PinnedGCHandle(
+                GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(configKey), GCHandleType.Pinned)))
+            using (var pinnedConfigValueName = new PinnedGCHandle(
+                GCHandle.Alloc(NativeOnnxValueHelper.StringToZeroTerminatedUtf8(configValue), GCHandleType.Pinned)))
+            {
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.OrtAddRunConfigEntry(handle,
+                                                       pinnedConfigKeyName.Pointer, pinnedConfigValueName.Pointer));
+            }
+        }
 
         #region SafeHandle
         /// <summary>

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -189,6 +189,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 opt.LogId = "MyLogTag";
                 Assert.Equal("MyLogTag", opt.LogId);
+
+                opt.AddRunConfigEntry("key", "value");
+
+                var ex = Assert.Throws<OnnxRuntimeException>(() => { opt.AddRunConfigEntry("", "missing key"); });
+                Assert.Contains("[ErrorCode:InvalidArgument] Config key is empty", ex.Message);
             }
         }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add ability to set RunOptions config entries. Largely a cut-and-paste of the existing code for setting SessionOptions config entries. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#13936

