### PR TITLE
[ROCm] add Softmax Tunable Op

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1460,6 +1460,7 @@ if (onnxruntime_USE_ROCM)
       device_gemm_add_fastgelu_instance
       device_gemm_fastgelu_instance
       device_batched_gemm_instance
+      device_softmax_instance
     )
     target_compile_definitions(onnxruntime_providers_rocm PRIVATE USE_COMPOSABLE_KERNEL)
   endif()

--- a/cmake/onnxruntime_rocm_hipify.cmake
+++ b/cmake/onnxruntime_rocm_hipify.cmake
@@ -122,6 +122,7 @@ set(provider_excluded_files
   "math/softmax_impl.cu"
   "math/softmax_warpwise_impl.cuh"
   "math/softmax_common.cc"
+  "math/softmax_common.h"
   "math/softmax.cc"
   "nn/conv.cc"
   "nn/conv.h"

--- a/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef USE_COMPOSABLE_KERNEL
+#include "ck/ck.hpp"
+#include "ck/library/tensor_operation_instance/gpu/softmax.hpp"
+#include "ck/tensor_operation/gpu/device/device_softmax.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#endif
+
+#include "core/providers/rocm/math/softmax_common.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+#ifdef USE_COMPOSABLE_KERNEL
+
+template <typename T>
+struct DataTypeAdaptor {
+  using type = T;
+};
+
+template <>
+struct DataTypeAdaptor<half> {
+  using type = ck::half_t;
+};
+
+template <>
+struct DataTypeAdaptor<BFloat16> {
+  using type = ck::bhalf16_t;
+};
+
+using Nop = ck::tensor_operation::element_wise::PassThrough;
+constexpr int Rank = 4;
+constexpr int NumReduceDim = 1;
+
+template <typename input_t, typename output_t, typename acc_t>
+auto GetCKSoftmaxTypeStringAndOps() {
+  using InDataType = typename DataTypeAdaptor<input_t>::type;
+  using OutDataType = typename DataTypeAdaptor<output_t>::type;
+  using AccDataType = typename DataTypeAdaptor<acc_t>::type;
+  using DeviceSoftmax = ck::tensor_operation::device::
+      DeviceSoftmax<InDataType, AccDataType, OutDataType, Nop, Nop, Rank>;
+  using InstanceFactory = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<DeviceSoftmax>;
+
+  std::vector<std::pair<std::string, tunable::Op<SoftmaxParams<input_t, output_t>>>> ret;
+  for (auto&& impl : InstanceFactory::GetInstances()) {
+    auto type_string = onnxruntime::MakeString(impl->GetTypeString());
+    auto invoker = impl->MakeInvokerPointer();
+
+    auto ck_softmax_op = [impl = std::move(impl), invoker = std::move(invoker)](const SoftmaxParams<input_t, output_t>* params) -> Status {
+      AccDataType alpha{1.0f};
+      AccDataType beta{0.0f};
+
+      TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(
+          params->is_log_softmax,
+          impl->GetTypeString(), " does not support log softmax");
+      TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(
+          impl->GetRank() != Rank || impl->GetNumReduceDim() != NumReduceDim,
+          impl->GetTypeString(), " does not support current Rank or NumReduceDim ", params->Signature());
+
+      std::vector<ck::index_t> in_lengths{1, 1, params->batch_count, params->softmax_elements};
+      std::vector<ck::index_t> in_strides{params->batch_count * params->input_stride, params->batch_count * params->input_stride, params->input_stride, 1};
+      std::vector<ck::index_t> reduce_dims{3};
+
+      auto nop = Nop{};
+      auto arg = impl->MakeArgumentPointer(in_lengths, in_strides, reduce_dims, &alpha, &beta,
+                                           params->input, params->output, nop, nop);
+      TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
+                                                impl->GetTypeString(), " does not support ", params->Signature());
+      invoker->Run(arg.get(), StreamConfig{params->stream});
+      return Status::OK();
+    };
+    ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_softmax_op)));
+  }
+  return ret;
+}
+#endif  // USE_COMPOSABLE_KERNEL
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
@@ -13,7 +13,7 @@
 #include "ck/tensor_operation/gpu/device/device_softmax.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#endif
+#endif  // USE_COMPOSABLE_KERNEL
 
 #include "core/providers/rocm/math/softmax_common.h"
 
@@ -41,21 +41,21 @@ using Nop = ck::tensor_operation::element_wise::PassThrough;
 constexpr int Rank = 4;
 constexpr int NumReduceDim = 1;
 
