### PR TITLE
Support building a QAT onnx model using onnxblock

### DIFF
--- a/orttraining/orttraining/python/training/onnxblock/_qat_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_qat_utils.py
@@ -1,6 +1,3 @@
-import onnx
-
-
 def get_quant_params(model):
     """Returns quantization parameters for the given model.
 

--- a/orttraining/orttraining/python/training/onnxblock/_qat_utils.py
+++ b/orttraining/orttraining/python/training/onnxblock/_qat_utils.py
@@ -1,0 +1,15 @@
+import onnx
+
+
+def get_quant_params(model):
+    """Returns quantization parameters for the given model.
+
+    Quantization parameters in this function refers to all scale and zero point
+    inputs to any QuantizeLinear, DequantizeLinear or FakeQuant node in the model."""
+
+    return {
+        quant_param_name
+        for node in model.graph.node
+        for quant_param_name in node.input[1:]
+        if node.op_type == "QuantizeLinear" or node.op_type == "DequantizeLinear" or node.op_type == "FakeQuant"
+    }


### PR DESCRIPTION
After performing static quantization, the quant params are a part of the model initializers.

`onnxblock` treats model initializers as model parameters (for most scenarios) since it does not know how to (*smartly*) distinguish between model parameters and model initializers (consts or overridable initializers).

Quant params are not learnable (for now), so these parameters should not be used to build gradients. Moreover, we even avoid moving these parameters to graph inputs because these parameters are simply scalars (or 1d tensors).

This pull request adds support for doing the above in `onnxblock`.

