### PR TITLE
fix reshape fusion error in numpy 1.24

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_reshape.py
+++ b/onnxruntime/python/tools/transformers/fusion_reshape.py
@@ -123,8 +123,8 @@ class FusionReshape(Fusion):
             if concat_2 is None:
                 return
             concat_value = numpy_helper.to_array(concat_2)
-            if isinstance(concat_value, list):
-                shape.extend(concat_value)
+            if isinstance(concat_value, np.ndarray):
+                shape.extend(concat_value.tolist())
             else:
                 shape.append(concat_value)
 
@@ -155,8 +155,8 @@ class FusionReshape(Fusion):
                 return
 
             concat_value = numpy_helper.to_array(concat_3)
-            if isinstance(concat_value, list):
-                shape.extend(concat_value)
+            if isinstance(concat_value, np.ndarray):
+                shape.extend(concat_value.tolist())
             else:
                 shape.append(concat_value)
 

--- a/tools/ci_build/requirements.txt
+++ b/tools/ci_build/requirements.txt
@@ -1,7 +1,7 @@
 # packages used by transformers tool test
 packaging
 protobuf==3.20.1
-numpy==1.23.5
+numpy==1.24.0
 coloredlogs==15.0
 transformers==4.24.0
 psutil


### PR DESCRIPTION
### Description
Fix https://github.com/microsoft/onnxruntime/issues/14017. 

Before: shape_value = np.asarray([0, 0, np.array([4]), np.array([8])], dtype=np.int64) raise Error in numpy 1.24.
After: shape_value = np.asarray([0, 0, 4, 8)], dtype=np.int64) is good in numpy 1.24.

Update test environment to use numpy 1.24.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


