### PR TITLE
delete unused local typedef VK to fix pipeline error

### DIFF
--- a/onnxruntime/core/providers/cuda/test/greedy_search_top_one.cc
+++ b/onnxruntime/core/providers/cuda/test/greedy_search_top_one.cc
@@ -31,7 +31,6 @@ void ComputeTop1Reference(const std::vector<float>& values,
                           std::vector<int32_t>& top_k_tokens,
                           int32_t batch_size,
                           int32_t vocab_size) {
-  using VK = std::pair<float, int32_t>;
 
   for (int32_t b = 0; b < batch_size; b++) {
     int32_t base_idx = b * vocab_size;


### PR DESCRIPTION
fix the error "/onnxruntime_src/onnxruntime/core/providers/cuda/test/greedy_search_top_one.cc:34:9: error: typedef ‘using VK = struct std::pair<float, int>’ locally defined but not used [-Werror=unused-local-typedefs]34 |   using VK = std::pair<float, int32_t>"