### PR TITLE
fix roctracer missing nccl operation bug

### DIFF
--- a/onnxruntime/core/providers/rocm/roctracer_manager.cc
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.cc
@@ -252,7 +252,7 @@ bool RoctracerManager::CreateEventForActivityRecord(const roctracer_record_t* re
       /* pid = */ -1,
       /* tid = */ -1,
       /* name = */ std::move(name),
-      /* ts = */ (int64_t)(record->begin_ns - start_time_ns) / 1000,
+      /* ts = */ (int64_t)(this->NormalizeGPUTimestampToCPUEpoch(record->begin_ns) - start_time_ns) / 1000,
       /* dur = */ (int64_t)(record->end_ns - record->begin_ns) / 1000,
       /* args = */ std::move(args)};
   return true;

--- a/onnxruntime/core/providers/rocm/roctracer_manager.cc
+++ b/onnxruntime/core/providers/rocm/roctracer_manager.cc
@@ -122,6 +122,14 @@ void RoctracerManager::FlushActivities() {
   roctracer_flush_activity();
 }
 
+uint64_t RoctracerManager::GetGPUTimestampInNanoseconds() {
+  uint64_t result;
+  if (roctracer_get_timestamp(&result) != ROCTRACER_STATUS_SUCCESS) {
+    ORT_THROW("Could not retrieve timestamp from GPU!");
+  }
+  return result;
+}
+
 static inline std::string MemcpyKindToString(hipMemcpyKind kind) {
   switch (kind) {
     case hipMemcpyHostToHost:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This change fixes a bug that when running ort with nccl collective operation on AMD, it can't trace nccl operation.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The reason of missing nccl operation in roctracer is that roctracer is using whitelist of which api can be traced, and nccl use hipExtLaunchKernel api which is not included in the whitelist. This fix is to add hipExtLaunchKernel into whitelist, then nccl operation could be traced.

