### PR TITLE
`symbolic_shape_infer.py`: Fix slicing a tensor that has a sympy.Min() in its shape

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1644,6 +1644,35 @@ class SymbolicShapeInference:
         )
 
     def _infer_Slice(self, node):
+        # SymPy fails to prove that `x_0 + ... + x_n >= 0` if one of `x_i` is a `sympy.Min(a, b)`,
+        # even when the relation holds for both `a` and `b`.
+        #
+        # When given `expr` of form `min(a, b) + ...`, this function returns `[a + ..., b + ...]`,
+        # so that we can prove inequalities for both expressions separately.
+        #
+        # If the number of `min(...)` subexpressions is not exactly one, this function just returns `[expr]`.
+        def flatten_min(expr):
+            assert isinstance(expr, sympy.Add), f"Expected a sum of two arguments, got {expr}"
+            min_positions = [
+                idx
+                for idx in range(len(expr.args))
+                if isinstance(expr.args[idx], sympy.Min)
+            ]
+            if len(min_positions) == 1:
+                min_pos = min_positions[0]
+                def replace_min_with_arg(arg_idx):
+                    replaced = list(expr.args)
+                    assert isinstance(replaced[min_pos], sympy.Min), f"Expected a sympy.Min() at position {min_pos}, got {replaced[min_pos]}"
+                    assert len(replaced[min_pos].args) == 2, f"Expected a sympy.Min() with exactly 2 arguments, got {replaced[min_pos]}"
+                    replaced[min_pos] = replaced[min_pos].args[arg_idx]
+                    return sympy.Add(*replaced)
+
+                return [
+                    replace_min_with_arg(0),
+                    replace_min_with_arg(1),
+                ]
+            return [expr]
+
         def less_equal(x, y):
             try:
                 return bool(x <= y)
@@ -1661,7 +1690,7 @@ class SymbolicShapeInference:
                 return bool(-y <= -x)
             except TypeError:
                 # the last attempt; this may raise TypeError
-                return bool(y - x >= 0)
+                return all(bool(d >= 0) for d in flatten_min(y - x))
 
         def handle_negative_index(index, bound):
             """normalizes a negative index to be in [0, bound)"""

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -427,6 +427,41 @@ class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
     def test_flip_of_concat(self):
         self.check_slice_of_concat(["N", "N", "N"], "-one", "-intmax", "-one", "3*N")
 
+    def test_slice_of_min(self):
+        graph_input = onnx.helper.make_tensor_value_info("input", TensorProto.FLOAT, ["N"])
+        graph_output = onnx.helper.make_tensor_value_info("output", TensorProto.FLOAT, None)
+        const_size = 42
+        half_const_size = const_size // 2
+        initializers = [
+            onnx.helper.make_tensor("const_tensor", TensorProto.FLOAT, [const_size], [42.0] * const_size),
+            onnx.helper.make_tensor("half_const_size", TensorProto.INT64, [], [half_const_size]),
+            onnx.helper.make_tensor("zeros", TensorProto.INT64, [1], [0]),
+            onnx.helper.make_tensor("ones", TensorProto.INT64, [1], [1]),
+        ]
+
+        nodes = [
+            # Get the shape of the input tensor: `input_tensor_shape = [N]`.
+            onnx.helper.make_node("Shape", ["input"], ["input_tensor_shape"]),
+            # The starts of the const tensor slice: `starts = [21 - N + 1]`.
+            onnx.helper.make_node("Sub", ["half_const_size", "input_tensor_shape"], ["starts_aux"]),
+            onnx.helper.make_node("Add", ["ones", "starts_aux"], ["starts"]),
+            # The ends of the const tensor slice: `ends = [21 + N]`.
+            onnx.helper.make_node("Add", ["half_const_size", "input_tensor_shape"], ["ends"]),
+            # Slice the const tensor: `slice_out = const_tensor[starts:ends]`.
+            onnx.helper.make_node("Slice", ["const_tensor", "starts", "ends", "zeros", "ones"], ["slice_out"]),
+            # Crop the const tensor slice using the shape of the input tensor: `slice_out_cropped = slice_out[0:input_tensor_shape]`.
+            onnx.helper.make_node("Slice", ["slice_out", "zeros", "input_tensor_shape", "zeros", "ones"], ["slice_out_cropped"]),
+            # Add the const tensor slice to the input tensor: `output = input + slice_out_cropped`.
+            onnx.helper.make_node("Add", ["slice_out_cropped", "input"], ["output"]),
+        ]
+
+        graph_def = onnx.helper.make_graph(nodes, "SliceOfMin", [graph_input], [graph_output], initializer=initializers)
+        onnx.save(onnx.helper.make_model(graph_def), "slice_of_min.onnx")
+        model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
+        output_dims = unique_element(model.graph.output).type.tensor_type.shape.dim
+        self.assertEqual(len(output_dims), 1)
+        self.assertEqual(output_dims[0].dim_param, "N")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

