### PR TITLE
fix build err inbuild with minimal_build conjuncting disable_exceptions flags

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -55,7 +55,7 @@ Status ComputeQLinearGlobalAvgPool(
   return Status::OK();
 }
 
-// we would either put the template function in header file add such declaration in the below
+// we would either put the template function in header file or add such declaration in the below to do explicit instantiation.
 template Status ComputeQLinearGlobalAvgPool<int8_t>(
     const int8_t* x,
     float x_scale,

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -56,9 +56,10 @@ Status ComputeQLinearGlobalAvgPool(
 }
 
 //GCC's unexplained behavior: GCC wouldn't generate corresponding symbols versus function instances below 
-//with " g++ -fno-exceptions xxxxx" when "--disable-exceptions" and "--minimal-build" are combined on linux for building ORT, 
+// when "--disable-exceptions" and "--minimal-build" are combined on linux for building ORT, 
 // but this two symbols are used by qlinear_pool.cc.
-//The other compilers wouldn't hit it and works fine. So we are doing explicit instantiation here for every compilers happy.
+//The other compilers wouldn't hit it and works fine and we also didn't see it in the other platforms, such as Andriod. 
+//So we are doing explicit instantiation here for every compilers/platforms happy.
 template Status ComputeQLinearGlobalAvgPool<int8_t>(
     const int8_t* x,
     float x_scale,

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -55,9 +55,10 @@ Status ComputeQLinearGlobalAvgPool(
   return Status::OK();
 }
 
-//GCC's Bug: GCC wouldn't generate corresponding symbols versus function instances below 
-//when built with "-fno-exceptions" under "--disable_exceptions flag in build.py", but this two symbols are used by qlinear_pool.cc.
-//The other compiler wouldn't hit it and works fine. So we are doing explicit instantiation here for every compilers happy.
+//GCC's unexplained behavior: GCC wouldn't generate corresponding symbols versus function instances below 
+//with " g++ -fno-exceptions xxxxx" when "--disable-exceptions" and "--minimal-build" are combined on linux for building ORT, 
+// but this two symbols are used by qlinear_pool.cc.
+//The other compilers wouldn't hit it and works fine. So we are doing explicit instantiation here for every compilers happy.
 template Status ComputeQLinearGlobalAvgPool<int8_t>(
     const int8_t* x,
     float x_scale,

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -55,7 +55,9 @@ Status ComputeQLinearGlobalAvgPool(
   return Status::OK();
 }
 
-// we would either put the template function in header file or add such declaration in the below to do explicit instantiation.
+//GCC's Bug: GCC wouldn't generate corresponding symbols versus function instances below 
+//when built with "-fno-exceptions" under "--disable_exceptions flag in build.py", but this two symbols are used by qlinear_pool.cc.
+//The other compiler wouldn't hit it and works fine. So we are doing explicit instantiation here for every compilers happy.
 template Status ComputeQLinearGlobalAvgPool<int8_t>(
     const int8_t* x,
     float x_scale,

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -55,6 +55,33 @@ Status ComputeQLinearGlobalAvgPool(
   return Status::OK();
 }
 
+// we would either put the template function in header file add such declaration in the below
+template Status ComputeQLinearGlobalAvgPool<int8_t>(
+    const int8_t* x,
+    float x_scale,
+    int8_t x_zero_point,
+    int8_t* y,
+    float y_scale,
+    int8_t y_zero_point,
+    int64_t N,
+    int64_t C,
+    int64_t image_size,
+    bool channels_last,
+    concurrency::ThreadPool* tp);
+
+template Status ComputeQLinearGlobalAvgPool<uint8_t>(
+    const uint8_t* x,
+    float x_scale,
+    uint8_t x_zero_point,
+    uint8_t* y,
+    float y_scale,
+    uint8_t y_zero_point,
+    int64_t N,
+    int64_t C,
+    int64_t image_size,
+    bool channels_last,
+    concurrency::ThreadPool* tp);
+
 Status QLinearGlobalAveragePool::Compute(OpKernelContext* context) const {
   const auto tensor_x_scale = context->Input<Tensor>(1);
   const auto tensor_x_zero_point = context->Input<Tensor>(2);

--- a/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc
@@ -55,11 +55,12 @@ Status ComputeQLinearGlobalAvgPool(
   return Status::OK();
 }
 
-//GCC's unexplained behavior: GCC wouldn't generate corresponding symbols versus function instances below 
-// when "--disable-exceptions" and "--minimal-build" are combined on linux for building ORT, 
-// but this two symbols are used by qlinear_pool.cc.
-//The other compilers wouldn't hit it and works fine and we also didn't see it in the other platforms, such as Andriod. 
-//So we are doing explicit instantiation here for every compilers/platforms happy.
+// GCC's unexplained behavior:
+// GCC wouldn't generate corresponding symbols versus function instances below when "--disable-exceptions"
+// and "--minimal-build" are combined on linux build.
+// But this two symbols are required by qlinear_pool.cc.
+// The other compilers wouldn't hit it and works fine, and we also didn't see it in the other platforms, such as Android.
+// So we are doing explicit instantiation here for every compilers/platforms happy.
 template Status ComputeQLinearGlobalAvgPool<int8_t>(
     const int8_t* x,
     float x_scale,


### PR DESCRIPTION
### Description
If we set flag 'disable_exceptions' to build ORT:

`onnxruntime/contrib_ops/cpu/quantization/qlinear_global_average_pool.cc.o` woundn't generate such symbols which used by qlinear_pool.c
```
0000000000000000 W _ZN11onnxruntime7contrib27ComputeQLinearGlobalAvgPoolIaEENS_6common6StatusEPKT_fS4_PS4_fS4_lllbPNS_11concurrency10ThreadPoolE
0000000000000000 W _ZN11onnxruntime7contrib27ComputeQLinearGlobalAvgPoolIhEENS_6common6StatusEPKT_fS4_PS4_fS4_lllbPNS_11concurrency10ThreadPoolE
```
so we get a error of undefined symbols of ComputeQLinearGlobalAvgPool<uin8_t> and ComputeQLinearGlobalAvgPool<in8_t>......


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


