### PR TITLE
[WIP] Re-enable real model tests from onnx repo

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -302,7 +302,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "59a48e761fe17aa5a31dc81c224c9d1ee01bfc7d",
+          "commitHash": "1ba785612a79fe749aa1e478336e534743372639",
           "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "onnx"

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -302,7 +302,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "1ba785612a79fe749aa1e478336e534743372639",
+          "commitHash": "59a48e761fe17aa5a31dc81c224c9d1ee01bfc7d",
           "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "onnx"

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -23,7 +23,7 @@ microsoft_gsl;https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip;cf36
 microsoft_wil;https://github.com/microsoft/wil/archive/5f4caba4e7a9017816e47becdd918fcc872039ba.zip;fd119887d0d17c37adf1fc227b054befa28158ad
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.3.zip;e4f37b93b2da78a5816c2495603a4188d316214b
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.79.0.zip;c8f04e378535ededbe5af52c8f969d2dedbe73d5
-onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.13.0.zip;8dda5079cdb5a134b08b0c73f4592a6404fc2dc6
+onnx;https://github.com/onnx/onnx/archive/59a48e761fe17aa5a31dc81c224c9d1ee01bfc7d.zip;dd02bab83ce4395939556d10eaf49e4417d4f159
 #use the commit where it's several commits after 8.5-GA branch (https://github.com/onnx/onnx-tensorrt/commit/369d6676423c2a6dbf4a5665c4b5010240d99d3c)
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/369d6676423c2a6dbf4a5665c4b5010240d99d3c.zip;62119892edfb78689061790140c439b111491275
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.2.zip;9f71dad95fb83438e88822a9969fc93773fd8c48

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -23,7 +23,7 @@ microsoft_gsl;https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip;cf36
 microsoft_wil;https://github.com/microsoft/wil/archive/5f4caba4e7a9017816e47becdd918fcc872039ba.zip;fd119887d0d17c37adf1fc227b054befa28158ad
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.3.zip;e4f37b93b2da78a5816c2495603a4188d316214b
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.79.0.zip;c8f04e378535ededbe5af52c8f969d2dedbe73d5
-onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.13.0.zip;8dda5079cdb5a134b08b0c73f4592a6404fc2dc6
+onnx;https://github.com/onnx/onnx/archive/e192ba01e438d22ca2dedd7956e28e3551626c91.zip;f5c5301f16f1e39c2c5891883d1d7da967b68638
 #use the commit where it's several commits after 8.5-GA branch (https://github.com/onnx/onnx-tensorrt/commit/369d6676423c2a6dbf4a5665c4b5010240d99d3c)
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/369d6676423c2a6dbf4a5665c4b5010240d99d3c.zip;62119892edfb78689061790140c439b111491275
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.2.zip;9f71dad95fb83438e88822a9969fc93773fd8c48

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -23,7 +23,7 @@ microsoft_gsl;https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip;cf36
 microsoft_wil;https://github.com/microsoft/wil/archive/5f4caba4e7a9017816e47becdd918fcc872039ba.zip;fd119887d0d17c37adf1fc227b054befa28158ad
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.3.zip;e4f37b93b2da78a5816c2495603a4188d316214b
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.79.0.zip;c8f04e378535ededbe5af52c8f969d2dedbe73d5
-onnx;https://github.com/onnx/onnx/archive/59a48e761fe17aa5a31dc81c224c9d1ee01bfc7d.zip;dd02bab83ce4395939556d10eaf49e4417d4f159
+onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.13.0.zip;8dda5079cdb5a134b08b0c73f4592a6404fc2dc6
 #use the commit where it's several commits after 8.5-GA branch (https://github.com/onnx/onnx-tensorrt/commit/369d6676423c2a6dbf4a5665c4b5010240d99d3c)
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/369d6676423c2a6dbf4a5665c4b5010240d99d3c.zip;62119892edfb78689061790140c439b111491275
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.2.zip;9f71dad95fb83438e88822a9969fc93773fd8c48

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -131,18 +131,7 @@
         "^test_edge_pad_cuda",
         "^test_reflect_pad_cuda",
         "^test_softplus_example_expanded_cuda",
-        "^test_softplus_expanded_cuda",
-
-        // TODO: Recover these real model tests from onnx
-        "^test_vgg19",
-        "^test_zfnet512",
-        "^test_bvlc_alexnet",
-        "^test_densenet121",
-        "^test_inception_v1",
-        "^test_inception_v2",
-        "^test_resnet50",
-        "^test_shufflenet",
-        "^test_squeezenet"
+        "^test_softplus_expanded_cuda"
     ],
     "current_failing_tests_x86": [
         "^test_vgg19",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,8 @@ flatbuffers
 isort
 jinja2
 numpy
-onnx
+-i https://test.pypi.org/simple/
+onnx==1.13.1rc1
 onnxmltools
 packaging
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ isort
 jinja2
 numpy
 --extra-index-url https://test.pypi.org/simple/
-onnx==1.13.1rc1
+onnx==1.13.1rc2
 onnxmltools
 packaging
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flatbuffers
 isort
 jinja2
 numpy
--i https://test.pypi.org/simple/
+--extra-index-url https://test.pypi.org/simple/
 onnx==1.13.1rc1
 onnxmltools
 packaging

--- a/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
@@ -11,7 +11,7 @@ steps:
       packageType: upack
       feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
       definition: '517c4f6f-5437-4392-a70d-4f15ec5be2f0'
-      version: 1.0.29
+      version: 1.0.30
       downloadPath: $(Build.BinariesDirectory)/deps
 
 # The private ADO project
@@ -22,7 +22,7 @@ steps:
       packageType: upack
       feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
       definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
-      version: 1.0.29
+      version: 1.0.30
       downloadPath: $(Build.BinariesDirectory)/deps
 
 # You can add more ADO accounts at here.

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
--i https://test.pypi.org/simple/
+--extra-index-url https://test.pypi.org/simple/
 onnx==1.13.1rc1
 protobuf==3.20.2
 sympy==1.10.1

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -4,7 +4,7 @@ pytest
 setuptools>=41.4.0
 wheel
 --extra-index-url https://test.pypi.org/simple/
-onnx==1.13.1rc1
+onnx==1.13.1rc2
 protobuf==3.20.2
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,8 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-onnx==1.13.0
+-i https://test.pypi.org/simple/
+onnx==1.13.1rc1
 protobuf==3.20.2
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,8 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel>=0.35.1
-onnx==1.13.0
+-i https://test.pypi.org/simple/
+onnx==1.13.1rc1
 argparse
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -5,7 +5,7 @@ pytest
 setuptools>=41.4.0
 wheel>=0.35.1
 --extra-index-url https://test.pypi.org/simple/
-onnx==1.13.1rc1
+onnx==1.13.1rc2
 argparse
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel>=0.35.1
--i https://test.pypi.org/simple/
+--extra-index-url https://test.pypi.org/simple/
 onnx==1.13.1rc1
 argparse
 sympy==1.10.1


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Revert https://github.com/microsoft/onnxruntime/pull/14606 and test ONNX 1.13.1rc1 from TestPyPI.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Re-enable real model tests from onnx repo.

