### PR TITLE
Remove the use of eval in test code

### DIFF
--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -6,7 +6,6 @@
 import operator
 import unittest
 
-import numpy as np
 import onnxruntime_pybind11_state as torch_ort
 import torch
 from parameterized import param, parameterized

--- a/orttraining/orttraining/eager/test/ort_ops.py
+++ b/orttraining/orttraining/eager/test/ort_ops.py
@@ -3,12 +3,13 @@
 
 # pylint: disable=missing-docstring, too-many-public-methods, no-member
 
+import operator
 import unittest
 
 import numpy as np
 import onnxruntime_pybind11_state as torch_ort
 import torch
-from parameterized import parameterized, param
+from parameterized import param, parameterized
 
 
 class OrtOpTests(unittest.TestCase):
@@ -570,11 +571,6 @@ class OrtOpTests(unittest.TestCase):
     # for floor and erf, the ort produces a roundoff error for NaN input, but cpu keeps it a NaN.
     # Thus, we use nan_to_num to ensure actual numbers are passed in.
 
-    # As many of the following use eval and make it appear to pylint that there are many unused variables,
-    # we disable those warnings
-
-    # pylint: disable=eval-used, unused-argument, unused-variable, no-self-argument,
-
     ops = [
         ["abs", torch.tensor([-1, -2, 3, -6, -7])],
         ["acos"],
@@ -616,20 +612,20 @@ class OrtOpTests(unittest.TestCase):
     # @parameterized.expand generate test methods for ops and using name_func we renaming the test to be test_{ops}
     @parameterized.expand(ops, name_func=rename_func)
     def test_op(self, test_name, tensor_test=torch.rand(6)):
-        # compile eval- creates a code object that evaluates the operator (for example torch.abs(tensor_test)) and returns its result.
-        cpu_result = eval(compile("torch." + test_name + "(tensor_test)", "<string>", "eval"))
-        ort_result = eval(compile("torch." + test_name + "(tensor_test.to(self.get_device()))", "<string>", "eval"))
+        cpu_result = getattr(torch, test_name)(tensor_test)
+        ort_result = getattr(torch, test_name)(tensor_test.to(self.get_device()))
+
         assert torch.allclose(cpu_result, ort_result.cpu(), equal_nan=True)
 
     @parameterized.expand(ops, name_func=rename_func)
-    def test_op_(self, test_name, tensor_test=torch.rand(6)):
+    def test_op_inplace(self, test_name, tensor_test=torch.rand(6)):
         device = self.get_device()
 
         cpu_tensor = tensor_test
         ort_tensor = cpu_tensor.to(device)
 
-        eval(compile("torch." + test_name + "_(cpu_tensor)", "<string>", "eval"))
-        eval(compile("torch." + test_name + "_(ort_tensor)", "<string>", "eval"))
+        getattr(torch, test_name + "_")(cpu_tensor)
+        getattr(torch, test_name + "_")(ort_tensor)
 
         assert torch.allclose(cpu_tensor, ort_tensor.cpu(), equal_nan=True)
 
@@ -648,10 +644,8 @@ class OrtOpTests(unittest.TestCase):
         cpu_out_tensor = torch.tensor([], dtype=tensor_test.dtype)
         ort_out_tensor = cpu_out_tensor.to(device)
 
-        st_cpu = f"torch.{test_name}(cpu_tensor, out=cpu_out_tensor)"
-        st_ort = f"torch.{test_name}(ort_tensor, out=ort_out_tensor)"
-        cpu_result = eval(compile(st_cpu, "<string>", "eval"))
-        ort_result = eval(compile(st_ort, "<string>", "eval"))
+        cpu_result = getattr(torch, test_name)(cpu_tensor, out=cpu_out_tensor)
+        ort_result = getattr(torch, test_name)(ort_tensor, out=ort_out_tensor)
 
         assert torch.allclose(cpu_result, ort_result.cpu(), equal_nan=True)
         assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu(), equal_nan=True)
@@ -670,12 +664,9 @@ class OrtOpTests(unittest.TestCase):
         for tensor_type in {torch.float, torch.bool}:
             cpu_out_tensor = torch.tensor([], dtype=tensor_type)
             ort_out_tensor = cpu_out_tensor.to(device)
