### PR TITLE
Transpose optimizer issue which could end up inserting a lot more Transpose nodes

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -894,6 +894,14 @@ static CostCheckResult
 PostLayoutTransformCostCheck(const api::GraphRef& graph, const api::NodeRef& node,
                              const std::vector<int64_t>& perm,
                              const std::unordered_set<std::string>& outputs_leading_to_transpose) {
+#ifdef USE_QNN
+  //  2, 3 dimension Transpose can also idienfied as layout transpose node, e.g perm [0, 2, 1]
+  //  Qnn layout sensitive ops doesn't support < 2D, exclude if perm rank < 4
+  if (perm.size() < 4) {
+    return CostCheckResult::kFallThrough;
+  }
+#endif
+
   // we aggressively push the layout transpose nodes
   if (perm == ChannelFirstToLastPerm(perm.size()) ||
       perm == ChannelLastToFirstPerm(perm.size())) {

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -231,7 +231,12 @@ static bool IsIdentityPerm(const std::vector<int64_t>& perm) {
 // Computes permutation from channel last to channel first ordering of given rank. Nearly all handlers work for any
 // permutation, but some are restricted. Also used for layout transformation.
 std::vector<int64_t> ChannelLastToFirstPerm(size_t rank) {
-  if (rank < 2) {
+  size_t rank_limit = 2;
+#ifdef USE_QNN
+  // Qnn layout sensitive ops doesn't support < 2D, exclude Transpose with perm like [0, 2, 1]
+  rank_limit = 4;
+#endif
+  if (rank < rank_limit) {
     return {};
   }
 

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -231,12 +231,7 @@ static bool IsIdentityPerm(const std::vector<int64_t>& perm) {
 // Computes permutation from channel last to channel first ordering of given rank. Nearly all handlers work for any
 // permutation, but some are restricted. Also used for layout transformation.
 std::vector<int64_t> ChannelLastToFirstPerm(size_t rank) {
-  size_t rank_limit = 2;
-#ifdef USE_QNN
-  // Qnn layout sensitive ops doesn't support < 2D, exclude Transpose with perm like [0, 2, 1]
-  rank_limit = 4;
-#endif
-  if (rank < rank_limit) {
+  if (rank < 2) {
     return {};
   }
 


### PR DESCRIPTION
### Description
Fix issue in Transpose optimizer that it could insert a lot more Transpose nodes

### Motivation and Context
Take the example below:
![image](https://user-images.githubusercontent.com/29932710/224472080-d6e5b502-56cc-472f-a68f-3840abfc0efd.png)
There's GlobalAveragePool op in the graph which is layout sensitive. So LayoutTransformer will insert Transpose nodes around it. Then it will apply Transpose Optimizer. 
Transpose Optimizer find the Transpose node (perm [0, 2, 1]) between Add and Concat, and identify it as layout transpose and try to optimize it around Concat (remove it and insert extra transpose on all other inputs & outputs). This is tend to optimize it further with the Transpose nodes inserted around GlobalAveragePool. But it's wrong because GlobalAveragePool is 4 dimensional data, however this Transpose (perm [0, 2, 1]) is 3 dimensional.

It's a big challenge for Transpose Optimizer to do a perfect job to identify this issue. Here we exclude this case for Qnn EP since Qnn layout sensitive Op only support > 2D. So directly exclude Transpose with perm rank < 4.