### PR TITLE
Re-enable react native e2e android unit test for CI and upgrade targetSDK level for test project

### DIFF
--- a/js/react_native/android/gradle.properties
+++ b/js/react_native/android/gradle.properties
@@ -16,4 +16,4 @@ android.useAndroidX=true
 OnnxruntimeModule_buildToolsVersion=29.0.2
 OnnxruntimeModule_compileSdkVersion=31
 OnnxruntimeModule_minSdkVersion=21
-OnnxruntimeModule_targetSdkVersion=29
+OnnxruntimeModule_targetSdkVersion=31

--- a/js/react_native/e2e/android/build.gradle
+++ b/js/react_native/e2e/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
         compileSdkVersion = 31
-        targetSdkVersion = 29
+        targetSdkVersion = 31
     }
     repositories {
         google()

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -129,7 +129,7 @@ jobs:
   - script: |
       python3 tools/python/run_android_emulator.py \
         --android-sdk-root $(ANDROID_SDK_ROOT) \
-        --create-avd --system-image "system-images;android-31;default;x86_64" \
+        --create-avd --system-image "system-images;android-30;default;x86_64" \
         --start --emulator-extra-args="-partition-size 4096" \
         --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
     displayName: Start Android Emulator
@@ -210,39 +210,39 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/ios'
     displayName: Pod install for onnxruntime react native ios e2e tests
 
-  #- script: |
-  #    keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -storepass android \
-  #      -keypass android -keyalg RSA -keysize 2048 -validity 999999 -dname "CN=Android Debug,O=Android,C=US"
-  #  workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
-  #  displayName: Generate a debug keystore
+  - script: |
+     keytool -genkey -v -keystore debug.keystore -alias androiddebugkey -storepass android \
+       -keypass android -keyalg RSA -keysize 2048 -validity 999999 -dname "CN=Android Debug,O=Android,C=US"
+    workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
+    displayName: Generate a debug keystore
 
-  #- task: CopyFiles@2
-  #  inputs:
+  - task: CopyFiles@2
+    inputs:
       # Mobile build:
       #  sourceFolder: $(Build.BinariesDirectory)/android-mobile-aar
       #  contents: onnxruntime-mobile-*.aar
-  #    sourceFolder: $(Build.BinariesDirectory)/android-full-aar
-  #    contents: onnxruntime-*.aar
-  #    targetFolder: $(Build.SourcesDirectory)/js/react_native/e2e/android/app/libs
-  #  displayName: Copy Android package to Android e2e test directory
+     sourceFolder: $(Build.BinariesDirectory)/android-full-aar
+     contents: onnxruntime-*.aar
+     targetFolder: $(Build.SourcesDirectory)/js/react_native/e2e/android/app/libs
+    displayName: Copy Android package to Android e2e test directory
 
-  #- template: android-dump-logs-from-steps.yml
-  #  parameters:
-  #    steps:
-  #    - task: Gradle@3
-  #      inputs:
-  #        gradleWrapperFile: '$(Build.SourcesDirectory)/js/react_native/e2e/android/gradlew'
-  #        workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
-  #        options: '--stacktrace'
-  #        tasks: ':app:connectedDebugAndroidTest'
-  #        publishJUnitResults: true
-  #        testResultsFiles: '**/TEST-*.xml'
-  #        testRunTitle: 'React Native Android e2e Test results'
-  #        javaHomeOption: 'path'
-  #        jdkDirectory: '$(JAVA_HOME_11_X64)'
-  #        sonarQubeRunAnalysis: false
-  #        spotBugsAnalysis: false
-  #      displayName: Run React Native Android e2e Tests
+  - template: android-dump-logs-from-steps.yml
+    parameters:
+     steps:
+     - task: Gradle@3
+       inputs:
+         gradleWrapperFile: '$(Build.SourcesDirectory)/js/react_native/e2e/android/gradlew'
+         workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/android'
+         options: '--stacktrace'
+         tasks: ':app:connectedDebugAndroidTest'
+         publishJUnitResults: true
+         testResultsFiles: '**/TEST-*.xml'
+         testRunTitle: 'React Native Android e2e Test results'
+         javaHomeOption: 'path'
+         jdkDirectory: '$(JAVA_HOME_11_X64)'
+         sonarQubeRunAnalysis: false
+         spotBugsAnalysis: false
+       displayName: Run React Native Android e2e Tests
 
   - script: |
       export FORCE_BUNDLING=1


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Re-enable the react native e2e android unit test for react native CI as recent change of specifying `default` instead of `google-apis` in android emulator CI tests gives pretty stable result for now. 

Upgrade the targetSDKversion for gradle test project in react-native/android to meet minimum target api level requirement for Google Play apps.

https://support.google.com/googleplay/android-developer/answer/11926878?hl=en

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

React Native CI issue.

