### PR TITLE
[ROCm] Support for gpt2-based model inferencing

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/attention.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/attention.cc
@@ -115,7 +115,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                                                    parameters.batch_size,
                                                    parameters.num_heads, 
                                                    parameters.head_size,
-                                                   parameters.sequence_length,, 
+                                                   parameters.sequence_length,
                                                    parameters.past_sequence_length); 
 
   auto work_space = GetScratchBuffer<void>(workSpaceSize, context->GetComputeStream());

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
@@ -20,28 +20,42 @@ namespace rocm {
       kRocmExecutionProvider,                                     \
       (*KernelDefBuilder::Create())                               \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
-      SkipLayerNorm<T>);
+      SkipLayerNorm<T, false>);                                   \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      SkipSimplifiedLayerNormalization,                           \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      SkipLayerNorm<T, true>);
 
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
 
 using namespace ONNX_NAMESPACE;
 
-template <typename T>
-SkipLayerNorm<T>::SkipLayerNorm(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {
+template <typename T, bool Simplified>
+SkipLayerNorm<T, Simplified>::SkipLayerNorm(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {
   ORT_ENFORCE(op_kernel_info.GetAttr<float>("epsilon", &epsilon_).IsOK());
   ORT_ENFORCE(epsilon_ >= 0);
 }
 
-template <typename T>
-Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
+template <typename T, bool Simplified>
+Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor* input = ctx->Input<Tensor>(0);
   const Tensor* skip = ctx->Input<Tensor>(1);
   const Tensor* gamma = ctx->Input<Tensor>(2);
-  const Tensor* beta = ctx->Input<Tensor>(3);
-  const Tensor* bias = ctx->Input<Tensor>(4);
+
+  const Tensor* beta = Simplified ? nullptr : ctx->Input<Tensor>(3);
+  const Tensor* bias = Simplified ? ctx->Input<Tensor>(3) : ctx->Input<Tensor>(4);
 
   Tensor* output = ctx->Output(0, input->Shape());
+
+  // For inferencing, we support one more optional output which is the sum
+  // of the input and skip tensors
+  Tensor* skip_input_bias_add_output = ctx->Output(3, input->Shape());
 
   if (input->Shape() != skip->Shape()) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -68,15 +82,17 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
                            "Last dimension of gamma and input does not match");
   }
 
-  if (nullptr != beta) {
-    const auto& beta_dims = beta->Shape().GetDims();
-    if (beta_dims.size() != 1) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "beta is expected to have 1 dimension, got ", beta_dims.size());
-    }
-    if (beta_dims[0] != input_dims[2]) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Last dimension of beta and input does not match");
+  if (!Simplified) {
+    if (nullptr != beta) {
+      const auto& beta_dims = beta->Shape().GetDims();
+      if (beta_dims.size() != 1) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                              "beta is expected to have 1 dimension, got ", beta_dims.size());
+      }
+      if (beta_dims[0] != input_dims[2]) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                              "Last dimension of beta and input does not match");
+      }
     }
   }
 
@@ -97,10 +113,11 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
   int64_t element_count = input_dims[0] * sequence_length * hidden_size;
   typedef typename ToHipType<T>::MappedType HipT;
 
-  return LaunchSkipLayerNormKernel<HipT>(
+  return LaunchSkipLayerNormKernel<HipT, Simplified>(
       GetTuningContext(),
       Stream(ctx),
       reinterpret_cast<HipT*>(output->MutableData<T>()),
+      skip_input_bias_add_output != nullptr ? reinterpret_cast<HipT*>(skip_input_bias_add_output->MutableData<T>()) : nullptr,
       reinterpret_cast<const HipT*>(input->Data<T>()),
       reinterpret_cast<const HipT*>(skip->Data<T>()),
       reinterpret_cast<const HipT*>(gamma->Data<T>()),

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
@@ -82,7 +82,7 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
                            "Last dimension of gamma and input does not match");
   }
 
