### PR TITLE
Register PytorchAtenDomain in RegisterOrtOpSchemas

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -4102,6 +4102,7 @@ void RegisterOrtOpSchemas() {
   }
   domainToVersionRangeInstance.AddDomainToVersion(onnxruntime::kMSExperimentalDomain, 1, 1);
   domainToVersionRangeInstance.AddDomainToVersion(onnxruntime::kMSNchwcDomain, 1, 1);
+  domainToVersionRangeInstance.AddDomainToVersion(onnxruntime::kPytorchAtenDomain, 1, 1);
 
   onnxruntime::contrib::RegisterContribSchemas();
   onnxruntime::training::RegisterTrainingOpSchemas();


### PR DESCRIPTION
### Description
Register `PytorchAtenDomain` in `RegisterOrtOpSchemas` before calling `RegisterContribSchemas`.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When building with `ENABLE_ATEN`, calling `RegisterOrtOpSchemas` will call `RegisterContribSchemas` which tries to [register ](https://github.com/microsoft/onnxruntime/blob/61e7636e618514c1d59c6d46bf7ccaa3df7fda88/onnxruntime/core/graph/contrib_ops/contrib_defs.cc#L2687) `ATen` operators. This results in the following error message because the `ATen` domain has not been registered:

```
##[error]CUSTOMBUILD(0,0): Error : Trying to register schema with name
ATen (domain: org.pytorch.aten version: 1) from file 
D:\a\_work\2\s\onnx-mlir\third_party\onnxruntime\onnxruntime\core\graph\contrib_ops\contrib_defs.cc line 2687,
but its domain is not known by the checker.
```

The PR adds the code to register the `ATen` domain before calling `RegisterContribSchemas`. I have not wrapped the domain registration code inside `#ifdef ENABLE_ATEN` to be consistent with the [equivalent code](https://github.com/microsoft/onnxruntime/blob/638f21b969143f65f4c47ce6b0f41f435e1d3ec3/onnxruntime/core/session/environment.cc#L233) in `environment.cc`.

