### PR TITLE
Add support for handling sbyte (Int8) data in C# inference tests

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
@@ -177,6 +177,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 return CreateNamedOnnxValueFromRawData<byte>(nodeName, tensor.RawData.ToArray(), sizeof(byte), intDims);
             }
+            else if (nodeMeta.ElementType == typeof(sbyte))
+            {
+                return CreateNamedOnnxValueFromRawData<sbyte>(nodeName, tensor.RawData.ToArray(), sizeof(sbyte), intDims);
+            }
             else if (nodeMeta.ElementType == typeof(bool))
             {
                 return CreateNamedOnnxValueFromRawData<bool>(nodeName, tensor.RawData.ToArray(), sizeof(bool), intDims);
@@ -192,7 +196,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             else
             {
                 //TODO: Add support for remaining types
-                throw new Exception($"Tensors of type {nameof(nodeMeta.ElementType)} not currently supporte in the LoadTensorFromEmbeddedResource");
+                throw new Exception($"Tensors of type {nameof(nodeMeta.ElementType)} not currently supported in the LoadTensorFromEmbeddedResource");
             }
         }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -352,7 +352,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 // unnecessary and fails as ORT support for Exp started at opset 6 (as ORT didn't exist until opset 7).
                 { "test_softplus_example_expanded", "Not applicable"},
                 { "test_softplus_expanded", "Not applicable"},
-                { "test_bitwise_or_i16_4d", "8bit test data is not support by C#"},
                 { "test_col2im_pads", "due to a typo in test data"},
                 { "test_optional_has_element_empty_optional_input", "C# API doesn't support optional input"},
                 { "test_optional_get_element_optional_tensor", "C# API doesn't support optional input"},
@@ -576,6 +575,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                                     else if (outputMeta.ElementType == typeof(byte))
                                     {
                                         Assert.Equal(result.AsTensor<byte>(), outputValue.AsTensor<byte>(), new ExactComparer<byte>());
+                                    }
+                                    else if (outputMeta.ElementType == typeof(sbyte))
+                                    {
+                                        Assert.Equal(result.AsTensor<sbyte>(), outputValue.AsTensor<sbyte>(), new ExactComparer<sbyte>());
                                     }
                                     else if (outputMeta.ElementType == typeof(bool))
                                     {


### PR DESCRIPTION
### Description
Add sbyte specific test case support.

### Motivation and Context
C# Test Data loading code and comparators are missing sbyte (Int8) specializations.
This fails a test

