### PR TITLE
Use ORT node names in DML graphs/ops

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -292,7 +292,8 @@ namespace DmlGraphFusionHelper
     {
         for (size_t i = 0; i < graphDesc.nodes.size(); ++i)
         {
-            dmlOperatorGraphNodes[i] = DML_OPERATOR_GRAPH_NODE_DESC{graphDesc.nodes[i].op.Get()};
+            auto& nodeInfo = graphDesc.nodes[i];
+            dmlOperatorGraphNodes[i] = DML_OPERATOR_GRAPH_NODE_DESC{nodeInfo.op.Get(), nodeInfo.name.data()};
             dmlGraphNodes[i] = DML_GRAPH_NODE_DESC{DML_GRAPH_NODE_TYPE_OPERATOR, &dmlOperatorGraphNodes[i]};
         }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.cpp
@@ -361,6 +361,7 @@ namespace Dml::GraphDescBuilder
 
                     NodeInfo nodeInfo = {};
                     nodeInfo.op = std::move(op);
+                    nodeInfo.name = node.Name();
                     graphNodes.push_back(std::move(nodeInfo));
                 }
             }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphDescBuilder.h
@@ -28,6 +28,7 @@ namespace Dml
         struct NodeInfo
         {
             Microsoft::WRL::ComPtr<IDMLOperator> op;
+            std::string name;
         };
 
         struct GraphDesc

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1015,7 +1015,7 @@ namespace Windows::AI::MachineLearning::Adapter
             return sizeof(wchar_t);
         }
         
-        int requiredSizeInChars = MultiByteToWideChar(CP_UTF8, 0, name.data(), name.size(), nullptr, 0);
+        int requiredSizeInChars = MultiByteToWideChar(CP_UTF8, 0, name.data(), static_cast<int>(name.size()), nullptr, 0);
         assert(requiredSizeInChars > 0);
 
         // Include null terminator.
@@ -1038,7 +1038,7 @@ namespace Windows::AI::MachineLearning::Adapter
         }
 
         uint32_t bufferSizeInChars = bufferSizeInBytes / sizeof(wchar_t);
-        int charsCopiedIfSucceeded = MultiByteToWideChar(CP_UTF8, 0, nodeName.data(), nodeName.size(), outputName, bufferSizeInChars);
+        int charsCopiedIfSucceeded = MultiByteToWideChar(CP_UTF8, 0, nodeName.data(), static_cast<int>(nodeName.size()), outputName, bufferSizeInChars);
 
         if (charsCopiedIfSucceeded > 0)
         {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -982,7 +982,7 @@ namespace Windows::AI::MachineLearning::Adapter
         m_abiExecutionObject.CopyTo(executionInterface);
     }
 
-    uint32_t STDMETHODCALLTYPE OpKernelInfoWrapper::GetUtf8NameSizeInBytes() const noexcept
+    uint32_t STDMETHODCALLTYPE OpKernelInfoWrapper::GetUtf8NameBufferSizeInBytes() const noexcept
     {
         // Include null terminator.
         return static_cast<uint32_t>(m_impl->node().Name().size() + 1);
@@ -1006,7 +1006,7 @@ namespace Windows::AI::MachineLearning::Adapter
         return S_OK;
     }
 
