### PR TITLE
[DML EP] Fix FusedMatMul crash when batch > 1

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -112,7 +112,6 @@ namespace DmlGraphFusionHelper
         onnxruntime::Graph& graph,
         _Out_ std::vector<bool>& inputsUsed,
         _Inout_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
-        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
         _Inout_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
         _Inout_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
         _Inout_opt_ std::vector<std::vector<std::byte>>* inputRawData)
@@ -163,7 +162,7 @@ namespace DmlGraphFusionHelper
             if (iter != initializerNameToInitializerMap.end())
             {
                 std::byte* tensorPtr = nullptr;
-                size_t tensorByteSize = 0;                
+                size_t tensorByteSize = 0;
                 std::vector<uint8_t> unpackedExternalTensor;
 
                 std::unique_ptr<std::byte[]> unpackedTensor;
@@ -398,7 +397,6 @@ namespace DmlGraphFusionHelper
         // Populate input bindings for operator initialization
         std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> initializeResourceRefs; // For lifetime control
         std::vector<DML_BUFFER_BINDING> initInputBindings(fusedNodeInputCount);
-        std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> initInputResources;  // For lifetime control
         std::vector<ComPtr<ID3D12Resource>> nonOwnedGraphInputsFromInitializers(fusedNodeInputCount);
 
         std::vector<bool> inputsUsed;
@@ -411,7 +409,6 @@ namespace DmlGraphFusionHelper
             graph,
             inputsUsed,
             initInputBindings,
-            initInputResources,
             nonOwnedGraphInputsFromInitializers,
             initializeResourceRefs,
             nullptr);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.h
@@ -39,20 +39,6 @@ namespace DmlGraphFusionHelper
         ID3D12Resource** resource,
         uint64_t* allocId);
 
