### PR TITLE
Consume ONNX 1.13.1 in ONNX Runtime

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -122,6 +122,16 @@
       "component": {
         "type": "git",
         "git": {
+          "commitHash": "81e7799c69044c745239202085eb0a98f102937b",
+          "repositoryUrl": "https://github.com/microsoft/onnxruntime-extensions.git"
+        },
+        "comments": "git submodule at cmake/external/onnxruntime-extensions"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
           "commitHash": "a20c65f2cd549445fda907f7b83894c8eb7427d6",
           "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
         },
@@ -436,16 +446,6 @@
           "repositoryUrl": "https://github.com/triton-inference-server/server.git"
         },
         "comments": "triton"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "81e7799c69044c745239202085eb0a98f102937b",
-          "repositoryUrl": "https://github.com/microsoft/onnxruntime-extensions.git"
-        },
-        "comments": "extensions"
       }
     }
   ]

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -122,16 +122,6 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "81e7799c69044c745239202085eb0a98f102937b",
-          "repositoryUrl": "https://github.com/microsoft/onnxruntime-extensions.git"
-        },
-        "comments": "git submodule at cmake/external/onnxruntime-extensions"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "commitHash": "a20c65f2cd549445fda907f7b83894c8eb7427d6",
           "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
         },
@@ -302,7 +292,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "1ba785612a79fe749aa1e478336e534743372639",
+          "commitHash": "ad834eb73ee0cd9b6fa9ea892caeed5fa17d7dc0",
           "repositoryUrl": "https://github.com/onnx/onnx.git"
         },
         "comments": "onnx"
@@ -326,16 +316,6 @@
           "repositoryUrl": "https://github.com/Maratyszcza/psimd.git"
         },
         "comments": "psimd"
-      }
-    },
-    {
-        "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "a20c65f2cd549445fda907f7b83894c8eb7427d6",
-          "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
-        },
-        "comments": "protobuf"
       }
     },
     {
@@ -455,28 +435,17 @@
           "commitHash": "75a84807a019bf4961faf713df9d748f0fc83b47",
           "repositoryUrl": "https://github.com/triton-inference-server/server.git"
         },
-        "comments": "triton server"
+        "comments": "triton"
       }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "3712ec3f0426f7132d3759b84683d7d11e9ba683",
-          "repositoryUrl": "https://github.com/triton-inference-server/client.git"
+          "commitHash": "81e7799c69044c745239202085eb0a98f102937b",
+          "repositoryUrl": "https://github.com/microsoft/onnxruntime-extensions.git"
         },
-        "comments": "triton client"
-      }
-    },
-    {
-      "Component": {
-        "Type": "other",
-        "other": {
-          "Name": "pthread",
-          "Version": "3.0.0",
-          "DownloadUrl": "https://sourceforge.net/projects/pthreads4w/files/pthreads4w-code-v3.0.0.zip"
-        },
-        "comments": "posix pthread library"
+        "comments": "extensions"
       }
     }
   ]

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -23,7 +23,7 @@ microsoft_gsl;https://github.com/microsoft/GSL/archive/refs/tags/v4.0.0.zip;cf36
 microsoft_wil;https://github.com/microsoft/wil/archive/5f4caba4e7a9017816e47becdd918fcc872039ba.zip;fd119887d0d17c37adf1fc227b054befa28158ad
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.3.zip;e4f37b93b2da78a5816c2495603a4188d316214b
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.79.0.zip;c8f04e378535ededbe5af52c8f969d2dedbe73d5
-onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.13.0.zip;8dda5079cdb5a134b08b0c73f4592a6404fc2dc6
+onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.13.1.zip;7a2517d3e7442109d540de2c86f29cd76d34cf28
 #use the commit where it's several commits after 8.5-GA branch (https://github.com/onnx/onnx-tensorrt/commit/369d6676423c2a6dbf4a5665c4b5010240d99d3c)
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/369d6676423c2a6dbf4a5665c4b5010240d99d3c.zip;62119892edfb78689061790140c439b111491275
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.2.zip;9f71dad95fb83438e88822a9969fc93773fd8c48

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -133,7 +133,7 @@
         "^test_softplus_example_expanded_cuda",
         "^test_softplus_expanded_cuda",
 
-        // TODO: Recover these real model tests from onnx
+        // TODO(https://github.com/onnx/onnx/issues/4885): remove these tests after they are deprecated in onnx
         "^test_vgg19",
         "^test_zfnet512",
         "^test_bvlc_alexnet",

--- a/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/download-deps.yml
@@ -11,7 +11,7 @@ steps:
       packageType: upack
       feed: '/7424c8e4-5c62-490e-95c4-79446f31017c'
       definition: '517c4f6f-5437-4392-a70d-4f15ec5be2f0'
-      version: 1.0.31
+      version: 1.0.32
       downloadPath: $(Build.BinariesDirectory)/deps
 
 # The private ADO project
@@ -22,7 +22,7 @@ steps:
       packageType: upack
       feed: '/4c7631f5-24c0-4307-8822-1aa8f180c325'
       definition: 'fd9dd5ad-b73e-4678-890e-edcf680dbc1a'
-      version: 1.0.31
+      version: 1.0.32
       downloadPath: $(Build.BinariesDirectory)/deps
 
 # You can add more ADO accounts at here.

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -3,7 +3,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel
-onnx==1.13.0
+onnx==1.13.1
 protobuf==3.20.2
 sympy==1.10.1
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=41.4.0
 wheel>=0.35.1
-onnx==1.13.0
+onnx==1.13.1
 argparse
 sympy==1.10.1
 flatbuffers


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Consume ONNX 1.13.1 in ONNX Runtime. (ONNX 1.13.0 to ONNX 1.13.1)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
ONNX 1.13.1 patch was just released yesterday. This PR is making ORT's ONNX submodule consistent with the latest released ONNX. Not sure whether this PR is really needed, but let me make it ready. Previous PR for testing ONNX 1.13.1rc2 : https://github.com/microsoft/onnxruntime/pull/14634.

Fixed [AB#13174](https://aiinfra.visualstudio.com/6a833879-cd9b-44a4-a9de-adc2d818f13c/_workitems/edit/13174) . 
