### PR TITLE
Address issue with uninitialized variable

### DIFF
--- a/orttraining/orttraining/training_api/module.cc
+++ b/orttraining/orttraining/training_api/module.cc
@@ -148,8 +148,7 @@ Module::Module(const std::string& train_model_path_or_bytes,
                const Environment& env,
                const std::vector<std::shared_ptr<IExecutionProvider>>& providers,
                const std::optional<std::string>& eval_model_path_or_bytes)
-    : named_parameters_{named_parameters} {
-
+    : named_parameters_{named_parameters}, eval_user_input_count_(0) {
   // Enforce weight prepacking is disabled
   // If user explicitly enabled weight prepacking then return error.
   // Default value is enabled. Therefore, explicitly disable it if the value is not set by user.

--- a/orttraining/orttraining/training_api/module.cc
+++ b/orttraining/orttraining/training_api/module.cc
@@ -148,7 +148,7 @@ Module::Module(const std::string& train_model_path_or_bytes,
                const Environment& env,
                const std::vector<std::shared_ptr<IExecutionProvider>>& providers,
                const std::optional<std::string>& eval_model_path_or_bytes)
-    : named_parameters_{named_parameters}, eval_user_input_count_(0) {
+    : named_parameters_{named_parameters} {
   // Enforce weight prepacking is disabled
   // If user explicitly enabled weight prepacking then return error.
   // Default value is enabled. Therefore, explicitly disable it if the value is not set by user.

--- a/orttraining/orttraining/training_api/module.h
+++ b/orttraining/orttraining/training_api/module.h
@@ -135,8 +135,8 @@ struct Module {
   bool accumulate_gradient_ = false;
   const std::unordered_map<std::string, std::shared_ptr<Parameter>>& named_parameters_;
   std::string eval_model_path_;
-  size_t train_user_input_count_;
-  size_t eval_user_input_count_;
+  size_t train_user_input_count_ = 0U;
+  size_t eval_user_input_count_ = 0U;
 };
 
 }  // namespace api


### PR DESCRIPTION
` eval_user_input_count_` was uninitialized when eval model was not provided by the user and upon calling `GetEvalModelInputCount` returned this uninitialized value.

This caused the error: `libc++abi: terminating with uncaught exception of type std::out_of_range: vector` when the eval input name was queried by the user based on the uninitialized eval input count from the earlier call.

This PR fixes that.

Thanks to @Craigacp for helping identify the problem.