### PR TITLE
Add PyTorch 2.0 to ORT transformer benchmarking

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -779,6 +779,10 @@ def main():
     enable_onnxruntime = "onnxruntime" in args.engines
     enable_tensorflow = "tensorflow" in args.engines
 
+    if enable_torch2 and torch.__version__ < "2.0.0":
+        logger.error(f"PyTorch version must be >=2.0.0 and you are using {torch.__version__}")
+        return
+
     config_modifier = ConfigModifier(args.force_num_layers)
 
     results = []

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -368,7 +368,9 @@ def run_pytorch(
                     device=device,
                 )
                 try:
-                    inference = torch.jit.trace(model, input_ids) if torchscript else torch.compile(model) if torch2 else model
+                    inference = (
+                        torch.jit.trace(model, input_ids) if torchscript else torch.compile(model) if torch2 else model
+                    )
                     inference(input_ids)
 
                     runtimes = timeit.repeat(lambda: inference(input_ids), repeat=repeat_times, number=1)

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -46,7 +46,6 @@ import os
 import timeit
 from datetime import datetime
 from enum import Enum
-from packaging import version
 
 import numpy
 import onnx
@@ -72,6 +71,7 @@ from onnx_exporter import (
     export_onnx_model_from_tf,
     load_pretrained_model,
 )
+from packaging import version
 from quantize_helper import QuantizeHelper
 
 logger = logging.getLogger("")

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -46,6 +46,7 @@ import os
 import timeit
 from datetime import datetime
 from enum import Enum
+from packaging import version
 
 import numpy
 import onnx
@@ -779,7 +780,7 @@ def main():
     enable_onnxruntime = "onnxruntime" in args.engines
     enable_tensorflow = "tensorflow" in args.engines
 
-    if enable_torch2 and torch.__version__ < "2.0.0":
+    if enable_torch2 and version.parse(torch.__version__) < version.parse("2.0.0"):
         logger.error(f"PyTorch version must be >=2.0.0 and you are using {torch.__version__}")
         return
 

--- a/onnxruntime/python/tools/transformers/run_benchmark.sh
+++ b/onnxruntime/python/tools/transformers/run_benchmark.sh
@@ -7,6 +7,7 @@
 # Please install PyTorch (see https://pytorch.org/) before running this benchmark. Like the following:
 # GPU:   conda install pytorch torchvision cudatoolkit=11.0 -c pytorch
 # CPU:   conda install pytorch torchvision cpuonly -c pytorch
+# To use torch2, please install the nightly PyTorch by replacing pytorch with pytorch-nightly.
 
 # When use_package=true, you need not copy other files to run benchmarks except this sh file.
 # Otherwise, it will use python script (*.py) files in this directory.
@@ -20,6 +21,7 @@ run_install=true
 run_ort=true
 run_ort_trt=false
 run_torch=false
+run_torch2=false
 run_torchscript=true
 run_tensorflow=false
 
@@ -61,7 +63,7 @@ models_to_test="bert-base-cased roberta-base distilbert-base-uncased"
 # export CUDA_VISIBLE_DEVICES=1
 
 # This script will generate a logs file with a list of commands used in tests.
-echo echo "ort=$run_ort torch=$run_torch torchscript=$run_torchscript tensorflow=$run_tensorflow gpu_fp32=$run_gpu_fp32 gpu_fp16=$run_gpu_fp16 cpu=$run_cpu optimizer=$use_optimizer batch=$batch_sizes sequence=$sequence_length models=$models_to_test" >> benchmark.log
+echo echo "ort=$run_ort torch=$run_torch torch2=$run_torch2 torchscript=$run_torchscript tensorflow=$run_tensorflow gpu_fp32=$run_gpu_fp32 gpu_fp16=$run_gpu_fp16 cpu=$run_cpu optimizer=$use_optimizer batch=$batch_sizes sequence=$sequence_length models=$models_to_test" >> benchmark.log
 
 # Set it to false to skip testing. You can use it to dry run this script with the log file.
 run_tests=true
@@ -150,6 +152,13 @@ run_one_test() {
       echo python $benchmark_script -e torch -m $1 $benchmark_options $2 $3 $4 >> benchmark.log
       if [ "$run_tests" = true ] ; then
         python $benchmark_script -e torch -m $1 $benchmark_options $2 $3 $4
+      fi
+    fi
+
+    if [ "$run_torch2" = true ] ; then
+      echo python $benchmark_script -e torch2 -m $1 $benchmark_options $2 $3 $4 >> benchmark.log
+      if [ "$run_tests" = true ] ; then
+        python $benchmark_script -e torch2 -m $1 $benchmark_options $2 $3 $4
       fi
     fi
 


### PR DESCRIPTION
### Description
This PR adds PyTorch 2.0 as an option when running the ORT transformer benchmarking script.


### Motivation and Context
PyTorch released [PyTorch 2.0](https://pytorch.org/get-started/pytorch-2.0/) in the nightly binaries and a stable release of PyTorch 2.0 is expected in March 2023.

