### PR TITLE
enable cache in orttraining-mac-ci

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
@@ -4,3 +4,4 @@ jobs:
     AllowReleasedOpsetOnly: 0
     BuildForAllArchs: false
     AdditionalBuildFlags: --enable_training
+    WithCache: true


### PR DESCRIPTION
### Description
enable compilation cache  in orttraining-mac-ci

### Motivation and Context
The workflow duration can be reduced to 12 minutes from about 100 minutes at best.
https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=911536&view=results

