### PR TITLE
Re-work OrtApi struct to satisfy C++20 compilers

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4088,7 +4088,17 @@ struct OrtApi {
   ORT_API2_STATUS(KernelInfoGetConstantInput_tensor, _In_ const OrtKernelInfo* info, size_t index, _Out_ int* is_constant, _Outptr_ const OrtValue** out); 
 
 #ifdef __cplusplus
-  OrtApi(const OrtApi&) = delete;  // Prevent users from accidentally copying the API structure, it should always be passed as a pointer
+  // We would like to disable copying of this structure
+  // However, deleting the copy constructor and assignment operator
+  // prevents us from initializing it memberwise.
+  // This m_no_copy implicitly deletes the copy constructor and assignment operator.
+  struct NoCopy {
+    int dummy = 5;
+    NoCopy() = default;
+    NoCopy(const NoCopy&) = delete;
+    NoCopy& operator=(const NoCopy&) = delete;
+  };
+  NoCopy m_no_copy;
 #endif
 };
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4086,19 +4086,6 @@ struct OrtApi {
    * \since Version 1.15.
    */
   ORT_API2_STATUS(KernelInfoGetConstantInput_tensor, _In_ const OrtKernelInfo* info, size_t index, _Out_ int* is_constant, _Outptr_ const OrtValue** out); 
-
-#ifdef __cplusplus
-  // We would like to disable copying of this structure
-  // However, deleting the copy constructor and assignment operator
-  // prevents us from initializing it memberwise.
-  // This m_no_copy implicitly deletes the copy constructor and assignment operator.
-  struct NoCopy {
-    NoCopy() = default;
-    NoCopy(const NoCopy&) = delete;
-    NoCopy& operator=(const NoCopy&) = delete;
-  };
-  NoCopy m_no_copy;
-#endif
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4093,7 +4093,6 @@ struct OrtApi {
   // prevents us from initializing it memberwise.
   // This m_no_copy implicitly deletes the copy constructor and assignment operator.
   struct NoCopy {
-    int dummy = 5;
     NoCopy() = default;
     NoCopy(const NoCopy&) = delete;
     NoCopy& operator=(const NoCopy&) = delete;

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2403,7 +2403,7 @@ Second example, if we wanted to add and remove some members, we'd do this:
     In GetApi we now make it return ort_api_3 for version 3.
 */
 
-static constexpr OrtApi ort_api_1_to_15 = {
+static const OrtApi ort_api_1_to_15 = {
     // NOTE: The ordering of these fields MUST not change after that version has shipped since existing binaries depend on this ordering.
 
     // Shipped as version 1 - DO NOT MODIFY (see above text for more information)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2403,7 +2403,7 @@ Second example, if we wanted to add and remove some members, we'd do this:
     In GetApi we now make it return ort_api_3 for version 3.
 */
 
-static const OrtApi ort_api_1_to_15 = {
+static constexpr OrtApi ort_api_1_to_15 = {
     // NOTE: The ordering of these fields MUST not change after that version has shipped since existing binaries depend on this ordering.
 
     // Shipped as version 1 - DO NOT MODIFY (see above text for more information)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Remove `deletion` of copy functions from `OrtApi` as its initialization no longer compiles in C++20.
Introduce a non-copyable member to implicitly delete copy ctor.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Inspired by https://github.com/microsoft/onnxruntime/pull/14901

Solution credits: @RyanUnderhill 

Cc: @georgthegreat

