### PR TITLE
Update run.py

### DIFF
--- a/tools/python/util/run.py
+++ b/tools/python/util/run.py
@@ -17,7 +17,7 @@ def run(
     capture_stderr=False,
     shell=False,
     env=None,
-    check=True,
+    check=False,
     quiet=False,
 ):
     """Runs a subprocess.


### PR DESCRIPTION
### Description
In this file, `onnxruntime/blob/main/tools/python/util/run.py`, the default value for the check argument is `True`. The value of the check argument goes to the python built-in function `subprocess.run`. This function, in the python 3.8 version, will raise a `CalledProcesserror` if the check argument is `True`. It would be problematic, for example, in the file `/onnxruntime/blob/main/tools/ci_build/build.py` at line 739, function `run_subprocess` uses this function. But, no value for the check argument is passed, even in `args`. Therefore, by default, It would lead to a `CalledProcesserror`. 



### Motivation and Context
I just turn the default value of the check argument to `False`.


