### PR TITLE
IdentityBuilder should add Delimit for each input

### DIFF
--- a/onnxruntime/core/optimizer/identical_children_consolidation.cc
+++ b/onnxruntime/core/optimizer/identical_children_consolidation.cc
@@ -110,17 +110,17 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
             default:
               break;
           }
-          indentity.append();
         } else {
           // TODO: handle non-scalar constant inputs, using checksum or something else
           return ignore_identity;
         }
       } else {
-        identity.append(name+"####");
+        identity.append(name);
       }
     } else {
       return ignore_identity;
     }
+    indentity.append("####");
   }
   return {identity};
 }

--- a/onnxruntime/core/optimizer/identical_children_consolidation.cc
+++ b/onnxruntime/core/optimizer/identical_children_consolidation.cc
@@ -120,7 +120,7 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
     } else {
       return ignore_identity;
     }
-    indentity.append("####");
+    identity.append("####");
   }
   return {identity};
 }

--- a/onnxruntime/core/optimizer/identical_children_consolidation.cc
+++ b/onnxruntime/core/optimizer/identical_children_consolidation.cc
@@ -116,7 +116,7 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
           return ignore_identity;
         }
       } else {
-        identity.append(name);
+        identity.append(name).append("####");
       }
     } else {
       return ignore_identity;

--- a/onnxruntime/core/optimizer/identical_children_consolidation.cc
+++ b/onnxruntime/core/optimizer/identical_children_consolidation.cc
@@ -110,6 +110,7 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
             default:
               break;
           }
+          indentity.append("####");
         } else {
           // TODO: handle non-scalar constant inputs, using checksum or something else
           return ignore_identity;
@@ -117,8 +118,10 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
       } else {
         identity.append(name);
       }
+    } else {
+      return ignore_identity;
     }
   }
-  return {identity.append("####")};
+  return {identity};
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/identical_children_consolidation.cc
+++ b/onnxruntime/core/optimizer/identical_children_consolidation.cc
@@ -110,13 +110,13 @@ string_view IdenticalChildrenConsolidation::IdentityBuilder(const Graph& graph, 
             default:
               break;
           }
-          indentity.append("####");
+          indentity.append();
         } else {
           // TODO: handle non-scalar constant inputs, using checksum or something else
           return ignore_identity;
         }
       } else {
-        identity.append(name).append("####");
+        identity.append(name+"####");
       }
     } else {
       return ignore_identity;


### PR DESCRIPTION
…("####") should append for each input_def, not only on the last one
else branch of this if should return ignore_identity
https://github.com/microsoft/onnxruntime/blob/3d7518762ace6929be98e1203174c2dbf1ac094e/onnxruntime/core/optimizer/identical_children_consolidation.cc#L66
identity.append("####") should append for each input_def, not only on the last one
### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


