### PR TITLE
Fix TunableOp signature generation

### DIFF
--- a/onnxruntime/core/framework/tunable.h
+++ b/onnxruntime/core/framework/tunable.h
@@ -128,6 +128,8 @@ class Op {
 template <typename ParamsT, typename TimerT>
 class TunableOp {
  public:
+  using ThisT = TunableOp<ParamsT, TimerT>;
+
   TunableOp() = default;
   TunableOp(TunableOp&&) = default;
   virtual ~TunableOp() = default;
@@ -169,7 +171,11 @@ class TunableOp {
     // Do nothing if we are not playing around with params
   }
 
-  std::string Signature() const {
+  std::string Signature() {
+    // NOTE: this is not thread-safe, but it seems to be harmless
+    if (signature_.empty()) {
+      signature_ = CreateSignature();
+    }
     return signature_;
   }
 
@@ -184,7 +190,7 @@ class TunableOp {
     this->ops_.emplace_back(std::move(op));
   }
 
-  void RegisterNestedTunableOp(TunableOp<ParamsT, TimerT>* op_ptr) {
+  void RegisterNestedTunableOp(ThisT* op_ptr) {
     nested_tunable_ops_.insert(op_ptr);
 
     // Add an op for this tunable op as well.
@@ -271,7 +277,7 @@ class TunableOp {
 #endif
   }
 
-  std::string signature_{CreateSignature()};
+  std::string signature_;
 
   // the default impl to use when tuning is disabled
   int default_id_{0};

--- a/onnxruntime/core/framework/tunable.h
+++ b/onnxruntime/core/framework/tunable.h
@@ -130,6 +130,7 @@ class TunableOp {
  public:
   TunableOp() = default;
   TunableOp(TunableOp&&) = default;
+  virtual ~TunableOp() = default;
 
   Status operator()(const ParamsT* params) {
     int id = default_id_;
@@ -168,7 +169,9 @@ class TunableOp {
     // Do nothing if we are not playing around with params
   }
 
-  virtual ~TunableOp() = default;
+  std::string Signature() const {
+    return signature_;
+  }
 
  protected:
   // set the default op to be used in non-tuning scenario
@@ -188,10 +191,6 @@ class TunableOp {
     RegisterOp([op_ptr](const ParamsT* params) {
       return op_ptr->operator()(params);
     });
-  }
-
-  std::string Signature() const {
-    return signature_;
   }
 
  private:


### PR DESCRIPTION
Currently, all generated op sigs are `TunableOp<ParamsT, TimerT>` which is causing signature collision when using rocblas solution api. This was not a problem before `TuningContext`, because the `KernelMap`s were not shared.

The root cause is the signature is initialized on Op consturction, specificially, only in base class ctor, which is causing the type info only caputre base class type info. That is, only the ParamsT + and base class. After this change, the we will encode the derived class type in the op sig. 