-            cpu_a_b_result = eval(
-                compile("torch." + math_sign_ops + "(cpu_a, cpu_b, out=cpu_out_tensor)", "<string>", "eval")
-            )
-            ort_a_b_result = eval(
-                compile("torch." + math_sign_ops + "(ort_a, ort_b, out=ort_out_tensor)", "<string>", "eval")
-            )
+            cpu_a_b_result = getattr(torch, math_sign_ops)(cpu_a, cpu_b, out=cpu_out_tensor)
+            ort_a_b_result = getattr(torch, math_sign_ops)(ort_a, ort_b, out=ort_out_tensor)
+
             assert torch.equal(cpu_a_b_result.to(device), ort_a_b_result)
             assert torch.equal(cpu_out_tensor, ort_out_tensor.to("cpu"))
             assert ort_out_tensor.dtype == tensor_type
@@ -699,35 +690,15 @@ class OrtOpTests(unittest.TestCase):
         cpu_out_tensor = torch.tensor([], dtype=torch.bool)
         ort_out_tensor = cpu_out_tensor.to(device)
 
-        cpu_int_int_result = eval(
-            compile(
-                "torch." + math_sign_ops + "(cpu_tensor_int, cpu_scalar_int_lt, out=cpu_out_tensor)", "<string>", "eval"
-            )
-        )
-        cpu_int_int_gt_result = eval(
-            compile("torch." + math_sign_ops + "(cpu_tensor_int, cpu_scalar_int_gt)", "<string>", "eval")
-        )
-        cpu_float_float_lt_result = eval(
-            compile("torch." + math_sign_ops + "(cpu_tensor_float, float_lt)", "<string>", "eval")
-        )
-        cpu_float_float_gt_result = eval(
-            compile("torch." + math_sign_ops + "(cpu_tensor_float, float_gt)", "<string>", "eval")
-        )
+        cpu_int_int_result = getattr(torch, math_sign_ops)(cpu_tensor_int, cpu_scalar_int_lt, out=cpu_out_tensor)
+        cpu_int_int_gt_result = getattr(torch, math_sign_ops)(cpu_tensor_int, cpu_scalar_int_gt)
+        cpu_float_float_lt_result = getattr(torch, math_sign_ops)(cpu_tensor_float, float_lt)
+        cpu_float_float_gt_result = getattr(torch, math_sign_ops)(cpu_tensor_float, float_gt)
 
-        ort_int_int_result = eval(
-            compile(
-                "torch." + math_sign_ops + "(ort_tensor_int, ort_scalar_int_lt, out=ort_out_tensor)", "<string>", "eval"
-            )
-        )
-        ort_int_int_gt_result = eval(
-            compile("torch." + math_sign_ops + "(ort_tensor_int, ort_scalar_int_gt)", "<string>", "eval")
-        )
-        ort_float_float_lt_result = eval(
-            compile("torch." + math_sign_ops + "(ort_tensor_float, float_lt)", "<string>", "eval")
-        )
-        ort_float_float_gt_result = eval(
-            compile("torch." + math_sign_ops + "(ort_tensor_float, float_gt)", "<string>", "eval")
-        )
+        ort_int_int_result = getattr(torch, math_sign_ops)(ort_tensor_int, ort_scalar_int_lt, out=ort_out_tensor)
+        ort_int_int_gt_result = getattr(torch, math_sign_ops)(ort_tensor_int, ort_scalar_int_gt)
+        ort_float_float_lt_result = getattr(torch, math_sign_ops)(ort_tensor_float, float_lt)
+        ort_float_float_gt_result = getattr(torch, math_sign_ops)(ort_tensor_float, float_gt)
 
         assert torch.equal(cpu_out_tensor, ort_out_tensor.to("cpu"))
         assert torch.equal(cpu_int_int_result, ort_int_int_result.to("cpu"))
@@ -735,88 +706,65 @@ class OrtOpTests(unittest.TestCase):
         assert torch.equal(cpu_float_float_lt_result, ort_float_float_lt_result.to("cpu"))
         assert torch.equal(cpu_float_float_gt_result, ort_float_float_gt_result.to("cpu"))
 
