### PR TITLE
Fixed some warnings that were treated as errors when compiling with D…

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
@@ -114,7 +114,7 @@ namespace Dml
             if (bucket->resources.empty())
             {
                 // No more resources in this bucket - allocate a new one
-                resourceWrapper = m_subAllocator->Alloc(bucketSize);
+                resourceWrapper = m_subAllocator->Alloc(onnxruntime::narrow<size_t>(bucketSize));
                 resourceId = ++m_currentResourceId;
             }
             else
@@ -129,7 +129,7 @@ namespace Dml
         {
             // The allocation will not be pooled.  Construct a new one
             bucketSize = (size + 3) & ~3;
-            resourceWrapper = m_subAllocator->Alloc(bucketSize);
+            resourceWrapper = m_subAllocator->Alloc(onnxruntime::narrow<size_t>(bucketSize));
             resourceId = ++m_currentResourceId;
         }
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlDFT.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlDFT.h
@@ -290,7 +290,7 @@ public:
             ORT_THROW_IF_FAILED(outputUnknown.As(&outputResource));
 
             // Get optional dft_length input
-            uint32_t dftLength = inputDims[m_axis];
+            uint32_t dftLength = inputDims[onnxruntime::narrow<size_t>(m_axis)];
             ComPtr<IMLOperatorTensor> dftLengthTensor;
             if (SUCCEEDED(context->GetInputTensor(1, &dftLengthTensor)) && dftLengthTensor != nullptr)
             {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConcatFromSequence.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorConcatFromSequence.cpp
@@ -108,7 +108,7 @@ public:
 
                 auto outputDescs = std::vector<DML_TENSOR_DESC> { m_outputTensorDesc.GetDmlDesc() };
                 auto inputDescs = std::vector<DML_TENSOR_DESC>(m_inputTensorDescs.size());
-                for (int i = 0; i < inputDescs.size(); i++)
+                for (size_t i = 0; i < inputDescs.size(); i++)
                 {
                     inputDescs[i] = m_inputTensorDescs[i].GetDmlDesc();
                 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlSTFT.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlSTFT.h
@@ -378,8 +378,7 @@ public:
             ORT_THROW_IF_FAILED(executionObject.As(&commandList));
 
             ComPtr<ID3D12Resource> framingOutputResource;
-            ORT_THROW_IF_FAILED(context->AllocateTemporaryData(m_framingOperator.outputBufferSizeInBytes, &framingOutputResource));
-
+            ORT_THROW_IF_FAILED(context->AllocateTemporaryData(onnxruntime::narrow<size_t>(m_framingOperator.outputBufferSizeInBytes), &framingOutputResource));
             DispatchFramingOperator(commandList.Get(), context, framingOutputResource.Get());
 
             ComPtr<ID3D12Resource> outputResource = DmlSTFTHelpers::GetOutputResourceFromKernelContext(context, 0);
@@ -450,7 +449,7 @@ public:
         auto tempBufferSize = bindingProps.TemporaryResourceSize;
         if (tempBufferSize > 0)
         {
-            ORT_THROW_IF_FAILED(context->AllocateTemporaryData(tempBufferSize, &tempBuffer));
+            ORT_THROW_IF_FAILED(context->AllocateTemporaryData(onnxruntime::narrow<size_t>(tempBufferSize), &tempBuffer));
 
             DML_BUFFER_BINDING bufferBinding = { tempBuffer.Get(), 0, tempBufferSize };
             DML_BINDING_DESC bindingDesc = { DML_BINDING_TYPE_BUFFER, &bufferBinding };


### PR DESCRIPTION
…ML in Win32/MSVC.

### Description
Use onnxruntime::narrow to silence some warnings that are turned into errors when compiling the DML provider in Win32.

Also one case of warning turned to error for mixing int loop variable type with a vector size() as upper bound.


### Motivation and Context
Solves [https://github.com/microsoft/onnxruntime/issues/14595](https://github.com/microsoft/onnxruntime/issues/14595)


