### PR TITLE
do not use raw pointer for CpuBuffersInfo::buffers

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
+++ b/onnxruntime/core/providers/cuda/cuda_stream_handle.cc
@@ -102,7 +102,7 @@ struct CpuBuffersInfo {
   // should contain all values in
   // deferred_release_buffer_pool_[my_stream]
   // when release my_stream's buffers.
-  void** buffers;
+  std::unique_ptr<void*[]> buffers;
   // CPU buffer buffers[i].
   // Number of buffer points in "buffers".
   size_t n_buffers;
@@ -117,7 +117,6 @@ static void CUDART_CB ReleaseCpuBufferCallback(void* raw_info) {
   for (size_t i = 0; i < info->n_buffers; ++i) {
     info->allocator->Free(info->buffers[i]);
   }
-  delete[] info->buffers;
 }
 
 Status CudaStream::CleanUpOnRunEnd() {
@@ -128,7 +127,7 @@ Status CudaStream::CleanUpOnRunEnd() {
   if (release_cpu_buffer_on_cuda_stream_ && cpu_allocator_->Info().alloc_type == OrtArenaAllocator) {
     std::unique_ptr<CpuBuffersInfo> cpu_buffers_info = std::make_unique<CpuBuffersInfo>();
     cpu_buffers_info->allocator = cpu_allocator_;
-    cpu_buffers_info->buffers = new void*[deferred_cpu_buffers_.size()];
+    cpu_buffers_info->buffers = std::make_unique<void*[]>(deferred_cpu_buffers_.size());
     for (size_t i = 0; i < deferred_cpu_buffers_.size(); ++i) {
       cpu_buffers_info->buffers[i] = deferred_cpu_buffers_.at(i);
     }


### PR DESCRIPTION
### Description
Do not use raw pointer for CpuBuffersInfo::buffers object



### Motivation and Context
This PR is to fix the bug 11159:
https://dev.azure.com/aiinfra/ONNX%20Runtime/_workitems/edit/11159/


