### PR TITLE
Update tune-performance.md with tooling info for opening .json perf traces

### DIFF
--- a/docs/performance/tune-performance/profiling-tools.md
+++ b/docs/performance/tune-performance/profiling-tools.md
@@ -35,11 +35,14 @@ sess_options.enable_profiling = True
 
 If you are using the onnxruntime_perf_test.exe tool, you can add `-p [profile_file]` to enable performance profiling.
 
-In both cases, you will get a JSON file which contains the detailed performance data (threading, latency of each operator, etc). This file is a standard performance tracing file, and to view it in a user-friendly way, you can open it by using chrome://tracing:
+In both cases, you will get a JSON file which contains the detailed performance data (threading, latency of each operator, etc). This file is a standard performance tracing file, and to view it in a user-friendly way, you can open it by using multiple tools.
 
-* Open Chrome browser
-* Type chrome://tracing in the address bar
-* Load the generated JSON file
+* (Windows) Use the WPA GUI to open the trace using the Perfetto OSS plugin - [Microsoft-Performance-Tools-Linux-Android](https://github.com/microsoft/Microsoft-Performance-Tools-Linux-Android)
+* [Perfetto UI](https://www.ui.perfetto.dev/) - Successor to Chrome Tracing UI
+* chrome://tracing: 
+  * Open a Chromium based browser such as Edge or Chrome
+  * Type chrome://tracing in the address bar
+  * Load the generated JSON file
 
 To profile CUDA kernels, please add the cupti library to your PATH and use the onnxruntime binary built from source with `--enable_cuda_profiling`.
 To profile ROCm kernels, please add the roctracer library to your PATH and use the onnxruntime binary built from source with `--enable_rocm_profiling`. 


### PR DESCRIPTION

### Description
-WPA OSS plugins
-Pertetto UI which is recommended by Google over deprecated chrome://tracing experience


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- I tried both chrome://tracing and Perfetto to open the .json and it's not a great expreince. If on Windows, WPA is a MUCH better experience and easier to work with the data/report. Also Google recommends Perfetto vs chrome://tracing so updated that as well