### PR TITLE
Fix training gpu ci related to pl upgrade

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_torch_lightning_basic.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_torch_lightning_basic.py
@@ -88,7 +88,7 @@ def main():
     # Train loop
     kwargs = {}
     if device == "cuda":
-        kwargs.update({"gpus": 1})
+        kwargs.update({"devices": 1, "accelerator": "gpu"})
     if args.train_steps > 0:
         kwargs.update({"max_steps": args.train_steps})
     if args.epochs > 0:


### PR DESCRIPTION
### Fix training gpu ci related to pl upgrade

As new version of pln relased, old parameter of pln.Trainer, gpus looks not supported. So we switch to new params to make it work. 

```
['/home/onnxruntimedev/miniconda3/bin/python3', 'orttraining_test_ortmodule_torch_lightning_basic.py', '--train-steps=470', '--epochs=2', '--batch-size=256', '--data-dir', '/mnist'] 

/home/onnxruntimedev/miniconda3/lib/python3.8/site-packages/torch/onnx/utils.py:1794: FutureWarning: The first argument to symbolic functions is deprecated in 1.13 and will be removed in the future. Please annotate treat the first argument (g) as GraphContext and use context information from the object instead. warnings.warn( Traceback (most recent call last): File "orttraining_test_ortmodule_torch_lightning_basic.py", line 101, in <module> main() File "orttraining_test_ortmodule_torch_lightning_basic.py", line 96, in main trainer = pl.Trainer(**kwargs) File "/home/onnxruntimedev/miniconda3/lib/python3.8/site-packages/pytorch_lightning/utilities/argparse.py", line 69, in insert_env_defaults return fn(self, **kwargs) TypeError: __init__() got an unexpected keyword argument 'gpus'
```
