### PR TITLE
Fix SAL annotation in private DML EP interface

### DIFF
--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -67,7 +67,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Writes the node name and null terminator into a char buffer.
     STDMETHOD(GetUtf8Name)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_(bufferSizeInBytes) char* name
+        _Out_writes_bytes_(bufferSizeInBytes) char* name
         ) const noexcept PURE;
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
@@ -77,7 +77,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Writes the node name and null terminator into a wchar buffer.
     STDMETHOD(GetWideName)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_(bufferSizeInBytes) wchar_t* name
+        _Out_writes_bytes_(bufferSizeInBytes) wchar_t* name
         ) const noexcept PURE;
 };
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -11,8 +11,8 @@ struct DML_OUTPUT_GRAPH_EDGE_DESC;
 struct DML_INTERMEDIATE_GRAPH_EDGE_DESC;
 
 // Either nodesAsOpDesc or nodesAsIDMLOperator is present.
-//  1) Operator kernels which implement operators using only a single DML operator will pass a DML_OPERATOR_DESC. 
-//     These kernels pass DML_OPERATOR_DESC, because while building Dml graph (inside FusedGraphKernel.cpp) we can change the 
+//  1) Operator kernels which implement operators using only a single DML operator will pass a DML_OPERATOR_DESC.
+//     These kernels pass DML_OPERATOR_DESC, because while building Dml graph (inside FusedGraphKernel.cpp) we can change the
 //     the flag of constant inputs to DML_TENSOR_FLAG_OWNED_BY_DML.
 //  2) Operator kernels which implement operators using DMLX graph, they will pass IDMLOperator and won't be able
 //     to use DML_TENSOR_FLAG_OWNED_BY_DML.
@@ -34,22 +34,22 @@ struct MLOperatorGraphDesc
 
 
 interface __declspec(uuid("aa2173bb-6684-4de8-abf2-9acbdf88b426"))
-IMLOperatorShapeInferenceContextPrivate : public IMLOperatorShapeInferenceContext 
+IMLOperatorShapeInferenceContextPrivate : public IMLOperatorShapeInferenceContext
 {
     STDMETHOD(GetConstantInputTensor)(
-        uint32_t inputIndex, 
+        uint32_t inputIndex,
         _Outptr_ IMLOperatorTensor** tensor
         ) const noexcept PURE;
 };
 
 interface __declspec(uuid("63bff199-0203-43c7-86c4-f442a599df4c"))
-IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContext 
+IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContext
 {
     STDMETHOD(GetConstantInputTensor)(
-        uint32_t inputIndex, 
+        uint32_t inputIndex,
         _Outptr_ IMLOperatorTensor** tensor
         ) const noexcept PURE;
-    
+
     STDMETHOD_(bool, IsDmlGraphNode)() const noexcept PURE;
 
     STDMETHOD(SetDmlOperator)(
@@ -63,11 +63,11 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
     //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).
     STDMETHOD_(uint32_t, GetUtf8NameBufferSizeInBytes)() const noexcept PURE;
- 
+
     //! Writes the node name and null terminator into a char buffer.
     STDMETHOD(GetUtf8Name)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_(bufferSizeInBytes) char* name
+        _Out_writes_bytes_(bufferSizeInBytes) char* name
         ) const noexcept PURE;
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
@@ -77,7 +77,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Writes the node name and null terminator into a wchar buffer.
     STDMETHOD(GetWideName)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_(bufferSizeInBytes) wchar_t* name
+        _Out_writes_bytes_(bufferSizeInBytes) wchar_t* name
         ) const noexcept PURE;
 };
 
@@ -105,7 +105,7 @@ IMLOperatorSupportQueryContextPrivate : public IMLOperatorAttributes1
     //! Gets the number of outputs to the operator.
     STDMETHOD_(uint32_t, GetOutputCount)() const noexcept PURE;
 
-    //! Returns true if an input to the operator is valid.  
+    //! Returns true if an input to the operator is valid.
     //! This always returns true except for optional inputs and invalid indices.
     STDMETHOD_(bool, IsInputValid)(uint32_t inputIndex) const noexcept PURE;
 
@@ -115,13 +115,13 @@ IMLOperatorSupportQueryContextPrivate : public IMLOperatorAttributes1
 
     //! Gets the description of the specified input edge of the operator.
     STDMETHOD(GetInputEdgeDescription)(
-        uint32_t inputIndex, 
+        uint32_t inputIndex,
         _Out_ MLOperatorEdgeDescription* edgeDescription
         ) const noexcept PURE;
 
     //! Gets the description of the specified output edge of the operator.
     STDMETHOD(GetOutputEdgeDescription)(
-        uint32_t outputIndex, 
+        uint32_t outputIndex,
         _Out_ MLOperatorEdgeDescription* edgeDescription
         ) const noexcept PURE;
 };

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/MLOperatorAuthorPrivate.h
@@ -11,8 +11,8 @@ struct DML_OUTPUT_GRAPH_EDGE_DESC;
 struct DML_INTERMEDIATE_GRAPH_EDGE_DESC;
 
 // Either nodesAsOpDesc or nodesAsIDMLOperator is present.
