### PR TITLE
[T5 optimization] script fusions and fixes

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -380,6 +380,8 @@ class SymbolicShapeInference:
             return list(self.initializers_[name].dims)
 
     def _try_get_shape(self, node, idx):
+        if idx > len(node.input) - 1:
+            return None
         name = node.input[idx]
         if name in self.known_vi_:
             vi = self.known_vi_[name]
@@ -2151,7 +2153,7 @@ class SymbolicShapeInference:
                 else:
                     head_size = query_shape[4]
 
-                past_shape = self._try_get_shape(node, 5)
+                past_shape = self._try_get_shape(node, 6)
 
                 if past_shape is not None:
                     if isinstance(past_shape[2], int) and isinstance(total_sequence_length, int):
@@ -2159,9 +2161,7 @@ class SymbolicShapeInference:
                     else:
                         total_sequence_length = f"{past_shape[2]}+{total_sequence_length}"
 
-                # Keep the batch size and total sequence length as string
-                present_shape = [str(batch_size), num_heads, str(total_sequence_length), head_size]
-                print(present_shape)
+                present_shape = [batch_size, num_heads, total_sequence_length, head_size]
 
                 assert output_dtype is not None
                 vi = self.known_vi_[node.output[1]]

--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -1404,13 +1404,12 @@ def generate_gpt2_init_decoder(
     OnnxModel.save(init_decoder_model_proto, init_decoder_onnx_path, save_as_external_data=use_external_data_format)
     return True
 
-# bugbug
-def make_dim_proto_numeric(model, config):
+def make_dim_proto_numeric_t5(model, config):
     """Make dim_proto numeric.
 
     Args:
-        model (BartForConditionalGeneration): Bart model.
-        config: Bart config.
+        model: T5 encoder and decoder model.
+        config: T5 config.
     """
     sequence_length = str(1)
     num_heads = str(config.num_heads)
@@ -1721,8 +1720,8 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
             # )
             # initializers.extend(moved_initializers)
 
-        make_dim_proto_numeric(encoder_model, config)
-        make_dim_proto_numeric(decoder_model, config)
+        make_dim_proto_numeric_t5(encoder_model, config)
+        make_dim_proto_numeric_t5(decoder_model, config)
 
         node.attribute.extend(
             [

--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -250,15 +250,6 @@ def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
     model_group.set_defaults(past_present_share_buffer=False)
 
     model_group.add_argument(
-        "--use_decoder_masked_multihead_attention",
-        required=False,
-        action="store_true",
-        help="Uses `DecoderMaskedMultiheadAttention` to optimize the unidirectional decoding Attention computation. "
-        "Must be used with `past_present_share_buffer`. Currently, only Attention head sizes of 64 and 128 are supported.",
-    )
-    model_group.set_defaults(use_decoder_masked_multihead_attention=False)
-
-    model_group.add_argument(
         "--prefix_vocab_mask",
         required=False,
         action="store_true",
@@ -706,13 +697,12 @@ def verify_t5_decoder_subgraph(graph: onnx.GraphProto, precision: Precision):
     float_type = TensorProto.FLOAT16 if is_float16 else TensorProto.FLOAT
 
     input_count = len(graph.input)
-    layer_count = (input_count - 3) // 4
+    layer_count = (input_count - 2) // 4
     assert layer_count >= 1
 
     # Expect inputs:
     #   input_ids: int32 (B, 1)
     #   encoder_attention_mask: int32 (B, encode_sequence_length)
-    #   encoder_hidden_states: (B, encode_sequence_length, encoder_hidden_size)
 
     #   past_key_self_0: (B, num_heads, past_decode_sequence_length, head_size)
     #   past_value_self_0: (B, num_heads, past_decode_sequence_length, head_size)
@@ -723,7 +713,7 @@ def verify_t5_decoder_subgraph(graph: onnx.GraphProto, precision: Precision):
     #   ... (for each cross attention layer)
 
     # TODO: encoder_hidden_states is optional
-    expected_inputs = ["input_ids", "encoder_attention_mask", "encoder_hidden_states"]
+    expected_inputs = ["input_ids", "encoder_attention_mask"]
     for i in range(layer_count):
         expected_inputs.append(f"past_key_self_{i}")
         expected_inputs.append(f"past_value_self_{i}")
@@ -1075,40 +1065,6 @@ def update_decoder_subgraph_past_present_share_buffer(subg):
     return subg
 
 
-def update_decoder_subgraph_use_decoder_masked_multihead_attention(subg) -> bool:
-    """Update the Attention nodes to DecoderMaskedMultiheadAttention.
-
-    Args:
-        subg (GraphProto): GraphProto of the decoder subgraph
-    """
-    decoder_masked_attention_supported_attr = [
-        "past_present_share_buffer",
-        "num_heads",
-        "scale",
-        "domain",
-    ]
-    new_nodes = []
-    for node in subg.node:
-        if node.op_type == "Attention":
-            kwargs = kwargs_of(node)
-            for k in kwargs.copy():
-                # The Attention operator does not support different qkv hidden sizes when past/present
-                # input/output exists (GPT2 model). Hence, we should never run into this.
-                # But, if we do, do not go ahead with the optimization.
-                if k == "qkv_hidden_sizes":
-                    return False
-
-                if k not in decoder_masked_attention_supported_attr:
-                    del kwargs[k]
-            nis = []
-            nis.extend(node.input)
-            node = onnx.helper.make_node("DecoderMaskedMultiheadAttention", nis, node.output, name=node.name, **kwargs)
-        new_nodes.extend([node])
-    subg.ClearField("node")
-    subg.node.extend(new_nodes)
-    return True
-
-
 def update_input_shapes_for_gpt2_decoder_model(decoder_onnx_path: str, use_external_data_format: bool = True):
     """Update the input shapes for the inputs "input_ids" and "position_ids" and make the sequence length dim value 1 for each of them.
        The decoder model will be over-written.
@@ -1405,6 +1361,42 @@ def generate_gpt2_init_decoder(
     OnnxModel.save(init_decoder_model_proto, init_decoder_onnx_path, save_as_external_data=use_external_data_format)
     return True
 
+# bugbug
+def make_dim_proto_numeric(model, config):
+    """Make dim_proto numeric.
+
+    Args:
+        model (BartForConditionalGeneration): Bart model.
+        config: Bart config.
+    """
+    sequence_length = str(1)
+    num_heads = str(config.num_heads)
+    hidden_size = str(config.d_model)
+    head_size = str(config.d_kv)
+
+    for tensor in model.graph.output:
+        for dim_proto in tensor.type.tensor_type.shape.dim:
+            if dim_proto.HasField("dim_param") and dim_proto.dim_param in [
+                sequence_length,
+                num_heads,
+                hidden_size,
+                head_size,
+            ]:
+                dim_value = int(dim_proto.dim_param)
+                dim_proto.Clear()
+                dim_proto.dim_value = dim_value
+
+    for tensor in model.graph.input:
+        for dim_proto in tensor.type.tensor_type.shape.dim:
+            if dim_proto.HasField("dim_param") and dim_proto.dim_param in [
+                sequence_length,
+                num_heads,
+                hidden_size,
+                head_size,
+            ]:
+                dim_value = int(dim_proto.dim_param)
+                dim_proto.Clear()
+                dim_proto.dim_value = dim_value
 
 def convert_generation_model(args: argparse.Namespace, generation_type: GenerationType = GenerationType.BEAMSEARCH):
     """Convert model according to command line arguments.
@@ -1686,6 +1678,9 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
             # )
             # initializers.extend(moved_initializers)
 
+        make_dim_proto_numeric(encoder_model, config)
+        make_dim_proto_numeric(decoder_model, config)
+
         node.attribute.extend(
             [
                 onnx.helper.make_attribute("encoder", encoder_model.graph),
@@ -1706,7 +1701,6 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
                 logger.info(
                     f"{len(initializers)} shared initializers ({[i.name for i in initializers]}) in decoder and init decoder subgraphs are moved to the main graph"
                 )
-            # Update for init decoder subgraph
             if past_present_share_buffer:
                 logger.info("*****update init decoder subgraph to make past and present share buffer******************")
                 update_decoder_subgraph_past_present_share_buffer(gpt2_init_decoder_model.graph)
@@ -1716,28 +1710,9 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
             initializers = move_initializers(decoder_model.graph)
             logger.info(f"{len(initializers)} initializers from the decoder are moved to the main graph")
 
-        # Update for non-init decoder subgraph
         if past_present_share_buffer:
             logger.info("*****update decoder subgraph to make past and present share buffer******************")
             update_decoder_subgraph_past_present_share_buffer(decoder_model.graph)
-
-        # If at all, the user requests the use of `use_decoder_masked_multihead_attention`,
-        # we can only use it in the decoder subgraph - it cannot be used in the init_decoder subgraph
-        # as the kernel only supports the decoding use-case (i.e.) when input sequence length is 1.
-        if args.use_decoder_masked_multihead_attention:
-            logger.info("Update decoder subgraph to use DecoderMaskedMultiheadAttention")
-
-            if not past_present_share_buffer:
-                raise ValueError(
-                    "`past_present_share_buffer` MUST be turned on to use `use_decoder_masked_multihead_attention`"
-                )
-
-            if not args.use_gpu:
-                raise ValueError("`use_decoder_masked_multihead_attention` option is only supported on GPUs")
-
-            if not update_decoder_subgraph_use_decoder_masked_multihead_attention(decoder_model.graph):
-                raise ValueError("Could not update the decoder subgraph to use DecoderMaskedMultiheadAttention")
-
         node.attribute.append(onnx.helper.make_attribute("decoder", decoder_model.graph))
 
     # graph inputs

--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -1404,6 +1404,7 @@ def generate_gpt2_init_decoder(
     OnnxModel.save(init_decoder_model_proto, init_decoder_onnx_path, save_as_external_data=use_external_data_format)
     return True
 
+
 def make_dim_proto_numeric_t5(model, config):
     """Make dim_proto numeric.
 
@@ -1439,6 +1440,7 @@ def make_dim_proto_numeric_t5(model, config):
                 dim_value = int(dim_proto.dim_param)
                 dim_proto.Clear()
                 dim_proto.dim_value = dim_value
+
 
 def convert_generation_model(args: argparse.Namespace, generation_type: GenerationType = GenerationType.BEAMSEARCH):
     """Convert model according to command line arguments.

--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -250,6 +250,15 @@ def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
     model_group.set_defaults(past_present_share_buffer=False)
 
     model_group.add_argument(
+        "--use_decoder_masked_multihead_attention",
+        required=False,
+        action="store_true",
+        help="Uses `DecoderMaskedMultiheadAttention` to optimize the unidirectional decoding Attention computation. "
+        "Must be used with `past_present_share_buffer`. Currently, only Attention head sizes of 64 and 128 are supported.",
+    )
+    model_group.set_defaults(use_decoder_masked_multihead_attention=False)
+
+    model_group.add_argument(
         "--prefix_vocab_mask",
         required=False,
         action="store_true",
@@ -1065,6 +1074,40 @@ def update_decoder_subgraph_past_present_share_buffer(subg):
     return subg
 
 
+def update_decoder_subgraph_use_decoder_masked_multihead_attention(subg) -> bool:
+    """Update the Attention nodes to DecoderMaskedMultiheadAttention.
+
+    Args:
+        subg (GraphProto): GraphProto of the decoder subgraph
+    """
+    decoder_masked_attention_supported_attr = [
+        "past_present_share_buffer",
+        "num_heads",
+        "scale",
+        "domain",
+    ]
+    new_nodes = []
+    for node in subg.node:
+        if node.op_type == "Attention":
+            kwargs = kwargs_of(node)
+            for k in kwargs.copy():
+                # The Attention operator does not support different qkv hidden sizes when past/present
+                # input/output exists (GPT2 model). Hence, we should never run into this.
+                # But, if we do, do not go ahead with the optimization.
+                if k == "qkv_hidden_sizes":
+                    return False
+
+                if k not in decoder_masked_attention_supported_attr:
+                    del kwargs[k]
+            nis = []
+            nis.extend(node.input)
+            node = onnx.helper.make_node("DecoderMaskedMultiheadAttention", nis, node.output, name=node.name, **kwargs)
+        new_nodes.extend([node])
+    subg.ClearField("node")
+    subg.node.extend(new_nodes)
+    return True
+
+
 def update_input_shapes_for_gpt2_decoder_model(decoder_onnx_path: str, use_external_data_format: bool = True):
     """Update the input shapes for the inputs "input_ids" and "position_ids" and make the sequence length dim value 1 for each of them.
        The decoder model will be over-written.
@@ -1701,6 +1744,7 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
                 logger.info(
                     f"{len(initializers)} shared initializers ({[i.name for i in initializers]}) in decoder and init decoder subgraphs are moved to the main graph"
                 )
+            # Update for init decoder subgraph
             if past_present_share_buffer:
                 logger.info("*****update init decoder subgraph to make past and present share buffer******************")
                 update_decoder_subgraph_past_present_share_buffer(gpt2_init_decoder_model.graph)
@@ -1710,9 +1754,28 @@ def convert_generation_model(args: argparse.Namespace, generation_type: Generati
             initializers = move_initializers(decoder_model.graph)
             logger.info(f"{len(initializers)} initializers from the decoder are moved to the main graph")
 
+        # Update for non-init decoder subgraph
         if past_present_share_buffer:
             logger.info("*****update decoder subgraph to make past and present share buffer******************")
             update_decoder_subgraph_past_present_share_buffer(decoder_model.graph)
+
+        # If at all, the user requests the use of `use_decoder_masked_multihead_attention`,
+        # we can only use it in the decoder subgraph - it cannot be used in the init_decoder subgraph
+        # as the kernel only supports the decoding use-case (i.e.) when input sequence length is 1.
+        if args.use_decoder_masked_multihead_attention:
+            logger.info("Update decoder subgraph to use DecoderMaskedMultiheadAttention")
+
+            if not past_present_share_buffer:
+                raise ValueError(
+                    "`past_present_share_buffer` MUST be turned on to use `use_decoder_masked_multihead_attention`"
+                )
+
+            if not args.use_gpu:
+                raise ValueError("`use_decoder_masked_multihead_attention` option is only supported on GPUs")
+
+            if not update_decoder_subgraph_use_decoder_masked_multihead_attention(decoder_model.graph):
+                raise ValueError("Could not update the decoder subgraph to use DecoderMaskedMultiheadAttention")
+
         node.attribute.append(onnx.helper.make_attribute("decoder", decoder_model.graph))
 
     # graph inputs

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -94,7 +94,7 @@ class FusionAttention(Fusion):
         num_heads: int,
         attention_mask: AttentionMask,
         use_multi_head_attention: bool = False,
-        search_op_types: List[str] = ["SkipLayerNormalization", "LayerNormalization"]
+        search_op_types: List[str] = ["SkipLayerNormalization", "LayerNormalization"],
     ):
         attention_op_name = "MultiHeadAttention" if use_multi_head_attention else "Attention"
         super().__init__(model, attention_op_name, search_op_types)
@@ -212,7 +212,7 @@ class FusionAttention(Fusion):
         input: str,
         output: str,
         add_qk_str: str,
-        scale: float=None,
+        scale: float = None,
     ) -> Union[NodeProto, None]:
         """Create an Attention node.
 

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -212,7 +212,7 @@ class FusionAttention(Fusion):
         input: str,
         output: str,
         add_qk_str: str,
-        scale: float = None,
+        scale: Union[float, None],
     ) -> Union[NodeProto, None]:
         """Create an Attention node.
 

--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -2,11 +2,8 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from enum import Enum
 from logging import getLogger
-from os import name
-from sys import path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from fusion_base import Fusion
@@ -14,7 +11,6 @@ from fusion_options import AttentionMaskFormat
 from fusion_utils import FusionUtils, NumpyHelper
 from onnx import NodeProto, TensorProto, helper, numpy_helper
 from onnx_model import OnnxModel
-from shape_infer_helper import SymbolicShapeInferenceHelper, get_shape_from_type_proto
 
 logger = getLogger(__name__)
 
@@ -212,7 +208,7 @@ class FusionAttention(Fusion):
         input: str,
         output: str,
         add_qk_str: str,
-        scale: Union[float, None],
+        scale: Optional[float] = None,
     ) -> Union[NodeProto, None]:
         """Create an Attention node.
 

--- a/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
@@ -92,14 +92,16 @@ class T5Decoder(torch.nn.Module):
         self.lm_head = lm_head
         self.config = config
 
-    def forward(self, decoder_input_ids, encoder_attention_mask, encoder_hidden_states, *past):
+    def forward(self, decoder_input_ids, encoder_attention_mask, *past):
 
         past_key_values = PastKeyValuesHelper.group_by_layer(past, self.config.num_layers)
 
+        # This is a hack since only the third dimension of encoder_hidden_states is used here
+        dummy_encoder_hidden_states = encoder_attention_mask.unsqueeze(2)
         decoder_outputs = self.decoder(
             input_ids=decoder_input_ids,
             past_key_values=past_key_values,
-            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states=dummy_encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
             use_cache=True,
             return_dict=True,
@@ -122,12 +124,12 @@ class T5DecoderInputs:
         self,
         decoder_input_ids,
         encoder_attention_mask,
-        encoder_hidden_states,
+        # encoder_hidden_states,
         past_key_values=None,
     ):
         self.decoder_input_ids: torch.LongTensor = decoder_input_ids
         self.encoder_attention_mask: torch.LongTensor = encoder_attention_mask
-        self.encoder_hidden_states: Union[torch.FloatTensor, torch.HalfTensor] = encoder_hidden_states
+        # self.encoder_hidden_states: Union[torch.FloatTensor, torch.HalfTensor] = encoder_hidden_states
         self.past_key_values: Union[List[torch.FloatTensor], List[torch.HalfTensor], None] = past_key_values
 
     @staticmethod
@@ -181,13 +183,13 @@ class T5DecoderInputs:
         )
 
         float_type = torch.float16 if float16 else torch.float32
-        encoder_hidden_state = torch.rand(
-            batch_size,
-            encode_sequence_length,
-            hidden_size,
-            dtype=float_type,
-            device=device,
-        )
+        # encoder_hidden_state = torch.rand(
+        #     batch_size,
+        #     encode_sequence_length,
+        #     hidden_size,
+        #     dtype=float_type,
+        #     device=device,
+        # )
 
         if past_decode_sequence_length > 0:
             self_attention_past_shape = [
@@ -212,25 +214,25 @@ class T5DecoderInputs:
         else:
             past = None
 
-        return T5DecoderInputs(decoder_input_ids, encoder_inputs.attention_mask, encoder_hidden_state, past)
+        return T5DecoderInputs(decoder_input_ids, encoder_inputs.attention_mask, past)
 
     def to_list(self) -> List:
         input_list = [
             self.decoder_input_ids,
             self.encoder_attention_mask,
-            self.encoder_hidden_states,
+            # self.encoder_hidden_states,
         ]
         if self.past_key_values:
             input_list.extend(self.past_key_values)
         return input_list
 
     def to_fp32(self):
-        encoder_hidden_state = self.encoder_hidden_states.to(dtype=torch.float32)
+        # encoder_hidden_state = self.encoder_hidden_states.to(dtype=torch.float32)
         past = [p.to(dtype=torch.float32) for p in self.past_key_values] if self.past_key_values else None
         return T5DecoderInputs(
             self.decoder_input_ids.clone(),
             self.encoder_attention_mask.clone(),
-            encoder_hidden_state,
+            # encoder_hidden_state,
             past,
         )
 
@@ -289,7 +291,7 @@ class T5DecoderHelper:
 
         input_names = ["input_ids"]
         input_names.append("encoder_attention_mask")
-        input_names.append("encoder_hidden_states")
+        #input_names.append("encoder_hidden_states")
         input_names.extend(input_past_names)
 
         dynamic_axes = {
@@ -362,7 +364,7 @@ class T5DecoderHelper:
         ort_inputs = {
             "input_ids": numpy.ascontiguousarray(inputs.decoder_input_ids.cpu().numpy()),
             "encoder_attention_mask": numpy.ascontiguousarray(inputs.encoder_attention_mask.cpu().numpy()),
-            "encoder_hidden_states": numpy.ascontiguousarray(inputs.encoder_hidden_states.cpu().numpy()),
+            # "encoder_hidden_states": numpy.ascontiguousarray(inputs.encoder_hidden_states.cpu().numpy()),
         }
 
         if inputs.past_key_values:
@@ -384,7 +386,7 @@ class T5DecoderHelper:
         max_cases: int = 4,
     ):
         """Compare the result from PyTorch and OnnxRuntime to verify the ONNX model is good."""
-        float16: bool = TypeHelper.get_input_type(ort_session, "encoder_hidden_states") == "tensor(float16)"
+        float16: bool = TypeHelper.get_input_type(ort_session, "past_key_self_0") == "tensor(float16)"
 
         test_cases = [(4, 11, 3), (1, 2, 5), (3, 1, 1), (8, 5, 2)]
         test_cases_max_diff = []

--- a/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
@@ -350,7 +350,6 @@ class T5DecoderHelper:
         ort_inputs = {
             "input_ids": numpy.ascontiguousarray(inputs.decoder_input_ids.cpu().numpy()),
             "encoder_attention_mask": numpy.ascontiguousarray(inputs.encoder_attention_mask.cpu().numpy()),
-            # "encoder_hidden_states": numpy.ascontiguousarray(inputs.encoder_hidden_states.cpu().numpy()),
         }
 
         if inputs.past_key_values:

--- a/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
@@ -124,12 +124,10 @@ class T5DecoderInputs:
         self,
         decoder_input_ids,
         encoder_attention_mask,
-        # encoder_hidden_states,
         past_key_values=None,
     ):
         self.decoder_input_ids: torch.LongTensor = decoder_input_ids
         self.encoder_attention_mask: torch.LongTensor = encoder_attention_mask
-        # self.encoder_hidden_states: Union[torch.FloatTensor, torch.HalfTensor] = encoder_hidden_states
         self.past_key_values: Union[List[torch.FloatTensor], List[torch.HalfTensor], None] = past_key_values
 
     @staticmethod
@@ -183,13 +181,6 @@ class T5DecoderInputs:
         )
 
         float_type = torch.float16 if float16 else torch.float32
-        # encoder_hidden_state = torch.rand(
-        #     batch_size,
-        #     encode_sequence_length,
-        #     hidden_size,
-        #     dtype=float_type,
-        #     device=device,
-        # )
 
         if past_decode_sequence_length > 0:
             self_attention_past_shape = [
@@ -220,19 +211,16 @@ class T5DecoderInputs:
         input_list = [
             self.decoder_input_ids,
             self.encoder_attention_mask,
-            # self.encoder_hidden_states,
         ]
         if self.past_key_values:
             input_list.extend(self.past_key_values)
         return input_list
 
     def to_fp32(self):
-        # encoder_hidden_state = self.encoder_hidden_states.to(dtype=torch.float32)
         past = [p.to(dtype=torch.float32) for p in self.past_key_values] if self.past_key_values else None
         return T5DecoderInputs(
             self.decoder_input_ids.clone(),
             self.encoder_attention_mask.clone(),
-            # encoder_hidden_state,
             past,
         )
 
@@ -280,7 +268,6 @@ class T5DecoderHelper:
         # Shape of input tensors (sequence_length==1):
         #    input_ids: (batch_size, sequence_length)
         #    encoder_attention_mask: (batch_size, encode_sequence_length)
-        #    encoder_hidden_states: (batch_size, encode_sequence_length, hidden_size)
         #    past_self_*: (batch_size, num_heads, past_decode_sequence_length, head_size)
         #    past_cross_*: (batch_size, num_heads, encode_sequence_length, head_size)
 
@@ -291,7 +278,6 @@ class T5DecoderHelper:
 
         input_names = ["input_ids"]
         input_names.append("encoder_attention_mask")
-        # input_names.append("encoder_hidden_states")
         input_names.extend(input_past_names)
 
         dynamic_axes = {

--- a/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_decoder.py
@@ -291,7 +291,7 @@ class T5DecoderHelper:
 
         input_names = ["input_ids"]
         input_names.append("encoder_attention_mask")
-        #input_names.append("encoder_hidden_states")
+        # input_names.append("encoder_hidden_states")
         input_names.extend(input_past_names)
 
         dynamic_axes = {

--- a/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
@@ -151,21 +151,18 @@ class T5Helper:
     def auto_mixed_precision(
         onnx_model: OnnxModel,
         op_block_list: List[str] = [
-            "Pow",
-            "ReduceMean",
-            "Add",
-            "Sqrt",
-            "Div",
+            "SimplifiedLayerNormalization",
+            "SkipSimplifiedLayerNormalization",
             "Mul",
-            "Softmax",
             "Relu",
+            "Add",
         ],
     ):
         """Convert model to mixed precision.
            It detects whether original model has fp16 precision weights, and set parameters for float16 conversion automatically.
         Args:
             onnx_model (OnnxModel): optimized ONNX model
-            op_block_list (List[str], optional): . Defaults to ["Pow", "ReduceMean", "Add", "Sqrt", "Div", "Mul", "Softmax", "Relu"]
+            op_block_list (List[str], optional): . Defaults to ["SimplifiedLayerNormalization", "SkipSimplifiedLayerNormalization", "Mul", "Relu", "Add"]
         Returns:
             parameters(dict): a dictionary of parameters used in float16 conversion
         """
@@ -245,7 +242,7 @@ class T5Helper:
             model_type="t5",
             num_heads=num_attention_heads,
             hidden_size=hidden_size,
-            opt_level=2 if not is_float16 and not use_external_data_format else 0,
+            opt_level=2 if not use_external_data_format else 0,
             optimization_options=optimization_options,
             use_gpu=False,
         )

--- a/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
@@ -231,6 +231,7 @@ class T5Helper:
 
         from fusion_options import FusionOptions
 
+        optimization_options = None
         if is_float16:
             optimization_options = FusionOptions("t5")
             optimization_options.enable_skip_layer_norm = False

--- a/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
@@ -153,7 +153,6 @@ class T5Helper:
         op_block_list: List[str] = [
             "SimplifiedLayerNormalization",
             "SkipSimplifiedLayerNormalization",
-            "Mul",
             "Relu",
             "Add",
         ],
@@ -162,7 +161,7 @@ class T5Helper:
            It detects whether original model has fp16 precision weights, and set parameters for float16 conversion automatically.
         Args:
             onnx_model (OnnxModel): optimized ONNX model
-            op_block_list (List[str], optional): . Defaults to ["SimplifiedLayerNormalization", "SkipSimplifiedLayerNormalization", "Mul", "Relu", "Add"]
+            op_block_list (List[str], optional): . Defaults to ["SimplifiedLayerNormalization", "SkipSimplifiedLayerNormalization", "Relu", "Add"]
         Returns:
             parameters(dict): a dictionary of parameters used in float16 conversion
         """

--- a/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
+++ b/onnxruntime/python/tools/transformers/models/t5/t5_helper.py
@@ -231,9 +231,7 @@ class T5Helper:
 
         from fusion_options import FusionOptions
 
-        optimization_options = None
-        if not use_gpu:
-            # Currently there is no SkipSimplifiedLayerNorm cpu kernel
+        if is_float16:
             optimization_options = FusionOptions("t5")
             optimization_options.enable_skip_layer_norm = False
 
@@ -245,7 +243,9 @@ class T5Helper:
             opt_level=2 if not use_external_data_format else 0,
             optimization_options=optimization_options,
             use_gpu=False,
+            only_onnxruntime=not use_gpu,
         )
+
         if is_float16:
             if auto_mixed_precision:
                 T5Helper.auto_mixed_precision(m)

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -893,6 +893,7 @@ class OnnxModel:
 
         sorted_node_set_len = -1
         graph_nodes = graph.node if not is_deterministic else sorted(graph.node, key=lambda x: x.name)
+        last_node_name = None
         while len(sorted_node_set) != len(graph_nodes):
             if len(sorted_node_set) == sorted_node_set_len:
                 break
@@ -908,9 +909,10 @@ class OnnxModel:
                         deps_set.add(output)
                     continue
                 failed = False
-                for input in node.input:
-                    if input != "" and input not in deps_set:
+                for input_name in node.input:
+                    if input_name != "" and input_name not in deps_set:
                         failed = True
+                        last_node_name = node.name
                 if not failed:
                     sorted_nodes.append(node)
                     sorted_node_set.add(node_idx)
@@ -921,7 +923,7 @@ class OnnxModel:
 
         if len(sorted_node_set) != len(graph.node):
             raise RuntimeError(
-                f"Graph is not a DAG: len(sorted_node_set)={len(sorted_node_set)}, len(graph.node)={len(graph.node)}"
+                f"Graph is not a DAG: len(sorted_node_set)={len(sorted_node_set)}, len(graph.node)={len(graph.node)}, failed at node {last_node_name}"
             )
 
         graph.ClearField("node")

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -9,6 +9,7 @@ import numpy as np
 from fusion_attention import AttentionMask, FusionAttention
 from fusion_base import Fusion
 from fusion_skiplayernorm import FusionSkipLayerNormalization
+from fusion_layernorm import FusionLayerNormalization
 from fusion_utils import NumpyHelper
 from onnx import NodeProto, TensorProto, helper
 from onnx_model import OnnxModel
@@ -16,7 +17,7 @@ from onnx_model_bert import BertOnnxModel
 
 logger = logging.getLogger(__name__)
 
-# TODO: Support decoder self/cross attention fusion and encoder self attention fusion
+# TODO: refactor
 class FusionT5Attention(FusionAttention):
     """
     Fuse T5 Attention subgraph into one Attention node.
@@ -29,25 +30,454 @@ class FusionT5Attention(FusionAttention):
         num_heads: int,
         attention_mask: AttentionMask,
     ):
-        super().__init__(model, hidden_size, num_heads, attention_mask)
+        super().__init__(
+            model,
+            hidden_size,
+            num_heads,
+            attention_mask,
+            use_multi_head_attention=False,
+            search_op_types=["SkipSimplifiedLayerNormalization", "Add"],
+        )
+        self.static_kv = 1
 
-    def create_attention_node(
+    def create_mha_node(
         self,
+        query: str,
+        key: str,
+        value: str,
         mask_index: str,
-        matmul: NodeProto,
-        add: NodeProto,
+        res_pos_bias: str,
+        past_key: str,
+        past_value: str,
+        output: str,
+        present_key: str,
+        present_value: str,
         num_heads: int,
         hidden_size: int,
-        input: str,
-        output: str,
-        add_qk_str: str,
     ) -> Union[NodeProto, None]:
-        # Not implemented yet
-        return None
+
+        assert num_heads > 0
+
+        if hidden_size > 0 and (hidden_size % num_heads) != 0:
+            logger.debug(f"input hidden size {hidden_size} is not a multiple of num of heads {num_heads}")
+            return None
+
+        attention_node_name = self.model.create_node_name("MultiHeadAttention")
+        attention_inputs = [
+            query,
+            "" if key is None else key,  # key
+            "" if value is None else value,  # value
+            "",  # bias
+        ]
+        if mask_index is not None:
+            attention_inputs.append(mask_index)
+        else:
+            attention_inputs.append("")
+
+        if res_pos_bias is not None:
+            attention_inputs.append(res_pos_bias)
+        else:
+            attention_inputs.append("")
+
+        if past_key is not None:
+            assert past_value is not None
+            attention_inputs.append(past_key)
+            attention_inputs.append(past_value)
+
+        attention_outputs = [output]
+        if present_key is not None:
+            assert present_value is not None
+            attention_outputs.append(present_key)
+            attention_outputs.append(present_value)
+
+        attention_node = helper.make_node(
+            "MultiHeadAttention",
+            inputs=attention_inputs,
+            outputs=attention_outputs,
+            name=attention_node_name,
+        )
+
+        attention_node.domain = "com.microsoft"
+        attention_node.attribute.extend([helper.make_attribute("num_heads", num_heads)])
+        attention_node.attribute.extend([helper.make_attribute("scale", 1.0)])
+        attention_node.attribute.extend([helper.make_attribute("static_kv", 0 if self.static_kv == 0 else 1)])
+        if self.mask_filter_value is not None:
+            attention_node.attribute.extend([helper.make_attribute("mask_filter_value", float(self.mask_filter_value))])
+
+        return attention_node
 
     def fuse(self, normalize_node, input_name_to_nodes, output_name_to_node):
-        # Not implemented yet
-        return
+        self.fuse_t5_encoder(normalize_node, input_name_to_nodes, output_name_to_node)
+        self.fuse_t5_decoder(normalize_node, input_name_to_nodes, output_name_to_node)
+
+    def fuse_t5_encoder(self, normalize_node, input_name_to_nodes, output_name_to_node):
+        if normalize_node.op_type != "SkipSimplifiedLayerNormalization" and normalize_node.op_type != "Add":
+            return
+
+        qkv_nodes = self.model.match_parent_path(
+            normalize_node,
+            ["MatMul", "Reshape", "Transpose", "MatMul"],
+            [1, 0, 0, 0],
+        )
+        if qkv_nodes is None:
+            return
+
+        _, reshape_qkv, transpose_qkv, matmul_qkv = qkv_nodes
+
+        qkv_shape_nodes = self.model.match_parent_path(
+            reshape_qkv,
+            ["Concat", "Unsqueeze", "Gather", "Shape"],
+            [1, 0, 0, 0],
+        )
+        if qkv_shape_nodes is None:
+            return
+        input_shape_node = qkv_shape_nodes[-1]
+
+        v_nodes = self.model.match_parent_path(
+            matmul_qkv,
+            ["Transpose", "Reshape", "MatMul"],
+            [1, 0, 0],
+        )
+        if v_nodes is None:
+            return
+        _, reshape_v, matmul_v = v_nodes
+        # todo: check reshape_v parent nodes
+
+        qk_nodes = self.model.match_parent_path(
+            matmul_qkv,
+            ["Softmax", "Add", "MatMul"],
+            [0, 0, 0],
+        )
+        if qk_nodes is None:
+            return
+        _, add_qk, matmul_qk = qk_nodes
+
+        mask_index = None
+        mask_nodes = self.model.match_parent_path(
+            add_qk,
+            ["Add", "Mul", "Sub", "Cast", "Unsqueeze", "Unsqueeze"],
+            [1, 1, 0, 1, 0, 0],
+        )
+        if mask_nodes is None:
+            return
+        mul_node = mask_nodes[1]
+        if mask_nodes[1].op_type != "Mul":
+            return
+
+        _, mul_val = self.model.get_constant_input(mul_node)
+        if mul_val != -10000:
+            self.mask_filter_value = mul_val
+
+        mask_index = self.attention_mask.process_mask(mask_nodes[-1].input[0])
+
+        res_pos_bias = None
+        rpb_nodes = self.model.match_parent_path(
+            add_qk,
+            ["Add", "RelativePositionBias"],
+            [1, 0],
+        )
+        if rpb_nodes is None:
+            return
+        rpb_add_node = rpb_nodes[0]
+        res_pos_bias = rpb_add_node.input[0]
+
+        k_nodes = self.model.match_parent_path(
+            matmul_qk,
+            ["Transpose", "Reshape", "MatMul"],
+            [1, 0, 0],
+        )
+        if k_nodes is None:
+            return
+        _, reshape_k, matmul_k = k_nodes
+        # todo: check reshape_k parent nodes
+
+        q_nodes = self.model.match_parent_path(
+            matmul_qk,
+            ["Transpose", "Reshape", "MatMul"],
+            [0, 0, 0],
+        )
+        if q_nodes is None:
+            return
+
+        transpose_q, reshape_q, matmul_q = q_nodes
+        # todo: check reshape_q parent nodes
+
+        if matmul_q.input[0] != input_shape_node.input[0]:
+            return
+
+        q_num_heads, q_hidden_size = self.get_num_heads_and_hidden_size(reshape_q)
+
+        new_node = self.create_attention_node(
+            mask_index,
+            matmul_q,
+            matmul_k,
+            matmul_v,
+            None,
+            None,
+            None,
+            q_num_heads,
+            q_hidden_size,
+            input_shape_node.input[0],
+            reshape_qkv.output[0],
+            res_pos_bias,
+            1.0,
+        )
+        if new_node is None:
+            return
+
+        self.nodes_to_add.append(new_node)
+        self.node_name_to_graph_name[new_node.name] = self.this_graph_name
+
+        self.nodes_to_remove.extend(qkv_nodes[1:])
+        self.nodes_to_remove.extend(qk_nodes)
+        self.nodes_to_remove.extend(k_nodes[:-1])
+        if v_nodes is not None:
+            self.nodes_to_remove.extend(v_nodes[:-1])
+        self.nodes_to_remove.extend(q_nodes[:-1])
+
+        self.prune_graph = True
+
+    def fuse_t5_decoder(self, normalize_node, input_name_to_nodes, output_name_to_node):
+        if normalize_node.op_type != "SkipSimplifiedLayerNormalization" and normalize_node.op_type != "Add":
+            return
+
+        qkv_nodes = self.model.match_parent_path(
+            normalize_node,
+            ["MatMul", "Reshape", "Transpose", "MatMul"],
+            [1, 0, 0, 0],
+        )
+        if qkv_nodes is None:
+            return
+
+        _, reshape_qkv, transpose_qkv, matmul_qkv = qkv_nodes
+
+        qkv_shape_nodes = self.model.match_parent_path(
+            reshape_qkv,
+            ["Concat", "Unsqueeze", "Gather", "Shape"],
+            [1, 0, 0, 0],
+        )
+        if qkv_shape_nodes is None:
+            return
+        input_shape_node = qkv_shape_nodes[-1]
+
+        value = None
+        past_value = None
+        present_value = None
+        v_nodes = self.model.match_parent_path(
+            matmul_qkv,
+            ["Concat", "Transpose", "Reshape", "MatMul"],
+            [1, 1, 0, 0],
+        )
+        if v_nodes is None:
+            v_nodes = self.model.match_parent_path(
+                matmul_qkv,
+                ["Transpose", "Reshape", "MatMul"],
+                [1, 0, 0],
+            )
+            if v_nodes is not None:
+                transpose_v, reshape_v, matmul_v = v_nodes
+                value = reshape_v.input[0]
+                present_value = transpose_v.output[0]
+                if "present_value" not in present_value:
+                    return
+                if matmul_v.input[0] != input_shape_node.input[0]:
+                    self.static_kv = 1
+                else:
+                    self.static_kv = 0
+            else:
+                past_value = matmul_qkv.input[1]
+                if past_value in output_name_to_node:
+                    return
+                if "past_value_cross" not in past_value:
+                    return
+                self.static_kv = 1
+        else:
+            concat_v, _, reshape_v, _ = v_nodes
+            past_value = concat_v.input[0]
+            if past_value in output_name_to_node:
+                return
+            if "past_value_self" not in past_value:
+                return
+            present_value = concat_v.output[0]
+            if "present_value_self" not in present_value:
+                return
+            value = reshape_v.input[0]
+            self.static_kv = 0
+
+        qk_nodes = self.model.match_parent_path(
+            matmul_qkv,
+            ["Softmax", "Add", "MatMul"],
+            [0, 0, 0],
+        )
+        if qk_nodes is None:
+            return
+        _, add_qk, matmul_qk = qk_nodes
+
+        mask_index = None
+        res_pos_bias = None
+        if self.static_kv == 1:
+            mask_nodes = self.model.match_parent_path(
+                add_qk,
+                ["Add", "Mul", "Sub", "Cast", "Unsqueeze", "Unsqueeze"],
+                [1, 1, 0, 1, 0, 0],
+            )
+            if mask_nodes is None:
+                return
+            mul_node = mask_nodes[1]
+            if mask_nodes[1].op_type != "Mul":
+                return
+
+            _, mul_val = self.model.get_constant_input(mul_node)
+            if mul_val != -10000:
+                self.mask_filter_value = mul_val
+
+            mask_index = self.attention_mask.process_mask(mask_nodes[-1].input[0])
+        else:
+            rpb_nodes = self.model.match_parent_path(
+                add_qk,
+                ["Add", "Slice"],
+                [1, 0],
+            )
+            if rpb_nodes is not None:
+                res_pos_bias = add_qk.input[1]
+            else:
+                rpb_nodes = self.model.match_parent_path(
+                    add_qk,
+                    ["Add", "RelativePositionBias"],
+                    [1, 0],
+                )
+                if rpb_nodes is None:
+                    return
+                res_pos_bias = add_qk.input[1]
+
+        key = None
+        past_key = None
+        present_key = None
+        if self.static_kv == 1:
+            k_nodes = self.model.match_parent_path(
+                matmul_qk,
+                ["Transpose", "Reshape", "MatMul"],
+                [1, 0, 0],
+            )
+            if k_nodes is not None:
+                transpose_k, reshape_k, _ = k_nodes
+                key = reshape_k.input[0]
+                present_key_transpose_nodes = input_name_to_nodes[reshape_k.output[0]]
+                for present_key_transpose_node in present_key_transpose_nodes:
+                    present_key_candidate = self.model.find_graph_output(present_key_transpose_node.output[0])
+                    if present_key_candidate is not None:
+                        present_key = present_key_candidate.name
+                        break
+                if present_key is None:
+                    return
+                if "present_key_cross" not in present_key:
+                    return
+            else:
+                k_nodes = self.model.match_parent_path(
+                    matmul_qk,
+                    ["Transpose"],
+                    [1],
+                )
+                if k_nodes is None:
+                    return
+                transpose_k = k_nodes[0]
+
+                past_key = transpose_k.input[0]
+                if past_key in output_name_to_node:
+                    return
+                if "past_key_cross" not in past_key:
+                    return
+        else:
+            k_nodes = self.model.match_parent_path(
+                matmul_qk,
+                ["Transpose", "Concat", "Reshape", "MatMul"],
+                [1, 0, 1, 0],
+            )
+            if k_nodes is not None:
+                _, concat_k, reshape_k, _ = k_nodes
+                key = reshape_k.input[0]
+                past_key_transpose_node = output_name_to_node[concat_k.input[0]]
+                past_key = past_key_transpose_node.input[0]
+                if past_key in output_name_to_node:
+                    return
+                if "past_key_self" not in past_key:
+                    return
+                present_key_transpose_nodes = input_name_to_nodes[concat_k.output[0]]
+                for present_key_transpose_node in present_key_transpose_nodes:
+                    # print("present_key_transpose_node:", present_key_transpose_node)
+                    present_key_candidate = self.model.find_graph_output(present_key_transpose_node.output[0])
+                    # print("present_key_candidate:", present_key_candidate)
+                    if present_key_candidate is not None:
+                        present_key = present_key_candidate.name
+                        break
+                if present_key is None:
+                    return
+                if "present_key_self" not in present_key:
+                    return
+            else:
+                k_nodes = self.model.match_parent_path(
+                    matmul_qk,
+                    ["Transpose", "Reshape", "MatMul"],
+                    [1, 0, 0],
+                )
+                if k_nodes is None:
+                    return
+                _, reshape_k, _ = k_nodes
+                key = reshape_k.input[0]
+                present_key_transpose_nodes = input_name_to_nodes[reshape_k.output[0]]
+                for present_key_transpose_node in present_key_transpose_nodes:
+                    present_key_candidate = self.model.find_graph_output(present_key_transpose_node.output[0])
+                    if present_key_candidate is not None:
+                        present_key = present_key_candidate.name
+                        break
+                if present_key is None:
+                    return
+                if "present_key_self" not in present_key:
+                    return
+
+        q_nodes = self.model.match_parent_path(
+            matmul_qk,
+            ["Transpose", "Reshape", "MatMul"],
+            [0, 0, 0],
+        )
+        if q_nodes is None:
+            return
+
+        transpose_q, reshape_q, matmul_q = q_nodes
+
+        if matmul_q.input[0] != input_shape_node.input[0]:
+            return
+
+        q_num_heads, q_hidden_size = self.get_num_heads_and_hidden_size(reshape_q)
+
+        new_node = self.create_mha_node(
+            matmul_q.output[0],
+            key,
+            value,
+            mask_index,
+            res_pos_bias,
+            past_key,
+            past_value,
+            reshape_qkv.output[0],
+            present_key,
+            present_value,
+            q_num_heads,
+            q_hidden_size,
+        )
+        if new_node is None:
+            return
+
+        self.nodes_to_add.append(new_node)
+        self.node_name_to_graph_name[new_node.name] = self.this_graph_name
+
+        self.nodes_to_remove.extend(qkv_nodes[1:])
+        self.nodes_to_remove.extend(qk_nodes)
+        self.nodes_to_remove.extend(k_nodes[:-1])
+        if v_nodes is not None:
+            self.nodes_to_remove.extend(v_nodes[:-1])
+        self.nodes_to_remove.extend(q_nodes[:-1])
+
+        self.prune_graph = True
 
 
 class FusionRelativePositionBiasBlock(Fusion):
@@ -135,12 +565,18 @@ class FusionRelativePositionBiasBlock(Fusion):
         self.node_name_to_graph_name[rpb_node.name] = self.this_graph_name
 
 
+class FusionSimplifiedLayerNormalization(FusionLayerNormalization):
+    def __init__(self, model: OnnxModel):
+        super().__init__(model)
+
+    def fuse(self, node, input_name_to_nodes, output_name_to_node):
+        # super().fuse(node, input_name_to_nodes, output_name_to_node)
+        return
+
+
 class FusionSkipSimplifiedLayerNormalization(FusionSkipLayerNormalization):
     def __init__(self, model: OnnxModel):
         super().__init__(model, "SkipSimplifiedLayerNormalization", "SimplifiedLayerNormalization")
-        self.shape_infer_helper = self.model.infer_runtime_shape(
-            {"batch_size": 2, "seq_len": 1, "encode_sequence_length": 8, "past_decode_sequence_length": 4}, update=True
-        )
 
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
         super().fuse(node, input_name_to_nodes, output_name_to_node)
@@ -151,16 +587,23 @@ class T5OnnxModel(BertOnnxModel):
         super().__init__(model, num_heads, hidden_size)
         self.attention_mask = AttentionMask(self)
         self.attention_fusion = FusionT5Attention(self, self.hidden_size, self.num_heads, self.attention_mask)
+        self.layer_norm_fusion = FusionSimplifiedLayerNormalization(self)
         self.skip_layer_norm_fusion = FusionSkipSimplifiedLayerNormalization(self)
         # TODO: consider retrive max_distance from model.
         # math.log(max_distance / (num_buckets // 2))
         self.rpb_fusion = FusionRelativePositionBiasBlock(self, 128)
 
     def fuse_attention(self):
-        self.attention_fusion.apply()
+        return
+        # self.attention_fusion.apply()
+
+    def fuse_layer_norm(self):
+        return
+        # self.layer_norm_fusion().apply()
 
     def fuse_skip_layer_norm(self):
-        self.skip_layer_norm_fusion.apply()
+        return
+        # self.skip_layer_norm_fusion.apply()
 
     # Remove get_extended_attention_mask() since it generates all zeros.
     def remove_extended_mask_decoder_init(self):
@@ -234,10 +677,13 @@ class T5OnnxModel(BertOnnxModel):
                 nodes_to_remove.append(node)
                 self.remove_nodes(nodes_to_remove)
 
+    def preprocess(self):
+        self.adjust_reshape_and_expand()
+        # self.rpb_fusion.apply()
+
     def postprocess(self):
-        self.rpb_fusion.apply()
         # remove get_extended_attention_mask() since it generates all zeros.
-        self.remove_extended_mask_decoder_init()
-        self.remove_extended_mask_decoder()
+        # self.remove_extended_mask_decoder_init()
+        # self.remove_extended_mask_decoder()
 
         self.prune_graph()

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -3,13 +3,12 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 import logging
-from typing import Union
+from typing import Dict, Union
 
 import numpy as np
 from fusion_attention import AttentionMask, FusionAttention
 from fusion_base import Fusion
 from fusion_skiplayernorm import FusionSkipLayerNormalization
-from fusion_layernorm import FusionLayerNormalization
 from fusion_utils import NumpyHelper
 from onnx import NodeProto, TensorProto, helper
 from onnx_model import OnnxModel
@@ -570,13 +569,51 @@ class FusionRelativePositionBiasBlock(Fusion):
         self.node_name_to_graph_name[rpb_node.name] = self.this_graph_name
 
 
-class FusionSimplifiedLayerNormalization(FusionLayerNormalization):
+class FusionSimplifiedLayerNormalization(Fusion):
     def __init__(self, model: OnnxModel):
-        super().__init__(model)
+        super().__init__(model, "SimplifiedLayerNormalization", "Mul")
 
-    def fuse(self, node, input_name_to_nodes, output_name_to_node):
-        # super().fuse(node, input_name_to_nodes, output_name_to_node)
-        return
+    def fuse(self, node, input_name_to_nodes: Dict, output_name_to_node: Dict):
+        if node.op_type != "Mul":
+            return
+
+        sim_ln_nodes = self.model.match_parent_path(
+            node,
+            ["Mul", "Div", "Sqrt", "Add", "ReduceMean", "Pow", "Add"],
+            [1, 1, 1, 0, 0, 0, 0],
+        )
+        if sim_ln_nodes is None:
+            return
+
+        pow_node = sim_ln_nodes[-2]
+        if not self.model.find_constant_input(pow_node, 2.0) == 1:
+            return
+
+        root_input = pow_node.input[0]
+
+        mul_node_1 = sim_ln_nodes[0]
+        if root_input != mul_node_1.input[0]:
+            return
+
+        second_add_node = sim_ln_nodes[3]
+        i, add_weight = self.model.get_constant_input(second_add_node)
+        if add_weight is None or add_weight <= 0 or add_weight > 1.0e-4:
+            logger.warning(f"epsilon value is not expeced: {add_weight}")
+            return
+
+        self.nodes_to_remove.extend(sim_ln_nodes[:-1])
+
+        normalize_node = helper.make_node(
+            "SimplifiedLayerNormalization",
+            inputs=[root_input, node.input[0]],
+            outputs=[node.output[0]],
+            name=self.model.create_node_name("SimplifiedLayerNormalization", name_prefix="LayerNorm"),
+        )
+        normalize_node.attribute.extend([helper.make_attribute("epsilon", float(add_weight))])
+        normalize_node.attribute.extend([helper.make_attribute("axis", int(-1))])
+        normalize_node.attribute.extend([helper.make_attribute("stash_type", int(1))])
+        self.nodes_to_add.append(normalize_node)
+        self.node_name_to_graph_name[normalize_node.name] = self.this_graph_name
 
 
 class FusionSkipSimplifiedLayerNormalization(FusionSkipLayerNormalization):
@@ -602,8 +639,7 @@ class T5OnnxModel(BertOnnxModel):
         self.attention_fusion.apply()
 
     def fuse_layer_norm(self):
-        return
-        # self.layer_norm_fusion().apply()
+        self.layer_norm_fusion.apply()
 
     def fuse_skip_layer_norm(self):
         self.skip_layer_norm_fusion.apply()

--- a/onnxruntime/python/tools/transformers/onnx_model_t5.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_t5.py
@@ -102,6 +102,7 @@ class FusionT5Attention(FusionAttention):
         if self.mask_filter_value is not None:
             attention_node.attribute.extend([helper.make_attribute("mask_filter_value", float(self.mask_filter_value))])
 
+        self.increase_counter("MultiHeadAttention")
         return attention_node
 
     def fuse(self, normalize_node, input_name_to_nodes, output_name_to_node):

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -25,11 +25,11 @@ else:
 
 class TestFusion(unittest.TestCase):
     def verify_fusion(self, optimized_model, expected_model_filename):
-        optimized_model.topological_sort()
+        optimized_model.topological_sort(is_deterministic=True)
 
         expected_model_path = os.path.join(os.path.dirname(__file__), "test_data", "models", expected_model_filename)
         expected_model = OnnxModel(onnx.load(expected_model_path))
-        expected_model.topological_sort()
+        expected_model.topological_sort(is_deterministic=True)
 
         self.assertEqual(str(optimized_model.model.graph), str(expected_model.model.graph))
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

1. added script for t5 encoder self attention and t5 decoder self/cross attention fusions. 
2. added simplified layernorm fusion for --external_data_format senario. (otherwise relying on ORT optimizer)
3. added rel_pos_bias shape inference code, modified attention/mha shape inference script.
4. reworked graph_topologic_sort() because the currently implementation is not functioning correctly. also added an option to topo-sort the graph in a deterministic way to let tests pass.

note:
1. the t5-beamsearch export code is slightly modified. specifically, encoder_hidden_states(ehs) is no longer an input to the t5 decoder since the ehs is not actually used in the graph execution. 
2. recent PRs do not add optimizations to t5 on cpu. 
3. the fp32 model(encoder and decoder) for t5-small, t5-base and t5-large can get a parity of e-5 and the corresponding beam search models generate same results as pytorch.
4. fp16(mixed-precision) models, however, get a parity around 3e-2 and some has maximum diff a bit over 3e-2. But the beam search models still generate same results as pytorch (based on limited input data)
5. mt-5 model has a parity issue at the moment, even before any optimization. will investigate later.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


