### PR TITLE
Remove redundant Dynamo Python package

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps_lort.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps_lort.sh
@@ -46,17 +46,5 @@ echo "Building and installing Pytorch"
 VERBOSE=1 BUILD_LAZY_TS_BACKEND=1 /opt/python/cp39-cp39/bin/python3.9 setup.py install
 cd ~ && /opt/python/cp39-cp39/bin/python3.9 -c "import torch; print(f'Installed Pytorch: {torch.__version__}')"
 
-cd /usr/local/
-echo "Cloning TorchDynamo"
-git clone --recursive https://github.com/pytorch/torchdynamo.git
-cd torchdynamo
-echo "Installing TorchDynamo requirements"
-/opt/python/cp39-cp39/bin/python3.9 -m pip install transformers
-/opt/python/cp39-cp39/bin/python3.9 -m pip install -r requirements.txt
-echo "Installing TorchDynamo"
-/opt/python/cp39-cp39/bin/python3.9 setup.py install
-cd ~ && /opt/python/cp39-cp39/bin/python3.9 -c "import torch; print(f'Installed Pytorch: {torch.__version__}')"
-cd ~ && /opt/python/cp39-cp39/bin/python3.9 -c "import torchdynamo; print(f'Installed TorchDynamo: {torchdynamo.__path__}')"
-
 cd /
 rm -rf /tmp/src


### PR DESCRIPTION
torchdynamo is moved to torch._dynamo. Since torch is already installed in CI, we don't need to install torchdynamo again.