### PR TITLE
[DML EP] Update DML_FEATURE_LEVEL 5.0

### DIFF
--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -159,7 +159,7 @@ std::shared_ptr<IExecutionProviderFactory> DMLProviderFactoryCreator::Create(int
   ComPtr<IDMLDevice> dml_device;
   ORT_THROW_IF_FAILED(DMLCreateDevice1(d3d12_device.Get(),
                                    flags,
-                                   DML_FEATURE_LEVEL_2_0,
+                                   DML_FEATURE_LEVEL_5_0,
                                    IID_PPV_ARGS(&dml_device)));
 
   return CreateExecutionProviderFactory_DML(dml_device.Get(), cmd_queue.Get());


### PR DESCRIPTION
### Description
DML EP was using very old feature level (2.0) which may lead to model (having latest operator) execution failure, if model is running against old DirectML.dll.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


