### PR TITLE
Unit test modification for TensorRT EP

### DIFF
--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -1842,7 +1842,8 @@ void TestAntialiasing(std::map<std::string, std::string> attributes,
   }
 
   test.AddOutput<T>("Y", output_shape, output_data);
-  test.Run(OpTester::ExpectResult::kExpectSuccess);
+  // TensorRT 8.5 supports operators up to Opset 17. Temporarily exclude TensorRT EP due to accurarcy issue.  
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(ResizeOpTest, Antialias_Bilinear_No_ExcludeOutside) {

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -894,7 +894,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_VITISAI=" + ("ON" if args.use_vitisai else "OFF"),
         "-Donnxruntime_USE_TENSORRT=" + ("ON" if args.use_tensorrt else "OFF"),
         "-Donnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS="
-        + ("ON" if args.test_all_timeout == "10800" else "OFF"),
+        + ("ON" if (args.test_all_timeout == "10800" and not args.use_tensorrt_builtin_parser)  else "OFF"),
         "-Donnxruntime_USE_TENSORRT_BUILTIN_PARSER=" + ("ON" if args.use_tensorrt_builtin_parser else "OFF"),
         "-Donnxruntime_TENSORRT_PLACEHOLDER_BUILDER=" + ("ON" if args.tensorrt_placeholder_builder else "OFF"),
         # set vars for TVM

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -500,11 +500,6 @@ def parse_arguments():
     )
     parser.add_argument("--tensorrt_home", help="Path to TensorRT installation dir")
     parser.add_argument("--test_all_timeout", default="10800", help="Set timeout for onnxruntime_test_all")
-    parser.add_argument(
-        "--skip_and_perform_filtered_tests",
-        action="store_true",
-        help="Skip time-consuming and only perform filtered tests for TensorRT EP",
-    )
     parser.add_argument("--use_migraphx", action="store_true", help="Build with MIGraphX")
     parser.add_argument("--migraphx_home", help="Path to MIGraphX installation dir")
     parser.add_argument("--use_full_protobuf", action="store_true", help="Use the full protobuf library")
@@ -894,7 +889,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_VITISAI=" + ("ON" if args.use_vitisai else "OFF"),
         "-Donnxruntime_USE_TENSORRT=" + ("ON" if args.use_tensorrt else "OFF"),
         "-Donnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS="
-        + ("ON" if (args.test_all_timeout == "10800" and not args.use_tensorrt_builtin_parser)  else "OFF"),
+        + ("ON" if (args.test_all_timeout == "10800" and not args.tensorrt_placeholder_builder)  else "OFF"),
         "-Donnxruntime_USE_TENSORRT_BUILTIN_PARSER=" + ("ON" if args.use_tensorrt_builtin_parser else "OFF"),
         "-Donnxruntime_TENSORRT_PLACEHOLDER_BUILDER=" + ("ON" if args.tensorrt_placeholder_builder else "OFF"),
         # set vars for TVM

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -889,7 +889,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_VITISAI=" + ("ON" if args.use_vitisai else "OFF"),
         "-Donnxruntime_USE_TENSORRT=" + ("ON" if args.use_tensorrt else "OFF"),
         "-Donnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS="
-        + ("ON" if (args.test_all_timeout == "10800" and not args.tensorrt_placeholder_builder)  else "OFF"),
+        + ("ON" if (args.test_all_timeout == "10800" and not args.tensorrt_placeholder_builder) else "OFF"),
         "-Donnxruntime_USE_TENSORRT_BUILTIN_PARSER=" + ("ON" if args.use_tensorrt_builtin_parser else "OFF"),
         "-Donnxruntime_TENSORRT_PLACEHOLDER_BUILDER=" + ("ON" if args.tensorrt_placeholder_builder else "OFF"),
         # set vars for TVM

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -889,7 +889,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_VITISAI=" + ("ON" if args.use_vitisai else "OFF"),
         "-Donnxruntime_USE_TENSORRT=" + ("ON" if args.use_tensorrt else "OFF"),
         "-Donnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS="
-        + ("ON" if (args.test_all_timeout == "10800" and not args.tensorrt_placeholder_builder) else "OFF"),
+        + ("ON" if not args.tensorrt_placeholder_builder else "OFF"),
         "-Donnxruntime_USE_TENSORRT_BUILTIN_PARSER=" + ("ON" if args.use_tensorrt_builtin_parser else "OFF"),
         "-Donnxruntime_TENSORRT_PLACEHOLDER_BUILDER=" + ("ON" if args.tensorrt_placeholder_builder else "OFF"),
         # set vars for TVM


### PR DESCRIPTION
Two modifications:

- After [TRT 8.5](https://github.com/microsoft/onnxruntime/pull/13867) being merged, we can manually set timeout and make TRT EP only run small portion of unit tests (`onnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS=ON`) due to additional TRT kernel overhead introduced by TRT 8.5 which increases test time a lot. This PR modifies the checking condition and make TensorRT CIs (can enable builder placeholder) still run most of the unit tests. 
- Exclude TRT EP from [Resize Opset 18](https://github.com/microsoft/onnxruntime/pull/13890) unit tests since TensorRT 8.5 supports operators up to Opset 17.