### PR TITLE
[Build] Fix arm64 Docker build (#14283)

### DIFF
--- a/dockerfiles/scripts/install_centos_arm64.sh
+++ b/dockerfiles/scripts/install_centos_arm64.sh
@@ -20,3 +20,4 @@ else
 fi
 python3 -m pip install --upgrade pip
 python3 -m pip install numpy
+python3 -m pip install packaging


### PR DESCRIPTION
### Description
 The building process for the arm64 architecture using Docker is not successful due to a missing python dependency “packaging”.  This PR adds that package. 

### Motivation and Context
Adding packaging dependency in the dockerfile will successfully build onnxruntime for arm64.
This shall fix this open issue : https://github.com/microsoft/onnxruntime/issues/14283


