### PR TITLE
Pin sphinx to avoid broken link

### DIFF
--- a/docs/python/inference/api_summary.rst
+++ b/docs/python/inference/api_summary.rst
@@ -210,7 +210,7 @@ API Details
 
 
 InferenceSession
-----------
+----------------
 
 .. autoclass:: onnxruntime.InferenceSession
     :members:

--- a/docs/python/inference/conf.py
+++ b/docs/python/inference/conf.py
@@ -16,7 +16,7 @@ import onnxruntime
 # -- Project information -----------------------------------------------------
 
 project = "ONNX Runtime"
-copyright = "2018-2021, Microsoft"
+copyright = "2018-2023, Microsoft"
 author = "Microsoft"
 version = onnxruntime.__version__
 release = version

--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -2,7 +2,7 @@ autopep8
 matplotlib
 scikit-learn
 skl2onnx
-sphinx
+sphinx==5.3.0
 sphinx-gallery
 sphinxcontrib.imagesvg
 sphinxcontrib.googleanalytics


### PR DESCRIPTION
The latest Sphinx version (6.1.3) is mis-generating the Python API docs, resulting in a link checker error. Pinning it to Sphinx 5.3.0 for now.


