### PR TITLE
Update inferencing.md with specific build instructions for VS 2022

### DIFF
--- a/docs/build/inferencing.md
+++ b/docs/build/inferencing.md
@@ -62,7 +62,7 @@ Open Developer Command Prompt for Visual Studio version you are going to use. Th
 ```
 .\build.bat --config RelWithDebInfo --build_shared_lib --parallel
 ```
-The default Windows CMake Generator is Visual Studio 2017, but you can also use the newer Visual Studio 2019 by passing `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`. Visual Studio 2022 should be fine too. We recommend using the latest one.
+The default Windows CMake Generator is Visual Studio 2017. For Visual Studio 2019 pass `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`. For Visual Studio 2022 pass `--cmake_generator "Visual Studio 17 2022"`. We recommend using the latest one.
 
 #### Linux
 

--- a/docs/build/inferencing.md
+++ b/docs/build/inferencing.md
@@ -62,7 +62,11 @@ Open Developer Command Prompt for Visual Studio version you are going to use. Th
 ```
 .\build.bat --config RelWithDebInfo --build_shared_lib --parallel
 ```
-The default Windows CMake Generator is Visual Studio 2017. For Visual Studio 2019 pass `--cmake_generator "Visual Studio 16 2019"` to `.\build.bat`. For Visual Studio 2022 pass `--cmake_generator "Visual Studio 17 2022"`. We recommend using the latest one.
+The default Windows CMake Generator is Visual Studio 2019. 
+For Visual Studio 2022 add `--cmake_generator "Visual Studio 17 2022"`. 
+For Visual Studio 2017 add `--cmake_generator "Visual Studio 15 2017"`. 
+
+We recommend using Visual Studio 2022.
 
 #### Linux
 


### PR DESCRIPTION
### Description
Update build inferencing.md with specific build instructions for VS 2022



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
I am on the latest VS IDE and build instructions led me down a path where I had to manually delete files to recover (stale cache). Explicitly stating the string needed for the VS2022 so that less users fall down this trap