### PR TITLE
Remove python37 and cuda37 packages in orttraing

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -29,8 +29,6 @@ stages:
 
       strategy:
         matrix:
-          Python37:
-            PythonVersion: '3.7'
           Python38:
             PythonVersion: '3.8'
           Python39:

--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda116.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cuda116.yml
@@ -16,7 +16,7 @@ stages:
     opset_version: '15'
     cuda_version: '11.6'
     gcc_version: 11
-    cmake_cuda_architectures: 37;50;52;60;61;70;75;80;86;87
+    cmake_cuda_architectures: 50;52;60;61;70;75;80;86;87
     docker_file: Dockerfile.manylinux2014_training_cuda11_6
     agent_pool: Onnxruntime-Linux-GPU
     upload_wheel: 'yes'
@@ -29,7 +29,7 @@ stages:
     opset_version: '15'
     cuda_version: '11.6'
     gcc_version: 11
-    cmake_cuda_architectures: 37;50;52;60;61;70;75;80;86;87
+    cmake_cuda_architectures: 50;52;60;61;70;75;80;86;87
     docker_file: Dockerfile.manylinux2014_training_cuda11_6
     agent_pool: Onnxruntime-Linux-GPU
     upload_wheel: 'no'

--- a/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-packaging-training-cuda-stage.yml
@@ -79,13 +79,6 @@ stages:
       pool: ${{ parameters.agent_pool }}
       strategy:
         matrix:
-          Python37:
-            PythonVersion: '3.7'
-            TorchVersion: ${{ parameters.torch_version }}
-            OpsetVersion: ${{ parameters.opset_version }}
-            CudaVersion: ${{ parameters.cuda_version }}
-            GccVersion: ${{ parameters.gcc_version }}
-            UploadWheel: ${{ parameters.upload_wheel }}
           Python38:
             PythonVersion: '3.8'
             TorchVersion: ${{ parameters.torch_version }}


### PR DESCRIPTION
### Description
supplement of #14874 and #14887

### Motivation and Context


N.B.
I'm not sure if python matrix of rocm is expected (python3.7-3.9)  @faxu @snnn 
(https://github.com/microsoft/onnxruntime/blob/main/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml)