-  if (!Simplified) {
+  if constexpr (!Simplified) {
     if (nullptr != beta) {
       const auto& beta_dims = beta->Shape().GetDims();
       if (beta_dims.size() != 1) {

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.h
@@ -11,7 +11,7 @@ namespace rocm {
 
 using namespace onnxruntime::rocm;
 
-template <typename T>
+template <typename T, bool Simplified>
 class SkipLayerNorm final : public RocmKernel {
  public:
   SkipLayerNorm(const OpKernelInfo& op_kernel_info);

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
@@ -53,7 +53,7 @@ Status LaunchSkipLayerNormKernel(
     return op(&params);
   }
 
-  return SkipLayerNormStaticSelection<T, Simplified>(&params)
+  return SkipLayerNormStaticSelection<T, Simplified>(&params);
 }
 
 template Status LaunchSkipLayerNormKernel<float, true>(

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
@@ -39,32 +39,44 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-template <typename T>
+template <typename T,  bool Simplified>
 Status LaunchSkipLayerNormKernel(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, T* output, const T* input, const T* skip, const T* gamma,
-    const T* beta, const T* bias, float epsilon, int ld, int element_count) {
+    RocmTuningContext* tuning_ctx, hipStream_t stream, T* output,  T* skip_input_bias_add_output, const T* input, 
+    const T* skip, const T* gamma, const T* beta, const T* bias, float epsilon, int ld, int element_count) {
   // this must be true because element_count is the total size of the tensor
   assert(element_count % ld == 0);
 
-  SkipLayerNormParams<T> params(tuning_ctx, stream, output, input, skip, gamma, beta, bias, epsilon, ld, element_count);
+  SkipLayerNormParams<T> params(tuning_ctx, stream, output, skip_input_bias_add_output, input, skip, gamma, beta, bias, epsilon, ld, element_count);
 
   if (tuning_ctx->IsTunableOpEnabled()) {
-    static SkipLayerNormTunableOp<T> op;
+    static SkipLayerNormTunableOp<T, Simplified> op;
     return op(&params);
   }
 
-  return SkipLayerNormStaticSelection<T>(&params);
+  return SkipLayerNormStaticSelection<T, Simplified>(&params)
 }
 
-template Status LaunchSkipLayerNormKernel<float>(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, float* output, const float* input,
-    const float* skip, const float* gamma, const float* beta,
+template Status LaunchSkipLayerNormKernel<float, true>(
+    RocmTuningContext* tuning_ctx, hipStream_t stream, float* output, float* skip_input_bias_add_output, 
+    const float* input, const float* skip, const float* gamma, const float* beta,
     const float* bias, float epsilon, int ld,
     int element_count);
 
-template Status LaunchSkipLayerNormKernel<half>(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, half* output, const half* input,
-    const half* skip, const half* gamma, const half* beta,
+template Status LaunchSkipLayerNormKernel<float, false>(
+    RocmTuningContext* tuning_ctx, hipStream_t stream, float* output, float* skip_input_bias_add_output, 
+    const float* input, const float* skip, const float* gamma, const float* beta,
+    const float* bias, float epsilon, int ld,
+    int element_count);
+
+template Status LaunchSkipLayerNormKernel<half, true>(
+    RocmTuningContext* tuning_ctx, hipStream_t stream, half* output, half* skip_input_bias_add_output, 
+    const half* input, const half* skip, const half* gamma, const half* beta,
+    const half* bias, float epsilon, int ld,
+    int element_count);
+
+template Status LaunchSkipLayerNormKernel<half, false>(
+    RocmTuningContext* tuning_ctx, hipStream_t stream, half* output, half* skip_input_bias_add_output, 
+    const half* input, const half* skip, const half* gamma, const half* beta,
     const half* bias, float epsilon, int ld,
     int element_count);
 

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
@@ -10,11 +10,12 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-template <typename T>
+template <typename T, bool Simplified>
 Status LaunchSkipLayerNormKernel(
     RocmTuningContext* tuning,
     hipStream_t stream,
     T* output,         // output tensor
+    T* skip_input_bias_add_output, // optional output tensor
     const T* input,    // input tensor
     const T* skip,     // skip tensor
     const T* gamma,    // Layer normalization gamma tensor

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
@@ -46,7 +46,7 @@ __global__ void SkipLayerNormKernel(
     
     output[idx] = val;
   }
-  if (Simplified) {
+  if constexpr (Simplified) {
     SimplifiedLayerNorm<T, TPB>(thread_data.value, ld, offset, gamma, epsilon, output);
     return;
   }
@@ -101,7 +101,7 @@ __global__ void SkipLayerNormKernelVec(
       *(reinterpret_cast<VecT*>(&output[idx])) = *reinterpret_cast<VecT*>(&input_v[0]);
     }
   }
-  if (Simplified) {
+  if constexpr (Simplified) {
     SimplifiedLayerNormVec<T, TPB, ILP>(thread_data.value, ld, offset, gamma, epsilon, output);
     return;
   }
@@ -155,7 +155,7 @@ __global__ void SkipLayerNormKernelSmall(
 
     thread_data = hipcub::KeyValuePair<T, T>(rldval_sum, rldvalsq_sum);
   }
-  if (Simplified) {
+  if constexpr (Simplified) {
     SimplifiedLayerNormSmall<T, TPB, ILP>(input_v, thread_data.value, ld, idx, gamma, epsilon, output);
     return;
   }

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl_kernel.h
@@ -23,10 +23,10 @@ half maybe2half(float x) {
   return __float2half_rn(x);
 }
 
-template <typename T, unsigned TPB>
+template <typename T, unsigned TPB, bool Simplified>
 __global__ void SkipLayerNormKernel(
     const int ld, const T* input, const T* skip, const T* beta, const T* gamma, const T* bias,
-    const T epsilon, T* output) {
+    const T epsilon, T* output, T* skip_input_bias_add_output) {
   const T reverse_ld = T(1.f / ld);
   const int offset = blockIdx.x * ld;
 
@@ -39,17 +39,26 @@ __global__ void SkipLayerNormKernel(
     const T val = (bias == nullptr) ? input[idx] + skip[idx] : input[idx] + skip[idx] + bias[i];
     const T rldval = reverse_ld * val;
     thread_data = pair_sum(thread_data, hipcub::KeyValuePair<T, T>(rldval, rldval * val));
+    
+    if (skip_input_bias_add_output != nullptr) {
+      skip_input_bias_add_output[idx] = val;
+    }
+    
     output[idx] = val;
   }
-
+  if (Simplified) {
+    SimplifiedLayerNorm<T, TPB>(thread_data.value, ld, offset, gamma, epsilon, output);
+    return;
+  }
   LayerNorm<T, TPB>(thread_data, ld, offset, beta, gamma, epsilon, output);
 }
 
 // Vectorized kernel
-template <typename T, unsigned TPB, int ILP>
+template <typename T, unsigned TPB, int ILP, bool Simplified>
 __global__ void SkipLayerNormKernelVec(
     const int ld, const T* input, const T* skip, const T* beta, const T* gamma,
-    const T* bias, const T epsilon, T* output, bool hasBias) {
+    const T* bias, const T epsilon, T* output, T* skip_input_bias_add_output, 
+    bool hasBias, bool hasSkipInputBiasAdditionOutput) {
   const T reverse_ld = T(1.f / ld);
   const int offset = blockIdx.x * ld;
 
@@ -58,7 +67,7 @@ __global__ void SkipLayerNormKernelVec(
   hipcub::KeyValuePair<T, T> thread_data(0, 0);
 
   using VecT = aligned_vector<T, ILP>;
-  T input_v[ILP], skip_v[ILP], bias_v[ILP];
+  T input_v[ILP], skip_v[ILP], bias_v[ILP], skip_input_bias_add_output_v[ILP];
   if (threadIdx.x * ILP < ld) {
     VecT* input_val = reinterpret_cast<VecT*>(&input_v);
     VecT* skip_val = reinterpret_cast<VecT*>(&skip_v);
@@ -76,26 +85,40 @@ __global__ void SkipLayerNormKernelVec(
       #pragma unroll
       for (int k = 0; k < ILP; k++) {
         input_v[k] += hasBias ? skip_v[k] + bias_v[k] : skip_v[k];
+
+        if (hasSkipInputBiasAdditionOutput) {
+          skip_input_bias_add_output_v[i] = input_v[i];
+        }
+
         const T rldval = reverse_ld * input_v[k];
         thread_data = pair_sum(thread_data, hipcub::KeyValuePair<T, T>(rldval, rldval * input_v[k]));
       }
+
+      if (hasSkipInputBiasAdditionOutput) {
+        *(reinterpret_cast<VecT*>(&skip_input_bias_add_output[idx])) = *reinterpret_cast<VecT*>(&skip_input_bias_add_output_v);
+      }
+
       *(reinterpret_cast<VecT*>(&output[idx])) = *reinterpret_cast<VecT*>(&input_v[0]);
     }
   }
-
+  if (Simplified) {
+    SimplifiedLayerNormVec<T, TPB, ILP>(thread_data.value, ld, offset, gamma, epsilon, output);
+    return;
+  }
   LayerNormVec<T, TPB, ILP>(thread_data, ld, offset, beta, gamma, epsilon, output);
 }
 
 // Vectorized kernel
-template <typename T, unsigned TPB, int ILP>
+template <typename T, unsigned TPB, int ILP, bool Simplified>
 __global__ void SkipLayerNormKernelSmall(
     const int ld, const T* input, const T* skip, const T* beta, const T* gamma,
-    const T* bias, const T epsilon, T* output, bool hasBias) {
+    const T* bias, const T epsilon, T* output, T* skip_input_bias_add_output,
+    bool hasBias, bool hasSkipInputBiasAdditionOutput) {
   const T rld = T(1.f / ld);
   const int idx = blockIdx.x * ld + threadIdx.x * ILP;  // grid_size = n / ld
 
   using VecT = aligned_vector<T, ILP>;
-  T input_v[ILP], skip_v[ILP], bias_v[ILP];
+  T input_v[ILP], skip_v[ILP], bias_v[ILP], skip_input_bias_add_output_v[ILP];
 
   hipcub::KeyValuePair<T, T> thread_data(T(0.f), T(0.f));
 
@@ -116,11 +139,25 @@ __global__ void SkipLayerNormKernelSmall(
     #pragma unroll
     for (int i = 0; i < ILP; i++) {
       input_v[i] += hasBias ? skip_v[i] + bias_v[i] : skip_v[i];
+
+      if (hasSkipInputBiasAdditionOutput) {
+        skip_input_bias_add_output_v[i] = input_v[i];
+      }
+
       const T rldval = rld * input_v[i];
       rldval_sum += rldval;
       rldvalsq_sum += rldval * input_v[i];
     }
+
+    if (hasSkipInputBiasAdditionOutput) {
+      *(reinterpret_cast<VecT*>(&skip_input_bias_add_output[idx])) = *reinterpret_cast<VecT*>(&skip_input_bias_add_output_v);
+    }
+
     thread_data = hipcub::KeyValuePair<T, T>(rldval_sum, rldvalsq_sum);
+  }
+  if (Simplified) {
+    SimplifiedLayerNormSmall<T, TPB, ILP>(input_v, thread_data.value, ld, idx, gamma, epsilon, output);
+    return;
   }
   LayerNormSmall<T, TPB, ILP>(input_v, thread_data, ld, idx, beta, gamma, epsilon, output);
 }

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -20,11 +20,11 @@ namespace rocm {
 
 template <typename T>
 struct SkipLayerNormParams : OpParams {
-  SkipLayerNormParams(RocmTuningContext* tuning_ctx, hipStream_t stream, T* output, const T* input,
+  SkipLayerNormParams(RocmTuningContext* tuning_ctx, hipStream_t stream, T* output, T* skip_input_bias_add_output, const T* input,
                       const T* skip, const T* gamma, const T* beta,
                       const T* bias, float epsilon, int ld, int element_count)
-      : OpParams(tuning_ctx, stream), output(output), input(input), skip(skip), gamma(gamma), beta(beta), bias(bias),
-        epsilon(epsilon), ld(ld), element_count(element_count) {}
+      : OpParams(tuning_ctx, stream), output(output), skip_input_bias_add_output(skip_input_bias_add_output), input(input), skip(skip), 
+        gamma(gamma), beta(beta), bias(bias), epsilon(epsilon), ld(ld), element_count(element_count) {}
 
   std::string Signature() const override {
     std::string sig = std::to_string(ld) + "_" + std::to_string(element_count);
@@ -32,6 +32,7 @@ struct SkipLayerNormParams : OpParams {
   }
 
   T* output;
+  T* skip_input_bias_add_output;
   const T* input;
   const T* skip;
   const T* gamma;
@@ -42,114 +43,115 @@ struct SkipLayerNormParams : OpParams {
   int element_count;
 };
 
-template <typename T, int ThreadsPerBlock, int VecSize>
+template <typename T, int ThreadsPerBlock, int VecSize, bool Simplified>
 Status SkipLayerNormSmallOp(const SkipLayerNormParams<T>* params) {
   TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(
       !((params->ld <= 1024 && params->ld % VecSize == 0 &&
          params->ld <= ThreadsPerBlock * VecSize && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)));
-  SkipLayerNormKernelSmall<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
-                                                          dim3(ThreadsPerBlock),
-                                                          0, params->stream>>>(
+  SkipLayerNormKernelSmall<T, ThreadsPerBlock, VecSize, Simplified><<<dim3(CeilDiv(params->element_count, params->ld)),
+                                                                      dim3(ThreadsPerBlock),
+                                                                      0, params->stream>>>(
       params->ld, params->input, params->skip,
-      params->beta, params->gamma, params->bias, maybe2half<T>(params->epsilon), params->output,
-      (params->bias == nullptr) ? false : true);
+      params->beta, params->gamma, params->bias, maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output,
+      (params->bias == nullptr) ? false : true, (params->skip_input_bias_add_output == nullptr) ? false : true);
   return HIP_CALL(hipGetLastError());
 }
 
-template <typename T, int ThreadsPerBlock, int VecSize>
+template <typename T, int ThreadsPerBlock, int VecSize, bool Simplified>
 Status SkipLayerNormRegularOp(const SkipLayerNormParams<T>* params) {
   TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(
       !((params->ld > 0 && params->ld % VecSize == 0 &&
          (params->ld >= ThreadsPerBlock * VecSize ||
           (params->ld < GPU_WARP_SIZE && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)))));
-  SkipLayerNormKernelVec<T, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
-                                                        dim3(ThreadsPerBlock),
-                                                        0, params->stream>>>(
+  SkipLayerNormKernelVec<T, ThreadsPerBlock, VecSize, Simplified><<<dim3(CeilDiv(params->element_count, params->ld)),
+                                                                    dim3(ThreadsPerBlock),
+                                                                    0, params->stream>>>(
       params->ld, params->input, params->skip,
-      params->beta, params->gamma, params->bias, maybe2half<T>(params->epsilon), params->output,
-      (params->bias == nullptr) ? false : true);
+      params->beta, params->gamma, params->bias, maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output,
+      (params->bias == nullptr) ? false : true, (params->skip_input_bias_add_output == nullptr) ? false : true);
   return HIP_CALL(hipGetLastError());
 }
 
-template <typename T>
+template <typename T, bool Simplified>
 Status SkipLayerNormStaticSelection(const SkipLayerNormParams<T>* params) {
   bool hasBias = (params->bias == nullptr) ? false : true;
+  bool hasSkipInputBiasAdditionOutput = (params->skip_input_bias_add_output == nullptr) ? false : true;
   if (0 == (params->ld % 4)) {
     const int grid_size = params->element_count / params->ld;
     if (params->ld <= 32) {
       constexpr int block_size = 32;
-      SkipLayerNormKernelSmall<T, block_size, 1><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 1, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 64) {
       constexpr int block_size = 64 / 2;
-      SkipLayerNormKernelSmall<T, block_size, 2><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 2, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 128) {
       constexpr int block_size = 128 / 4;
-      SkipLayerNormKernelSmall<T, block_size, 4><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 4, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 384) {
       constexpr int block_size = 384 / 4;
-      SkipLayerNormKernelSmall<T, block_size, 4><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 4, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 768) {
       constexpr int block_size = 768 / 4;
-      SkipLayerNormKernelSmall<T, block_size, 4><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 4, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 1024) {
       constexpr int block_size = 1024 / 4;
-      SkipLayerNormKernelSmall<T, block_size, 4><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 4, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else {
       constexpr int block_size = 256;
-      SkipLayerNormKernel<T, block_size><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernel<T, block_size, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output);
     }
   } else {
     const int grid_size = params->element_count / params->ld;
     if (params->ld <= 32) {
       constexpr int block_size = 32;
-      SkipLayerNormKernelSmall<T, block_size, 1><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 1, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 64) {
       constexpr int block_size = 64;
-      SkipLayerNormKernelSmall<T, block_size, 1><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 1, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld <= 128) {
       constexpr int block_size = 128;
-      SkipLayerNormKernelSmall<T, block_size, 1><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 1, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else if (params->ld == 384) {
       constexpr int block_size = 384;
-      SkipLayerNormKernelSmall<T, block_size, 1><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernelSmall<T, block_size, 1, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output, hasBias);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output, hasBias, hasSkipInputBiasAdditionOutput);
     } else {
       constexpr int block_size = 256;
-      SkipLayerNormKernel<T, block_size><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernel<T, block_size, Simplified><<<grid_size, block_size, 0, params->stream>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
-          maybe2half<T>(params->epsilon), params->output);
+          maybe2half<T>(params->epsilon), params->output, params->skip_input_bias_add_output);
     }
   }
   return HIP_CALL(hipPeekAtLastError());
 }
 
 #define ADD_OP_FOR_ALL_VEC_SIZE(name, threads_per_block) \
-  this->RegisterOp(name<T, threads_per_block, 1>);       \
-  this->RegisterOp(name<T, threads_per_block, 2>);       \
-  this->RegisterOp(name<T, threads_per_block, 4>);       \
-  this->RegisterOp(name<T, threads_per_block, 8>);       \
-  this->RegisterOp(name<T, threads_per_block, 16>);
+  this->RegisterOp(name<T, threads_per_block, 1, Simplified>);       \
+  this->RegisterOp(name<T, threads_per_block, 2, Simplified>);       \
+  this->RegisterOp(name<T, threads_per_block, 4, Simplified>);       \
+  this->RegisterOp(name<T, threads_per_block, 8, Simplified>);       \
+  this->RegisterOp(name<T, threads_per_block, 16, Simplified>);
 
 #define ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(name) \
   ADD_OP_FOR_ALL_VEC_SIZE(name, 64)                         \
@@ -159,11 +161,11 @@ Status SkipLayerNormStaticSelection(const SkipLayerNormParams<T>* params) {
   ADD_OP_FOR_ALL_VEC_SIZE(name, 320)                        \
   ADD_OP_FOR_ALL_VEC_SIZE(name, 384)
 
-template <typename T>
+template <typename T, bool Simplified>
 class SkipLayerNormTunableOp : public TunableOp<SkipLayerNormParams<T>> {
  public:
   SkipLayerNormTunableOp() {
-    this->RegisterOp(SkipLayerNormStaticSelection<T>);
+    this->RegisterOp(SkipLayerNormStaticSelection<T, Simplified>);
     ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmallOp)
     ADD_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegularOp)
 

--- a/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
@@ -75,6 +75,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SkipSimplifiedLayerNormalization);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SkipSimplifiedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu);
@@ -190,6 +192,8 @@ Status RegisterRocmContribKernels(KernelRegistry& kernel_registry) {
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ScaledTanh)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SkipLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SkipLayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, SkipSimplifiedLayerNormalization)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, SkipSimplifiedLayerNormalization)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ThresholdedRelu)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ThresholdedRelu)>,
     // BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ThresholdedRelu)>,

--- a/onnxruntime/core/providers/rocm/rocm_execution_provider.h
+++ b/onnxruntime/core/providers/rocm/rocm_execution_provider.h
@@ -14,7 +14,7 @@
 #include "core/providers/rocm/rocm_pch.h"
 #include "core/providers/rocm/shared_inc/rocm_utils.h"
 #include "core/providers/rocm/shared_inc/rocm_call.h"
-#include "core/providers/rocm/tunable/rocm_tunable.h"
+#include "core/providers/rocm/tunable/rocm_tuning_context.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
@@ -110,7 +110,7 @@ class SkipLayerNormTunable : public IKernelExplorer {
  private:
   using ParamsT = contrib::rocm::SkipLayerNormParams<T>;
   ParamsT params_{};
-  contrib::rocm::SkipLayerNormTunableOp<T, bool> op_{};
+  contrib::rocm::SkipLayerNormTunableOp<T, Simplified> op_{};
 };
 
 #define REGISTER_OP(name, type, threads_per_block, vec_size)                                                   \

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
@@ -110,7 +110,7 @@ class SkipLayerNormTunable : public IKernelExplorer {
  private:
   using ParamsT = contrib::rocm::SkipLayerNormParams<T>;
   ParamsT params_{};
-  contrib::rocm::SkipLayerNormTunableOp<T, Simplified> op_{};
+  contrib::rocm::SkipLayerNormTunableOp<T, bool> op_{};
 };
 
 #define REGISTER_OP(name, type, threads_per_block, vec_size)                                                   \

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
@@ -110,7 +110,7 @@ class SkipLayerNormTunable : public IKernelExplorer {
  private:
   using ParamsT = contrib::rocm::SkipLayerNormParams<T>;
   ParamsT params_{};
-  contrib::rocm::SkipLayerNormTunableOp<T> op_{};
+  contrib::rocm::SkipLayerNormTunableOp<T, Simplified> op_{};
 };
 
 #define REGISTER_OP(name, type, threads_per_block, vec_size)                                                   \

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/skip_layer_norm.cu
@@ -14,22 +14,22 @@ namespace py = pybind11;
 
 namespace onnxruntime {
 
-template <typename T, int ThreadsPerBlock, int VecSize>
+template <typename T, int ThreadsPerBlock, int VecSize, bool Simplified>
 class SkipLayerNormSmall : public IKernelExplorer {
  public:
-  SkipLayerNormSmall(DeviceArray& output, DeviceArray& input, DeviceArray& skip,
+  SkipLayerNormSmall(DeviceArray& output, DeviceArray& skip_input_bias_add_output, DeviceArray& input, DeviceArray& skip,
                      DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
                      float epsilon, int hidden_size, int element_count)
-      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
-                static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), static_cast<T*>(beta.ptr()),
-                static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(skip_input_bias_add_output.ptr()), 
+                static_cast<T*>(input.ptr()), static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), 
+                static_cast<T*>(beta.ptr()), static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
 
   void Run() override {
-    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormSmallOp<T, ThreadsPerBlock, VecSize>(&params_)));
+    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormSmallOp<T, ThreadsPerBlock, VecSize, Simplified>(&params_)));
   }
 
   bool IsSupported() {
-    Status status = contrib::rocm::SkipLayerNormSmallOp<T, ThreadsPerBlock, VecSize>(&params_);
+    Status status = contrib::rocm::SkipLayerNormSmallOp<T, ThreadsPerBlock, VecSize, Simplified>(&params_);
     return status.IsOK();
   }
 
@@ -38,22 +38,22 @@ class SkipLayerNormSmall : public IKernelExplorer {
   ParamsT params_{};
 };
 
-template <typename T, int ThreadsPerBlock, int VecSize>
+template <typename T, int ThreadsPerBlock, int VecSize, bool Simplified>
 class SkipLayerNormRegular : public IKernelExplorer {
  public:
-  SkipLayerNormRegular(DeviceArray& output, DeviceArray& input, DeviceArray& skip,
+  SkipLayerNormRegular(DeviceArray& output, DeviceArray& skip_input_bias_add_output, DeviceArray& input, DeviceArray& skip,
                        DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
                        float epsilon, int hidden_size, int element_count)
-      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
-                static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), static_cast<T*>(beta.ptr()),
-                static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(skip_input_bias_add_output.ptr()), 
+                static_cast<T*>(input.ptr()), static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), 
+                static_cast<T*>(beta.ptr()), static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
 
   void Run() override {
-    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize>(&params_)));
+    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize, Simplified>(&params_)));
   }
 
   bool IsSupported() {
-    Status status = contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize>(&params_);
+    Status status = contrib::rocm::SkipLayerNormRegularOp<T, ThreadsPerBlock, VecSize, Simplified>(&params_);
     return status.IsOK();
   }
 
@@ -62,22 +62,22 @@ class SkipLayerNormRegular : public IKernelExplorer {
   ParamsT params_{};
 };
 
-template <typename T>
+template <typename T, bool Simplified>
 class SkipLayerNormStaticSelection : public IKernelExplorer {
  public:
-  SkipLayerNormStaticSelection(DeviceArray& output, DeviceArray& input, DeviceArray& skip,
-                               DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
+  SkipLayerNormStaticSelection(DeviceArray& output, DeviceArray& skip_input_bias_add_output, DeviceArray& input, 
+                               DeviceArray& skip, DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
                                float epsilon, int hidden_size, int element_count)
-      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
-                static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), static_cast<T*>(beta.ptr()),
-                static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(skip_input_bias_add_output.ptr()), 
+                static_cast<T*>(input.ptr()), static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), 
+                static_cast<T*>(beta.ptr()), static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {}
 
   void Run() override {
-    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormStaticSelection<T>(&params_)));
+    ORT_THROW_IF_ERROR((contrib::rocm::SkipLayerNormStaticSelection<T, Simplified>(&params_)));
   }
 
   bool IsSupported() {
-    Status status = contrib::rocm::SkipLayerNormStaticSelection<T>(&params_);
+    Status status = contrib::rocm::SkipLayerNormStaticSelection<T, Simplified>(&params_);
     return status.IsOK();
   }
 
