### PR TITLE
Correct logic for GPU backend detection

### DIFF
--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -74,7 +74,7 @@ def optimize_by_onnxruntime(
 
     import onnxruntime
 
-    if use_gpu and not set(onnxruntime.get_available_providers()).isdisjoint(
+    if use_gpu and set(onnxruntime.get_available_providers()).isdisjoint(
         ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
     ):
         logger.error("There is no gpu for onnxruntime to do optimization.")
@@ -112,7 +112,7 @@ def optimize_by_onnxruntime(
             gpu_ep.append("ROCMExecutionProvider")
 
         session = onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=gpu_ep, **kwargs)
-        assert set(onnxruntime.get_available_providers()).isdisjoint(
+        assert not set(onnxruntime.get_available_providers()).isdisjoint(
             ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
         )
 


### PR DESCRIPTION
Correct logic used for isdisjoint call in checking for GPU backends in accuracy tests.

### Description
<!-- Describe your changes. -->
Currently these checks yield the opposite of the desired logic.  Correcting use of logical
negation to get correct results.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Without this change GPU backends for accuracy tests do not work.

