### PR TITLE
[T5 optimization] fuse rel_pos_bias and remove extended mask

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -1038,7 +1038,7 @@ class OnnxModel:
             return False
         if tensor1.HasField("raw_data") and tensor2.HasField("raw_data"):
             return tensor1.raw_data == tensor2.raw_data
-        return numpy_helper.to_array(tensor1) == numpy_helper.to_array(tensor2)
+        return (numpy_helper.to_array(tensor1) == numpy_helper.to_array(tensor2)).all()
 
     def remove_duplicated_initializer(self):
         """Remove initializers with duplicated values, and only keep the first one.

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -170,17 +170,25 @@ class T5OnnxModel(BertOnnxModel):
             if node.op_type == "Add":
                 extended_mask_nodes = self.match_parent_path(
                     node,
-                    ["Mul", "Sub", "Mul", "Unsqueeze", "Cast", "LessOrEqual", "Tile", "Concat", "Unsqueeze", "Gather", "Shape"],
-                    [1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0]
+                    [
+                        "Mul",
+                        "Sub",
+                        "Mul",
+                        "Unsqueeze",
+                        "Cast",
+                        "LessOrEqual",
+                        "Tile",
+                        "Concat",
+                        "Unsqueeze",
+                        "Gather",
+                        "Shape",
+                    ],
+                    [1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0],
                 )
                 if extended_mask_nodes is None:
                     continue
 
-                rpb_nodes = self.match_parent_path(
-                    node,
-                    ["RelativePositionBias"],
-                    [0]
-                )
+                rpb_nodes = self.match_parent_path(node, ["RelativePositionBias"], [0])
                 if rpb_nodes is None:
                     continue
 
@@ -197,17 +205,26 @@ class T5OnnxModel(BertOnnxModel):
             if node.op_type == "Add":
                 extended_mask_nodes = self.match_parent_path(
                     node,
-                    ["Mul", "Sub", "Mul", "Unsqueeze", "Concat", "Cast", "LessOrEqual", "Tile", "Concat", "Unsqueeze", "Gather", "Shape"],
-                    [1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0]
+                    [
+                        "Mul",
+                        "Sub",
+                        "Mul",
+                        "Unsqueeze",
+                        "Concat",
+                        "Cast",
+                        "LessOrEqual",
+                        "Tile",
+                        "Concat",
+                        "Unsqueeze",
+                        "Gather",
+                        "Shape",
+                    ],
+                    [1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0],
                 )
                 if extended_mask_nodes is None:
                     continue
 
-                rpb_nodes = self.match_parent_path(
-                    node,
-                    ["Slice", "RelativePositionBias"],
-                    [0, 0]
-                )
+                rpb_nodes = self.match_parent_path(node, ["Slice", "RelativePositionBias"], [0, 0])
                 if rpb_nodes is None:
                     continue
 
@@ -217,7 +234,6 @@ class T5OnnxModel(BertOnnxModel):
                 nodes_to_remove.extend(extended_mask_nodes)
                 nodes_to_remove.append(node)
                 self.remove_nodes(nodes_to_remove)
-
 
     def postprocess(self):
         self.rpb_fusion.apply()

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -5,6 +5,7 @@
 import logging
 from typing import Union
 
+import numpy as np
 from fusion_attention import AttentionMask, FusionAttention
 from fusion_base import Fusion
 from fusion_skiplayernorm import FusionSkipLayerNormalization
@@ -12,8 +13,6 @@ from fusion_utils import NumpyHelper
 from onnx import NodeProto, TensorProto, helper
 from onnx_model import OnnxModel
 from onnx_model_bert import BertOnnxModel
-
-import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -100,7 +100,7 @@ class FusionRelativePositionBiasBlock(Fusion):
             if range_nodes is None:
                 return
 
-        range = range_nodes[-1]
+        range_node = range_nodes[-1]
 
         self.nodes_to_remove.extend(compute_bias_nodes)
         self.nodes_to_remove.extend(compute_buckets_nodes)
@@ -119,7 +119,7 @@ class FusionRelativePositionBiasBlock(Fusion):
         )
 
         self.model.add_initializer(bias_table, self.this_graph_name)
-        inputs = [bias_table.name, range.input[1], range.input[1]]
+        inputs = [bias_table.name, range_node.input[1], range_node.input[1]]
         outputs = [unsqueeze.output[0]]
         rpb_node = helper.make_node(
             "RelativePositionBias",

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -7,9 +7,9 @@ from typing import Union
 
 from fusion_attention import AttentionMask, FusionAttention
 from fusion_base import Fusion
-from fusion_utils import NumpyHelper
 from fusion_skiplayernorm import FusionSkipLayerNormalization
-from onnx import NodeProto, TensorProto, helper, numpy_helper
+from fusion_utils import NumpyHelper
+from onnx import NodeProto, TensorProto, helper
 from onnx_model import OnnxModel
 from onnx_model_bert import BertOnnxModel
 

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -50,6 +50,7 @@ class FusionT5Attention(FusionAttention):
         # Not implemented yet
         return
 
+
 class FusionRelativePositionBiasBlock(Fusion):
     def __init__(self, model: OnnxModel, max_distance: int):
         super().__init__(model, "RelativePositionBias", ["Add", "Slice"])
@@ -64,15 +65,11 @@ class FusionRelativePositionBiasBlock(Fusion):
             return
 
         compute_bias_nodes = self.model.match_parent_path(
-            node,
-            ["Unsqueeze", "Transpose", "Gather", "Where"],
-            [0, 0, 0, 1]
+            node, ["Unsqueeze", "Transpose", "Gather", "Where"], [0, 0, 0, 1]
         )
         if compute_bias_nodes is None:
             compute_bias_nodes = self.model.match_parent_path(
-                node,
-                ["Unsqueeze", "Transpose", "Gather", "Add", "Where"],
-                [0, 0, 0, 1, 1]
+                node, ["Unsqueeze", "Transpose", "Gather", "Add", "Where"], [0, 0, 0, 1, 1]
             )
             if compute_bias_nodes is None:
                 return
@@ -94,13 +91,11 @@ class FusionRelativePositionBiasBlock(Fusion):
         range_nodes = self.model.match_parent_path(
             div,
             ["Cast", "Neg", "Min", "ConstantOfShape", "Shape", "Sub", "Unsqueeze", "Range"],
-            [0, 0, 0, 1, 0, 0, 0, 0]
+            [0, 0, 0, 1, 0, 0, 0, 0],
         )
         if range_nodes is None:
             range_nodes = self.model.match_parent_path(
-                div,
-                ["Cast", "Abs", "Sub", "Unsqueeze", "Range"],
-                [0, 0, 0, 0, 0]
+                div, ["Cast", "Abs", "Sub", "Unsqueeze", "Range"], [0, 0, 0, 0, 0]
             )
             self.is_bidirectional = True
             if range_nodes is None:

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -50,13 +50,6 @@ class FusionT5Attention(FusionAttention):
         # Not implemented yet
         return
 
-
-# Attr("max_distance", "Max distance", AttributeProto::INT)
-# Attr("is_bidirectional", "Default value is 0.", AttributeProto::INT, static_cast<int64_t>(0))
-# Input(0, "bias_table", "2D input tensor with shape (num_buckets, num_heads), COL-major(See UT for example)", "T")
-# Input(1, "query_length", "The length of query. Self Attention requires query_length = key_length", "U")
-# Input(2, "key_length", "The length of key.", "U")
-# Output(0, "output", "4D output tensor with shape (1, num_heads, sequence_length, sequence_length)", "T")
 class FusionRelativePositionBiasBlock(Fusion):
     def __init__(self, model: OnnxModel, max_distance: int):
         super().__init__(model, "RelativePositionBias", ["Add", "Slice"])
@@ -65,6 +58,8 @@ class FusionRelativePositionBiasBlock(Fusion):
         self.is_bidirectional = False
 
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
+        # TODO: optimization opportunity: Only last dimension of relative_position_bias is used in decoder.
+        # Cuda kernel can be optimized to only compute last dimension.
         if node.op_type != "Add" and node.op_type != "Slice":
             return
 
@@ -74,7 +69,13 @@ class FusionRelativePositionBiasBlock(Fusion):
             [0, 0, 0, 1]
         )
         if compute_bias_nodes is None:
-            return
+            compute_bias_nodes = self.model.match_parent_path(
+                node,
+                ["Unsqueeze", "Transpose", "Gather", "Add", "Where"],
+                [0, 0, 0, 1, 1]
+            )
+            if compute_bias_nodes is None:
+                return
 
         gather = compute_bias_nodes[2]
         where = compute_bias_nodes[-1]
@@ -82,45 +83,42 @@ class FusionRelativePositionBiasBlock(Fusion):
 
         compute_buckets_nodes = self.model.match_parent_path(
             where,
-            ["Min", "ConstantOfShape", "Shape", "Add", "Cast", "Mul", "Div", "Log", "Div", "Cast", "Neg"],
-            [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ["Min", "ConstantOfShape", "Shape", "Add", "Cast", "Mul", "Div", "Log", "Div"],
+            [2, 1, 0, 0, 0, 0, 0, 0, 0],
         )
         if compute_buckets_nodes is None:
             return
 
-        neg = compute_buckets_nodes[-1]
-
-        less_nodes = self.model.match_parent_path(
-            where,
-            ["Less"],
-            [0]
-        )
-        if less_nodes is None:
-            return
-
-        less = less_nodes[0]
-        if (less.input[0] != neg.output[0]):
-            return
+        div = compute_buckets_nodes[-1]
 
         range_nodes = self.model.match_parent_path(
-            neg,
-            ["Min", "ConstantOfShape", "Shape", "Sub", "Unsqueeze", "Range"],
-            [0, 1, 0, 0, 0, 0]
+            div,
+            ["Cast", "Neg", "Min", "ConstantOfShape", "Shape", "Sub", "Unsqueeze", "Range"],
+            [0, 0, 0, 1, 0, 0, 0, 0]
         )
         if range_nodes is None:
-            return
+            range_nodes = self.model.match_parent_path(
+                div,
+                ["Cast", "Abs", "Sub", "Unsqueeze", "Range"],
+                [0, 0, 0, 0, 0]
+            )
+            self.is_bidirectional = True
+            if range_nodes is None:
+                return
+
         range = range_nodes[-1]
 
         self.nodes_to_remove.extend(compute_bias_nodes)
         self.nodes_to_remove.extend(compute_buckets_nodes)
-        self.nodes_to_remove.extend(less_nodes)
         self.nodes_to_remove.extend(range_nodes)
+
+        node_name_prefix = "encoder" if self.is_bidirectional else "decoder"
 
         table_weight_i = self.model.get_initializer(gather.input[0])
         table_weight = NumpyHelper.to_array(table_weight_i)
         table_weight_t = np.transpose(table_weight)
         bias_table = helper.make_tensor(
-            name="bias_table_weight",
+            name=node_name_prefix + "bias_table_weight",
             data_type=TensorProto.FLOAT,
             dims=[np.shape(table_weight)[0], np.shape(table_weight)[1]],
             vals=table_weight_t.flatten().tolist(),
@@ -133,7 +131,7 @@ class FusionRelativePositionBiasBlock(Fusion):
             "RelativePositionBias",
             inputs=inputs,
             outputs=outputs,
-            name=self.model.create_node_name("RelativePositionBias", name_prefix="RPB"),
+            name=self.model.create_node_name("RelativePositionBias", name_prefix=node_name_prefix),
         )
         rpb_node.domain = "com.microsoft"
         rpb_node.attribute.extend([helper.make_attribute("max_distance", self.max_distance)])


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

1. fuse rel_pos_bias in T5.
2. remove extended masks in T5 decoder and decoder_init since they generate all zeros
3. fix a bug in onnx_model.py


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


