### PR TITLE
Enable some ops for QDQ Node Unit support

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -30,21 +30,31 @@ void Selectors::RegisterSelector(const OpVersionsAndSelector::OpVersionsMap& ops
 static const OpVersionsAndSelector::OpVersionsMap GetMiscOpVersionsMap() {
   return {{"Gather", {}},
           {"Reshape", {}},
+          {"Flatten", {}},
           {"Transpose", {}},
           {"MaxPool", {12}},
           {"Resize", {}},
+          {"Split", {}},
           {"Squeeze", {}},
           {"Unsqueeze", {}}};
 }
 
 static const OpVersionsAndSelector::OpVersionsMap GetUnaryOpVersionsMap() {
   return {{"AveragePool", {}},
+          {"GlobalAveragePool", {}},
+          {"LeakyRelu", {}},
+          {"ReduceMean", {}},
+          {"Relu", {}},
+          {"Sigmoid", {}},
           {"Softmax", {}},
-          {"LeakyRelu", {}}};
+          {"Sqrt", {}}};
 }
 static const OpVersionsAndSelector::OpVersionsMap GetBinaryOpVersionsMap() {
   return {{"Add", {}},
-          {"Mul", {}}};
+          {"Div", {}},
+          {"Mul", {}},
+          {"Pow", {}},
+          {"Sub", {}}};
 }
 static const OpVersionsAndSelector::OpVersionsMap GetVariadicOpVersionsMap() {
   return {{"Concat", {}}};


### PR DESCRIPTION
### Description
Enable some ops for QDQ Node Unit support: Flatten, Split, GlobalAveragePool, ReduceMean, Relu, Sigmoid, Sqrt, Div, Mul, Pow, Sub.



