### PR TITLE
FasterTransformer model wrapper using custom op

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -500,25 +500,12 @@ if (onnxruntime_USE_CUDA)
 
     set(FT_VIT_LIBS 
       ${onnxruntime_FT_HOME}/build/lib/libViTINT8.so
-      #${onnxruntime_FT_HOME}/build/lib/libViTINT8.a
       ${onnxruntime_FT_HOME}/build/lib/libtrt_fused_multi_head_attention.a 
       ${onnxruntime_FT_HOME}/build/lib/libvit_kernels.a 
       ${onnxruntime_FT_HOME}/build/lib/libcublasINT8MMWrapper.a 
       ${onnxruntime_FT_HOME}/build/lib/libnvtx_utils.a 
       ${onnxruntime_FT_HOME}/build/lib/libmemory_utils.a
       ${onnxruntime_FT_HOME}/build/lib/libcuda_utils.a
-
-
-      #${onnxruntime_FT_HOME}/build/lib/libtensor.a
-      #${onnxruntime_FT_HOME}/build/lib/libadd_residual_kernels.a
-      #${onnxruntime_FT_HOME}/build/lib/libbert_preprocess_kernels.a
-      #${onnxruntime_FT_HOME}/build/lib/liblayernorm_int8_kernels.a
-      #${onnxruntime_FT_HOME}/build/lib/liblayernorm_kernels.a
-      #${onnxruntime_FT_HOME}/build/lib/liblayout_transformer_int8_kernels.a
-      #${onnxruntime_FT_HOME}/build/lib/libUnfusedAttentionLayerINT8.a
-      #${onnxruntime_FT_HOME}/build/lib/libUnfusedAttentionLayer.a
-      #${onnxruntime_FT_HOME}/build/lib/libFusedAttentionLayerINT8.a
-      #${onnxruntime_FT_HOME}/build/lib/libFusedAttentionLayer.a
     )
     MESSAGE(STATUS "FT ViT libs: ${FT_VIT_LIBS}")
     target_link_libraries(custom_op_ft_wrapper_library PRIVATE ${FT_VIT_LIBS} cublas cublasLt cudart cudnn m)
@@ -526,7 +513,6 @@ if (onnxruntime_USE_CUDA)
     string(CONCAT ONNXRUNTIME_CUSTOM_OP_FT_WRAPPER_LIB_LINK_FLAG
            "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/custom_ops/cuda/ft_custom_op_lib.lds "
            "-Xlinker --gc-sections -z noexecstack")
-           #"-Xlinker --no-undefined -Xlinker --gc-sections -z noexecstack")
 
     set_property(TARGET custom_op_ft_wrapper_library APPEND_STRING PROPERTY LINK_FLAGS ${ONNXRUNTIME_CUSTOM_OP_FT_WRAPPER_LIB_LINK_FLAG})
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable")

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -376,6 +376,9 @@ if (onnxruntime_USE_CUDA)
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_cuda_cc_srcs} ${onnxruntime_providers_cuda_shared_srcs} ${onnxruntime_providers_cuda_cu_srcs})
   set(onnxruntime_providers_cuda_src ${onnxruntime_providers_cuda_cc_srcs} ${onnxruntime_providers_cuda_shared_srcs} ${onnxruntime_providers_cuda_cu_srcs})
 
+  include_directories("/home/azureuser/repos/FasterTransformer")
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable")
+
   # disable contrib ops conditionally
   if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
     if (NOT onnxruntime_ENABLE_ATEN)
@@ -485,6 +488,59 @@ if (onnxruntime_USE_CUDA)
   endif()
 
   add_dependencies(onnxruntime_providers_cuda onnxruntime_providers_shared ${onnxruntime_EXTERNAL_DEPENDENCIES})
+
+  set(FT_VIT_LIBS 
+      # vit_example deps
+      /home/azureuser/repos/FasterTransformer/build/lib/libViTINT8.so
+      /home/azureuser/repos/FasterTransformer/build/lib/libtrt_fused_multi_head_attention.a 
+      /home/azureuser/repos/FasterTransformer/build/lib/libvit_kernels.a 
+      /home/azureuser/repos/FasterTransformer/build/lib/libcublasINT8MMWrapper.a 
+      /home/azureuser/repos/FasterTransformer/build/lib/libnvtx_utils.a 
+      /home/azureuser/repos/FasterTransformer/build/lib/libmemory_utils.a
+      /home/azureuser/repos/FasterTransformer/build/lib/libcuda_utils.a
+
+      ## ViTINT8 deps
+      #/home/azureuser/repos/FasterTransformer/build/lib/libUnfusedAttentionLayerINT8.a
+      #/home/azureuser/repos/FasterTransformer/build/lib/libFusedAttentionLayerINT8.a
+      #/home/azureuser/repos/FasterTransformer/build/lib/libFfnLayerINT8.a 
+      #/home/azureuser/repos/FasterTransformer/build/lib/liblayernorm_kernels.a
+      #/home/azureuser/repos/FasterTransformer/build/lib/liblayernorm_int8_kernels.a
+
+      ## Ffnlayer deps
+      #/home/azureuser/repos/FasterTransformer/build/lib/libtensor.a
+      #/home/azureuser/repos/FasterTransformer/build/lib/libmoe_kernels.a
+
+      #/home/azureuser/repos/FasterTransformer/build/lib/libunfused_attention_int8_kernels.a
+  )
+  MESSAGE(STATUS "FT VIT libs: ${FT_VIT_LIBS}")
+
+  file(GLOB_RECURSE onnxruntime_custom_op_ft_wrapper_srcs
+       "${ONNXRUNTIME_ROOT}/custom_ops/cuda/*.cc"
+       "${ONNXRUNTIME_ROOT}/custom_ops/cuda/*.h"
+  )
+
+  #file(GLOB_RECURSE all_ft_static_libs 
+      #"/home/azureuser/repos/FasterTransformer/build/lib/lib*.a"
+  #)
+  #MESSAGE(STATUS "FT VIT libs: ${all_ft_static_libs}")
+
+  onnxruntime_add_shared_library_module(custom_op_ft_wrapper_library ${onnxruntime_custom_op_ft_wrapper_srcs})
+  target_include_directories(custom_op_ft_wrapper_library PRIVATE ${ONNXRUNTIME_ROOT}/include/onnxruntime/core/session 
+                                                                  /home/azureuser/FasterTransformer
+                                                                  ${onnxruntime_CUDNN_HOME}/include
+                                                                  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+  target_link_libraries(custom_op_ft_wrapper_library PRIVATE ${FT_VIT_LIBS} cublas cublasLt cudart cudnn m)
+  #target_link_libraries(custom_op_ft_wrapper_library PRIVATE ${all_ft_static_libs} cublas cublasLt cudart cudnn m)
+
+  string(CONCAT ONNXRUNTIME_CUSTOM_OP_FT_WRAPPER_LIB_LINK_FLAG
+         "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/custom_ops/cuda/ft_custom_op_lib.lds "
+         #"-Xlinker --no-undefined -Xlinker --gc-sections -z noexecstack")
+         "-Xlinker --gc-sections -z noexecstack")
+
+  set_property(TARGET custom_op_ft_wrapper_library APPEND_STRING PROPERTY LINK_FLAGS
+               ${ONNXRUNTIME_CUSTOM_OP_FT_WRAPPER_LIB_LINK_FLAG})
+
   target_link_libraries(onnxruntime_providers_cuda PRIVATE cublasLt cublas cudnn curand cufft ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
   if(onnxruntime_CUDNN_HOME)
     target_include_directories(onnxruntime_providers_cuda PRIVATE ${onnxruntime_CUDNN_HOME}/include)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -500,12 +500,25 @@ if (onnxruntime_USE_CUDA)
 
     set(FT_VIT_LIBS 
       ${onnxruntime_FT_HOME}/build/lib/libViTINT8.so
+      #${onnxruntime_FT_HOME}/build/lib/libViTINT8.a
       ${onnxruntime_FT_HOME}/build/lib/libtrt_fused_multi_head_attention.a 
       ${onnxruntime_FT_HOME}/build/lib/libvit_kernels.a 
       ${onnxruntime_FT_HOME}/build/lib/libcublasINT8MMWrapper.a 
       ${onnxruntime_FT_HOME}/build/lib/libnvtx_utils.a 
       ${onnxruntime_FT_HOME}/build/lib/libmemory_utils.a
       ${onnxruntime_FT_HOME}/build/lib/libcuda_utils.a
+
+
+      #${onnxruntime_FT_HOME}/build/lib/libtensor.a
+      #${onnxruntime_FT_HOME}/build/lib/libadd_residual_kernels.a
+      #${onnxruntime_FT_HOME}/build/lib/libbert_preprocess_kernels.a
+      #${onnxruntime_FT_HOME}/build/lib/liblayernorm_int8_kernels.a
+      #${onnxruntime_FT_HOME}/build/lib/liblayernorm_kernels.a
+      #${onnxruntime_FT_HOME}/build/lib/liblayout_transformer_int8_kernels.a
+      #${onnxruntime_FT_HOME}/build/lib/libUnfusedAttentionLayerINT8.a
+      #${onnxruntime_FT_HOME}/build/lib/libUnfusedAttentionLayer.a
+      #${onnxruntime_FT_HOME}/build/lib/libFusedAttentionLayerINT8.a
+      #${onnxruntime_FT_HOME}/build/lib/libFusedAttentionLayer.a
     )
     MESSAGE(STATUS "FT ViT libs: ${FT_VIT_LIBS}")
     target_link_libraries(custom_op_ft_wrapper_library PRIVATE ${FT_VIT_LIBS} cublas cublasLt cudart cudnn m)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -517,10 +517,6 @@ if (onnxruntime_USE_CUDA)
 
     set_property(TARGET custom_op_ft_wrapper_library APPEND_STRING PROPERTY LINK_FLAGS ${ONNXRUNTIME_CUSTOM_OP_FT_WRAPPER_LIB_LINK_FLAG})
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable")
-    
-    if (onnxruntime_FT_ENABLE_WEIGHTS_COPY)
-      add_definitions(-DFT_ENABLE_WEIGHTS_COPY=1)
-    endif()
   endif()
 
   target_link_libraries(onnxruntime_providers_cuda PRIVATE cublasLt cublas cudnn curand cufft ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)

--- a/include/onnxruntime/core/framework/op_kernel_info.h
+++ b/include/onnxruntime/core/framework/op_kernel_info.h
@@ -43,7 +43,9 @@ class OpKernelInfo : public OpNodeProtoHelper<ProtoHelperNodeContext> {
 
   const onnxruntime::Node& node() const noexcept;
 
+  bool IsConstantInput(int input_index) const;
   bool TryGetConstantInput(int input_index, const Tensor** constant_input_value) const;
+  bool TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const;
 
  private:
   ORT_DISALLOW_MOVE(OpKernelInfo);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3956,6 +3956,21 @@ struct OrtApi {
    */
   void(ORT_API_CALL* ReleaseDnnlProviderOptions)(_Frees_ptr_opt_ OrtDnnlProviderOptions* input);
 
+  /** \brief Get a ::OrtValue tensor stored as a constant initializer in the graph node.
+   *
+   * Used in the CreateKernel callback of an OrtCustomOp to get a tensor value.
+   *
+   * \param[in] info ::OrtKernelInfo instance.
+   * \param[in] index The node index.
+   * \param[out] is_constant Is it a constant node input or not.
+   * \param[out] out The OrtValue tensor value. 
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.15.
+   */
+  ORT_API2_STATUS(KernelInfoGetConstantInput_tensor, _In_ const OrtKernelInfo* info, size_t index, _Out_ int* is_constant, _Outptr_ const OrtValue** out); 
+
 #ifdef __cplusplus
   OrtApi(const OrtApi&) = delete;  // Prevent users from accidentally copying the API structure, it should always be passed as a pointer
 #endif

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1552,6 +1552,8 @@ struct KernelInfoImpl : Base<T> {
 
   TypeInfo GetInputTypeInfo(size_t index) const;
   TypeInfo GetOutputTypeInfo(size_t index) const;
+
+  ConstValue GetTensorConstantInput(size_t index, int* is_constant) const;
 };
 
 }  // namespace detail

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1542,6 +1542,13 @@ inline Value KernelInfoImpl<T>::GetTensorAttribute(const char* name, OrtAllocato
   return Value{out};
 }
 
+template <typename T>
+inline ConstValue KernelInfoImpl<T>::GetTensorConstantInput(size_t index, int* is_constant) const {
+  const OrtValue* out = nullptr;
+  ThrowOnError(GetApi().KernelInfoGetConstantInput_tensor(this->p_, index, is_constant, &out));
+  return ConstValue{out};
+}
+
 inline void attr_utils::GetAttr(const OrtKernelInfo* p, const char* name, float& out) {
   Ort::ThrowOnError(GetApi().KernelInfoGetAttribute_float(p, name, &out));
 }

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -105,6 +105,41 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constan
 }
 */
 
+bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
+  if (OpKernelInfo::IsConstantInput(input_index)) {
+
+    //// Chi debug ...
+    //if (input_index == 1) {
+        //std::cout << "In OpKernelInfo::TryGetConstantInput ..." << std::endl;
+        //const OrtValue* p_ort_value = &constant_initialized_tensors_.at(input_index);
+        //std::cout << "p_ort_value" << std::endl;
+        //std::cout << p_ort_value << std::endl;
+        //const Tensor* p_tensor = &constant_initialized_tensors_.at(input_index).Get<Tensor>(); 
+        //std::cout << "p_tensor" << std::endl;
+        //std::cout << p_tensor << std::endl;
+
+        //const void* input_data = p_tensor->DataRaw(); 
+        //const float* p_input_data = reinterpret_cast<const float*>(input_data);
+        //std::cout << "p_input_data" << std::endl;
+        //std::cout << p_input_data << std::endl;
+        //std::cout << "p_input_data[0]" << std::endl;
+        //std::cout << p_input_data[0] << std::endl;
+    //}
+
+    *constant_input_value = &constant_initialized_tensors_.at(input_index);
+    return true;
+  }
+  return false;
+}
+
+bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_input_value) const {
+  if (OpKernelInfo::IsConstantInput(input_index)) {
+    *constant_input_value  = &constant_initialized_tensors_.at(input_index).Get<Tensor>();
+    return true;
+  }
+  return false;
+}
+
 bool OpKernelInfo::IsConstantInput(int input_index) const {
   if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
     return false;
@@ -128,19 +163,4 @@ bool OpKernelInfo::IsConstantInput(int input_index) const {
   return true;
 }
 
-bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
-  if (OpKernelInfo::IsConstantInput(input_index)) {
-    *constant_input_value = &constant_initialized_tensors_.at(input_index);
-    return true;
-  }
-  return false;
-}
-
-bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_input_value) const {
-  if (OpKernelInfo::IsConstantInput(input_index)) {
-    *constant_input_value  = &constant_initialized_tensors_.at(input_index).Get<Tensor>();
-    return true;
-  }
-  return false;
-}
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -107,25 +107,6 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constan
 
 bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
   if (OpKernelInfo::IsConstantInput(input_index)) {
-
-    //// Chi debug ...
-    //if (input_index == 1) {
-        //std::cout << "In OpKernelInfo::TryGetConstantInput ..." << std::endl;
-        //const OrtValue* p_ort_value = &constant_initialized_tensors_.at(input_index);
-        //std::cout << "p_ort_value" << std::endl;
-        //std::cout << p_ort_value << std::endl;
-        //const Tensor* p_tensor = &constant_initialized_tensors_.at(input_index).Get<Tensor>(); 
-        //std::cout << "p_tensor" << std::endl;
-        //std::cout << p_tensor << std::endl;
-
-        //const void* input_data = p_tensor->DataRaw(); 
-        //const float* p_input_data = reinterpret_cast<const float*>(input_data);
-        //std::cout << "p_input_data" << std::endl;
-        //std::cout << p_input_data << std::endl;
-        //std::cout << "p_input_data[0]" << std::endl;
-        //std::cout << p_input_data[0] << std::endl;
-    //}
-
     *constant_input_value = &constant_initialized_tensors_.at(input_index);
     return true;
   }

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -54,57 +54,6 @@ const onnxruntime::Node& OpKernelInfo::node() const noexcept {
   return node_;
 }
 
