### PR TITLE
Fix prefast warnings

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.h
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.h
@@ -20,7 +20,6 @@ class NvtxRangeCreator;
 }
 
 struct ProviderInfo_CUDA {
-  virtual ~ProviderInfo_CUDA() {}  // This is declared due to a TSA warning, the only instantiation of this class is a global variable of automatic storage.
 
   virtual OrtStatus* SetCurrentGpuDeviceId(_In_ int device_id) = 0;
   virtual OrtStatus* GetCurrentGpuDeviceId(_In_ int* device_id) = 0;

--- a/onnxruntime/core/providers/cuda/cuda_provider_factory.h
+++ b/onnxruntime/core/providers/cuda/cuda_provider_factory.h
@@ -60,6 +60,9 @@ struct ProviderInfo_CUDA {
   // tests and is only called from onnxruntime_test_all. Release builds don't need this function.
   virtual bool TestAll() = 0;
 #endif
+
+protected:
+  ~ProviderInfo_CUDA() = default;  // Can only be destroyed through a subclass instance
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/transpose.cc
+++ b/onnxruntime/core/providers/cuda/tensor/transpose.cc
@@ -155,7 +155,7 @@ Status Transpose::DoTranspose(const cudaDeviceProp& prop,
         }
       }
       for (auto j = i + 1; j < new_rank; j++) {
-        new_permutations[j - 1] = new_permutations[j];
+        new_permutations[static_cast<ptrdiff_t>(j) - 1] = new_permutations[j];
       }
 
       // update input dims


### PR DESCRIPTION
### Description

In transpose.cc:
Arithmetic overflow: Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).

In cuda_provider_factory.h:
The type 'struct onnxruntime::CUDA_Provider' with a virtual function needs either public virtual or protected non-virtual destructor (c.35).

