### PR TITLE
Fix CI failure: temporarily disable real model tests from onnx repo

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -131,7 +131,18 @@
         "^test_edge_pad_cuda",
         "^test_reflect_pad_cuda",
         "^test_softplus_example_expanded_cuda",
-        "^test_softplus_expanded_cuda"
+        "^test_softplus_expanded_cuda",
+
+        // TODO: Recover these real model tests from onnx
+        "^test_vgg19",
+        "^test_zfnet512",
+        "^test_bvlc_alexnet",
+        "^test_densenet121",
+        "^test_inception_v1",
+        "^test_inception_v2",
+        "^test_resnet50",
+        "^test_shufflenet",
+        "^test_squeezenet"
     ],
     "current_failing_tests_x86": [
         "^test_vgg19",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
To faster unblock pipeline failure globally, disable these real models tests from onnx repo for now. Meanwhile, we are trying to move these models to Azure.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
https://github.com/onnx/onnx/issues/4857 these models in onnx repo are broken. They are setup 4 years ago and the owner of these AWS instances is unfound.

