### PR TITLE
Fix typos in sources: operater, tranform, neccessary, trainig

### DIFF
--- a/js/web/lib/onnxjs/ort-schema/README.md
+++ b/js/web/lib/onnxjs/ort-schema/README.md
@@ -1,5 +1,5 @@
 # ORT Format File
-This directory contains [the generated ts file](ort-generated.ts) neccessary to support the ORT file format. The file is generated from [the ORT file format schema](https://github.com/microsoft/onnxruntime/blob/d42399e1b07ce61e95aae88bc6b6ea5dcaae2011/onnxruntime/core/flatbuffers/schema/ort.fbs). Please do not directly modify [the generated ts header file](ort-generated.ts).
+This directory contains [the generated ts file](ort-generated.ts) necessary to support the ORT file format. The file is generated from [the ORT file format schema](https://github.com/microsoft/onnxruntime/blob/d42399e1b07ce61e95aae88bc6b6ea5dcaae2011/onnxruntime/core/flatbuffers/schema/ort.fbs). Please do not directly modify [the generated ts header file](ort-generated.ts).
 
 [The ORT file format schema](https://github.com/microsoft/onnxruntime/blob/d42399e1b07ce61e95aae88bc6b6ea5dcaae2011/onnxruntime/core/flatbuffers/schema/ort.fbs) uses [FlatBuffers](https://github.com/google/flatbuffers) serialization library. To update [its generated ts file](ort-generated.ts),
 

--- a/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/argmax_op_builder.cc
@@ -51,7 +51,7 @@ Status ArgMaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     auto it = node.OutputEdgesBegin();
     const auto* succ_node(graph_viewer.GetNode(it->GetNode().Index()));
     // If Argmax's successive node is a Cast from int64 to int32 output
-    // The 'cast to' type is checked in operater supported related, omit the check here
+    // The 'cast to' type is checked in operator supported related, omit the check here
     if (succ_node->OpType() == "Cast") {
       // Skip the cast's input/argmax's output
       *layer->mutable_input()->Add() = node.InputDefs()[0]->Name();

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMaxUnpool.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMaxUnpool.cpp
@@ -34,10 +34,10 @@ public:
         poolingDesc.IndicesTensor = &inputDescs[1];
         poolingDesc.OutputTensor = outputDescs.data();
 
-        DML_OPERATOR_DESC operaterDesc = {};
-        operaterDesc.Type = DML_OPERATOR_MAX_UNPOOLING;
-        operaterDesc.Desc = &poolingDesc;
-        SetDmlOperatorDesc(operaterDesc, kernelCreationContext);
+        DML_OPERATOR_DESC operatorDesc = {};
+        operatorDesc.Type = DML_OPERATOR_MAX_UNPOOLING;
+        operatorDesc.Desc = &poolingDesc;
+        SetDmlOperatorDesc(operatorDesc, kernelCreationContext);
     }
 };
 

--- a/onnxruntime/python/tools/transformers/notebooks/Inference_Bert_with_OnnxRuntime_on_AzureML.ipynb
+++ b/onnxruntime/python/tools/transformers/notebooks/Inference_Bert_with_OnnxRuntime_on_AzureML.ipynb
@@ -57,7 +57,7 @@
     "# behave differently in inference and training mode.\n",
     "model.eval()\n",
     "\n",
-    "# Generate dummy inputs to the model. Adjust if neccessary\n",
+    "# Generate dummy inputs to the model. Adjust if necessary.\n",
     "inputs = {\n",
     "        'input_ids':   torch.randint(32, [2, 32], dtype=torch.long).to(device), # list of numerical ids for the tokenised text\n",
     "        'attention_mask': torch.ones([2, 32], dtype=torch.long).to(device),        # dummy list of ones\n",
@@ -276,7 +276,7 @@
    "source": [
     "## Step 2.2 - Write scoring file\n",
     "\n",
-    "We are now going to deploy our ONNX model on Azure ML using the ONNX Runtime. We begin by writing a score.py file that will be invoked by the web service call. The `init()` function is called once when the container is started so we load the model using the ONNX Runtime into a global session object. Then the `run()` function is called when we run the model using the Azure ML web service. Add neccessary `preprocess()` and `postprocess()` steps. The following score.py file uses `bert-squad` as an example and assumes the inputs will be in the following format. "
+    "We are now going to deploy our ONNX model on Azure ML using the ONNX Runtime. We begin by writing a score.py file that will be invoked by the web service call. The `init()` function is called once when the container is started so we load the model using the ONNX Runtime into a global session object. Then the `run()` function is called when we run the model using the Azure ML web service. Add necessary `preprocess()` and `postprocess()` steps. The following score.py file uses `bert-squad` as an example and assumes the inputs will be in the following format. "
    ]
   },
   {

--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -256,7 +256,7 @@ class BertOnnxModel(OnnxModel):
         nodes_to_remove = []
         for node in self.nodes():
             if node.op_type == "Reshape":
-                # Clean up unneccessary reshape nodes.
+                # Clean up unnecessary reshape nodes.
                 # Find reshape nodes with no actually data in "shape" attribute and remove.
                 reshape_shape = self.get_constant_value(node.input[1])
                 if reshape_shape is not None and reshape_shape.size == 0:

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2586,7 +2586,7 @@ TEST(CApiTest, TestPerSessionCustomThreadPoolHooks) {
   ASSERT_TRUE(custom_join_hook_called == (thread_count - 1) << 1);
 }
 
-// Preventing resize tranformer issue:
+// Preventing resize transformer issue:
 // https://github.com/microsoft/onnxruntime/issues/9857
 #ifndef REDUCED_OPS_BUILD
 TEST(CApiTest, crop_and_resize) {

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -78,7 +78,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         self._debug_options = debug_options
         self._fallback_manager = fallback_manager
 
-        # Original and flattened (tranformed) output module
+        # Original and flattened (transformed) output module
         self._flattened_module = module
 
         # onnx models

--- a/orttraining/orttraining/test/python/orttraining_test_utils.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utils.py
@@ -196,7 +196,7 @@ def run_test(
         )
         print("running with old frontend API")
 
-    # trainig loop
+    # training loop
     eval_batch = None
     if not use_new_api:
         model.train()

--- a/orttraining/orttraining/test/python/qat_poc_example/README.md
+++ b/orttraining/orttraining/test/python/qat_poc_example/README.md
@@ -1,6 +1,6 @@
 ## Quantization Aware Training (QAT) with onnxruntime POC
 
-This directory contains a complete example of how users can perform QAT in onnxruntime (as a Proof of Concept). There are two approaches to perform QAT in ort - a). Using `onnxruntime.trainig.api` and b). Using `onnxruntime.training.ORTModule`. The contents of this tutorial focus on the former (QAT with `ORTModule` is still under development and is not ready).
+This directory contains a complete example of how users can perform QAT in onnxruntime (as a Proof of Concept). There are two approaches to perform QAT in ort - a). Using `onnxruntime.training.api` and b). Using `onnxruntime.training.ORTModule`. The contents of this tutorial focus on the former (QAT with `ORTModule` is still under development and is not ready).
 
 We will walk through a POC example using the `MNIST` dataset and a simple neural network with two linear layers:
 


### PR DESCRIPTION
### Description
While browsing the sources I found several typos here and there.
I collected them to a single PR and fixed them.
Namely these typos are: operater, tranform, neccessary, trainig.
After fixing none of them was found anymore:

$ git grep "operater"
$ git grep "tranform"
$ git grep "neccessary"
$ git grep "trainig"
$ 

### Motivation and Context
Since some of the typos are in example notebooks and markdown files, users can see them.