-    void ProcessInputData(
-        const ExecutionProviderImpl* providerImpl,
-        const std::vector<uint8_t>& isInputsUploadedByDmlEP,
-        std::vector<DML_INPUT_GRAPH_EDGE_DESC>& inputEdges,
-        const gsl::span<const std::string> subGraphInputArgNames,
-        const std::unordered_map<std::string, std::pair<const ONNX_NAMESPACE::TensorProto*, bool>>& isInitializerTransferable,
-        onnxruntime::Graph& graph,
-        _Out_ std::vector<bool>& inputsUsed,
-        _Inout_ std::vector<DML_BUFFER_BINDING>& initInputBindings,
-        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initInputResources,
-        _Inout_ std::vector<ComPtr<ID3D12Resource>>& nonOwnedGraphInputsFromInitializers,
-        _Inout_ std::vector<ComPtr<ID3D12Resource>>& initializeResourceRefs,
-        _Inout_opt_ std::vector<std::vector<std::byte>>* inputRawData);
-
     std::unordered_map<const onnx::TensorProto*, std::vector<uint32_t>>
     GetInitializerToPartitionMap(
         const onnxruntime::GraphViewer& graph,
@@ -71,7 +57,7 @@ namespace DmlGraphFusionHelper
         _Inout_ std::vector<DML_GRAPH_EDGE_DESC>& dmlIntermediateEdges);
 
     void CreateIDmlCompiledOperatorAndRegisterKernel(
-        onnxruntime::Graph& graph, 
+        onnxruntime::Graph& graph,
         const onnxruntime::IndexedSubGraph& indexedSubGraph,
         const onnxruntime::Node& fusedNode,
         const std::unordered_map<std::string, GraphNodeProperties>& partitionNodePropsMap,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorFusedMatMul.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorFusedMatMul.cpp
@@ -15,8 +15,8 @@ public:
     {
         // FusedMatMul has two inputs, but DML GEMM requires 3 input bindings (a null binding for the C Tensor).
         ML_CHECK_VALID_ARGUMENT(kernelInfo.GetInputCount() == 2);
-        
-        // Need these shapes to apply transpose and 
+
+        // Need these shapes to apply transpose and
         // numpy MatMul's behavior https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
         std::vector<DimensionType> inputShape0 = kernelInfo.GetTensorShapeDescription().GetInputTensorShape(0);
         std::vector<DimensionType> inputShape1 = kernelInfo.GetTensorShapeDescription().GetInputTensorShape(1);
@@ -27,7 +27,7 @@ public:
         const int32_t transBatchB = kernelInfo.GetOptionalAttribute<int32_t>(AttrName::TransBatchB, 0);
         const int32_t transB = kernelInfo.GetOptionalAttribute<int32_t>(AttrName::TransB, 0);
 
-        // As of now, CPU FusedMatMul has this extra validation 
+        // As of now, CPU FusedMatMul has this extra validation
         // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/cpu/math/matmul_helper.h#L72
         // Although, DML kernel can work without this validation, but adding this just to be in sync.
         if (transBatchA || transBatchB)
@@ -42,7 +42,7 @@ public:
 
         OperatorHelper::FusedMatMulShapeMapping(sizesA, stridesA, sizesB, stridesB, outputShape);
 
-        // At this point, we have manipulated input/output shapes and strides and 
+        // At this point, we have manipulated input/output shapes and strides and
         // we do not care about actual input shapes present in the model (.onnx file).
         // Create the TensorDesc with the manipulated input shapes becuase we don't want incorrect
         // broadcasting to be happen inside TensorDesc constructor.
@@ -50,7 +50,7 @@ public:
         gsl::span<const uint32_t> inputShapes[2] = {sizesA, sizesB};
         gsl::span<const uint32_t> outputShapes[1] = {outputShape};
         DmlOperator::InitializeWithShapes(kernelInfo, inputIndices, std::nullopt, inputShapes, outputShapes, 1);
-        
+
         m_inputTensorDescs[0].SetStrides(stridesA);
         m_inputTensorDescs[1].SetStrides(stridesB);
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.cpp
@@ -212,12 +212,20 @@ gsl::span<const uint32_t> TensorDesc::GetStrides() const
 
 void TensorDesc::SetStrides(gsl::span<const uint32_t> strides)
 {
+    m_bufferTensorDesc.Strides = strides.empty() ? nullptr : strides.data();
+
     if (!strides.empty())
     {
         ML_CHECK_VALID_ARGUMENT(strides.size() <= std::size(m_strides));
-        m_bufferTensorDesc.Strides = strides.data();
+        ML_CHECK_VALID_ARGUMENT(strides.size() == m_bufferTensorDesc.DimensionCount);
         std::copy(strides.begin(), strides.end(), m_strides);
     }
+
+    m_bufferTensorDesc.TotalTensorSizeInBytes = DMLCalcBufferTensorSize(
+        m_bufferTensorDesc.DataType,
+        m_bufferTensorDesc.DimensionCount,
+        m_sizes,
+        strides.empty() ? nullptr : m_strides);
 }
 
 DML_TENSOR_DESC TensorDesc::GetDmlDesc()

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/TensorDesc.h
@@ -44,9 +44,9 @@ namespace Dml
         gsl::span<const uint32_t> GetSizes() const { return { m_sizes, m_sizes + m_bufferTensorDesc.DimensionCount }; }
         gsl::span<const uint32_t> GetStrides() const;
         void SetStrides(gsl::span<const uint32_t> strides);
-  
+
         inline uint64_t GetBufferSizeInBytes() const
-        { 
+        {
             assert(m_tensorType == DML_TENSOR_TYPE_BUFFER);
             return m_bufferTensorDesc.TotalTensorSizeInBytes;
         }


### PR DESCRIPTION
### Description
Fix FusedMatMul crash when batch > 1



### Motivation and Context
FusedMatMul calls `SetStrides` on its input tensors but doesn't update the tensorSizeInBytes value. Calling `SetStrides` is very error-prone because it puts the tensor in an invalid state, and the caller needs to manually adjust it after the call. To avoid this situation in the future, we now update the size of the tensor in the `SetStrides` call itself.


