### PR TITLE
fix windows build error

### DIFF
--- a/onnxruntime/core/providers/cuda/test/greedy_search_top_one.cc
+++ b/onnxruntime/core/providers/cuda/test/greedy_search_top_one.cc
@@ -18,7 +18,7 @@ void FillAndShuffle(std::vector<float>& values, int32_t batch_size, int32_t voca
   std::mt19937 generator(rd());
   for (int32_t batch = 0; batch < batch_size; batch++) {
     for (int32_t vocab = 0; vocab < vocab_size; vocab++) {
-      values[batch * vocab_size + vocab] = vocab;
+      values[batch * vocab_size + vocab] = static_cast<float>(vocab);
     }
     std::shuffle(values.begin() + batch * vocab_size,
                  values.begin() + batch * vocab_size + vocab_size,


### PR DESCRIPTION
### Description
Fix https://github.com/microsoft/onnxruntime/issues/14359

test\greedy_search_top_one.cc(21,44): warning C4244: '=':
conversion from 'int32_t' to '_Ty', possible loss of data [C:\Users\11000978\onnxruntime\build\Windows\Debug\onnxrunti
me_providers_cuda.vcxproj]



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