@@ -86,15 +86,15 @@ class SkipLayerNormStaticSelection : public IKernelExplorer {
   ParamsT params_{};
 };
 
-template <typename T>
+template <typename T, bool Simplified>
 class SkipLayerNormTunable : public IKernelExplorer {
  public:
-  SkipLayerNormTunable(DeviceArray& output, DeviceArray& input, DeviceArray& skip,
+  SkipLayerNormTunable(DeviceArray& output, DeviceArray& skip_input_bias_add_output, DeviceArray& input, DeviceArray& skip,
                        DeviceArray& gamma, DeviceArray& beta, DeviceArray& bias,
                        float epsilon, int hidden_size, int element_count)
-      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(input.ptr()),
-                static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), static_cast<T*>(beta.ptr()),
-                static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {
+      : params_(TuningContext(), Stream(), static_cast<T*>(output.ptr()), static_cast<T*>(skip_input_bias_add_output.ptr()), 
+                static_cast<T*>(input.ptr()), static_cast<T*>(skip.ptr()), static_cast<T*>(gamma.ptr()), 
+                static_cast<T*>(beta.ptr()), static_cast<T*>(bias.ptr()), epsilon, hidden_size, element_count) {
 
     params_.TuningContext()->EnableTunableOp();
   }
@@ -113,52 +113,61 @@ class SkipLayerNormTunable : public IKernelExplorer {
   contrib::rocm::SkipLayerNormTunableOp<T, Simplified> op_{};
 };
 
-#define REGISTER_OP(name, type, threads_per_block, vec_size)                                                   \
-  py::class_<name<type, threads_per_block, vec_size>>(m, #name "_" #type "_" #threads_per_block "_" #vec_size) \
-      .def(py::init<DeviceArray&, DeviceArray&, DeviceArray&, DeviceArray&,                                    \
-                    DeviceArray&, DeviceArray&,                                                                \
-                    float, int, int>())                                                                        \
-      .def("SetRepeats", &name<type, threads_per_block, vec_size>::SetRepeats)                                 \
-      .def("Profile", &name<type, threads_per_block, vec_size>::Profile)                                       \
-      .def("Run", &name<type, threads_per_block, vec_size>::Run)                                               \
-      .def("IsSupported", &name<type, threads_per_block, vec_size>::IsSupported);
+#define REGISTER_OP(name, type, threads_per_block, vec_size, Simplified)                                                                    \
+  py::class_<name<type, threads_per_block, vec_size, Simplified>>(m, #name "_" #type "_" #threads_per_block "_" #vec_size "_" #Simplified)  \
+      .def(py::init<DeviceArray&, DeviceArray&, DeviceArray&, DeviceArray&,                                                                 \
+                    DeviceArray&, DeviceArray&, DeviceArray&,                                                                               \
+                    float, int, int>())                                                                                                     \
+      .def("SetRepeats", &name<type, threads_per_block, vec_size, Simplified>::SetRepeats)                                                  \
+      .def("Profile", &name<type, threads_per_block, vec_size, Simplified>::Profile)                                                        \
+      .def("Run", &name<type, threads_per_block, vec_size, Simplified>::Run)                                                                \
+      .def("IsSupported", &name<type, threads_per_block, vec_size, Simplified>::IsSupported);
 
-#define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, threads_per_block) \
-  REGISTER_OP(name, type, threads_per_block, 1)                     \
-  REGISTER_OP(name, type, threads_per_block, 2)                     \
-  REGISTER_OP(name, type, threads_per_block, 4)                     \
-  REGISTER_OP(name, type, threads_per_block, 8)                     \
-  REGISTER_OP(name, type, threads_per_block, 16)
+#define REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, threads_per_block, Simplified) \
+  REGISTER_OP(name, type, threads_per_block, 1, Simplified)                     \
+  REGISTER_OP(name, type, threads_per_block, 2, Simplified)                     \
+  REGISTER_OP(name, type, threads_per_block, 4, Simplified)                     \
+  REGISTER_OP(name, type, threads_per_block, 8, Simplified)                     \
+  REGISTER_OP(name, type, threads_per_block, 16, Simplified)
 
-#define REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(name, type) \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 64)                         \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 128)                        \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 192)                        \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 256)                        \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 320)                        \
-  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 384)
+#define REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(name, type, Simplified) \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 64, Simplified)                         \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 128, Simplified)                        \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 192, Simplified)                        \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 256, Simplified)                        \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 320, Simplified)                        \
+  REGISTER_OP_FOR_ALL_VEC_SIZE(name, type, 384, Simplified)
 
-#define REGISTER_OP_TYPED(name, type)                                       \
-  py::class_<name<type>>(m, #name "_" #type)                                \
+#define REGISTER_OP_TYPED(name, type, Simplified)                           \
+  py::class_<name<type, Simplified>>(m, #name "_" #type "_" #Simplified)    \
       .def(py::init<DeviceArray&, DeviceArray&, DeviceArray&, DeviceArray&, \
-                    DeviceArray&, DeviceArray&,                             \
+                    DeviceArray&, DeviceArray&, DeviceArray&,               \
                     float, int, int>())                                     \
-      .def("SetRepeats", &name<type>::SetRepeats)                           \
-      .def("Profile", &name<type>::Profile)                                 \
-      .def("Run", &name<type>::Run)                                         \
-      .def("IsSupported", &name<type>::IsSupported);
+      .def("SetRepeats", &name<type, Simplified>::SetRepeats)               \
+      .def("Profile", &name<type, Simplified>::Profile)                     \
+      .def("Run", &name<type, Simplified>::Run)                             \
+      .def("IsSupported", &name<type, Simplified>::IsSupported);
 
 void InitSkipLayerNorm(py::module m) {
-  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, half);
-  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, float);
-  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, half);
-  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, float);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, half, true);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, float, true);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, half, false);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormSmall, float, false);
 
