### PR TITLE
Enable ccache for HIP objects

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -972,6 +972,8 @@ def generate_build_tree(
             cmake_args.append("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
             if args.use_cuda:
                 cmake_args.append("-DCMAKE_CUDA_COMPILER_LAUNCHER=ccache")
+            if args.use_rocm:
+                cmake_args.append("-DCMAKE_HIP_COMPILER_LAUNCHER=ccache")
     # By default cmake does not check TLS/SSL certificates. Here we turn it on.
     # But, in some cases you may also need to supply a CA file.
     add_default_definition(cmake_extra_defines, "CMAKE_TLS_VERIFY", "ON")

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -60,8 +60,7 @@ jobs:
         "$(TODAY)" |
     displayName: Cache Task
 
-  - script: |
-      sudo mkdir -p $(Pipeline.Workspace)/ccache
+  - script: mkdir -p $(CCACHE_DIR)
     condition: ne(variables.CACHE_RESTORED, 'true')
     displayName: Create Cache Dir
 

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -18,6 +18,10 @@ jobs:
       value: false
     - name: RocmVersion
       value: 5.4
+    - name: CCACHE_DIR
+      value: $(Pipeline.Workspace)/ccache
+    - name: TODAY
+      value: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
 
   # generated from tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
   container:
@@ -46,6 +50,24 @@ jobs:
         bash ./tools/ci_build/github/pai/pai_get_thread.sh $(Agent.Name)
     target: host
 
+  - task: Cache@2
+    inputs:
+      key: '"$(TODAY)" | "$(Build.SourceBranch)" | "$(Build.SourceVersion)"'
+      path: $(CCACHE_DIR)
+      cacheHitVar: CACHE_RESTORED
+      restoreKeys: |
+        "$(TODAY)" | "$(Build.SourceBranch)"
+        "$(TODAY)" |
+    displayName: Cache Task
+
+  - script: |
+      sudo mkdir -p $(Pipeline.Workspace)/ccache
+    condition: ne(variables.CACHE_RESTORED, 'true')
+    displayName: Create Cache Dir
+
+  - script: ccache -z && ccache -s
+    displayName: Show Cache Stats Before Building
+
   - task: CmdLine@2
     inputs:
       script: |-
@@ -57,6 +79,7 @@ jobs:
           --cmake_extra_defines \
               CMAKE_HIP_COMPILER=${ROCM_HOME}/llvm/bin/clang++ \
               onnxruntime_BUILD_KERNEL_EXPLORER=ON \
+          --use_cache \
           --use_rocm \
           --rocm_version=$(RocmVersion) \
           --rocm_home ${ROCM_HOME} \
@@ -68,6 +91,9 @@ jobs:
           --build_wheel \
           --skip_tests
     displayName: 'Build onnxruntime'
+
+  - script: ccache -s
+    displayName: Show Cache Stats After Building
 
   - bash: |-
       echo "##vso[task.setvariable variable=onnxruntimeBuildSucceeded]true"

--- a/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
@@ -15,6 +15,13 @@ RUN cd /usr/local && \
     wget -q -O - https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar zxf -
 ENV PATH=/usr/local/cmake-${CMAKE_VERSION}-linux-x86_64/bin:${PATH}
 
+# ccache
+RUN mkdir -p /tmp/ccache && \
+    cd /tmp/ccache && \
+    wget -q -O - https://github.com/ccache/ccache/releases/download/v4.7.4/ccache-4.7.4-linux-x86_64.tar.xz | tar --strip 1 -J -xf - && \
+    cp /tmp/ccache/ccache /usr/bin && \
+    rm -rf /tmp/ccache
+
 # rocm-ci branch contains instrumentation needed for loss curves and perf
 RUN git clone https://github.com/microsoft/huggingface-transformers.git &&\
       cd huggingface-transformers &&\


### PR DESCRIPTION
This enables HIP compiler to be launched with `ccache` when build with `--use_cache`
