### PR TITLE
Fix onnxruntime-CI-nightly-ort-pipeline Failure

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
         --rm \
         --volume $(Build.SourcesDirectory)/orttraining/orttraining/test/python:/onnxruntime_src \
         --volume $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly:/requirements_torch_nightly \
-        ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu116-py38-torch1140dev \
+        ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu116-py38-torch200dev \
          bash -c "python3 -m pip install -r /requirements_torch_nightly/requirements.txt && python3 -m pytest -sv /onnxruntime_src/orttraining_test_ortmodule_api.py"
     displayName: 'Run ORTModule Tests'
     condition: succeededOrFailed()


### PR DESCRIPTION
PyTorch skipped version 1.14 and jumped to 2.0, while the image for the onnxruntime-CI-nightly-ort-pipeline is still using nightly-ubuntu2004-cu116-py38-torch1140dev. Switch to the new torch version image to fix the failure of the pipeline.

