### PR TITLE
Fix test_custom_op_get_const_input inference test on Android CI

### DIFF
--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1207,7 +1207,7 @@ TEST(CApiTest, RegisterCustomOpForCPUAndCUDA) {
 }
 #endif
 
-#if (!defined(ORT_MINIMAL_BUILD)) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
+#if (!defined(__ANDROID__)) && ((!defined(ORT_MINIMAL_BUILD)) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
 TEST(CApiTest, test_custom_op_get_const_input) {
   const auto* model_path = TSTR("testdata/test_kernel_info_get_const_input.onnx");
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1207,7 +1207,7 @@ TEST(CApiTest, RegisterCustomOpForCPUAndCUDA) {
 }
 #endif
 
-#if (!defined(__ANDROID__)) && ((!defined(ORT_MINIMAL_BUILD)) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS))
+#if (!defined(ORT_MINIMAL_BUILD)) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
 TEST(CApiTest, test_custom_op_get_const_input) {
   const auto* model_path = TSTR("testdata/test_kernel_info_get_const_input.onnx");
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1627,6 +1627,7 @@ def run_android_tests(args, source_dir, build_dir, config, cwd):
                 adb_push("libonnxruntime.so", device_dir, cwd=cwd)
                 adb_push("onnxruntime_shared_lib_test", device_dir, cwd=cwd)
                 adb_push("libcustom_op_library.so", device_dir, cwd=cwd)
+                adb_push("libcustom_op_get_const_input_test_library.so", device_dir, cwd=cwd)
                 adb_push("onnxruntime_customopregistration_test", device_dir, cwd=cwd)
                 adb_shell("chmod +x {}/onnxruntime_shared_lib_test".format(device_dir))
                 adb_shell("chmod +x {}/onnxruntime_customopregistration_test".format(device_dir))


### PR DESCRIPTION
Fix test_custom_op_get_const_input for inference test on Android CI and copy custom op libraries to the emulator.


