### PR TITLE
Use cache for compilation in container

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -669,6 +669,8 @@ def parse_arguments():
 
     parser.add_argument("--use_xnnpack", action="store_true", help="Enable xnnpack EP.")
 
+    parser.add_argument("--use_cache", action="store_true", help="Use compiler cache in CI")
+
     args = parser.parse_args()
     if args.android_sdk_path:
         args.android_sdk_path = os.path.normpath(args.android_sdk_path)
@@ -952,6 +954,9 @@ def generate_build_tree(
         "-Donnxruntime_USE_XNNPACK=" + ("ON" if args.use_xnnpack else "OFF"),
         "-Donnxruntime_USE_CANN=" + ("ON" if args.use_cann else "OFF"),
     ]
+    if args.use_cache:
+        cmake_args.append("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+        cmake_args.append("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
     # By default cmake does not check TLS/SSL certificates. Here we turn it on.
     # But, in some cases you may also need to supply a CA file.
     add_default_definition(cmake_extra_defines, "CMAKE_TLS_VERIFY", "ON")

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -87,6 +87,7 @@ jobs:
               --build_wheel \
               --enable_onnx_tests \
               --enable_transformers_tool_test \
+              --use_cache \
               --build_java --build_nodejs --update --build --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON; \
             ccache -s"
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -13,6 +13,7 @@ jobs:
     clean: all
   variables:
     skipComponentGovernanceDetection: true
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   pool: Linux-CPU-2019
   steps:
   - checkout: self
@@ -35,6 +36,24 @@ jobs:
       DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
       Repository: onnxruntimecpubuild
 
+  - script: |
+      sudo apt-get install ccache -y
+      echo "##vso[task.prependpath]/usr/lib/ccache"
+    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)" | cpu'
+      path: $(CCACHE_DIR)
+      cacheHitVar: CACHE_RESTORED
+      restoreKeys: |
+        ccache | "$(Agent.OS)" | cpu
+    displayName: ccache
+
+  - script: |
+      sudo mkdir -p $(Pipeline.Workspace)/ccache
+    condition: ne(variables.CACHE_RESTORED, 'true')
+    displayName: Create Cache Dir
+
   - task: CmdLine@2
     displayName: 'build'
     inputs:
@@ -45,10 +64,16 @@ jobs:
           --volume $(Build.SourcesDirectory):/onnxruntime_src \
           --volume $(Build.BinariesDirectory):/build \
           --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
+          --volume $(Pipeline.Workspace)/ccache:/cache \
           -e ALLOW_RELEASED_ONNX_OPSET_ONLY=0 \
           -e NIGHTLY_BUILD \
           -e BUILD_BUILDNUMBER \
+          -e CCACHE_DIR=/cache \
           onnxruntimecpubuild \
+          /bin/bash -c "
+            set -ex; \
+            env; \
+            ccache -s; \
             /opt/python/cp38-cp38/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \
               --config Debug Release \
@@ -58,7 +83,8 @@ jobs:
               --build_wheel \
               --enable_onnx_tests \
               --enable_transformers_tool_test \
-              --build_java --build_nodejs --update --build --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON
+              --build_java --build_nodejs --update --build --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON; \
+            ccache -s"
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
@@ -144,7 +170,3 @@ jobs:
       searchFolder: '$(Build.BinariesDirectory)'
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
-
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -16,6 +16,10 @@ jobs:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
   pool: Linux-CPU-2019
   steps:
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()
+
   - checkout: self
     clean: true
     submodules: none

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -78,7 +78,6 @@ jobs:
           onnxruntimecpubuild \
           /bin/bash -c "
             set -ex; \
-            env; \
             ccache -s; \
             /opt/python/cp38-cp38/bin/python3 /onnxruntime_src/tools/ci_build/build.py \
               --build_dir /build --cmake_generator Ninja \

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -44,6 +44,7 @@ jobs:
       sudo apt-get install ccache -y
       echo "##vso[task.prependpath]/usr/lib/ccache"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+
   - task: Cache@2
     inputs:
       key: '"ccache" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
@@ -51,7 +52,7 @@ jobs:
       restoreKeys: |
         "ccache" | "$(Build.SourceBranch)"
       cacheHitVar: CACHE_RESTORED
-    displayName: ccache
+    displayName: Cach Task
 
   - script: |
       sudo mkdir -p $(Pipeline.Workspace)/ccache

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -51,6 +51,7 @@ jobs:
       path: $(CCACHE_DIR)
       restoreKeys: |
         "ccache" | "$(Build.SourceBranch)"
+        "ccache"
       cacheHitVar: CACHE_RESTORED
     displayName: Cach Task
 

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -46,11 +46,11 @@ jobs:
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
   - task: Cache@2
     inputs:
-      key: 'ccache | "$(Agent.OS)" | cpu'
+      key: '"ccache" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
       path: $(CCACHE_DIR)
-      cacheHitVar: CACHE_RESTORED
       restoreKeys: |
-        ccache | "$(Agent.OS)" | cpu
+        "ccache" | "$(Build.SourceBranch)"
+      cacheHitVar: CACHE_RESTORED
     displayName: ccache
 
   - script: |

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps.sh
@@ -83,6 +83,12 @@ echo "Installing Node.js"
 GetFile https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.gz /tmp/src/node-v16.14.2-linux-x64.tar.gz
 tar --strip 1 -xf /tmp/src/node-v16.14.2-linux-x64.tar.gz -C /usr
 
+echo "Installing CCache"
+mkdir -p /tmp/ccache
+GetFile https://github.com/ccache/ccache/releases/download/v4.7.4/ccache-4.7.4-linux-x86_64.tar.xz /tmp/src/ccache-4.7.4-linux-x86_64.tar.xz
+tar --strip 1 -xf /tmp/src/ccache-4.7.4-linux-x86_64.tar.xz -C /tmp/ccache
+cp /tmp/ccache/ccache /usr/bin
+
 cd /tmp/src
 GetFile https://downloads.gradle-dn.com/distributions/gradle-6.3-bin.zip /tmp/src/gradle-6.3-bin.zip
 unzip /tmp/src/gradle-6.3-bin.zip


### PR DESCRIPTION
### Description
For compilation in container,  ADO Cache task doesn't work directly.
The workaround is to mount the cache directory to the container, and let CCache in container to read/write cache data.
In short, we just leverage ADO API to download/upload cache data.

The Post-jobs works in stack-mode, So the PostBuildCleanUp Tasks should be defined first.
Thus, The PostBuildCleanUp would be executed lastly.
Else, Cache Task would fail to upload cache because the Agent Directory is cleaned.



