### PR TITLE
Fix `ValueError` when testing PyTorch performance

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -1850,7 +1850,7 @@ def test_torch_performance(
             num_return_sequences=args.num_return_sequences,
             length_penalty=args.length_penalty,
             repetition_penalty=args.repetition_penalty,
-            bad_words_ids=bad_words_ids,
+            bad_words_ids=bad_words_ids if bad_words_ids else None,
             return_dict_in_generate=True,
             output_scores=args.output_sequences_scores or args.output_token_scores,
         )


### PR DESCRIPTION
### Description
Fixed an exception that is thrown inside `transformers` when trying to test PyTorch performance:
```
> python convert_generation.py -m gpt2 --output gpt2_greedy_search.onnx --num_beams 1 --num_return_sequences 1 --torch_performance
[...]
Torch and ORT result is  same                                                                                                                                   
Traceback (most recent call last):                                                                                                                              
  File ".../onnxruntime/python/tools/transformers/convert_generation.py", line 2329, in <module>                                             
    main()                                                                                                                                                      
  File ".../onnxruntime/python/tools/transformers/convert_generation.py", line 2317, in main                                                 
    result = test_gpt_model(args, sentences=sentences, is_greedy=is_greedy)                                                                                     
  File ".../onnxruntime/python/tools/transformers/convert_generation.py", line 2063, in test_gpt_model                                       
    torch_latency_output = test_torch_performance(                                                                                                              
  File ".../onnxruntime/python/tools/transformers/convert_generation.py", line 1840, in test_torch_performance                               
    _ = model.generate(                                                                                                                                         
  File ".../venv/lib/python3.9/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context                                         
    return func(*args, **kwargs)                                                                                                                                
  File ".../venv/lib/python3.9/site-packages/transformers/generation/utils.py", line 1481, in generate                                          
    logits_processor = self._get_logits_processor(                                                                                                              
  File ".../venv/lib/python3.9/site-packages/transformers/generation/utils.py", line 846, in _get_logits_processor                              
    processors.append(NoBadWordsLogitsProcessor(bad_words_ids, eos_token_id))                                                                                   
  File ".../venv/lib/python3.9/site-packages/transformers/generation/logits_process.py", line 405, in __init__                                      raise ValueError(f"`bad_words_ids` has to be a non-empty list, but is {bad_words_ids}.")                                                                    
ValueError: `bad_words_ids` has to be a non-empty list, but is [].
```

### Motivation and Context
`transformers` uses a somewhat weird API where you either have to pass `None` or a non-empty list as `bad_words_id`. There's three places in `convert_generation.py` which call `model.generate()` on a `transformers` model using `bad_words_id`. Two of them correctly convert an empty list to `None` ([1](https://github.com/microsoft/onnxruntime/blob/4ef64f3681819924b93d9b844ab847d2eb4b4fad/onnxruntime/python/tools/transformers/convert_generation.py#L1941), [2](https://github.com/microsoft/onnxruntime/blob/4ef64f3681819924b93d9b844ab847d2eb4b4fad/onnxruntime/python/tools/transformers/convert_generation.py#L2154)), but the one inside `test_torch_performance()` doesn't.

