### PR TITLE
Objective-C lib: Added support for int64 and uint64.

### DIFF
--- a/objectivec/include/ort_enums.h
+++ b/objectivec/include/ort_enums.h
@@ -36,6 +36,8 @@ typedef NS_ENUM(int32_t, ORTTensorElementDataType) {
   ORTTensorElementDataTypeUInt8,
   ORTTensorElementDataTypeInt32,
   ORTTensorElementDataTypeUInt32,
+  ORTTensorElementDataTypeInt64,
+  ORTTensorElementDataTypeUInt64,
 };
 
 /**

--- a/objectivec/src/ort_enums.mm
+++ b/objectivec/src/ort_enums.mm
@@ -51,6 +51,8 @@ constexpr TensorElementTypeInfo kElementTypeInfos[]{
     {ORTTensorElementDataTypeUInt8, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, sizeof(uint8_t)},
     {ORTTensorElementDataTypeInt32, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, sizeof(int32_t)},
     {ORTTensorElementDataTypeUInt32, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32, sizeof(uint32_t)},
+    {ORTTensorElementDataTypeInt64, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, sizeof(int64_t)},
+    {ORTTensorElementDataTypeUInt64, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, sizeof(uint64_t)},
 };
 
 struct GraphOptimizationLevelInfo {


### PR DESCRIPTION
### Description
Added support for int64 and uint64 in Objective-C lib.

### Motivation and Context
Int64 is rarely used, but we needed it. The Int64 inference worked after the change (tested).