### PR TITLE
Let Cmake decide where to place abseil

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -19,8 +19,6 @@ endif()
 # that namespace at build time.
 FetchContent_Declare(
     abseil_cpp
-    PREFIX "${CMAKE_CURRENT_BINARY_DIR}/abseil-cpp"
-    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/abseil-cpp"
     URL ${DEP_URL_abseil_cpp}
     URL_HASH SHA1=${DEP_SHA1_abseil_cpp}
     PATCH_COMMAND ${ABSL_PATCH_COMMAND}


### PR DESCRIPTION
### Description
Remove Abseil module placement specifications


### Motivation and Context
Allow Cmake defaults take place and possible redirection of all submodules for sharing between the local builds.