-    uint32_t STDMETHODCALLTYPE OpKernelInfoWrapper::GetWideNameSizeInBytes() const noexcept
+    uint32_t STDMETHODCALLTYPE OpKernelInfoWrapper::GetWideNameBufferSizeInBytes() const noexcept
     {
         const auto& name = m_impl->node().Name(); 
         if (name.empty())

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -331,7 +331,7 @@ class OnnxTensorWrapper : public WRL::Base<IMLOperatorTensor>, public Closable
 class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     onnxruntime::ProtoHelperNodeContext,
     WRL::Base<
-        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
+        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate1, IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
         IMLOperatorTensorShapeDescription, IMLOperatorAttributes1>,
     onnxruntime::null_type>
 {
@@ -373,6 +373,12 @@ class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     {
         return E_NOTIMPL;
     }
+
+    uint32_t STDMETHODCALLTYPE GetUtf8NameSizeInBytes() const noexcept override;
+    HRESULT STDMETHODCALLTYPE GetUtf8Name(uint32_t bufferSizeInBytes, char* name) const noexcept override;
+
+    uint32_t STDMETHODCALLTYPE GetWideNameSizeInBytes() const noexcept override;
+    HRESULT STDMETHODCALLTYPE GetWideName(uint32_t bufferSizeInBytes, wchar_t* name) const noexcept override;
 
 private:
     // For shape info, in addition to the info

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -374,12 +374,12 @@ class OpKernelInfoWrapper : public OpNodeInfoWrapper<
         return E_NOTIMPL;
     }
 
-    // IMLOperatorKernelCreationContextNonGraphNode methods.
+    // IMLOperatorKernelCreationContextNodeWrapperPrivate methods.
 
-    uint32_t STDMETHODCALLTYPE GetUtf8NameSizeInBytes() const noexcept override;
+    uint32_t STDMETHODCALLTYPE GetUtf8NameBufferSizeInBytes() const noexcept override;
     HRESULT STDMETHODCALLTYPE GetUtf8Name(uint32_t bufferSizeInBytes, char* name) const noexcept override;
 
-    uint32_t STDMETHODCALLTYPE GetWideNameSizeInBytes() const noexcept override;
+    uint32_t STDMETHODCALLTYPE GetWideNameBufferSizeInBytes() const noexcept override;
     HRESULT STDMETHODCALLTYPE GetWideName(uint32_t bufferSizeInBytes, wchar_t* name) const noexcept override;
 
 private:

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -331,7 +331,7 @@ class OnnxTensorWrapper : public WRL::Base<IMLOperatorTensor>, public Closable
 class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     onnxruntime::ProtoHelperNodeContext,
     WRL::Base<
-        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate1, IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
+        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
         IMLOperatorTensorShapeDescription, IMLOperatorAttributes1>,
     onnxruntime::null_type>
 {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -331,8 +331,8 @@ class OnnxTensorWrapper : public WRL::Base<IMLOperatorTensor>, public Closable
 class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     onnxruntime::ProtoHelperNodeContext,
     WRL::Base<
-        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
-        IMLOperatorTensorShapeDescription, IMLOperatorAttributes1, IMLOperatorKernelCreationContextNodeWrapperPrivate>,
+        Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextNodeWrapperPrivate, IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
+        IMLOperatorTensorShapeDescription, IMLOperatorAttributes1>,
     onnxruntime::null_type>
 {
  public:

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.h
@@ -332,7 +332,7 @@ class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     onnxruntime::ProtoHelperNodeContext,
     WRL::Base<
         Microsoft::WRL::ChainInterfaces<IMLOperatorKernelCreationContextPrivate, IMLOperatorKernelCreationContext>,
-        IMLOperatorTensorShapeDescription, IMLOperatorAttributes1>,
+        IMLOperatorTensorShapeDescription, IMLOperatorAttributes1, IMLOperatorKernelCreationContextNodeWrapperPrivate>,
     onnxruntime::null_type>
 {
  public:
@@ -373,6 +373,8 @@ class OpKernelInfoWrapper : public OpNodeInfoWrapper<
     {
         return E_NOTIMPL;
     }
+
+    // IMLOperatorKernelCreationContextNonGraphNode methods.
 
     uint32_t STDMETHODCALLTYPE GetUtf8NameSizeInBytes() const noexcept override;
     HRESULT STDMETHODCALLTYPE GetUtf8Name(uint32_t bufferSizeInBytes, char* name) const noexcept override;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -89,6 +89,11 @@ namespace Dml
         {
             DML_EXECUTION_FLAGS executionFlags = GetExecutionFlags();
             ORT_THROW_IF_FAILED(m_dmlDevice->CompileOperator(dmlOperator.Get(), executionFlags, IID_PPV_ARGS(&m_compiledOperator)));
+            
+            // Static buffer (might truncate name) to avoid excessive dynamic allocation only for debugging purposes.
+            wchar_t nodeName[512];
+            ORT_THROW_IF_FAILED(kernelInfo.GetInterfacePrivate()->GetWideName(sizeof(nodeName), nodeName));
+            ORT_THROW_IF_FAILED(m_compiledOperator->SetName(nodeName));
 
             UINT64 persistentResourceSize = m_compiledOperator->GetBindingProperties().PersistentResourceSize;
             if (persistentResourceSize > 0)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -92,7 +92,7 @@ namespace Dml
             
             // Static buffer (might truncate name) to avoid excessive dynamic allocation only for debugging purposes.
             wchar_t nodeName[512];
-            ORT_THROW_IF_FAILED(kernelInfo.GetInterfacePrivate()->GetWideName(sizeof(nodeName), nodeName));
+            ORT_THROW_IF_FAILED(kernelInfo.GetNodeWrapperInterface()->GetWideName(sizeof(nodeName), nodeName));
             ORT_THROW_IF_FAILED(m_compiledOperator->SetName(nodeName));
 
             UINT64 persistentResourceSize = m_compiledOperator->GetBindingProperties().PersistentResourceSize;

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
@@ -494,6 +494,11 @@ public:
         return m_impl;
     }
 
+    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate1> GetInterfacePrivate() const noexcept
+    {
+        return m_implPrivate;
+    }
+
     Microsoft::WRL::ComPtr<IUnknown> GetExecutionInterface() const noexcept
     {
         Microsoft::WRL::ComPtr<IUnknown> ret;
@@ -556,7 +561,7 @@ public:
 
  private:
     Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContext> m_impl;
-    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate> m_implPrivate;
+    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate1> m_implPrivate;
 };
 
 class MLShapeInferenceContext : public MLOperatorAttributes

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
@@ -486,6 +486,7 @@ public:
     MLOperatorKernelCreationContext(IMLOperatorKernelCreationContext* impl) : MLOperatorAttributes(impl), m_impl(impl)
     {
         m_impl.As(&m_implPrivate);
+        m_impl.As(&m_nodeWrapperImpl);
     }
 
     // For cases of interop where the caller needs to pass the unwrapped class across a boundary.
@@ -494,9 +495,9 @@ public:
         return m_impl;
     }
 
-    IMLOperatorKernelCreationContextPrivate* GetInterfacePrivate() const noexcept
+    IMLOperatorKernelCreationContextNodeWrapperPrivate* GetNodeWrapperInterface() const noexcept
     {
-        return m_implPrivate.Get();
+        return m_nodeWrapperImpl.Get();
     }
 
     Microsoft::WRL::ComPtr<IUnknown> GetExecutionInterface() const noexcept
@@ -562,6 +563,7 @@ public:
  private:
     Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContext> m_impl;
     Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate> m_implPrivate;
+    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextNodeWrapperPrivate> m_nodeWrapperImpl;
 };
 
 class MLShapeInferenceContext : public MLOperatorAttributes

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorHelper.h
@@ -494,9 +494,9 @@ public:
         return m_impl;
     }
 
-    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate1> GetInterfacePrivate() const noexcept
+    IMLOperatorKernelCreationContextPrivate* GetInterfacePrivate() const noexcept
     {
-        return m_implPrivate;
+        return m_implPrivate.Get();
     }
 
     Microsoft::WRL::ComPtr<IUnknown> GetExecutionInterface() const noexcept
@@ -561,7 +561,7 @@ public:
 
  private:
     Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContext> m_impl;
-    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate1> m_implPrivate;
+    Microsoft::WRL::ComPtr<IMLOperatorKernelCreationContextPrivate> m_implPrivate;
 };
 
 class MLShapeInferenceContext : public MLOperatorAttributes

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -57,6 +57,30 @@ IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContex
     ) const noexcept PURE;
 };
 
