### PR TITLE
Fix prefast warning

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/conv.cc
@@ -173,7 +173,7 @@ Status Conv<T, NHWC>::UpdateState(OpKernelContext* context, bool bias_expected) 
     TensorShapeVector slice_axes;
     slice_axes.reserve(kernel_rank);
 
-    const size_t spatial_dim_start = channels_last ? 1 : 2;
+    constexpr size_t spatial_dim_start = channels_last ? 1 : 2;
     const size_t spatial_dim_end = spatial_dim_start + kernel_rank;
     TensorShape spatial_shape = X->Shape().Slice(spatial_dim_start, spatial_dim_end);
 


### PR DESCRIPTION
### Description
Fix a prefast warning:  `The const variable 'spatial_dim_start' can be computed at compile-time. Consider using constexpr (con.5).`



### Motivation and Context

Fixed [AB#12263](https://aiinfra.visualstudio.com/6a833879-cd9b-44a4-a9de-adc2d818f13c/_workitems/edit/12263)


