### PR TITLE
[ROCm][MIGraphX EP]Add back in support for gfx1030

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -264,7 +264,7 @@ if (onnxruntime_USE_ROCM)
   endif()
 
   if (NOT CMAKE_HIP_ARCHITECTURES)
-    set(CMAKE_HIP_ARCHITECTURES "gfx906;gfx908;gfx90a")
+    set(CMAKE_HIP_ARCHITECTURES "gfx906;gfx908;gfx90a;gfx1030")
   endif()
 
   file(GLOB rocm_cmake_components ${onnxruntime_ROCM_HOME}/lib/cmake/*)


### PR DESCRIPTION
Removed due to debug flags before commit via #14170. Fixes builds for Navi cards of onnxrt as this shouldn't have been removed

### Description
<!-- Describe your changes. -->
Adds back in proper build support for the Navi gen cards (gfx1030) 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Discovered an issue during onnxruntime builds with segfaults during test runs

