### PR TITLE
[doc] Fix used invalid plural form of the word information in comments

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h
@@ -68,7 +68,7 @@ class ModelBuilder {
   // The initializer will be processed separately, skip it as an initializer
   void AddInitializerToSkip(const std::string& tensor_name);
 
-  // Register informations for a particular operand
+  // Register the name and index for a particular operand
   void RegisterOperand(const std::string& name, uint32_t index,
                        const android::nn::wrapper::OperandType& operand_type);
 

--- a/orttraining/orttraining/training_api/optimizer.cc
+++ b/orttraining/orttraining/training_api/optimizer.cc
@@ -202,7 +202,7 @@ Status Optimizer::Step() {
 Status Optimizer::GetStateDict(OptimizerCheckpointState& optimizer_checkpoint_state) {
   auto& grouped_optimizer_states = optimizer_checkpoint_state.group_named_optimizer_states;
 
-  // To support multiple groups, Optimizer constructor need accept informations for groupping.
+  // To support multiple groups, the Optimizer constructor needs to accept information for grouping.
   grouped_optimizer_states.insert({GROUP_ZERO_NAME, std::make_shared<GroupOptimizerState>(optimizer_state_)});
 
   // Pass the optimizer session data transfer manager for data copying when saving.


### PR DESCRIPTION
### Description
This PR fixes all occurrences of the word 'informations' in the comments (reason see below).
For this the sentences are a bit changed so the 'singular form' fits in.
Since this is a very small fix, no issue was created.

### Motivation and Context
As shown by 'git grep' the ONNX sources contain the invalid plural form of the word information:

$ git grep "informations"
onnxruntime/core/providers/nnapi/nnapi_builtin/builders/model_builder.h:  // Register informations for a particular operand
orttraining/orttraining/training_api/optimizer.cc:  // To support multiple groups, Optimizer constructor need accept informations for groupping.
$ 

The word 'informations' is not valid, see here: https://blog.harwardcommunications.com/2010/11/09/information/
Thus this little fix...