### PR TITLE
[ROCm] use pytest-xdist for fast pytest

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -84,7 +84,7 @@ jobs:
     inputs:
       script: |-
         export KERNEL_EXPLORER_BUILD_DIR=./build/Release
-        pytest ./onnxruntime/python/tools/kernel_explorer/
+        pytest ./onnxruntime/python/tools/kernel_explorer/ -n 16 --reruns 1
     displayName: 'Run kernel explorer tests'
     condition: and(succeededOrFailed(), eq(variables.onnxruntimeBuildSucceeded, 'true'))
 

--- a/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
@@ -37,7 +37,9 @@ RUN pip install \
       sentencepiece \
       dill==0.3.4 \
       wget \
-      pytorch_lightning==1.6.0
+      pytorch_lightning==1.6.0 \
+      pytest-xdist \
+      pytest-rerunfailures
 
 RUN pip install torch-ort --no-dependencies
 ENV ORTMODULE_ONNX_OPSET_VERSION=15


### PR DESCRIPTION
### Description

Use pytest-xdist to distribute tests across multiple CPUs to speed up test execution.
Use pytest-rerunfailures to rerun failed test in case of pytest-xdist crash.
`pytest -n 16` can reduce pytest time from 80 minutes to 20 minutes.


### Motivation and Context
Now kernel explorer pytest of ROCm CI takes nearly 1 hour 20 minutes. It will take longer time when we add more tunableOp in the future.


