### PR TITLE
[doc] revise example C++ code of using file path

### DIFF
--- a/docs/execution-providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution-providers/OpenVINO-ExecutionProvider.md
@@ -170,7 +170,7 @@ Use the ONNX API's.[documentation](https://github.com/onnx/onnx/blob/master/docs
 
 Example:
 
-```bash
+```python
 import onnx
 onnx_model = onnx.load("model.onnx") # Your model in memory as ModelProto
 onnx.save_model(onnx_model, 'saved_model.onnx', save_as_external_data=True, all_tensors_to_one_file=True, location='data/weights_data', size_threshold=1024, convert_attribute=False)

--- a/docs/performance/graph-optimizations.md
+++ b/docs/performance/graph-optimizations.md
@@ -135,11 +135,11 @@ session = rt.InferenceSession("<model_path>", sess_options)
   g_ort->SetSessionGraphOptimizationLevel(session_options, ORT_ENABLE_EXTENDED);
 
   // To enable model serialization after graph optimization set this
-  const wchar_t* optimized_model_path = L"optimized_model_path";
+  const ORTCHAR_T* optimized_model_path = ORT_TSTR("optimized_model_path");
   g_ort->SetOptimizedModelFilePath(session_options, optimized_model_path);
 
   OrtSession* session;
-  const wchar_t* model_path = L"model_path";
+  const ORTCHAR_T* model_path = ORT_TSTR("model_path");
   g_ort->CreateSession(env, model_path, session_option, &session);
 ```
 

--- a/docs/performance/tune-performance.md
+++ b/docs/performance/tune-performance.md
@@ -531,7 +531,7 @@ api.SessionOptionsAppendExecutionProvider_CUDA_V2(static_cast<OrtSessionOptions*
 
 
 // Create IO bound inputs and outputs.
-Ort::Session session(*ort_env, L"matmul_2.onnx", session_options);
+Ort::Session session(*ort_env, ORT_TSTR("matmul_2.onnx"), session_options);
 Ort::MemoryInfo info_cuda("Cuda", OrtAllocatorType::OrtArenaAllocator, 0, OrtMemTypeDefault);
 Ort::Allocator cuda_allocator(session, info_cuda);
 

--- a/docs/reference/operators/add-custom-op.md
+++ b/docs/reference/operators/add-custom-op.md
@@ -94,7 +94,7 @@ Ort::SessionOptions session_options;
 session_options.Add(domain);  // Add the domain to the session options.
 
 // Create a session.
-Ort::Session session(env, "my_model_with_custom_ops.onnx", session_options);
+Ort::Session session(env, ORT_TSTR("my_model_with_custom_ops.onnx"), session_options);
 ```
 ## Create a library of custom operators
 Custom operators can be defined in a separate shared library (e.g., a .dll on Windows or a .so on Linux). A custom operator library must export and implement a `RegisterCustomOps` function. The `RegisterCustomOps` function adds a `Ort::CustomOpDomain` containing the library's custom operators to the provided session options.
@@ -183,9 +183,9 @@ Once compiled, the custom operator shared library can then be registered with an
 Ort::Env env;
 Ort::SessionOptions session_options;
 
-session_options.RegisterCustomOpsLibrary(L"my_custom_op.dll");
+session_options.RegisterCustomOpsLibrary_V2(ORT_TSTR("my_custom_op.dll"));
 
-Ort::Session session(env, "my_model.onnx", session_options);
+Ort::Session session(env, ORT_TSTR("my_model.onnx"), session_options);
 ```
 
 ### Examples
@@ -300,7 +300,7 @@ custom_op_configs.AddConfig("OpenVINO_Wrapper", "device_type", "CPU");
 // Register custom op library and pass in the custom op configs (optional).
 session_options.RegisterCustomOpsLibrary("MyOpenVINOWrapper_Lib.so", custom_op_configs);
 
-Ort::Session session(env, "custom_op_mnist_ov_wrapper.onnx", session_options);
+Ort::Session session(env, ORT_TSTR("custom_op_mnist_ov_wrapper.onnx"), session_options);
 ```
 
 Refer to the [complete OpenVINO custom operator wrapper example](https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/test/testdata/custom_op_openvino_wrapper_library) for more details. To create an ONNX model that wraps an external model or weights, refer to the [create_custom_op_wrapper.py tool](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/custom_op_wrapper/create_custom_op_wrapper.py).

--- a/docs/tutorials/accelerate-pytorch/pytorch.md
+++ b/docs/tutorials/accelerate-pytorch/pytorch.md
@@ -157,7 +157,7 @@ Then you can run the ONNX model in the environment of your choice. The ONNXRunti
   // Allocate ONNXRuntime session
   auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
   Ort::Env env;
-  Ort::Session session{env, L"model.onnx", Ort::SessionOptions{nullptr}};
+  Ort::Session session{env, ORT_TSTR("model.onnx"), Ort::SessionOptions{nullptr}};
 
   // Allocate model inputs: fill in shape and size
   std::array<float, ...> input{};

--- a/docs/tutorials/mnist_cpp.md
+++ b/docs/tutorials/mnist_cpp.md
@@ -128,13 +128,13 @@ To make things more interesting, the window painting handler graphs the probabil
 ### The Ort::Session
 
 1. Creation: The Ort::Session is created inside the MNIST structure here:
-     ```
-    Ort::Session session_{env, L"model.onnx", Ort::SessionOptions{nullptr}};
+     ```c++
+    Ort::Session session_{env, ORT_TSTR("model.onnx"), Ort::SessionOptions{nullptr}};
     ```
     [[Source]](https://github.com/microsoft/onnxruntime/blob/521dc757984fbf9770d0051997178fbb9565cd52/samples/c_cxx/MNIST/MNIST.cpp#L43)
 
 2. Setup inputs & outputs: The input & output tensors are created here:
-    ```
+    ```c++
     MNIST() {
     auto allocator_info = Ort::AllocatorInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
     input_tensor_ = Ort::Value::CreateTensor<float>(allocator_info, input_image_.data(), input_image_.size(), input_shape_.data(), input_shape_.size());
@@ -146,7 +146,7 @@ To make things more interesting, the window painting handler graphs the probabil
     In this usage, we're providing the memory location for the data instead of having Ort allocate the buffers. This is simpler in this case since the buffers are small and can just be fixed members of the MNIST struct.
 
 3. Run: Running the session is done in the Run() method:
-    ```
+    ```c++
      int Run() {
     const char* input_names[] = {"Input3"};
     const char* output_names[] = {"Plus214_Output_0"};


### PR DESCRIPTION
### Description
revise example C++ code of using file path.

normalize the example code to use macros `ORTCHAR_T` and `ORT_TSTR` defined in onnxruntime_c_api.h so that the code works in both Windows and UNIX.

This PR resolves #14859