### PR TITLE
Make some variables constexpr in orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc.

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
+++ b/orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc
@@ -209,7 +209,7 @@ Status launch_lamb_compute_direction(
   ORT_ENFORCE(group_count == static_cast<int>(epsilons.size()));
 
   constexpr int tensor_count_per_group = 6;
-  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
+  constexpr int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   // Bucketize tensor groups by the associated optimizer configuration.
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::map<std::tuple<float, float, float, float, float>, std::vector<std::vector<void*>>> buckets;
@@ -309,7 +309,7 @@ Status launch_lamb_reduction(
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::vector<std::vector<void*>> buckets;
   std::vector<int> tensor_sizes_in_buckets;
-  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
+  constexpr int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       ORT_RETURN_IF_ERROR(reduce_square_sum(
@@ -396,7 +396,7 @@ Status launch_lamb_update(
   // If two tensor groups use different "alpha", they should be put into two distinct buckets.
   std::vector<std::vector<void*>> buckets;
   std::vector<int> tensor_sizes_in_bucket;
-  const int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
+  constexpr int max_tensor_size = compute_max_tensor_size_per_launch<tensor_count_per_group>(4);
   for (int i = 0; i < group_count; ++i) {
     if (tensor_sizes[i] > max_tensor_size) {
       LambUpdate(


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Make some variables constexpr in orttraining/orttraining/training_ops/cuda/optimizer/lamb.cc.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address code analysis warnings.
