### PR TITLE
Add ms domain during saving onnx model in onnx_model.py

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -917,6 +917,16 @@ class OnnxModel:
     ):
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
+        # Add ms domain if needed
+        ms_opset = [opset for opset in model.opset_import if opset.domain == "com.microsoft"]
+        # Check whether there is custom op in top level graph (our fusion is on top level right now).
+        # May need to extend to subgraph if our fusion are extended to subgraphs.
+        ms_node = [node for node in model.graph.node if node.domain == "com.microsoft"]
+        if ms_node and not ms_opset:
+            opset = model.opset_import.add()
+            opset.version = 1
+            opset.domain = "com.microsoft"
+
         if save_as_external_data:
             # Save model to external data, which is needed for model size > 2GB
             output_dir = Path(output_path).parent


### PR DESCRIPTION
### Description
Add domain "com.microsoft" during saving model if needed.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The transformers optimization tools might add contrib ops with domain "com.microsoft". We need add the domain to model.opset_import otherwise onnx shape inference might report error that domain is not imported.

