### PR TITLE
Enable parallel computation in Clip_6 op

### DIFF
--- a/onnxruntime/core/providers/cpu/math/clip.cc
+++ b/onnxruntime/core/providers/cpu/math/clip.cc
@@ -70,10 +70,29 @@ template <typename T>
 Status Clip_6<T>::Compute(OpKernelContext* ctx) const {
   const auto* X = ctx->Input<Tensor>(0);
   Tensor* Y = ctx->Output(0, X->Shape());
-  EigenVectorMap<T>(Y->MutableData<T>(), onnxruntime::narrow<size_t>(Y->Shape().Size()) ) =
-      ConstEigenVectorMap<T>(X->Data<T>(), onnxruntime::narrow<size_t>(X->Shape().Size()) )
-          .cwiseMax(this->min_)
-          .cwiseMin(this->max_);
+  
+  // We split input/output data into chunks. Each chunk has N elements 
+  // (except, maybe, the last chunk), and we use a thread pool to process
+  // the chunks in parallel. N = 16384 was selected based on performance
+  // results on input tensors of 10^i elements for i in [1 .. 6].
+  static constexpr int64_t length_per_task = 16384;
+  
+  int64_t elem_count = Y->Shape().Size();
+  int64_t task_count = (elem_count + length_per_task - 1) / length_per_task;
+
+  concurrency::ThreadPool::TryBatchParallelFor(
+      ctx->GetOperatorThreadPool(), 
+      static_cast<int32_t>(task_count),
+      [&](ptrdiff_t task_idx) {
+          const auto start = task_idx * length_per_task;
+          int64_t count = std::min(length_per_task, elem_count - start);
+
+          EigenVectorMap<T>(Y->MutableData<T>() + start, count) =
+              ConstEigenVectorMap<T>(X->Data<T>() + start, count)
+                  .cwiseMax(this->min_)
+                  .cwiseMin(this->max_);
+  }, 0);
+
   return Status::OK();
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR speeds-up the Clip-6 operation by replacing its sequential implementation with a parallelized one. The parallelization is achieved by dividing the input data into chunks of size N and using a thread pool to process the chunks in parallel. The chunk size N is set to 16K based on performance evaluation on input tensors of 10^i elements for i in [1 .. 6].


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The Clip operation is frequently executed in image processing models. Its implementation can be easily parallelized and therefore sped up when executed on a multi-core machine. On long inputs (>= 100K elements) this PR achieves speedup of over 2.4x. On shorter inputs, this PR does not introduce any substantial performance change.

