### PR TITLE
Skip some attention op tests in A100

### DIFF
--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/platform/env_var_utils.h"
 #include "gtest/gtest.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
@@ -1718,6 +1719,13 @@ TEST(AttentionTest, AttentionMaskIndexOutOfRange) {
 #if !defined(__wasm__)
 // TODO: fix in web assembly
 TEST(AttentionTest, AttentionPastState_dynamic) {
+  // ORT enables TF32 in GEMM for A100. TF32 will cause precsion loss and fail this test.
+  // Do not run this test unless TF32 is disabled explicitly.
+  if (HasCudaEnvironment(800) && ParseEnvironmentVariableWithDefault<int>("NVIDIA_TF32_OVERRIDE", 1) != 0) {
+    GTEST_SKIP() << "Skipping AttentionPastState_dynamic in A100 since TF32 is enabled";
+    return;
+  }
+
   // create rand inputs
   RandomValueGenerator random{};
 
@@ -1865,6 +1873,13 @@ static void RunModelWithRandomInput(
     std::vector<int32_t>& mask_index_data,
     std::string& onnx_model,
     bool is_float16) {
+  // ORT enables TF32 in GEMM for A100. TF32 will cause precsion loss and fail this test.
+  // Do not run this test unless TF32 is disabled explicitly.
+  if (HasCudaEnvironment(800) && ParseEnvironmentVariableWithDefault<int>("NVIDIA_TF32_OVERRIDE", 1) != 0) {
+    GTEST_SKIP() << "Skipping RunModelWithRandomInput in A100 since TF32 is enabled";
+    return;
+  }
+
   RandomValueGenerator random{234};
 
   constexpr int hidden_size = 768;


### PR DESCRIPTION
### Description

Skip some attention_op tests in A100 due to TF32 is enabled in GEMM, and that causes some unit tests fails in A100.

TF32 is enabled by default for GEMM:
https://github.com/microsoft/onnxruntime/blob/6090d8cd6eb89ab8da000ba41ccabb48ce798feb/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h#L36
Right now, it can be turned off by environment variables. We will not skip these tests if TF32 is turned off.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Some tests using threshold for float32 failed in A100 machine due to this. Skip those tests for now.
