### PR TITLE
[CoreML EP] Add Pad op support 

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <variant>
-
 #include "core/providers/common.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/providers/coreml/builders/helper.h"

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -184,6 +184,13 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     // CoreML PaddinglayerParams: https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#paddinglayerparams
     const auto input_rank = input_shape.size();
     InlinedVector<int64_t> axes_tensor_data = GetPaddingAxesData(initializers, node, input_rank);
+    for (size_t i = 0; i < axes_tensor_data.size(); i++) {
+      if (axes_tensor_data[i] < 0) {
+        LOGS(logger, VERBOSE) << "Negative axis value is not supported for now: axes["
+                              << i << "] = " << axes_tensor_data[i];
+        return false;
+      }
+    }
     int64_t num_axes = axes_tensor_data.size();
 
     for (int64_t i = 0; i < num_axes; i++) {

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -75,7 +75,7 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
   InlinedVector<int64_t> axes_tensor_data;
   if (input_defs.size() > 3) {
-    // optional input axes is provided
+    // optional input axes is provided, use axes initializer data
     const ONNX_NAMESPACE::TensorProto& axes_tensor = *model_builder.GetInitializerTensors().at(input_defs[3]->Name());
     Initializer axes_initializer(axes_tensor);
     const auto* axes_data = axes_initializer.data<int64_t>();
@@ -173,7 +173,7 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     const auto input_rank = input_shape.size();
     InlinedVector<int64_t> axes_tensor_data;
     if (input_defs.size() > 3) {
-      // optional axes input is provided
+      // optional axes input is provided, use axes initializer data
       const auto axes_initializer_it = initializers.find(input_defs[3]->Name());
       if (axes_initializer_it == initializers.end()) {
         LOGS(logger, VERBOSE) << "If provided, axes must be a constant initializer.";

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/common/safeint.h"
-#include "core/common/span_utils.h"
 #include "core/providers/common.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/providers/coreml/builders/helper.h"

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/common.h"
 #include "core/common/safeint.h"
+#include "core/common/span_utils.h"
+#include "core/providers/common.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/providers/coreml/builders/helper.h"
 #include "core/providers/shared/utils/utils.h"
@@ -46,6 +47,9 @@ class PadOpBuilder : public BaseOpBuilder {
 void PadOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
   model_builder.AddInitializerToSkip(node.InputDefs()[1]->Name());  //  pads
   model_builder.AddInitializerToSkip(node.InputDefs()[2]->Name());  //  constant_value
+  if (node.InputDefs().size() > 3) {
+    model_builder.AddInitializerToSkip(node.InputDefs()[3]->Name());  // axes
+  }
 }
 
 Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -59,26 +63,43 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
   GetShape(*input_defs[0], input_shape, logger);
-  const auto input_rank = SafeInt<int64_t>(input_shape.size());
+  const auto input_rank = input_shape.size();
 
   const auto& pads_tensor = *model_builder.GetInitializerTensors().at(input_defs[1]->Name());            // pads
   const auto& constant_value_tensor = *model_builder.GetInitializerTensors().at(input_defs[2]->Name());  // constant_value
 
-  float pad_value = 0.0f;
-  Initializer pad_value_raw_data_init(constant_value_tensor);
-  pad_value = pad_value_raw_data_init.DataAsSpan<float>()[0];
-  constant_padding_type->set_value(pad_value);
+  Initializer constant_value_raw_data_init(constant_value_tensor);
+  float constant_value = constant_value_raw_data_init.DataAsSpan<float>()[0];
+  constant_padding_type->set_value(constant_value);
 
   Initializer pads_initializer_raw_data(pads_tensor);
   auto pads_span = pads_initializer_raw_data.DataAsSpan<int64_t>();
 
+  // if not provided, make a default axes as [0, 1, ..., input_rank - 1]
+  std::vector<int64_t> default_axes(input_rank);
+  std::iota(std::begin(default_axes), std::end(default_axes), 0);
+  auto axes_tensor_data = gsl::span<const int64_t>(default_axes);
+  if (input_defs.size() > 3) {
+    // optional input axes is provided
+    const ONNX_NAMESPACE::TensorProto& axes_tensor = *model_builder.GetInitializerTensors().at(input_defs[3]->Name());
+    Initializer axes_initializer_raw_data(axes_tensor);
+    axes_tensor_data = axes_initializer_raw_data.DataAsSpan<int64_t>();
+  }
+  int64_t num_axes = axes_tensor_data.size();
+
   // Add padding
   auto* height_border = coreml_pad->mutable_paddingamounts()->add_borderamounts();
-  height_border->set_startedgesize(pads_span[input_rank - 2]);
-  height_border->set_endedgesize(pads_span[2 * input_rank - 2]);
   auto* width_border = coreml_pad->mutable_paddingamounts()->add_borderamounts();
-  width_border->set_startedgesize(pads_span[input_rank - 1]);
-  width_border->set_endedgesize(pads_span[2 * input_rank - 1]);
+  for (int64_t i = 0; i < num_axes; i++) {
+    if (SafeInt<int64_t>(axes_tensor_data[i]) == input_rank - 2) {
+      height_border->set_startedgesize(pads_span[i]);
+      height_border->set_endedgesize(pads_span[i + num_axes]);
+    }
+    if (SafeInt<int64_t>(axes_tensor_data[i]) == input_rank - 1) {
+      width_border->set_startedgesize(pads_span[i]);
+      width_border->set_endedgesize(pads_span[i + num_axes]);
+    }
+  }
 
   *layer->mutable_input()->Add() = input_defs[0]->Name();
   *layer->mutable_output()->Add() = node.OutputDefs()[0]->Name();
@@ -107,7 +128,7 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
   }
 
   if (std::find(input_shape.begin(), input_shape.end(), int64_t{0}) != input_shape.end()) {
-    LOGS(logger, VERBOSE) << "Pad input with zero elements for dimension is not supported";
+    LOGS(logger, VERBOSE) << "Input with a 0 for a dimension is not supported";
     return false;
   }
 
@@ -115,7 +136,7 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     NodeAttrHelper helper(node);
     const auto mode = helper.Get("mode", "constant");
     if (mode != "constant") {
-      LOGS(logger, VERBOSE) << "Only support constant mode Pad operator for now, mode: " << mode;
+      LOGS(logger, VERBOSE) << "Only `constant` mode Pad is currently supported for now, mode: " << mode;
       return false;
     }
 
@@ -125,44 +146,61 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     }
   }
 
-  // only support if `pads` input is known and does not contain negative values and only has non-zero padding values
+  // only support if `pads` input is known and does not contain negative values and only applies padding values
   // for last two dimensions.
   {
     const auto pads_initializer_it = initializers.find(input_defs[1]->Name());
     if (pads_initializer_it == initializers.end()) {
-      LOGS(logger, VERBOSE) << "pads must be known";
+      LOGS(logger, VERBOSE) << "pads must be a constant intializer.";
       return false;
     }
 
     const ONNX_NAMESPACE::TensorProto& pads_initializer = *pads_initializer_it->second;
     Initializer unpacked_tensor(pads_initializer);
 
-    auto tensor_data = unpacked_tensor.DataAsSpan<int64_t>();
+    auto pads_tensor_data = unpacked_tensor.DataAsSpan<int64_t>();
     for (int64_t i = 0; i < unpacked_tensor.size(); i++) {
-      if (tensor_data[i] < 0) {
+      if (pads_tensor_data[i] < 0) {
         LOGS(logger, VERBOSE) << "Negative pad value is not supported: pads["
-                              << i << "] = " << tensor_data[i];
+                              << i << "] = " << pads_tensor_data[i];
         return false;
       }
     }
 
-    // Check that the input pads value only have non-zero values on last two dimensions - [H,W].
-    // As CoreML PaddinglayerParams only apply padding on the last two dimensions:
-    // https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#paddinglayerparams
-    const auto input_rank = SafeInt<int64_t>(input_shape.size());
-    for (int64_t i = 0; i < unpacked_tensor.size(); i++) {
-      if (!(i == input_rank - 1 || i == input_rank - 2 ||
-            i == 2 * input_rank - 1 || i == 2 * input_rank - 2) &&
-          tensor_data[i] != 0) {
-        LOGS(logger, VERBOSE) << "CoreML Pads value only support padding on last two dimensions.";
+    // Check that only supports padding on last two dimensions - [H,W].
+    // CoreML PaddinglayerParams: https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#paddinglayerparams
+    const auto input_rank = input_shape.size();
+    // if not provided, make a default axes input as [0, 1, ..., input_rank - 1]
+    std::vector<int64_t> default_axes(input_rank);
+    std::iota(std::begin(default_axes), std::end(default_axes), 0);
+    auto axes_tensor_data = gsl::span<const int64_t>(default_axes);
+    if (input_defs.size() > 3) {
+      // optional axes input is provided
+      const auto axes_initializer_it = initializers.find(input_defs[3]->Name());
+      if (axes_initializer_it == initializers.end()) {
+        LOGS(logger, VERBOSE) << "If provided, axes must be a constant intializer.";
         return false;
+      }
+      const ONNX_NAMESPACE::TensorProto& axes_initializer = *axes_initializer_it->second;
+      Initializer unpacked_tensor(axes_initializer);
+      axes_tensor_data = unpacked_tensor.DataAsSpan<int64_t>();
+    }
+    int64_t num_axes = axes_tensor_data.size();
+    for (int64_t i = 0; i < num_axes; i++) {
+      if (SafeInt<int64_t>(axes_tensor_data[i]) < input_rank - 2) {
+        if (pads_tensor_data[i] != 0 || pads_tensor_data[i + num_axes] != 0) {
+          // for axis specified that is not the last two dimension, padding is not supported. i.e.
+          // non-zero value appears in `pads` input for corresponding non-last two dimensions.
+          LOGS(logger, VERBOSE) << "CoreML only supports padding on last two dimensions.";
+          return false;
+        }
       }
     }
   }
 
   // only support if `constant_value` input is known
   if (!Contains(initializers, input_defs[2]->Name())) {
-    LOGS(logger, VERBOSE) << "constant_value must be known";
+    LOGS(logger, VERBOSE) << "constant_value must be a constant initializer.";
     return false;
   }
 

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <math.h>
+
+#include "core/providers/common.h"
+#include "core/framework/tensorprotoutils.h"
+#include "core/providers/coreml/builders/helper.h"
+#include "core/providers/shared/utils/utils.h"
+#include "core/optimizer/initializer.h"
+
+#ifdef __APPLE__
+#include "core/providers/coreml/builders/model_builder.h"
+#endif
+#include "core/providers/coreml/builders/op_builder_factory.h"
+
+#include "base_op_builder.h"
+#include "builder_utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+class PadOpBuilder : public BaseOpBuilder {
+  // Add operator related
+#ifdef __APPLE__
+ public:
+  void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const override;
+
+ private:
+  [[nodiscard]] Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                             const logging::Logger& logger) const override;
+#endif
+
+  // Operator support related
+ private:
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+};
+
+// Add operator related
+
+#ifdef __APPLE__
+void PadOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
+  model_builder.AddInitializerToSkip(node.InputDefs()[1]->Name());  //  pads
+  model_builder.AddInitializerToSkip(node.InputDefs()[2]->Name());  //  constant_value
+
+  // Currently we don't support optional `axes` input for Pad.
+  if (node.InputDefs().size() > 3) {
+    model_builder.AddInitializerToSkip(node.InputDefs()[3]->Name());  // axes
+    model_builder.AddInputToSkip(node.InputDefs()[3]->Name());
+  }
+}
+
+Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
+                                           const Node& node,
+                                           const logging::Logger& logger) const {
+  std::unique_ptr<COREML_SPEC::NeuralNetworkLayer> layer = CreateNNLayer(model_builder, node);
+
+  auto* coreml_pad = layer->mutable_padding();
+  auto* constant_padding_type = coreml_pad->mutable_constant();  // CoreML::Specification::PaddingLayerParams_PaddingConstant
+
+  const auto& input_defs = node.InputDefs();
+
+  const auto& pads_tensor = *model_builder.GetInitializerTensors().at(input_defs[1]->Name());            // pads
+  const auto& constant_value_tensor = *model_builder.GetInitializerTensors().at(input_defs[2]->Name());  // constant_value
+
+  float pad_value = 0.0f;
+  Initializer pad_value_raw_data_init(constant_value_tensor);
+  pad_value = pad_value_raw_data_init.DataAsSpan<float>()[0];
+  constant_padding_type->set_value(pad_value);
+
+  Initializer pads_initializer_raw_data(pads_tensor);
+  auto pads_span = pads_initializer_raw_data.DataAsSpan<int64_t>();
+
+  auto* height_border = coreml_pad->mutable_paddingamounts()->add_borderamounts();
+  height_border->set_startedgesize(pads_span[0]);
+  height_border->set_endedgesize(pads_span[2]);
+  auto* width_border = coreml_pad->mutable_paddingamounts()->add_borderamounts();
+  width_border->set_startedgesize(pads_span[1]);
+  width_border->set_endedgesize(pads_span[3]);
+
+  *layer->mutable_input()->Add() = input_defs[0]->Name();
+  *layer->mutable_output()->Add() = node.OutputDefs()[0]->Name();
+
+  model_builder.AddLayer(std::move(layer));
+
+  return Status::OK();
+}
+#endif
+
+// Operator support related
+
+bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                     const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  const auto& initializers = input_params.graph_viewer.GetAllInitializedTensors();
+
+  {
+    std::vector<int64_t> input_shape;
+    if (!GetShape(*input_defs[0], input_shape, logger))
+      return false;
+
+    if (input_shape.size() > 4 || input_shape.empty()) {
+      LOGS_DEFAULT(VERBOSE) << "Pad only supports up to 1-4d shape, input is "
+                            << input_shape.size() << "d shape";
+      return false;
+    }
+
+    if (std::find(input_shape.begin(), input_shape.end(), uint32_t{0}) != input_shape.end()) {
+      LOGS_DEFAULT(VERBOSE) << "Pad input with zero elements for dimension is not supported";
+      return false;
+    }
+  }
+
+  {
+    NodeAttrHelper helper(node);
+    const auto mode = helper.Get("mode", "constant");
+    if (mode != "constant") {
+      LOGS(logger, VERBOSE) << "Only support constant mode Pad operator for now, mode: " << mode;
+      return false;
+    }
+
+    if (input_defs.size() < 3) {
+      LOGS(logger, VERBOSE) << "Input pads and constant_value are required for current support of constant mode Pad op.";
+      return false;
+    }
+  }
+
+  // only support if `pads` input is known and does not contain negative values
+  {
+    const auto pads_initializer_it = initializers.find(input_defs[1]->Name());
+    if (pads_initializer_it == initializers.end()) {
+      LOGS_DEFAULT(VERBOSE) << "pads must be known";
+      return false;
+    }
+
+    const ONNX_NAMESPACE::TensorProto& pads_initializer = *pads_initializer_it->second;
+    Initializer unpacked_tensor(pads_initializer);
+
+    // Note: CoreML uses BorderAmounts type for paddings which requires both start/end edgesizes.
+    // https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#borderamounts
+    if (unpacked_tensor.size() != 4) {
+      LOGS_DEFAULT(VERBOSE) << "Only support length 4 pads input, pads length: "
+                            << unpacked_tensor.size();
+      return false;
+    }
+
+    auto tensor_data = unpacked_tensor.DataAsSpan<int64_t>();
+    for (int64_t i = 0; i < unpacked_tensor.size(); i++) {
+      if (tensor_data[i] < 0) {
+        LOGS_DEFAULT(VERBOSE) << "Negative pad value is not supported: pads["
+                              << i << "] = " << tensor_data[i];
+        return false;
+      }
+    }
+  }
+
+  // only support if `constant_value` input is known
+  if (!Contains(initializers, input_defs[2]->Name())) {
+    LOGS_DEFAULT(VERBOSE) << "constant_value must be known";
+    return false;
+  }
+
+  return true;
+}
+
+void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<PadOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -103,7 +103,7 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
       return false;
     }
 
