### PR TITLE
Draft: Support External weight in optimizer serialization

### DIFF
--- a/onnxruntime/core/framework/session_options.h
+++ b/onnxruntime/core/framework/session_options.h
@@ -64,6 +64,12 @@ struct SessionOptions {
   // unless the filepath ends in '.ort' (case insensitive).
   std::basic_string<ORTCHAR_T> optimized_model_filepath;
 
+  // Non empty filepath enables serialization large initializers into external files.
+  std::basic_string<ORTCHAR_T> optimized_external_initializer_filepath;
+
+  // Size threshold for offloading initializers to external files.
+  size_t optimized_external_initializer_threshold_num_bytes = 1024;
+
   // enable the memory pattern optimization.
   // The idea is if the input shapes are the same, we could trace the internal memory allocation
   // and generate a memory pattern for future request. So next time we could just do one allocation

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1497,7 +1497,17 @@ common::Status InferenceSession::Initialize() {
       if (saving_ort_format) {
         ORT_RETURN_IF_ERROR_SESSIONID_(SaveToOrtFormat(session_options_.optimized_model_filepath));
       } else {
-        ORT_RETURN_IF_ERROR_SESSIONID_(Model::Save(*model_, session_options_.optimized_model_filepath));
+        if (!session_options_.optimized_external_initializer_filepath.empty()) {
+          ORT_RETURN_IF_ERROR_SESSIONID_(Model::SaveWithExternalInitializers(
+              *model_,
+              session_options_.optimized_model_filepath,
+              session_options_.optimized_external_initializer_filepath,
+              session_options_.optimized_external_initializer_threshold_num_bytes));
+        } else {
+          ORT_RETURN_IF_ERROR_SESSIONID_(Model::Save(
+              *model_,
+              session_options_.optimized_model_filepath));
+        }
       }
     }
 #endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1143,6 +1143,25 @@ Serialized model format will default to ONNX unless:
 
 )pbdoc")
       .def_property(
+          "optimized_external_initializer_filepath",
+          [](const PySessionOptions* options) -> std::basic_string<ORTCHAR_T> {
+            return options->value.optimized_external_initializer_filepath;
+          },
+          [](PySessionOptions* options, std::basic_string<ORTCHAR_T> optimized_external_initializer_filepath) -> void {
+            options->value.optimized_external_initializer_filepath = std::move(optimized_external_initializer_filepath);
+          },
+          R"pbdoc(Non empty filepath enables serialization large initializers into external files.)pbdoc")
+      .def_property(
+          "optimized_external_initializer_threshold_num_bytes",
+          [](const PySessionOptions* options) -> size_t {
+            return options->value.optimized_external_initializer_threshold_num_bytes;
+          },
+          [](PySessionOptions* options, size_t optimized_external_initializer_threshold_num_bytes) -> void {
+            options->value.optimized_external_initializer_threshold_num_bytes =
+                optimized_external_initializer_threshold_num_bytes;
+          },
+          R"pbdoc(Size threshold for offloading initializers to external files. Default is 1024.)pbdoc")
+      .def_property(
           "enable_mem_pattern",
           [](const PySessionOptions* options) -> bool { return options->value.enable_mem_pattern; },
           [](PySessionOptions* options, bool enable_mem_pattern) -> void {
@@ -1333,7 +1352,7 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
             ORT_THROW("External initializers are not supported in this build.");
 #endif
       });
-      
+
   py::class_<RunOptions>(m, "RunOptions", R"pbdoc(Configuration information for a single Run.)pbdoc")
       .def(py::init())
       .def_readwrite("log_severity_level", &RunOptions::run_log_severity_level,


### PR DESCRIPTION
### Description
Allow Inference Session Optimizer to output models with external initializer files.



### Motivation and Context
Without it, optimizer can't write out models that exceed protobuf length limit of 2GiB. This particularly is blocking StableDiffusion v2.1 from being serialized after the optimization step. https://huggingface.co/spaces/stabilityai/stable-diffusion


