### PR TITLE
Remove torch package from requirements.txt of stable diffusion models

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/requirements.txt
@@ -10,5 +10,6 @@ packaging==23.0
 protobuf==3.20.3
 psutil==5.9.4
 sympy==1.11.1
---extra-index-url https://download.pytorch.org/whl/cu117
-torch==1.13.1+cu117
+#Tested with PyTorch 1.13.1+cu117 (see pytorch.org for more download options).
+#--extra-index-url https://download.pytorch.org/whl/cu117
+#torch==1.13.1+cu117


### PR DESCRIPTION
### Description
Remove torch package from requirements to unblock nuget windowsai pipeline which does not allow --extra-index-url

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


