### PR TITLE
BUG FIX: the if...else in  telemetry-steps.yml does not really work

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/telemetry-steps.yml
@@ -2,18 +2,18 @@
 # variable
 
 steps:
-  - powershell: |
-      if ($env:TELEMETRYGUID) {
-        $length = $env:TELEMETRYGUID.length
-        $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
-          TraceLoggingOptionGroup("+$env:TELEMETRYGUID.substring(1, $length-2)+")"
-        New-Item -Path "$(Build.SourcesDirectory)\include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
-        Write-Host "##vso[task.setvariable variable=TelemetryOption]--use_telemetry"
-        Write-Host "Telemetry is enabled."
-      } else {
-        Write-Host "##vso[task.setvariable variable=TelemetryOption]"
-        Write-Host "Telemetry is disabled."
-      }
+  # TELEMETRYGUID is a runtime variable that is stored on the pipeline in an old-fashioned way. So it cannot be used in
+  # template expressions. We access it through env variables.
+  - task: PowerShell@2
     displayName: 'Set TelemetryOption variable and optionally create TraceLoggingConfigPrivate.h for WinML Telemetry'
+    inputs:
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)\tools\ci_build\github\windows\set_telemetry_var.ps1
+      failOnStderr: true
+      showWarnings: true
+      workingDirectory: $(Build.SourcesDirectory)
     env:
+      # When the pipeline variable does not exist, the following line will create a new env variable with value of
+      # what you see here. 
       TELEMETRYGUID: $(TELEMETRYGUID)
+      

--- a/tools/ci_build/github/windows/set_telemetry_var.ps1
+++ b/tools/ci_build/github/windows/set_telemetry_var.ps1
@@ -1,0 +1,15 @@
+# The first part of the expression in the following "if" statement is necessary, otherwise it will report an error,
+# "You cannot call a method on a null-valued expression.", when the env variable does not exist.
+if (-not [string]::IsNullOrEmpty( $Env:TELEMETRYGUID) -and $Env:TELEMETRYGUID.StartsWith('"')) {
+    $length = $Env:TELEMETRYGUID.length
+	# See https://learn.microsoft.com/en-us/windows/win32/api/traceloggingprovider/nf-traceloggingprovider-traceloggingoptiongroup
+	# The value of the env variable must have quotes, because we do not add the quotes here.
+    $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
+      TraceLoggingOptionGroup("+$Env:TELEMETRYGUID.substring(1, $length-2)+")"
+    New-Item -Path "include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
+    Write-Host "##vso[task.setvariable variable=TelemetryOption]--use_telemetry"
+    Write-Host "Telemetry is enabled."
+} else {
+	Write-Host "##vso[task.setvariable variable=TelemetryOption]"
+	Write-Host "Telemetry is disabled."
+}


### PR DESCRIPTION
### Description
BUG FIX: the if...else in  telemetry-steps.yml does not really work. It always says "Telemetry is disabled." even through the pipeline doesn't have the pipeline variable. 

### Motivation and Context
For example, recently I setup a new pipeline in https://dev.azure.com/onnxruntime/onnxruntime/_build without setting the ADO variable, but the powershell code still thinks that we have enabled telemetry.

See:
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=910107&view=results

The reason it didn't work because when the pipeline variable("TELEMETRYGUID") doesn't exist,  the occurrence of  "$(TELEMETRYGUID)" would be not replace to anything. It will remain as it is

