### PR TITLE
[ROCm] Add ROCm5.4 to python package pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
@@ -38,15 +38,27 @@ stages:
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.7'
-      RocmVersion: '5.3.2'
+      RocmVersion: '5.4'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.8'
+      RocmVersion: '5.4'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.9'
+      RocmVersion: '5.4'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.7'
+      RocmVersion: '5.4'
       BuildConfig: 'RelWithDebInfo'
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.8'
-      RocmVersion: '5.3.2'
+      RocmVersion: '5.4'
       BuildConfig: 'RelWithDebInfo'
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
-      RocmVersion: '5.3.2'
+      RocmVersion: '5.4'
       BuildConfig: 'RelWithDebInfo'


### PR DESCRIPTION
Add ROCm5.4 to python package pipeline.
The download link of ROCm5.4 nightly build whl is https://download.onnxruntime.ai/onnxruntime_nightly_rocm54.html
The download linkd of ROCm5.4 nightly build whl with profiling is https://download.onnxruntime.ai/onnxruntime_nightly_rocm54.profiling.html


