### PR TITLE
Fix CPU memory leak due to external weights not getting memory unmapped when using non-CPU EP.

### DIFF
--- a/onnxruntime/core/framework/callback.h
+++ b/onnxruntime/core/framework/callback.h
@@ -40,6 +40,7 @@ struct OrtCallbackInvoker {
  */
 class ScopedOrtCallbackInvoker {
  public:
+  ScopedOrtCallbackInvoker() {}
   explicit ScopedOrtCallbackInvoker(OrtCallback callback) noexcept
       : callback_(callback) {}
 
@@ -69,6 +70,6 @@ class ScopedOrtCallbackInvoker {
 
  private:
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(ScopedOrtCallbackInvoker);
-  OrtCallback callback_;
+  OrtCallback callback_{};
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/callback.h
+++ b/onnxruntime/core/framework/callback.h
@@ -40,7 +40,6 @@ struct OrtCallbackInvoker {
  */
 class ScopedOrtCallbackInvoker {
  public:
-  ScopedOrtCallbackInvoker() {}
   explicit ScopedOrtCallbackInvoker(OrtCallback callback) noexcept
       : callback_(callback) {}
 
@@ -70,6 +69,6 @@ class ScopedOrtCallbackInvoker {
 
  private:
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(ScopedOrtCallbackInvoker);
-  OrtCallback callback_{};
+  OrtCallback callback_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -161,9 +161,11 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     }
 
     OrtCallback ext_data_deleter;
+    ScopedOrtCallbackInvoker scoped_ort_callback_invoker;
     if (utils::HasExternalData(tensor_proto)) {
       ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor,
                                                      ext_data_deleter));
+      scoped_ort_callback_invoker = ScopedOrtCallbackInvoker(ext_data_deleter);
     } else {
       ORT_RETURN_IF_ERROR(utils::TensorProtoToTensor(env, proto_path.c_str(), tensor_proto, *p_deserialize_tensor));
     }

--- a/onnxruntime/core/framework/session_state_utils.cc
+++ b/onnxruntime/core/framework/session_state_utils.cc
@@ -161,7 +161,7 @@ static common::Status DeserializeTensorProto(const Env& env, const std::basic_st
     }
 
     OrtCallback ext_data_deleter;
-    ScopedOrtCallbackInvoker scoped_ort_callback_invoker;
+    std::optional<ScopedOrtCallbackInvoker> scoped_ort_callback_invoker;
     if (utils::HasExternalData(tensor_proto)) {
       ORT_RETURN_IF_ERROR(ExtDataTensorProtoToTensor(env, proto_path, tensor_proto, *p_deserialize_tensor,
                                                      ext_data_deleter));


### PR DESCRIPTION
### Description
Fix CPU memory leak due to external weights not getting memory unmapped when using non-CPU EP.

Sample program that creates a session in a loop of 5
Before (1.14.1 release)
![image](https://user-images.githubusercontent.com/2732907/224930176-83de02f5-a0a3-4989-9f7b-603f6c4fefe7.png)

After
![image](https://user-images.githubusercontent.com/2732907/224930111-6059d438-f467-405f-b3f6-833d46827420.png)

### Motivation and Context
Fixes https://github.com/microsoft/onnxruntime/issues/14466 and a bunch of others