-template <typename input_t, typename output_t, typename acc_t>
+template <typename InputT, typename OutputT, typename AccT>
 auto GetCKSoftmaxTypeStringAndOps() {
-  using InDataType = typename DataTypeAdaptor<input_t>::type;
-  using OutDataType = typename DataTypeAdaptor<output_t>::type;
-  using AccDataType = typename DataTypeAdaptor<acc_t>::type;
+  using InDataType = typename DataTypeAdaptor<InputT>::type;
+  using OutDataType = typename DataTypeAdaptor<OutputT>::type;
+  using AccDataType = typename DataTypeAdaptor<AccT>::type;
   using DeviceSoftmax = ck::tensor_operation::device::
       DeviceSoftmax<InDataType, AccDataType, OutDataType, Nop, Nop, Rank>;
   using InstanceFactory = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<DeviceSoftmax>;
 
-  std::vector<std::pair<std::string, tunable::Op<SoftmaxParams<input_t, output_t>>>> ret;
+  std::vector<std::pair<std::string, tunable::Op<SoftmaxParams<InputT, OutputT>>>> ret;
   for (auto&& impl : InstanceFactory::GetInstances()) {
     auto type_string = onnxruntime::MakeString(impl->GetTypeString());
     auto invoker = impl->MakeInvokerPointer();
 
-    auto ck_softmax_op = [impl = std::move(impl), invoker = std::move(invoker)](const SoftmaxParams<input_t, output_t>* params) -> Status {
+    auto ck_softmax_op = [impl = std::move(impl), invoker = std::move(invoker)](const SoftmaxParams<InputT, OutputT>* params) -> Status {
       AccDataType alpha{1.0f};
       AccDataType beta{0.0f};
 

--- a/onnxruntime/core/providers/rocm/math/softmax_common.h
+++ b/onnxruntime/core/providers/rocm/math/softmax_common.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/status.h"
+#include "core/providers/rocm/miopen_common.h"
+#include "core/providers/rocm/tunable/rocm_tunable.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+template <typename input_t, typename output_t>
+struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
+  SoftmaxParams(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
+                int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : OpParams(stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride), output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
+
+  std::string Signature() const override {
+    std::string sig = std::to_string(batch_count) + "_" + std::to_string(softmax_elements);
+    return sig;
+  }
+
+  output_t* output;
+  const input_t* input;
+  int softmax_elements;
+  int input_stride;
+  int output_stride;
+  int batch_count;
+  bool is_log_softmax;
+};
+
+Status SoftmaxForward(miopenHandle_t miopen_handle, const void* alpha, const miopenTensorDescriptor_t input_tensor,
+                      const void* input_data, const void* beta, const miopenTensorDescriptor_t output_tensor,
+                      void* output_data);
+
+Status SoftmaxBackward(miopenHandle_t miopen_handle, bool is_log_softmax, const void* alpha,
+                       const miopenTensorDescriptor_t input_tensor, const void* output_data,
+                       const void* output_grad_data, const void* beta, const miopenTensorDescriptor_t output_tensor,
+                       void* input_grad_data);
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/softmax_common.h
+++ b/onnxruntime/core/providers/rocm/math/softmax_common.h
@@ -11,10 +11,10 @@ namespace onnxruntime {
 namespace rocm {
 
 template <typename InputT, typename OutputT>
-struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
-  SoftmaxParams(hipStream_t stream, OutputT* output, const InputT* input, int softmax_elements,
-                int input_stride, int output_stride, int batch_count, bool is_log_softmax)
-      : OpParams(stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride), output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
+struct SoftmaxParams : tunable::OpParams {
+  SoftmaxParams(tunable::RocmTuningContext* tuning_ctx, hipStream_t stream, OutputT* output, const InputT* input,
+                int softmax_elements, int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : OpParams(tuning_ctx, stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride), output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
 
   std::string Signature() const override {
     std::string sig = std::to_string(batch_count) + "_" + std::to_string(softmax_elements);

--- a/onnxruntime/core/providers/rocm/math/softmax_common.h
+++ b/onnxruntime/core/providers/rocm/math/softmax_common.h
@@ -10,9 +10,9 @@
 namespace onnxruntime {
 namespace rocm {
 
-template <typename input_t, typename output_t>
+template <typename InputT, typename OutputT>
 struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
-  SoftmaxParams(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
+  SoftmaxParams(hipStream_t stream, OutputT* output, const InputT* input, int softmax_elements,
                 int input_stride, int output_stride, int batch_count, bool is_log_softmax)
       : OpParams(stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride), output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
 
@@ -21,8 +21,8 @@ struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
     return sig;
   }
 
-  output_t* output;
-  const input_t* input;
+  OutputT* output;
+  const InputT* input;
   int softmax_elements;
   int input_stride;
   int output_stride;

--- a/onnxruntime/core/providers/rocm/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/rocm/math/softmax_impl.cu
@@ -75,15 +75,6 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
   return HIP_CALL(hipGetLastError());
 }
 
-#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t)                                                                                                                                                        \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count); \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count);
-
-SPECIALIZED_SOFTMAX_IMPL(float, float, float)
-SPECIALIZED_SOFTMAX_IMPL(half, half, float)
-SPECIALIZED_SOFTMAX_IMPL(double, double, double)
-SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
-
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
 Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
                                           int input_stride, int output_stride, int batch_count) {
@@ -102,7 +93,13 @@ Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, 
   return HIP_CALL(hipGetLastError());
 }
 
-#define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                   \
+#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t)                             \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(  \
+      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,    \
+      int softmax_elements_stride, int batch_count);                                   \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(   \
+      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,    \
+      int softmax_elements_stride, int batch_count);                                   \
   template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>( \
       hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);                           \
@@ -110,10 +107,10 @@ Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, 
       hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);
 
-SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(float, float, float)
-SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(half, half, float)
-SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(double, double, double)
-SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(BFloat16, BFloat16, float)
+SPECIALIZED_SOFTMAX_IMPL(float, float, float)
+SPECIALIZED_SOFTMAX_IMPL(half, half, float)
+SPECIALIZED_SOFTMAX_IMPL(double, double, double)
+SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 #ifndef DISABLE_CONTRIB_OPS
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(half, float, float)  // used by BeamSearch op

--- a/onnxruntime/core/providers/rocm/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/rocm/math/softmax_impl.cu
@@ -1,18 +1,18 @@
 /**
-* Copyright (c) 2016-present, Facebook, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /* Modifications Copyright (c) Microsoft. */
 
@@ -51,39 +51,23 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
     dim3 threads(warp_size, warps_per_block, 1);
     // Launch code would be more elegant if C++ supported FOR CONSTEXPR
     switch (log2_elements) {
-      case 0:  // 1
-        softmax_warp_forward<input_t, output_t, acc_t, 0, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 1:  // 2
-        softmax_warp_forward<input_t, output_t, acc_t, 1, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 2:  // 4
-        softmax_warp_forward<input_t, output_t, acc_t, 2, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 3:  // 8
-        softmax_warp_forward<input_t, output_t, acc_t, 3, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 4:  // 16
-        softmax_warp_forward<input_t, output_t, acc_t, 4, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 5:  // 32
-        softmax_warp_forward<input_t, output_t, acc_t, 5, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 6:  // 64
-        softmax_warp_forward<input_t, output_t, acc_t, 6, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 7:  // 128
-        softmax_warp_forward<input_t, output_t, acc_t, 7, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 8:  // 256
-        softmax_warp_forward<input_t, output_t, acc_t, 8, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 9:  // 512
-        softmax_warp_forward<input_t, output_t, acc_t, 9, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 10:  // 1024
-        softmax_warp_forward<input_t, output_t, acc_t, 10, is_log_softmax><<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
+#define LAUNCH_SOFTMAX_WARP_FORWARD(L2E)                                                         \
+  case L2E:                                                                                      \
+    softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax>                          \
+        <<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count,                      \
+                                                     softmax_elements_stride, softmax_elements); \
+    break;
+      LAUNCH_SOFTMAX_WARP_FORWARD(0);   // 1
+      LAUNCH_SOFTMAX_WARP_FORWARD(1);   // 2
+      LAUNCH_SOFTMAX_WARP_FORWARD(2);   // 4
+      LAUNCH_SOFTMAX_WARP_FORWARD(3);   // 8
+      LAUNCH_SOFTMAX_WARP_FORWARD(4);   // 16
+      LAUNCH_SOFTMAX_WARP_FORWARD(5);   // 32
+      LAUNCH_SOFTMAX_WARP_FORWARD(6);   // 64
+      LAUNCH_SOFTMAX_WARP_FORWARD(7);   // 128
+      LAUNCH_SOFTMAX_WARP_FORWARD(8);   // 256
+      LAUNCH_SOFTMAX_WARP_FORWARD(9);   // 512
+      LAUNCH_SOFTMAX_WARP_FORWARD(10);  // 1024
       default:
         break;
     }
@@ -91,9 +75,9 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
   return HIP_CALL(hipGetLastError());
 }
 
-#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t) \
-template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count); \
-template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count);
+#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t)                                                                                                                                                        \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count); \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements, int softmax_elements_stride, int batch_count);
 
 SPECIALIZED_SOFTMAX_IMPL(float, float, float)
 SPECIALIZED_SOFTMAX_IMPL(half, half, float)
@@ -102,28 +86,28 @@ SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
 Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
-                                        int input_stride, int output_stride, int batch_count) {
+                                          int input_stride, int output_stride, int batch_count) {
   dim3 grid(batch_count);
   constexpr int ILP = sizeof(float4) / sizeof(input_t);
   dim3 block = SoftMax_getBlockSize(ILP, softmax_elements);
   if (is_log_softmax) {
     softmax_block_forward<ILP, input_t, acc_t, output_t, LogSoftMaxForwardEpilogue>
-    <<<grid, block, block.x * sizeof(acc_t), stream>>>(output, const_cast<input_t*>(input),
-                                                       softmax_elements, input_stride, output_stride);
+        <<<grid, block, block.x * sizeof(acc_t), stream>>>(output, const_cast<input_t*>(input),
+                                                           softmax_elements, input_stride, output_stride);
   } else {
     softmax_block_forward<ILP, input_t, acc_t, output_t, SoftMaxForwardEpilogue>
-    <<<grid, block, block.x * sizeof(acc_t), stream>>>(output, const_cast<input_t*>(input),
-                                                       softmax_elements, input_stride, output_stride);
+        <<<grid, block, block.x * sizeof(acc_t), stream>>>(output, const_cast<input_t*>(input),
+                                                           softmax_elements, input_stride, output_stride);
   }
-  return HIP_CALL(hipGetLastError()); 
+  return HIP_CALL(hipGetLastError());
 }
 
-#define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                      \
-  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>(    \
-      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements,    \
-      int input_stride, int output_stride, int batch_count);                              \
-  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(     \
-      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements,    \
+#define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                   \
+  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>( \
+      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
+      int input_stride, int output_stride, int batch_count);                           \
+  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(  \
+      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);
 
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(float, float, float)
@@ -135,5 +119,5 @@ SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(half, float, float)  // used by BeamSearch op
 #endif
 
-}
-}
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/rocm/math/softmax_impl.cu
@@ -51,12 +51,12 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
     dim3 threads(warp_size, warps_per_block, 1);
     // Launch code would be more elegant if C++ supported FOR CONSTEXPR
     switch (log2_elements) {
-#define LAUNCH_SOFTMAX_WARP_FORWARD(L2E)                                                         \
-  case L2E:                                                                                      \
-    softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax>                          \
-        <<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count,                      \
-                                                     softmax_elements_stride, softmax_elements); \
-    break;
+    #define LAUNCH_SOFTMAX_WARP_FORWARD(L2E)                                                         \
+      case L2E:                                                                                      \
+        softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax>                          \
+            <<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count,                      \
+                                                        softmax_elements_stride, softmax_elements);  \
+        break;
       LAUNCH_SOFTMAX_WARP_FORWARD(0);   // 1
       LAUNCH_SOFTMAX_WARP_FORWARD(1);   // 2
       LAUNCH_SOFTMAX_WARP_FORWARD(2);   // 4
