### PR TITLE
Add noexcept annotation to address prefast warnings

### DIFF
--- a/include/onnxruntime/core/common/gpu_profiler_common.h
+++ b/include/onnxruntime/core/common/gpu_profiler_common.h
@@ -33,24 +33,24 @@ namespace profiling {
 
 class ProfilerActivityBuffer {
  public:
-  ProfilerActivityBuffer()
+  ProfilerActivityBuffer() noexcept
       : data_(nullptr), size_(0) {}
 
-  ProfilerActivityBuffer(const char* data, size_t size)
+  ProfilerActivityBuffer(const char* data, size_t size) noexcept
       : data_(std::make_unique<char[]>(size)), size_(size) {
     memcpy(data_.get(), data, size_);
   }
 
-  ProfilerActivityBuffer(const ProfilerActivityBuffer& other)
+  ProfilerActivityBuffer(const ProfilerActivityBuffer& other) noexcept
       : ProfilerActivityBuffer(other.GetData(), other.GetSize()) {}
 
-  ProfilerActivityBuffer(ProfilerActivityBuffer&& other)
+  ProfilerActivityBuffer(ProfilerActivityBuffer&& other) noexcept
       : ProfilerActivityBuffer() {
     std::swap(data_, other.data_);
     std::swap(size_, other.size_);
   }
 
-  ProfilerActivityBuffer& operator=(const ProfilerActivityBuffer& other) {
+  ProfilerActivityBuffer& operator=(const ProfilerActivityBuffer& other) noexcept {
     if (&other == this) {
       return *this;
     }
@@ -59,7 +59,7 @@ class ProfilerActivityBuffer {
     return *this;
   }
 
-  ProfilerActivityBuffer& operator=(ProfilerActivityBuffer&& other) {
+  ProfilerActivityBuffer& operator=(ProfilerActivityBuffer&& other) noexcept {
     if (&other == this) {
       return *this;
     }


### PR DESCRIPTION
### Description
Add noexcept annotations to move constructors and assignment ops to address prefast warnings. 
(see https://dev.azure.com/aiinfra/ONNX%20Runtime/_workitems/edit/11012/)