`_infer_Slice()` is a function (arguably the most complex one) in `symbolic_shape_infer.py` that infers the shape of the output of a `Slice` node. This commit fixes an edge case in `_infer_Slice()` caused by a SymPy quirk.

When both the end of the slice (let's call it `e`) and the corresponding dimension of the sliced tensor (let's call it `dim`) are arbitrary symbolic expressions, `symbolic_shape_infer.py` [checks](https://github.com/microsoft/onnxruntime/blob/de7a868d5f3390d7c095a53c26abd39f402f3f93/onnxruntime/python/tools/symbolic_shape_infer.py#L1728) if `e <= dim`. Comparing symbolic expressions is hard in general, so if the comparison fails, `symbolic_shape_infer.py` [gives up](https://github.com/microsoft/onnxruntime/blob/de7a868d5f3390d7c095a53c26abd39f402f3f93/onnxruntime/python/tools/symbolic_shape_infer.py#L1734) and assumes that `e` is equal to `dim`.

A failure of this sort currently happens for expressions of the form `Y - X >= 0` where `Y` contains a `sympy.Min()` (`symbolic_shape_infer.py` tries to rewrite `X <= Y` comparisons in various ways, and `Y - X >= 0` is [one of them](https://github.com/microsoft/onnxruntime/blob/de7a868d5f3390d7c095a53c26abd39f402f3f93/onnxruntime/python/tools/symbolic_shape_infer.py#L1664)). An simple example to illustrate this:
```python
>>> import sympy
>>> X = sympy.Symbol('X', positive=True, integer=True)
>>> 
>>> y1 = 9999
>>> Y1 = X + y1 - 5000
>>> bool(Y1 - X >= 0)
True
>>> 
>>> y2 = X + 4999
>>> Y2 = X + y2 - 5000
>>> bool(Y2 - X >= 0)
True
>>> 
>>> y3 = sympy.Min(y1, y2)
>>> Y3 = X + y3 - 5000
>>> bool(Y3 - X >= 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../venv/lib/python3.9/site-packages/sympy/core/relational.py", line 511, in __bool__
    raise TypeError("cannot determine truth value of Relational")
TypeError: cannot determine truth value of Relational
```

If you assume that `X` is positive symbol (`symbolic_shape` [does assume](https://github.com/microsoft/onnxruntime/blob/de7a868d5f3390d7c095a53c26abd39f402f3f93/onnxruntime/python/tools/symbolic_shape_infer.py#L2129) this for graph inputs), then both `Y1 >= X` and `Y2 >= X` holds, and SymPy can prove this. This means that `Y3 >= X` also holds (since `Y3` is essentially equal to either `Y1` or `Y2`, depending on the value of `X`), but this is too hard for SymPy to prove. I confirmed that this is still the case for the latest SymPy version (`1.11.1`).

This commit tries to fix this edge case by slightly rewriting the expression containing `sympy.Min()`. I explain the details in the comments in `symbolic_shape_infer.py`, so I won't duplicate them in the PR description.

### Motivation and Context
This sounds like a very contrived example, but it actually appeared in the wild when we tried to infer shapes for an ONNX graph exported from PyTorch that used relative-position multihead attention from Fairseq. The problematic line is [here](https://github.com/facebookresearch/fairseq/blob/7d050ada7d365b535bf7c634ed3bcaf1cc2930b1/fairseq/modules/espnet_multihead_attention.py#L192). In our codebase, we have something like `matrix_bd = matrix_bd[:, :, :, : matrix_ac.size(-1)]` before we add `matrix_ac` and `matrix_bd`. `matrix_bd` is itself a result of another slice, hence its shape contains `sympy.Min()`, and the SymPy weirdness described above prevents `symbolic_shape_infer.py` from correctly inferring the final shape of `matrix_bd`. Then `symbolic_shape_infer.py` explodes when we try to add `matrix_ac` and `matrix_bd`, because their shapes are not compatible.

I added a small self-contained unit test to illustrate the problem. *Without* the fix, `slice_out_cropped` has shape `[N + Min(42, N + 21) - 22]`, and `input` has shape `[N]`, and we get this:
```
> python onnxruntime_test_python_symbolic_shape_infer.py
..................Cannot determine if 22 - N < 0
Unable to determine if N <= N + Min(42, N + 21) - 22, treat as equal
E....
======================================================================
ERROR: test_slice_of_min (__main__.TestSymbolicShapeInferenceForSlice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dfyz/onnxruntime/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py", line 460, in test_slice_of_min
    model = SymbolicShapeInference.infer_shapes(onnx.helper.make_model(graph_def))
  File "/home/dfyz/onnxruntime/onnxruntime/test/python/../../python/tools/symbolic_shape_infer.py", line 2461, in infer_shapes
    raise Exception("Incomplete symbolic shape inference")
Exception: Incomplete symbolic shape inference

----------------------------------------------------------------------
Ran 23 tests in 0.486s

FAILED (errors=1)
```

*With* the fix, both tensors have shape `[N]`, and the test passes.