### PR TITLE
Fix support Split-op second input

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1780,8 +1780,8 @@ class SymbolicShapeInference:
         axis = handle_negative_axis(get_attribute(node, "axis", 0), len(input_sympy_shape))
         split = None
         # Depending on op-version 'split' is provided as attribute or via 2nd input
-        opset = get_opset(self.out_mp_) or 0  # «or 0» is to satisfy the pyright check and to restore defaults
-        if opset < 13:
+        opset = get_opset(self.out_mp_)
+        if opset is None or opset < 13:
             split = get_attribute(node, "split")
         elif len(node.input) == 2:
             split = self._try_get_value(node, 1)

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1780,7 +1780,8 @@ class SymbolicShapeInference:
         axis = handle_negative_axis(get_attribute(node, "axis", 0), len(input_sympy_shape))
         split = None
         # Depending on op-version 'split' is provided as attribute or via 2nd input
-        if get_opset(self.out_mp_) < 13:
+        opset = get_opset(self.out_mp_) or 0  # «or 0» is to satisfy the pyright check and to restore defaults
+        if opset < 13:
             split = get_attribute(node, "split")
         elif len(node.input) == 2:
             split = self._try_get_value(node, 1)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -1418,6 +1418,13 @@ def test_gradient_correctness_chunk(dim, chunks):
         def forward(self, input):
             return input.chunk(chunks, dim=self.dim)
 
+    # Stub (opset with parameters through attributes) to avoid non-constant tensor inputs to Split node,
+    #  see https://github.com/microsoft/onnxruntime/pull/14311#issuecomment-1400239111 for details.
+    if Version(torch.__version__) < Version("1.13.0"):
+        from onnxruntime.training import ortmodule
+
+        ortmodule.ONNX_OPSET_VERSION = 12
+
     device = "cuda"
     pt_model = NeuralNetChunk(dim).to(device)
     ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(save_onnx=(chunks > 1), onnx_prefix="chunk_model"))


### PR DESCRIPTION
### Description
Support for latest Split-operator versions with parameters passed as input. Only constant inputs (initializers) are supported for now (`sympy` needs placeholders to make calculations).



### Motivation and Context
In version 13 of Split operator its attribute `split` [was moved](https://onnx.ai/onnx/operators/text_diff_Split_11_13.html) to input. Right now it is just ignored if met (that’s a error).