@@ -101,10 +101,10 @@ Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, 
       hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,    \
       int softmax_elements_stride, int batch_count);                                   \
   template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>( \
-      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
+      hipStream_t stream, output_t * output, const input_t* input, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);                           \
   template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(  \
-      hipStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
+      hipStream_t stream, output_t * output, const input_t* input, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);
 
 SPECIALIZED_SOFTMAX_IMPL(float, float, float)

--- a/onnxruntime/core/providers/rocm/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/rocm/math/softmax_impl.cu
@@ -51,12 +51,12 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
     dim3 threads(warp_size, warps_per_block, 1);
     // Launch code would be more elegant if C++ supported FOR CONSTEXPR
     switch (log2_elements) {
-    #define LAUNCH_SOFTMAX_WARP_FORWARD(L2E)                                                         \
-      case L2E:                                                                                      \
-        softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax>                          \
-            <<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count,                      \
-                                                        softmax_elements_stride, softmax_elements);  \
-        break;
+      #define LAUNCH_SOFTMAX_WARP_FORWARD(L2E)                                                         \
+        case L2E:                                                                                      \
+          softmax_warp_forward<input_t, output_t, acc_t, L2E, is_log_softmax>                          \
+              <<<dim3(blocks), dim3(threads), 0, stream>>>(dst, src, batch_count,                      \
+                                                          softmax_elements_stride, softmax_elements); \
+          break;
       LAUNCH_SOFTMAX_WARP_FORWARD(0);   // 1
       LAUNCH_SOFTMAX_WARP_FORWARD(1);   // 2
       LAUNCH_SOFTMAX_WARP_FORWARD(2);   // 4
