### PR TITLE
Added NPU enum for binding

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -150,6 +150,8 @@ const char* GetDeviceName(const OrtDevice& device) {
       return CUDA;
     case OrtDevice::FPGA:
       return "FPGA";
+    case OrtDevice::NPU:
+      return "NPU";
     default:
       ORT_THROW("Unknown device type: ", device.Type());
   }
@@ -1055,6 +1057,8 @@ void addObjectMethods(py::module& m, Environment& env, ExecutionProviderRegistra
       .def("device_type", &OrtDevice::Type, R"pbdoc(Device Type.)pbdoc")
       .def_static("cpu", []() { return OrtDevice::CPU; })
       .def_static("cuda", []() { return OrtDevice::GPU; })
+      .def_static("fpga", []() { return OrtDevice::FPGA; })
+      .def_static("npu", []() { return OrtDevice::NPU; })
       .def_static("default_memory", []() { return OrtDevice::MemType::DEFAULT; });
 
   py::class_<OrtArenaCfg> ort_arena_cfg_binding(m, "OrtArenaCfg");


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Added NPU device type for GetDeviceName() and added binding for getting FPGA/NPU enums.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When trying to affine ortvalue to NPU device type, it failed because GetDeviceName does not support NPU type. Added bindings for getting FPGA/NPU enums to establish mapping for pytorch device type and ort device type in python.