### PR TITLE
Fix prune_graph and gpt attention fusion scripts

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_gpt_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_gpt_attention.py
@@ -43,7 +43,7 @@ class FusionGptAttentionPastBase(Fusion):
         #             |
         #         {present}
         gather = self.model.get_parent(concat_v, 0, output_name_to_node)
-        if gather.op_type != "Gather":
+        if gather is None or gather.op_type != "Gather":
             logger.debug("match_past_pattern_1: expect Gather for past")
             return None
 
@@ -53,7 +53,7 @@ class FusionGptAttentionPastBase(Fusion):
         past = gather.input[0]
 
         parent = self.model.get_parent(concat_k, 0, output_name_to_node)
-        if parent.op_type == "Gather":
+        if parent and parent.op_type == "Gather":
             gather_past_k = parent
         else:
             past_k_nodes = self.model.match_parent_path(concat_k, ["Transpose", "Gather"], [0, 0])
@@ -95,12 +95,12 @@ class FusionGptAttentionPastBase(Fusion):
         #               {present}
         #
         squeeze = self.model.get_parent(concat_v, 0, output_name_to_node)
-        if squeeze.op_type != "Squeeze":
+        if squeeze is None or squeeze.op_type != "Squeeze":
             logger.debug("match_past_pattern_2: expect Squeeze as parent of concat_v")
             return None
 
         split = self.model.get_parent(squeeze, 0, output_name_to_node)
-        if split.op_type != "Split":
+        if split is None or split.op_type != "Split":
             logger.debug("match_past_pattern_2: expect Split for past path")
             return None
 


### PR DESCRIPTION
### Description
Fix two issues:
(1) GPT attention fusion: get_parent could return None when the input is initializer, add a check
(2) ONNX node could have optional inputs and outputs. During prune_graph, we shall exclude empty inputs/outputs. Here we exclude "" from output_name_to_node and input_name_to_nodes.
(3) Add an option allow_remove_graph_inputs in prune_graph



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


