### PR TITLE
Fix build error on Windows if Python debug libraries are installed

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -238,8 +238,21 @@ add_dependencies(onnxruntime_pybind11_state ${onnxruntime_pybind11_state_depende
 
 if (MSVC)
   set_target_properties(onnxruntime_pybind11_state PROPERTIES LINK_FLAGS "${ONNXRUNTIME_SO_LINK_FLAG}")
-  # if MSVC, pybind11 looks for release version of python lib (pybind11/detail/common.h undefs _DEBUG)
-  target_link_libraries(onnxruntime_pybind11_state PRIVATE Python::Module)
+  # if MSVC, pybind11 undefines _DEBUG in pybind11/detail/common.h, which causes the pragma in pyconfig.h
+  # from the python installation to require the release version of the lib
+  # e.g. from a python 3.10 install:
+  #                       if defined(_DEBUG)
+  #                               pragma comment(lib,"python310_d.lib")
+  #                       elif defined(Py_LIMITED_API)
+  #                               pragma comment(lib,"python3.lib")
+  #                       else
+  #                               pragma comment(lib,"python310.lib")
+  #                       endif /* _DEBUG */
+  #
+  # See https://github.com/pybind/pybind11/issues/3403 for more background info.
+  #
+  # Explicitly use the release version of the python library to make the project file consistent with this.
+  target_link_libraries(onnxruntime_pybind11_state PRIVATE ${Python_LIBRARY_RELEASE})
 elseif (APPLE)
   set_target_properties(onnxruntime_pybind11_state PROPERTIES LINK_FLAGS "${ONNXRUNTIME_SO_LINK_FLAG} -undefined dynamic_lookup")
   set_target_properties(onnxruntime_pybind11_state PROPERTIES


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
If a user installs the debug libraries from Python on Windows the ORT python project file attempts to use the debug python lib, which conflicts with a pragma in pyconfig.h that wants the release lib (due to pybind11 undefining _DEBUG).

Explicitly use the release lib instead of Python::Module so the build doesn't break.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix obtuse build break. 