-/*
-bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_input_value) const {
-  if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
-    return false;
-  }
-  auto& input_arg_name = node_.InputDefs()[input_index]->Name();
-  int input_arg_index = -1;
-  if (!ort_value_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
-    return false;
-  }
-
-  auto iter = constant_initialized_tensors_.find(input_arg_index);
-  if (constant_initialized_tensors_.end() == iter) {
-    return false;
-  }
-
-  if (!iter->second.IsTensor()) {
-    // Only constant Tensor input is supported right now, since we're using initializers to store the data.
-    return false;
-  }
-
-  *constant_input_value = &iter->second.Get<Tensor>();
-  return true;
-}
-
-bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
-  if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
-    return false;
-  }
-  auto& input_arg_name = node_.InputDefs()[input_index]->Name();
-  int input_arg_index = -1;
-  if (!ort_value_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
-    return false;
-  }
-
-  auto iter = constant_initialized_tensors_.find(input_arg_index);
-  if (constant_initialized_tensors_.end() == iter) {
-    return false;
-  }
-
-  if (!iter->second.IsTensor()) {
-    // Only constant Tensor input is supported right now, since we're using initializers to store the data.
-    return false;
-  }
-
-  *constant_input_value = &iter->second;
-  //std::cout << &iter->second << std::endl;
-  return true;
-}
-*/
-
 bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
   if (OpKernelInfo::IsConstantInput(input_index)) {
     *constant_input_value = &constant_initialized_tensors_.at(input_index);

--- a/onnxruntime/core/framework/op_kernel_info.cc
+++ b/onnxruntime/core/framework/op_kernel_info.cc
@@ -54,6 +54,7 @@ const onnxruntime::Node& OpKernelInfo::node() const noexcept {
   return node_;
 }
 
+/*
 bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_input_value) const {
   if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
     return false;
@@ -76,5 +77,70 @@ bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_
 
   *constant_input_value = &iter->second.Get<Tensor>();
   return true;
+}
+
+bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
+  if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
+    return false;
+  }
+  auto& input_arg_name = node_.InputDefs()[input_index]->Name();
+  int input_arg_index = -1;
+  if (!ort_value_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
+    return false;
+  }
+
+  auto iter = constant_initialized_tensors_.find(input_arg_index);
+  if (constant_initialized_tensors_.end() == iter) {
+    return false;
+  }
+
+  if (!iter->second.IsTensor()) {
+    // Only constant Tensor input is supported right now, since we're using initializers to store the data.
+    return false;
+  }
+
+  *constant_input_value = &iter->second;
+  //std::cout << &iter->second << std::endl;
+  return true;
+}
+*/
+
+bool OpKernelInfo::IsConstantInput(int input_index) const {
+  if (input_index < 0 || input_index >= gsl::narrow_cast<int>(node_.InputDefs().size())) {
+    return false;
+  }
+  auto& input_arg_name = node_.InputDefs()[input_index]->Name();
+  int input_arg_index = -1;
+  if (!ort_value_name_idx_map_.GetIdx(input_arg_name, input_arg_index).IsOK()) {
+    return false;
+  }
+
+  auto iter = constant_initialized_tensors_.find(input_arg_index);
+  if (constant_initialized_tensors_.end() == iter) {
+    return false;
+  }
+
+  if (!iter->second.IsTensor()) {
+    // Only constant Tensor input is supported right now, since we're using initializers to store the data.
+    return false;
+  }
+
+  return true;
+}
+
+bool OpKernelInfo::TryGetConstantInput(int input_index, const OrtValue** constant_input_value) const {
+  if (OpKernelInfo::IsConstantInput(input_index)) {
+    *constant_input_value = &constant_initialized_tensors_.at(input_index);
+    return true;
+  }
+  return false;
+}
+
+bool OpKernelInfo::TryGetConstantInput(int input_index, const Tensor** constant_input_value) const {
+  if (OpKernelInfo::IsConstantInput(input_index)) {
+    *constant_input_value  = &constant_initialized_tensors_.at(input_index).Get<Tensor>();
+    return true;
+  }
+  return false;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -54,15 +54,6 @@ ORT_API_STATUS_IMPL(OrtApis::KernelContext_GetOutputCount, _In_ const OrtKernelC
 ORT_API_STATUS_IMPL(OrtApis::KernelContext_GetInput, _In_ const OrtKernelContext* context, _In_ size_t index, _Out_ const OrtValue** out) {
   API_IMPL_BEGIN
   *out = reinterpret_cast<const OrtValue*>(reinterpret_cast<const onnxruntime::OpKernelContextInternal*>(context)->GetInputMLValue(index));
-  const OrtValue* value = *out;
-  const onnxruntime::Tensor& tensor = value->Get<onnxruntime::Tensor>();
-  const void* input_data = tensor.DataRaw(); 
-  const float* p_input_data = reinterpret_cast<const float*>(input_data);
-  //std::cout << "OrtApis::KernelContext_GetInput" << std::endl;
-  //std::cout << "p_input_data" << std::endl;
-  //std::cout << p_input_data << std::endl;
-  //std::cout << "p_input_data[0]" << std::endl;
-  //std::cout << p_input_data[0] << std::endl;
   return nullptr;
   API_IMPL_END
 };
@@ -292,33 +283,10 @@ ORT_API_STATUS_IMPL(OrtApis::KernelInfoGetConstantInput_tensor, _In_ const OrtKe
                     _Out_ int* is_constant, _Outptr_ const OrtValue** out) {
   API_IMPL_BEGIN
   const auto* op_info = reinterpret_cast<const onnxruntime::OpKernelInfo*>(info);
-  //const OrtValue* value;
   *is_constant = static_cast<int>(op_info->TryGetConstantInput(index, out));
-  //*is_constant = static_cast<int>(op_info->TryGetConstantInput(index, &value));
-  //if (index > 0) {
-      //std::cout << "In OrtApis::KernelInfoGetConstantInput_tensor" << std::endl;
-      ////const OrtValue* value = *out;
-      //std::cout << value << std::endl;
-      //const onnxruntime::Tensor& tensor = value->Get<onnxruntime::Tensor>();
-      //std::cout << "In OrtApis::KernelInfoGetConstantInput_tensor" << std::endl;
-      //const void* input_data = tensor.DataRaw(); 
-      //std::cout << "In OrtApis::KernelInfoGetConstantInput_tensor" << std::endl;
-      //const float* p_input_data = reinterpret_cast<const float*>(input_data);
-      //std::cout << "p_input_data" << std::endl;
-      //std::cout << p_input_data << std::endl;
-      //std::cout << "p_input_data[0]" << std::endl;
-      //std::cout << p_input_data[0] << std::endl;
-  //}
   return nullptr;
   API_IMPL_END
 };
-
-//ORT_API_STATUS_IMPL(OrtApis::KernelContext_GetInput, _In_ const OrtKernelContext* context, _In_ size_t index, _Out_ const OrtValue** out) {
-  //API_IMPL_BEGIN
-  //*out = reinterpret_cast<const OrtValue*>(reinterpret_cast<const onnxruntime::OpKernelContextInternal*>(context)->GetInputMLValue(index));
-  //return nullptr;
-  //API_IMPL_END
-//};
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 #include "core/framework/customregistry.h"

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -279,6 +279,15 @@ ORT_API_STATUS_IMPL(OrtApis::KernelInfo_GetOutputTypeInfo, _In_ const OrtKernelI
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(OrtApis::KernelInfoGetConstantInput_tensor, _In_ const OrtKernelInfo* info, _In_ size_t index,
+                    _Out_ int* is_constant, _Outptr_ const OrtValue** out) {
+  API_IMPL_BEGIN
+  const auto* op_info = reinterpret_cast<const onnxruntime::OpKernelInfo*>(info);
+  *is_constant = static_cast<int>(op_info->TryGetConstantInput(index, out));
+  return nullptr;
+  API_IMPL_END
+};
+
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 #include "core/framework/customregistry.h"
 namespace onnxruntime {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2697,6 +2697,7 @@ static constexpr OrtApi ort_api_1_to_15 = {
     &OrtApis::UpdateDnnlProviderOptions,
     &OrtApis::GetDnnlProviderOptionsAsString,
     &OrtApis::ReleaseDnnlProviderOptions,
+    &OrtApis::KernelInfoGetConstantInput_tensor,
 };
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -442,4 +442,6 @@ ORT_API_STATUS_IMPL(GetDnnlProviderOptionsAsString, _In_ const OrtDnnlProviderOp
                     _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
 ORT_API(void, ReleaseDnnlProviderOptions, _Frees_ptr_opt_ OrtDnnlProviderOptions*);
 
+ORT_API_STATUS_IMPL(KernelInfoGetConstantInput_tensor, _In_ const OrtKernelInfo* info, _In_ size_t index,
+                    _Out_ int* is_constant, _Outptr_ const OrtValue** out);
 }  // namespace OrtApis

--- a/onnxruntime/custom_ops/cuda/ft_custom_op_lib.cc
+++ b/onnxruntime/custom_ops/cuda/ft_custom_op_lib.cc
@@ -1,23 +1,5 @@
 #include "ft_custom_op_lib.h"
 #include "ft_vit_int8_custom_op.h"
-#include "core/framework/provider_options.h"
-
-//namespace onnxruntime {
-
-//common::Status CreateFTCustomOpDomainList(CUDAExecutionProviderInfo& info) {
-  //std::unique_ptr<OrtProviderCustomOpDomain> custom_op_domain = std::make_unique<OrtProviderCustomOpDomain>();
-  ////custom_op_domain->domain_ = "fastertransformer";
-  //custom_op_domain->domain_ = "trt.plugins";
-
-  //std::unique_ptr<FTViTCustomOp> vit_custom_op = std::make_unique<FTViTCustomOp>(onnxruntime::kCudaExecutionProvider, nullptr);
-  //custom_op_domain->custom_ops_.push_back(vit_custom_op.release());
-  //info.custom_op_domain_list.push_back(custom_op_domain.release());
-
-
-  //return common::Status::OK();
-//}
-
-//}
 
 static const char* c_OpDomain = "fastertransformer";
 constexpr const char* c_ORTCudaExecutionProvider = "CUDAExecutionProvider";
@@ -52,5 +34,4 @@ OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtA
   }
 
   return result;
-
 }

--- a/onnxruntime/custom_ops/cuda/ft_custom_op_lib.cc
+++ b/onnxruntime/custom_ops/cuda/ft_custom_op_lib.cc
@@ -1,0 +1,56 @@
+#include "ft_custom_op_lib.h"
+#include "ft_vit_int8_custom_op.h"
+#include "core/framework/provider_options.h"
+
+//namespace onnxruntime {
+
+//common::Status CreateFTCustomOpDomainList(CUDAExecutionProviderInfo& info) {
+  //std::unique_ptr<OrtProviderCustomOpDomain> custom_op_domain = std::make_unique<OrtProviderCustomOpDomain>();
+  ////custom_op_domain->domain_ = "fastertransformer";
+  //custom_op_domain->domain_ = "trt.plugins";
+
+  //std::unique_ptr<FTViTCustomOp> vit_custom_op = std::make_unique<FTViTCustomOp>(onnxruntime::kCudaExecutionProvider, nullptr);
+  //custom_op_domain->custom_ops_.push_back(vit_custom_op.release());
+  //info.custom_op_domain_list.push_back(custom_op_domain.release());
+
+
+  //return common::Status::OK();
+//}
+
+//}
+
+static const char* c_OpDomain = "fastertransformer";
+constexpr const char* c_ORTCudaExecutionProvider = "CUDAExecutionProvider";
+
+static void AddOrtCustomOpDomain(Ort::CustomOpDomain&& domain) {
+  static std::vector<Ort::CustomOpDomain> ort_custom_op_domain_container;
+  static std::mutex ort_custom_op_domain_mutex;
+  std::lock_guard<std::mutex> lock(ort_custom_op_domain_mutex);
+  ort_custom_op_domain_container.push_back(std::move(domain));
+}
+
+OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api_base) {
+
+  // Allow use of Ort::GetApi() in C++ API implementations.
+  Ort::InitApi(api_base->GetApi(ORT_API_VERSION));
+  Ort::UnownedSessionOptions session_options(options);
+
+  static FTViTINT8CustomOp vit_int_custom_op(c_ORTCudaExecutionProvider, nullptr);
+
+  OrtStatus* result = nullptr;
+
+  try {
+    Ort::CustomOpDomain domain{c_OpDomain};
+    domain.Add(&vit_int_custom_op);
+
+    session_options.Add(domain);
+    AddOrtCustomOpDomain(std::move(domain));
+
+  } catch(const std::exception& e) {
+    Ort::Status status{e};
+    result = status.release();
+  }
+
+  return result;
+
+}

--- a/onnxruntime/custom_ops/cuda/ft_custom_op_lib.h
+++ b/onnxruntime/custom_ops/cuda/ft_custom_op_lib.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <onnxruntime_c_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ORT_EXPORT OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api_base);
+
+#ifdef __cplusplus
+}
+#endif