@@ -74,6 +74,19 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, output_t* dst, cons
   }
   return HIP_CALL(hipGetLastError());
 }
+
+#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t)                            \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>( \
+      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,   \
+      int softmax_elements_stride, int batch_count);                                  \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(  \
+      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,   \
+      int softmax_elements_stride, int batch_count);
+
+SPECIALIZED_SOFTMAX_IMPL(float, float, float)
+SPECIALIZED_SOFTMAX_IMPL(half, half, float)
+SPECIALIZED_SOFTMAX_IMPL(double, double, double)
+SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
 Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
@@ -93,24 +106,18 @@ Status dispatch_blockwise_softmax_forward(hipStream_t stream, output_t* output, 
   return HIP_CALL(hipGetLastError());
 }
 
-#define SPECIALIZED_SOFTMAX_IMPL(input_t, output_t, acc_t)                             \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(  \
-      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,    \
-      int softmax_elements_stride, int batch_count);                                   \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(   \
-      hipStream_t stream, output_t * dst, const input_t* src, int softmax_elements,    \
-      int softmax_elements_stride, int batch_count);                                   \
-  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>( \
+#define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                     \
+  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>(   \
       hipStream_t stream, output_t * output, const input_t* input, int softmax_elements, \
-      int input_stride, int output_stride, int batch_count);                           \
-  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(  \
+      int input_stride, int output_stride, int batch_count);                             \
+  template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(    \
       hipStream_t stream, output_t * output, const input_t* input, int softmax_elements, \
       int input_stride, int output_stride, int batch_count);
 
-SPECIALIZED_SOFTMAX_IMPL(float, float, float)
-SPECIALIZED_SOFTMAX_IMPL(half, half, float)
-SPECIALIZED_SOFTMAX_IMPL(double, double, double)
-SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
+SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(float, float, float)
+SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(half, half, float)
+SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(double, double, double)
+SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 #ifndef DISABLE_CONTRIB_OPS
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(half, float, float)  // used by BeamSearch op

--- a/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
@@ -35,7 +35,7 @@ struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
 };
 
 template <typename input_t, typename output_t, typename acc_t, int VecSize>
