### PR TITLE
Revert "Allow PostAnalysis@2 task to continue on error for Windows_Pa…

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -279,14 +279,12 @@ jobs:
           msBuildCommandline: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe" "$(Build.BinariesDirectory)\Debug\onnxruntime.sln" /p:platform="$(MsbuildPlatform)" /p:configuration=Debug /p:VisualStudioVersion="16.0" /m /p:PreferredToolArchitecture=x64'
           excludedPaths: '$(Build.BinariesDirectory)#$(Build.SourcesDirectory)\cmake#C:\program files (x86)'
 
-      # TODO: continueOnError: true is a temporary workaround for Windows_Packaging_CPU_x86_default
       - task: PostAnalysis@2
         inputs:
           GdnBreakAllTools: false
           GdnBreakGdnToolBinSkim: true
           GdnBreakPolicy: M365
           GdnBreakPolicyMinSev: Error
-        continueOnError: true
 
       - task: TSAUpload@2
         displayName: 'TSA upload'


### PR DESCRIPTION
…ckaging_CPU_x86_default (#14332)"

This reverts commit a491f33f54b92264ac5059d1c0dd133d23c85dcd.

### Description


### Motivation and Context
It looks an ADO issue.
Now, it's recovered.
It could be reenabled.


