### PR TITLE
Use today's cache only

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -15,7 +15,6 @@ jobs:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-    #YESTERDAY: ${{ (Get-Date).AddDays(-1).ToString("yyyyMMdd") }}
   pool: Linux-CPU-2019
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
@@ -47,7 +46,6 @@ jobs:
       key: '"$(TODAY)" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
-      # only get 2 days ccache
       restoreKeys: |
         "$(TODAY)"" | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -14,6 +14,8 @@ jobs:
   variables:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    today: $(Get-Date -Format yyyyMMdd)
+    yesterday: $( (Get-Date).AddDays(-1) -Format yyyyMMdd)
   pool: Linux-CPU-2019
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
@@ -42,13 +44,13 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"$((Get-Date).ToString("ddMMyy"))" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
+      key: '$(today) | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
       # only get 2 days ccache
       restoreKeys: |
-        $((Get-Date).ToString("ddMMyy")) | "ccache" | "$(Build.SourceBranch)"
-        $((Get-Date).AddDays(-1).ToString("ddMMyy")) | "ccache" | "$(Build.SourceBranch)"
+        $(today) | "ccache" | "$(Build.SourceBranch)"
+        $(yesterday) | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -14,8 +14,8 @@ jobs:
   variables:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
-    today: $(Get-Date -Format yyyyMMdd)
-    yesterday: $( (Get-Date).AddDays(-1) -Format yyyyMMdd)
+    TODAY: ${{ Get-Date -Format yyyyMMdd }}
+    YESTERDAY: ${{ (Get-Date).AddDays(-1) -Format yyyyMMdd }}
   pool: Linux-CPU-2019
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
@@ -44,13 +44,13 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '$(today) | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
+      key: $(TODAY) | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
       # only get 2 days ccache
       restoreKeys: |
-        $(today) | "ccache" | "$(Build.SourceBranch)"
-        $(yesterday) | "ccache" | "$(Build.SourceBranch)"
+        $(TODAY) | "ccache" | "$(Build.SourceBranch)"
+        $(YESTERDAY) | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -14,8 +14,8 @@ jobs:
   variables:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
-    TODAY: ${{ (Get-Date).ToString("yyyyMMdd") }}
-    YESTERDAY: ${{ (Get-Date).AddDays(-1).ToString("yyyyMMdd") }}
+    TODAY: $[format('{0:dd}.{0:MM}.{0:yyyy}', pipeline.startTime)]
+    #YESTERDAY: ${{ (Get-Date).AddDays(-1).ToString("yyyyMMdd") }}
   pool: Linux-CPU-2019
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
@@ -50,7 +50,6 @@ jobs:
       # only get 2 days ccache
       restoreKeys: |
         $(TODAY) | "ccache" | "$(Build.SourceBranch)"
-        $(YESTERDAY) | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -47,7 +47,8 @@ jobs:
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
       restoreKeys: |
-        "$(TODAY)"" | "ccache" | "$(Build.SourceBranch)"
+        "$(TODAY)" | "$(Build.SourceBranch)"
+        "$(TODAY)" |
     displayName: Cach Task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -14,8 +14,8 @@ jobs:
   variables:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
-    TODAY: ${{ Get-Date -Format yyyyMMdd }}
-    YESTERDAY: ${{ (Get-Date).AddDays(-1) -Format yyyyMMdd }}
+    TODAY: ${{ (Get-Date).ToString("yyyyMMdd") }}
+    YESTERDAY: ${{ (Get-Date).AddDays(-1).ToString("yyyyMMdd") }}
   pool: Linux-CPU-2019
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -42,12 +42,13 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
+      key: '"$((Get-Date).ToString("ddMMyy"))" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
+      # only get 2 days ccache
       restoreKeys: |
-        "ccache" | "$(Build.SourceBranch)"
-        "ccache"
+        $((Get-Date).ToString("ddMMyy")) | "ccache" | "$(Build.SourceBranch)"
+        $((Get-Date).AddDays(-1).ToString("ddMMyy")) | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   variables:
     skipComponentGovernanceDetection: true
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
-    TODAY: $[format('{0:dd}.{0:MM}.{0:yyyy}', pipeline.startTime)]
+    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
     #YESTERDAY: ${{ (Get-Date).AddDays(-1).ToString("yyyyMMdd") }}
   pool: Linux-CPU-2019
   steps:
@@ -44,12 +44,12 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: $(TODAY) | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"
+      key: '"$(TODAY)" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
       path: $(CCACHE_DIR)
       cacheHitVar: CACHE_RESTORED
       # only get 2 days ccache
       restoreKeys: |
-        $(TODAY) | "ccache" | "$(Build.SourceBranch)"
+        "$(TODAY)"" | "ccache" | "$(Build.SourceBranch)"
     displayName: Cach Task
 
   - script: |


### PR DESCRIPTION
### Description
Add date value of today into the cache key.

### Motivation and Context
Microsoft-host agent has only 10GB for build.
To limit cache size, pipeline only use cache generated today.


