### PR TITLE
[Fix]add missing deque header in allocation_planner.cc

### DIFF
--- a/onnxruntime/core/framework/allocation_planner.cc
+++ b/onnxruntime/core/framework/allocation_planner.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <sstream>
 #include <ctime>
+#include <deque>
 #include <iomanip>
 #include "core/common/exceptions.h"
 #include "core/common/inlined_containers.h"


### PR DESCRIPTION
### Description


### Motivation and Context
Fix the compilation error:
`##[error]onnxruntime\core\framework\allocation_planner.cc(1006,10): Error C2039: 'deque': is not a member of 'std'`
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=258983&view=logs&j=854fcffa-0b81-519d-3fe9-fd85c1b5a0e7&t=4ac43cdd-8a03-5d18-7310-aa7d8cbddd9f&l=1227

