### PR TITLE
Fix skew between GPU/CPU timestamps in ORT profiler

### DIFF
--- a/include/onnxruntime/core/common/gpu_profiler_common.h
+++ b/include/onnxruntime/core/common/gpu_profiler_common.h
@@ -336,8 +336,8 @@ protected:
 
   uint64_t GetCPUTimestampInNanoseconds() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
-      std::chrono::high_resolution_clock::now().time_since_epoch()
-    ).count();
+               std::chrono::high_resolution_clock::now().time_since_epoch())
+        .count();
   }
 
   std::mutex manager_instance_mutex_;

--- a/include/onnxruntime/core/common/gpu_profiler_common.h
+++ b/include/onnxruntime/core/common/gpu_profiler_common.h
@@ -227,7 +227,7 @@ class GPUTracerManager {
     gpu_ts1 = this_as_derived->GetGPUTimestampInNanoseconds();
     cpu_ts = this->GetCPUTimestampInNanoseconds();
 
-    // actual measurement of skew
+    // Estimate the skew/offset between the CPU and GPU timestamps.
     gpu_ts1 = this_as_derived->GetGPUTimestampInNanoseconds();
     cpu_ts = this->GetCPUTimestampInNanoseconds();
     gpu_ts2 = this_as_derived->GetGPUTimestampInNanoseconds();
@@ -282,7 +282,7 @@ protected:
     events_pending_client_mapping_.erase(pending_it);
   }
 