-  REGISTER_OP_TYPED(SkipLayerNormTunable, half);
-  REGISTER_OP_TYPED(SkipLayerNormTunable, float);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, half, true);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, float, true);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, half, false);
+  REGISTER_OP_FOR_ALL_THREADS_PER_BLOCK_ALL_VEC_SIZE(SkipLayerNormRegular, float, false);
 
-  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, half);
-  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, float);
+  REGISTER_OP_TYPED(SkipLayerNormTunable, half, true);
+  REGISTER_OP_TYPED(SkipLayerNormTunable, float, true);
+  REGISTER_OP_TYPED(SkipLayerNormTunable, half, false);
+  REGISTER_OP_TYPED(SkipLayerNormTunable, float, false);
+
+  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, half, true);
+  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, float, true);
+  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, half, false);
+  REGISTER_OP_TYPED(SkipLayerNormStaticSelection, float, false);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -436,8 +436,8 @@ TEST(SkipLayerNormTest, SkipLayerNormBatch2_Bias) {
           hidden_size);
 }
 
-// Don't enable this test for DML/ROCM builds as these EP doesn't produce the new optional output yet
-#if !defined(USE_ROCM) && !defined(USE_DML)
+// Don't enable this test for DML builds as these EP doesn't produce the new optional output yet
+#if !defined(USE_DML)
 TEST(SkipLayerNormTest, SkipLayerNormBatch2_Bias_ProducingOptionalOutput) {
   int batch_size = 2;
   int sequence_length = 2;


### PR DESCRIPTION
When inferencing real gpt2-based model, found some gaps between CUDA and ROCm codebase.

The fixes include:
1. minimum code change to fix tensor shape on Attention Op
2. Support optional output tensor with SkipLayerNorm
3. enabling SkipSimplifiedLayerNorm
4. fix a build error found on MI200



