### PR TITLE
Del ort_model._modules to foward its accessing to torch_model._modules

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/ortmodule.py
+++ b/orttraining/orttraining/python/training/ortmodule/ortmodule.py
@@ -104,6 +104,10 @@ class ORTModule(torch.nn.Module):
         # else, they will be assigned to self._torch_module.original_module instead.
         self._is_initialized = True
 
+        # del the ort._modules so that all reference to  ort._modules will be forward to the underlying torch_model
+        # through '__getattr__'
+        del self._modules
+
     # IMPORTANT: DO NOT add code here
     # This declaration is for automatic document generation purposes only
     # The actual forward implementation is bound during ORTModule initialization

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4192,7 +4192,8 @@ def test_load_state_dict_for_wrapped_ortmodule():
     x = torch.randn(N, D_in, device=device)
     _ = wrapper_module(x)
 
-    state_dict1 = wrapper_module.state_dict()
+    # Must copy the state_dict or else they are sharing the same memory
+    state_dict1 = copy.deepcopy(wrapper_module.state_dict())
     list(next(iter(state_dict1.items())))[1] += 10
     wrapper_module.load_state_dict(state_dict1)
     state_dict2 = wrapper_module.state_dict()


### PR DESCRIPTION
### General Description
Missing '_modules' attribute in ORTModule will cause load_state_dict for wrapped_ortmodule fail.
The ut of 'test_load_state_dict_for_wrapped_ortmodule' has not catch this problem is because it didn't copy the state_dict
and the two state_dicts shared the same memory.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

reference:https://github.com/microsoft/onnxruntime/pull/7847 
