### PR TITLE
[DML EP] Force layer norm inputs to be 4D to better target metacommands

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -25,10 +25,30 @@ public:
             std::nullopt,
             kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0));
 
-        const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
+        constexpr static uint32_t minimumDimensionCount = 4;
 
+        // Pad the input and the output with trailing 1's until they are at least 4D
+        for (uint32_t i = 0; i < kernelCreationContext.GetInputCount(); ++i)
+        {
+            auto sizes = m_inputTensorDescs[i].GetSizes();
+            std::vector<uint32_t> tensorShape(sizes.begin(), sizes.end());
+            tensorShape.resize(std::max<size_t>(tensorShape.size(), minimumDimensionCount), 1);
+
+            if (m_inputTensorDescs[i].GetDmlDataType() != DML_TENSOR_TYPE_INVALID)
+            {
+                m_inputTensorDescs[i] = TensorDesc(
+                    m_inputTensorDescs[i].GetDmlDataType(),
+                    tensorShape);
+            }
+        }
+
+        m_outputTensorDescs[0] = TensorDesc(
+            m_outputTensorDescs[0].GetDmlDataType(),
+            m_inputTensorDescs[0].GetSizes());
+
+        const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
+        uint32_t inputDimCount = m_inputTensorDescs[0].GetDimensionCount();
         int32_t onnxAxis = kernelCreationContext.GetOptionalAttribute<int32_t>(AttrName::Axis, -1);
-        uint32_t inputDimCount = kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
         onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, inputDimCount);
         std::vector<uint32_t> onnxAxes(static_cast<size_t>(inputDimCount) - static_cast<size_t>(onnxAxis));
         std::iota(onnxAxes.begin(), onnxAxes.end(), onnxAxis);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -48,9 +48,10 @@ public:
 
         const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
         int32_t onnxAxis = kernelCreationContext.GetOptionalAttribute<int32_t>(AttrName::Axis, -1);
-        uint32_t inputDimCount = m_inputTensorDescs[0].GetDimensionCount();
-        onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, inputDimCount);
-        std::vector<uint32_t> onnxAxes(static_cast<size_t>(inputDimCount) - static_cast<size_t>(onnxAxis));
+        uint32_t onnxDimCount = kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
+        uint32_t dmlDimCount = m_inputTensorDescs[0].GetDimensionCount();
+        onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, onnxDimCount);
+        std::vector<uint32_t> onnxAxes(static_cast<size_t>(dmlDimCount) - static_cast<size_t>(onnxAxis));
         std::iota(onnxAxes.begin(), onnxAxes.end(), onnxAxis);
 
         assert(m_inputTensorDescs.size() == 3);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorLayerNormalization.cpp
@@ -47,8 +47,8 @@ public:
             m_inputTensorDescs[0].GetSizes());
 
         const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
-        uint32_t inputDimCount = m_inputTensorDescs[0].GetDimensionCount();
         int32_t onnxAxis = kernelCreationContext.GetOptionalAttribute<int32_t>(AttrName::Axis, -1);
+        uint32_t inputDimCount = m_inputTensorDescs[0].GetDimensionCount();
         onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, inputDimCount);
         std::vector<uint32_t> onnxAxes(static_cast<size_t>(inputDimCount) - static_cast<size_t>(onnxAxis));
         std::iota(onnxAxes.begin(), onnxAxes.end(), onnxAxis);


### PR DESCRIPTION
### Description
Force layer norm inputs to be 4D to better target metacommands

### Motivation and Context
This may improve performance on some hardware by allowing the driver to return valid layouts to DML when querying for metacommand support.