--- a/onnxruntime/custom_ops/cuda/ft_custom_op_lib.lds
+++ b/onnxruntime/custom_ops/cuda/ft_custom_op_lib.lds
@@ -1,0 +1,6 @@
+VERS_1.0.0 {
+ global:
+  RegisterCustomOps;
+ local:
+    *;
+};

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -112,7 +112,7 @@ FTViTINT8CustomKernel::FTViTINT8CustomKernel(const OrtKernelInfo* info,
                                              int has_cls_token,
                                              int is_fp16,
                                              int int8_mode):
-batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), layer_num_(layer_num), has_cls_token_(has_cls_token), is_fp16_(is_fp16)
+batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is_fp16)
 {
     checkCUDNN(cudnnCreate(&cudnn_handle_));
     checkCUDNN(cudnnSetStream(cudnn_handle_, stream_));
@@ -226,60 +226,6 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), layer_num_(
                 inter_size,
                 int(attention_type_));
 }
-
-//void FTViTINT8CustomKernel::loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const float*>& w)
-//{
-    //Ort::ConstKernelInfo kinfo(info);
-    //std::unordered_map<std::string, Ort::ConstValue> weights_map = {};
-
-    //// Get weights (constant inputs) from kernel info
-    //for (size_t i = 0; i < kinfo.GetInputCount(); i++) {
-        //std::string name = kinfo.GetInputName(i);
-        //int is_constant = 0;
-        //kinfo.GetTensorConstantInput(i, &is_constant);
-        //if (is_constant) {
-            //weights_map[name] = kinfo.GetTensorConstantInput(i, &is_constant); 
-        //}
-    //}
-
-    //// Load weights pointer
-    //long unsigned int idx = 0;
-    //for (auto& name : pre_layer_weight_names) {
-        //if (!(has_cls_token_ > 0) && name == "transformer.embeddings.cls_token") {
-            //continue;
-        //}
-
-        //auto iter = weights_map.find(name);
-        //if (iter != weights_map.end()) {
-            //Ort::ConstValue ort_val = iter->second; 
-            //w[idx++] = ort_val.GetTensorData<float>();
-        //}
-    //}
-
-    //for (int i = 0; i < layer_num_; i++) {
-        //for (auto& name : layer_weight_names) {
-            //char str_buf[1024];
-            //sprintf(str_buf, name, i);
-            //std::string string_buf = str_buf;
-
-            //auto iter = weights_map.find(string_buf);
-            //if (iter != weights_map.end()) {
-                //Ort::ConstValue ort_val = iter->second; 
-                //w[idx++] = ort_val.GetTensorData<float>();
-            //}
-        //}
-    //}
-
-    //for (auto& name : post_layer_weight_names) {
-        //auto iter = weights_map.find(name);
-        //if (iter != weights_map.end()) {
-            //Ort::ConstValue ort_val = iter->second; 
-            //w[idx++] = ort_val.GetTensorData<float>();
-        //}
-    //}
-
-    //FT_CHECK(idx == w.size());
-//}
 
 void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
     Ort::KernelContext kcontext(context);

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+#include "ft_vit_int8_custom_op.h"
+#include "core/framework/provider_options.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include <cuda_profiler_api.h>
+#include <iostream>
+#include <sys/time.h>
+
+using namespace onnxruntime;
+using namespace fastertransformer;
+
+FTViTINT8CustomKernel::FTViTINT8CustomKernel(const OrtKernelInfo* info, void* compute_stream) {
+
+    const int batch_size    = 1;
+    const int img_size      = 224;
+    const int patch_size    = 16;
+    const int embed_dim     = 768;
+    const int head_num      = 12;
+    const int layer_num     = 12;
+    const int has_cls_token = 1;
+    const int is_fp16       = 0;
+    const int int8_mode     = 2;
+
+
+    checkCUDNN(cudnnCreate(&cudnn_handle_));
+    checkCUDNN(cudnnSetStream(cudnn_handle_, stream_));
+    check_cuda_error(cublasCreate(&cublas_handle_));
+    check_cuda_error(cublasSetStream(cublas_handle_, stream_));
+    check_cuda_error(cublasLtCreate(&cublaslt_handle_));
+
+    cublas_algo_map_ = new cublasAlgoMap("igemm_config.in");
+
+    int sm = getSMVersion();
+
+    cublas_wrapper_mutex_ = new std::mutex();
+
+    bool use_ORDER_COL32_2R_4R4 = false;
+#if (CUDART_VERSION >= 11000)
+    if (sm >= 80) {
+        use_ORDER_COL32_2R_4R4 = true;
+    }
+#endif
+
+    cublas_wrapper_ = new cublasINT8MMWrapper(
+        cublas_handle_, cublaslt_handle_, stream_, cublas_algo_map_, cublas_wrapper_mutex_, use_ORDER_COL32_2R_4R4);
+
+    //if (std::is_same<T, half>::value) {
+        //cublas_wrapper->setFP16GemmConfig();
+    //}
+    //else if (std::is_same<T, float>::value) {
+        //cublas_wrapper->setFP32GemmConfig();
+    //}
+    cublas_wrapper_->setFP32GemmConfig();
+
+    const int  in_chans       = 3;
+    const int  inter_size     = embed_dim * 4;
+    const int  head_dim       = embed_dim / head_num;
+    const bool with_cls_token = has_cls_token > 0;
+    const int  seq_len        = (img_size / patch_size) * (img_size / patch_size) + (with_cls_token ? 1 : 0);
+
+    //ViTINT8Weight<T> params =
+        //ViTINT8Weight<T>(embed_dim, inter_size, layer_num, img_size, patch_size, in_chans, with_cls_token);
+    params_ = ViTINT8Weight<float>(embed_dim, inter_size, layer_num, img_size, patch_size, in_chans, with_cls_token);
+
+    FT_LOG_INFO("batch_size: %d, img_size : %d,\n"
+                "patch_size: %d, embed_dim: %d,\n"
+                "head_num  : %d, head_dim : %d,\n"
+                "layer_num : %d, seq_len  : %d,\n"
+                "inter_size:%d\n",
+                batch_size,
+                img_size,
+                patch_size,
+                embed_dim,
+                head_num,
+                head_dim,
+                layer_num,
+                seq_len,
+                inter_size);
+
+    //AttentionType attention_type = getAttentionType<T>(head_dim, getSMVersion(), true, seq_len);
+    attention_type_ = getAttentionType<float>(head_dim, getSMVersion(), true, seq_len);
+    printf("attention_type: %d\n", int(attention_type_));
+
+    fastertransformer::Allocator<AllocatorType::CUDA> allocator(0);
+    int max_batch = batch_size;
+    printf("before ViTTransformerINT8\n");
+    vit_ = new ViTTransformerINT8<float>(max_batch,
+                                         img_size,
+                                         in_chans,
+                                         patch_size,
+                                         embed_dim,
+                                         head_num,
+                                         inter_size,
+                                         layer_num,
+                                         with_cls_token,
+                                         getSMVersion(),
+                                         1.0f,
+                                         int8_mode,
+                                         stream_,
+                                         cudnn_handle_,
+                                         cublas_wrapper_,
+                                         &allocator,
+                                         false,
+                                         attention_type_);
+    printf("after ViTTransformerINT8\n");
+}
+
+void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
+
+    const int batch_size    = 1;
+    const int img_size      = 224;
+    const int patch_size    = 16;
+    const int embed_dim     = 768;
+    const int has_cls_token = 1;
+    const int  in_chans       = 3;
+    const bool with_cls_token = has_cls_token > 0;
+    const int seq_len       = (img_size / patch_size) * (img_size / patch_size) + (with_cls_token ? 1 : 0);
+
+    FT_LOG_INFO("batch_size: %d, img_size : %d,\n"
+                "patch_size: %d, embed_dim: %d,\n"
+                "seq_len  : %d,\n",
+                batch_size,
+                img_size,
+                patch_size,
+                embed_dim,
+                seq_len);
+
+    //float *input_d, *output_d;
+    //deviceMalloc(&input_d, batch_size * img_size * img_size * in_chans, false);
+    //deviceMalloc(&output_d, batch_size * seq_len * embed_dim, false);
+
+    Ort::KernelContext kcontext(context);
+
+    const size_t num_inputs = kcontext.GetInputCount();
+    printf("number of input %ld\n", num_inputs);
+    Ort::ConstValue ort_val = kcontext.GetInput(0);
+    const void* p_input_data = ort_val.GetTensorData<void>();
+    //const size_t num_outputs = kcontext.GetOutputCount();
+
+    std::vector<int64_t> output_shape{(int64_t)batch_size, (int64_t)seq_len, (int64_t)embed_dim};
+    Ort::UnownedValue ort_val_output = kcontext.GetOutput(0, output_shape);
+    const void* p_output_data = ort_val_output.GetTensorData<void>();
+
+    std::vector<fastertransformer::Tensor> input_tensors = std::vector<fastertransformer::Tensor>{
+        fastertransformer::Tensor{MEMORY_GPU,
+               getTensorType<float>(),
+               std::vector<size_t>{(size_t)batch_size, (size_t)in_chans, (size_t)img_size, (size_t)img_size},
+               p_input_data}};
+               //input_d}};
+
+    std::vector<fastertransformer::Tensor> output_tensors =
+        std::vector<fastertransformer::Tensor>{fastertransformer::Tensor{MEMORY_GPU,
+                                   getTensorType<float>(),
+                                   std::vector<size_t>{(size_t)batch_size, (size_t)seq_len, (size_t)embed_dim},
+                                   p_output_data}};
+                                   //output_d}};
+
+    printf("before forward\n");
+    vit_->forward(&output_tensors, &input_tensors, &params_);
+    printf("after forward\n");
+}
+
+void FTViTINT8CustomKernel::Release() {
+    delete vit_;
+    delete cublas_algo_map_;
+    delete cublas_wrapper_mutex_;
+
+    sync_check_cuda_error();
+
+    // free data
+    check_cuda_error(cublasDestroy(cublas_handle_));
+    check_cuda_error(cublasLtDestroy(cublaslt_handle_));
+    checkCUDNN(cudnnDestroy(cudnn_handle_));
+
+    cudaDeviceSynchronize();
+    check_cuda_error(cudaGetLastError());
+}

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -157,13 +157,11 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
 
     if (is_fp16_) {
         params_fp16_ = ViTINT8Weight<half>(embed_dim, inter_size, layer_num, img_size, patch_size, in_chans, with_cls_token);
-#ifdef FT_ENABLE_WEIGHTS_COPY 
         std::vector<const half*> w_fp16;
         w_fp16.resize(weights_num);
         loadWeightsPtrINT8<half>(info, w_fp16, layer_num, with_cls_token); 
         const half* const* pp_buf = &w_fp16[0];
-        params_fp16_.CopyWeightsFromHostBuffers(pp_buf);
-#endif
+        params_fp16_.AssignWeightsFromDeviceBuffers(pp_buf);
         attention_type_ = getAttentionType<half>(head_dim, getSMVersion(), true, seq_len);
         vit_fp16_ = new ViTTransformerINT8<half>(max_batch,
                                             img_size,
@@ -186,13 +184,11 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
     }
     else {
         params_fp32_ = ViTINT8Weight<float>(embed_dim, inter_size, layer_num, img_size, patch_size, in_chans, with_cls_token);
-#ifdef FT_ENABLE_WEIGHTS_COPY 
         std::vector<const float*> w_fp32;
         w_fp32.resize(weights_num);
         loadWeightsPtrINT8<float>(info, w_fp32, layer_num, with_cls_token); 
         const float* const* pp_buf = &w_fp32[0];
-        params_fp32_.CopyWeightsFromHostBuffers(pp_buf);
-#endif
+        params_fp32_.AssignWeightsFromDeviceBuffers(pp_buf);
         attention_type_ = getAttentionType<float>(head_dim, getSMVersion(), true, seq_len);
         vit_fp32_ = new ViTTransformerINT8<float>(max_batch,
                                              img_size,
@@ -241,18 +237,6 @@ void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
     const void* p_output_data = ort_val_output.GetTensorData<void>();
 
     if (is_fp16_) {
-#ifndef FT_ENABLE_WEIGHTS_COPY 
-        int index = 0;
-        std::vector<const half*> w_fp16;
-        w_fp16.resize(weights_num_);
-        // skip first input, weights start from second input 
-        for (size_t i = 1; i < kcontext.GetInputCount(); i++) {
-            w_fp16[index++] = kcontext.GetInput(i).GetTensorData<half>(); 
-        }
-        const half* const* pp_buf = &w_fp16[0];
-        params_fp16_.AssignWeightsFromDeviceBuffers(pp_buf);
-#endif
-
         std::vector<fastertransformer::Tensor> input_tensors = std::vector<fastertransformer::Tensor>{
             fastertransformer::Tensor{MEMORY_GPU,
                                       getTensorType<half>(),
@@ -267,18 +251,6 @@ void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
         vit_fp16_->forward(&output_tensors, &input_tensors, &params_fp16_);
     }
     else {
-#ifndef FT_ENABLE_WEIGHTS_COPY 
-        int index = 0;
-        std::vector<const float*> w_fp32;
-        w_fp32.resize(weights_num_);
-        // skip first input, weights start from second input 
-        for (size_t i = 1; i < kcontext.GetInputCount(); i++) {
-            w_fp32[index++] = kcontext.GetInput(i).GetTensorData<float>(); 
-        }
-        const float* const* pp_buf = &w_fp32[0];
-        params_fp32_.AssignWeightsFromDeviceBuffers(pp_buf);
-#endif
-
         std::vector<fastertransformer::Tensor> input_tensors = std::vector<fastertransformer::Tensor>{
             fastertransformer::Tensor{MEMORY_GPU,
                                       getTensorType<float>(),

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -134,7 +134,7 @@ void FTViTINT8CustomKernel<T>::Compute(OrtKernelContext* context) {
 }
 
 template<typename T>
-void FTViTINT8CustomKernel<T>::Release() {
+FTViTINT8CustomKernel<T>::~FTViTINT8CustomKernel() {
     delete vit_;
     delete cublas_algo_map_;
     delete cublas_wrapper_mutex_;

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -46,6 +46,7 @@ const std::vector<std::string> pre_layer_weight_names  = {"transformer.embedding
 const std::vector<std::string> post_layer_weight_names = {"transformer.encoder.encoder_norm.weight",
                                                           "transformer.encoder.encoder_norm.bias"};
 
+#define FT_CUSTOM_OP_DEBUG
 template<typename T>
 void loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const T*>& w, int layer_num, bool with_cls_token = true)
 {
@@ -60,14 +61,18 @@ void loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const T*>& w, int
         if (is_constant) {
             weights_map[name] = value; 
 
-            //// Chi debug ...
+            //// Chi debug ... weights are in GPU, following code will get segfault
             //if (i == 1) {
-                //std::cout << "in loadWeightsPtrINT8" << std::endl;
+                //std::cout << "[ORT Custom Op] in loadWeightsPtrINT8" << std::endl;
                 //std::cout << name << std::endl;
                 //const float* p_value_data = value.GetTensorData<const float>(); 
                 //std::cout << p_value_data[0] << std::endl;
+                //std::cout << p_value_data[1] << std::endl;
+                //std::cout << p_value_data[3] << std::endl;
+                //std::cout << p_value_data[4] << std::endl;
+                //std::cout << p_value_data[5] << std::endl;
             //}
-            //std::cout << "in loadWeightsPtrINT8" << std::endl;
+            //std::cout << "[loadWeightsPtrINT8]" << std::endl;
             //std::cout << name << std::endl;
             //const float* p_value_data = value.GetTensorData<const float>(); 
             //std::cout << p_value_data << std::endl;
@@ -85,9 +90,13 @@ void loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const T*>& w, int
         if (iter != weights_map.end()) {
             Ort::ConstValue ort_val = iter->second; 
             w[idx++] = ort_val.GetTensorData<T>();
-            std::cout << name << std::endl;
-            std::cout << idx - 1 << std::endl;
-            std::cout << w[idx-1] << std::endl; 
+            //std::cout << name << std::endl;
+            //std::cout << idx - 1 << std::endl;
+            //std::cout << w[idx-1] << std::endl; 
+            //const T* p_value_data = ort_val.GetTensorData<const T>(); 
+            //std::cout << p_value_data[0] << std::endl;
+            //std::cout << p_value_data[1] << std::endl;
+            //std::cout << p_value_data[3] << std::endl;
         }
     }
 
@@ -101,9 +110,16 @@ void loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const T*>& w, int
             if (iter != weights_map.end()) {
                 Ort::ConstValue ort_val = iter->second; 
                 w[idx++] = ort_val.GetTensorData<T>();
-                std::cout << string_buf << std::endl;
-            std::cout << idx - 1 << std::endl;
-                std::cout << w[idx-1] << std::endl; 
+                if (string_buf == "transformer.encoder.layer.11.h_amaxList" || string_buf == "transformer.encoder.layer.11.amaxList") {
+                    const float* ptr = ort_val.GetTensorData<float>();
+                    std::cout << string_buf << std::endl;
+                    std::cout << ptr[0] << std::endl;
+                    std::cout << ptr[1] << std::endl;
+                    std::cout << ptr[2] << std::endl;
+                    std::cout << ptr[7013] << std::endl;
+                    std::cout << ptr[7014] << std::endl;
+                    std::cout << ptr[7015] << std::endl;
+                }
             }
         }
     }
@@ -113,9 +129,9 @@ void loadWeightsPtrINT8(const OrtKernelInfo* info, std::vector<const T*>& w, int
         if (iter != weights_map.end()) {
             Ort::ConstValue ort_val = iter->second; 
             w[idx++] = ort_val.GetTensorData<T>();
-            std::cout << name << std::endl;
-            std::cout << idx - 1 << std::endl;
-            std::cout << w[idx-1] << std::endl; 
+            //std::cout << name << std::endl;
+            //std::cout << idx - 1 << std::endl;
+            //std::cout << w[idx-1] << std::endl; 
         }
     }
 
@@ -182,7 +198,9 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
         w_fp16.resize(weights_num);
         loadWeightsPtrINT8<half>(info, w_fp16, layer_num, with_cls_token); 
         const half* const* pp_buf = &w_fp16[0];
-        params_fp16_.AssignWeightsFromDeviceBuffers(pp_buf);
+        //params_fp16_.AssignWeightsFromDeviceBuffers(pp_buf);
+        params_fp16_.CopyWeightsFromHostBuffers(pp_buf);
+        //params_fp16_.print();
         attention_type_ = getAttentionType<half>(head_dim, getSMVersion(), true, seq_len);
         vit_fp16_ = new ViTTransformerINT8<half>(max_batch,
                                             img_size,
@@ -202,6 +220,28 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
                                             allocator_,
                                             false,
                                             attention_type_);
+
+        /*
+        size_t size = params_fp16_.GetSerializeSize();
+        std::cout << "size is " << size << std::endl;
+        std::vector<half> weights;
+        weights.resize(size);
+        //std::cout << weights << std::endl;
+        params_fp16_.serialize(&weights[0]);
+        std::cout << "serialize done" << std::endl;
+
+        FILE *fp, *fp2;
+        fp=fopen("serailized_weights_fp16.txt","w");
+        //fp2=fopen("serailized_weights_2.txt","w");
+        fwrite(&weights[0], 1, size, fp);
+        fclose(fp);
+        for (unsigned i = 0; i < 10; i++) {
+           //fprintf(fp2, "%f\n", weights[i]);
+           //printf("%hf\n", weights[i]);
+            std::cout << weights[i] << std::endl;
+        }
+        //fclose(fp2);
+        */
     }
     else {
         params_fp32_ = ViTINT8Weight<float>(embed_dim, inter_size, layer_num, img_size, patch_size, in_chans, with_cls_token);
@@ -209,7 +249,9 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
         w_fp32.resize(weights_num);
         loadWeightsPtrINT8<float>(info, w_fp32, layer_num, with_cls_token); 
         const float* const* pp_buf = &w_fp32[0];
-        params_fp32_.AssignWeightsFromDeviceBuffers(pp_buf);
+        //params_fp32_.AssignWeightsFromDeviceBuffers(pp_buf);
+        params_fp32_.CopyWeightsFromHostBuffers(pp_buf);
+        params_fp32_.print();
         attention_type_ = getAttentionType<float>(head_dim, getSMVersion(), true, seq_len);
         vit_fp32_ = new ViTTransformerINT8<float>(max_batch,
                                              img_size,
@@ -229,6 +271,28 @@ batch_size_(batch_size), img_size_(img_size), embed_dim_(embed_dim), is_fp16_(is
                                              allocator_,
                                              false,
                                              attention_type_);
+
+        /*
+        size_t size = params_fp32_.GetSerializeSize();
+        std::cout << "size is " << size << std::endl;
+        std::vector<float> weights;
+        weights.resize(size);
+        //std::cout << weights << std::endl;
+        params_fp32_.serialize(&weights[0]);
+        std::cout << "serialize done" << std::endl;
+
+        FILE *fp, *fp2;
+        fp=fopen("serailized_weights.txt","w");
+        //fp2=fopen("serailized_weights_2.txt","w");
+        fwrite(&weights[0], 1, size, fp);
+        fclose(fp);
+        for (unsigned i = 0; i < 10; i++) {
+           //fprintf(fp2, "%f\n", weights[i]);
+           printf("%f\n", weights[i]);
+        }
+        //fclose(fp2);
+        */
+
     }
 
     FT_LOG_INFO("batch_size: %d, img_size : %d,\n"
@@ -257,7 +321,54 @@ void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
 
     if (is_fp16_) {
         const half* p_input_data = ort_val.GetTensorData<half>();
-        half* p_output_data = ort_val_output.GetTensorMutableData<half>();
+        //p_fp16_output_data_ = ort_val_output.GetTensorMutableData<half>();
+
+        //// allocate buffer for output
+        //if (!is_fp16_output_buffer_allocated_) {
+            ////deviceMalloc(&output_d, batch_size_ * seq_len_ * embed_dim_, true);
+            //check_cuda_error(cudaMalloc((void**)(&p_fp16_output_data_), sizeof(half) * batch_size_ * seq_len_ * embed_dim_));
+            //is_fp16_output_buffer_allocated_ = true;
+        //}
+        
+        half *p_fp16_output_data_;
+        deviceMalloc(&p_fp16_output_data_, batch_size_ * seq_len_ * embed_dim_, false);
+        //check_cuda_error(cudaMalloc((void**)(&p_fp16_output_data_), sizeof(half) * batch_size_ * seq_len_ * embed_dim_));
+
+        size_t size = batch_size_*3*img_size_*img_size_;
+        half c_tmp[size];
+        cudaMemcpy(
+             c_tmp, p_input_data, sizeof(half)*size, cudaMemcpyDeviceToHost);
+        std::cout << "\n[Ort Custom Op Compute before] input:" << std::endl;
+        std::cout << c_tmp[0] << std::endl;
+        std::cout << c_tmp[1] << std::endl;
+        std::cout << c_tmp[2] << std::endl;
+        std::cout << "..." << std::endl;
+        std::cout << c_tmp[size-3] << std::endl;
+        std::cout << c_tmp[size-2] << std::endl;
+        std::cout << c_tmp[size-1] << std::endl;
+
+        /*
+        if (write_ == 0) {
+            FILE *fp, *fp2;
+            int size = batch_size_*in_chans_*img_size_*img_size_;  
+            std::cout << size << std::endl;
+            half c_tmp_input_fp16[size];
+            cudaMemcpy(
+                 c_tmp_input_fp16, p_input_data, sizeof(half)*size, cudaMemcpyDeviceToHost);
+            //std::cout << "here 2" << std::endl;
+            fp=fopen("serailized_input_fp16.txt","w");
+            //fp2=fopen("serailized_input_2.txt","w");
+            fwrite(c_tmp_input_fp16, sizeof(half), size , fp);
+            fclose(fp);
+            for (unsigned i = 0; i < 10; i++) {
+               //fprintf(fp2, "%f\n", weights[i]);
+               //printf("%f\n", c_tmp_input[i]);
+                std::cout << c_tmp_input_fp16[i] << std::endl;
+            }
+            ////fclose(fp2);
+            write_ = 1;
+        }
+        */
 
         std::vector<fastertransformer::Tensor> input_tensors = std::vector<fastertransformer::Tensor>{
             fastertransformer::Tensor{MEMORY_GPU,
@@ -269,13 +380,68 @@ void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
             fastertransformer::Tensor{MEMORY_GPU,
                                       getTensorType<half>(),
                                       std::vector<size_t>{(size_t)batch_size_, (size_t)seq_len_, (size_t)embed_dim_},
-                                      p_output_data}};
+                                      p_fp16_output_data_}};
+
         vit_fp16_->forward(&output_tensors, &input_tensors, &params_fp16_);
+
+
+        half tmp[3];
+        cudaMemcpy(
+             tmp, p_fp16_output_data_, sizeof(half)*3, cudaMemcpyDeviceToHost);
+             //tmp, output_tensors.at(0).getPtr<half>(), sizeof(half)*3, cudaMemcpyDeviceToHost);
+        std::cout << "[Ort Custom Op Compute done] output:" << std::endl;
+        std::cout << tmp[0] << std::endl;
+        std::cout << tmp[1] << std::endl;
+        std::cout << tmp[2] << std::endl;
+
+        check_cuda_error(cudaFree(p_fp16_output_data_));
+
     }
     else {
         const float* p_input_data = ort_val.GetTensorData<float>();
-        float* p_output_data = ort_val_output.GetTensorMutableData<float>();
+        //p_fp32_output_data_ = ort_val_output.GetTensorMutableData<float>();
 
+        //// allocate buffer for output
+        //if (!is_fp32_output_buffer_allocated_) {
+            ////deviceMalloc(&p_fp32_output_data_, batch_size_ * seq_len_ * embed_dim_, false);
+            //check_cuda_error(cudaMalloc((void**)(&p_fp32_output_data_), sizeof(float) * batch_size_ * seq_len_ * embed_dim_));
+            //is_fp32_output_buffer_allocated_ = true;
+        //}
+
+        float *p_fp32_output_data_;
+        deviceMalloc(&p_fp32_output_data_, batch_size_ * seq_len_ * embed_dim_, false);
+        //check_cuda_error(cudaMalloc((void**)(&p_fp32_output_data_), sizeof(float) * batch_size_ * seq_len_ * embed_dim_));
+
+        /*
+        float c_tmp[3] = {0.0, 0.0, 0.0};
+        cudaMemcpy(
+             c_tmp, p_input_data, sizeof(float)*3, cudaMemcpyDeviceToHost);
+        std::cout << "[Ort Custom Op Compute before] input:" << std::endl;
+        std::cout << c_tmp[0] << std::endl;
+        std::cout << c_tmp[1] << std::endl;
+        std::cout << c_tmp[2] << std::endl;
+
+        if (write_ == 0) {
+            FILE *fp, *fp2;
+            int size = batch_size_*in_chans_*img_size_*img_size_;  
+            std::cout << size << std::endl;
+            float c_tmp_input[size];
+            std::cout << "here 1" << std::endl;
+            cudaMemcpy(
+                 c_tmp_input, p_input_data, sizeof(float)*size, cudaMemcpyDeviceToHost);
+            //std::cout << "here 2" << std::endl;
+            fp=fopen("serailized_input.txt","w");
+            //fp2=fopen("serailized_input_2.txt","w");
+            fwrite(c_tmp_input, sizeof(float), size , fp);
+            fclose(fp);
+            for (unsigned i = 0; i < 10; i++) {
+               //fprintf(fp2, "%f\n", weights[i]);
+               printf("%f\n", c_tmp_input[i]);
+            }
+            ////fclose(fp2);
+            write_ = 1;
+        }
+        */
         std::vector<fastertransformer::Tensor> input_tensors = std::vector<fastertransformer::Tensor>{
             fastertransformer::Tensor{MEMORY_GPU,
                                       getTensorType<float>(),
@@ -286,8 +452,19 @@ void FTViTINT8CustomKernel::Compute(OrtKernelContext* context) {
             fastertransformer::Tensor{MEMORY_GPU,
                                       getTensorType<float>(),
                                       std::vector<size_t>{(size_t)batch_size_, (size_t)seq_len_, (size_t)embed_dim_},
-                                      p_output_data}};
+                                      p_fp32_output_data_}};
         vit_fp32_->forward(&output_tensors, &input_tensors, &params_fp32_);
+
+        /*
+        float tmp[3];
+        cudaMemcpy(
+             tmp, p_output_data, sizeof(float)*3, cudaMemcpyDeviceToHost);
+        std::cout << "[Ort Custom Op Compute done] output:" << std::endl;
+        std::cout << tmp[0] << std::endl;
+        std::cout << tmp[1] << std::endl;
+        std::cout << tmp[2] << std::endl;
+        */
+        check_cuda_error(cudaFree(p_fp32_output_data_));
     }
 }
 
@@ -304,6 +481,12 @@ FTViTINT8CustomKernel::~FTViTINT8CustomKernel() {
     sync_check_cuda_error();
 
     // free data
+    //if (is_fp16_output_buffer_allocated_) {
+        //check_cuda_error(cudaFree(p_fp16_output_data_));
+    //}
+    //if (is_fp32_output_buffer_allocated_) {
+        //check_cuda_error(cudaFree(p_fp32_output_data_));
+    //}
     check_cuda_error(cublasDestroy(cublas_handle_));
     check_cuda_error(cublasLtDestroy(cublaslt_handle_));
     checkCUDNN(cudnnDestroy(cudnn_handle_));
@@ -315,9 +498,20 @@ FTViTINT8CustomKernel::~FTViTINT8CustomKernel() {
 //
 // FTViTINT8CustomOp 
 //
+
 FTViTINT8CustomOp::FTViTINT8CustomOp(const char* provider, void* compute_stream) {
     provider_ = provider; 
     compute_stream_ = compute_stream;
+}
+
+OrtMemType FTViTINT8CustomOp::GetInputMemoryType(size_t index) const {
+    if (index == 0) {
+        return OrtMemTypeDefault;
+    } else {
+        // Second input and the rest of them are weights and we want them to be placed in CPU memory first,
+        // so that we can leverage FT weight's function CopyWeightsFromHostBuffers. 
+        return OrtMemTypeCPUInput;
+    }
 }
 
 void* FTViTINT8CustomOp::CreateKernel(const OrtApi& api, const OrtKernelInfo* info) const { 

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -22,7 +22,6 @@ FTViTINT8CustomKernel<T>::FTViTINT8CustomKernel(const OrtKernelInfo* info,
                                                 int head_num,
                                                 int layer_num,
                                                 int has_cls_token,
-                                                int is_fp16,
                                                 int int8_mode):
 batch_size_(batch_size), img_size_(img_size), patch_size_(patch_size), embed_dim_(embed_dim), has_cls_token_(has_cls_token) 
 {
@@ -122,21 +121,21 @@ void FTViTINT8CustomKernel<T>::Compute(OrtKernelContext* context) {
         fastertransformer::Tensor{MEMORY_GPU,
                getTensorType<T>(),
                std::vector<size_t>{(size_t)batch_size_, (size_t)in_chans, (size_t)img_size_, (size_t)img_size_},
-               p_input_data}};
+               (const T*)p_input_data}};
 
     std::vector<fastertransformer::Tensor> output_tensors =
         std::vector<fastertransformer::Tensor>{fastertransformer::Tensor{MEMORY_GPU,
                                    getTensorType<T>(),
                                    std::vector<size_t>{(size_t)batch_size_, (size_t)seq_len, (size_t)embed_dim_},
-                                   p_output_data}};
+                                   (T*)p_output_data}};
 
-    CudaTimer cuda_timer(stream_);
-    cuda_timer.start();
+    //CudaTimer cuda_timer(stream_);
+    //cuda_timer.start();
 
     vit_->forward(&output_tensors, &input_tensors, &params_);
 
-    float total_time = cuda_timer.stop();
-    printf("vit forward time:%.2f ms\n", total_time);
+    //float total_time = cuda_timer.stop();
+    //printf("vit forward time:%.2f ms\n", total_time);
 }
 
 template<typename T>
@@ -208,7 +207,6 @@ void* FTViTINT8CustomOp::CreateKernel(const OrtApi& api, const OrtKernelInfo* in
                                                 num_heads,
                                                 layer_num,
                                                 with_cls_token,
-                                                is_fp16,
                                                 int8_mode); 
     } else {
         return new FTViTINT8CustomKernel<float>(info,
@@ -220,7 +218,6 @@ void* FTViTINT8CustomOp::CreateKernel(const OrtApi& api, const OrtKernelInfo* in
                                                 num_heads,
                                                 layer_num,
                                                 with_cls_token,
-                                                is_fp16,
                                                 int8_mode); 
 
     }

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.cc
@@ -13,6 +13,8 @@
 using namespace onnxruntime;
 using namespace fastertransformer;
 
+fastertransformer::Allocator<AllocatorType::CUDA> allocator(0);
+
 FTViTINT8CustomKernel::FTViTINT8CustomKernel(const OrtKernelInfo* info, void* compute_stream) {
 
     const int batch_size    = 1;
@@ -85,7 +87,6 @@ FTViTINT8CustomKernel::FTViTINT8CustomKernel(const OrtKernelInfo* info, void* co
     attention_type_ = getAttentionType<float>(head_dim, getSMVersion(), true, seq_len);
     printf("attention_type: %d\n", int(attention_type_));
 
-    fastertransformer::Allocator<AllocatorType::CUDA> allocator(0);
     int max_batch = batch_size;
     printf("before ViTTransformerINT8\n");
     vit_ = new ViTTransformerINT8<float>(max_batch,

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -41,7 +41,6 @@ struct FTViTINT8CustomKernel {
   cublasAlgoMap* cublas_algo_map_;
   void* compute_stream_;
 
-  // set with default values
   int batch_size_;
   int img_size_;
   int patch_size_;

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -41,6 +41,8 @@ struct FTViTINT8CustomKernel {
   ViTTransformerINT8<float>* vit_fp32_;
   ViTTransformerINT8<half>* vit_fp16_;
   cublasAlgoMap* cublas_algo_map_;
+  //float* p_fp32_output_data_;
+  //half* p_fp16_output_data_;
   void* compute_stream_;
 
   int batch_size_;
@@ -51,12 +53,17 @@ struct FTViTINT8CustomKernel {
   int in_chans_;
   int is_fp16_;
   int weights_num_;
+  bool is_fp16_output_buffer_allocated_ = false;
+  bool is_fp32_output_buffer_allocated_ = false;
+  int write_ = 1;
 };
 
 struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel> {
   explicit FTViTINT8CustomOp(const char* provider, void* compute_stream);
 
   void* CreateKernel(const OrtApi&, const OrtKernelInfo*) const;
+
+  OrtMemType GetInputMemoryType(size_t index) const;
 
   const char* GetName() const { return name_; };
 
@@ -70,7 +77,7 @@ struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomK
 
   ONNXTensorElementDataType GetInputType(size_t) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
 
-  OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_VARIADIC; };   
+  OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_OPTIONAL; };   
 
   size_t GetOutputTypeCount() const { return num_outputs_; };
 
@@ -78,12 +85,12 @@ struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomK
 
   ONNXTensorElementDataType GetOutputType(size_t) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
 
-  OrtCustomOpInputOutputCharacteristic GetOutputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_VARIADIC; };
+  OrtCustomOpInputOutputCharacteristic GetOutputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_OPTIONAL; };
 
  private:
   const char* provider_;
   void* compute_stream_;
   const char* name_{"FTViTINT8"};
-  size_t num_inputs_ = 1;  // set to 1 to match with default min_arity for variadic input  
-  size_t num_outputs_ = 1; // set to 1 to match with default min_arity for variadic output 
+  size_t num_inputs_ = 223;
+  size_t num_outputs_ = 1;
 };

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -40,6 +40,13 @@ struct FTViTINT8CustomKernel {
   ViTTransformerINT8<T>* vit_;
   cublasAlgoMap* cublas_algo_map_;
   void* compute_stream_;
+
+  // set with default values
+  int batch_size_;
+  int img_size_;
+  int patch_size_;
+  int embed_dim_;
+  int has_cls_token_;
 };
 
 struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel<float>> {

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -47,8 +47,6 @@ struct FTViTINT8CustomKernel {
   int img_size_;
   int patch_size_;
   int embed_dim_;
-  int layer_num_;
-  int has_cls_token_;
   int seq_len_;
   int in_chans_;
   int is_fp16_;

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -47,6 +47,8 @@ struct FTViTINT8CustomKernel {
   int img_size_;
   int patch_size_;
   int embed_dim_;
+  int layer_num_;
+  int has_cls_token_;
   int seq_len_;
   int in_chans_;
   int is_fp16_;

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -41,8 +41,6 @@ struct FTViTINT8CustomKernel {
   ViTTransformerINT8<float>* vit_fp32_;
   ViTTransformerINT8<half>* vit_fp16_;
   cublasAlgoMap* cublas_algo_map_;
-  //float* p_fp32_output_data_;
-  //half* p_fp16_output_data_;
   void* compute_stream_;
 
   int batch_size_;
@@ -53,9 +51,6 @@ struct FTViTINT8CustomKernel {
   int in_chans_;
   int is_fp16_;
   int weights_num_;
-  bool is_fp16_output_buffer_allocated_ = false;
-  bool is_fp32_output_buffer_allocated_ = false;
-  int write_ = 1;
 };
 
 struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel> {
@@ -65,23 +60,17 @@ struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomK
 
   OrtMemType GetInputMemoryType(size_t index) const;
 
-  const char* GetName() const { return name_; };
-
-  void SetName(const char* name) { name_ = name; };
+  const char* GetName() const { return "FTViTINT8"; };
 
   const char* GetExecutionProviderType() const { return provider_; };
 
-  size_t GetInputTypeCount() const { return num_inputs_; };
-
-  void SetInputTypeCount(size_t num) { num_inputs_ = num; };
+  size_t GetInputTypeCount() const { return 223; };
 
   ONNXTensorElementDataType GetInputType(size_t) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
 
   OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_OPTIONAL; };   
 
-  size_t GetOutputTypeCount() const { return num_outputs_; };
-
-  void SetOutputTypeCount(size_t num) { num_outputs_ = num; };
+  size_t GetOutputTypeCount() const { return 1; };
 
   ONNXTensorElementDataType GetOutputType(size_t) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
 
@@ -90,7 +79,4 @@ struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomK
  private:
   const char* provider_;
   void* compute_stream_;
-  const char* name_{"FTViTINT8"};
-  size_t num_inputs_ = 223;
-  size_t num_outputs_ = 1;
 };

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -26,7 +26,7 @@ struct FTViTINT8CustomKernel {
 
   void Compute(OrtKernelContext* context);
 
-  void Release();
+  ~FTViTINT8CustomKernel();
 
  private:
   cudnnHandle_t    cudnn_handle_;

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -21,7 +21,6 @@ struct FTViTINT8CustomKernel {
                         int head_num,
                         int layer_num,
                         int has_cls_token,
-                        int is_fp16,
                         int int8_mode);
 
   void Compute(OrtKernelContext* context);

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -34,6 +34,7 @@ struct FTViTINT8CustomKernel {
   cudaStream_t     stream_ = 0;
   cublasINT8MMWrapper* cublas_wrapper_;
   std::mutex* cublas_wrapper_mutex_;
+  fastertransformer::Allocator<AllocatorType::CUDA>* allocator_;
   AttentionType attention_type_;
   ViTINT8Weight<T> params_;
   ViTTransformerINT8<T>* vit_;
@@ -44,7 +45,8 @@ struct FTViTINT8CustomKernel {
   int img_size_;
   int patch_size_;
   int embed_dim_;
-  int has_cls_token_;
+  int seq_len_;
+  int in_chans_;
 };
 
 struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel<float>> {

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -50,6 +50,7 @@ struct FTViTINT8CustomKernel {
   int seq_len_;
   int in_chans_;
   int is_fp16_;
+  int weights_num_;
 };
 
 struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel> {

--- a/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
+++ b/onnxruntime/custom_ops/cuda/ft_vit_int8_custom_op.h
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#define ORT_API_MANUAL_INIT
+#include "core/session/onnxruntime_c_api.h"
+#include "core/session/onnxruntime_cxx_api.h"
+
+#include "src/fastertransformer/models/vit_int8/ViTINT8.h"
+#include "src/fastertransformer/utils/nvtx_utils.h"
+
+using namespace fastertransformer;
+
+struct FTViTINT8CustomKernel {
+  FTViTINT8CustomKernel(const OrtKernelInfo*, void* compute_stream);
+
+  void Compute(OrtKernelContext* context);
+
+  void Release();
+
+ private:
+  cudnnHandle_t    cudnn_handle_;
+  cublasHandle_t   cublas_handle_;
+  cublasLtHandle_t cublaslt_handle_;
+  cudaStream_t     stream_ = 0;
+  cublasINT8MMWrapper* cublas_wrapper_;
+  std::mutex* cublas_wrapper_mutex_;
+  AttentionType attention_type_;
+  ViTINT8Weight<float> params_;
+  ViTTransformerINT8<float>* vit_;
+  cublasAlgoMap* cublas_algo_map_;
+
+  void* compute_stream_;
+};
+
+struct FTViTINT8CustomOp : Ort::CustomOpBase<FTViTINT8CustomOp, FTViTINT8CustomKernel> {
+  explicit FTViTINT8CustomOp(const char* provider, void* compute_stream) : provider_(provider), compute_stream_(compute_stream) {}
+
+  void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* info) const { return new FTViTINT8CustomKernel(info, compute_stream_); };
+
+  const char* GetName() const { return name_; };
+
+  void SetName(const char* name) { name_ = name; };
+
+  const char* GetExecutionProviderType() const { return provider_; };
+
+  size_t GetInputTypeCount() const { return num_inputs_; };
+
+  void SetInputTypeCount(size_t num) { num_inputs_ = num; };
+
+  ONNXTensorElementDataType GetInputType(size_t /*index*/) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
+
+  OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_VARIADIC; };   
+
+  size_t GetOutputTypeCount() const { return num_outputs_; };
+
+  void SetOutputTypeCount(size_t num) { num_outputs_ = num; };
+
+  ONNXTensorElementDataType GetOutputType(size_t /*index*/) const { return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED; };
+
+  OrtCustomOpInputOutputCharacteristic GetOutputCharacteristic(size_t) const { return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_VARIADIC; };
+
+ private:
+  const char* provider_;
+  void* compute_stream_;
+  const char* name_{"FTViTINT8"};
+  size_t num_inputs_ = 1;  // set to 1 to match with default min_arity for variadic input  
+  size_t num_outputs_ = 1; // set to 1 to match with default min_arity for variadic output 
+};

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -98,6 +98,9 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     cuda_options.do_copy_in_default_stream = !performance_test_config.run_config.do_cuda_copy_in_separate_stream;
     // TODO: Support arena configuration for users of perf test
     session_options.AppendExecutionProvider_CUDA(cuda_options);
+
+    const char* lib_name   = "/mnt/test_build_cuda/Release/libcustom_op_ft_wrapper_library.so";
+    session_options.RegisterCustomOpsLibrary(lib_name);
 #else
     ORT_THROW("CUDA is not supported in this build\n");
 #endif

--- a/onnxruntime/test/testdata/ft_custom_op_test/CMakeLists.txt
+++ b/onnxruntime/test/testdata/ft_custom_op_test/CMakeLists.txt
@@ -5,11 +5,11 @@ project(test LANGUAGES C CXX)
 set(CMAKE_BUILD_TYPE Debug)
 
 include_directories( 
-  /home/azureuser/repos/ort/include/onnxruntime/core/session
+  ../../../../include/onnxruntime/core/session
 )
         
 ADD_EXECUTABLE(ft_custom_op_test ft_custom_op_test.cc)
 target_link_libraries(
   ft_custom_op_test 
-  /mnt/test_build_cuda/Release/libonnxruntime.so 
+  ../../../../build/Release/libonnxruntime.so 
 )

--- a/onnxruntime/test/testdata/ft_custom_op_test/CMakeLists.txt
+++ b/onnxruntime/test/testdata/ft_custom_op_test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.17)
+
+project(test LANGUAGES C CXX)
+
+set(CMAKE_BUILD_TYPE Debug)
+
+include_directories( 
+  /home/azureuser/repos/ort/include/onnxruntime/core/session
+)
+        
+ADD_EXECUTABLE(ft_custom_op_test ft_custom_op_test.cc)
+target_link_libraries(
+  ft_custom_op_test 
+  /mnt/test_build_cuda/Release/libonnxruntime.so 
+)

--- a/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
+++ b/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
@@ -1,0 +1,107 @@
+// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+//
+
+#include <assert.h>
+#include <onnxruntime_cxx_api.h>
+
+#include <iostream>
+#include <vector>
+
+void run_ort() {
+  Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "test");
+  const auto& api = Ort::GetApi();
+  OrtTensorRTProviderOptionsV2* tensorrt_options;
+
+  Ort::SessionOptions session_options;
+  session_options.SetIntraOpNumThreads(1);
+
+  session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
+
+  const char* model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_bs_1_size_224_mode_2.onnx";
+  const char* lib_name   = "/mnt/test_build_cuda/Release/libcustom_op_ft_wrapper_library.so"; 
+
+  OrtCUDAProviderOptions cuda_options;
+  cuda_options.device_id = 0;
+  session_options.AppendExecutionProvider_CUDA(cuda_options);
+
+  session_options.RegisterCustomOpsLibrary(lib_name);
+
+  Ort::Session session(env, model_path, session_options);
+
+  //*************************************************************************
+  // print model input layer (node names, types, shape etc.)
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  // print number of model input nodes
+  const size_t num_input_nodes = session.GetInputCount();
+  std::vector<Ort::AllocatedStringPtr> input_names_ptr;
+  std::vector<const char*> input_node_names;
+  input_names_ptr.reserve(num_input_nodes);
+  input_node_names.reserve(num_input_nodes);
+  std::vector<int64_t> input_node_dims = {1, 3, 224, 224};  // simplify... this model has only 1 input node {1, 3, 224, 224}.
+                                         // Otherwise need vector<vector<>>
+
+  std::cout << "Number of inputs = " << num_input_nodes << std::endl;
+
+  // iterate over all input nodes
+  for (size_t i = 0; i < num_input_nodes; i++) {
+    // print input node names
+    auto input_name = session.GetInputNameAllocated(i, allocator);
+    std::cout << "Input " << i << " : name =" << input_name.get() << std::endl;
+    input_node_names.push_back(input_name.get());
+    input_names_ptr.push_back(std::move(input_name));
+
+    // print input node types
+    auto type_info = session.GetInputTypeInfo(i);
+    auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+
+    ONNXTensorElementDataType type = tensor_info.GetElementType();
+    std::cout << "Input " << i << " : type = " << type << std::endl;
+
+    // print input shapes/dims
+    //input_node_dims = tensor_info.GetShape();
+    std::cout << "Input " << i << " : num_dims = " << input_node_dims.size() << '\n';
+    for (size_t j = 0; j < input_node_dims.size(); j++) {
+      std::cout << "Input " << i << " : dim[" << j << "] =" << input_node_dims[j] << '\n';
+    }
+    std::cout << std::flush;
+  }
+
+  constexpr size_t input_tensor_size = 224 * 224 * 3;  // simplify ... using known dim values to calculate size
+                                                       // use OrtGetTensorShapeElementCount() to get official size!
+
+  std::vector<float> input_tensor_values(input_tensor_size);
+  std::vector<const char*> output_node_names = {"output"};
+  //std::vector<const char*> output_node_names = {"bbox", "class", "landmarks", "confidence"};
+
+  // initialize input data with values in [0.0, 1.0]
+  for (unsigned int i = 0; i < input_tensor_size; i++) input_tensor_values[i] = (float)i / (input_tensor_size + 1);
+
+  // create input tensor object from data values
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  auto input_tensor = Ort::Value::CreateTensor<float>(memory_info, input_tensor_values.data(), input_tensor_size,
+                                                            input_node_dims.data(), 4);
+  assert(input_tensor.IsTensor());
+
+  // score model & input tensor, get back output tensor
+  auto output_tensors =
+      session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
+  assert(output_tensors.size() == 1 && output_tensors.front().IsTensor());
+
+  //// Get pointer to output tensor float values
+  float* floatarr = output_tensors.front().GetTensorMutableData<float>();
+  //assert(abs(floatarr[0] - 0.000045) < 1e-6);
+
+  // score the model, and print scores for first 5 classes
+  for (int i = 0; i < 5; i++) {
+    std::cout << "Score for class [" << i << "] =  " << floatarr[i] << '\n';
+  }
+  std::cout << std::flush;
+  std::cout << "Done!" << std::endl;
+}
+
+int main(int /*argc*/, char*[]) {
+  run_ort();
+  return 0;
+}

--- a/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
+++ b/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
@@ -99,7 +99,7 @@ void run_ort(const char* model_path, const char* lib_name = nullptr) {
 int main(int argc, char* argv[]) {
   if (argc == 2) {
     const char* lib_name   = "./libcustom_op_ft_wrapper_library.so"; 
-    run_ort(argv[1]);
+    run_ort(argv[1], lib_name);
   } else if (argc == 3) {
     run_ort(argv[1], argv[2]);
   } else {

--- a/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
+++ b/onnxruntime/test/testdata/ft_custom_op_test/ft_custom_op_test.cc
@@ -18,8 +18,21 @@ void run_ort() {
 
   session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
 
-  const char* model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_bs_1_size_224_mode_2.onnx";
   const char* lib_name   = "/mnt/test_build_cuda/Release/libcustom_op_ft_wrapper_library.so"; 
+  char* model_path = nullptr;
+
+  int is_fp16 = 1; // input type
+  int batch_size = 16;
+
+  if (is_fp16){
+    //model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp16_bs_32_size_224_mode_2.onnx";
+    //model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp16_bs_16_size_224_mode_2.onnx";
+    model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp16_bs_1_size_224_mode_2.onnx";
+  } else {
+    //model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp32_bs_32_size_224_mode_2.onnx";
+    //model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp32_bs_16_size_224_mode_2.onnx";
+    model_path = "/mnt/repos/FasterTransformer/examples/tensorrt/vit/ft_vit_int8_input_fp32_bs_1_size_224_mode_2.onnx";
+  }
 
   OrtCUDAProviderOptions cuda_options;
   cuda_options.device_id = 0;
@@ -39,9 +52,10 @@ void run_ort() {
   std::vector<const char*> input_node_names;
   input_names_ptr.reserve(num_input_nodes);
   input_node_names.reserve(num_input_nodes);
-  std::vector<int64_t> input_node_dims = {1, 3, 224, 224};  // simplify... this model has only 1 input node {1, 3, 224, 224}.
+  std::vector<int64_t> input_node_dims = {batch_size, 3, 224, 224};  // simplify... this model has only 1 input node {1, 3, 224, 224}.
                                          // Otherwise need vector<vector<>>
 
+  std::cout << "=== FP Custom Op Test ===" << std::endl;
   std::cout << "Number of inputs = " << num_input_nodes << std::endl;
 
   // iterate over all input nodes
@@ -68,36 +82,62 @@ void run_ort() {
     std::cout << std::flush;
   }
 
-  constexpr size_t input_tensor_size = 224 * 224 * 3;  // simplify ... using known dim values to calculate size
+  int input_tensor_size = batch_size * 224 * 224 * 3;  // simplify ... using known dim values to calculate size
                                                        // use OrtGetTensorShapeElementCount() to get official size!
 
-  std::vector<float> input_tensor_values(input_tensor_size);
   std::vector<const char*> output_node_names = {"output"};
-  //std::vector<const char*> output_node_names = {"bbox", "class", "landmarks", "confidence"};
 
-  // initialize input data with values in [0.0, 1.0]
-  for (unsigned int i = 0; i < input_tensor_size; i++) input_tensor_values[i] = (float)i / (input_tensor_size + 1);
+  if (is_fp16) {
+    Ort::Float16_t input_tensor_values[input_tensor_size];
+    for (unsigned int i = 0; i < input_tensor_size; i++) input_tensor_values[i] = 15360;
 
-  // create input tensor object from data values
-  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  auto input_tensor = Ort::Value::CreateTensor<float>(memory_info, input_tensor_values.data(), input_tensor_size,
+    // create input tensor object from data values
+    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    auto input_tensor = Ort::Value::CreateTensor<Ort::Float16_t>(memory_info, input_tensor_values, input_tensor_size,
                                                             input_node_dims.data(), 4);
-  assert(input_tensor.IsTensor());
-
-  // score model & input tensor, get back output tensor
-  auto output_tensors =
+    assert(input_tensor.IsTensor());
+    // warn up
+    for (int i = 0; i < 1; i++) {
+       session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
+    }
+    
+    // score model & input tensor, get back output tensor
+    auto output_tensors =
       session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
-  assert(output_tensors.size() == 1 && output_tensors.front().IsTensor());
+    assert(output_tensors.size() == 1 && output_tensors.front().IsTensor());
 
-  //// Get pointer to output tensor float values
-  float* floatarr = output_tensors.front().GetTensorMutableData<float>();
-  //assert(abs(floatarr[0] - 0.000045) < 1e-6);
+    // Get pointer to output tensor float values
+    float* floatarr = output_tensors.front().GetTensorMutableData<float>();
 
-  // score the model, and print scores for first 5 classes
-  for (int i = 0; i < 5; i++) {
-    std::cout << "Score for class [" << i << "] =  " << floatarr[i] << '\n';
+  } else {
+    std::vector<float> input_tensor_values(input_tensor_size);
+
+    // initialize input data with values in [0.0, 1.0]
+    for (unsigned int i = 0; i < input_tensor_size; i++) input_tensor_values[i] = (float)i / (input_tensor_size + 1);
+
+    // create input tensor object from data values
+    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    auto input_tensor = Ort::Value::CreateTensor<float>(memory_info, input_tensor_values.data(), input_tensor_size,
+                                                            input_node_dims.data(), 4);
+    assert(input_tensor.IsTensor());
+    // warn up
+    for (int i = 0; i < 1; i++) {
+       session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
+    }
+    // score model & input tensor, get back output tensor
+    auto output_tensors =
+      session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
+    assert(output_tensors.size() == 1 && output_tensors.front().IsTensor());
+
+    // Get pointer to output tensor float values
+    float* floatarr = output_tensors.front().GetTensorMutableData<float>();
   }
-  std::cout << std::flush;
+
+  //// score the model, and print scores for first 5 classes
+  //for (int i = 0; i < 5; i++) {
+    //std::cout << "Score for class [" << i << "] =  " << floatarr[i] << '\n';
+  //}
+  //std::cout << std::flush;
   std::cout << "Done!" << std::endl;
 }
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -678,6 +678,24 @@ def parse_arguments():
         help="enable rocm kernel profiling.",
     )
 
+    # link FasterTransformer libs 
+    parser.add_argument(
+        "--enable_ft",
+        action="store_true",
+        help="enable and link FasterTransformer libs",
+    )
+
+    parser.add_argument(
+        "--ft_home",
+        help="Path to FasterTransformer home."
+    )
+
+    parser.add_argument(
+        "--ft_enable_weights_copy",
+        action="store_true",
+        help="enable duplicate model weights copy from host to device.",
+    )
+
     parser.add_argument("--use_xnnpack", action="store_true", help="Enable xnnpack EP.")
     parser.add_argument("--use_azure", action="store_true", help="Enable azure EP.")
 
@@ -1316,6 +1334,17 @@ def generate_build_tree(
                     "-DVERSION_PRIVATE_PART={}{}".format(MM, DD),
                     "-DVERSION_STRING={}.{}.{}.{}".format(ort_major, ort_minor, build_number, source_version[0:7]),
                 ]
+
+
+    if args.use_cuda and args.enable_ft:
+        if is_windows():
+            log.warning("FasterTransformer doesn't support Windows now.")
+        else:
+            cmake_args += [
+                "-Donnxruntime_ENABLE_FT=ON",
+                "-Donnxruntime_FT_HOME=" + args.ft_home,
+                "-Donnxruntime_FT_ENABLE_WEIGHTS_COPY=" + ("ON" if args.ft_enable_weights_copy else "OFF"),
+            ]
 
     for config in configs:
         config_build_dir = get_config_build_dir(build_dir, config)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -690,12 +690,6 @@ def parse_arguments():
         help="Path to FasterTransformer home."
     )
 
-    parser.add_argument(
-        "--ft_enable_weights_copy",
-        action="store_true",
-        help="enable duplicate model weights copy from host to device.",
-    )
-
     parser.add_argument("--use_xnnpack", action="store_true", help="Enable xnnpack EP.")
     parser.add_argument("--use_azure", action="store_true", help="Enable azure EP.")
 
@@ -1343,7 +1337,6 @@ def generate_build_tree(
             cmake_args += [
                 "-Donnxruntime_ENABLE_FT=ON",
                 "-Donnxruntime_FT_HOME=" + args.ft_home,
-                "-Donnxruntime_FT_ENABLE_WEIGHTS_COPY=" + ("ON" if args.ft_enable_weights_copy else "OFF"),
             ]
 
     for config in configs:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This is the FasterTransfomer model-level integration using ORT [custom op runtime wrapper](https://github.com/microsoft/onnxruntime/pull/13427). Here we only focus on FT ViTINT8 model and others can reference this PR for integrating other FT models.

Before using this FT model wrapper, firstly you need to download FT [repos ](https://github.com/NVIDIA/FasterTransformer)and manually build from source. Most of the FT libraries are built to be static libraries by default, for example `libViTINT8.a`, but our current implementation is to make ORT dynamically link FT lib. Therefore, we also need to modify the [CMake file](https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/models/vit_int8/CMakeLists.txt#L17) to make it shared/dynamic library. 
(NOTE: We can also make ORT statically link with FT lib, but it requires explicit statically other dependences as well.)


### What have been added

- New API `KernelInfoGetConstantInput_tensor`.
 During custom op kernel initialization, it needs to get the model weights (saved as node's constant inputs) ready for FT's weights instantiation. What's why we need to add this new API to make kernel info capable of getting constant inputs.

- Custom op and custom op kernel to wrap FT ViTINT8 model.
During custom op kernel initialization, it can fetch attributes from kernel info to determine which kind of FT ViTINT8 instance create. During custom op kernel compute/inference, it can get input/output from kernel context and then assign input/output buffers for ViTINT8 instance to run.

### Notes

- Use custom op `GetInputMemoryType` to place weights in CPU memory and later call FT weight `CopyWeightsFromHostBuffers` during custom op kernel initialization. By doing so, we can properly feed weights to ViTINT8 instance without modifying FT souce code.