### PR TITLE
Update rust doc comments

### DIFF
--- a/rust/onnxruntime-sys/Cargo.toml
+++ b/rust/onnxruntime-sys/Cargo.toml
@@ -22,6 +22,7 @@ libloading = "0.7"
 [build-dependencies]
 bindgen = "0.63"
 cmake = "0.1"
+doxygen-rs = "0.3"
 
 # Used on unix
 flate2 = "1.0"

--- a/rust/onnxruntime-sys/Cargo.toml
+++ b/rust/onnxruntime-sys/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.0.14"
 
 links = "onnxruntime"
 
-description = "Unsafe wrapper around Microsoft's ONNX Runtime"
+description = "low-level wrapper around Microsoft's ONNXRuntime"
 documentation = "https://docs.rs/onnxruntime-sys"
 homepage = "https://github.com/microsoft/onnxruntime"
 license = "MIT OR Apache-2.0"

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -8,6 +8,8 @@ use std::{
     str::FromStr,
 };
 
+use bindgen::callbacks::ParseCallbacks;
+
 /// ONNX Runtime version
 ///
 /// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
@@ -57,6 +59,15 @@ fn main() {
     generate_bindings(&include_dir);
 }
 
+#[derive(Debug)]
+struct Cb;
+
+impl ParseCallbacks for Cb {
+    fn process_comment(&self, comment: &str) -> Option<String> {
+        Some(doxygen_rs::transform(comment))
+    }
+}
+
 fn generate_bindings(include_dir: &Path) {
     let clang_args = &[
         format!("-I{}", include_dir.display()),
@@ -88,6 +99,7 @@ fn generate_bindings(include_dir: &Path) {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(Cb))
         .dynamic_library_name("onnxruntime")
         .allowlist_type("Ort.*")
         .allowlist_type("Onnx.*")

--- a/rust/onnxruntime/src/lib.rs
+++ b/rust/onnxruntime/src/lib.rs
@@ -1,20 +1,19 @@
 #![warn(missing_docs)]
 
-//! ONNX Runtime
+//! Onnxruntime
 //!
-//! This crate is a (safe) wrapper around Microsoft's [ONNX Runtime](https://github.com/microsoft/onnxruntime/)
-//! through its C API.
+//! # Build
 //!
-//! From its [GitHub page](https://github.com/microsoft/onnxruntime/):
+//! ## Environment variables
 //!
-//! > ONNX Runtime is a cross-platform, high performance ML inferencing and training accelerator.
+//! `ORT_RUST_STRATEGY`
+//! - compile Use cmake to build the Onnxruntime library (default)
+//! - system Use an installed Onnxruntime library
+//! - download Download a pre-built library
 //!
-//! The (highly) unsafe [C API](https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/session/onnxruntime_c_api.h)
-//! is wrapped using bindgen as [`onnxruntime-sys`](https://crates.io/crates/onnxruntime-sys).
+//! `ORT_RUST_LIB_LOCATION` only used if `ORT_RUST_STRATEGY=system`
+//! The location of the Onnxruntime library.
 //!
-//! The unsafe bindings are wrapped in this crate to expose a safe API.
-//!
-//! For now, efforts are concentrated on the inference API. Training is _not_ supported.
 //!
 //! # Example
 //!


### PR DESCRIPTION
### Description
The rust-bindgen tool takes C comments and turns them into Rust doc comments. Because the C comments are written in Doxygen, the comments need to be parsed. This pr parses the doxygen comments as part of the Rust build. The Rust docs then will not contain Doxygen commands like `\brief`.

This PR also changes the Lib doc comments.

This is the command that should be used to build the rust documentation.

`RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps`

@RyanUnderhill

