### PR TITLE
Reuse KernelDef from KernelCreateInfo during standalone op creation

### DIFF
--- a/onnxruntime/core/session/standalone_op_invoker.cc
+++ b/onnxruntime/core/session/standalone_op_invoker.cc
@@ -371,12 +371,6 @@ onnxruntime::Status CreateOp(const OrtKernelInfo* info,
     node_ptr->AddAttributeProto(*attr_proto);
   }
 
-  //auto kernel_def_builder = KernelDefBuilder::Create();
-  //kernel_def_builder->SetName(op_name);
-  //kernel_def_builder->SetDomain(domain);
-  //kernel_def_builder->SinceVersion(version);
-  //auto kernel_def = kernel_def_builder->Build();
-
   static std::unordered_map<int, OrtValue> kEmptyValueMap;
   static OrtValueNameIdxMap kEmptyNameMap;
 

--- a/onnxruntime/core/session/standalone_op_invoker.cc
+++ b/onnxruntime/core/session/standalone_op_invoker.cc
@@ -371,16 +371,16 @@ onnxruntime::Status CreateOp(const OrtKernelInfo* info,
     node_ptr->AddAttributeProto(*attr_proto);
   }
 
-  auto kernel_def_builder = KernelDefBuilder::Create();
-  kernel_def_builder->SetName(op_name);
-  kernel_def_builder->SetDomain(domain);
-  kernel_def_builder->SinceVersion(version);
-  auto kernel_def = kernel_def_builder->Build();
+  //auto kernel_def_builder = KernelDefBuilder::Create();
+  //kernel_def_builder->SetName(op_name);
+  //kernel_def_builder->SetDomain(domain);
+  //kernel_def_builder->SinceVersion(version);
+  //auto kernel_def = kernel_def_builder->Build();
 
   static std::unordered_map<int, OrtValue> kEmptyValueMap;
   static OrtValueNameIdxMap kEmptyNameMap;
 
-  OpKernelInfo tmp_kernel_info(*node_ptr.get(), *kernel_def, *ep, kEmptyValueMap, kEmptyNameMap, kernel_info->GetDataTransferManager());
+  OpKernelInfo tmp_kernel_info(*node_ptr.get(), *kernel_create_info->kernel_def, *ep, kEmptyValueMap, kEmptyNameMap, kernel_info->GetDataTransferManager());
   std::unique_ptr<onnxruntime::OpKernel> op_kernel;
 
   static FuncManager kFuncMgr;


### PR DESCRIPTION
During standalone op creation - reuse kernel def structure from kernel create info.

