### PR TITLE
Updated issue router to migrated project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
-          project-url: https://github.com/microsoft/onnxruntime/projects/6
+          project-url: https://github.com/orgs/microsoft/projects/635
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labeled: documentation


### PR DESCRIPTION
The action add-to-project does not work with classic projects. Migrated the docs and samples project to the non classic project and updated the link in the issue router config



