### PR TITLE
Perform QlinearConv for multiple batches in single parallel

### DIFF
--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -671,7 +671,7 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
   if (use_indirection_buffer) {
     // Allocate indirection buffer pointers and prepare a padding vector for
     // the im2col transform.
-    ind_buf_length = kernel_size * output_image_size;
+    ind_buf_length = SafeInt<size_t>(kernel_size) * output_image_size;
     if (parallel_batch)
       ind_buf_length *= N; // ind buffer per each image in the batch
     auto* indirection_data = alloc->Alloc(SafeInt<size_t>(sizeof(const ActType*)) * ind_buf_length);

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -727,7 +727,7 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
 
       ActType const** worker_indirection_buffer = nullptr;
       if (indirection_buffer) {
-        size_t offset = (image_id * output_image_size + output_start) * kernel_size;
+        size_t offset = SafeInt<size_t>(image_id * output_image_size + output_start) * kernel_size;
         assert(offset < ind_buf_length);
         worker_indirection_buffer = static_cast<ActType const**>(indirection_buffer.get()) + offset;
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -646,6 +646,7 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
 
   BufferUniquePtr col_buffer;
   BufferUniquePtr indirection_buffer;
+  size_t ind_buf_length = 0;
   std::vector<ActType> padding_data;
 
   bool use_indirection_buffer = false;
@@ -664,10 +665,16 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
       memset(col_data, 0, SafeInt<size_t>(sizeof(ActType)) * group_col_buffer_size);
     }
   }
+
+  bool parallel_batch = is_symmetric_conv_ && channels_last_;
+
   if (use_indirection_buffer) {
     // Allocate indirection buffer pointers and prepare a padding vector for
     // the im2col transform.
-    auto* indirection_data = alloc->Alloc(SafeInt<size_t>(sizeof(const ActType*)) * kernel_size * output_image_size);
+    ind_buf_length = kernel_size * output_image_size;
+    if (parallel_batch)
+      ind_buf_length *= N; // ind buffer per each image in the batch
+    auto* indirection_data = alloc->Alloc(SafeInt<size_t>(sizeof(const ActType*)) * ind_buf_length);
     indirection_buffer = BufferUniquePtr(indirection_data, BufferDeleter(alloc));
     padding_data.resize(static_cast<size_t>(C), X_zero_point_value);
   }
@@ -708,6 +715,69 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
   const int32_t degree_of_par = concurrency::ThreadPool::DegreeOfParallelism(thread_pool);
   const int32_t stride_m = ComputeOutputStride(degree_of_par, output_image_size, group_output_channels, kernel_dim, compute_stride);
   const int64_t task_count = (output_image_size + stride_m - 1) / stride_m;
+
+  if (parallel_batch) // process all batch images in the same parallel section
+  {
+    auto conv_worker = [&](ptrdiff_t batch) {
+      int64_t image_id = batch / task_count;
+      int64_t output_start = (batch % task_count) * stride_m;
+      int64_t output_count = std::min((int64_t)stride_m, output_image_size - output_start);
+
+      auto* worker_input_image = Xdata + X_offset * image_id;
+
+      ActType const** worker_indirection_buffer = nullptr;
+      if (indirection_buffer) {
+        size_t offset = (image_id * output_image_size + output_start) * kernel_size;
+        assert(offset < ind_buf_length);
+        worker_indirection_buffer = static_cast<ActType const**>(indirection_buffer.get()) + offset;
+
+        math::Im2col<ActType, StorageOrder::NHWC>()(
+          worker_input_image,
+          C,
+          input_shape.GetDims().data(),
+          output_shape.GetDims().data(),
+          kernel_shape.data(),
+          strides.data(),
+          dilations.data(),
+          pads.data(),
+          static_cast<ptrdiff_t>(kernel_rank),
+          output_start,
+          output_count,
+          worker_indirection_buffer,
+          padding_data.data());
+      }
+
+      auto* worker_output = Ydata + Y_offset * image_id + output_start * M;
+
+      MLAS_CONV_SYM_PARAMS conv_params = {};
+      if (worker_indirection_buffer) {
+        conv_params.InputIndirection = reinterpret_cast<void const**>(worker_indirection_buffer);
+      } else {
+        conv_params.InputDirect = worker_input_image + output_start * C;
+      }
+      conv_params.Filter = packed_W_buffer_.get();
+      conv_params.Output = worker_output;
+      conv_params.InputChannels = static_cast<size_t>(C);
+      conv_params.OutputChannels = static_cast<size_t>(M);
+      conv_params.OutputCount = static_cast<size_t>(output_count);
+      conv_params.KernelSize = static_cast<size_t>(kernel_size);
+      conv_params.Bias = column_sums_.data();
+      conv_params.Scale = output_scales.data();
+      conv_params.PerChannelScale = output_scales.size() > 1;
+      conv_params.OutputZeroPoint = Y_zero_point_value;
+      conv_params.InputIsSigned = std::is_signed<ActType>::value;
+
+      if (is_depthwise_conv) {
+        MlasConvSymDepthwise(conv_params);
+      } else {
+        MlasConvSym(conv_params);
+      }
+    };
+
+    concurrency::ThreadPool::TrySimpleParallelFor(thread_pool, task_count * N, conv_worker);
+
+    return Status::OK();
+  }
 
   for (int64_t image_id = 0; image_id < N; ++image_id) {
     const auto* input_data = Xdata;


### PR DESCRIPTION
### Description
 
This code change allows for the QlinearConv operator to sync batches into a single parallel section. This allows for the tasks of all the batches to be made available for threads to exercise. This would act alternatively to the existing method which parallelizes the tasks of induvial images separately which forces threads to wait for all an entire image’s tasks to complete before continuing. 

### ****Motivation and Context****
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

For int8 convolution models where multiple batches are being utilized, this patch delivers an **inference improvement of up-to 41% and 39% for Mobilenet_edtpu (U8S8) and Resnet50(U8S8) respectively** on systems with higher core counts. The patch, delivers the highest benefit on systems with higher thread counts and when utilizing large batch sizes.

 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/asatti/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/asatti/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Fixed;
	text-align:center;
	vertical-align:middle;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;
	background:#B4C6E7;
	mso-pattern:black none;}
.xl66
	{text-align:center;
	vertical-align:middle;}
.xl67
	{text-align:center;
	vertical-align:middle;
	border-top:none;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:none;}
.xl68
	{mso-number-format:Fixed;
	text-align:center;
	vertical-align:middle;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
.xl69
	{mso-number-format:"0\.0%";
	text-align:center;
	vertical-align:middle;
	border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:none;
	border-left:1.0pt solid windowtext;}
.xl70
	{mso-number-format:"0\.0%";
	text-align:center;
	vertical-align:middle;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



  |   | Batch 2 | Batch 4 | Batch 8 | Batch 16 | Batch 32 | Batch 64
-- | -- | -- | -- | -- | -- | -- | --
resnet50 | % Gain | 22.0% | 25.0% | 32.0% | 36.0% | 33.0% | 32.0%



</body>

</html>

