### PR TITLE
[QNN EP] Update QNN SDK to 2.8

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -3,7 +3,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: qnn-v2.6.0.221227110525_42395
+  default: qnn-v2.8.0.230223123141_52150
   values:
   - qnn-v2.6.0.221227110525_42395
   - qnn-v2.8.0.230223123141_52150

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -28,8 +28,6 @@ jobs:
   - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
     displayName: Install coreutils and ninja
 
-  - template: templates/set-up-gradle-wrapper-step.yml
-
   - script: sudo chmod go+rw /dev/kvm
     displayName: Update permissions to KVM
 

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -1,9 +1,23 @@
+parameters:
+
+- name: QnnSdk
+  displayName: QNN SDK version
+  type: string
+  default: qnn-v2.6.0.221227110525_42395
+  values:
+  - qnn-v2.6.0.221227110525_42395
+  - qnn-v2.8.0.230223123141_52150
+
 jobs:
 - job: Build_QNN_EP
-  pool: Onnxruntime-QNNEP-Ubuntu-2004-CPU
+  pool: onnxruntime-qnn-ubuntu-2004-cpu
   timeoutInMinutes: 30
   workspace:
     clean: all
+
+  variables:
+    - name: QNN_SDK_ROOT
+      value: /data/qnnsdk/${{parameters.QnnSdk}}
 
   steps:
   - task: UsePythonVersion@0
@@ -27,11 +41,6 @@ jobs:
     displayName: set Android ENVs
 
   - script: |
-      echo "##vso[task.setvariable variable=QNN_SDK_ROOT]/data/qnnsdk/qnn-v2.6.0.221227110525_42395"
-    displayName: set QNN_SDK_ROOT
-
-  - script: |
-      env | egrep -e ANDROID -e QNN
       python3 tools/ci_build/build.py \
         --config Release \
         --android \
@@ -42,12 +51,15 @@ jobs:
         --android_api=30 \
         --parallel \
         --use_qnn \
-        --qnn_home $QNN_SDK_ROOT \
+        --qnn_home $(QNN_SDK_ROOT) \
         --cmake_generator=Ninja \
         --skip_tests
+    displayName: Build QNN EP
+
+  - script: |
       mkdir -p build_qnn/Release/testdata/QNN/node_tests
       cp -r cmake/external/onnx//onnx/backend/test/data/node/test_basic_conv_with_padding build_qnn/Release/testdata/QNN/node_tests
-    displayName: QNN EP, Build
+    displayName: Initialize test directories
 
   - task: JavaToolInstaller@0
     displayName: Use jdk 8

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -3,7 +3,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: qnn-v2.6.0.221227110525_42395
+  default: qnn-v2.8.0.230223123141_52150
   values:
   - qnn-v2.6.0.221227110525_42395
   - qnn-v2.8.0.230223123141_52150

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -3,7 +3,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: qnn-v2.8.0.230223123141_52150
+  default: qnn-v2.6.0.221227110525_42395
   values:
   - qnn-v2.6.0.221227110525_42395
   - qnn-v2.8.0.230223123141_52150
@@ -32,10 +32,6 @@ jobs:
 
       - script: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
         displayName: Install coreutils and ninja
-
-      - script: |
-          ls -al $(QNN_SDK_ROOT)
-        displayName: Show QNN SDK contents
 
       - script: |
           python3 tools/ci_build/build.py \

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -1,9 +1,23 @@
+parameters:
+
+- name: QnnSdk
+  displayName: QNN SDK version
+  type: string
+  default: qnn-v2.8.0.230223123141_52150
+  values:
+  - qnn-v2.6.0.221227110525_42395
+  - qnn-v2.8.0.230223123141_52150
+
 jobs:
   - job: Build_QNN_EP
     pool: onnxruntime-qnn-ubuntu-2004-cpu
     timeoutInMinutes: 60
     workspace:
       clean: all
+
+    variables:
+      - name: QNN_SDK_ROOT
+        value: /data/qnnsdk/${{QnnSdk}}
 
     steps:
       - script: |
@@ -20,8 +34,8 @@ jobs:
         displayName: Install coreutils and ninja
 
       - script: |
-          echo "##vso[task.setvariable variable=QNN_SDK_ROOT]/data/qnnsdk/qnn-v2.6.0.221227110525_42395"
-        displayName: set QNN_SDK_ROOT
+          ls -al $(QNN_SDK_ROOT)
+        displayName: Show QNN SDK contents
 
       - script: |
           python3 tools/ci_build/build.py \
@@ -29,7 +43,7 @@ jobs:
             --config Release \
             --parallel \
             --use_qnn \
-            --qnn_home $QNN_SDK_ROOT \
+            --qnn_home $(QNN_SDK_ROOT) \
             --cmake_generator=Ninja \
             --skip_tests
         displayName: Build QNN EP
@@ -39,7 +53,7 @@ jobs:
             --build_dir build \
             --config Release \
             --test \
-            --qnn_home $QNN_SDK_ROOT \
+            --qnn_home $(QNN_SDK_ROOT) \
             --cmake_generator=Ninja \
             --skip_submodule_sync \
             --ctest_path ""
@@ -50,7 +64,7 @@ jobs:
         inputs:
           script: |
             ./build/Release/onnx_test_runner -e qnn \