+interface __declspec(uuid("1d2e1226-a918-4236-8775-175cf1f52c9a"))
+IMLOperatorKernelCreationContextPrivate1 : public IMLOperatorKernelCreationContextPrivate 
+{
+    //! Gets the minimum size of a char buffer to store the node name (including null terminator).
+    //! Returns 0 if the node has no name.
+    STDMETHOD_(uint32_t, GetUtf8NameSizeInBytes)() const noexcept PURE;
+ 
+    //! Writes the node name and null terminator into a char buffer.
+    STDMETHOD(GetUtf8Name)(
+        uint32_t bufferSizeInBytes,
+        _Out_writes_(bufferSizeInBytes) char* name
+        ) const noexcept PURE;
+
+    //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
+    //! Returns 0 if the node has no name.
+    STDMETHOD_(uint32_t, GetWideNameSizeInBytes)() const noexcept PURE;
+
+    //! Writes the node name and null terminator into a wchar buffer.
+    STDMETHOD(GetWideName)(
+        uint32_t bufferSizeInBytes,
+        _Out_writes_(bufferSizeInBytes) wchar_t* name
+        ) const noexcept PURE;
+};
+
 //! \interface IMLOperatorAttributes1
 //! \brief Represents the values of an operator's attributes, as determined by a model using the operator.
 //! This interface is called by implementations of custom operator kernels, and by implementations

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -62,7 +62,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
 {
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
     //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).
-    STDMETHOD_(uint32_t, GetUtf8NameSizeInBytes)() const noexcept PURE;
+    STDMETHOD_(uint32_t, GetUtf8NameBufferSizeInBytes)() const noexcept PURE;
  
     //! Writes the node name and null terminator into a char buffer.
     STDMETHOD(GetUtf8Name)(
@@ -72,7 +72,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
     //! Returns sizeof(wchar_t) if the node has no name (calling GetWideName will write a null terminator).
-    STDMETHOD_(uint32_t, GetWideNameSizeInBytes)() const noexcept PURE;
+    STDMETHOD_(uint32_t, GetWideNameBufferSizeInBytes)() const noexcept PURE;
 
     //! Writes the node name and null terminator into a wchar buffer.
     STDMETHOD(GetWideName)(

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -58,7 +58,7 @@ IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContex
 };
 
 interface __declspec(uuid("1d2e1226-a918-4236-8775-175cf1f52c9a"))
-IMLOperatorKernelCreationContextNodeWrapperPrivate : public IUnknown
+IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCreationContextPrivate
 {
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
     //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -55,7 +55,11 @@ IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContex
     STDMETHOD(SetDmlOperator)(
         _In_ const MLOperatorGraphDesc* operatorGraphDesc
     ) const noexcept PURE;
+};
 
+interface __declspec(uuid("1d2e1226-a918-4236-8775-175cf1f52c9a"))
+IMLOperatorKernelCreationContextNodeWrapperPrivate : public IUnknown
+{
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
     //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).
     STDMETHOD_(uint32_t, GetUtf8NameSizeInBytes)() const noexcept PURE;
@@ -67,7 +71,7 @@ IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContex
         ) const noexcept PURE;
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
-    //! Returns sizeof(wchar_t) if the node has no name (calling GetWideName will write a single null terminator).
+    //! Returns sizeof(wchar_t) if the node has no name (calling GetWideName will write a null terminator).
     STDMETHOD_(uint32_t, GetWideNameSizeInBytes)() const noexcept PURE;
 
     //! Writes the node name and null terminator into a wchar buffer.

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -55,13 +55,9 @@ IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContex
     STDMETHOD(SetDmlOperator)(
         _In_ const MLOperatorGraphDesc* operatorGraphDesc
     ) const noexcept PURE;
-};
 
-interface __declspec(uuid("1d2e1226-a918-4236-8775-175cf1f52c9a"))
-IMLOperatorKernelCreationContextPrivate1 : public IMLOperatorKernelCreationContextPrivate 
-{
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
-    //! Returns 0 if the node has no name.
+    //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).
     STDMETHOD_(uint32_t, GetUtf8NameSizeInBytes)() const noexcept PURE;
  
     //! Writes the node name and null terminator into a char buffer.
@@ -71,7 +67,7 @@ IMLOperatorKernelCreationContextPrivate1 : public IMLOperatorKernelCreationConte
         ) const noexcept PURE;
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
-    //! Returns 0 if the node has no name.
+    //! Returns sizeof(wchar_t) if the node has no name (calling GetWideName will write a single null terminator).
     STDMETHOD_(uint32_t, GetWideNameSizeInBytes)() const noexcept PURE;
 
     //! Writes the node name and null terminator into a wchar buffer.


### PR DESCRIPTION
### Description
Applies ORT node names to corresponding compiled operators or DML graph nodes.

### Motivation and Context
This makes it easier to correlate ONNX nodes to events in PIX GPU captures when using the DML EP. Names set in the DML graph nodes require additional modifications to the DML runtime library (available in a future NuGet package).

