### PR TITLE
fix transformer model unit tests

### DIFF
--- a/onnxruntime/test/python/transformers/test_gpt2_to_onnx.py
+++ b/onnxruntime/test/python/transformers/test_gpt2_to_onnx.py
@@ -14,7 +14,7 @@ from parity_utilities import find_transformers_source
 from onnxruntime import get_available_providers
 
 if find_transformers_source(sub_dir_paths=["models", "gpt2"]):
-    from convert_to_onnx import main as gpt2_to_onnx
+    from models.gpt2.convert_to_onnx import main as gpt2_to_onnx
 else:
     from onnxruntime.transformers.models.gpt2.convert_to_onnx import main as gpt2_to_onnx
 

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -242,7 +242,7 @@ class TestModelOptimization(unittest.TestCase):
 
     @pytest.mark.slow
     def test_huggingface_openaigpt_fusion(self):
-        self._test_optimizer_on_huggingface_model("openai-gpt", [0, 12, 0, 12, 0, 24, 0])
+        self._test_optimizer_on_huggingface_model("openai-gpt", [0, 12, 0, 12, 0, 0, 24])
 
     @pytest.mark.slow
     @unittest.skip("skip failed fusion test of gpt-2 on PyTorch 1.12 and transformers 4.18. TODO: fix it")


### PR DESCRIPTION
For following failures, folder of convert_to_onnx should be specified to import for source code case:
FAILED test_gpt2_to_onnx.py::TestGpt2ConvertToOnnx::test_auto_mixed_precision
FAILED test_gpt2_to_onnx.py::TestGpt2ConvertToOnnx::test_stage1 - TypeError: ...
FAILED test_gpt2_to_onnx.py::TestGpt2ConvertToOnnx::test_stage2 - TypeError: ...

For failure below, SkipLayerNormal is fused:
FAILED test_optimizer.py::TestModelOptimization::test_huggingface_openaigpt_fusion