-              -v -j 1 -c 1 -i "backend_path|$QNN_SDK_ROOT/target/x86_64-linux-clang/lib/libQnnCpu.so" \
+              -v -j 1 -c 1 -i "backend_path|$(QNN_SDK_ROOT)/target/x86_64-linux-clang/lib/libQnnCpu.so" \
               cmake/external/onnx/onnx/backend/test/data/node
 
       - task: CmdLine@2
@@ -58,7 +72,7 @@ jobs:
         inputs:
           script: |
             ./build/Release/onnx_test_runner -e qnn \
-              -v -j 1 -c 1 -i "backend_path|$QNN_SDK_ROOT/target/x86_64-linux-clang/lib/libQnnCpu.so" \
+              -v -j 1 -c 1 -i "backend_path|$(QNN_SDK_ROOT)/target/x86_64-linux-clang/lib/libQnnCpu.so" \
               /data/float32_models
 
       - task: CmdLine@2
@@ -66,6 +80,6 @@ jobs:
         inputs:
           script: |
             ./build/Release/onnx_test_runner -e qnn \
-              -v -j 1 -c 1 -i "backend_path|$QNN_SDK_ROOT/target/x86_64-linux-clang/lib/libQnnHtp.so" \
+              -v -j 1 -c 1 -i "backend_path|$(QNN_SDK_ROOT)/target/x86_64-linux-clang/lib/libQnnHtp.so" \
               /data/qdq_models
 

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
 
     variables:
       - name: QNN_SDK_ROOT
-        value: /data/qnnsdk/${{QnnSdk}}
+        value: /data/qnnsdk/${{parameters.QnnSdk}}
 
     steps:
       - script: |

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -20,7 +20,7 @@ jobs:
     BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
     QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
-  timeoutInMinutes: 200
+  timeoutInMinutes: 240
   workspace:
     clean: all
   steps:

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -3,7 +3,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: qnn-v2.6.0.221227161714_42395_win
+  default: qnn-v2.8.0.230223123141_52150_win
   values:
   - qnn-v2.6.0.221227161714_42395_win
   - qnn-v2.8.0.230223123141_52150_win

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -1,3 +1,13 @@
+parameters:
+
+- name: QnnSdk
+  displayName: QNN SDK version
+  type: string
+  default: qnn-v2.6.0.221227161714_42395_win
+  values:
+  - qnn-v2.6.0.221227161714_42395_win
+  - qnn-v2.8.0.230223123141_52150_win
+
 jobs:
 - job: 'build'
   pool: 'Onnxruntime-QNNEP-Windows-2022-ARM64-CPU'
@@ -5,11 +15,11 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    EnvSetupScript: setup_env_qnn.bat
     buildArch: arm64
     setVcvars: true
     BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
+    QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
   timeoutInMinutes: 200
   workspace:
     clean: all
@@ -33,13 +43,6 @@ jobs:
       versionSpec: '3.x'
       addToPath: true
       architecture: $(buildArch)
-
-  - task: BatchScript@1
-    displayName: 'setup env'
-    inputs:
-      filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\$(EnvSetupScript)'
-      modifyEnvironment: true
-      workingFolder: '$(Build.BinariesDirectory)'
 
   - task: PythonScript@0
     displayName: 'Generate cmake config'

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -1,3 +1,13 @@
+parameters:
+
+- name: QnnSdk
+  displayName: QNN SDK version
+  type: string
+  default: qnn-v2.6.0.221227161714_42395_win
+  values:
+  - qnn-v2.6.0.221227161714_42395_win
+  - qnn-v2.8.0.230223123141_52150_win
+
 jobs:
 - job: 'build'
   pool: 'Onnxruntime-QNNEP-Windows-2022-CPU'
@@ -5,11 +15,11 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    EnvSetupScript: setup_env_qnn.bat
     buildArch: x64
     setVcvars: true
     BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
+    QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
   timeoutInMinutes: 150
   workspace:
     clean: all
@@ -20,13 +30,6 @@ jobs:
       versionSpec: '3.7'
       addToPath: true
       architecture: $(buildArch)
-
-  - task: BatchScript@1
-    displayName: 'setup env'
-    inputs:
-      filename: '$(Build.SourcesDirectory)\tools\ci_build\github\windows\$(EnvSetupScript)'
-      modifyEnvironment: true
-      workingFolder: '$(Build.BinariesDirectory)'
 
   - task: PythonScript@0
     displayName: 'Generate cmake config'

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -3,7 +3,7 @@ parameters:
 - name: QnnSdk
   displayName: QNN SDK version
   type: string
-  default: qnn-v2.6.0.221227161714_42395_win
+  default: qnn-v2.8.0.230223123141_52150_win
   values:
   - qnn-v2.6.0.221227161714_42395_win
   - qnn-v2.8.0.230223123141_52150_win

--- a/tools/ci_build/github/windows/setup_env_qnn.bat
+++ b/tools/ci_build/github/windows/setup_env_qnn.bat
@@ -1,1 +1,0 @@
-set QNN_SDK_ROOT=C:\data\qnnsdk\qnn-v2.6.0.221227161714_42395_win


### PR DESCRIPTION
### Description
- Add QNN 2.8 SDK
- Make QNN SDK version a pipeline template parameter for QNN pipelines.

![image](https://user-images.githubusercontent.com/19691973/223957679-e7ffbf7b-28d5-46e8-a6d2-b76c2b55a25c.png)




### Motivation and Context
Updates to latest QNN SDK version, and allows testing different QNN SDK versions without modifying yaml files.