### PR TITLE
[CUDA] Optimize Perf for AtomicAdd of Half Type

### DIFF
--- a/onnxruntime/core/providers/rocm/atomic/common.cuh
+++ b/onnxruntime/core/providers/rocm/atomic/common.cuh
@@ -52,5 +52,12 @@ __device__ __forceinline__ void atomic_add(BFloat16* address, BFloat16 value) {
   } while (assumed != old);
 }
 
+// This function is added to speed up atomic add for half/bf16 type on CUDA. For ROCM, use default implementation.
+template <typename T>
+__device__ __forceinline__ void AtomicAdd(T *start_addr, size_t index, const size_t numel, T value) {
+  ORT_UNUSED_PARAMETER(numel);
+  atomic_add(start_addr + index, value);
+}
+
 }  // namespace rocm
 }  // namespace onnxruntime


### PR DESCRIPTION
CUDA's atomicAdd for half and bf16 is very slow. This PR uses __half2 as internal type to reimplement the atomic_add for half type on CUDA, which is much faster than the old implementation.

Take DebertaV2 model as example, the GatherElementsGrad kernel calls atomic_add a lot. Running this model on 1 V100 with batch size 2. For PyTorch, the gather_elements_grad kernel takes ~700-800 us for each single kernel, our old ORT implementation takes ~12-13 ms, after the change, it takes ~600-700 us, which is nearly 20x faster than the old implementation.

For the step time of the whole model running, PT is ~200 ms, old ORT impl is ~330 ms, the new impl is ~190 ms. The old impl is much slower than PT, now we are faster than PT.