### PR TITLE
Add Java and Objective-C bindings for RegisterCustomOpsUsingFunction.

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -702,6 +702,29 @@ public class OrtSession implements AutoCloseable {
     }
 
     /**
+     * Registers custom ops for use with {@link OrtSession}s using this SessionOptions by calling
+     * the specified native function name. The custom ops library must either be linked against, or
+     * have previously been loaded by the user.
+     *
+     * <p>The registration function must have the signature:
+     *
+     * <p>&emsp;<OrtStatus* (*fn)(OrtSessionOptions* options, const OrtApiBase* api);
+     *
+     * <p>See https://onnxruntime.ai/docs/reference/operators/add-custom-op.html for more
+     * information on custom ops. See
+     * https://github.com/microsoft/onnxruntime/blob/342a5bf2b756d1a1fc6fdc582cfeac15182632fe/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc#L115
+     * for an example of a custom op library registration function.
+     *
+     * @param registration_func_name The name of the registration function to call.
+     * @throws OrtException If there was an error finding or calling the registration function.
+     */
+    public void registerCustomOpsUsingFunction(String registration_func_name) throws OrtException {
+      checkClosed();
+      registerCustomOpsUsingFunction(
+          OnnxRuntime.ortApiHandle, nativeHandle, registration_func_name);
+    }
+
+    /**
      * Sets the value of a symbolic dimension. Fixed dimension computations may have more
      * optimizations applied to them.
      *
@@ -1038,6 +1061,9 @@ public class OrtSession implements AutoCloseable {
 
     private native long registerCustomOpLibrary(long apiHandle, long nativeHandle, String path)
         throws OrtException;
+
+    private native void registerCustomOpsUsingFunction(
+        long apiHandle, long nativeHandle, String func_name) throws OrtException;
 
     private native void closeCustomLibraries(long[] nativeHandle);
 

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -720,8 +720,7 @@ public class OrtSession implements AutoCloseable {
      */
     public void registerCustomOpsUsingFunction(String registrationFuncName) throws OrtException {
       checkClosed();
-      registerCustomOpsUsingFunction(
-          OnnxRuntime.ortApiHandle, nativeHandle, registrationFuncName);
+      registerCustomOpsUsingFunction(OnnxRuntime.ortApiHandle, nativeHandle, registrationFuncName);
     }
 
     /**

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -708,7 +708,7 @@ public class OrtSession implements AutoCloseable {
      *
      * <p>The registration function must have the signature:
      *
-     * <p>&emsp;<OrtStatus* (*fn)(OrtSessionOptions* options, const OrtApiBase* api);
+     * <p>&emsp;OrtStatus* (*fn)(OrtSessionOptions* options, const OrtApiBase* api);
      *
      * <p>See https://onnxruntime.ai/docs/reference/operators/add-custom-op.html for more
      * information on custom ops. See

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -715,13 +715,13 @@ public class OrtSession implements AutoCloseable {
      * https://github.com/microsoft/onnxruntime/blob/342a5bf2b756d1a1fc6fdc582cfeac15182632fe/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc#L115
      * for an example of a custom op library registration function.
      *
-     * @param registration_func_name The name of the registration function to call.
+     * @param registrationFuncName The name of the registration function to call.
      * @throws OrtException If there was an error finding or calling the registration function.
      */
-    public void registerCustomOpsUsingFunction(String registration_func_name) throws OrtException {
+    public void registerCustomOpsUsingFunction(String registrationFuncName) throws OrtException {
       checkClosed();
       registerCustomOpsUsingFunction(
-          OnnxRuntime.ortApiHandle, nativeHandle, registration_func_name);
+          OnnxRuntime.ortApiHandle, nativeHandle, registrationFuncName);
     }
 
     /**
@@ -1063,7 +1063,7 @@ public class OrtSession implements AutoCloseable {
         throws OrtException;
 
     private native void registerCustomOpsUsingFunction(
-        long apiHandle, long nativeHandle, String func_name) throws OrtException;
+        long apiHandle, long nativeHandle, String registrationFuncName) throws OrtException;
 
     private native void closeCustomLibraries(long[] nativeHandle);
 

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -281,6 +281,26 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_regis
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    registerCustomOpsUsingFunction
+ * Signature: (JJLjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_registerCustomOpsUsingFunction
+    (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong optionsHandle, jstring functionName) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+
+  // Extract the string chars
+  const char* cFuncName = (*jniEnv)->GetStringUTFChars(jniEnv, functionName, NULL);
+
+  // Register the custom ops by calling the function
+  checkOrtStatus(jniEnv,api,api->RegisterCustomOpsUsingFunction((OrtSessionOptions*)optionsHandle,cFuncName));
+
+  // Release the string chars
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv,functionName,cFuncName);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    closeCustomLibraries
  * Signature: ([J)V
  */

