### PR TITLE
[js/web] remove 'module' field from package.json

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -8,7 +8,6 @@
     "type": "git"
   },
   "author": "fs-eire",
-  "module": "./lib/index.js",
   "version": "1.15.0",
   "jsdelivr": "dist/ort.min.js",
   "dependencies": {


### PR DESCRIPTION
### Description
this is a workaround for [#14529](https://github.com/microsoft/onnxruntime/issues/14504) when consuming onnxruntime-web as ES module.