### PR TITLE
Support external output tensors for DORT

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -150,6 +150,8 @@ const char* GetDeviceName(const OrtDevice& device) {
       return CUDA;
     case OrtDevice::FPGA:
       return "FPGA";
+    case OrtDevice::NPU:
+      return "NPU";
     default:
       ORT_THROW("Unknown device type: ", device.Type());
   }
@@ -1055,6 +1057,8 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
       .def("device_type", &OrtDevice::Type, R"pbdoc(Device Type.)pbdoc")
       .def_static("cpu", []() { return OrtDevice::CPU; })
       .def_static("cuda", []() { return OrtDevice::GPU; })
+      .def_static("fpga", []() { return OrtDevice::FPGA; })
+      .def_static("npu", []() { return OrtDevice::NPU; })
       .def_static("default_memory", []() { return OrtDevice::MemType::DEFAULT; });
 
   py::class_<OrtArenaCfg> ort_arena_cfg_binding(m, "OrtArenaCfg");

--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -406,7 +406,6 @@ def _run_onnx_session_with_ortvaluevector(
     inputs = tuple(a.contiguous() for a in inputs)
     _nvtx_range_pop()
 
-
     _nvtx_range_push("push_back_batch")
 
     ort_inputs = _get_ortvalues_from_torch_tensors(inputs, input_devices)
@@ -487,7 +486,7 @@ class OrtBackend:
         3. Inside _ort_accelerated_call, it creates onnxruntime.InferenceSession and calls it to execute the sub-graph.
     """
 
-    def __init__(self, ep: str = "", preallocate_output:bool=False):
+    def __init__(self, ep: str = "", preallocate_output: bool = False):
         self._supported_ops = OrtOperatorSupport()
         # TODO: this is a naive implementation of cache without proper guard
         self._partitioner_cache: Dict[torch.fx.GraphModule, torch.fx.GraphModule] = {}
@@ -505,7 +504,6 @@ class OrtBackend:
         # It can be avoided by allowing for preallocation for output buffers allocated by a custom aten allocator,
         # and use the preallocated output buffers for InferenceSession not holding any ownership for them.
         self.preallocate_output = preallocate_output
-
 
     def _ort_acclerated_call(self, graph_module: torch.fx.GraphModule, *args, **kwargs):
         if graph_module in self._ort_execution_info.sessions:
@@ -590,7 +588,7 @@ class OrtBackend:
                 output_names,
                 prim_outputs,
                 output_devices,
-                self.preallocate_output
+                self.preallocate_output,
             )
             _nvtx_range_pop()
             if self._ort_execution_info.assert_allclose_to_baseline:
@@ -613,7 +611,7 @@ class OrtBackend:
                 output_names,
                 (prim_outputs,),
                 output_devices,
-                self.preallocate_output
+                self.preallocate_output,
             )
             assert len(onnx_outputs) == 1
             if self._ort_execution_info.assert_allclose_to_baseline:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Support externally-managed output tensors (torch Tensors) for dort. 
Add `preallocate_output` option to OrtBackend to rely on externally-managed output tensors for dort.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
DORT currently allocates and returns output ortvalues and convert them to torch Tensors. The conversion based on dlpack does not support torch Tensors for custom Aten backends, and it is not yet possible to transfer the ownership from ortvalue to external handle (torch Tensor). 

To avoid this issue, the PR change provides an option (`preallocate_output`) to allocate output tensors externally in pytorch, which creates torch Tensor for an Aten backend, and let dort take pointers from torch Tensors to construct output ortvalues instead of allocating them inside InferenceSession.

