### PR TITLE
DML EP return clearer error message when users attempt to use software adapter

### DIFF
--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -129,7 +129,7 @@ std::shared_ptr<IExecutionProviderFactory> DMLProviderFactoryCreator::Create(int
   // anyway) such as operation kernel registry enumeration for documentation purposes.
   if (!skip_software_device_check)
   {
-    ORT_THROW_HR_IF(E_INVALIDARG, IsSoftwareAdapter(adapter.Get()));
+    ORT_THROW_HR_IF(ERROR_GRAPHICS_INVALID_DISPLAY_ADAPTER, IsSoftwareAdapter(adapter.Get()));
   }
 
   ComPtr<ID3D12Device> d3d12_device;


### PR DESCRIPTION
### Description
The DML EP provider factory verifies the adapter id is a real GPU (not some software emulation like WARP which would be quite slow or basic display driver which lacks D3D compute ability), but the automated tests sometimes erratically get run on a variety of ADO cloud machines that lack a GPU or are in a bad state such that Windows fell back to software emulation. In such cases, you end up reaching the `!IsSoftwareAdapter` check in the provider factory ([line 132](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/dml/dml_provider_factory.cc#L132)) and seeing in the pipeline logs E_INVALIDARG. Let's return a more immediately enlightening error code like ERROR_GRAPHICS_INVALID_DISPLAY_ADAPTER rather than just E_INVALIDARG.

### Motivation and Context
- *Why is this change required? What problem does it solve* Pipeline noise.
- *If it fixes an open issue, please link to the issue here.* NA.