### PR TITLE
Update ORT format v5 change docs to cover limited backwards compatibility in 1.14.

### DIFF
--- a/docs/ORT_Format_Update_in_1.13.md
+++ b/docs/ORT_Format_Update_in_1.13.md
@@ -1,12 +1,27 @@
 # ORT Format Update in 1.13
 
 In ONNX Runtime 1.13, there was a breaking change to the
-[ORT format](https://onnxruntime.ai/docs/reference/ort-format-models.html) in order to enable additional execution
-providers with statically registered kernels in a minimal build.
+[ORT format](https://onnxruntime.ai/docs/reference/ort-format-models.html) (version 5) in order to enable additional
+execution providers with statically registered kernels in a minimal build.
 More details can be found [here](../onnxruntime/core/flatbuffers/schema/README.md#version-5).
 
-Unfortunately, this means that any older models (prior to ORT format version 5) will no longer work with ONNX Runtime
-1.13 or later and must be re-converted.
+## Backwards Compatibility
+
+### ONNX Runtime 1.13
+Any older models (prior to ORT format version 5) will no longer work with ONNX Runtime 1.13 and must be re-converted.
+
+### ONNX Runtime 1.14+
+ONNX Runtime 1.14+ provides limited backwards compatibility for loading older models (prior to ORT format version 5).
+- In a full build, older models may be loaded but any saved runtime optimizations will be ignored.
+- In a minimal build, older models cannot be loaded.
+
+An older model may be re-converted.
+
+It is also possible to load an older ORT format model in a full build and then save it back out as an ORT format model.
+This process may be used to upgrade an ORT format model. However, any saved runtime optimizations from the older model
+will be ignored.
+
+## Re-converting an ORT format model
 Please refer
 [here](https://onnxruntime.ai/docs/reference/ort-format-models.html#convert-onnx-models-to-ort-format) for instructions
 on how to convert an ONNX model to ORT format.

--- a/onnxruntime/core/flatbuffers/schema/README.md
+++ b/onnxruntime/core/flatbuffers/schema/README.md
@@ -50,10 +50,10 @@ Support for storing `graph_doc_string` field in Model (ORT FlatBuffers format).
 Update kernel def hashing to not depend on ordering of type constraint types (NOT BACKWARDS COMPATIBLE).
 
 ## Version 5
-Deprecate kernel def hashes and add KernelTypeStrResolver info to replace them (NOT BACKWARDS COMPATIBLE).
-The change to the ORT format itself is not backwards compatibility-breaking, but ORT does not provide backwards
+Remove kernel def hashes and add KernelTypeStrResolver info to replace them (LIMITED BACKWARDS COMPATIBILITY).
+The change to the ORT format itself is not backwards compatibility-breaking, but ORT provides limited backwards
 compatibility for processing older models with missing KernelTypeStrResolver info.
 
 The motivation for this update is to support additional execution providers with statically registered kernels.
-The original approach of using kernel def hashes is not so extensible as it requires the execution provider providing
+The original approach of using kernel def hashes was not so extensible as it required the execution provider providing
 hashes to be enabled at model conversion time.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1015,7 +1015,7 @@ Status InferenceSession::LoadOrtModelWithLoader(std::function<Status()> load_ort
   // TODO This change was introduced in 1.13. Remove this note a few releases later, e.g., 1.15.
   constexpr auto* kOrtFormatVersion5BreakingChangeNote =
       "This build doesn't support ORT format models older than version 5. "
-      "See: https://github.com/microsoft/onnxruntime/blob/rel-1.13.0/docs/ORT_Format_Update_in_1.13.md";
+      "See: https://github.com/microsoft/onnxruntime/blob/rel-1.14.0/docs/ORT_Format_Update_in_1.13.md";
 
   ORT_RETURN_IF(!is_supported,
                 "The ORT format model version [", fbs_ort_model_version->string_view(),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update ORT format v5 change docs to cover limited backwards compatibility in 1.14.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Document limited backwards compatibility for older ORT format models added since 1.13.