-//  1) Operator kernels which implement operators using only a single DML operator will pass a DML_OPERATOR_DESC.
-//     These kernels pass DML_OPERATOR_DESC, because while building Dml graph (inside FusedGraphKernel.cpp) we can change the
+//  1) Operator kernels which implement operators using only a single DML operator will pass a DML_OPERATOR_DESC. 
+//     These kernels pass DML_OPERATOR_DESC, because while building Dml graph (inside FusedGraphKernel.cpp) we can change the 
 //     the flag of constant inputs to DML_TENSOR_FLAG_OWNED_BY_DML.
 //  2) Operator kernels which implement operators using DMLX graph, they will pass IDMLOperator and won't be able
 //     to use DML_TENSOR_FLAG_OWNED_BY_DML.
@@ -34,22 +34,22 @@ struct MLOperatorGraphDesc
 
 
 interface __declspec(uuid("aa2173bb-6684-4de8-abf2-9acbdf88b426"))
-IMLOperatorShapeInferenceContextPrivate : public IMLOperatorShapeInferenceContext
+IMLOperatorShapeInferenceContextPrivate : public IMLOperatorShapeInferenceContext 
 {
     STDMETHOD(GetConstantInputTensor)(
-        uint32_t inputIndex,
+        uint32_t inputIndex, 
         _Outptr_ IMLOperatorTensor** tensor
         ) const noexcept PURE;
 };
 
 interface __declspec(uuid("63bff199-0203-43c7-86c4-f442a599df4c"))
-IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContext
+IMLOperatorKernelCreationContextPrivate : public IMLOperatorKernelCreationContext 
 {
     STDMETHOD(GetConstantInputTensor)(
-        uint32_t inputIndex,
+        uint32_t inputIndex, 
         _Outptr_ IMLOperatorTensor** tensor
         ) const noexcept PURE;
-
+    
     STDMETHOD_(bool, IsDmlGraphNode)() const noexcept PURE;
 
     STDMETHOD(SetDmlOperator)(
@@ -63,11 +63,11 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Gets the minimum size of a char buffer to store the node name (including null terminator).
     //! Returns 1 if the node has no name (calling GetUtf8Name will write a single null terminator).
     STDMETHOD_(uint32_t, GetUtf8NameBufferSizeInBytes)() const noexcept PURE;
-
+ 
     //! Writes the node name and null terminator into a char buffer.
     STDMETHOD(GetUtf8Name)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_bytes_(bufferSizeInBytes) char* name
+        _Out_writes_(bufferSizeInBytes) char* name
         ) const noexcept PURE;
 
     //! Gets the minimum size of a wchar buffer to store the node name (including null terminator).
@@ -77,7 +77,7 @@ IMLOperatorKernelCreationContextNodeWrapperPrivate : public IMLOperatorKernelCre
     //! Writes the node name and null terminator into a wchar buffer.
     STDMETHOD(GetWideName)(
         uint32_t bufferSizeInBytes,
-        _Out_writes_bytes_(bufferSizeInBytes) wchar_t* name
+        _Out_writes_(bufferSizeInBytes) wchar_t* name
         ) const noexcept PURE;
 };
 
@@ -105,7 +105,7 @@ IMLOperatorSupportQueryContextPrivate : public IMLOperatorAttributes1
     //! Gets the number of outputs to the operator.
     STDMETHOD_(uint32_t, GetOutputCount)() const noexcept PURE;
 
-    //! Returns true if an input to the operator is valid.
+    //! Returns true if an input to the operator is valid.  
     //! This always returns true except for optional inputs and invalid indices.
     STDMETHOD_(bool, IsInputValid)(uint32_t inputIndex) const noexcept PURE;
 
@@ -115,13 +115,13 @@ IMLOperatorSupportQueryContextPrivate : public IMLOperatorAttributes1
 
     //! Gets the description of the specified input edge of the operator.
     STDMETHOD(GetInputEdgeDescription)(
-        uint32_t inputIndex,
+        uint32_t inputIndex, 
         _Out_ MLOperatorEdgeDescription* edgeDescription
         ) const noexcept PURE;
 
     //! Gets the description of the specified output edge of the operator.
     STDMETHOD(GetOutputEdgeDescription)(
-        uint32_t outputIndex,
+        uint32_t outputIndex, 
         _Out_ MLOperatorEdgeDescription* edgeDescription
         ) const noexcept PURE;
 };


### PR DESCRIPTION
In #14461 I added a private interface to MLOperatorAuthorPrivate.h to pipe ORT node names through to the debug name of DML operators/graphs. The wrong SAL annotation was used on the `Get*Name` methods, which confused static analysis tools into thinking there is a potential buffer overrun.