### PR TITLE
Run filtered unit tests for python package test pipelines for TRT EP due to significantly increased of test time 

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -734,9 +734,12 @@ endif()
 set(test_all_args)
 if (onnxruntime_USE_TENSORRT)
     if (onnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS)
-       # TRT EP package pipelines takes much longer time to run tests with TRT 8.5. We can't use placeholder to reduce testing time due to application test deadlock.
-       # Therefore we only run filtered TRT EP tests.
-      list(APPEND test_all_args "--gtest_filter=*tensorrt_*:*TensorrtExecutionProviderTest*" )
+      # Due to the size increase of TRT kernel library, the load time has increased from upgrading 8.4 -> 8.5 by a somewhat significant amount.
+      # This impacts every TRT EP test, especially the significant test time increase for gpu package pipeline which includes TRT EP 
+      # (we can't use builder placeholder to reduce test time for its deadlock issue found on Windows).
+      # Therefore we only run a portion of the tests for gpu package pipeline. But still we enable all the tests in regular CIs to avoid regressions.
+      list(APPEND test_all_args "--gtest_filter=*cpu_*:*cuda_*:*tensorrt_*:*TensorrtExecutionProviderTest*" )
+
       #list(APPEND test_all_args "--gtest_filter=-*cpu_*:*cuda_*:*ContribOpTest*:*QuantGemmTest*:*QLinearConvTest*:*MurmurHash3OpTest*:*PadOpTest*:*QLinearConvTest*" )
     else()
       # TRT EP CI takes much longer time when updating to TRT 8.2

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -736,7 +736,7 @@ if (onnxruntime_USE_TENSORRT)
     if (onnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS)
       # Due to the size increase of TRT kernel library, the load time has increased from upgrading 8.4 -> 8.5 by a somewhat significant amount.
       # This impacts every TRT EP test, especially the significant test time increase for gpu package pipeline which includes TRT EP 
-      # (we can't use builder placeholder to reduce test time for its deadlock issue found on Windows).
+      # (we can't use builder placeholder to reduce test time because of its deadlock issue found on Windows).
       # Therefore we only run a portion of the tests for gpu package pipeline. But still we enable all the tests in regular CIs to avoid regressions.
       list(APPEND test_all_args "--gtest_filter=*cpu_*:*cuda_*:*tensorrt_*:*TensorrtExecutionProviderTest*" )
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1756,7 +1756,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                         # we enable all the tests in regular CIs to avoid regressions.
                         run_subprocess(
                             [
-                                os.path.join(cwd, exe), 
+                                os.path.join(cwd, exe),
                                 "--gtest_filter=*cpu_*:*cuda_*:*tensorrt_*:*TensorrtExecutionProviderTest*",
                             ],
                             cwd=cwd,

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1751,7 +1751,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                         # upgrading 8.4 -> 8.5 by a somewhat significant amount.
                         # This impacts every TRT EP test, especially the significant test time increase
                         # for gpu package pipeline which includes TRT EP (we can't use builder placeholder
-                        # to reduce test time for its deadlock issue found on Windows).
+                        # to reduce test time because of its deadlock issue found on Windows).
                         # Therefore we only run a portion of the tests for gpu package pipeline. But still
                         # we enable all the tests in regular CIs to avoid regressions.
                         run_subprocess(

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1757,10 +1757,10 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                         run_subprocess(
                             [
                                 os.path.join(cwd, exe), 
-                                "--gtest_filter=*cpu_*:*cuda_*:*tensorrt_*:*TensorrtExecutionProviderTest*"
+                                "--gtest_filter=*cpu_*:*cuda_*:*tensorrt_*:*TensorrtExecutionProviderTest*",
                             ],
                             cwd=cwd,
-                            dll_path=dll_path
+                            dll_path=dll_path,
                         )
                     else:
                         run_subprocess([os.path.join(cwd, exe)], cwd=cwd, dll_path=dll_path)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1746,7 +1746,7 @@ def run_onnxruntime_tests(args, source_dir, ctest_path, build_dir, configs):
                     executables.append("onnxruntime_customopregistration_test")
 
                 for exe in executables:
-                    if args.use_tensorrt and not args.tensorrt_placeholder_builder: 
+                    if exe == "onnxruntime_test_all" and args.use_tensorrt and not args.tensorrt_placeholder_builder:
                         # Due to the size increase of TRT kernel library, the load time has increased from
                         # upgrading 8.4 -> 8.5 by a somewhat significant amount.
                         # This impacts every TRT EP test, especially the significant test time increase


### PR DESCRIPTION
This PR makes [ONNX Runtime Python Test Pipeline](https://dev.azure.com/aiinfra/Lotus/_build?definitionId=1164&_a=summary) perform filtered tests to reduce significant test time (double to almost 6 hours) due to TRT 8.5 library size increase that causes kernel loading time increase. 