### PR TITLE
Exclude affinity-setting logic from minimal build

### DIFF
--- a/onnxruntime/core/util/thread_utils.cc
+++ b/onnxruntime/core/util/thread_utils.cc
@@ -88,7 +88,7 @@ CreateThreadPoolHelper(Env* env, OrtThreadPoolParams options) {
   // override affinity setting if specified from customer
   if (!options.affinity_str.empty()) {
 #if defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-    ORT_THROW("Setting customized thread affinity is not supported in this build.");
+    ORT_THROW("Setting thread affinity is not implemented in this build.");
     return nullptr;
 #else
     to.affinities = ReadThreadAffinityConfig(options.affinity_str);
@@ -213,8 +213,8 @@ ORT_API_STATUS_IMPL(SetGlobalIntraOpThreadAffinity, _Inout_ OrtThreadingOptions*
 #if defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   ORT_UNUSED_PARAMETER(tp_options);
   ORT_UNUSED_PARAMETER(affinity_string);
-  return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
-                               "Setting customized thread affinity is not supported in this build.");
+  return OrtApis::CreateStatus(ORT_NOT_IMPLEMENTED,
+                               "Setting thread affinity is not implemented in this build.");
 #else
   if (!tp_options) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Received null OrtThreadingOptions");

--- a/onnxruntime/core/util/thread_utils.cc
+++ b/onnxruntime/core/util/thread_utils.cc
@@ -16,6 +16,7 @@
 namespace onnxruntime {
 namespace concurrency {
 
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
 // Extract affinity from affinity string.
 // Processor id from affinity string starts from 1,
 // but internally, processor id starts from 0, so here we minus the id by 1
@@ -68,6 +69,7 @@ static std::vector<LogicalProcessors> ReadThreadAffinityConfig(const std::string
   }
   ORT_THROW("Failed to read affinities from affinity string");
 }
+#endif
 
 static std::unique_ptr<ThreadPool>
 CreateThreadPoolHelper(Env* env, OrtThreadPoolParams options) {

--- a/onnxruntime/core/util/thread_utils.cc
+++ b/onnxruntime/core/util/thread_utils.cc
@@ -19,7 +19,7 @@ namespace concurrency {
 // Extract affinity from affinity string.
 // Processor id from affinity string starts from 1,
 // but internally, processor id starts from 0, so here we minus the id by 1
-std::vector<LogicalProcessors> ReadThreadAffinityConfig(const std::string& affinity_str) {
+static std::vector<LogicalProcessors> ReadThreadAffinityConfig(const std::string& affinity_str) {
   ORT_TRY {
     std::vector<LogicalProcessors> logical_processors_vector;
     auto affinities = utils::SplitString(affinity_str, ";");

--- a/onnxruntime/core/util/thread_utils.cc
+++ b/onnxruntime/core/util/thread_utils.cc
@@ -211,6 +211,8 @@ ORT_API_STATUS_IMPL(SetGlobalCustomJoinThreadFn, _Inout_ OrtThreadingOptions* tp
 
 ORT_API_STATUS_IMPL(SetGlobalIntraOpThreadAffinity, _Inout_ OrtThreadingOptions* tp_options, const char* affinity_string) {
 #if defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  ORT_UNUSED_PARAMETER(tp_options);
+  ORT_UNUSED_PARAMETER(affinity_string);
   return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                "Setting customized thread affinity is not supported in this build.");
 #else

--- a/onnxruntime/test/global_thread_pools/test_main.cc
+++ b/onnxruntime/test/global_thread_pools/test_main.cc
@@ -94,8 +94,10 @@ int main(int argc, char** argv) {
     st_ptr.reset(g_ort->SetGlobalIntraOpThreadAffinity(tp_options, long_affinity_str.c_str()));
     ORT_RETURN_IF_NULL_STATUS(st_ptr);
 
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
     st_ptr.reset(g_ort->SetGlobalIntraOpThreadAffinity(tp_options, affinity_stream.str().c_str()));
     ORT_RETURN_IF_NON_NULL_STATUS(st_ptr);
+#endif
 
     st_ptr.reset(g_ort->SetGlobalCustomCreateThreadFn(tp_options, CreateThreadCustomized));
     ORT_RETURN_IF_NON_NULL_STATUS(st_ptr);

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -544,6 +544,8 @@ TEST(ThreadPoolTest, TestStackSize) {
 #endif
 #endif
 
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
+
 #ifndef ORT_NO_EXCEPTIONS
 TEST(ThreadPoolTest, TestAffinityStringMisshaped) {
   OrtThreadPoolParams tp_params;
@@ -666,6 +668,7 @@ TEST(ThreadPoolTest, TestDefaultAffinity) {
     }
   }
 }
+#endif
 #endif
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -56,6 +56,7 @@ TEST(CApiTest, model_from_array) {
 #endif
 }
 
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD)
 TEST(CApiTest, session_options_empty_affinity_string) {
   Ort::SessionOptions options;
   options.AddConfigEntry(kOrtSessionOptionsConfigIntraOpThreadAffinities, "");
@@ -68,6 +69,7 @@ TEST(CApiTest, session_options_empty_affinity_string) {
     ASSERT_THAT(ex.what(), testing::HasSubstr("Affinity string must not be empty"));
   }
 }
+#endif
 
 #endif
 

--- a/onnxruntime/test/shared_lib/test_session_options.cc
+++ b/onnxruntime/test/shared_lib/test_session_options.cc
@@ -15,7 +15,7 @@ TEST(CApiTest, session_options_graph_optimization_level) {
   options.SetGraphOptimizationLevel(ORT_ENABLE_EXTENDED);
 }
 
-#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_NO_EXCEPTIONS)
+#if !defined(ORT_MINIMAL_BUILD) && !defined(ORT_EXTENDED_MINIMAL_BUILD) && !defined(ORT_NO_EXCEPTIONS)
 
 TEST(CApiTest, session_options_oversized_affinity_string) {
   Ort::SessionOptions options;


### PR DESCRIPTION
Comment out the affinity-setting logic which introduced an unnecessary binary size increase for the minimal build.

