### PR TITLE
Replace distutils by setuptools to import build_ext

### DIFF
--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+# pylint: disable=W0622
 
 """Test export of PyTorch operators using ONNX Runtime contrib ops."""
 
@@ -17,7 +18,7 @@ from onnxruntime.tools import pytorch_export_contrib_ops
 
 
 def _torch_version_lower_than(version: str):
-    from packaging.version import Version as LooseVersion
+    from packaging.version import Version as LooseVersion  # pylint: disable=C0415
 
     return LooseVersion(torch.__version__) < LooseVersion(version)
 

--- a/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
+++ b/onnxruntime/test/python/test_pytorch_export_contrib_ops.py
@@ -4,7 +4,6 @@
 """Test export of PyTorch operators using ONNX Runtime contrib ops."""
 
 import copy
-import distutils.version
 import io
 import unittest
 
@@ -18,7 +17,9 @@ from onnxruntime.tools import pytorch_export_contrib_ops
 
 
 def _torch_version_lower_than(version: str):
-    return distutils.version.LooseVersion(torch.__version__) < distutils.version.LooseVersion(version)
+    from packaging.version import Version as LooseVersion
+
+    return LooseVersion(torch.__version__) < LooseVersion(version)
 
 
 def ort_test_with_input(ort_sess, input, output, rtol, atol):

--- a/orttraining/orttraining/python/ort_trainer.py
+++ b/orttraining/orttraining/python/ort_trainer.py
@@ -1,7 +1,7 @@
 import io
 import os
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version as LooseVersion
 
 import numpy as np
 import onnx

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -12,8 +12,8 @@ import random
 import traceback
 import types
 import warnings
-from distutils.version import LooseVersion
 from typing import List
+from packaging.version import Version as StrictVersion
 
 import numpy as np
 import torch

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -13,7 +13,7 @@ import traceback
 import types
 import warnings
 from typing import List
-from packaging.version import Version as StrictVersion
+from packaging.version import Version as LooseVersion
 
 import numpy as np
 import torch

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -1,5 +1,4 @@
 import inspect
-import math
 import os
 import tempfile
 from functools import partial

--- a/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
+++ b/orttraining/orttraining/test/python/orttraining_test_orttrainer_frontend.py
@@ -2,9 +2,8 @@ import inspect
 import math
 import os
 import tempfile
-from distutils.version import StrictVersion
 from functools import partial
-
+from packaging.version import Version as StrictVersion
 import _test_commons
 import _test_helpers
 import onnx

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import platform
 import subprocess
 import sys
 from distutils import log as logger
-from distutils.command.build_ext import build_ext as _build_ext
+from setuptools.command.build_ext import build_ext as _build_ext
 from glob import glob, iglob
 from os import environ, getcwd, path, popen, remove
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,8 @@ try:
 
         def run(self):
             if is_manylinux:
+                from distutils import log as logger
+
                 source = "onnxruntime/capi/onnxruntime_pybind11_state.so"
                 dest = "onnxruntime/capi/onnxruntime_pybind11_state_manylinux1.so"
                 logger.info("copying %s -> %s", source, dest)
@@ -295,6 +297,8 @@ try:
                 self._rewrite_ld_preload(to_preload_cann)
             _bdist_wheel.run(self)
             if is_manylinux and not disable_auditwheel_repair and not is_openvino:
+                from distutils import log as logger
+
                 assert self.dist_dir is not None
                 file = glob(path.join(self.dist_dir, "*linux*.whl"))[0]
                 logger.info("repairing %s for manylinux1", file)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # ------------------------------------------------------------------------
+# pylint: disable=C0103
 
 import datetime
 import platform
@@ -11,6 +12,7 @@ from glob import glob, iglob
 from os import environ, getcwd, path, popen, remove
 from pathlib import Path
 from shutil import copyfile
+import logging
 
 from packaging.tags import sys_tags
 from setuptools import Extension, setup
@@ -20,6 +22,7 @@ from setuptools.command.install import install as InstallCommandBase
 nightly_build = False
 package_name = "onnxruntime"
 wheel_name_suffix = None
+logger = logging.getLogger()
 
 
 def parse_arg_remove_boolean(argv, arg_name):
@@ -108,8 +111,6 @@ is_manylinux = environ.get("AUDITWHEEL_PLAT", None) in manylinux_tags
 
 class build_ext(_build_ext):
     def build_extension(self, ext):
-        from distutils import log as logger
-
         dest_file = self.get_ext_fullpath(ext.name)
         logger.info("copying %s -> %s", ext.sources[0], dest_file)
         copyfile(ext.sources[0], dest_file)
