### PR TITLE
[ROCm] Update doc for ROCm 5.4

### DIFF
--- a/docs/build/training.md
+++ b/docs/build/training.md
@@ -94,7 +94,7 @@ The default AMD GPU build requires ROCm software toolkit installed on the system
 2. Create the ONNX Runtime wheel
 
    * Change to the ONNX Runtime repo base folder: `cd onnxruntime`
-   * Run `./build.sh --config Release --enable_training --build_wheel --parallel --use_rocm --rocm_home /opt/rocm --nccl_home /opt/rocm --mpi_home <location for openmpi>`
+   * Run `./build.sh --config Release --enable_training --build_wheel --parallel --skip_tests --use_rocm --rocm_home /opt/rocm --nccl_home /opt/rocm --mpi_home <location for openmpi>`
 
     This produces the .whl file in `./build/Linux/Release/dist` for ONNX Runtime Training.
 

--- a/docs/build/training.md
+++ b/docs/build/training.md
@@ -82,7 +82,7 @@ These dependency versions should reflect what is in the [Dockerfiles](https://gi
 
 The default AMD GPU build requires ROCm software toolkit installed on the system:
 
-* [ROCm](https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.2.3/page/How_to_Install_ROCm.html#_How_to_Install) 5.2.3
+* [ROCm](https://docs.amd.com/bundle/ROCm-Installation-Guide-v5.4/page/How_to_Install_ROCm.html#_How_to_Install) 5.4
 * [OpenMPI](https://www.open-mpi.org/) 4.0.4
   * See [install_openmpi.sh](https://github.com/microsoft/onnxruntime/blob/main/tools/ci_build/github/linux/docker/scripts/install_openmpi.sh)
 
@@ -94,9 +94,9 @@ The default AMD GPU build requires ROCm software toolkit installed on the system
 2. Create the ONNX Runtime wheel
 
    * Change to the ONNX Runtime repo base folder: `cd onnxruntime`
-   * Run `./build.sh --config RelWithDebInfo --enable_training --build_wheel --use_rocm --rocm_home /opt/rocm --nccl_home /opt/rocm --mpi_home <location for openmpi>`
+   * Run `./build.sh --config Release --enable_training --build_wheel --parallel --use_rocm --rocm_home /opt/rocm --nccl_home /opt/rocm --mpi_home <location for openmpi>`
 
-    This produces the .whl file in `./build/Linux/RelWithDebInfo/dist` for ONNX Runtime Training.
+    This produces the .whl file in `./build/Linux/Release/dist` for ONNX Runtime Training.
 
 ## DNNL and MKLML
 

--- a/index.html
+++ b/index.html
@@ -284,6 +284,10 @@
 															<span>Direct<abbr>ML</abbr></span>
 														</div>
 														<div class="col-lg-3 col-md-3 r-option version" role="option"
+															tabindex="-1" aria-selected="false" id="MIGraphX">
+															<span>MIGraphX </span>
+														</div>
+														<div class="col-lg-3 col-md-3 r-option version" role="option"
 															tabindex="-1" aria-selected="false" id="NNAPI">
 															<span>NNAPI </span>
 														</div>
@@ -294,6 +298,10 @@
 														<div class="col-lg-3 col-md-3 r-option version" role="option"
 															tabindex="-1" aria-selected="false" id="OpenVINO">
 															<span>OpenVINO</span>
+														</div>
+														<div class="col-lg-3 col-md-3 r-option version" role="option"
+															tabindex="-1" aria-selected="false" id="ROCm">
+															<span>ROCm </span>
 														</div>
 														<div class="col-lg-3 col-md-3 r-option version" role="option"
 															tabindex="-1" aria-selected="false" id="SNPE">
@@ -318,14 +326,6 @@
 														<div class="col-lg-3 col-md-3 r-option version" role="option"
 															tabindex="-1" aria-selected="false" id="CANN">
 															<span>CANN (Preview)</span>
-														</div>
-														<div class="col-lg-3 col-md-3 r-option version" role="option"
-															tabindex="-1" aria-selected="false" id="MIGraphX">
-															<span>MIGraphX (Preview)</span>
-														</div>
-														<div class="col-lg-3 col-md-3 r-option version" role="option"
-															tabindex="-1" aria-selected="false" id="ROCm">
-															<span>ROCm (Preview)</span>
 														</div>
 														<div class="col-lg-3 col-md-3 r-option version" role="option"
 															tabindex="-1" aria-selected="false" id="RockchipNPU">

--- a/js/script.js
+++ b/js/script.js
@@ -1039,22 +1039,22 @@ var validCombos = {
     "linux,Python,X86,VitisAI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-vitisai' target='_blank'>here</a>",
     
-    "linux,Python,X86,MIGraphX":
+    "linux,Python,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
     
-    "linux,C-API,X86,MIGraphX":
+    "linux,C-API,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
     
-    "linux,C++,X86,MIGraphX":
+    "linux,C++,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
     
-    "linux,Python,X86,ROCm":
+    "linux,Python,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
     
-    "linux,C-API,X86,ROCm":
+    "linux,C-API,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
     
-    "linux,C++,X86,ROCm":
+    "linux,C++,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
 
     "linux,Python,ARM64,ACL":


### PR DESCRIPTION
### Description
1. Delete preview label for ROCm/MIGraphX and update ROCm/MIGraphX supported architecture. https://peixuanzuo.github.io/onnxruntime/
2. Update rocm training guide to ROCm5.4. https://peixuanzuo.github.io/onnxruntime/docs/build/training.html#gpu--rocm


