### PR TITLE
Remove duplicate symbols

### DIFF
--- a/onnxruntime/core/providers/cuda/math/einsum.cc
+++ b/onnxruntime/core/providers/cuda/math/einsum.cc
@@ -4,14 +4,6 @@
 #include "einsum.h"
 
 namespace onnxruntime {
-
-// This function must exist due to the C++ base class constructor needing this to be defined for the vtable, but it is never called.
-Status Einsum::DeviceCompute(OpKernelContext* /*context*/, const std::vector<const Tensor*>& /*inputs*/,
-                             AllocatorPtr /*allocator*/, concurrency::ThreadPool* /*tp*/) const {
-  assert(false);
-  return Status::OK();
-}
-
 namespace cuda {
 
 ONNX_OPERATOR_KERNEL_EX(

--- a/onnxruntime/core/providers/rocm/math/einsum.cc
+++ b/onnxruntime/core/providers/rocm/math/einsum.cc
@@ -4,14 +4,6 @@
 #include "einsum.h"
 
 namespace onnxruntime {
-
-// This function must exist due to the C++ base class constructor needing this to be defined for the vtable, but it is never called.
-Status Einsum::DeviceCompute(OpKernelContext* /*context*/, const std::vector<const Tensor*>& /*inputs*/,
-                             AllocatorPtr /*allocator*/, concurrency::ThreadPool* /*tp*/) const {
-  assert(false);
-  return Status::OK();
-}
-
 namespace rocm {
 
 ONNX_OPERATOR_KERNEL_EX(


### PR DESCRIPTION
### Description

This does not allow using static linkage of cuda provider and onnxruntime itself.
I was unable to reproduce vtable error mentioned above the symbol definition.

Could we run the CI to test if the problem still exists?

