### PR TITLE
Fix ios/android packaging pipeline failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -125,7 +125,7 @@ jobs:
         --test-series "master" \
         --locale "en_US" \
         --build-dir $(Build.BinariesDirectory)/app_center_test_mobile/ios_package_test/DerivedData/Build/Products/Debug-iphoneos \
-        --token $(app_center_api_token)
+        --token $(app_center_api_token_2)
     displayName: "[Mobile] Run E2E tests on App Center"
 
   # create and test full pods
@@ -172,7 +172,7 @@ jobs:
         --test-series "master" \
         --locale "en_US" \
         --build-dir $(Build.BinariesDirectory)/app_center_test_full/ios_package_test/DerivedData/Build/Products/Debug-iphoneos \
-        --token $(app_center_api_token)
+        --token $(app_center_api_token_2)
     displayName: "[Full] Run E2E tests on App Center"
 
   - bash: |

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -72,7 +72,7 @@ jobs:
         --test-series "master" \
         --locale "en_US" \
         --build-dir ./app/build/outputs/apk/androidTest/debug \
-        --token $(app_center_api_token)
+        --token $(app_center_api_token_2)
     displayName: Run E2E tests using App Center
     workingDirectory: $(Build.BinariesDirectory)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Generated a new user api token for app center. Previous one is no longer valid.

Variable Group linked to the pipeline is also updated accordingly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix packaging pipeline