-  uint64_t NormalizeGPUTimestampNanoseconds(uint64_t gpu_timestamp_in_nanoseconds) {
+  uint64_t NormalizeGPUTimestampToCPUEpoch(uint64_t gpu_timestamp_in_nanoseconds) {
     return gpu_timestamp_in_nanoseconds + this->offset_to_add_to_gpu_timestamps_;
   }
 

--- a/onnxruntime/core/providers/cuda/cupti_manager.cc
+++ b/onnxruntime/core/providers/cuda/cupti_manager.cc
@@ -141,7 +141,7 @@ void CUPTIManager::ProcessActivityBuffers(const std::vector<ProfilerActivityBuff
               /* pid = */ -1,
               /* tid = */ -1,
               /* name = */ std::move(name),
-              /* ts = */ (int64_t)(this->NormalizeGPUTimestampNanoseconds(mmcpy->start) - start_time_ns) / 1000,
+              /* ts = */ (int64_t)(this->NormalizeGPUTimestampToCPUEpoch(mmcpy->start) - start_time_ns) / 1000,
               /* dur = */ (int64_t)(mmcpy->end - mmcpy->start) / 1000,
               /* args = */ std::move(args)};
           MapEventToClient(mmcpy->correlationId, std::move(event));

--- a/onnxruntime/core/providers/cuda/cupti_manager.cc
+++ b/onnxruntime/core/providers/cuda/cupti_manager.cc
@@ -38,6 +38,14 @@ CUPTIManager& CUPTIManager::GetInstance() {
   return instance;
 }
 
+uint64_t CUPTIManager::GetGPUTimestampInNanoseconds() {
+  uint64_t result;
+  if (cuptiGetTimestamp(&result) != CUPTI_SUCCESS) {
+    ORT_THROW("Could not retrieve timestamp from GPU!");
+  }
+  return result;
+}
+
 CUPTIManager::~CUPTIManager() {}
 
 bool CUPTIManager::OnStartLogging() {

--- a/onnxruntime/core/providers/cuda/cupti_manager.h
+++ b/onnxruntime/core/providers/cuda/cupti_manager.h
@@ -35,6 +35,7 @@ class CUPTIManager : public GPUTracerManager<CUPTIManager> {
   void ProcessActivityBuffers(const std::vector<ProfilerActivityBuffer>& buffers,
                               const TimePoint& start_time);
   void FlushActivities();
+  uint64_t GetGPUTimestampInNanoseconds();
 
  private:
   static constexpr size_t kActivityBufferSize = 32 * 1024;

--- a/onnxruntime/core/providers/cuda/cupti_manager.h
+++ b/onnxruntime/core/providers/cuda/cupti_manager.h
@@ -25,6 +25,7 @@ class CUPTIManager : public GPUTracerManager<CUPTIManager> {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CUPTIManager);
   ~CUPTIManager();
   static CUPTIManager& GetInstance();
+  uint64_t GetGPUTimestampInNanoseconds();
 
  protected:
   bool PushUniqueCorrelation(uint64_t unique_cid);

--- a/onnxruntime/core/providers/cuda/cupti_manager.h
+++ b/onnxruntime/core/providers/cuda/cupti_manager.h
@@ -25,7 +25,6 @@ class CUPTIManager : public GPUTracerManager<CUPTIManager> {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(CUPTIManager);
   ~CUPTIManager();
   static CUPTIManager& GetInstance();
-  uint64_t GetGPUTimestampInNanoseconds();
 
  protected:
   bool PushUniqueCorrelation(uint64_t unique_cid);

--- a/onnxruntime/core/providers/rocm/roctracer_manager.cc
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.cc
@@ -28,6 +28,14 @@ RoctracerManager& RoctracerManager::GetInstance() {
   return instance;
 }
 
+uint64_t RoctracerManager::GetGPUTimestampInNanoseconds() {
+  uint64_t result;
+  if (roctracer_get_timestamp(&result) != ROCTRACER_STATUS_SUCCESS) {
+    ORT_THROW("Could not retrieve timestamp from GPU!");
+  }
+  return result;
+}
+
 RoctracerManager::~RoctracerManager() {}
 
 #define ROCTRACER_STATUS_RETURN_FALSE_ON_FAIL(expr_) \

--- a/onnxruntime/core/providers/rocm/roctracer_manager.cc
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.cc
@@ -243,7 +243,7 @@ bool RoctracerManager::CreateEventForActivityRecord(const roctracer_record_t* re
       /* pid = */ -1,
       /* tid = */ -1,
       /* name = */ std::move(name),
-      /* ts = */ (int64_t)(this->NormalizeGPUTimestampNanoseconds(record->begin_ns) - start_time_ns) / 1000,
+      /* ts = */ (int64_t)(this->NormalizeGPUTimestampToCPUEpoch(record->begin_ns) - start_time_ns) / 1000,
       /* dur = */ (int64_t)(record->end_ns - record->begin_ns) / 1000,
       /* args = */ std::move(args)};
   return true;

--- a/onnxruntime/core/providers/rocm/roctracer_manager.h
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.h
@@ -31,6 +31,7 @@ class RoctracerManager : public GPUTracerManager<RoctracerManager> {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(RoctracerManager);
   ~RoctracerManager();
   static RoctracerManager& GetInstance();
+  uint64_t GetGPUTimestampInNanoseconds();
 
  protected:
   bool PushUniqueCorrelation(uint64_t unique_cid);

--- a/onnxruntime/core/providers/rocm/roctracer_manager.h
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.h
@@ -31,7 +31,6 @@ class RoctracerManager : public GPUTracerManager<RoctracerManager> {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(RoctracerManager);
   ~RoctracerManager();
   static RoctracerManager& GetInstance();
-  uint64_t GetGPUTimestampInNanoseconds();
 
  protected:
   bool PushUniqueCorrelation(uint64_t unique_cid);
@@ -41,6 +40,7 @@ class RoctracerManager : public GPUTracerManager<RoctracerManager> {
   void ProcessActivityBuffers(const std::vector<ProfilerActivityBuffer>& buffers,
                               const TimePoint& start_time);
   void FlushActivities();
+  uint64_t GetGPUTimestampInNanoseconds();
 
  private:
   RoctracerManager() = default;


### PR DESCRIPTION
### Description
This PR fixes the skew between GPU/CPU timestamps with a more reliable algorithm.

### Motivation and Context
An earlier implementation attempted to guess the right correction to apply, but this led to misleading profile outputs. This PR fixes this problem by utilizing a more reliable technique to normalize GPU timestamps. Attached are sample profile outputs and visualization screen-grabs from a run of a transformer-based model before and after the fix.

Before Fix:
![profile_visualization_cuda_without_fix](https://user-images.githubusercontent.com/17418420/208197234-7390d8e3-4354-4e67-93cf-958c319146ee.png)

After Fix:
![profile_visualization_cuda_with_fix](https://user-images.githubusercontent.com/17418420/208197230-3e108b82-8dfa-476b-9277-7895639a3785.png)

Profiler outputs that are rendered in the visualizations above:
[sample_outputs.zip](https://github.com/microsoft/onnxruntime/files/10249689/sample_outputs.zip)
