### PR TITLE
Handle unused function inputs

### DIFF
--- a/onnxruntime/core/graph/function_utils.cc
+++ b/onnxruntime/core/graph/function_utils.cc
@@ -229,7 +229,18 @@ static void IOTypeConstraintHelper(const ONNX_NAMESPACE::FunctionProto& onnx_fun
 
   int i = 0;
   for (auto& input : input_types_list) {
-    op_schema->Input(i, input.first, "", input.second);
+    if (! input.first.empty()) {
+      op_schema->Input(i, input.first, "", input.second);
+    } else {
+      // Handle unused input: its type can be anything.
+      std::string type_str = "Tin" + std::to_string(i);
+      op_schema->Input(i, onnx_func_proto.input(i), "", type_str);
+      auto& dest_types = type_constraint_map[type_str];
+      dest_types.reserve(dest_types.size() + all_types.size());
+      for (const auto& data_type : all_types) {
+        dest_types.emplace_back(data_type);
+      }
+    }
     ++i;
   }
   i = 0;

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -372,5 +372,23 @@ TEST(FunctionTest, OuterScopeName) {
 
   Check(code, "x", {1.0, 2.0, 3.0}, "y", {1.0, 2.0, 3.0, 0.0, 0.0, 0.0});
 }
+
+// Test use of functions with unused inputs:
+TEST(FunctionTest, UnusedFunctionInputs) {
+  const char* code = R"(
+    <ir_version: 8, opset_import: ["" : 17, "local" : 1]>
+    mymodel (float[3] x) => (float[3] y) {
+      y = local.func (x, x, x)
+    }
+
+    <opset_import: ["" : 17 ],  domain: "local">
+    func (a, b, c) => (y) {
+      y = Mul (a, b)
+    }
+  )";
+
+  Check(code, "x", {1.0, 2.0, 3.0}, "y", {1.0, 4.0, 9.0});
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

Fix issue relating to unused inputs of model-local functions. ORT creates a schema for all such functions. The creation of this schema does not handle unused function-inputs. The schema-creation relies on the use of the function-inputs to infer type-constraints for the input, and the code ends up creating an erroneous input-descriptor when there is no use of the function-input.

The fix is to create an input with the given name, with a type-constraint that allows all types.

### Motivation and Context
Fix https://github.com/microsoft/onnxruntime/issues/15046



