### PR TITLE
Fix prefast scan complaints 

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -749,7 +749,7 @@ extern "C" {
 
 #define MLAS_SGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
 #define MLAS_DGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
-#define MLAS_QGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
+#define MLAS_QGEMM_THREAD_COMPLEXITY                65536
 
 //
 // Single-threaded single precision matrix/matrix multiply operation.
@@ -2076,7 +2076,7 @@ MlasMultiplyFloat64x2(MLAS_FLOAT64X2 Vector1, MLAS_FLOAT64X2 Vector2)
 #endif
 }
 
-#endif
+#endif  // !MLAS_FLOAT64X2_UNSUPPORTED
 
 //
 // Reads a platform specific time stamp counter.


### PR DESCRIPTION
### Description

Fix prefast warning
https://dev.azure.com/aiinfra/ONNX%20Runtime/_workitems/edit/12821/


### Motivation and Context

This one is just excessive and annoying. It warned that I should cast value to 8bytes before using * operator. But the expression is:
(size_t(64) * size_t(1024))

size_t is 8 bytes on 64b systems. And when it is 4 bytes on 32b systems, the cast is expensive and completely unnecessary.