-Status SoftmaxBlockwiseOp(SoftmaxParams<input_t, output_t>* params) {
+Status SoftmaxBlockwiseOp(const SoftmaxParams<input_t, output_t>* params) {
   dim3 grid(params->batch_count);
   dim3 block = SoftMax_getBlockSize(VecSize, params->softmax_elements);
   if (params->is_log_softmax) {
@@ -51,6 +51,41 @@ Status SoftmaxBlockwiseOp(SoftmaxParams<input_t, output_t>* params) {
   }
   return HIP_CALL(hipGetLastError());
 }
+
+template <typename input_t, typename output_t, typename acc_t>
+Status SoftmaxBlockwiseStaticSelection(const SoftmaxParams<input_t, output_t>* params) {
+  dim3 grid(params->batch_count);
+  constexpr int ILP = sizeof(float4) / sizeof(input_t);
+  dim3 block = SoftMax_getBlockSize(ILP, params->softmax_elements);
+  if (params->is_log_softmax) {
+    softmax_block_forward<ILP, input_t, acc_t, output_t, LogSoftMaxForwardEpilogue>
+        <<<grid, block, block.x * sizeof(acc_t), params->stream>>>(params->output, const_cast<input_t*>(params->input),
+                                                                   params->softmax_elements, params->input_stride,
+                                                                   params->output_stride);
+  } else {
+    softmax_block_forward<ILP, input_t, acc_t, output_t, SoftMaxForwardEpilogue>
+        <<<grid, block, block.x * sizeof(acc_t), params->stream>>>(params->output, const_cast<input_t*>(params->input),
+                                                                   params->softmax_elements, params->input_stride,
+                                                                   params->output_stride);
+  }
+  return HIP_CALL(hipGetLastError());
+}
+
+template <typename input_t, typename output_t, typename acc_t>
+class SoftmaxTunableOp : public onnxruntime::rocm::tunable::TunableOp<SoftmaxParams<input_t, output_t>> {
+ public:
+  SoftmaxTunableOp() {
+    this->RegisterOp(SoftmaxBlockwiseStaticSelection<input_t, output_t, acc_t>);
+    this->RegisterOp(SoftmaxBlockwiseOp<input_t, output_t, acc_t, 1>);
+    this->RegisterOp(SoftmaxBlockwiseOp<input_t, output_t, acc_t, 2>);
+    this->RegisterOp(SoftmaxBlockwiseOp<input_t, output_t, acc_t, 4>);
+    this->RegisterOp(SoftmaxBlockwiseOp<input_t, output_t, acc_t, 8>);
+    this->RegisterOp(SoftmaxBlockwiseOp<input_t, output_t, acc_t, 16>);
+
+    // NOTE: the 1st kernel is SoftmaxBlockwise Original implementation.
+    this->SetDefaultId(0);
+  }
+};
 
 }  // namespace rocm
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include "core/providers/rocm/cu_inc/common.cuh"
+#include "core/providers/rocm/math/softmax_warpwise_impl.cuh"
+#include "core/providers/rocm/math/softmax_blockwise_impl.cuh"
+#include "core/providers/rocm/tunable/rocm_tunable.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+template <typename input_t, typename output_t>
+struct SoftmaxParams : onnxruntime::rocm::tunable::OpParams {
+  SoftmaxParams(hipStream_t stream, output_t* output, const input_t* input, int softmax_elements,
+                int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : OpParams(stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride),
+        output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
+
+  std::string Signature() const override {
+    std::string sig = std::to_string(batch_count) + "_" + std::to_string(softmax_elements);
+    return sig;
+  }
+
+  output_t* output;
+  const input_t* input;
+  int softmax_elements;
+  int input_stride;
+  int output_stride;
+  int batch_count;
+  bool is_log_softmax;
+};
+
+template <typename input_t, typename output_t, typename acc_t, int VecSize>
+Status SoftmaxBlockwiseOp(SoftmaxParams<input_t, output_t>* params) {
+  dim3 grid(params->batch_count);
+  dim3 block = SoftMax_getBlockSize(VecSize, params->softmax_elements);
+  if (params->is_log_softmax) {
+    softmax_block_forward<VecSize, input_t, acc_t, output_t, LogSoftMaxForwardEpilogue>
+        <<<grid, block, block.x * sizeof(acc_t), params->stream>>>(params->output, const_cast<input_t*>(params->input),
+                                                                   params->softmax_elements, params->input_stride,
+                                                                   params->output_stride);
+  } else {
+    softmax_block_forward<VecSize, input_t, acc_t, output_t, SoftMaxForwardEpilogue>
+        <<<grid, block, block.x * sizeof(acc_t), params->stream>>>(params->output, const_cast<input_t*>(params->input),
+                                                                   params->softmax_elements, params->input_stride,
+                                                                   params->output_stride);
+  }
+  return HIP_CALL(hipGetLastError());
+}
+
+}  // namespace rocm
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_tunable_op.cuh
@@ -6,8 +6,8 @@
 #include <hip/hip_runtime.h>
 
 #include "core/providers/rocm/cu_inc/common.cuh"
-#include "core/providers/rocm/math/softmax_common.h"
 #include "core/providers/rocm/math/softmax_ck.cuh"
+#include "core/providers/rocm/math/softmax_common.h"
 #include "core/providers/rocm/math/softmax_warpwise_impl.cuh"
 #include "core/providers/rocm/math/softmax_blockwise_impl.cuh"
 #include "core/providers/rocm/tunable/rocm_tunable.h"

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer.cc
@@ -7,8 +7,9 @@
 #include "python/tools/kernel_explorer/kernels/vector_add.h"
 #include "python/tools/kernel_explorer/kernels/rocm/fast_gelu.h"
 #include "python/tools/kernel_explorer/kernels/rocm/gemm.h"
-#include "python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.h"
 #include "python/tools/kernel_explorer/kernels/rocm/gemm_fast_gelu.h"
+#include "python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.h"
+#include "python/tools/kernel_explorer/kernels/rocm/softmax.h"
 
 namespace py = pybind11;
 
@@ -24,6 +25,7 @@ PYBIND11_MODULE(_kernel_explorer, m) {
   InitGemm(m);
   InitSkipLayerNorm(m);
   InitGemmFastGelu(m);
+  InitSoftmax(m);
 #endif
 
   m.def("is_composable_kernel_available", []() {

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
@@ -37,6 +37,51 @@ class SoftmaxBlockwise : public IKernelExplorer {
   ParamsT params_{};
 };
 
+template <typename T>
+class SoftmaxBlockwiseStaticSelection : public IKernelExplorer {
+ public:
+  SoftmaxBlockwiseStaticSelection(DeviceArray& output, DeviceArray& input, int softmax_elements,
+                                  int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {}
+
+  bool IsSupported() {
+    return true;
+  }
+
+  void Run() override {
+    ORT_THROW_IF_ERROR((rocm::SoftmaxBlockwiseStaticSelection<T, T, rocm::AccumulationType_t<T>>(&params_)));
+  }
+
+ private:
+  using ParamsT = rocm::SoftmaxParams<T, T>;
+  ParamsT params_{};
+};
+
+template <typename T>
+class SoftmaxTunable : public IKernelExplorer {
+ public:
+  SoftmaxTunable(DeviceArray& output, DeviceArray& input, int softmax_elements,
+                 int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
+    op_.EnableTuning();
+  }
+
+  void Run() override {
+    ORT_THROW_IF_ERROR(op_(&params_));
+  }
+
+  bool IsSupported() {
+    return true;
+  }
+
+ private:
+  using ParamsT = rocm::SoftmaxParams<T, T>;
+  ParamsT params_{};
+  rocm::SoftmaxTunableOp<T, T, rocm::AccumulationType_t<T>> op_{};
+};
+
 #define REGISTER_OP(name, type, vec_size)                                    \
   py::class_<name<type, vec_size>>(m, #name "_" #type "_" #vec_size)         \
       .def(py::init<DeviceArray&, DeviceArray&, int, int, int, int, bool>()) \
@@ -52,9 +97,23 @@ class SoftmaxBlockwise : public IKernelExplorer {
   REGISTER_OP(name, type, 8)                     \
   REGISTER_OP(name, type, 16)
 
+#define REGISTER_OP_TYPED(name, type)                                        \
+  py::class_<name<type>>(m, #name "_" #type)                                 \
+      .def(py::init<DeviceArray&, DeviceArray&, int, int, int, int, bool>()) \
+      .def("SetRepeats", &name<type>::SetRepeats)                            \
+      .def("Profile", &name<type>::Profile)                                  \
+      .def("Run", &name<type>::Run)                                          \
+      .def("IsSupported", &name<type>::IsSupported);
+
 void InitSoftmax(py::module m) {
   REGISTER_OP_FOR_ALL_VEC_SIZE(SoftmaxBlockwise, half);
   REGISTER_OP_FOR_ALL_VEC_SIZE(SoftmaxBlockwise, float);
+
+  REGISTER_OP_TYPED(SoftmaxBlockwiseStaticSelection, half);
+  REGISTER_OP_TYPED(SoftmaxBlockwiseStaticSelection, float);
+
+  REGISTER_OP_TYPED(SoftmaxTunable, half);
+  REGISTER_OP_TYPED(SoftmaxTunable, float);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "python/tools/kernel_explorer/kernels/rocm/softmax.h"
+
+#include <hip/hip_fp16.h>
+#include <pybind11/pybind11.h>
+
+#include "python/tools/kernel_explorer/device_array.h"
+#include "python/tools/kernel_explorer/kernel_explorer_interface.h"
+#include "core/providers/rocm/math/softmax_tunable_op.cuh"
+#include "core/providers/rocm/shared_inc/accumulation_type.h"
+
+namespace py = pybind11;
+
+namespace onnxruntime {
+
+template <typename T, int VecSize>
+class SoftmaxBlockwise : public IKernelExplorer {
+ public:
+  SoftmaxBlockwise(DeviceArray& output, DeviceArray& input, int softmax_elements,
+                   int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {}
+
+  void Run() override {
+    ORT_THROW_IF_ERROR((rocm::SoftmaxBlockwiseOp<T, T, rocm::AccumulationType_t<T>, VecSize>(&params_)));
+  }
+
+  bool IsSupported() {
+    Status status = rocm::SoftmaxBlockwiseOp<T, T, rocm::AccumulationType_t<T>, VecSize>(&params_);
+    return status.IsOK();
+  }
+
+ private:
+  using ParamsT = rocm::SoftmaxParams<T, T>;
+  ParamsT params_{};
+};
+
+#define REGISTER_OP(name, type, vec_size)                                    \
+  py::class_<name<type, vec_size>>(m, #name "_" #type "_" #vec_size)         \
+      .def(py::init<DeviceArray&, DeviceArray&, int, int, int, int, bool>()) \
+      .def("SetRepeats", &name<type, vec_size>::SetRepeats)                  \
+      .def("Profile", &name<type, vec_size>::Profile)                        \
+      .def("Run", &name<type, vec_size>::Run)                                \
+      .def("IsSupported", &name<type, vec_size>::IsSupported);
+
+#define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type) \
+  REGISTER_OP(name, type, 1)                     \
+  REGISTER_OP(name, type, 2)                     \
+  REGISTER_OP(name, type, 4)                     \
+  REGISTER_OP(name, type, 8)                     \
+  REGISTER_OP(name, type, 16)
+
+void InitSoftmax(py::module m) {
+  REGISTER_OP_FOR_ALL_VEC_SIZE(SoftmaxBlockwise, half);
+  REGISTER_OP_FOR_ALL_VEC_SIZE(SoftmaxBlockwise, float);
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
@@ -5,11 +5,17 @@
 
 #include <hip/hip_fp16.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
-#include "python/tools/kernel_explorer/device_array.h"
-#include "python/tools/kernel_explorer/kernel_explorer_interface.h"
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/providers/rocm/math/softmax_ck.cuh"
 #include "core/providers/rocm/math/softmax_tunable_op.cuh"
 #include "core/providers/rocm/shared_inc/accumulation_type.h"
+#include "python/tools/kernel_explorer/device_array.h"
+#include "python/tools/kernel_explorer/kernel_explorer_interface.h"
 
 namespace py = pybind11;
 
@@ -21,20 +27,27 @@ class SoftmaxBlockwise : public IKernelExplorer {
   SoftmaxBlockwise(DeviceArray& output, DeviceArray& input, int softmax_elements,
                    int input_stride, int output_stride, int batch_count, bool is_log_softmax)
       : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
-                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {}
+                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
+    type_string_ = "SoftmaxBlockwise_" + std::to_string(VecSize);
+  }
 
   void Run() override {
     ORT_THROW_IF_ERROR((rocm::SoftmaxBlockwiseOp<T, T, rocm::AccumulationType_t<T>, VecSize>(&params_)));
   }
 
-  bool IsSupported() {
+  std::vector<std::string> ListOps() const {
+    return {type_string_};
+  }
+
+  bool SelectOp(const std::string& name) {
     Status status = rocm::SoftmaxBlockwiseOp<T, T, rocm::AccumulationType_t<T>, VecSize>(&params_);
-    return status.IsOK();
+    return status.IsOK() && name == type_string_;
   }
 
  private:
   using ParamsT = rocm::SoftmaxParams<T, T>;
   ParamsT params_{};
+  std::string type_string_{};
 };
 
 template <typename T>
@@ -45,12 +58,16 @@ class SoftmaxBlockwiseStaticSelection : public IKernelExplorer {
       : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
                 softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {}
 
-  bool IsSupported() {
-    return true;
-  }
-
   void Run() override {
     ORT_THROW_IF_ERROR((rocm::SoftmaxBlockwiseStaticSelection<T, T, rocm::AccumulationType_t<T>>(&params_)));
+  }
+
+  std::vector<std::string> ListOps() const {
+    return {"SoftmaxBlockwiseStaticSelection"};
+  }
+
+  bool SelectOp(const std::string& name) {
+    return name == "SoftmaxBlockwiseStaticSelection";
   }
 
  private:
@@ -72,8 +89,12 @@ class SoftmaxTunable : public IKernelExplorer {
     ORT_THROW_IF_ERROR(op_(&params_));
   }
 
-  bool IsSupported() {
-    return true;
+  std::vector<std::string> ListOps() const {
+    return {"SoftmaxTunable"};
+  }
+
+  bool SelectOp(const std::string& name) {
+    return name == "SoftmaxTunable";
   }
 
  private:
@@ -82,13 +103,58 @@ class SoftmaxTunable : public IKernelExplorer {
   rocm::SoftmaxTunableOp<T, T, rocm::AccumulationType_t<T>> op_{};
 };
 
+#ifdef USE_COMPOSABLE_KERNEL
+template <typename T>
+class CKSoftmax : public IKernelExplorer {
+ public:
+  CKSoftmax(DeviceArray& output, DeviceArray& input, int softmax_elements,
+            int input_stride, int output_stride, int batch_count, bool is_log_softmax)
+      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+                softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
+    for (auto&& [type_string, op] : rocm::GetCKSoftmaxTypeStringAndOps<T, T, rocm::AccumulationType_t<T>>()) {
+      type_strings_.emplace_back(std::move(type_string));
+      ops_.emplace_back(std::move(op));
+    }
+  }
+
+  void Run() override {
+    ORT_THROW_IF_ERROR(ops_[selected_op_](&params_));
+  }
+
+  std::vector<std::string> ListOps() const {
+    return type_strings_;
+  }
+
+  bool SelectOp(const std::string& name) {
+    for (size_t i = 0; i < ops_.size(); i++) {
+      if (type_strings_[i] == name) {
+        selected_op_ = i;
+        Status status = ops_[i](&params_);
+        return status.IsOK();
+      }
+    }
+
+    ORT_THROW("Cannot find implementation ", name);
+  }
+
+ private:
+  using ParamsT = rocm::SoftmaxParams<T, T>;
+  using OpT = rocm::tunable::Op<ParamsT>;
+  ParamsT params_{};
+  std::vector<OpT> ops_;
+  std::vector<std::string> type_strings_;
+  size_t selected_op_{};
+};
+#endif  // USE_COMPOSABLE_KERNEL
+
 #define REGISTER_OP(name, type, vec_size)                                    \
   py::class_<name<type, vec_size>>(m, #name "_" #type "_" #vec_size)         \
       .def(py::init<DeviceArray&, DeviceArray&, int, int, int, int, bool>()) \
       .def("SetRepeats", &name<type, vec_size>::SetRepeats)                  \
       .def("Profile", &name<type, vec_size>::Profile)                        \
       .def("Run", &name<type, vec_size>::Run)                                \
-      .def("IsSupported", &name<type, vec_size>::IsSupported);
+      .def("ListOps", &name<type, vec_size>::ListOps)                        \
+      .def("SelectOp", &name<type, vec_size>::SelectOp);
 
 #define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type) \
   REGISTER_OP(name, type, 1)                     \
@@ -103,7 +169,8 @@ class SoftmaxTunable : public IKernelExplorer {
       .def("SetRepeats", &name<type>::SetRepeats)                            \
       .def("Profile", &name<type>::Profile)                                  \
       .def("Run", &name<type>::Run)                                          \
-      .def("IsSupported", &name<type>::IsSupported);
+      .def("ListOps", &name<type>::ListOps)                                  \
+      .def("SelectOp", &name<type>::SelectOp);
 
 void InitSoftmax(py::module m) {
   REGISTER_OP_FOR_ALL_VEC_SIZE(SoftmaxBlockwise, half);
@@ -114,6 +181,11 @@ void InitSoftmax(py::module m) {
 
   REGISTER_OP_TYPED(SoftmaxTunable, half);
   REGISTER_OP_TYPED(SoftmaxTunable, float);
+
+#ifdef USE_COMPOSABLE_KERNEL
+  REGISTER_OP_TYPED(CKSoftmax, half);
+  REGISTER_OP_TYPED(CKSoftmax, float);
+#endif  // USE_COMPOSABLE_KERNEL
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.cu
@@ -26,7 +26,7 @@ class SoftmaxBlockwise : public IKernelExplorer {
  public:
   SoftmaxBlockwise(DeviceArray& output, DeviceArray& input, int softmax_elements,
                    int input_stride, int output_stride, int batch_count, bool is_log_softmax)
-      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
                 softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
     type_string_ = "SoftmaxBlockwise_" + std::to_string(VecSize);
   }
@@ -55,7 +55,7 @@ class SoftmaxBlockwiseStaticSelection : public IKernelExplorer {
  public:
   SoftmaxBlockwiseStaticSelection(DeviceArray& output, DeviceArray& input, int softmax_elements,
                                   int input_stride, int output_stride, int batch_count, bool is_log_softmax)
-      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
                 softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {}
 
   void Run() override {
@@ -80,9 +80,9 @@ class SoftmaxTunable : public IKernelExplorer {
  public:
   SoftmaxTunable(DeviceArray& output, DeviceArray& input, int softmax_elements,
                  int input_stride, int output_stride, int batch_count, bool is_log_softmax)
-      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
                 softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
-    op_.EnableTuning();
+    params_.TuningContext()->EnableTunableOp();
   }
 
   void Run() override {
@@ -109,7 +109,7 @@ class CKSoftmax : public IKernelExplorer {
  public:
   CKSoftmax(DeviceArray& output, DeviceArray& input, int softmax_elements,
             int input_stride, int output_stride, int batch_count, bool is_log_softmax)
-      : params_(this->Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
                 softmax_elements, input_stride, output_stride, batch_count, is_log_softmax) {
     for (auto&& [type_string, op] : rocm::GetCKSoftmaxTypeStringAndOps<T, T, rocm::AccumulationType_t<T>>()) {
       type_strings_.emplace_back(std::move(type_string));

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/softmax.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace onnxruntime {
+
+void InitSoftmax(py::module m);
+
+}

--- a/onnxruntime/python/tools/kernel_explorer/kernels/softmax_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/softmax_test.py
@@ -1,0 +1,132 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import re
+import sys
+from dataclasses import dataclass
+from itertools import product
+
+import kernel_explorer as ke
+import numpy as np
+import pytest
+from utils import dtype_to_bytes
+
+
+def get_test_sizes():
+    batch_count = [1, 8]
+    softmax_elements = [1, 2, 3, 4, 5, 7, 8, 9, 11, 16, 31, 32, 33, 64, 65, 127, 128, 1024, 1025, 2048, 4096]
+    is_log_softmax = [True, False]
+    return product(batch_count, softmax_elements, is_log_softmax)
+
+
+def dtype_to_funcs(dtype):
+    type_map = {
+        "float16": list(filter(lambda x: re.match("Softmax.*_half.*", x), dir(ke))),
+        "float32": list(filter(lambda x: re.match("Softmax.*_float.*", x), dir(ke))),
+    }
+    return type_map[dtype]
+
+
+def softmax(x, is_log_softmax):
+    x = x - np.max(x, axis=-1, keepdims=1)
+    if is_log_softmax:
+        return x - np.log(np.sum(np.exp(x), axis=-1, keepdims=1))
+    return (np.exp(x)) / np.sum(np.exp(x), axis=-1, keepdims=1)
+
+
+def run_softmax(batch_count, softmax_elements, is_log_softmax, dtype, func):
+    np.random.seed(0)
+    x = np.random.rand(batch_count, softmax_elements).astype(dtype)
+    y = np.random.rand(batch_count, softmax_elements).astype(dtype)
+
+    x_d = ke.DeviceArray(x)
+    y_d = ke.DeviceArray(y)
+
+    softmax_func = getattr(ke, func)
+    softmax_op = softmax_func(
+        y_d, x_d, softmax_elements, softmax_elements, softmax_elements, batch_count, is_log_softmax
+    )
+    if softmax_op.IsSupported():
+        softmax_op.Run()
+        y_d.UpdateHostNumpyArray()
+
+        y_ref = softmax(x, is_log_softmax)
+        np.testing.assert_allclose(y_ref, y, rtol=1e-02)
+
+
+dtypes = ["float16", "float32"]
+
+
+@pytest.mark.parametrize("batch_count, softmax_elements, is_log_softmax", get_test_sizes())
+@pytest.mark.parametrize("dtype", dtypes)
+def test_softmax(batch_count, softmax_elements, is_log_softmax, dtype):
+    for f in dtype_to_funcs(dtype):
+        run_softmax(batch_count, softmax_elements, is_log_softmax, dtype, f)
+
+
+@dataclass
+class SoftmaxMetric(ke.BandwidthMetric):
+    batch_count: int
+    softmax_elements: int
+    is_log_softmax: bool
+
+    def report(self):
+        prefix = f"{self.name:<50} {self.dtype} batch_count={self.batch_count:<4} softmax_elements={self.softmax_elements:<4} "
+        if self.duration > 0:
+            return prefix + f"{self.duration:.2f} us, {self.gbps:.2f} GB/s"
+        return prefix + "not supported or redundant"
+
+
+def profile_softmax_func(batch_count, softmax_elements, is_log_softmax, dtype, func):
+    np.random.seed(0)
+    x = np.random.rand(batch_count, softmax_elements).astype(dtype)
+    y = np.random.rand(batch_count, softmax_elements).astype(dtype)
+
+    x_d = ke.DeviceArray(x)
+    y_d = ke.DeviceArray(y)
+
+    softmax_func = getattr(ke, func)
+    softmax_op = softmax_func(
+        y_d, x_d, softmax_elements, softmax_elements, softmax_elements, batch_count, is_log_softmax
+    )
+    if softmax_op.IsSupported():
+        duration_ms = softmax_op.Profile()
+    total_bytes = 2 * batch_count * softmax_elements * dtype_to_bytes(dtype)
+
+    ke.report(SoftmaxMetric(func, dtype, duration_ms, total_bytes, batch_count, softmax_elements, is_log_softmax))
+
+
+def profile_with_args(batch_count, softmax_elements, is_log_softmax, dtype, sort):
+    with ke.benchmark(sort):
+        for func in dtype_to_funcs(dtype):
+            profile_softmax_func(batch_count, softmax_elements, is_log_softmax, dtype, func)
+
+
+profile_size = [(1, 2048), (8, 2048), (65536, 4096)]
+
+
+def profile():
+    for dtype in dtypes:
+        for batch_count, softmax_elements in profile_size:
+            profile_with_args(batch_count, softmax_elements, True, dtype, True)
+            print()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group("profile with args")
+    group.add_argument("batch_count", type=int)
+    group.add_argument("softmax_elements", type=int)
+    group.add_argument("is_log_softmax", type=int)
+    group.add_argument("dtype", choices=dtypes)
+    group.add_argument("--sort", action="store_true")
+
+    if len(sys.argv) == 1:
+        profile()
+    else:
+        args = parser.parse_args()
+        profile_with_args(args.batch_count, args.softmax_elements, args.is_log_softmax, args.dtype, args.sort)


### PR DESCRIPTION
### Description
Add Softmax Tunable Op, only include blockwise vec implementation and composable kernel.
Related PR: https://github.com/microsoft/onnxruntime/pull/14475, https://github.com/microsoft/onnxruntime/pull/14612

