### PR TITLE
Add catch-all exception handler to API_IMPL_END

### DIFF
--- a/onnxruntime/core/framework/error_code_helper.h
+++ b/onnxruntime/core/framework/error_code_helper.h
@@ -24,7 +24,11 @@ Status ToStatus(const OrtStatus* ort_status, common::StatusCategory category = c
   }                                                                 \
   catch (const std::exception& ex) {                                \
     return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, ex.what()); \
+  }                                                                 \
+  catch (...) {                                                     \
+    return OrtApis::CreateStatus(ORT_FAIL, "Unknown Exception");    \
   }
+
 #else
 #define API_IMPL_BEGIN {
 #define API_IMPL_END }


### PR DESCRIPTION
### Description
Fairly self explanatory. Someone pointed out we could miss some exceptions, and we never want to throw exceptions through the C API.

### Motivation and Context
This doesn't fix any known issue, it's just a good idea to have.

