### PR TITLE
Print value errors in ort.InferenceSession to user

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -364,9 +364,9 @@ class InferenceSession(Session):
 
         try:
             self._create_inference_session(providers, provider_options, disabled_optimizers)
-        except ValueError:
+        except ValueError as e:
             if self._enable_fallback:
-                print("EP Error using {}".format(providers))
+                print("EP Error '{}' when using {}".format(e, providers))
                 print("Falling back to {} and retrying.".format(self._fallback_providers))
                 self._create_inference_session(self._fallback_providers, None)
                 # Fallback only once.


### PR DESCRIPTION
### Description

When fallback is enabled during InferenceSession creation, but there is an error in the session_opts or provider_opts, the Inference session will simply fallback to other providers. 
This will hide such simple to fix errors:
```
EP Error 'provider_options' values must be dicts. when using ['TensorrtExecutionProvider']
Falling back to ['CUDAExecutionProvider', 'CPUExecutionProvider'] and retrying.
```
Linked issue: #12639