### PR TITLE
Allow Tensor to be scalar if it is not per channel.

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -692,7 +692,7 @@ class ONNXQuantizer:
         quantized_bias_scale_name = quantized_bias_name + "_scale"
         bias_scale_data = np.asarray(bias_scale, dtype=np.float32).reshape(-1)
         if self.is_per_channel():
-            packed_bias_scale_initializer = onnx.numpy_helper.from_array(bias_scale_data, )
+            packed_bias_scale_initializer = onnx.numpy_helper.from_array(bias_scale_data, quantized_bias_scale_name)
         else:
             packed_bias_scale_initializer = onnx.helper.make_tensor(quantized_bias_scale_name, onnx_proto.TensorProto.FLOAT, [], bias_scale_data)
         self.model.initializer().extend([packed_bias_scale_initializer])

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -706,7 +706,7 @@ class ONNXQuantizer:
             packed_bias_zp_initializer = onnx.numpy_helper.from_array(bias_zp_data, quantized_bias_zp_name)
         else:
             packed_bias_zp_initializer = onnx.helper.make_tensor(
-                quantized_bias_zp_name, self.weight_qType, [], bias_zp_data
+                quantized_bias_zp_name, onnx_proto.TensorProto.INT32, [], bias_zp_data
             )
         self.model.initializer().extend([packed_bias_zp_initializer])
 

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -691,13 +691,19 @@ class ONNXQuantizer:
         # update scale initializer
         quantized_bias_scale_name = quantized_bias_name + "_scale"
         bias_scale_data = np.asarray(bias_scale, dtype=np.float32).reshape(-1)
-        packed_bias_scale_initializer = onnx.numpy_helper.from_array(bias_scale_data, quantized_bias_scale_name)
+        if self.is_per_channel():
+            packed_bias_scale_initializer = onnx.numpy_helper.from_array(bias_scale_data, )
+        else:
+            packed_bias_scale_initializer = onnx.helper.make_tensor(quantized_bias_scale_name, onnx_proto.TensorProto.FLOAT, [], bias_scale_data)
         self.model.initializer().extend([packed_bias_scale_initializer])
 
         # update zero initializer
         quantized_bias_zp_name = quantized_bias_name + "_zero_point"
         bias_zp_data = np.zeros(bias_scale.shape, dtype=np.int32).reshape(-1)
-        packed_bias_zp_initializer = onnx.numpy_helper.from_array(bias_zp_data, quantized_bias_zp_name)
+        if self.is_per_channel():
+            packed_bias_zp_initializer = onnx.numpy_helper.from_array(bias_zp_data, quantized_bias_zp_name)
+        else:
+            packed_bias_zp_initializer = onnx.helper.make_tensor(quantized_bias_zp_name, self.weight_qType, [], bias_zp_data)
         self.model.initializer().extend([packed_bias_zp_initializer])
 
         assert bias_name not in self.quantized_value_map
@@ -1057,7 +1063,6 @@ class ONNXQuantizer:
             if node.input[0] not in self.tensors_range.keys() or node.output[0] not in self.tensors_range.keys():
                 continue
             self.tensors_range[node.input[0]] = self.tensors_range[node.output[0]]
-
         quantization_params = {}
         for tensor_name in self.tensors_range.keys():
             rmin, rmax = self.tensors_range[tensor_name]

--- a/onnxruntime/python/tools/quantization/onnx_quantizer.py
+++ b/onnxruntime/python/tools/quantization/onnx_quantizer.py
@@ -694,7 +694,9 @@ class ONNXQuantizer:
         if self.is_per_channel():
             packed_bias_scale_initializer = onnx.numpy_helper.from_array(bias_scale_data, quantized_bias_scale_name)
         else:
-            packed_bias_scale_initializer = onnx.helper.make_tensor(quantized_bias_scale_name, onnx_proto.TensorProto.FLOAT, [], bias_scale_data)
+            packed_bias_scale_initializer = onnx.helper.make_tensor(
+                quantized_bias_scale_name, onnx_proto.TensorProto.FLOAT, [], bias_scale_data
+            )
         self.model.initializer().extend([packed_bias_scale_initializer])
 
         # update zero initializer
@@ -703,7 +705,9 @@ class ONNXQuantizer:
         if self.is_per_channel():
             packed_bias_zp_initializer = onnx.numpy_helper.from_array(bias_zp_data, quantized_bias_zp_name)
         else:
-            packed_bias_zp_initializer = onnx.helper.make_tensor(quantized_bias_zp_name, self.weight_qType, [], bias_zp_data)
+            packed_bias_zp_initializer = onnx.helper.make_tensor(
+                quantized_bias_zp_name, self.weight_qType, [], bias_zp_data
+            )
         self.model.initializer().extend([packed_bias_zp_initializer])
 
         assert bias_name not in self.quantized_value_map


### PR DESCRIPTION
### Description
Allow Tensor to be scalar if it is not per channel.



### Motivation and Context
[<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->](https://github.com/microsoft/onnxruntime/issues/13915)


