### PR TITLE
Improve rpb cuda kernel

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/relative_attn_bias.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/relative_attn_bias.cc
@@ -57,6 +57,7 @@ Status RelPosAttnBias<T>::ComputeInternal(OpKernelContext* context) const {
 
   typedef typename ToCudaType<T>::MappedType CudaT;
 
+  auto& device_prop = GetDeviceProp();
   return LaunchRelPosAttnBiasKernel<CudaT>(Stream(context),
                                            reinterpret_cast<CudaT*>(output->template MutableData<T>()),
                                            reinterpret_cast<const CudaT*>(bias_table->template Data<T>()),
@@ -64,7 +65,8 @@ Status RelPosAttnBias<T>::ComputeInternal(OpKernelContext* context) const {
                                            static_cast<int>(query_len),
                                            static_cast<int>(num_buckets),
                                            max_distance_,
-                                           is_bidirectional_);
+                                           is_bidirectional_,
+                                           device_prop.maxThreadsPerBlock);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/relative_attn_bias_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/relative_attn_bias_impl.h
@@ -18,7 +18,8 @@ Status LaunchRelPosAttnBiasKernel(
     const int seq_len,
     const int num_bucket,
     const int max_distance,
-    const bool is_bidirectional
+    const bool is_bidirectional,
+    const int max_threads_per_block
 );
 
 }  // namespace cuda


### PR DESCRIPTION
### Description
Average latency (ms) of float16 relative position bias cuda kernel on V100:

Kernel\Seq_Len  | 16 | 32 | 64 | 128 | 256 | 384 | 512 | 768 | 1024 | 2048 | 4096
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before| 0.0494 | 0.0654 | 0.1519 | 0.4322 | 1.1865 | 2.4091 | 4.3676 | 14.912 | 36.517 | 142.09 | 561.80
After | 0.0483 | 0.0651 | 0.1294 | 0.3858 | 1.1128 | 2.2988 | 3.8391 | 14.290 | 34.542 | 136.13 | 529.54

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Review of this comment https://github.com/microsoft/onnxruntime/pull/14149/#discussion_r1063152021