### PR TITLE
[js] remove 'npm bin'

### DIFF
--- a/js/node/script/build.ts
+++ b/js/node/script/build.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {execSync, spawnSync} from 'child_process';
+import {spawnSync} from 'child_process';
 import * as fs from 'fs-extra';
 import minimist from 'minimist';
 import * as os from 'os';
@@ -31,17 +31,14 @@ const ROOT_FOLDER = path.join(__dirname, '..');
 const BIN_FOLDER = path.join(ROOT_FOLDER, 'bin');
 const BUILD_FOLDER = path.join(ROOT_FOLDER, 'build');
 
-const NPM_BIN_FOLDER = execSync('npm bin', {encoding: 'utf8'}).trim();
-const CMAKE_JS_FULL_PATH = path.join(NPM_BIN_FOLDER, 'cmake-js');
-
 // if rebuild, clean up the dist folders
 if (REBUILD) {
   fs.removeSync(BIN_FOLDER);
   fs.removeSync(BUILD_FOLDER);
 }
 
-const command = CMAKE_JS_FULL_PATH;
 const args = [
+  'cmake-js',
   (REBUILD ? 'reconfigure' : 'configure'),
   `--arch=${ARCH}`,
   '--CDnapi_build_version=3',
@@ -63,7 +60,7 @@ if (os.platform() === 'darwin') {
 }
 
 // launch cmake-js configure
-const procCmakejs = spawnSync(command, args, {shell: true, stdio: 'inherit', cwd: ROOT_FOLDER});
+const procCmakejs = spawnSync('npx', args, {shell: true, stdio: 'inherit', cwd: ROOT_FOLDER});
 if (procCmakejs.status !== 0) {
   if (procCmakejs.error) {
     console.error(procCmakejs.error);

--- a/js/web/script/build.ts
+++ b/js/web/script/build.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {execSync, spawnSync} from 'child_process';
+import {spawnSync} from 'child_process';
 import * as fs from 'fs-extra';
 import minimist from 'minimist';
 import npmlog from 'npmlog';
@@ -30,14 +30,15 @@ const ANALYZER = !!args.a || !!args.analyzer;
 const FILTER = args.f || args.filter;
 
 // Path variables
-const WASM_BINDING_FOLDER = path.join(__dirname, '..', 'lib', 'wasm', 'binding');
+const ROOT_FOLDER = path.join(__dirname, '..');
+const WASM_BINDING_FOLDER = path.join(ROOT_FOLDER, 'lib', 'wasm', 'binding');
 const WASM_BINDING_JS_PATH = path.join(WASM_BINDING_FOLDER, 'ort-wasm.js');
 const WASM_BINDING_THREADED_JS_PATH = path.join(WASM_BINDING_FOLDER, 'ort-wasm-threaded.js');
 const WASM_BINDING_THREADED_WORKER_JS_PATH = path.join(WASM_BINDING_FOLDER, 'ort-wasm-threaded.worker.js');
 const WASM_BINDING_THREADED_MIN_JS_PATH = path.join(WASM_BINDING_FOLDER, 'ort-wasm-threaded.min.js');
 const WASM_BINDING_THREADED_MIN_WORKER_JS_PATH = path.join(WASM_BINDING_FOLDER, 'ort-wasm-threaded.min.worker.js');
 
-const WASM_DIST_FOLDER = path.join(__dirname, '..', 'dist');
+const WASM_DIST_FOLDER = path.join(ROOT_FOLDER, 'dist');
 const WASM_WASM_PATH = path.join(WASM_DIST_FOLDER, 'ort-wasm.wasm');
 const WASM_THREADED_WASM_PATH = path.join(WASM_DIST_FOLDER, 'ort-wasm-threaded.wasm');
 const WASM_SIMD_WASM_PATH = path.join(WASM_DIST_FOLDER, 'ort-wasm-simd.wasm');
@@ -54,10 +55,6 @@ function validateFile(path: string): void {
     throw new Error(`file is empty: ${path}`);
   }
 }
-
-npmlog.info('Build.Bundle', 'Retrieving npm bin folder...');
-const npmBin = execSync('npm bin', {encoding: 'utf8'}).trimRight();
-npmlog.info('Build.Bundle', `Retrieving npm bin folder... DONE, folder: ${npmBin}`);
 
 if (WASM) {
   npmlog.info('Build', 'Validating WebAssembly artifacts...');
@@ -83,16 +80,15 @@ if (WASM) {
  */
 `;
 
-  const terserCommand = path.join(npmBin, 'terser');
   npmlog.info('Build', 'Minimizing file "ort-wasm-threaded.js"...');
   try {
     const terser = spawnSync(
-        terserCommand,
+        'npx',
         [
-          WASM_BINDING_THREADED_JS_PATH, '--compress', 'passes=2', '--format', 'comments=false', '--mangle',
+          'terser', WASM_BINDING_THREADED_JS_PATH, '--compress', 'passes=2', '--format', 'comments=false', '--mangle',
           'reserved=[_scriptDir]', '--module'
         ],
-        {shell: true, encoding: 'utf-8'});
+        {shell: true, encoding: 'utf-8', cwd: ROOT_FOLDER});
     if (terser.status !== 0) {
       console.error(terser.error);
       process.exit(terser.status === null ? undefined : terser.status);
@@ -112,10 +108,10 @@ if (WASM) {
   npmlog.info('Build', 'Minimizing file "ort-wasm-threaded.worker.js"...');
   try {
     const terser = spawnSync(
-        terserCommand,
+        'npx',
         [
-          WASM_BINDING_THREADED_WORKER_JS_PATH, '--compress', 'passes=2', '--format', 'comments=false', '--mangle',
-          'reserved=[_scriptDir]', '--toplevel'
+          'terser', WASM_BINDING_THREADED_WORKER_JS_PATH, '--compress', 'passes=2', '--format', 'comments=false',
+          '--mangle', 'reserved=[_scriptDir]', '--toplevel'
         ],
         {shell: true, encoding: 'utf-8'});
     if (terser.status !== 0) {
@@ -138,16 +134,15 @@ if (WASM) {
 npmlog.info('Build', 'Building bundle...');
 {
   npmlog.info('Build.Bundle', 'Running webpack to generate bundles...');
-  const webpackCommand = path.join(npmBin, 'webpack');
-  const webpackArgs = ['--env', `--bundle-mode=${MODE}`];
+  const webpackArgs = ['webpack', '--env', `--bundle-mode=${MODE}`];
   if (ANALYZER) {
     webpackArgs.push('--env', '-a');
   }
   if (FILTER) {
     webpackArgs.push('--env', `-f=${FILTER}`);
   }
-  npmlog.info('Build.Bundle', `CMD: ${webpackCommand} ${webpackArgs.join(' ')}`);
-  const webpack = spawnSync(webpackCommand, webpackArgs, {shell: true, stdio: 'inherit'});
+  npmlog.info('Build.Bundle', `CMD: npx ${webpackArgs.join(' ')}`);
+  const webpack = spawnSync('npx', webpackArgs, {shell: true, stdio: 'inherit', cwd: ROOT_FOLDER});
   if (webpack.status !== 0) {
     console.error(webpack.error);
     process.exit(webpack.status === null ? undefined : webpack.status);

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -4,7 +4,7 @@
 /* eslint-disable guard-for-in */
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-import {execSync, spawnSync} from 'child_process';
+import {spawnSync} from 'child_process';
 import * as fs from 'fs-extra';
 import * as globby from 'globby';
 import {default as minimatch} from 'minimatch';
@@ -395,28 +395,23 @@ function tryLocateOpTestManifest(searchPattern: string): string {
 
 function run(config: Test.Config) {
   // STEP 1. write file cache to testdata-file-cache-*.json
-  npmlog.info('TestRunnerCli.Run', '(1/5) Writing file cache to file: testdata-file-cache-*.json ...');
+  npmlog.info('TestRunnerCli.Run', '(1/4) Writing file cache to file: testdata-file-cache-*.json ...');
   const fileCacheUrls = saveFileCache(fileCache);
   if (fileCacheUrls.length > 0) {
     config.fileCacheUrls = fileCacheUrls;
   }
   npmlog.info(
       'TestRunnerCli.Run',
-      `(1/5) Writing file cache to file: testdata-file-cache-*.json ... ${
+      `(1/4) Writing file cache to file: testdata-file-cache-*.json ... ${
           fileCacheUrls.length > 0 ? `DONE, ${fileCacheUrls.length} file(s) generated` : 'SKIPPED'}`);
 
   // STEP 2. write the config to testdata-config.json
-  npmlog.info('TestRunnerCli.Run', '(2/5) Writing config to file: testdata-config.json ...');
+  npmlog.info('TestRunnerCli.Run', '(2/4) Writing config to file: testdata-config.json ...');
   saveConfig(config);
-  npmlog.info('TestRunnerCli.Run', '(2/5) Writing config to file: testdata-config.json ... DONE');
+  npmlog.info('TestRunnerCli.Run', '(2/4) Writing config to file: testdata-config.json ... DONE');
 
-  // STEP 3. get npm bin folder
-  npmlog.info('TestRunnerCli.Run', '(3/5) Retrieving npm bin folder...');
-  const npmBin = execSync('npm bin', {encoding: 'utf8'}).trimRight();
-  npmlog.info('TestRunnerCli.Run', `(3/5) Retrieving npm bin folder... DONE, folder: ${npmBin}`);
-
-  // STEP 4. generate bundle
-  npmlog.info('TestRunnerCli.Run', '(4/5) Running build to generate bundle...');
+  // STEP 3. generate bundle
+  npmlog.info('TestRunnerCli.Run', '(3/4) Running build to generate bundle...');
   const buildCommand = `node ${path.join(__dirname, 'build')}`;
   const buildArgs = [`--bundle-mode=${args.env === 'node' ? 'node' : args.bundleMode}`];
   if (args.backends.indexOf('wasm') === -1) {
@@ -428,40 +423,37 @@ function run(config: Test.Config) {
     console.error(build.error);
     process.exit(build.status === null ? undefined : build.status);
   }
-  npmlog.info('TestRunnerCli.Run', '(4/5) Running build to generate bundle... DONE');
+  npmlog.info('TestRunnerCli.Run', '(3/4) Running build to generate bundle... DONE');
 
   if (args.env === 'node') {
     // STEP 5. run tsc and run mocha
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running tsc...');
-    const tscCommand = path.join(npmBin, 'tsc');
-    const tsc = spawnSync(tscCommand, {shell: true, stdio: 'inherit'});
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running tsc...');
+    const tsc = spawnSync('npx', ['tsc'], {shell: true, stdio: 'inherit'});
     if (tsc.status !== 0) {
       console.error(tsc.error);
       process.exit(tsc.status === null ? undefined : tsc.status);
     }
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running tsc... DONE');
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running tsc... DONE');
 
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running mocha...');
-    const mochaCommand = path.join(npmBin, 'mocha');
-    const mochaArgs = [path.join(TEST_ROOT, 'test-main'), `--timeout ${args.debug ? 9999999 : 60000}`];
-    npmlog.info('TestRunnerCli.Run', `CMD: ${mochaCommand} ${mochaArgs.join(' ')}`);
-    const mocha = spawnSync(mochaCommand, mochaArgs, {shell: true, stdio: 'inherit'});
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running mocha...');
+    const mochaArgs = ['mocha', path.join(TEST_ROOT, 'test-main'), `--timeout ${args.debug ? 9999999 : 60000}`];
+    npmlog.info('TestRunnerCli.Run', `CMD: npx ${mochaArgs.join(' ')}`);
+    const mocha = spawnSync('npx', mochaArgs, {shell: true, stdio: 'inherit'});
     if (mocha.status !== 0) {
       console.error(mocha.error);
       process.exit(mocha.status === null ? undefined : mocha.status);
     }
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running mocha... DONE');
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running mocha... DONE');
 
   } else {
     // STEP 5. use Karma to run test
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running karma to start test runner...');
-    const karmaCommand = path.join(npmBin, 'karma');
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running karma to start test runner...');
     const browser = getBrowserNameFromEnv(
         args.env,
         args.bundleMode === 'perf' ? 'perf' :
             args.debug             ? 'debug' :
                                      'test');
-    const karmaArgs = ['start', `--browsers ${browser}`];
+    const karmaArgs = ['karma', 'start', `--browsers ${browser}`];
     if (args.debug) {
       karmaArgs.push('--log-level info --timeout-mocha 9999999');
     } else {
@@ -520,13 +512,13 @@ function run(config: Test.Config) {
         spawnSync(deleteEdgeActiveRecoveryCommand, {shell: true, stdio: 'inherit'});
       }
     }
-    npmlog.info('TestRunnerCli.Run', `CMD: ${karmaCommand} ${karmaArgs.join(' ')}`);
-    const karma = spawnSync(karmaCommand, karmaArgs, {shell: true, stdio: 'inherit'});
+    npmlog.info('TestRunnerCli.Run', `CMD: npx ${karmaArgs.join(' ')}`);
+    const karma = spawnSync('npx', karmaArgs, {shell: true, stdio: 'inherit'});
     if (karma.status !== 0) {
       console.error(karma.error);
       process.exit(karma.status === null ? undefined : karma.status);
     }
-    npmlog.info('TestRunnerCli.Run', '(5/5) Running karma to start test runner... DONE');
+    npmlog.info('TestRunnerCli.Run', '(4/4) Running karma to start test runner... DONE');
   }
 }
 


### PR DESCRIPTION
### Description
'npm bin' is deprecated in latest version. use 'npx' instead. 

This PR resolves #14934