### PR TITLE
rm build files at the last step in Linux CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -171,3 +171,7 @@ jobs:
       searchFolder: '$(Build.BinariesDirectory)'
       testRunTitle: 'Unit Test Run'
     condition: succeededOrFailed()
+
+  - script: |
+      rm -rf '$(Build.BinariesDirectory)'
+    displayName: remove build files

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       cacheHitVar: CACHE_RESTORED
       restoreKeys: |
         "ccache" | "$(Build.SourceBranch)"
-        "ccache"
+        "ccache" | "refs/heads/main"
     displayName: Cach Task
 
   - script: |
@@ -173,5 +173,7 @@ jobs:
     condition: succeededOrFailed()
 
   - script: |
+      rm -rf '$(Build.SourcesDirectory)'
       rm -rf '$(Build.BinariesDirectory)'
+      df -h
     displayName: remove build files


### PR DESCRIPTION
### Description
remove all build files at the last step in Linux CI

### Motivation and Context
To reduce the risk of the out of disk.
Before clean agent directory task, some other Post-Job task might create new files.

###Ref
```
Microsoft-hosted agents:
Provide 10 GB of storage for your source and build outputs.
```
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#capabilities-and-limitations

