### PR TITLE
Remove root in run_python_dockerbuild.sh

### DIFF
--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -15,7 +15,6 @@ docker run --rm \
     --volume $BUILD_BINARIESDIRECTORY:/build \
     --volume /data/models:/build/models:ro \
     --volume $HOME/.onnx:/home/onnxruntimedev/.onnx \
-    -u root \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \


### PR DESCRIPTION
Running docker in root causes the pipeline to be stateful and subsequently fail