### PR TITLE
Add protected destructor to Provider structure

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_host_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_host_api.h
@@ -28,6 +28,9 @@ struct Provider {
 
   virtual void Initialize() = 0; // Called right after loading the shared library, if this throws any errors Shutdown() will be called and the library unloaded
   virtual void Shutdown() = 0; // Called right before unloading the shared library
+
+protected:
+  ~Provider() = default; // Can only be destroyed through a subclass instance
 };
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)


### PR DESCRIPTION
### Description
Add protected destructor so that any inherited classes can't accidentally be deleted through a pointer to the base.

Fixes this prefast warning:
The type 'struct onnxruntime::CUDA_Provider' with a virtual function needs either public virtual or protected non-virtual destructor (c.35).

Internal bug 8999


