### PR TITLE
Improve compatibility with certain STL's

### DIFF
--- a/include/onnxruntime/core/common/exceptions.h
+++ b/include/onnxruntime/core/common/exceptions.h
@@ -52,7 +52,7 @@ class OnnxRuntimeException : public std::exception {
     if (!location.stacktrace.empty()) {
       ss << "Stacktrace:\n";
       // skip the first entry in the stacktrace as we have that information from location.ToString()
-      std::copy(++location.stacktrace.begin(), location.stacktrace.end(), std::ostream_iterator<std::string>(ss, "\n"));
+      std::copy(std::next(location.stacktrace.begin()), location.stacktrace.end(), std::ostream_iterator<std::string>(ss, "\n"));
     }
 
     what_ = ss.str();

--- a/include/onnxruntime/core/framework/sparse_tensor.h
+++ b/include/onnxruntime/core/framework/sparse_tensor.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if !defined(DISABLE_SPARSE_TENSORS)
-
 #pragma once
+
+#if !defined(DISABLE_SPARSE_TENSORS)
 
 #include "core/framework/data_types.h"
 #include "core/framework/tensor_shape.h"

--- a/include/onnxruntime/core/graph/graph_nodes.h
+++ b/include/onnxruntime/core/graph/graph_nodes.h
@@ -94,7 +94,7 @@ class ValidNodes {
    public:
     using iterator_category = std::input_iterator_tag;
     using value_type = T;
-    using difference_type = typename TIterator::difference_type;
+    using difference_type = typename std::iterator_traits<TIterator>::difference_type;
     using pointer = T*;
     using reference = T&;
     using const_reference = const T&;


### PR DESCRIPTION
We use customized libc++ which uses raw pointers as `std::vector::iterator`.

As per [expr.pre.incr](https://eel.is/c++draft/expr.compound#expr.pre.incr), builtin `operator++` can only be applied to lvalue, while `std::vector::begin()` returns an rvalue.

See [this](https://godbolt.org/z/d3a1aKTWP) godbolt snippet for the details.

