### PR TITLE
Disable unit tests for decoder masked multihead attention on CC 5.2 or lower GPUs

### DIFF
--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -635,7 +635,7 @@ std::vector<MLFloat16> Softmax_QK_Transpose_V(MLFloat16* softmax_qk_transpose_ma
   return output;
 }
 TEST(DecoderMaskedMultiheadAttentionTest, Test_fp32) {
-  // The kernel is only supported for CC 5.3 or higher
+  // The kernel is only supported on CC 5.3 or higher GPUs
   if (NeedSkipIfCudaArchLowerThan(530)) {
     return;
   }
@@ -747,7 +747,7 @@ TEST(DecoderMaskedMultiheadAttentionTest, Test_fp32) {
 }
 
 TEST(DecoderMaskedMultiheadAttentionTest, Test_fp16) {
-  // The kernel is only supported for CC 5.3 or higher
+  // The kernel is only supported on CC 5.3 or higher GPUs
   if (NeedSkipIfCudaArchLowerThan(530)) {
     return;
   }

--- a/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/decoder_masked_multihead_attention_op_test.cc
@@ -635,6 +635,11 @@ std::vector<MLFloat16> Softmax_QK_Transpose_V(MLFloat16* softmax_qk_transpose_ma
   return output;
 }
 TEST(DecoderMaskedMultiheadAttentionTest, Test_fp32) {
+  // The kernel is only supported for CC 5.3 or higher
+  if (NeedSkipIfCudaArchLowerThan(530)) {
+    return;
+  }
+
   // Vary batch size
   for (int batch_size = 1; batch_size <= 5; batch_size += 2) {
     // Vary kv_lengths
@@ -742,6 +747,11 @@ TEST(DecoderMaskedMultiheadAttentionTest, Test_fp32) {
 }
 
 TEST(DecoderMaskedMultiheadAttentionTest, Test_fp16) {
+  // The kernel is only supported for CC 5.3 or higher
+  if (NeedSkipIfCudaArchLowerThan(530)) {
+    return;
+  }
+
   // Vary batch size
   for (int batch_size = 1; batch_size <= 5; batch_size += 2) {
     // Vary kv_lengths


### PR DESCRIPTION
### Description
A couple of pipelines use an Azure VM SKU that have M60 GPUs (CC 5.2 cards) and the decoder masked multihead attention is not supported on these cards and so the corresponding tests fail. An ONNX model using this op will notify the user that using this op is not supported on cards whose CC is < 5.3 as we have relevant checks in `GreedySearch` and `BeamSearch` (op will only be used in the `GreedySearch`/`BeamSearch` context). This PR disables the unit tests for the kernel on CC 5.2 or lower cards.

### Motivation and Context
Fix broken pipelines


