### PR TITLE
Fix build errors (warnings as errors) with clang-15

### DIFF
--- a/orttraining/orttraining/models/mnist/mnist_data_provider.cc
+++ b/orttraining/orttraining/models/mnist/mnist_data_provider.cc
@@ -23,14 +23,14 @@ pair<vector<vector<float>>, vector<vector<float>>> NormalizeData(const vector<Im
         normalized_image[j] = 1.0f;
       }
     }
-    normalized_images.emplace_back(move(normalized_image));
+    normalized_images.emplace_back(std::move(normalized_image));
   }
 
   vector<vector<float>> one_hot_labels;
   for (size_t i = 0; i < labels.size(); i++) {
     vector<float> one_hot_label(10, 0.0f);
     one_hot_label[labels[i]] = 1.0f;  //one hot
-    one_hot_labels.emplace_back(move(one_hot_label));
+    one_hot_labels.emplace_back(std::move(one_hot_label));
   }
   return make_pair(normalized_images, one_hot_labels);
 }

--- a/orttraining/orttraining/models/runner/training_util.cc
+++ b/orttraining/orttraining/models/runner/training_util.cc
@@ -36,7 +36,7 @@ common::Status DataSet::AddData(DataSet::SampleType&& single_sample) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "DataSet::AddData failed");
   }
 
-  data_.emplace_back(move(single_sample));
+  data_.emplace_back(std::move(single_sample));
   return Status::OK();
 }
 
@@ -59,7 +59,7 @@ common::Status DataSet::AddData(const vector<ONNX_NAMESPACE::TensorProto>& featu
     ortvalue_buffers_.emplace_back(std::move(buffer));
   }
 
-  data_.emplace_back(move(sample));
+  data_.emplace_back(std::move(sample));
   return Status::OK();
 }
 


### PR DESCRIPTION
### Description
Compiling with clang-15 results in the following `-Wunqualified-std-cast-call` warnings (as errors) 
```
orttraining/orttraining/models/mnist/mnist_data_provider.cc:26:36: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    normalized_images.emplace_back(move(normalized_image));
                                   ^
                                   std::
orttraining/orttraining/models/mnist/mnist_data_provider.cc:33:33: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
    one_hot_labels.emplace_back(move(one_hot_label));
                                ^
                                std::

orttraining/orttraining/models/runner/training_util.cc:39:22: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  data_.emplace_back(move(single_sample));
                     ^
                     std::
orttraining/orttraining/models/runner/training_util.cc:62:22: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  data_.emplace_back(move(sample));
                     ^
                     std::
```

