### PR TITLE
Initialize bias_weight in fusion_skiplayernorm.py

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -150,6 +150,7 @@ class FusionBiasSkipLayerNormalization(Fusion):
 
         # bias should be one dimension
         bias_index = -1
+        bias_weight = None
         for i, input in enumerate(add.input):
             initializer = self.model.get_initializer(input)
             if initializer is None:


### PR DESCRIPTION
As per title, fixes https://github.com/microsoft/onnxruntime/issues/13625

Uncountered the issue when using the optimization with codegen model.

