### PR TITLE
[Testing] Arrange parity utilities for onnxruntime parity tests to set order pr…

### DIFF
--- a/onnxruntime/test/python/transformers/parity_utilities.py
+++ b/onnxruntime/test/python/transformers/parity_utilities.py
@@ -138,7 +138,7 @@ def create_ort_session(onnx_model_path, use_gpu=True):
     sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_DISABLE_ALL
     sess_options.intra_op_num_threads = 2
     sess_options.log_severity_level = 2
-    execution_providers = ["CPUExecutionProvider"]
+    execution_providers = []
 
     if use_gpu:
         if torch.version.cuda:
@@ -146,6 +146,8 @@ def create_ort_session(onnx_model_path, use_gpu=True):
         elif torch.version.hip:
             execution_providers.append("MIGraphXExecutionProvider")
             execution_providers.append("ROCMExecutionProvider")
+
+    execution_providers.append("CPUExecutionProvider")
 
     return InferenceSession(onnx_model_path, sess_options, providers=execution_providers)
 


### PR DESCRIPTION
Current configuration has CPU as the highest priority as per the specification found at : https://onnxruntime.ai/docs/api/python/api_summary.html#inferencesession

_"providers – Optional sequence of providers in order of decreasing precedence.
             Values can either be provider names or tuples of (provider name, options dict). If not provided,
	     then all available providers are used with the default precedence."_

### Description
<!-- Describe your changes. -->

Sets correct operator precedence for the EPs in parity utilities for test runs

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Ruling out any odd out of order issues when setting up tests for multiple EPs
