### PR TITLE
Allow PostAnalysis@2 task to continue on error for Windows_Packaging_CPU_x86_default

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -285,6 +285,7 @@ jobs:
           GdnBreakGdnToolBinSkim: true
           GdnBreakPolicy: M365
           GdnBreakPolicyMinSev: Error
+        continueOnError: true
 
       - task: TSAUpload@2
         displayName: 'TSA upload'

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -279,6 +279,7 @@ jobs:
           msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe" "$(Build.BinariesDirectory)\Debug\onnxruntime.sln" /p:platform="$(MsbuildPlatform)" /p:configuration=Debug /p:VisualStudioVersion="16.0" /m /p:PreferredToolArchitecture=x64'
           excludedPaths: '$(Build.BinariesDirectory)#$(Build.SourcesDirectory)\cmake#C:\program files (x86)'
 
+      # TODO: continueOnError: true is a temporary workaround for Windows_Packaging_CPU_x86_default
       - task: PostAnalysis@2
         inputs:
           GdnBreakAllTools: false


### PR DESCRIPTION
### Description
Allows the PostAnalysis@2 task for windows CI jobs to continue even if an error is encountered.


### Motivation and Context
This is a temporary workaround that enables the `Windows_Packaging_CPU_x86_default` job within the Zip-Nuget-Java-NodeJS packaging pipeline to finish. A recent update to dotnet 6 has broken the PostAnalysis task for this job.

This task was originally added by https://github.com/microsoft/onnxruntime/pull/13694
