### PR TITLE
Hot fix for prefast failure to unblock python package pipeline

### DIFF
--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -813,6 +813,9 @@ void RawAttentionEmptyPastState(bool past_present_share_buffer) {
   }
 }
 
+// Disable Causal_EmptyPastState temporarily in Windows build since prefast crashes in python package pipelines
+// TODO(tianleiwu): change the test to load test data from file.
+#ifndef _MSC_VER
 #ifndef ENABLE_TRAINING  // TRT fused attention is enabled only on non-training builds
 static void GetWeightAndBiasForHiddenSize64(std::vector<float>& weight_data, std::vector<float>& bias_data) {
   weight_data = {
@@ -2342,6 +2345,7 @@ TEST(AttentionTest, Causal_EmptyPastState) {
                      use_past_state, past_sequence_length, &past_data, &present_data);
   }
 }
+#endif
 #endif
 
 TEST(AttentionTest, AttentionEmptyPastState) {


### PR DESCRIPTION
### Description
Hot fix python packaging pipeline failures by disabling an attention op test which causes cl crashes in prefast build.

Verified that python package is good with this hot fix:
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=263786&view=results

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Failed in prefast build that linker crashes:
```
 cl : command line error D8040: error creating or communicating with child process
```
The cause is high stack usage in an attention op unit test introduced in https://github.com/microsoft/onnxruntime/pull/13953.
