### PR TITLE
Fix CI build with no Abseil.

### DIFF
--- a/onnxruntime/core/optimizer/attention_fusion_helper.h
+++ b/onnxruntime/core/optimizer/attention_fusion_helper.h
@@ -1543,7 +1543,7 @@ bool FuseGptAttention(Node& layer_norm, Graph& graph, int64_t hidden_size, std::
       kMSDomain);
   attention_node.AddAttribute("num_heads", num_heads);
   attention_node.AddAttribute("unidirectional", static_cast<int64_t>(unidir_mask_result.is_unidirectional));
-  if (mask_nodes.mask_filter_value != -10000.0f or unidir_mask_result.mask_filter_value != -10000.0f) {
+  if (mask_nodes.mask_filter_value != -10000.0f || unidir_mask_result.mask_filter_value != -10000.0f) {
     float mask_filter_value = mask_nodes.mask_filter_value != -10000.0f ?
                               mask_nodes.mask_filter_value : unidir_mask_result.mask_filter_value;
     attention_node.AddAttribute("mask_filter_value", mask_filter_value);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use '||' instead of 'or' in onnxruntime/core/optimizer/attention_fusion_helper.h.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix CI build with no Abseil.

https://learn.microsoft.com/en-us/cpp/cpp/logical-or-operator-pipe-pipe?view=msvc-170#operator-keyword-for-

"In Microsoft C++, the [/permissive-](https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170) or [/Za](https://learn.microsoft.com/en-us/cpp/build/reference/za-ze-disable-language-extensions?view=msvc-170) compiler option is required to enable the alternative spelling."

Simple fix is to just use '||' instead.