-    if (std::find(input_shape.begin(), input_shape.end(), uint32_t{0}) != input_shape.end()) {
+    if (std::find(input_shape.begin(), input_shape.end(), int64_t{0}) != input_shape.end()) {
       LOGS_DEFAULT(VERBOSE) << "Pad input with zero elements for dimension is not supported";
       return false;
     }

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -97,9 +97,7 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   Initializer pads_initializer(pads_tensor);
   auto pads_span = pads_initializer.DataAsSpan<int64_t>();
 
-  std::cout << "before get padding axes data: " << std::endl;
   InlinedVector<int64_t> axes_tensor_data = GetPaddingAxesData(model_builder.GetInitializerTensors(), node, input_rank);
-  std::cout << "after get padding axes data: " << std::endl;
   int64_t num_axes = axes_tensor_data.size();
 
   // Add padding
@@ -129,11 +127,8 @@ Status PadOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
                                      const logging::Logger& logger) const {
-  std::cout << "enter isopsupportedimpl " << std::endl;
   const auto& input_defs = node.InputDefs();
   const auto& initializers = input_params.graph_viewer.GetAllInitializedTensors();
-
-  std::cout << "enter isopsupportedimpl " << std::endl;
 
   std::vector<int64_t> input_shape;
   if (!GetShape(*input_defs[0], input_shape, logger))
@@ -208,8 +203,6 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     LOGS(logger, VERBOSE) << "constant_value must be a constant initializer.";
     return false;
   }
