### PR TITLE
Fix issue with LayerNormalization fusion

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4553,7 +4553,7 @@ TEST_F(GraphTransformationTests, LayerNormWithCastFusionTest_4) {
     Graph& graph = p_model->MainGraph();
 
     // assign the nodes. as LayerNormFusion happens in level 2 it can have EP specific logic
-    const ProviderType provider = ep_has_fp16_layernorm ? kCudaExecutionProvider : kCpuExecutionProvider;
+    const char* provider = ep_has_fp16_layernorm ? kCudaExecutionProvider : kCpuExecutionProvider;
     for (auto& node : graph.Nodes()) {
       node.SetExecutionProviderType(provider);
     }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Don't include an initial cast from fp16 to fp32 in the LayerNormalization fusion unless the node will be assigned to an EP that supports fp16 input. Currently that is CUDA/ROCm and DML.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#15021 

