### PR TITLE
Add support for converting DLTensor for NPU device type

### DIFF
--- a/onnxruntime/core/dlpack/dlpack_converter.cc
+++ b/onnxruntime/core/dlpack/dlpack_converter.cc
@@ -86,6 +86,8 @@ OrtDevice GetOrtDevice(const DLDevice& device) {
     case DLDeviceType::kDLCUDA:
     case DLDeviceType::kDLROCM:
       return OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(device.device_id));
+    case DLDeviceType::kDLExtDev:
+      return OrtDevice(OrtDevice::NPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(device.device_id));
     default:
       ORT_THROW("Unsupported device type");
   }
@@ -149,6 +151,10 @@ const char* GetOrtDeviceName(const OrtDevice& device) {
       return CPU;
     case OrtDevice::GPU:
       return CUDA;
+    case OrtDevice::FPGA:
+      return "fpga";
+    case OrtDevice::NPU:
+      return "npu";
     default:
       ORT_THROW("Unknown device type: ", device.Type());
   }
@@ -194,6 +200,9 @@ DLDevice GetDlpackDevice(const OrtValue& ort_value, const int64_t& device_id) {
       device.device_type = DLDeviceType::kDLCUDA;
 #endif
       break;
+    case OrtDevice::FPGA:
+    case OrtDevice::NPU:
+      device.device_type = DLDeviceType::kDLExtDev;
     default:
       ORT_THROW("Cannot pack tensors on this device.");
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR extends dlpack convertor in onnxruntime to support DLDeviceType::kDLExtDev.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
ORT InferenceSession (used for ORTModule and DORT) produces results as ortvalue, and convert them to at Tensor through dlpack. Currently, it supports converting tensors for CPU and GPU. This PR adds support for the conversion for NPU ORT device type between `DLTensor` and ORT tensor for NPU device type. Currently in the PR, tensor conversion through DLPack borrows DLExtDevice, which is planned to use DLMsNpu once a [PR](https://github.com/dmlc/dlpack/pull/120) that supports DLMsNpu is merged.

Related PR in pytorch for the conversion between DLTensor and at Tensor for ORT NPU device type: https://github.com/pytorch/pytorch/pull/95859