@@ -161,7 +162,7 @@ try:
                     f.write('    os.environ["ORT_CUDA_UNAVAILABLE"] = "1"\n')
 
         def _rewrite_ld_preload_tensorrt(self, to_preload):
-            with open("onnxruntime/capi/_ld_preload.py", "a") as f:
+            with open("onnxruntime/capi/_ld_preload.py", "a", encoding="ascii") as f:
                 if len(to_preload) > 0:
                     f.write("from ctypes import CDLL, RTLD_GLOBAL\n")
                     f.write("try:\n")
@@ -173,8 +174,6 @@ try:
 
         def run(self):
             if is_manylinux:
-                from distutils import log as logger
-
                 source = "onnxruntime/capi/onnxruntime_pybind11_state.so"
                 dest = "onnxruntime/capi/onnxruntime_pybind11_state_manylinux1.so"
                 logger.info("copying %s -> %s", source, dest)
@@ -297,8 +296,6 @@ try:
                 self._rewrite_ld_preload(to_preload_cann)
             _bdist_wheel.run(self)
             if is_manylinux and not disable_auditwheel_repair and not is_openvino:
-                from distutils import log as logger
-
                 assert self.dist_dir is not None
                 file = glob(path.join(self.dist_dir, "*linux*.whl"))[0]
                 logger.info("repairing %s for manylinux1", file)
@@ -430,8 +427,8 @@ if not path.exists(README):
 
 if not path.exists(README):
     raise FileNotFoundError("Unable to find 'README.rst'")
-with open(README) as f:
-    long_description = f.read()
+with open(README, "r", encoding="utf-8") as fdesc:
+    long_description = fdesc.read()
 
 # Include files in onnxruntime/external if --enable_external_custom_op_schemas build.sh command
 # line option is specified.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import platform
 import subprocess
 import sys
 from distutils import log as logger
-from setuptools.command.build_ext import build_ext as _build_ext
 from glob import glob, iglob
 from os import environ, getcwd, path, popen, remove
 from pathlib import Path
@@ -16,6 +15,7 @@ from shutil import copyfile
 
 from packaging.tags import sys_tags
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.install import install as InstallCommandBase
 
 nightly_build = False

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import datetime
 import platform
 import subprocess
 import sys
-from distutils import log as logger
 from glob import glob, iglob
 from os import environ, getcwd, path, popen, remove
 from pathlib import Path
@@ -109,6 +108,7 @@ is_manylinux = environ.get("AUDITWHEEL_PLAT", None) in manylinux_tags
 
 class build_ext(_build_ext):
     def build_extension(self, ext):
+        from distutils import log as logger
         dest_file = self.get_ext_fullpath(ext.name)
         logger.info("copying %s -> %s", ext.sources[0], dest_file)
         copyfile(ext.sources[0], dest_file)

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ is_manylinux = environ.get("AUDITWHEEL_PLAT", None) in manylinux_tags
 class build_ext(_build_ext):
     def build_extension(self, ext):
         from distutils import log as logger
+
         dest_file = self.get_ext_fullpath(ext.name)
         logger.info("copying %s -> %s", ext.sources[0], dest_file)
         copyfile(ext.sources[0], dest_file)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # pylint: disable=C0103
 
 import datetime
+import logging
 import platform
 import subprocess
 import sys
@@ -12,7 +13,6 @@ from glob import glob, iglob
 from os import environ, getcwd, path, popen, remove
 from pathlib import Path
 from shutil import copyfile
-import logging
 
 from packaging.tags import sys_tags
 from setuptools import Extension, setup

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -11,8 +11,9 @@ import shlex
 import shutil
 import subprocess
 import sys
-from distutils.version import LooseVersion
 from pathlib import Path
+
+from packaging.version import Version as LooseVersion
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     # This is deprecated and will be removed in Python 3.12.
     # See https://docs.python.org/3/library/distutils.html.
-    from distutils.version import LooseVersion
+    from distutils.version import LooseVersion  # pylint: disable=W4901
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -13,7 +13,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from packaging.version import Version as LooseVersion
+try:
+    from packaging.version import Version as LooseVersion
+except ImportError:
+    # This is deprecated and will be removed in Python 3.12.
+    # See https://docs.python.org/3/library/distutils.html.
+    from distutils.version import LooseVersion
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))

--- a/tools/ci_build/requirements.txt
+++ b/tools/ci_build/requirements.txt
@@ -1,4 +1,5 @@
 # packages used by transformers tool test
+packaging
 protobuf==3.20.1
 numpy==1.23.5
 coloredlogs==15.0


### PR DESCRIPTION
### Description
Uses setuptools instead of distutils.



### Motivation and Context
Fixes #14107.


