### PR TITLE
make WITHCACHE as an option in MacOS workflow

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
@@ -4,3 +4,4 @@ jobs:
     AllowReleasedOpsetOnly: 0
     BuildForAllArchs: false
     AdditionalBuildFlags: --build_objc --enable_language_interop_ops --build_wheel
+    WithCache: true

--- a/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-ci.yml
@@ -17,6 +17,11 @@ parameters:
   displayName: Build for all CPU ARCHs
   type: boolean
 
+- name: WithCache
+  displayName: Build with Cache
+  type: boolean
+  default: false
+
 jobs:
 - job: MacOS_C_API_Packaging_CPU_x64
   workspace:
@@ -25,6 +30,7 @@ jobs:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: ${{ parameters.AllowReleasedOpsetOnly }}
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   pool:
     vmImage: 'macOS-11'
   timeoutInMinutes:  300
@@ -48,14 +54,16 @@ jobs:
         brew install ccache
         echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
       displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+      condition: eq(${{ parameters.WITHCACHE }}, true)
 
     - task: Cache@2
       inputs:
-        key: 'ccache | "$(Agent.OS)" | protocol | "$(Build.SourceVersion)" '
+        key:  ' "$(TODAY)" | ccache | protocol | "$(Build.SourceVersion)" '
         path: $(CCACHE_DIR)
         restoreKeys: |
-          ccache | "$(Agent.OS)" | protocol
+          "$(TODAY)" | ccache | protocol
       displayName: ccache protocol
+      condition: eq(${{ parameters.WITHCACHE }}, true)
 
     - script: |
         set -e -x
@@ -73,14 +81,16 @@ jobs:
         ccache -s
         ccache -z
       displayName: Show Cache stats and Clear protolbuf stats.
+      condition: eq(${{ parameters.WITHCACHE }}, true)
 
     - task: Cache@2
       inputs:
-        key: 'ccache | "$(Agent.OS)" | onnxruntime | "$(Build.SourceVersion)" '
+        key: ' "$(TODAY)" | ccache  | onnxruntime | "$(Build.SourceVersion)" '
         path: $(CCACHE_DIR)
         restoreKeys: |
-          ccache | "$(Agent.OS)" | onnxruntime
+          "$(TODAY)" | ccache | onnxruntime
       displayName: ccache MacOS Build
+      condition: eq(${{ parameters.WITHCACHE }}, true)
 
     - ${{ if eq(parameters.BuildForAllArchs, true) }}:
       - template: mac-packaging.yml
@@ -109,6 +119,7 @@ jobs:
         ccache -s
         ccache -z
       displayName: Show Cache stats
+      condition: eq(${{ parameters.WITHCACHE }}, true)
 
     - task: PublishPipelineArtifact@1
       inputs:


### PR DESCRIPTION
### Description
1. Set the WithCache default value as false in Mac OS CI workflow too.
2.  Add date of today in cache key to avoid cache size keep increasing too.

WithCache, the pipeline duration reduced from 70 more minutes to 10 more minutes


