### PR TITLE
Fix use_count assert in allocation_planner

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -229,8 +229,10 @@ class PlannerImpl {
   int& UseCount(const OrtValueName& name) { return UseCount(Index(name)); }
 
   int DecrementUseCount(OrtValueIndex n) {
-    int& use_count = --UseCount(n);
-    assert(use_count >= 0);
+    int& use_count = UseCount(n);
+    if (use_count > 0) {
+      --use_count;
+    }
     return use_count;
   }
 


### PR DESCRIPTION
### Description
It seems that the design does not ensure use_count >= 0. Remove the assert.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

use_count become -1 when I run stable diffusion, and assert failure is raised.