-    binary_ops = [  # [op, op_sign, alpha_supported]
-        ["add", "+", True],
-        ["sub", "-", True],
-        ["mul", "*", False],
-        ["div", "/", False],
+    binary_ops = [  # [op, op, alpha_supported]
+        ["add", operator.add, True],
+        ["sub", operator.sub, True],
+        ["mul", operator.mul, False],
+        ["div", operator.truediv, False],
     ]
 
     @parameterized.expand(binary_ops, name_func=rename_func)
-    def test_op_binary_tensor(self, binary_op, op_sign, alpha_supported):
+    def test_op_binary_tensor(self, binary_op, op, alpha_supported):
         device = self.get_device()
         cpu_input = torch.rand(3, 1)  # use broadcasting in the second dim.
         ort_input = cpu_input.to(device)
         cpu_other = torch.rand(3, 3)
         ort_other = cpu_other.to(device)
 
-        # verify op_sign works
-        cpu_result = eval(compile("cpu_input " + op_sign + " cpu_other", "<string>", "eval"))
-        ort_result = eval(compile("ort_input " + op_sign + " ort_other", "<string>", "eval"))
+        # verify op works
+        cpu_result = op(cpu_input, cpu_other)
+        ort_result = op(ort_input, ort_other)
         assert torch.allclose(cpu_result, ort_result.cpu())
 
         # verify torch op with out param works
         cpu_out_tensor = torch.tensor([])
         ort_out_tensor = cpu_out_tensor.to(device)
-        cpu_result = eval(
-            compile("torch." + binary_op + "(cpu_input, cpu_other, out=cpu_out_tensor)", "<string>", "eval")
-        )
-        ort_result = eval(
-            compile("torch." + binary_op + "(ort_input, ort_other, out=ort_out_tensor)", "<string>", "eval")
-        )
+        cpu_result = getattr(torch, binary_op)(cpu_input, cpu_other, out=cpu_out_tensor)
+        ort_result = getattr(torch, binary_op)(ort_input, ort_other, out=ort_out_tensor)
+
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
 
         if alpha_supported:
-            cpu_result = eval(
-                compile(
-                    "torch." + binary_op + "(cpu_input, cpu_other, alpha=2.5, out=cpu_out_tensor)", "<string>", "eval"
-                )
-            )
-            ort_result = eval(
-                compile(
-                    "torch." + binary_op + "(ort_input, ort_other, alpha=2.5, out=ort_out_tensor)", "<string>", "eval"
-                )
-            )
+            cpu_result = getattr(torch, binary_op)(cpu_input, cpu_other, alpha=2.5, out=cpu_out_tensor)
+            ort_result = getattr(torch, binary_op)(ort_input, ort_other, alpha=2.5, out=ort_out_tensor)
             assert torch.allclose(cpu_result, ort_result.cpu())
             assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
 
     @parameterized.expand(binary_ops, name_func=rename_func)
-    def test_op_binary_scalar(self, binary_op, op_sign, alpha_supported):
+    def test_op_binary_scalar(self, binary_op, op, alpha_supported):
         device = self.get_device()
         cpu_input = torch.ones(3, 3)
         ort_input = cpu_input.to(device)
         cpu_other = 3.1
         ort_other = 3.1
 
-        # verify op_sign works
-        cpu_result = eval(compile("cpu_input " + op_sign + " cpu_other", "<string>", "eval"))
-        ort_result = eval(compile("ort_input " + op_sign + " ort_other", "<string>", "eval"))
+        # verify op works
+        cpu_result = op(cpu_input, cpu_other)
+        ort_result = op(ort_input, ort_other)
         assert torch.allclose(cpu_result, ort_result.cpu())
 
         # verify torch op with out param works
         cpu_out_tensor = torch.tensor([])
         ort_out_tensor = cpu_out_tensor.to(device)
-        cpu_result = eval(
-            compile("torch." + binary_op + "(cpu_input, cpu_other, out=cpu_out_tensor)", "<string>", "eval")
-        )
-        ort_result = eval(
-            compile("torch." + binary_op + "(ort_input, ort_other, out=ort_out_tensor)", "<string>", "eval")
-        )
+        cpu_result = getattr(torch, binary_op)(cpu_input, cpu_other, out=cpu_out_tensor)
+        ort_result = getattr(torch, binary_op)(ort_input, ort_other, out=ort_out_tensor)
         assert torch.allclose(cpu_result, ort_result.cpu())
         assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
 
         if alpha_supported:
-            cpu_result = eval(
-                compile(
-                    "torch." + binary_op + "(cpu_input, cpu_other, alpha=2.5, out=cpu_out_tensor)", "<string>", "eval"
-                )
-            )
-            ort_result = eval(
-                compile(
-                    "torch." + binary_op + "(ort_input, ort_other, alpha=2.5, out=ort_out_tensor)", "<string>", "eval"
-                )
-            )
+            cpu_result = getattr(torch, binary_op)(cpu_input, cpu_other, alpha=2.5, out=cpu_out_tensor)
+            ort_result = getattr(torch, binary_op)(ort_input, ort_other, alpha=2.5, out=ort_out_tensor)
             assert torch.allclose(cpu_result, ort_result.cpu())
             assert torch.allclose(cpu_out_tensor, ort_out_tensor.cpu())
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -45,6 +45,7 @@ DEFAULT_OPSET = 15
 
 # PyTorch model definitions for tests
 
+
 class NeuralNetSinglePositionalArgument(torch.nn.Module):
     def __init__(self, input_size, hidden_size, num_classes):
         super(NeuralNetSinglePositionalArgument, self).__init__()

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -571,7 +571,7 @@ def test_compare_pytorch_forward_call_positional_and_keyword_arguments(forward_f
     assert ortmodule_result == ortmodule_result_again
     assert pytorch_result == ortmodule_result
 
-    prediction = forward_function(model).item()
+    prediction = forward_function(model).sum()
     prediction.backward()
 
 
@@ -5260,8 +5260,8 @@ def test_sigmoid_grad_opset13():
         del os.environ["ORTMODULE_ONNX_OPSET_VERSION"]
     else:
         os.environ["ORTMODULE_ONNX_OPSET_VERSION"] = old_opset
-    assert ortmodule.ONNX_OPSET_VERSION == 13
-    ortmodule.ONNX_OPSET_VERSION = old_opst_cst
+    assert ortmodule_module.ONNX_OPSET_VERSION == 13
+    ortmodule_module.ONNX_OPSET_VERSION = old_opst_cst
 
 
 @pytest.mark.parametrize("opset_version", [12, 13, 14, 15])

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2189,7 +2189,6 @@ def test_ortmodule_inputs_with_dynamic_shape():
 
 
 def test_bert_inputs_with_dynamic_shape():
-
     # create pytorch model with dropout disabled
     pt_model = _get_bert_for_sequence_classification_model(
         "cuda", is_training=True, hidden_dropout_prob=0.0, attention_probs_dropout_prob=0.0
@@ -2776,7 +2775,6 @@ def test_model_with_multiple_devices_to_cuda():
 
 @pytest.mark.parametrize("device", ["cuda", "cuda:0", "cuda:1", "cuda:2"])
 def test_model_with_different_cuda_devices(device):
-
     # Trick to run this test in single GPU machines
     device_id = _utils.get_device_index(device)
     if device_id >= torch.cuda.device_count():
@@ -2933,7 +2931,6 @@ def test_nested_return_value_module(device):
 
 @pytest.mark.parametrize("data_device, model_device", (["cuda", "cpu"], ["cpu", "cuda"]))
 def test_forward_data_and_model_on_different_devices(data_device, model_device):
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     N, D_in, H, D_out = 64, 784, 500, 10
@@ -2945,7 +2942,10 @@ def test_forward_data_and_model_on_different_devices(data_device, model_device):
 
     # Now that the model has been exported, feed in data from device other than the model device
     x = torch.randn(N, D_in, device=data_device)
-    from onnxruntime.training.ortmodule._fallback import ORTModuleDeviceException, _FallbackPolicy
+    from onnxruntime.training.ortmodule._fallback import (
+        ORTModuleDeviceException,
+        _FallbackPolicy,
+    )
 
     if _test_helpers.is_all_or_nothing_fallback_enabled(None, _FallbackPolicy.FALLBACK_UNSUPPORTED_DEVICE):
         # Fallback
@@ -3067,7 +3067,6 @@ def test_model_wrapped_inside_torch_no_grad():
 
 
 def test_model_initializer_requires_grad_changes_from_one_forward_to_next():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     device = "cuda"
@@ -3460,7 +3459,6 @@ def test_train_eval_with_various_outputs():
 
 
 def test_forward_dynamic_args():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     device = "cuda"
@@ -3474,7 +3472,6 @@ def test_forward_dynamic_args():
 
     # Make sure model runs without any exception
     for i in range(2):
-
         # Test both train and inference mode
         if i % 2 == 0:
             model.train()
@@ -3506,7 +3503,6 @@ def test_forward_dynamic_args():
 
 
 def test_forward_dynamic_kwargs():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     one = torch.FloatTensor([1])
@@ -3515,7 +3511,6 @@ def test_forward_dynamic_kwargs():
 
     # Make sure model runs without any exception
     for i in range(2):
-
         # Test both train and inference mode
         if i % 2 == 0:
             model.train()
@@ -3564,44 +3559,46 @@ def test_forward_dynamic_kwargs():
 @pytest.mark.parametrize(
     "forward_statement",
     [  # Only pos_X, pos_X as positionals
-        "model(pos_0, pos_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1),
         # Only pos_X, pos_X as keywords
-        "model(pos_0=pos_0, pos_1=pos_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0=pos_0, pos_1=pos_1),
         # pos_X + *args, pos_X as positionals
-        "model(pos_0, pos_1, *args)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args),
         # pos_X + kw_X, pos_X as positionals
-        "model(pos_0, pos_1, kw_0=kw_0, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, kw_0=kw_0, kw_1=kw_1),
         # pos_X + kw_X,  pos_X as keywords
-        "model(pos_0=pos_0, pos_1=pos_1, kw_0=kw_0, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0=pos_0, pos_1=pos_1, kw_0=kw_0, kw_1=kw_1),
         # pos_X + kw_X, pos_X as positionals (missing kw_1)
-        "model(pos_0, pos_1, kw_0=kw_0)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, kw_0=kw_0),
         # pos_X + kw_X, pos_X as keywords (missing kw_1)
-        "model(pos_0=pos_0, pos_1=pos_1, kw_0=kw_0)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0=pos_0, pos_1=pos_1, kw_0=kw_0),
         # pos_X + kw_X, pos_X as positionals (missing kw_0)
-        "model(pos_0, pos_1, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, kw_1=kw_1),
         # pos_X + kw_X, pos_X as keywords (missing kw_0)
-        "model(pos_0=pos_0, pos_1=pos_1, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0=pos_0, pos_1=pos_1, kw_1=kw_1),
         # pos_X + kwargs, pos_X as positionals
-        "model(pos_0, pos_1, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, **kwargs),
         # pos_X + kwargs, pos_X as keywords
-        "model(pos_0=pos_0, pos_1=pos_1, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0=pos_0, pos_1=pos_1, **kwargs),
         # pos_X + *args + kw_X, pos_X as positionals
-        "model(pos_0, pos_1, *args, kw_0=kw_0, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, kw_0=kw_0, kw_1=kw_1),
         # pos_X + *args + kw_X, pos_X as positionals (missing kw_0)
-        "model(pos_0, pos_1, *args, kw_1=kw_1)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, kw_1=kw_1),
         # pos_X + *args + kw_X, pos_X as positionals (missing kw_1)
-        "model(pos_0, pos_1, *args, kw_0=kw_0)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, kw_0=kw_0),
         # pos_X + *args + kwargs, pos_X as positionals
-        "model(pos_0, pos_1, *args, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, **kwargs),
         # pos_X + *args + kw_X + kwargs, pos_X as positionals
-        "model(pos_0, pos_1, *args, kw_0=kw_0, kw_1=kw_1, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(
+            pos_0, pos_1, *args, kw_0=kw_0, kw_1=kw_1, **kwargs
+        ),
         # pos_X + *args + kw_X + kwargs, pos_X as positionals (missing kw_0)
-        "model(pos_0, pos_1, *args, kw_1=kw_1, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, kw_1=kw_1, **kwargs),
         # pos_X + *args + kw_X + kwargs, pos_X as positionals (missing kw_1)
-        "model(pos_0, pos_1, *args, kw_0=kw_0, **kwargs)",
+        lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1, *args, kw_0=kw_0, **kwargs),
     ],
 )
-def test_forward_call_kwargs_input(forward_statement):
+def test_forward_call_kwargs_input(forward_function):
     class KwargsNet(torch.nn.Module):
         def __init__(self, input_size, hidden_size, num_classes):
             super(KwargsNet, self).__init__()
@@ -3644,7 +3641,7 @@ def test_forward_call_kwargs_input(forward_statement):
     kwargs = {"kwargs_0": torch.randn(N, D_in, device=device), "kwargs_1": torch.randn(D_in, D_in, device=device)}
 
     # Training step
-    prediction = eval(forward_statement)
+    prediction = forward_function(model, pos_0, pos_1, kw_0, kw_1, args, kwargs)
     assert prediction is not None
     prediction = prediction.sum()
     prediction.backward()
@@ -3669,7 +3666,6 @@ def test_repro_iscontiguous():
 
 
 def test_forward_call_default_input():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     class UnusedNet(torch.nn.Module):
@@ -3795,7 +3791,6 @@ def test_forward_call_kwargs_input_unexpected_order():
 
 
 def test_forward_call_lots_None():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     class NoneNet(torch.nn.Module):
@@ -3943,7 +3938,6 @@ def test_primitive_inputs(bool_argument, int_argument, float_argument):
 
 @pytest.mark.parametrize("bool_arguments", [(True, False), (False, True)])
 def test_changing_bool_input_re_exports_model(bool_arguments):
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     class PrimitiveTypesInputNet(torch.nn.Module):
@@ -4116,7 +4110,6 @@ def test_output_order():
 
 @pytest.mark.parametrize("device", ["cuda", "cpu", None])
 def test_stateless_model_specified_device(device):
-
     N, D_in, H, D_out = 32, 784, 500, 10
     pt_model = StatelessModel().to(device)
     ort_model = ORTModule(copy.deepcopy(pt_model))
@@ -4131,7 +4124,6 @@ def test_stateless_model_specified_device(device):
 
 
 def test_stateless_model_unspecified_device():
-
     N, D_in, H, D_out = 32, 784, 500, 10
     pt_model = StatelessModel()
     ort_model = ORTModule(copy.deepcopy(pt_model))
@@ -4238,7 +4230,6 @@ def test_hf_save_pretrained():
 
 
 def test_ortmodule_string_inputs_are_ignored():
-
     pt_model = MyStrNet()
     ort_model = ORTModule(copy.deepcopy(pt_model))
     x = torch.randn(1, 2)
@@ -4346,7 +4337,6 @@ def test_ortmodule_nested_list_input():
 
 @pytest.mark.parametrize("mode", ["training", "inference"])
 def test_debug_options_save_onnx_models_os_environment(mode):
-
     device = "cuda"
     N, D_in, H, D_out = 64, 784, 500, 10
     # Create a temporary directory for the onnx_models
@@ -4370,7 +4360,6 @@ def test_debug_options_save_onnx_models_os_environment(mode):
 
 @pytest.mark.parametrize("mode", ["training", "inference"])
 def test_debug_options_save_onnx_models_cwd(mode):
-
     device = "cuda"
     N, D_in, H, D_out = 64, 784, 500, 10
     model = NeuralNetSinglePositionalArgument(D_in, H, D_out).to(device)
@@ -4395,7 +4384,6 @@ def test_debug_options_save_onnx_models_cwd(mode):
 
 
 def test_debug_options_save_onnx_models_validate_fail_on_non_writable_dir():
-
     os.environ["ORTMODULE_SAVE_ONNX_PATH"] = "/non/existent/directory"
     with pytest.raises(Exception) as ex_info:
         _ = DebugOptions(save_onnx=True, onnx_prefix="my_model")
@@ -4793,7 +4781,6 @@ def test_ortmodule_setattr_ortmodule_attribute():
 
 
 def test_ortmodule_setattr_signals_model_changed():
-
     os.environ["ORTMODULE_SKIPCHECK_POLICY"] = "SKIP_CHECK_DISABLED"
 
     class UserNet(torch.nn.Module):
@@ -4928,7 +4915,6 @@ def test_ortmodule_skip_check_load_from_os_env(policy_str, policy):
 
 @pytest.mark.parametrize("is_training,deterministic", list(itertools.product([True, False], repeat=2)))
 def test_ortmodule_determinism_flag(is_training, deterministic):
-
     torch.use_deterministic_algorithms(deterministic)
 
     N, D_in, H, D_out = 64, 784, 500, 10
@@ -5053,7 +5039,6 @@ def test_override_pytorch_exporter_kwargs_using_ortmodule_extension():
 
 
 def test_ortmodule_fused_adam_optimizer_correctness():
-
     torch.manual_seed(8888)
 
     device = "cuda"
@@ -5102,7 +5087,6 @@ def test_ortmodule_fused_adam_optimizer_correctness():
 
 
 def test_ortmodule_fused_adam_optimizer_correctness_torch():
-
     torch.manual_seed(8888)
 
     device = "cuda"
@@ -5324,7 +5308,6 @@ def test_opset_version_change(opset_version):
 
 
 def test_serialize_ortmodule():
-
     device = "cuda"
     N, D_in, H, D_out = 64, 784, 500, 10
     pt_model = SerializationNet(D_in, H, D_out).to(device)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -535,41 +535,42 @@ def test_forward_call_positional_and_keyword_arguments():
     prediction.backward()
 
 
+_ONE = torch.FloatTensor([1])
+
+
 @pytest.mark.parametrize(
-    "forward_statement",
+    "forward_function",
     [
-        "model(one)",
-        "model(x=one)",
-        "model(one, None, None)",
-        "model(one, None, z=None)",
-        "model(one, None)",
-        "model(x=one, y=one)",
-        "model(y=one, x=one)",
-        "model(y=one, z=None, x=one)",
-        "model(one, None, z=one)",
-        "model(x=one, z=one)",
-        "model(one, z=one)",
-        "model(one, z=one, y=one)",
-        "model(one, one, one)",
-        "model(one, None, one)",
-        "model(z=one, x=one, y=one)",
-        "model(z=one, x=one, y=None)",
+        lambda model: model(_ONE),
+        lambda model: model(x=_ONE),
+        lambda model: model(_ONE, None, None),
+        lambda model: model(_ONE, None, z=None),
+        lambda model: model(_ONE, None),
+        lambda model: model(x=_ONE, y=_ONE),
+        lambda model: model(y=_ONE, x=_ONE),
+        lambda model: model(y=_ONE, z=None, x=_ONE),
+        lambda model: model(_ONE, None, z=_ONE),
+        lambda model: model(x=_ONE, z=_ONE),
+        lambda model: model(_ONE, z=_ONE),
+        lambda model: model(_ONE, z=_ONE, y=_ONE),
+        lambda model: model(_ONE, _ONE, _ONE),
+        lambda model: model(_ONE, None, _ONE),
+        lambda model: model(z=_ONE, x=_ONE, y=_ONE),
+        lambda model: model(z=_ONE, x=_ONE, y=None),
     ],
 )
-def test_compare_pytorch_forward_call_positional_and_keyword_arguments(forward_statement):
-    one = torch.FloatTensor([1])
-
+def test_compare_pytorch_forward_call_positional_and_keyword_arguments(forward_function):
     model = NeuralNetSimplePositionalAndKeywordArguments()
-    pytorch_result = eval(forward_statement + ".item()")
+    pytorch_result = forward_function(model).item()
 
     model = NeuralNetSimplePositionalAndKeywordArguments()
     model = ORTModule(model)
-    ortmodule_result = eval(forward_statement + ".item()")
-    ortmodule_result_again = eval(forward_statement + ".item()")
+    ortmodule_result = forward_function(model).item()
+    ortmodule_result_again = forward_function(model).item()
     assert ortmodule_result == ortmodule_result_again
     assert pytorch_result == ortmodule_result
 
-    prediction = eval(forward_statement).sum()
+    prediction = forward_function(model).item()
     prediction.backward()
 
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -3558,7 +3558,7 @@ def test_forward_dynamic_kwargs():
 
 
 @pytest.mark.parametrize(
-    "forward_statement",
+    "forward_function",
     [  # Only pos_X, pos_X as positionals
         lambda model, pos_0, pos_1, kw_0, kw_1, args, kwargs: model(pos_0, pos_1),
         # Only pos_X, pos_X as keywords


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove the use of `eval` in test code so we don't (1) use eval and (2) create "unused" local vars that ruff will remove. Predecessor to #15085 
