### PR TITLE
fix CI onnxruntime_test_python_sparse_matmul.py

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
@@ -36,7 +36,7 @@ class TestSparseToDenseMatmul(unittest.TestCase):
         """
         # The below values are a part of the model
         dense_shape = [3, 3]
-        values = np.array([1.764052391052246, 0.40015721321105957, 0.978738009929657], np.float)
+        values = np.array([1.764052391052246, 0.40015721321105957, 0.978738009929657], np.float32)
         indices = np.array([2, 3, 5], np.int64)
         sess = onnxrt.InferenceSession(
             get_name("sparse_initializer_as_output.onnx"),
@@ -404,7 +404,7 @@ class TestSparseToDenseMatmul(unittest.TestCase):
                 5862,
                 6165,
             ],
-            np.float,
+            np.float32,
         ).reshape(common_shape)
 
         sess = onnxrt.InferenceSession(


### PR DESCRIPTION
### Description

Numpy1.24.0 removed the np.float. 
```

  /opt/hostedtoolcache/Python/3.8.15/x64/bin/python onnxruntime_test_python_sparse_matmul.py
EE.
======================================================================
ERROR: testRunContribSparseMatMul (__main__.TestSparseToDenseMatmul)
Mutliple sparse COO tensor to dense
----------------------------------------------------------------------
Traceback (most recent call last):
  File "onnxruntime_test_python_sparse_matmul.py", line 407, in testRunContribSparseMatMul
    np.float,
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float'

======================================================================
ERROR: testRunSparseOutputOnly (__main__.TestSparseToDenseMatmul)
Try running models using the new run_with_ort_values
----------------------------------------------------------------------
Traceback (most recent call last):
  File "onnxruntime_test_python_sparse_matmul.py", line 39, in testRunSparseOutputOnly
    values = np.array([1.764052391052246, 0.40015721321105957, 0.978738009929657], np.float)
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float'

```



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


