### PR TITLE
Warn users using the init_decoder subgraph attribute in CPU BeamSearch/GreedySearch

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -78,7 +78,8 @@ void BeamSearch::Init(const OpKernelInfo& info) {
 
     // TODO (hasesh): Remove this once the CPU kernel supports init_decoder
     if (has_init_decoder_ && Node().GetExecutionProviderType() != kCudaExecutionProvider) {
-      ORT_THROW("Currently, using the init_decoder attribute is only supported on CUDA");
+      LOGS_DEFAULT(WARNING) << "Using init_decoder subgraph attribute is not supported yet in CPU. "
+                               "So, the decoder subgraph will be used for all decoding iterations";
     }
   }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -75,6 +75,11 @@ void BeamSearch::Init(const OpKernelInfo& info) {
     if (info.GetAttr<ONNX_NAMESPACE::GraphProto>("init_decoder", &proto).IsOK()) {
       has_init_decoder_ = true;
     }
+
+    // TODO (hasesh): Remove this once the CPU kernel supports init_decoder
+    if (has_init_decoder_ && Node().GetExecutionProviderType() != kCudaExecutionProvider) {
+      ORT_THROW("Currently, using the init_decoder attribute is only supported on CUDA");
+    }
   }
 
   // Make sure the decoder sub-graph attribute is present for all model types.

--- a/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
@@ -97,7 +97,8 @@ void GreedySearch::Init(const OpKernelInfo& info) {
 
     // TODO (hasesh): Remove this once the CPU kernel supports init_decoder
     if (has_init_decoder_ && Node().GetExecutionProviderType() != kCudaExecutionProvider) {
-      ORT_THROW("Currently, using the init_decoder attribute is only supported on CUDA");
+      LOGS_DEFAULT(WARNING) << "Using init_decoder subgraph attribute is not supported yet in CPU. "
+                               "So, the decoder subgraph will be used for all decoding iterations";
     }
   }
 

--- a/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/greedy_search.cc
@@ -94,6 +94,11 @@ void GreedySearch::Init(const OpKernelInfo& info) {
     if (info.GetAttr<ONNX_NAMESPACE::GraphProto>("init_decoder", &proto).IsOK()) {
       has_init_decoder_ = true;
     }
+
+    // TODO (hasesh): Remove this once the CPU kernel supports init_decoder
+    if (has_init_decoder_ && Node().GetExecutionProviderType() != kCudaExecutionProvider) {
+      ORT_THROW("Currently, using the init_decoder attribute is only supported on CUDA");
+    }
   }
 
   // Make sure the decoder sub-graph attribute is present for all model types.


### PR DESCRIPTION
### Description
The CPU BeamSearch/GreedySearch does not support the GPT2 init_decoder subgraph yet. Warn users that it will not be used.



