### PR TITLE
[Fix] Error in Linux_Packaging_combined_GPU of nuget packaing pipeline

### DIFF
--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -44,7 +44,11 @@ def parse_args():
 
     parser.add_argument("--manylinux-src", default="manylinux", help="Path to manylinux src folder")
 
-    parser.add_argument("--multiple_repos", action="store_true", help="used in packaging pipeline, which couldn't use get-docker-images-steps.yml")
+    parser.add_argument(
+        "--multiple_repos",
+        action="store_true",
+        help="used in packaging pipeline, which couldn't use get-docker-images-steps.yml",
+    )
 
     return parser.parse_args()
 

--- a/tools/ci_build/get_docker_image.py
+++ b/tools/ci_build/get_docker_image.py
@@ -44,6 +44,8 @@ def parse_args():
 
     parser.add_argument("--manylinux-src", default="manylinux", help="Path to manylinux src folder")
 
+    parser.add_argument("--multiple_repos", action="store_true", help="used in packaging pipeline, which couldn't use get-docker-images-steps.yml")
+
     return parser.parse_args()
 
 
@@ -75,6 +77,25 @@ def main():
     if not dst_deps_file.exists():
         log.info(f"Copy deps.txt to : {dst_deps_file}")
         shutil.copyfile(Path(REPO_DIR) / "cmake" / "deps.txt", str(dst_deps_file))
+
+    if "manylinux" in args.dockerfile and args.multiple_repos:
+        manylinux_build_scripts_folder = Path(args.manylinux_src) / "docker" / "build_scripts"
+        dest = Path(args.context) / "build_scripts"
+        if dest.exists():
+            log.info("Deleting: {}".format(str(dest)))
+            shutil.rmtree(str(dest))
+        shutil.copytree(str(manylinux_build_scripts_folder), str(dest))
+        src_entrypoint_file = str(Path(args.manylinux_src) / "docker" / "manylinux-entrypoint")
+        dst_entrypoint_file = str(Path(args.context) / "manylinux-entrypoint")
+        shutil.copyfile(src_entrypoint_file, dst_entrypoint_file)
+        shutil.copymode(src_entrypoint_file, dst_entrypoint_file)
+        run(
+            "patch",
+            "-p1",
+            "-i",
+            str((Path(SCRIPT_DIR) / "github" / "linux" / "docker" / "manylinux.patch").resolve()),
+            cwd=str(dest),
+        )
 
     if use_container_registry:
         run(

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -289,12 +289,25 @@ jobs:
   - checkout: manylinux                      # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/manylinux
     submodules: false
 
-  - template: templates/get-docker-image-steps.yml
+  - script: |
+        set -e -x
+        cd $(Build.SourcesDirectory)
+        mv manylinux onnxruntime
+        ls
+  - template: templates/with-container-registry-steps.yml
     parameters:
-      Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5
-      Context: tools/ci_build/github/linux/docker
-      DockerBuildArgs: "--network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64 --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-11/root --build-arg PREPEND_PATH=/opt/rh/devtoolset-11/root/usr/bin: --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-11/root/usr/lib64:/opt/rh/devtoolset-11/root/usr/lib:/opt/rh/devtoolset-11/root/usr/lib64/dyninst:/opt/rh/devtoolset-11/root/usr/lib/dyninst:/usr/local/lib64 --build-arg BUILD_UID=$( id -u )"
-      Repository: onnxruntimecuda116xtrt85build
+      Steps:
+      - script: |
+          tools/ci_build/get_docker_image.py \
+            --dockerfile tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5 \
+            --context tools/ci_build/github/linux/docker \
+            --docker-build-args "--network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64 --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-11/root --build-arg PREPEND_PATH=/opt/rh/devtoolset-11/root/usr/bin: --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-11/root/usr/lib64:/opt/rh/devtoolset-11/root/usr/lib:/opt/rh/devtoolset-11/root/usr/lib64/dyninst:/opt/rh/devtoolset-11/root/usr/lib/dyninst:/usr/local/lib64 --build-arg BUILD_UID=$( id -u )" \
+            --container-registry onnxruntimebuildcache \
+            --multiple_repos \
+            --repository onnxruntimecuda116xtrt85build
+        displayName: "Get onnxruntimecuda116xtrt85build image for tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5"
+        workingDirectory: $(Build.SourcesDirectory)/onnxruntime
+      ContainerRegistry: onnxruntimebuildcache
 
   - template: templates/set-version-number-variables-step.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -289,25 +289,12 @@ jobs:
   - checkout: manylinux                      # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/manylinux
     submodules: false
 
-  - script: |
-        set -e -x
-        cd $(Build.SourcesDirectory)
-        mv manylinux onnxruntime
-        ls
-
-  - template: templates/with-container-registry-steps.yml
+  - template: templates/get-docker-image-steps.yml
     parameters:
-      Steps:
-      - script: |
-          tools/ci_build/get_docker_image.py \
-            --dockerfile tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5 \
-            --context tools/ci_build/github/linux/docker \
-            --docker-build-args "--network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64 --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-11/root --build-arg PREPEND_PATH=/opt/rh/devtoolset-11/root/usr/bin: --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-11/root/usr/lib64:/opt/rh/devtoolset-11/root/usr/lib:/opt/rh/devtoolset-11/root/usr/lib64/dyninst:/opt/rh/devtoolset-11/root/usr/lib/dyninst:/usr/local/lib64 --build-arg BUILD_UID=$( id -u )" \
-            --container-registry onnxruntimebuildcache \
-            --repository onnxruntimecuda116xtrt85build
-        displayName: "Get onnxruntimecuda116xtrt85build image for tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5"
-        workingDirectory: $(Build.SourcesDirectory)/onnxruntime
-      ContainerRegistry: onnxruntimebuildcache
+      Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_6_tensorrt8_5
+      Context: tools/ci_build/github/linux/docker
+      DockerBuildArgs: "--network=host --build-arg POLICY=manylinux2014 --build-arg PLATFORM=x86_64 --build-arg DEVTOOLSET_ROOTPATH=/opt/rh/devtoolset-11/root --build-arg PREPEND_PATH=/opt/rh/devtoolset-11/root/usr/bin: --build-arg LD_LIBRARY_PATH_ARG=/opt/rh/devtoolset-11/root/usr/lib64:/opt/rh/devtoolset-11/root/usr/lib:/opt/rh/devtoolset-11/root/usr/lib64/dyninst:/opt/rh/devtoolset-11/root/usr/lib/dyninst:/usr/local/lib64 --build-arg BUILD_UID=$( id -u )"
+      Repository: onnxruntimecuda116xtrt85build
 
   - template: templates/set-version-number-variables-step.yml
     parameters:


### PR DESCRIPTION
### Description


### Motivation and Context
It caused by the #14958, in the nuget packaging pipeline, it calls get_docker_image.py directly rather than by get-docker-image-steps.yml. Considering the difference, one parameter is added for compatibility.


### Test Link
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=288042&view=logs&j=505ca2b7-596d-550d-8417-9b1519e87977


