### PR TITLE
Do not apply QuickGeluFusion if an intermediate tensor is a graph output

### DIFF
--- a/onnxruntime/core/optimizer/quick_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/quick_gelu_fusion.cc
@@ -30,7 +30,8 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     int alpha_index = -1;
     float alpha = 1.0f;
     if (graph_utils::IsSupportedOptypeVersionAndDomain(node, "Mul", {7, 13, 14}) &&
-        graph_utils::IsSupportedProvider(node, GetCompatibleExecutionProviders()) && node.GetOutputEdgesCount() == 1) {
+        graph_utils::IsSupportedProvider(node, GetCompatibleExecutionProviders()) && node.GetOutputEdgesCount() == 1 &&
+	!graph.NodeProducesGraphOutput(node)) {
       for (int i = 0; i < static_cast<int>(node.InputDefs().size()); ++i) {
         const NodeArg& input_arg = *(node.InputDefs()[i]);
         if (!optimizer_utils::IsScalar(input_arg)) continue;
@@ -68,7 +69,7 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     Node& sigmoid_node = *p_sigmoid_node;
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(sigmoid_node, "Sigmoid", {6, 13}) ||
         !graph_utils::IsSupportedProvider(sigmoid_node, GetCompatibleExecutionProviders()) ||
-        sigmoid_node.GetOutputEdgesCount() != 1) {
+        sigmoid_node.GetOutputEdgesCount() != 1 || graph.NodeProducesGraphOutput(sigmoid_node)) {
       continue;
     }
     nodes_to_fuse.emplace_back(sigmoid_node);


### PR DESCRIPTION
### Description

This strengthens the application condition of QuickGeluFusion, preventing it from being applied when an intermedaite tensor is a graph output.

### Motivation and Context

If tensor `t2` or `t3` is a graph output, the following graph

```mermaid
graph LR;
  t1((t1)) --> Mul1[Mul];
  Mul1 --> t2((t2))
  t2 --> Sigmoid;
  Sigmoid --> t3((t3));
  t3 --> Mul2[Mul];
  Mul2 --> t4((t4));
```

must not be optimized into

```mermaid
graph LR;
  t1((t1)) --> QuickGelu;
  QuickGelu --> t4((t4));
```

, as the values of tensor `t2` and `t3` are not computed in the latter graph.


The current condition, `GetOutputEdgesCount() == 1`, by itself is insufficient to block the application of QuickGeluFusion. Note that, in the former graph, the first Mul operator is only connected to the Sigmoid operator and the Sigmoid operator is only connected to the second Mul operator. As a result, the number of output edges for both the first Mul and Sigmoid is equal to 1.