### PR TITLE
increase Test GPU Job's timeout to 8 hours

### DIFF
--- a/tools/ci_build/github/azure-pipelines/py-package-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-package-test-pipeline.yml
@@ -35,6 +35,7 @@ stages:
       machine_pool: 'Onnxruntime-Linux-GPU'
       device: 'GPU'
       python_wheel_suffix: '_gpu'
+      timeout: 480
 
 
 # if final job not extecuted, it will not run nightlly build

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-linux-test.yml
@@ -16,9 +16,13 @@ parameters:
   type: string
   default: ''
 
+- name: timeout
+  type: number
+  default: 120
+
 jobs:
 - job: Linux_Test_${{ parameters.device }}${{ parameters.extra_job_id }}_${{ parameters.arch }}
-  timeoutInMinutes: 360
+  timeoutInMinutes: ${{ parameters.timeout }}
   variables:
     skipComponentGovernanceDetection: true
   workspace:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

### Motivation and Context
In practice, 6 hours is not enough to finish the job.


