### PR TITLE
Linux QNN Pipeline: fix build error reporting

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1175,6 +1175,7 @@ def generate_build_tree(
             cmake_args += ["-DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=" + args.xcode_code_signing_team_id]
 
     if args.use_qnn:
+        raise BuildError("Temp build error for testing pipeline reporting. REMOVE")  # TODO: remove
         if args.qnn_home is None or os.path.exists(args.qnn_home) is False:
             raise BuildError("qnn_home=" + qnn_home + " not valid." + " qnn_home paths must be specified and valid.")
         cmake_args += ["-Donnxruntime_USE_QNN=ON"]

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1175,7 +1175,6 @@ def generate_build_tree(
             cmake_args += ["-DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=" + args.xcode_code_signing_team_id]
 
     if args.use_qnn:
-        raise BuildError("Temp build error for testing pipeline reporting. REMOVE")  # TODO: remove
         if args.qnn_home is None or os.path.exists(args.qnn_home) is False:
             raise BuildError("qnn_home=" + qnn_home + " not valid." + " qnn_home paths must be specified and valid.")
         cmake_args += ["-Donnxruntime_USE_QNN=ON"]

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -24,10 +24,6 @@ jobs:
         displayName: set QNN_SDK_ROOT
 
       - script: |
-          env | egrep -e QNN
-        displayName: List QNN env variables
-
-      - script: |
           python3 tools/ci_build/build.py \
             --build_dir build \
             --config Release \

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -25,6 +25,9 @@ jobs:
 
       - script: |
           env | egrep -e QNN
+        displayName: List QNN env variables
+
+      - script: |
           python3 tools/ci_build/build.py \
             --build_dir build \
             --config Release \
@@ -33,8 +36,7 @@ jobs:
             --qnn_home $QNN_SDK_ROOT \
             --cmake_generator=Ninja \
             --skip_tests
-          mkdir -p build/Release/testdata/QNN/node_tests
-        displayName: QNN EP, Build
+        displayName: Build QNN EP
 
       - script: |
           python3 tools/ci_build/build.py \


### PR DESCRIPTION
### Description
Split up the ORT build step in the Linux QNN CI Pipeline.


### Motivation and Context
Build errors were not being immediately reported at the end of the build step. The build step currently concatenates multiple shell commands, and the return code for the last (mkdir) was being reported. This PR ensures that the return code of the `python build.py ...` command is reported for the build step.