### PR TITLE
FIX: macOS CI pipeline doesn't run tests

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
@@ -3,4 +3,4 @@ jobs:
   parameters:
     AllowReleasedOpsetOnly: 0
     BuildForAllArchs: false
-    AdditionalBuildFlags: --build_objc --enable_language_interop_ops
+    AdditionalBuildFlags: --build_objc --enable_language_interop_ops --build_wheel

--- a/tools/ci_build/github/azure-pipelines/templates/mac-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-packaging.yml
@@ -22,6 +22,11 @@ steps:
         python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --update --build  ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --build_shared_lib --config Release
       displayName: 'Build ${{ parameters.MacosArch }}'
 
+    - ${{ if eq(parameters.MacosArch, 'x86_64') }}:
+      - script: |
+          python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --test  ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --build_shared_lib --config Release
+        displayName: 'Running Tests'
+
     - task: ShellScript@2
       displayName: 'Copy build artifacts for zipping'
       inputs:


### PR DESCRIPTION
### Description
Fix a problem: macOS CI pipeline doesn't run tests. It is due a code refactoring I recently made. 

### Motivation and Context
Add the tests back.


