### PR TITLE
Fix warning c26409

### DIFF
--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -73,7 +73,7 @@ struct KernelTwo {
 
 struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne> {
   void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* /* info */) const {
-    return new KernelOne();
+    return std::make_unique<KernelOne>().release();
   };
 
   const char* GetName() const { return "CustomOpOne"; };
@@ -92,7 +92,7 @@ struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne> {
 
 struct CustomOpTwo : Ort::CustomOpBase<CustomOpTwo, KernelTwo> {
   void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* /* info */) const {
-    return new KernelTwo();
+    return std::make_unique<CustomOpTwo>().release();
   };
 
   const char* GetName() const { return "CustomOpTwo"; };


### PR DESCRIPTION
We should avoid using `new` and `delete` in C/C++ code whenever possible as suggested by VC compiler.