### PR TITLE
Add Environment Variables for cuda tensor dumper

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_shared.h
@@ -7,7 +7,7 @@
 #include <random>
 #include "core/common/gsl.h"
 #include "core/framework/allocator.h"
-#include "core/framework/ort_value.h"
+#include "contrib_ops/cpu/utils/console_dumper.h"
 
 namespace onnxruntime {
 
@@ -161,50 +161,6 @@ struct IGenerationParameters {
   int seed = 0;
   int min_tokens_to_keep = 1;
   bool custom_sampling = false;
-};
-
-// #define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
-#ifdef DEBUG_GENERATION
-#define DUMP_TENSOR_LEVEL 2
-#else
-#define DUMP_TENSOR_LEVEL 0  // change it to 1 or 2 if want to enable dumping for code not in generation.
-#endif
-
-#if DUMP_TENSOR_LEVEL > 0
-#define DUMP_TENSOR_INIT() transformers::CudaTensorConsoleDumper dumper
-#define DUMP_TENSOR(...) dumper.Print(__VA_ARGS__)
-#else
-#define DUMP_TENSOR_INIT()
-#define DUMP_TENSOR(...)
-#endif
-#if DUMP_TENSOR_LEVEL > 1
-#define DUMP_TENSOR_D(...) dumper.Print(__VA_ARGS__)
-#else
-#define DUMP_TENSOR_D(...)
-#endif
-
-class IConsoleDumper {
- public:
-  IConsoleDumper() : is_enabled_(true) {}
-  virtual ~IConsoleDumper() {}
-  void Disable() { is_enabled_ = false; }
-  bool IsEnabled() const { return is_enabled_; }
-  virtual void Print(const char* name, const float* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const size_t* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1) const = 0;
-  virtual void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const = 0;
-  virtual void Print(const char* name, const Tensor& value) const = 0;
-  virtual void Print(const char* name, const OrtValue& value) const = 0;
-  virtual void Print(const char* name, int index, bool end_line) const = 0;
-  virtual void Print(const char* name, const std::string& value, bool end_line) const = 0;
-
- protected:
-  bool is_enabled_;
 };
 
 }  // namespace transformers

--- a/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
+++ b/onnxruntime/contrib_ops/cpu/utils/console_dumper.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include <string>
+#include "core/framework/ort_value.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace transformers {
+
+// #define DEBUG_GENERATION 1  // uncomment it for debugging generation (like beam search etc)
+#ifdef DEBUG_GENERATION
+#define DUMP_TENSOR_LEVEL 2
+#else
+#define DUMP_TENSOR_LEVEL 0  // change it to 1 or 2 if want to enable dumping for code not in generation.
+#endif
+
+#if DUMP_TENSOR_LEVEL > 0
+#define DUMP_TENSOR_INIT() transformers::CudaTensorConsoleDumper dumper
+#define DUMP_TENSOR(...) dumper.Print(__VA_ARGS__)
+#else
+#define DUMP_TENSOR_INIT()
+#define DUMP_TENSOR(...)
+#endif
+#if DUMP_TENSOR_LEVEL > 1
+#define DUMP_TENSOR_D(...) dumper.Print(__VA_ARGS__)
+#else
+#define DUMP_TENSOR_D(...)
+#endif
+
+class IConsoleDumper {
+ public:
+  IConsoleDumper() : is_enabled_(true) {}
+  virtual ~IConsoleDumper() {}
+  void Disable() { is_enabled_ = false; }
+  bool IsEnabled() const { return is_enabled_; }
+  virtual void Print(const char* name, const float* tensor, int dim0, int dim1) const = 0;
+  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1) const = 0;
+  virtual void Print(const char* name, const size_t* tensor, int dim0, int dim1) const = 0;
+  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1) const = 0;
+  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1) const = 0;
+  virtual void Print(const char* name, const float* tensor, int dim0, int dim1, int dim2) const = 0;
+  virtual void Print(const char* name, const MLFloat16* tensor, int dim0, int dim1, int dim2) const = 0;
+  virtual void Print(const char* name, const int64_t* tensor, int dim0, int dim1, int dim2) const = 0;
+  virtual void Print(const char* name, const int32_t* tensor, int dim0, int dim1, int dim2) const = 0;
+  virtual void Print(const char* name, const Tensor& value) const = 0;
+  virtual void Print(const char* name, const OrtValue& value) const = 0;
+  virtual void Print(const char* name, int index, bool end_line) const = 0;
+  virtual void Print(const char* name, const std::string& value, bool end_line) const = 0;
+
+ protected:
+  bool is_enabled_;
+};
+
+}  // namespace transformers
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/transformers/dump_cuda_tensor.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/dump_cuda_tensor.h
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include <string>
 #include "core/framework/tensorprotoutils.h"
 #include "core/framework/ort_value.h"
-#include "contrib_ops/cpu/transformers/generation_shared.h"
+#include "contrib_ops/cpu/utils/console_dumper.h"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/core/framework/print_tensor_utils.h
+++ b/onnxruntime/core/framework/print_tensor_utils.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <iomanip>
+#include <iostream>
 
 namespace onnxruntime {
 namespace utils {
@@ -38,19 +39,23 @@ inline void PrintValue(const T& value) {
 }
 
 // Explicit specialization
-template <> inline void PrintValue(const MLFloat16& value) {
+template <>
+inline void PrintValue(const MLFloat16& value) {
   std::cout << std::setprecision(8) << value.ToFloat();
 }
 
-template <> inline void PrintValue(const BFloat16& value) {
+template <>
+inline void PrintValue(const BFloat16& value) {
   std::cout << std::setprecision(8) << value.ToFloat();
 }
 
-template <> inline void PrintValue(const uint8_t& value) {
+template <>
+inline void PrintValue(const uint8_t& value) {
   std::cout << static_cast<uint32_t>(value);
 }
 
-template <> inline void PrintValue(const int8_t& value) {
+template <>
+inline void PrintValue(const int8_t& value) {
   std::cout << static_cast<int32_t>(value);
 }
 


### PR DESCRIPTION
### Description
(1) Add two environment variables to configure the cuda dumper: `ORT_TENSOR_SNIPPET_THRESHOLD` and `ORT_TENSOR_SNIPPET_EDGE_ITEMS`
(2) Move IConsoleDumper definition to a separated file console_dumper.h.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


