### PR TITLE
change deepspeed version in warning from 0.7.3 to 0.8.0

### DIFF
--- a/orttraining/orttraining/python/training/optim/_ds_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_ds_modifier.py
@@ -42,7 +42,7 @@ class DeepSpeedZeROModifier(FP16OptimizerModifier):
         if ds_version > Version("0.8.0") or ds_version < Version("0.4.0"):
             warnings.warn(
                 "Skip modifying optimizer because of unsupported DeepSpeed version {}, "
-                "supported version: 0.4.0 - 0.7.3.".format(deepspeed.__version__),
+                "supported version: 0.4.0 - 0.8.0.".format(deepspeed.__version__),
                 UserWarning,
             )
             return False


### PR DESCRIPTION
### Description
change deepspeed version in warning from 0.7.3 to 0.8.0



### Motivation and Context
The version was updated for Deepspeed support in ORT from 0.7.3 to 0.8.0 but wasn't updated in the warnings message and this PR is to fix that.