-
-  std::cout << "exit isopsupportedimpl " << std::endl;
 
   return true;
 }

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -53,7 +53,7 @@ InlinedVector<int64_t> GetPaddingAxesData(const InitializedTensorSet& initialize
     const ONNX_NAMESPACE::TensorProto& axes_tensor = *initializers.at(input_defs[3]->Name());
     Initializer axes_initializer(axes_tensor);
     const auto axes_data_span = axes_initializer.DataAsSpan<int64_t>();
-    axes_tensor_data.assgin(axes_data_span.begin(), axes_data_span.end());
+    axes_tensor_data.assign(axes_data_span.begin(), axes_data_span.end());
   } else {
     // if not provided, make a default axes as [0, 1, ..., input_rank - 1]
     InlinedVector<int64_t> default_axes(input_rank);

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -54,6 +54,9 @@ InlinedVector<int64_t> GetPaddingAxesData(const InitializedTensorSet& initialize
     Initializer axes_initializer(axes_tensor);
     const auto axes_data_span = axes_initializer.DataAsSpan<int64_t>();
     axes_tensor_data.assign(axes_data_span.begin(), axes_data_span.end());
+    for (size_t i = 0; i < axes_tensor_data.size(); i++) {
+      axes_tensor_data[i] = HandleNegativeAxis(axes_tensor_data[i], SafeInt<int64_t>(input_rank));
+    }
   } else {
     // if not provided, make a default axes as [0, 1, ..., input_rank - 1]
     InlinedVector<int64_t> default_axes(input_rank);
@@ -184,13 +187,6 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     // CoreML PaddinglayerParams: https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#paddinglayerparams
     const auto input_rank = input_shape.size();
     InlinedVector<int64_t> axes_tensor_data = GetPaddingAxesData(initializers, node, input_rank);
-    for (size_t i = 0; i < axes_tensor_data.size(); i++) {
-      if (axes_tensor_data[i] < 0) {
-        LOGS(logger, VERBOSE) << "Negative axis value is not supported for now: axes["
-                              << i << "] = " << axes_tensor_data[i];
-        return false;
-      }
-    }
     int64_t num_axes = axes_tensor_data.size();
 
     for (int64_t i = 0; i < num_axes; i++) {

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/common.h"
 #include "core/framework/tensorprotoutils.h"
+#include "core/framework/tensor_shape.h"
 #include "core/providers/coreml/builders/helper.h"
 #include "core/providers/shared/utils/utils.h"
 #include "core/optimizer/initializer.h"
@@ -140,8 +141,9 @@ bool PadOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParam
     return false;
   }
 
-  if (std::find(input_shape.begin(), input_shape.end(), int64_t{0}) != input_shape.end()) {
-    LOGS(logger, VERBOSE) << "Cases that input dimensions with value of 0 is not supported";
+  const TensorShape shape(input_shape);
+  if (shape.Size() == 0) {
+    LOGS(logger, VERBOSE) << "Cases that input data being empty due to a dimension with value of 0 is not supported";
     return false;
   }
 

--- a/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/pad_op_builder.cc
@@ -33,7 +33,7 @@ class PadOpBuilder : public BaseOpBuilder {
   bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
                          const logging::Logger& logger) const override;
 
-  int GetMinSupportedOpSet(const Node& node) const override {
+  int GetMinSupportedOpSet(const Node& /* node */) const override {
     // Note: before Pad-11, inputs `pads` and `constant_value` were attributes
     return 11;
   }

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -90,6 +90,10 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateLRNOpBuilder("LRN", op_registrations);
   }
 
+  {  // Pad
+    CreatePadOpBuilder("Pad", op_registrations);
+  }
+
   return op_registrations;
 }
 

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -34,6 +34,7 @@ void CreateArgMaxOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateCastOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateFlattenOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -829,99 +829,99 @@ TEST(PadOpTest, ConstantPadAxes) {
 TEST(PadOpTest, ConstantPadAxes_1) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
-  test.AddInput<int32_t>("data", {1, 2, 2, 2},
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
-  test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
-  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<float>("data", {1, 2, 2, 2},
+                       {1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f});
+  test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1}, true /* pads_is_initializer */);
+  test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
   test.AddInput<int64_t>("axes", {2}, {2, 3}, true /* axes_is_initializer */);
-  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
-                          {0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0});
+  test.AddOutput<float>("output", {1, 2, 2, 4},
+                        {0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(PadOpTest, ConstantPadAxes_2) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
-  test.AddInput<int32_t>("data", {1, 2, 2, 2},
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
-  test.AddInput<int64_t>("pads", {4}, {1, 1, 1, 1});
-  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<float>("data", {1, 2, 2, 2},
+                       {1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f});
+  test.AddInput<int64_t>("pads", {4}, {1, 1, 1, 1}, true /* pads_is_initializer */);
+  test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
   test.AddInput<int64_t>("axes", {2}, {2, 3}, true /* axes_is_initializer */);
-  test.AddOutput<int32_t>("output", {1, 2, 4, 4},
-                          {0, 0, 0, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 0, 0, 0,
-                           0, 0, 0, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 0, 0, 0});
+  test.AddOutput<float>("output", {1, 2, 4, 4},
+                        {0.0f, 0.0f, 0.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 0.0f, 0.0f, 0.0f,
+                         0.0f, 0.0f, 0.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 0.0f, 0.0f, 0.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(PadOpTest, ConstantPadAxes_3) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
-  test.AddInput<int32_t>("data", {1, 2, 2, 2},
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
-  test.AddInput<int64_t>("pads", {8}, {0, 0, 0, 1, 0, 0, 0, 1});
-  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<float>("data", {1, 2, 2, 2},
+                       {1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f});
+  test.AddInput<int64_t>("pads", {8}, {0, 0, 0, 1, 0, 0, 0, 1}, true /* pads_is_initializer */);
+  test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
   test.AddInput<int64_t>("axes", {4}, {0, 1, 2, 3}, true /* axes_is_initializer */);
-  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
-                          {0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0});
+  test.AddOutput<float>("output", {1, 2, 2, 4},
+                        {0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(PadOpTest, ConstantPadAxes_outoforder) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
-  test.AddInput<int32_t>("data", {1, 2, 2, 2},
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
-  test.AddInput<int64_t>("pads", {4}, {1, 0, 1, 0});
-  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<float>("data", {1, 2, 2, 2},
+                       {1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f});
+  test.AddInput<int64_t>("pads", {4}, {1, 0, 1, 0}, true /* pads_is_initializer */);
+  test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
   test.AddInput<int64_t>("axes", {2}, {3, 2}, true /* axes_is_initializer */);
-  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
-                          {0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0});
+  test.AddOutput<float>("output", {1, 2, 2, 4},
+                        {0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
 TEST(PadOpTest, ConstantPadAxes_one_dimension_specified) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
-  test.AddInput<int32_t>("data", {1, 2, 2, 2},
-                         {1, 1,
-                          1, 1,
-                          1, 1,
-                          1, 1});
-  test.AddInput<int64_t>("pads", {2}, {1, 1});
-  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<float>("data", {1, 2, 2, 2},
+                       {1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f,
+                        1.0f, 1.0f});
+  test.AddInput<int64_t>("pads", {2}, {1, 1}, true /* pads_is_initializer */);
+  test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
   test.AddInput<int64_t>("axes", {1}, {3}, true /* axes_is_initializer */);
-  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
-                          {0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0,
-                           0, 1, 1, 0});
+  test.AddOutput<float>("output", {1, 2, 2, 4},
+                        {0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f,
+                         0.0f, 1.0f, 1.0f, 0.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -821,15 +821,12 @@ TEST(PadOpTest, ConstantPadAxes) {
                            0, 1, 1, 0,
                            0, 1, 1, 0,
                            0, 1, 1, 0});
-  // CoreML EP requires axes if provided to be a constant initializer and only supports padding specified on last two
-  // dimensions, skip this test for CoreML EP here.
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kCoreMLExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+// CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
+// added the following test cases (can be taken by CoreML):
 TEST(PadOpTest, ConstantPadAxes_1) {
-  // CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
-  // added the following test case (can be taken by CoreML):
-  // Given a provided axes input with last two dimensions specified.
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
   test.AddInput<int32_t>("data", {1, 2, 2, 2},
@@ -849,9 +846,6 @@ TEST(PadOpTest, ConstantPadAxes_1) {
 }
 
 TEST(PadOpTest, ConstantPadAxes_2) {
-  // CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
-  // added the following test case (can be taken by CoreML):
-  // Given a provided axes input with last two dimensions specified.
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
   test.AddInput<int32_t>("data", {1, 2, 2, 2},
@@ -871,6 +865,63 @@ TEST(PadOpTest, ConstantPadAxes_2) {
                            0, 1, 1, 0,
                            0, 1, 1, 0,
                            0, 0, 0, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(PadOpTest, ConstantPadAxes_3) {
+  OpTester test("Pad", 18);
+  test.AddAttribute("mode", "constant");
+  test.AddInput<int32_t>("data", {1, 2, 2, 2},
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<int64_t>("pads", {8}, {0, 0, 0, 1, 0, 0, 0, 1});
+  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<int64_t>("axes", {4}, {0, 1, 2, 3}, true /* axes_is_initializer */);
+  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
+                          {0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(PadOpTest, ConstantPadAxes_outoforder) {
+  OpTester test("Pad", 18);
+  test.AddAttribute("mode", "constant");
+  test.AddInput<int32_t>("data", {1, 2, 2, 2},
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<int64_t>("pads", {4}, {1, 0, 1, 0});
+  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<int64_t>("axes", {2}, {3, 2}, true /* axes_is_initializer */);
+  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
+                          {0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(PadOpTest, ConstantPadAxes_one_dimension_specified) {
+  OpTester test("Pad", 18);
+  test.AddAttribute("mode", "constant");
+  test.AddInput<int32_t>("data", {1, 2, 2, 2},
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<int64_t>("pads", {2}, {1, 1});
+  test.AddInput<int32_t>("value", {1}, {0});
+  test.AddInput<int64_t>("axes", {1}, {3}, true /* axes_is_initializer */);
+  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
+                          {0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -828,5 +828,57 @@ TEST(PadOpTest, ConstantPadAxes) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+TEST(PadOpTest, ConstantPadAxesWithLast2Dim) {
+  OpTester test("Pad", 18);
+  test.AddAttribute("mode", "constant");
+  test.AddInput<int32_t>("data", {1, 2, 2, 2},
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
+  test.AddInput<int32_t>("value", {1}, {0});
+#if defined(USE_COREML) && defined(__APPLE__)
+  // input test case is supported by CoreML EP
+  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /*axes_is_initializer*/);
+#else
+  test.AddInput<int32_t>("axes", {2}, {2, 3});
+#endif
+  test.AddOutput<int32_t>("output", {1, 2, 2, 4},
+                          {0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(PadOpTest, ConstantPadAxesWithLast2Dim_2) {
+  OpTester test("Pad", 18);
+  test.AddAttribute("mode", "constant");
+  test.AddInput<int32_t>("data", {1, 2, 2, 2},
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
+  test.AddInput<int64_t>("pads", {4}, {1, 1, 1, 1});
+  test.AddInput<int32_t>("value", {1}, {0});
+#if defined(USE_COREML) && defined(__APPLE__)
+  // input test case is supported by CoreML EP
+  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /*axes_is_initializer*/);
+#else
+  test.AddInput<int32_t>("axes", {2}, {2, 3});
+#endif
+  test.AddOutput<int32_t>("output", {1, 2, 4, 4},
+                          {0, 0, 0, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 0, 0, 0,
+                           0, 0, 0, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 0, 0, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -815,7 +815,11 @@ TEST(PadOpTest, ConstantPadAxes) {
                           1, 1});
   test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
   test.AddInput<int32_t>("value", {1}, {0});
+#if defined(USE_COREML) && defined(__APPLE__)
+  test.AddInput<int64_t>("axes", {2}, {1, 3}, true /*axes_is_initializer*/);
+#else
   test.AddInput<int32_t>("axes", {2}, {1, 3});
+#endif
   test.AddOutput<int32_t>("output", {1, 2, 2, 4},
                           {0, 1, 1, 0,
                            0, 1, 1, 0,

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -826,6 +826,7 @@ TEST(PadOpTest, ConstantPadAxes) {
 
 // CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
 // added the following test cases (can be taken by CoreML):
+#if (defined(USE_COREML) && defined(__APPLE__))
 TEST(PadOpTest, ConstantPadAxes_1) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
@@ -925,5 +926,28 @@ TEST(PadOpTest, ConstantPadAxes_one_dimension_specified) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+/*
+  Note: Disable the Negative Axes test for ConstantPad for now until onnx shape inferencing
+  add support for handling negative axes.
+*/
+// TEST(PadOpTest, ConstantPadAxes_negative) {
+//   OpTester test("Pad", 18);
+//   test.AddAttribute("mode", "constant");
+//   test.AddInput<float>("data", {1, 2, 2, 2},
+//                        {1.0f, 1.0f,
+//                         1.0f, 1.0f,
+//                         1.0f, 1.0f,
+//                         1.0f, 1.0f});
+//   test.AddInput<int64_t>("pads", {2}, {1, 1}, true /* pads_is_initializer */);
+//   test.AddInput<float>("value", {1}, {0.0f}, true /* value_is_initializer */);
+//   test.AddInput<int64_t>("axes", {1}, {-1}, true /* axes_is_initializer */);
+//   test.AddOutput<float>("output", {1, 2, 2, 4},
+//                         {0.0f, 1.0f, 1.0f, 0.0f,
+//                          0.0f, 1.0f, 1.0f, 0.0f,
+//                          0.0f, 1.0f, 1.0f, 0.0f,
+//                          0.0f, 1.0f, 1.0f, 0.0f});
+//   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+// }
+#endif
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -815,20 +815,20 @@ TEST(PadOpTest, ConstantPadAxes) {
                           1, 1});
   test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
   test.AddInput<int32_t>("value", {1}, {0});
-#if defined(USE_COREML) && defined(__APPLE__)
-  test.AddInput<int64_t>("axes", {2}, {1, 3}, true /*axes_is_initializer*/);
-#else
   test.AddInput<int32_t>("axes", {2}, {1, 3});
-#endif
   test.AddOutput<int32_t>("output", {1, 2, 2, 4},
                           {0, 1, 1, 0,
                            0, 1, 1, 0,
                            0, 1, 1, 0,
                            0, 1, 1, 0});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  // CoreML EP requires axes if provided to be a constant initializer, skip this test for CoreML EP here.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kCoreMLExecutionProvider});
 }
 
-TEST(PadOpTest, ConstantPadAxesWithLast2Dim) {
+TEST(PadOpTest, ConstantPadAxes_1) {
+  // CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
+  // added the following test case (can be taken by CoreML):
+  // Given a provided axes input with last two dimensions specified.
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
   test.AddInput<int32_t>("data", {1, 2, 2, 2},
@@ -838,12 +838,7 @@ TEST(PadOpTest, ConstantPadAxesWithLast2Dim) {
                           1, 1});
   test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
   test.AddInput<int32_t>("value", {1}, {0});
-#if defined(USE_COREML) && defined(__APPLE__)
-  // input test case is supported by CoreML EP
-  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /*axes_is_initializer*/);
-#else
-  test.AddInput<int32_t>("axes", {2}, {2, 3});
-#endif
+  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /* axes_is_initializer */);
   test.AddOutput<int32_t>("output", {1, 2, 2, 4},
                           {0, 1, 1, 0,
                            0, 1, 1, 0,
@@ -852,7 +847,10 @@ TEST(PadOpTest, ConstantPadAxesWithLast2Dim) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
-TEST(PadOpTest, ConstantPadAxesWithLast2Dim_2) {
+TEST(PadOpTest, ConstantPadAxes_2) {
+  // CoreML EP only supports padding on last two dimensions and requires axes to be an initializer if provided,
+  // added the following test case (can be taken by CoreML):
+  // Given a provided axes input with last two dimensions specified.
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
   test.AddInput<int32_t>("data", {1, 2, 2, 2},
@@ -862,12 +860,7 @@ TEST(PadOpTest, ConstantPadAxesWithLast2Dim_2) {
                           1, 1});
   test.AddInput<int64_t>("pads", {4}, {1, 1, 1, 1});
   test.AddInput<int32_t>("value", {1}, {0});
-#if defined(USE_COREML) && defined(__APPLE__)
-  // input test case is supported by CoreML EP
-  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /*axes_is_initializer*/);
-#else
-  test.AddInput<int32_t>("axes", {2}, {2, 3});
-#endif
+  test.AddInput<int64_t>("axes", {2}, {2, 3}, true /* axes_is_initializer */);
   test.AddOutput<int32_t>("output", {1, 2, 4, 4},
                           {0, 0, 0, 0,
                            0, 1, 1, 0,

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -75,14 +75,11 @@ static void RunAllOpsetAllDomainPadTests(
   };
   const std::vector<TestParams> all_test_params {
     {false, false},
-#if defined(USE_NNAPI) && defined(__ANDROID__)
-    // only enable when building NNAPI EP on Android
-    // test runs out of memory in QEMU aarch64 environment, so don't enable otherwise
-    // TODO try to enable when we move from QEMU to arm64 CI machines
-    {true, true},
-#endif
-#if defined(USE_COREML) && defined(__APPLE__)
-    {true, true},
+#if (defined(USE_NNAPI) && defined(__ANDROID__)) || (defined(USE_COREML) && defined(__APPLE__))
+        // only enable when building NNAPI EP on Android or building CoreML EP for Apple environment
+        // test runs out of memory in QEMU aarch64 environment, so don't enable otherwise
+        // TODO try to enable when we move from QEMU to arm64 CI machines
+        {true, true},
 #endif
   };
   for (const auto& test_params : all_test_params) {
@@ -812,22 +809,18 @@ TEST(PadOpTest, ConstantPadAxes) {
   OpTester test("Pad", 18);
   test.AddAttribute("mode", "constant");
   test.AddInput<int32_t>("data", {1, 2, 2, 2},
-  {
-    1, 1,
-    1, 1,
-    1, 1,
-    1, 1});
+                         {1, 1,
+                          1, 1,
+                          1, 1,
+                          1, 1});
   test.AddInput<int64_t>("pads", {4}, {0, 1, 0, 1});
   test.AddInput<int32_t>("value", {1}, {0});
   test.AddInput<int32_t>("axes", {2}, {1, 3});
   test.AddOutput<int32_t>("output", {1, 2, 2, 4},
-  {
-    0, 1, 1, 0,
-    0, 1, 1, 0,
-    0, 1, 1, 0,
-    0, 1, 1, 0
-    }
-  );
+                          {0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -821,7 +821,8 @@ TEST(PadOpTest, ConstantPadAxes) {
                            0, 1, 1, 0,
                            0, 1, 1, 0,
                            0, 1, 1, 0});
-  // CoreML EP requires axes if provided to be a constant initializer, skip this test for CoreML EP here.
+  // CoreML EP requires axes if provided to be a constant initializer and only supports padding specified on last two
+  // dimensions, skip this test for CoreML EP here.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kCoreMLExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/pad_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/pad_test.cc
@@ -81,6 +81,9 @@ static void RunAllOpsetAllDomainPadTests(
     // TODO try to enable when we move from QEMU to arm64 CI machines
     {true, true},
 #endif
+#if defined(USE_COREML) && defined(__APPLE__)
+    {true, true},
+#endif
   };
   for (const auto& test_params : all_test_params) {
     // opset 10


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As title.

- Only support constant mode Pad for CoreML EP for now.
- Enable Pad tests for CoreML with inputs as initializer types.

CoreML Spec for reference:
https://apple.github.io/coremltools/mlmodel/Format/NeuralNetwork.html#paddinglayerparams


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fill operator gaps for ClipChamp models.
