### PR TITLE
Adding RunOptions synchronization behaviour to C/C++ API

### DIFF
--- a/include/onnxruntime/core/framework/run_options.h
+++ b/include/onnxruntime/core/framework/run_options.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include "core/session/onnxruntime_c_api.h"
 #include "core/framework/config_options.h"
+#include "core/session/onnxruntime_run_options_config_keys.h"
 
 /**
  * Configuration information for a Run call.
@@ -26,10 +27,6 @@ struct OrtRunOptions {
   // Set to 'true' to run only the nodes from feeds to required fetches.
   // So it is possible that only some of the nodes are executed.
   bool only_execute_path_to_fetches = false;
-
-  // Set to 'true' to synchronize execution providers with CPU at the end of session run.
-  // Taking CUDA EP as an example, it will trigger cudaStreamSynchronize on the compute stream.
-  bool synchronize_execution_providers = true;
 
 #ifdef ENABLE_TRAINING
   // Used by onnxruntime::training::TrainingSession. This class is now deprecated.

--- a/include/onnxruntime/core/framework/run_options.h
+++ b/include/onnxruntime/core/framework/run_options.h
@@ -7,7 +7,6 @@
 #include <atomic>
 #include "core/session/onnxruntime_c_api.h"
 #include "core/framework/config_options.h"
-#include "core/session/onnxruntime_run_options_config_keys.h"
 
 /**
  * Configuration information for a Run call.

--- a/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
@@ -26,7 +26,7 @@
 // By default, the value for this key is empty (i.e.) no memory arenas are shrunk
 static const char* const kOrtRunOptionsConfigEnableMemoryArenaShrinkage = "memory.enable_memory_arena_shrinkage";
 
-// Set to '0' to not synchronize execution providers with CPU at the end of session run.
-// Per default it will be set to '1'
-// Taking CUDA EP as an example, it will trigger cudaStreamSynchronize on the compute stream.
-static const char* const kOrtRunOptionsConfigSynchronizeExecutionProviders = "synchronize_execution_providers";
+// Set to '1' to not synchronize execution providers with CPU at the end of session run.
+// Per default it will be set to '0'
+// Taking CUDA EP as an example, it omit triggering cudaStreamSynchronize on the compute stream.
+static const char* const kOrtRunOptionsConfigDisableSynchronizeExecutionProviders = "disable_synchronize_execution_providers";

--- a/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
@@ -26,7 +26,7 @@
 // By default, the value for this key is empty (i.e.) no memory arenas are shrunk
 static const char* const kOrtRunOptionsConfigEnableMemoryArenaShrinkage = "memory.enable_memory_arena_shrinkage";
 
-// when any CUDA work is issued (CUDA + TensorRT EP) the InferenceSession::run method will synchronize
-// after submitting the work - this option enables to return right after submitting all the work
-// This requires the user to handle synchronization points to wait for a finished inference if needed
-static const char* const kOrtRunOptionsConfigDisableSynchronization = "cuda.disable_sync_execution";
+// Set to '0' to not synchronize execution providers with CPU at the end of session run.
+// Per default it will be set to '1'
+// Taking CUDA EP as an example, it will trigger cudaStreamSynchronize on the compute stream.
+static const char* const kOrtRunOptionsConfigSynchronizeExecutionProviders = "synchronize_execution_providers";

--- a/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h
@@ -25,3 +25,8 @@
 // Example usage: "cpu:0;gpu:0" (or) "gpu:0"
 // By default, the value for this key is empty (i.e.) no memory arenas are shrunk
 static const char* const kOrtRunOptionsConfigEnableMemoryArenaShrinkage = "memory.enable_memory_arena_shrinkage";
+
+// when any CUDA work is issued (CUDA + TensorRT EP) the InferenceSession::run method will synchronize
+// after submitting the work - this option enables to return right after submitting all the work
+// This requires the user to handle synchronization points to wait for a finished inference if needed
+static const char* const kOrtRunOptionsConfigDisableSynchronization = "cuda.disable_sync_execution";

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -795,7 +795,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
                                   logger);
   }
 #endif
-  bool synchronize_execution_providers = std::stoi(run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigSynchronizeExecutionProviders, "1"));
+  bool synchronize_execution_providers = run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigDisableSynchronizeExecutionProviders, "0") == "0";
   return ExecuteGraph(session_state,
                       feeds_fetches_manager,
                       feeds, fetches,

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -21,6 +21,7 @@
 #include "core/mlas/inc/mlas.h"
 #include "core/framework/TensorSeq.h"
 #include "core/framework/run_options.h"
+#include "core/session/onnxruntime_run_options_config_keys.h"
 #ifdef USE_AZURE
 #include "core/framework/cloud_executor.h"
 #endif
@@ -794,7 +795,7 @@ common::Status ExecuteGraph(const SessionState& session_state,
                                   logger);
   }
 #endif
-  bool synchronize_execution_providers = !run_options.config_options.GetConfigEntry(kOrtRunOptionsConfigDisableSynchronization).has_value();
+  bool synchronize_execution_providers = std::stoi(run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigSynchronizeExecutionProviders, "1"));
   return ExecuteGraph(session_state,
                       feeds_fetches_manager,
                       feeds, fetches,

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -20,6 +20,7 @@
 #include "core/framework/tensorprotoutils.h"
 #include "core/mlas/inc/mlas.h"
 #include "core/framework/TensorSeq.h"
+#include "core/framework/run_options.h"
 #ifdef USE_AZURE
 #include "core/framework/cloud_executor.h"
 #endif
@@ -793,13 +794,14 @@ common::Status ExecuteGraph(const SessionState& session_state,
                                   logger);
   }
 #endif
+  bool synchronize_execution_providers = !run_options.config_options.GetConfigEntry(kOrtRunOptionsConfigDisableSynchronization).has_value();
   return ExecuteGraph(session_state,
                       feeds_fetches_manager,
                       feeds, fetches,
                       execution_mode,
                       run_options.terminate,
                       logger,
-                      run_options.synchronize_execution_providers,
+                      synchronize_execution_providers,
                       run_options.only_execute_path_to_fetches);
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1997,7 +1997,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
 
     // info all execution providers InferenceSession:Run ended
     for (auto* xp : exec_providers_to_stop) {
-      bool synchronize_execution_providers = !run_options.config_options.GetConfigEntry(kOrtRunOptionsConfigDisableSynchronization).has_value();
+      bool synchronize_execution_providers = std::stoi(run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigSynchronizeExecutionProviders, "1"));
       auto status = xp->OnRunEnd(synchronize_execution_providers);
       ORT_CHECK_AND_SET_RETVAL(status);
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1997,7 +1997,7 @@ Status InferenceSession::Run(const RunOptions& run_options,
 
     // info all execution providers InferenceSession:Run ended
     for (auto* xp : exec_providers_to_stop) {
-      bool synchronize_execution_providers = std::stoi(run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigSynchronizeExecutionProviders, "1"));
+      bool synchronize_execution_providers = run_options.config_options.GetConfigOrDefault(kOrtRunOptionsConfigDisableSynchronizeExecutionProviders, "0") == "0";
       auto status = xp->OnRunEnd(synchronize_execution_providers);
       ORT_CHECK_AND_SET_RETVAL(status);
     }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1997,7 +1997,8 @@ Status InferenceSession::Run(const RunOptions& run_options,
 
     // info all execution providers InferenceSession:Run ended
     for (auto* xp : exec_providers_to_stop) {
-      auto status = xp->OnRunEnd(run_options.synchronize_execution_providers);
+      bool synchronize_execution_providers = !run_options.config_options.GetConfigEntry(kOrtRunOptionsConfigDisableSynchronization).has_value();
+      auto status = xp->OnRunEnd(synchronize_execution_providers);
       ORT_CHECK_AND_SET_RETVAL(status);
     }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1368,8 +1368,6 @@ RunOptions instance. The individual calls will exit gracefully and return an err
 #endif
       .def_readwrite("only_execute_path_to_fetches", &RunOptions::only_execute_path_to_fetches,
                      R"pbdoc(Only execute the nodes needed by fetch list)pbdoc")
-      .def_readwrite("synchronize_execution_providers", &RunOptions::synchronize_execution_providers,
-                     R"pbdoc(Synchronize execution providers after executing session.)pbdoc")
       .def(
           "add_run_config_entry",
           [](RunOptions* options, const char* config_key, const char* config_value) -> void {

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -4,6 +4,7 @@
 #include "api.h"
 
 #include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/onnxruntime_run_options_config_keys.h"
 
 #include <iostream>
 #include <vector>
@@ -338,12 +339,7 @@ OrtRunOptions* OrtCreateRunOptions(size_t log_severity_level,
     RETURN_NULLPTR_IF_ERROR(RunOptionsUnsetTerminate, run_options);
   }
 
-  if (synchronize) {
-    RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options);
-  } else {
-    RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options);
-  }
-
+  RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options, kOrtRunOptionsConfigSynchronizeExecutionProviders, synchronize ?"1" : "0");
   if (tag != nullptr) {
     RETURN_NULLPTR_IF_ERROR(RunOptionsSetRunTag, run_options, tag);
   }

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -322,6 +322,7 @@ void OrtReleaseTensor(OrtValue* tensor) {
 OrtRunOptions* OrtCreateRunOptions(size_t log_severity_level,
                                    size_t log_verbosity_level,
                                    bool terminate,
+                                   bool synchronize,
                                    const char* tag) {
   OrtRunOptions* run_options = nullptr;
   RETURN_NULLPTR_IF_ERROR(CreateRunOptions, &run_options);
@@ -335,6 +336,12 @@ OrtRunOptions* OrtCreateRunOptions(size_t log_severity_level,
     RETURN_NULLPTR_IF_ERROR(RunOptionsSetTerminate, run_options);
   } else {
     RETURN_NULLPTR_IF_ERROR(RunOptionsUnsetTerminate, run_options);
+  }
+
+  if (synchronize) {
+    RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options);
+  } else {
+    RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options);
   }
 
   if (tag != nullptr) {

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -4,7 +4,6 @@
 #include "api.h"
 
 #include "core/session/onnxruntime_cxx_api.h"
-#include "core/session/onnxruntime_run_options_config_keys.h"
 
 #include <iostream>
 #include <vector>
@@ -323,7 +322,6 @@ void OrtReleaseTensor(OrtValue* tensor) {
 OrtRunOptions* OrtCreateRunOptions(size_t log_severity_level,
                                    size_t log_verbosity_level,
                                    bool terminate,
-                                   bool synchronize,
                                    const char* tag) {
   OrtRunOptions* run_options = nullptr;
   RETURN_NULLPTR_IF_ERROR(CreateRunOptions, &run_options);
@@ -339,7 +337,6 @@ OrtRunOptions* OrtCreateRunOptions(size_t log_severity_level,
     RETURN_NULLPTR_IF_ERROR(RunOptionsUnsetTerminate, run_options);
   }
 
-  RETURN_NULLPTR_IF_ERROR(AddRunConfigEntry, run_options, kOrtRunOptionsConfigSynchronizeExecutionProviders, synchronize ?"1" : "0");
   if (tag != nullptr) {
     RETURN_NULLPTR_IF_ERROR(RunOptionsSetRunTag, run_options, tag);
   }

--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -396,7 +396,7 @@ def _run_onnx_session_with_ortvaluevector(
 
     _nvtx_range_push("run_with_ortvaluevector")
     run_options = onnxruntime.RunOptions()
-    run_options.add_run_config_entry("synchronize_execution_providers", "0")
+    run_options.add_run_config_entry("disable_synchronize_execution_providers", "1")
     sess.run_with_ortvaluevector(run_options, input_names, ort_inputs, output_names, ort_outputs, output_devices)
     _nvtx_range_pop()
 

--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -396,7 +396,7 @@ def _run_onnx_session_with_ortvaluevector(
 
     _nvtx_range_push("run_with_ortvaluevector")
     run_options = onnxruntime.RunOptions()
-    run_options.synchronize_execution_providers = True
+    run_options.add_run_config_entry("cuda.disable_sync_execution", "1")
     sess.run_with_ortvaluevector(run_options, input_names, ort_inputs, output_names, ort_outputs, output_devices)
     _nvtx_range_pop()
 

--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -396,7 +396,7 @@ def _run_onnx_session_with_ortvaluevector(
 
     _nvtx_range_push("run_with_ortvaluevector")
     run_options = onnxruntime.RunOptions()
-    run_options.add_run_config_entry("cuda.disable_sync_execution", "1")
+    run_options.add_run_config_entry("synchronize_execution_providers", "0")
     sess.run_with_ortvaluevector(run_options, input_names, ort_inputs, output_names, ort_outputs, output_devices)
     _nvtx_range_pop()
 


### PR DESCRIPTION
### Description
This is exposing the already existent interface of asynchronous work of all CUDA base EP's (CUDA + TensorRT).


### Motivation and Context
This is something requested in #12216. It will enable users to build an efficient data pipeline with ONNXRuntime and CUDA pre-/post-processing. PCI traffic to the CUDA device can be run during inference as soon as the postprocessing consumed the input buffer and it can be overwritten. To do this work has to be submitted async to the device. Please see below screenshots showing the illustration of this using NSight Systems.

Async: 
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/44298237/209894303-706460ed-cbdb-4be2-a2e4-0c111ec875dd.png">

Synchronous:
<img width="1302" alt="image" src="https://user-images.githubusercontent.com/44298237/209894630-1ce40925-bbd5-470d-b888-46553ab75fb9.png">

Note the gap in between the 2 inference runs due to issuing PCI traffic in between and to the CPU overhead the active synchronization has.


