### PR TITLE
Add link to Python API examples

### DIFF
--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -204,7 +204,7 @@ You can also bind inputs and outputs directly to a PyTorch tensor.
 
     session.run_with_iobinding(binding)
     
-    You can also see code examples of this API in in the [ONNX RUntime inferences examples](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py).
+You can also see code examples of this API in in the [ONNX RUntime inferences examples](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py).
 
 
 API Details

--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -203,6 +203,8 @@ You can also bind inputs and outputs directly to a PyTorch tensor.
     )
 
     session.run_with_iobinding(binding)
+    
+    You can also see code examples of this API in in the [ONNX RUntime inferences examples](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py).
 
 
 API Details

--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -204,7 +204,7 @@ You can also bind inputs and outputs directly to a PyTorch tensor.
 
     session.run_with_iobinding(binding)
     
-You can also see code examples of this API in in the _`ONNX Runtime inferences examples <https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py>`_.
+You can also see code examples of this API in in the `ONNX Runtime inferences examples <https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py>`_.
 
 
 API Details

--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -204,7 +204,7 @@ You can also bind inputs and outputs directly to a PyTorch tensor.
 
     session.run_with_iobinding(binding)
     
-You can also see code examples of this API in in the `ONNX Runtime inferences examples <https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py>`.
+You can also see code examples of this API in in the _`ONNX Runtime inferences examples <https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py>`_.
 
 
 API Details

--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -204,7 +204,7 @@ You can also bind inputs and outputs directly to a PyTorch tensor.
 
     session.run_with_iobinding(binding)
     
-You can also see code examples of this API in in the [ONNX RUntime inferences examples](https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py).
+You can also see code examples of this API in in the `ONNX Runtime inferences examples <https://github.com/microsoft/onnxruntime-inference-examples/blob/main/python/api/onnxruntime-python-api.py>`.
 
 
 API Details


### PR DESCRIPTION
Fixes #10834

