### PR TITLE
Fix nightly ort training ci pipeline

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
@@ -1,3 +1,4 @@
 scikit-learn
+packaging==21.3
 transformers==v4.4.2
 wget


### PR DESCRIPTION
Nightly pipeline is failing because of removal of support of `LegacyVersion` from packaging==22.0.

Pinning the python module version for mitigating ci failures.