### PR TITLE
Address SDL warnings in recent STFT changes

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/External/D3DX12/d3dx12.h
@@ -749,8 +749,10 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
         barrier.Aliasing.pResourceAfter = pResourceAfter;
         return result;
     }
+    // NOTE: local edit to original header to fix SAL annotation.
+    // See https://github.com/microsoft/DirectX-Headers/pull/89
     static inline CD3DX12_RESOURCE_BARRIER UAV(
-        _In_ ID3D12Resource* pResource) noexcept
+        _In_opt_ ID3D12Resource* pResource) noexcept
     {
         CD3DX12_RESOURCE_BARRIER result = {};
         D3D12_RESOURCE_BARRIER &barrier = result;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlSTFT.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlSTFT.h
@@ -416,7 +416,9 @@ public:
         std::array<DML_BINDING_DESC, 2> inputBindings;
         uint32_t inputBindingsCount = 1;
 
-        std::array<D3D12_RESOURCE_BARRIER, 3> barriers;
+        // NOTE: avoiding std::array for barriers to avoid buggy code analysis thinking
+        // barrierCount is outside the valid range.
+        D3D12_RESOURCE_BARRIER barriers[3];
         uint32_t barrierCount = 0;
 
         ComPtr<ID3D12Resource> signalResource = DmlSTFTHelpers::GetInputResourceFromKernelContext(context, DmlSTFTKernelInputIndex::Signal);
@@ -464,7 +466,7 @@ public:
         }
 
         // Transition resources COMMON -> UAV
-        commandList->ResourceBarrier(barrierCount, barriers.data());
+        commandList->ResourceBarrier(barrierCount, barriers);
 
         m_framingOperator.commandRecorder->RecordDispatch(
             commandList,
@@ -478,7 +480,7 @@ public:
             std::swap(barriers[barrierIndex].Transition.StateBefore, barriers[barrierIndex].Transition.StateAfter);
         }
 
-        commandList->ResourceBarrier(barrierCount, barriers.data());
+        commandList->ResourceBarrier(barrierCount, barriers);
     }
 };
 


### PR DESCRIPTION
### Description
Addresses two separate SDL warnings, neither of which point to a cause for concern:
1. `The expression '0<=_Param_(1)&&_Param_(1)<=3-1' is not true at this call.
at D:\a\_work\1\s\onnxruntime\core\providers\dml\DmlExecutionProvider\src\Operators\\DmlSTFT.h@443,33`. In other words, the tool thinks one of the calls to `barriers[barrierCount++]` will be an index-of-of-range issue, even those this is not currently possible. Switching a normal C array avoids this complaint.
2. `'_Param_(1)' could be '0': this does not adhere to the specification for the function 'CD3DX12_RESOURCE_BARRIER::UAV'`. The d3dx12 helper for UAV barriers has the wrong SAL annotation and doesn't allow a null resource (`_In_`), even though a null resource is legal and well defined. Updated the annotation to `_In_out_` and created a PR upstream.

### Motivation and Context
Pacify SDL tasks in CI pipelines.