### PR TITLE
Expose OrtApiBase in Java bindings.

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -78,6 +78,9 @@ final class OnnxRuntime {
   /** Tracks if the shared providers have been extracted */
   private static final Set<String> extractedSharedProviders = new HashSet<>();
 
+  /** The OrtBaseApi handle. Only needed for direct registration of custom ops. */
+  static long ortBaseHandle;
+
   /** The API handle. */
   static long ortApiHandle;
 
@@ -138,7 +141,8 @@ final class OnnxRuntime {
 
       load(ONNXRUNTIME_LIBRARY_NAME);
       load(ONNXRUNTIME_JNI_LIBRARY_NAME);
-      ortApiHandle = initialiseAPIBase(ORT_API_VERSION_11);
+      ortBaseHandle = getApiBase();
+      ortApiHandle = initialiseApi(ortBaseHandle, ORT_API_VERSION_11);
       providers = initialiseProviders(ortApiHandle);
       loaded = true;
     } finally {
@@ -419,12 +423,20 @@ final class OnnxRuntime {
   }
 
   /**
+   * Get a reference to the OrtApiBase struct.
+   *
+   * @return A pointer to the OrtApiBase struct.
+   */
+  private static native long getApiBase();
+
+  /**
    * Get a reference to the API struct.
    *
+   * @param ortApiBaseHandle The OrtApiBase struct handle obtained from getApiBase.
    * @param apiVersionNumber The API version to use.
    * @return A pointer to the API struct.
    */
-  private static native long initialiseAPIBase(int apiVersionNumber);
+  private static native long initialiseApi(long ortApiBaseHandle, int apiVersionNumber);
 
   /**
    * Gets the array of available providers.

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -9,13 +9,25 @@
 
 /*
  * Class:     ai_onnxruntime_OnnxRuntime
- * Method:    initialiseAPIBase
- * Signature: (I)J
+ * Method:    getApiBase
+ * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseAPIBase(JNIEnv* jniEnv, jclass clazz,
-                                                                          jint apiVersion) {
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxRuntime_getApiBase(JNIEnv* jniEnv, jclass clazz) {
   (void)jniEnv; (void)clazz;  // required JNI parameters not needed by functions which don't call back into Java.
-  const OrtApi* ortPtr = OrtGetApiBase()->GetApi((uint32_t)apiVersion);
+  const OrtApiBase* ortApiBasePtr = OrtGetApiBase();
+  return (jlong)ortApiBasePtr;
+}
+
+/*
+ * Class:     ai_onnxruntime_OnnxRuntime
+ * Method:    initialiseApi
+ * Signature: (JI)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseApi(JNIEnv* jniEnv, jclass clazz,
+                                                                      jlong apiBaseHandle, jint apiVersion) {
+  (void)jniEnv; (void)clazz;  // required JNI parameters not needed by functions which don't call back into Java.
+  const OrtApiBase* apiBase = (const OrtApiBase*)apiBaseHandle;
+  const OrtApi* ortPtr = apiBase->GetApi((uint32_t)apiVersion);
   return (jlong)ortPtr;
 }
 


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
Expose OrtApiBase in Java bindings so user can call RegisterCustomOps function from a custom ops library directly.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Make usage of ORT + ort-extensions packages consistent across mobile platforms. 

