### PR TITLE
Fix: Add def main() in onnxruntime_test.py

### DIFF
--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -127,7 +127,7 @@ def run_model(
     return 0, feeds, num_iters > 0 and outputs
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description="Simple ONNX Runtime Test Tool.")
     parser.add_argument("model_path", help="model path")
     parser.add_argument(
@@ -155,3 +155,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     exit_code, _, _ = run_model(args.model_path, args.num_iters, args.debug, args.profile, args.symbolic_dims)
     sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
- Defines a method `main()` in [onnxruntime_test.py](https://github.com/leso-kn/onnxruntime/blob/dc30b5fa501a3d5937259e53903b054c7f3ad876/onnxruntime/python/tools/onnxruntime_test.py#L130).

### Motivation and Context
- This is required for `/usr/bin/onnxruntime_test` to work when installing system wide (e.g. through `setup.py install`)

**Fixes the following error:**

```bash
> onnxruntime_test -h
Traceback (most recent call last):
  File "/usr/bin/onnxruntime_test", line 33, in <module>
    sys.exit(load_entry_point('onnxruntime==1.14.1', 'console_scripts', 'onnxruntime_test')())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/onnxruntime_test", line 25, in importlib_load_entry_point
    return next(matches).load()
          ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 204, in load
    return functools.reduce(getattr, attrs, module)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'onnxruntime.tools.onnxruntime_test' has no attribute 'main'
```

**With this PR**

```bash
> onnxruntime_test -h
usage: onnxruntime_test [-h] [--debug] [--profile] [--symbolic_dims SYMBOLIC_DIMS] model_path [num_iters]
[...]
```