--- a/java/src/test/java/ai/onnxruntime/InferenceTest.java
+++ b/java/src/test/java/ai/onnxruntime/InferenceTest.java
@@ -1088,9 +1088,12 @@ public class InferenceTest {
           TestHelpers.getResourcePath("/custom_op_library/custom_op_test.onnx").toString();
 
       try (SessionOptions options = new SessionOptions()) {
-        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+        String osName = System.getProperty("os.name").toLowerCase();
+        boolean isWindows = osName.contains("windows");
+        boolean isMac = osName.contains("mac");
 
-        // on Windows, Java.System.load will make the symbols from the loaded library available.
+        // on Windows and mac, Java.System.load will make the symbols from the loaded library
+        // available.
         // on other platforms the dlsym uses RTLD_LOCAL so they're not. Would need to use something
         // like
         // https://github.com/java-native-access/jna to achieve that.
@@ -1105,7 +1108,7 @@ public class InferenceTest {
           System.load(customLibraryName);
           options.registerCustomOpsUsingFunction("RegisterCustomOps");
 
-          if (isWindows) {
+          if (isWindows || isMac) {
             if (OnnxRuntime.extractCUDA()) {
               options.addCUDA();
             }
@@ -1117,7 +1120,8 @@ public class InferenceTest {
           }
         } catch (OrtException e) {
           System.out.println(e.getMessage());
-          assertTrue(!isWindows, "Expected to not throw OrtException on Windows");
+          assertTrue(
+              !(isWindows || isMac), "Expected to not throw OrtException on Windows or macOS");
           assertTrue(e.getMessage().contains("Failed to get symbol RegisterCustomOps"));
         }
       }

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -106,9 +106,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithError:(NSError**)error NS_SWIFT_NAME(init());
 
 /**
+ * Appends an execution provider to the session options to enable the execution provider to be used when running
+ * the model.
+ *
  * Available since 1.14.
- * Appends an execution provider to the session configuration options.
- * The execution provider list is ordered by decreasing priority
+ *
+ * The execution provider list is ordered by decreasing priority.
+ * i.e. the first provider registered has the highest priority.
+ *
  * @param providerName Provider name. For example, "xnnpack".
  * @param providerOptions Provider-specific options. For example, for provider "xnnpack", {"intra_op_num_threads": "2"}.
  * @param error Optional error information set if an error occurs.
@@ -184,9 +189,11 @@ NS_ASSUME_NONNULL_BEGIN
                         error:(NSError**)error;
 
 /**
- * Registers custom ops for use with {@link ORTSession}s using this SessionOptions by calling the specified
+ * Registers custom ops for use with `ORTSession`s using this SessionOptions by calling the specified
  * native function name. The custom ops library must either be linked against, or have previously been loaded
  * by the user.
+ *
+ * Available since 1.14.
  *
  * The registration function must have the signature:
  *    OrtStatus* (*fn)(OrtSessionOptions* options, const OrtApiBase* api);

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -183,6 +183,25 @@ NS_ASSUME_NONNULL_BEGIN
                         value:(NSString*)value
                         error:(NSError**)error;
 
+/**
+ * Registers custom ops for use with {@link ORTSession}s using this SessionOptions by calling the specified
+ * native function name. The custom ops library must either be linked against, or have previously been loaded
+ * by the user.
+ *
+ * The registration function must have the signature:
+ *    OrtStatus* (*fn)(OrtSessionOptions* options, const OrtApiBase* api);
+ *
+ * See https://onnxruntime.ai/docs/reference/operators/add-custom-op.html for more information on custom ops.
+ * See https://github.com/microsoft/onnxruntime/blob/342a5bf2b756d1a1fc6fdc582cfeac15182632fe/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc#L115
+ * for an example of a custom op library registration function.
+ *
+ * @param registration_func_name The name of the registration function to call.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the registration function was successfully called.
+ */
+- (BOOL)registerCustomOpsUsingFunction:(NSString*)registrationFuncName
+                                 error:(NSError**)error;
+
 @end
 
 /**

--- a/objectivec/src/ort_session.mm
+++ b/objectivec/src/ort_session.mm
@@ -219,12 +219,12 @@ NS_ASSUME_NONNULL_BEGIN
   try {
     std::unordered_map<std::string, std::string> options;
     NSArray* keys = [providerOptions allKeys];
-  
+
     for (NSString* key in keys) {
       NSString* value = [providerOptions objectForKey:key];
       options.emplace(key.UTF8String, value.UTF8String);
     }
-  
+
     _sessionOptions->AppendExecutionProvider(providerName.UTF8String, options);
     return YES;
   }
@@ -282,6 +282,15 @@ NS_ASSUME_NONNULL_BEGIN
                         error:(NSError**)error {
   try {
     _sessionOptions->AddConfigEntry(key.UTF8String, value.UTF8String);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)registerCustomOpsUsingFunction:(NSString*)registrationFuncName
+                                 error:(NSError**)error {
+  try {
+    _sessionOptions->RegisterCustomOpsUsingFunction(registrationFuncName.UTF8String);
     return YES;
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add bindings for Android and iOS.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable mobile app linking against ort-extensions library and registering the custom ops with ORT. 

