### PR TITLE
Fix a bug in t5 beamsearch with half precision

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search.cc
@@ -245,7 +245,7 @@ Status BeamSearch::Compute(OpKernelContext* ctx) const {
         init_beam_state_fp16_func_,
         device_copy_func_,
         device_copy_int32_func_,
-        create_encoder_inputs_func_,
+        create_encoder_inputs_func_ ? create_encoder_inputs_func_ : GenerationCpuDeviceHelper::CreateEncoderInputs,
         update_decoder_feeds_fp16_func_,
         expand_buffer_int32_func_,
         expand_buffer_float_func_,


### PR DESCRIPTION
the CreateEncoderInputs functor was passed to the ctor as nullptr when type is MLFloat16.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


