### PR TITLE
detach patch manylinux from get_docker_image

### DIFF
--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -13,10 +13,7 @@ from logger import get_logger
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
-
 sys.path.append(os.path.join(REPO_DIR, "tools", "python"))
-
-
 from util import run  # noqa: E402
 
 log = get_logger("get_docker_image")
@@ -74,7 +71,7 @@ def main():
     # The docker file may provide a special deps.txt in its docker context dir and uses that one.
     # Otherwise, copy a generic one from this repo's cmake dir.
     if not dst_deps_file.exists():
-        log.info("Copy deps.txt to : {}".format(str(dst_deps_file)))
+        log.info(f"Copy deps.txt to : {dst_deps_file}")
         shutil.copyfile(Path(REPO_DIR) / "cmake" / "deps.txt", str(dst_deps_file))
 
     if use_container_registry:

--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -77,25 +77,6 @@ def main():
         log.info("Copy deps.txt to : {}".format(str(dst_deps_file)))
         shutil.copyfile(Path(REPO_DIR) / "cmake" / "deps.txt", str(dst_deps_file))
 
-    if "manylinux" in args.dockerfile:
-        manylinux_build_scripts_folder = Path(args.manylinux_src) / "docker" / "build_scripts"
-        dest = Path(args.context) / "build_scripts"
-        if dest.exists():
-            log.info("Deleting: {}".format(str(dest)))
-            shutil.rmtree(str(dest))
-
-        shutil.copytree(str(manylinux_build_scripts_folder), str(dest))
-        src_entrypoint_file = str(Path(args.manylinux_src) / "docker" / "manylinux-entrypoint")
-        dst_entrypoint_file = str(Path(args.context) / "manylinux-entrypoint")
-        shutil.copyfile(src_entrypoint_file, dst_entrypoint_file)
-        shutil.copymode(src_entrypoint_file, dst_entrypoint_file)
-        run(
-            "patch",
-            "-p1",
-            "-i",
-            str((Path(SCRIPT_DIR) / "github" / "linux" / "docker" / "manylinux.patch").resolve()),
-            cwd=str(dest),
-        )
     if use_container_registry:
         run(
             args.docker_path,

--- a/tools/ci_build/github/azure-pipelines/templates/get-docker-image-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/get-docker-image-steps.yml
@@ -15,26 +15,33 @@ parameters:
   default: true
 - name: ScriptName
   type: string
-  default: "tools/ci_build/get_docker_image.py" 
+  default: "tools/ci_build/get_docker_image.py"
 - name: UpdateDepsTxt
   type: boolean
   default: true
-  
+
 steps:
 
 - ${{ if eq(parameters.UpdateDepsTxt, true)}}:
-  - template: download-deps.yml  
+  - template: download-deps.yml
 
 - ${{ if contains(parameters.Dockerfile, 'manylinux') }}:
     - checkout: manylinux
     - script: |
-        set -e -x 
+        set -e -x
         mv manylinux onnxruntime
         mv onnxruntime ..
         cd ..
         rmdir $(Build.SourcesDirectory)
         mv onnxruntime $(Build.SourcesDirectory)
       displayName: "Move Manylinux source code to ORT folder"
+    # It makes the files in context keep consistent before and after docker build step.
+    - task: PythonScript@0
+      inputs:
+        scriptPath: $(Build.SourcesDirectory)/tools/ci_build/patch_manylinux.py
+        arguments: --dockerfile "${{ parameters.Dockerfile }}" --context "${{ parameters.Context }}"
+        pythonInterpreter: /usr/bin/python3
+      displayName: patch manylinux
 
 - ${{ if eq(parameters.UseImageCacheContainerRegistry, true) }}:
   - template: with-container-registry-steps.yml

--- a/tools/ci_build/patch_manylinux.py
+++ b/tools/ci_build/patch_manylinux.py
@@ -12,10 +12,7 @@ from logger import get_logger
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
-
 sys.path.append(os.path.join(REPO_DIR, "tools", "python"))
-
-
 from util import run  # noqa: E402
 
 log = get_logger("patch_manylinux")
@@ -38,17 +35,13 @@ def parse_args():
 def main():
     args = parse_args()
 
-    log.debug(
-        "Dockerfile: {}, context: {}".format(
-            args.dockerfile, args.context
-        )
-    )
+    log.debug(f"Dockerfile: {args.dockerfile}, context: {args.context}")
 
     if "manylinux" in args.dockerfile:
         manylinux_build_scripts_folder = Path(args.manylinux_src) / "docker" / "build_scripts"
         dest = Path(args.context) / "build_scripts"
         if dest.exists():
-            log.info("Deleting: {}".format(str(dest)))
+            log.info(f"Deleting: {str(dest)}")
             shutil.rmtree(str(dest))
 
         shutil.copytree(str(manylinux_build_scripts_folder), str(dest))

--- a/tools/ci_build/patch_manylinux.py
+++ b/tools/ci_build/patch_manylinux.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from logger import get_logger
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
+
+sys.path.append(os.path.join(REPO_DIR, "tools", "python"))
+
+
+from util import run  # noqa: E402
+
+log = get_logger("patch_manylinux")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Build a docker image and push it to a remote Azure Container Registry."
+        "The content in the remote registry can be used as a cache when we need to build the thing again."
+        "The user must be logged in to the container registry."
+    )
+
+    parser.add_argument("--dockerfile", default="Dockerfile", help="Path to the Dockerfile.")
+    parser.add_argument("--context", default=".", help="Path to the build context.")
+    parser.add_argument("--manylinux-src", default="manylinux", help="Path to manylinux src folder")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    log.debug(
+        "Dockerfile: {}, context: {}".format(
+            args.dockerfile, args.context
+        )
+    )
+
+    if "manylinux" in args.dockerfile:
+        manylinux_build_scripts_folder = Path(args.manylinux_src) / "docker" / "build_scripts"
+        dest = Path(args.context) / "build_scripts"
+        if dest.exists():
+            log.info("Deleting: {}".format(str(dest)))
+            shutil.rmtree(str(dest))
+
+        shutil.copytree(str(manylinux_build_scripts_folder), str(dest))
+        src_entrypoint_file = str(Path(args.manylinux_src) / "docker" / "manylinux-entrypoint")
+        dst_entrypoint_file = str(Path(args.context) / "manylinux-entrypoint")
+        shutil.copyfile(src_entrypoint_file, dst_entrypoint_file)
+        shutil.copymode(src_entrypoint_file, dst_entrypoint_file)
+        run(
+            "patch",
+            "-p1",
+            "-i",
+            str((Path(SCRIPT_DIR) / "github" / "linux" / "docker" / "manylinux.patch").resolve()),
+            cwd=str(dest),
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Description
Make patch manylinux one single step.


### Motivation and Context
If we want to use hash of docker-related files as the cache key, the files should keep consistent before and after docker build.
And changes in generated build_scripts should trigger rebuilding the image as well.


