### PR TITLE
[Fix] CPU memory type need device_id=0 to get allocator

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -815,7 +815,8 @@ class PlannerImpl {
           if (!node_output->Exists()) continue;
           OrtValueIndex index = Index(node_output->Name());
           ProcessDef(index, node_output);
-          auto allocator = exec_provider->GetAllocator(exec_provider->GetDeviceId(), p_kernel_def->OutputMemoryType(i));
+          int device_id = p_kernel_def->IsOutputOnCpu(i) ? 0 : exec_provider->GetDeviceId();
+          auto allocator = exec_provider->GetAllocator(device_id, p_kernel_def->OutputMemoryType(i));
           ORT_ENFORCE(allocator);
           plan_.SetLocation(static_cast<size_t>(index),
                             allocator->Info());


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix an error: 
`onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Exception during initialization: /onnxruntime_src/onnxruntime/core/framework/allocation_planner.cc:819 onnxruntime::common::Status onnxruntime::PlannerImpl::ComputeValueLocation() allocator was false.`

This error happens when we run huggingface models with DDP on multi-GPUs. In a thread with rank>0, it will attempt to obtain a CPU memory allocator with device_id>0, which causes the error. There is a workaround judges whether node’s output is on the CPU or not. If the output is on CPU, we set device_id = 0.



