### PR TITLE
GetTrainingApi to not print to stderr when not an ort training build

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/Training/NativeTrainingMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Training/NativeTrainingMethods.shared.cs
@@ -53,10 +53,10 @@ namespace Microsoft.ML.OnnxRuntime
                 DOrtGetApi OrtGetApi = (DOrtGetApi)Marshal.GetDelegateForFunctionPointer(NativeMethods.OrtGetApiBase().GetApi, typeof(DOrtGetApi));
 
                 // TODO: Make this save the pointer, and not copy the whole structure across
-                api_ = (OrtApi)OrtGetApi(4 /*ORT_API_VERSION*/);
+                api_ = (OrtApi)OrtGetApi(13 /*ORT_API_VERSION*/);
 
                 OrtGetTrainingApi = (DOrtGetTrainingApi)Marshal.GetDelegateForFunctionPointer(api_.GetTrainingApi, typeof(DOrtGetTrainingApi));
-                trainingApiPtr = OrtGetTrainingApi(4 /*ORT_API_VERSION*/);
+                trainingApiPtr = OrtGetTrainingApi(13 /*ORT_API_VERSION*/);
                 if (trainingApiPtr != IntPtr.Zero)
                 {
                     trainingApi_ = (OrtTrainingApi)Marshal.PtrToStructure(trainingApiPtr, typeof(OrtTrainingApi));

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3546,7 +3546,7 @@ struct OrtApi {
    *
    * \param[in] version Must be ::ORT_API_VERSION
    * \return The ::OrtTrainingApi for the version requested.
-   *         nullptr will be returned and no error message will be printedif the training api is not supported with
+   *         nullptr will be returned and no error message will be printed if the training api is not supported with
    *         this build.
    *         nullptr will be returned and an error message will be printed if the provided version is unsupported, for
    *         example when using a runtime older than the version created with this header file.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -30,7 +30,7 @@
  *
  * This value is used by some API functions to behave as this version of the header expects.
  */
-#define ORT_API_VERSION 14
+#define ORT_API_VERSION 15
 
 #ifdef __cplusplus
 extern "C" {
@@ -3946,6 +3946,12 @@ struct OrtApi {
    * \since Version 1.14.
    */
   void(ORT_API_CALL* ReleaseDnnlProviderOptions)(_Frees_ptr_opt_ OrtDnnlProviderOptions* input);
+
+  /** \brief Utility to check if the training apis can be queried.
+   *
+   * \since Version 1.15.
+   */
+  bool(ORT_API_CALL* IsTrainingApiAvailable)();
 
 #ifdef __cplusplus
   OrtApi(const OrtApi&) = delete;  // Prevent users from accidentally copying the API structure, it should always be passed as a pointer

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdbool.h>
 
 /** \brief The API version defined in this header
  *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3896,7 +3896,7 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
-   * \since Version 1.14.
+   * \since Version 1.15.
    */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_Dnnl,
                   _In_ OrtSessionOptions* options, _In_ const OrtDnnlProviderOptions* dnnl_options);
@@ -3907,7 +3907,7 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
-   * \since Version 1.14.
+   * \since Version 1.15.
    */
   ORT_API2_STATUS(CreateDnnlProviderOptions, _Outptr_ OrtDnnlProviderOptions** out);
 
@@ -3925,7 +3925,7 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
-   * \since Version 1.14.
+   * \since Version 1.15.
    */
   ORT_API2_STATUS(UpdateDnnlProviderOptions, _Inout_ OrtDnnlProviderOptions* dnnl_options,
                   _In_reads_(num_keys) const char* const* provider_options_keys,
@@ -3944,13 +3944,13 @@ struct OrtApi {
    *
    * \snippet{doc} snippets.dox OrtStatus Return Value
    *
-   * \since Version 1.14.
+   * \since Version 1.15.
    */
   ORT_API2_STATUS(GetDnnlProviderOptionsAsString, _In_ const OrtDnnlProviderOptions* dnnl_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 
   /** \brief Release an ::OrtDnnlProviderOptions
    *
-   * \since Version 1.14.
+   * \since Version 1.15.
    */
   void(ORT_API_CALL* ReleaseDnnlProviderOptions)(_Frees_ptr_opt_ OrtDnnlProviderOptions* input);
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdbool.h>
 
 /** \brief The API version defined in this header
  *
@@ -3545,6 +3544,13 @@ struct OrtApi {
 
   /* \brief: Get the training C Api
    *
+   * \param[in] version Must be ::ORT_API_VERSION
+   * \return The ::OrtTrainingApi for the version requested.
+   *         nullptr will be returned and no error message will be printedif the training api is not supported with
+   *         this build.
+   *         nullptr will be returned and an error message will be printed if the provided version is unsupported, for
+   *         example when using a runtime older than the version created with this header file.
+   *
    * \since Version 1.13
    */
   const OrtTrainingApi*(ORT_API_CALL* GetTrainingApi)(uint32_t version)NO_EXCEPTION;
@@ -3947,12 +3953,6 @@ struct OrtApi {
    * \since Version 1.14.
    */
   void(ORT_API_CALL* ReleaseDnnlProviderOptions)(_Frees_ptr_opt_ OrtDnnlProviderOptions* input);
-
-  /** \brief Utility to check if the training apis can be queried.
-   *
-   * \since Version 1.15.
-   */
-  bool(ORT_API_CALL* IsTrainingApiAvailable)();
 
 #ifdef __cplusplus
   OrtApi(const OrtApi&) = delete;  // Prevent users from accidentally copying the API structure, it should always be passed as a pointer

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2383,7 +2383,7 @@ Second example, if we wanted to add and remove some members, we'd do this:
     In GetApi we now make it return ort_api_3 for version 3.
 */
 
-static constexpr OrtApi ort_api_1_to_14 = {
+static constexpr OrtApi ort_api_1_to_15 = {
     // NOTE: The ordering of these fields MUST not change after that version has shipped since existing binaries depend on this ordering.
 
     // Shipped as version 1 - DO NOT MODIFY (see above text for more information)
@@ -2707,7 +2707,7 @@ static_assert(std::string_view(ORT_VERSION) == "1.15.0",
 
 ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
   if (version >= 1 && version <= ORT_API_VERSION)
-    return &ort_api_1_to_14;
+    return &ort_api_1_to_15;
 
   fprintf(stderr, "The given version [%u] is not supported, only version 1 to %u is supported in this build.\n",
           version, ORT_API_VERSION);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2339,15 +2339,6 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 #endif
 }
 
-ORT_API(bool, OrtApis::IsTrainingApiAvailable) {
-#ifdef ENABLE_TRAINING_APIS
-  return true;
-#else
-
-  return false;
-#endif
-}
-
 static constexpr OrtApiBase ort_api_base = {
     &OrtApis::GetApi,
     &OrtApis::GetVersionString,

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2331,6 +2331,7 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 
   fprintf(stderr, "The given version [%u] is not supported. Training api only supports version 13 to %u.\n",
           version, ORT_API_VERSION);
+  return nullptr;
 #else
 
   ORT_UNUSED_PARAMETER(version);

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2677,7 +2677,6 @@ static constexpr OrtApi ort_api_1_to_14 = {
     &OrtApis::UpdateDnnlProviderOptions,
     &OrtApis::GetDnnlProviderOptionsAsString,
     &OrtApis::ReleaseDnnlProviderOptions,
-    &OrtApis::IsTrainingApiAvailable,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2326,13 +2326,14 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSes
 
 ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 #ifdef ENABLE_TRAINING_APIS
-  return OrtTrainingApis::GetTrainingApi(version);
+  if (version >= 13 && version <= ORT_API_VERSION)
+    return OrtTrainingApis::GetTrainingApi(version);
+
+  fprintf(stderr, "The given version [%u] is not supported. Training api only supports version 13 to %u.\n",
+          version, ORT_API_VERSION);
 #else
 
   ORT_UNUSED_PARAMETER(version);
-  fprintf(stderr,
-          "Training APIs are not supported with this build. Please build onnxruntime "
-          "from source with the build flags enable_training_apis to retrieve the training APIs.\n");
 
   return nullptr;
 #endif

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2325,16 +2325,23 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSes
 }
 
 ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
-#ifdef ENABLE_TRAINING_APIS
-  return OrtTrainingApis::GetTrainingApi(version);
-#else
+  if (OrtApis::IsTrainingApiAvailable()) {
+    return OrtTrainingApis::GetTrainingApi(version);
+  }
 
-  ORT_UNUSED_PARAMETER(version);
   fprintf(stderr,
           "Training APIs are not supported with this build. Please build onnxruntime "
           "from source with the build flags enable_training_apis to retrieve the training APIs.\n");
 
   return nullptr;
+}
+
+ORT_API(bool, OrtApis::IsTrainingApiAvailable) {
+#ifdef ENABLE_TRAINING_APIS
+  return true;
+#else
+
+  return false;
 #endif
 }
 
@@ -2676,6 +2683,7 @@ static constexpr OrtApi ort_api_1_to_14 = {
     &OrtApis::UpdateDnnlProviderOptions,
     &OrtApis::GetDnnlProviderOptionsAsString,
     &OrtApis::ReleaseDnnlProviderOptions,
+    &OrtApis::IsTrainingApiAvailable,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2325,15 +2325,17 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsSetCustomJoinThreadFn, _Inout_ OrtSes
 }
 
 ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
-  if (OrtApis::IsTrainingApiAvailable()) {
-    return OrtTrainingApis::GetTrainingApi(version);
-  }
+#ifdef ENABLE_TRAINING_APIS
+  return OrtTrainingApis::GetTrainingApi(version);
+#else
 
+  ORT_UNUSED_PARAMETER(version);
   fprintf(stderr,
           "Training APIs are not supported with this build. Please build onnxruntime "
           "from source with the build flags enable_training_apis to retrieve the training APIs.\n");
 
   return nullptr;
+#endif
 }
 
 ORT_API(bool, OrtApis::IsTrainingApiAvailable) {

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -442,6 +442,4 @@ ORT_API_STATUS_IMPL(GetDnnlProviderOptionsAsString, _In_ const OrtDnnlProviderOp
                     _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 ORT_API(void, ReleaseDnnlProviderOptions, _Frees_ptr_opt_ OrtDnnlProviderOptions*);
 
-ORT_API(bool, IsTrainingApiAvailable);
-
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -442,5 +442,6 @@ ORT_API_STATUS_IMPL(GetDnnlProviderOptionsAsString, _In_ const OrtDnnlProviderOp
                     _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 ORT_API(void, ReleaseDnnlProviderOptions, _Frees_ptr_opt_ OrtDnnlProviderOptions*);
 
-}  // namespace OrtApis
+ORT_API(bool, IsTrainingApiAvailable);
 
+}  // namespace OrtApis


### PR DESCRIPTION
From #14027:

> The integration into the build system will need some changes when https://github.com/microsoft/onnxruntime/pull/13964 is merged in, it'll need packaging changes to emit two different jars (onnxruntime-training and onnxruntime), and I've not added the enable training flag to any of the CI pipelines. It looks like there isn't a better way to see if training is available than calling api->GetTrainingApi but if it's turned off it unavoidably logs something to stderr. That would be nice to fix as currently all non-training builds of ORT for Java will log that on startup.

Trying to address this by exposing another function that returns whether or not the training api is available.