### PR TITLE
fix miopen new API cannot be supported by ROCm5.2.3

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -207,6 +207,8 @@ option(onnxruntime_USE_COMPOSABLE_KERNEL "Enable composable kernel for ROCm EP" 
 option(onnxruntime_USE_ROCBLAS_EXTENSION_API "Enable rocblas tuning for ROCm EP" OFF)
 option(onnxruntime_BUILD_KERNEL_EXPLORER "Build Kernel Explorer for testing and profiling GPU kernels" OFF)
 
+option(onnxruntime_USE_MIOPEN_TENSOR_LAYOUT "use miopenTensorLayout_t from MIOpen " ON)
+
 option(onnxruntime_BUILD_CACHE "onnxruntime build with cache" OFF)
 # https://zeux.io/2010/11/22/z7-everything-old-is-new-again/
 cmake_dependent_option(MSVC_Z7_OVERRIDE "replacing /Zi and /ZI with /Z7 when using MSVC with CCache" ON "onnxruntime_BUILD_CACHE; MSVC" OFF)
@@ -302,6 +304,8 @@ if (onnxruntime_USE_ROCM)
   if (onnxruntime_USE_COMPOSABLE_KERNEL AND ROCM_VERSION_DEV VERSION_LESS "5.3")
     message(WARNING "composable kernel is only supported on ROCm >= 5.3")
     set(onnxruntime_USE_COMPOSABLE_KERNEL OFF)
+    message(WARNING "miopenTensorLayout_t is only supported on ROCm >= 5.3")
+    set(onnxruntime_USE_MIOPEN_TENSOR_LAYOUT OFF)
   endif()
 endif()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -303,7 +303,6 @@ if (onnxruntime_USE_ROCM)
     message(WARNING "composable kernel is only supported on ROCm >= 5.3")
     set(onnxruntime_USE_COMPOSABLE_KERNEL OFF)
   endif()
-
 endif()
 
 if (APPLE)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -207,8 +207,6 @@ option(onnxruntime_USE_COMPOSABLE_KERNEL "Enable composable kernel for ROCm EP" 
 option(onnxruntime_USE_ROCBLAS_EXTENSION_API "Enable rocblas tuning for ROCm EP" OFF)
 option(onnxruntime_BUILD_KERNEL_EXPLORER "Build Kernel Explorer for testing and profiling GPU kernels" OFF)
 
-option(onnxruntime_USE_MIOPEN_TENSOR_LAYOUT "use miopenTensorLayout_t from MIOpen " ON)
-
 option(onnxruntime_BUILD_CACHE "onnxruntime build with cache" OFF)
 # https://zeux.io/2010/11/22/z7-everything-old-is-new-again/
 cmake_dependent_option(MSVC_Z7_OVERRIDE "replacing /Zi and /ZI with /Z7 when using MSVC with CCache" ON "onnxruntime_BUILD_CACHE; MSVC" OFF)
@@ -304,9 +302,8 @@ if (onnxruntime_USE_ROCM)
   if (onnxruntime_USE_COMPOSABLE_KERNEL AND ROCM_VERSION_DEV VERSION_LESS "5.3")
     message(WARNING "composable kernel is only supported on ROCm >= 5.3")
     set(onnxruntime_USE_COMPOSABLE_KERNEL OFF)
-    message(WARNING "miopenTensorLayout_t is only supported on ROCm >= 5.3")
-    set(onnxruntime_USE_MIOPEN_TENSOR_LAYOUT OFF)
   endif()
+
 endif()
 
 if (APPLE)

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1378,6 +1378,33 @@ if (onnxruntime_USE_ROCM)
   find_package(hiprand REQUIRED)
   find_package(rocblas REQUIRED)
   find_package(MIOpen REQUIRED)
+
+  # MIOpen version
+  if(NOT DEFINED ENV{MIOPEN_PATH})
+    set(MIOPEN_PATH ${onnxruntime_ROCM_HOME}/miopen)
+  else()
+    set(MIOPEN_PATH $ENV{MIOPEN_PATH})
+  endif()
+
+  file(READ ${MIOPEN_PATH}/include/miopen/version.h MIOPEN_HEADER_CONTENTS)
+        string(REGEX MATCH "define MIOPEN_VERSION_MAJOR * +([0-9]+)"
+                                 MIOPEN_VERSION_MAJOR "${MIOPEN_HEADER_CONTENTS}")
+        string(REGEX REPLACE "define MIOPEN_VERSION_MAJOR * +([0-9]+)" "\\1"
+                                 MIOPEN_VERSION_MAJOR "${MIOPEN_VERSION_MAJOR}")
+        string(REGEX MATCH "define MIOPEN_VERSION_MINOR * +([0-9]+)"
+                                 MIOPEN_VERSION_MINOR "${MIOPEN_HEADER_CONTENTS}")
+        string(REGEX REPLACE "define MIOPEN_VERSION_MINOR * +([0-9]+)" "\\1"
+                                 MIOPEN_VERSION_MINOR "${MIOPEN_VERSION_MINOR}")
+        string(REGEX MATCH "define MIOPEN_VERSION_PATCH * +([0-9]+)"
+                                 MIOPEN_VERSION_PATCH "${MIOPEN_HEADER_CONTENTS}")
+        string(REGEX REPLACE "define MIOPEN_VERSION_PATCH * +([0-9]+)" "\\1"
+                                 MIOPEN_VERSION_PATCH "${MIOPEN_VERSION_PATCH}")
+  set(MIOPEN_VERSION_DEV "${MIOPEN_VERSION_MAJOR}.${MIOPEN_VERSION_MINOR}.${MIOPEN_VERSION_PATCH}")
+  math(EXPR MIOPEN_VERSION_DEV_INT "(${MIOPEN_VERSION_MAJOR}*10000) + (${MIOPEN_VERSION_MINOR}*100) + ${MIOPEN_VERSION_PATCH}")
+  message("MIOPEN_VERSION_DEV: ${MIOPEN_VERSION_DEV}")
+  message("MIOPEN_VERSION_DEV_INT:   ${MIOPEN_VERSION_DEV_INT}")
+  add_definitions(-DMIOPEN_VERSION=${MIOPEN_VERSION_DEV_INT})
+
   find_library(RCCL_LIB rccl REQUIRED)
   find_library(ROCTRACER_LIB roctracer64 REQUIRED)
   set(ONNXRUNTIME_ROCM_LIBS roc::rocblas MIOpen ${RCCL_LIB} ${ROCTRACER_LIB})

--- a/onnxruntime/core/providers/rocm/miopen_common.h
+++ b/onnxruntime/core/providers/rocm/miopen_common.h
@@ -14,6 +14,14 @@ const double MIOPEN_BN_MIN_EPSILON = 1e-5;
 namespace onnxruntime {
 namespace rocm {
 
+// Define miopenTensorLayout_t there if ROCm version < 5.3.0.
+#ifndef USE_MIOPEN_TENSOR_LAYOUT
+typedef enum {
+  miopenTensorNCHW = 0,
+  miopenTensorNHWC = 1,
+} miopenTensorLayout_t;
+#endif
+
 #define MIOPEN_CONVOLUTION_FWD_ALGO_COUNT 6
 #define MIOPEN_CONVOLUTION_BWD_FILTER_ALGO_COUNT 4
 #define MIOPEN_CONVOLUTION_BWD_DATA_ALGO_COUNT 6

--- a/onnxruntime/core/providers/rocm/miopen_common.h
+++ b/onnxruntime/core/providers/rocm/miopen_common.h
@@ -14,8 +14,7 @@ const double MIOPEN_BN_MIN_EPSILON = 1e-5;
 namespace onnxruntime {
 namespace rocm {
 
-// Define miopenTensorLayout_t there if ROCm version < 5.3.0.
-#ifndef USE_MIOPEN_TENSOR_LAYOUT
+#if MIOPEN_VERSION < 21800
 typedef enum {
   miopenTensorNCHW = 0,
   miopenTensorNHWC = 1,


### PR DESCRIPTION
miopenTensorLayout_t was added after MIOpen version 2.18.0. Define it in ORT when use MIOpen version lower than 2.18.0.