### PR TITLE
Remove intermedia obj files once build finished

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
@@ -209,6 +209,20 @@ jobs:
     displayName: cache stat
     condition: eq(${{ parameters.WITH_CACHE }}, true)
 
+  - powershell: |
+      Get-Volume D
+    displayName: check disk size
+
+  - task: DeleteFiles@1
+    displayName: 'Delete intermedia files from $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
+    inputs:
+      SourceFolder: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
+      Contents: |
+        **/*.obj
+
+  - powershell: |
+      Get-Volume D
+    displayName: check disk size
 
   - ${{ if eq(parameters.EnablePython, true) }}:
       - task: PythonScript@0

--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -146,7 +146,7 @@ stages:
         isTraining: true
         ORT_EP_NAME: CPU
         GenerateDocumentation: false
-        WITH_CACHE: false
+        WITH_CACHE: true
         MachinePool: 'onnxruntime-Win2019-CPU-training'
 
 - stage: training_x64_release


### PR DESCRIPTION
### Description
Remove intermedia obj files and reenable cache

### Motivation and Context
Recently, training_debug_x64 pipeline often failed due to not enough space.
It could free nearly 8G space by deleting obj files.
So, the compilation cache can be reenabled

