### PR TITLE
Fix API docs deploy so that a PR is not required

### DIFF
--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - java
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -44,3 +44,4 @@ jobs:
           branch: gh-pages
           folder: java/build/docs/javadoc
           target-folder: docs/api/java
+          clean: true

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Get source commit
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          clean: false
       - name: Log source commit
         run: echo $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
       - name: Deploy

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: gh-pages
           clean: false
-      - name: Log commit docs were generated from
+      - name: Log source commit
         run: echo $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -29,15 +29,9 @@ jobs:
         with:
           ref: gh-pages
           clean: false
-      - name: Move API docs into target area
-        run: |
-          rm -rf docs/api/java
-          mv java/build/docs/javadoc docs/api/java
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+      - name: Java API docs artifact
+        uses: actions/upload-artifact@v3
         with:
-          branch: gh-pages-pr
-          base: gh-pages
-          title: '[Automated]: Update Java API docs'
-          commit-message: 'Update Java API docs to commit ${{ steps.vars.outputs.sha_short }}'
-          add-paths: docs/api/java
+          name: java-apidocs-${{ steps.vars.outputs.sha_short }}
+          path: |
+            java/build/docs/javadoc

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: java/build/docs/javadoc
           branch: gh-pages
-          target: docs/api/java
+          folder: java/build/docs/javadoc
+          target-folder: docs/api/java

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -29,13 +29,9 @@ jobs:
           build-root-directory: java
           gradle-executable: java/gradlew
           arguments: javadoc
-      - name: Set commit ID
+      - name: Get source commit
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          clean: false
       - name: Log source commit
         run: echo $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
       - name: Deploy

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: "apidocs-java"
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -32,12 +32,8 @@ jobs:
         with:
           ref: gh-pages
           clean: false
-      - name: Java API docs artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: java-apidocs-${{ steps.vars.outputs.sha_short }}
-          path: |
-            java/build/docs/javadoc
+      - name: Log commit docs were generated from
+        run: cat $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -5,6 +5,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Generate Java docs
@@ -35,3 +38,9 @@ jobs:
           name: java-apidocs-${{ steps.vars.outputs.sha_short }}
           path: |
             java/build/docs/javadoc
+      - name: Deploy
+        uses: JamesIves/github-deploy-action@v4
+        with:
+          folder: java/build/docs/javadoc
+          branch: gh-pages
+          target: docs/api/java

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -33,7 +33,7 @@ jobs:
           ref: gh-pages
           clean: false
       - name: Log commit docs were generated from
-        run: cat $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
+        run: echo $(git rev-parse --short HEAD) > java/build/docs/javadoc/version.txt
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/publish-java-apidocs.yml
+++ b/.github/workflows/publish-java-apidocs.yml
@@ -39,7 +39,7 @@ jobs:
           path: |
             java/build/docs/javadoc
       - name: Deploy
-        uses: JamesIves/github-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: java/build/docs/javadoc
           branch: gh-pages


### PR DESCRIPTION
Fixes this [issue](https://github.com/microsoft/onnxruntime/actions/runs/4387534694/jobs/7682945415#step:12:534) and removes the extra PR step in the workflow.

Also logs the commit of the main branch that the docs were generated from to a file called version.txt at the root of the API docs tree.

Tested for Java API docs and results staged here: https://natke.github.io/onnxruntime/docs/api/java/index.html

If approved, I can migrate all of the other API docs generation workflows to use this scheme.