### PR TITLE
fix optimizer typo

### DIFF
--- a/onnxruntime/core/optimizer/gather_fusion.h
+++ b/onnxruntime/core/optimizer/gather_fusion.h
@@ -10,7 +10,7 @@ namespace onnxruntime {
 /**
 @Class GatherToSplitFusion
 
-Fuse multiple Gather nodes that comsuming one output to one Split node.
+Fuse multiple Gather nodes that consuming one output to one Split node.
 */
 class GatherToSplitFusion : public GraphTransformer {
  public:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR fixes a typo in the comment of `gather_fusion.h` under optimizer


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


