### PR TITLE
extend timeout of Build_wasm_Release_static_library

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -85,7 +85,7 @@ stages:
         ExtraBuildArgs: '$(ExtraBuildArgs)'
         PoolName: ${{ parameters.PoolName }}
         SkipPublish: true
-        TimeoutInMinutes: 180
+        TimeoutInMinutes: 240
 
 - stage: Build_web_Release
   dependsOn: Build_wasm_Release


### PR DESCRIPTION
### Description
Extend the timeout to 240 minutes. 
3 hours isn't enough now.

### Motivation and Context
The job duration is increased and it's easy to time out now.
The Build_wasm_Release_static_library job is the most time-consuming job in Pull Request CIs and it's required.
cc @snnn @faxu @fs-eire 


