### PR TITLE
Fuse 'Add' operator into FP16 Conv

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -50,6 +50,7 @@ Do not modify directly.*
   * <a href="#com.microsoft.MurmurHash3">com.microsoft.MurmurHash3</a>
   * <a href="#com.microsoft.NGramRepeatBlock">com.microsoft.NGramRepeatBlock</a>
   * <a href="#com.microsoft.NhwcConv">com.microsoft.NhwcConv</a>
+  * <a href="#com.microsoft.NhwcFusedConv">com.microsoft.NhwcFusedConv</a>
   * <a href="#com.microsoft.NhwcMaxPool">com.microsoft.NhwcMaxPool</a>
   * <a href="#com.microsoft.PackedAttention">com.microsoft.PackedAttention</a>
   * <a href="#com.microsoft.Pad">com.microsoft.Pad</a>
@@ -2562,6 +2563,66 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
+</dl>
+
+
+### <a name="com.microsoft.NhwcFusedConv"></a><a name="com.microsoft.nhwcfusedconv">**com.microsoft.NhwcFusedConv**</a>
+
+  NhwcFusedConv is a float16 Conv operator with optional activation and add operators fused in.
+  It also processes both NHWC and NCHW format.
+
+#### Version
+
+This version of the operator has been available since version 1 of the 'com.microsoft' operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>activation</tt> : string</dt>
+<dd></dd>
+<dt><tt>activation_params</tt> : list of floats</dt>
+<dd></dd>
+<dt><tt>auto_pad</tt> : string</dt>
+<dd></dd>
+<dt><tt>channels_last</tt> : int</dt>
+<dd>0(default) when input tensor is NCHW, else the input is NHWC</dd>
+<dt><tt>dilations</tt> : list of ints</dt>
+<dd></dd>
+<dt><tt>group</tt> : int</dt>
+<dd></dd>
+<dt><tt>kernel_shape</tt> : list of ints</dt>
+<dd></dd>
+<dt><tt>pads</tt> : list of ints</dt>
+<dd></dd>
+<dt><tt>strides</tt> : list of ints</dt>
+<dd></dd>
+</dl>
+
+#### Inputs (2 - 4)
+
+<dl>
+<dt><tt>X</tt> : T</dt>
+<dd></dd>
+<dt><tt>W</tt> : T</dt>
+<dd></dd>
+<dt><tt>B</tt> (optional) : T</dt>
+<dd></dd>
+<dt><tt>Z</tt> (optional) : T</dt>
+<dd>Tensor to be added to the output, must be the same shape and format as the output tensor.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T</dt>
+<dd></dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float16)</dt>
+<dd>Constrain input and output types to float tensors</dd>
 </dl>
 
 

--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2568,8 +2568,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 ### <a name="com.microsoft.NhwcFusedConv"></a><a name="com.microsoft.nhwcfusedconv">**com.microsoft.NhwcFusedConv**</a>
 
-  NhwcFusedConv is a float16 Conv operator with optional activation and add operators fused in.
-  It also processes both NHWC and NCHW format.
+  NhwcFusedConv is a Conv operator with optional activation and add operators fused in.
+  Only has fp16 implementation as of 2023/04/15.
 
 #### Version
 
@@ -2584,8 +2584,6 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd></dd>
 <dt><tt>auto_pad</tt> : string</dt>
 <dd></dd>
-<dt><tt>channels_last</tt> : int</dt>
-<dd>0(default) when input tensor is NCHW, else the input is NHWC</dd>
 <dt><tt>dilations</tt> : list of ints</dt>
 <dd></dd>
 <dt><tt>group</tt> : int</dt>

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -16,9 +16,6 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv);
-#ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 1, MLFloat16, FusedConv);
-#endif
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GreedySearch);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Sampling);
@@ -81,6 +78,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 // ******** End: Quantization ******************* //
 
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, NhwcFusedConv);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, MaxPool);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, AveragePool);
 #endif
@@ -154,6 +152,7 @@ Status RegisterNchwcKernels(KernelRegistry& kernel_registry) {
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
 Status RegisterFp16Kernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, NhwcFusedConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, MaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, AveragePool)>,
   };
@@ -228,9 +227,6 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, EmbedLayerNormalization)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv)>,
-#ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 1, MLFloat16, FusedConv)>,
-#endif
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GreedySearch)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, Sampling)>,

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -17,7 +17,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv);
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, FusedConv);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 1, MLFloat16, FusedConv);
 #endif
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GreedySearch);
@@ -229,7 +229,7 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, ExpandDims)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedConv)>,
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
-    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, FusedConv)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 1, MLFloat16, FusedConv)>,
 #endif
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, FusedGemm)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GreedySearch)>,

--- a/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
+++ b/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
@@ -13,7 +13,6 @@ namespace onnxruntime {
 namespace contrib {
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearAveragePool);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearConvTranspose);
-class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, FusedConv);
 }  // namespace contrib
 namespace internal_nhwc_onnx {
 
@@ -49,21 +48,6 @@ void RegisterNHWCSchemaWithActivation(const RegistrationFunc& f, ::ONNX_NAMESPAC
                   })
                   .SetDomain(onnxruntime::kMSInternalNHWCDomain)));
 }
-
-void RegisterNHWCSchemaWithSumActivation(const RegistrationFunc& f, ::ONNX_NAMESPACE::OpSchema&& schema) {
-  auto onnx_inferencing_func = schema.GetTypeAndShapeInferenceFunction();
-  f(std::move(::ONNX_NAMESPACE::OpSchema(schema)
-                  .Input(3, "Z", "", "T", ::ONNX_NAMESPACE::OpSchema::Optional)
-                  .Attr("activation", "", ONNX_NAMESPACE::AttributeProto::STRING, ONNX_NAMESPACE::OPTIONAL_VALUE)
-                  .Attr("activation_params", "", ONNX_NAMESPACE::AttributeProto::FLOATS, ONNX_NAMESPACE::OPTIONAL_VALUE)
-                  .TypeAndShapeInferenceFunction([onnx_inferencing_func](ONNX_NAMESPACE::InferenceContext& ctx) {
-                    NhwcInferenceContext nhwc_ctx(ctx);
-                    onnx_inferencing_func(nhwc_ctx);
-                    nhwc_ctx.PropagateOutputShape();
-                  })
-                  .SetDomain(onnxruntime::kMSInternalNHWCDomain)));
-}
-
 }  // namespace
 
 #define REGISTER_NHWC_SCHEMA_FROM_MSDOMAIN(RegistrationFn, Op, SinceVersion) \
@@ -134,8 +118,6 @@ void OpSet_Internal_NHWC_ONNX::ForEachSchema(const std::function<void(ONNX_NAMES
   // internal QLinear ops
   REGISTER_NHWC_SCHEMA_FROM_MSDOMAIN(fn, QLinearAveragePool, 1);
   REGISTER_NHWC_SCHEMA_FROM_MSDOMAIN(fn, QLinearConvTranspose, 1);
-  RegisterNHWCSchemaWithSumActivation(
-      fn, contrib::GetOpSchema<contrib::ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, FusedConv)>());
 
   // not all schema are registered here. For part of layout insensitive ops
   // we will use onnx schema directly, for others, like fused-node/qdq-group

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -13,6 +13,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearGlobalAveragePool
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearAveragePool);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearConv);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, NhwcConv);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, NhwcFusedConv);
 
 // Quantization ops
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DequantizeLinear);
@@ -109,6 +110,7 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearAveragePool)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearConv)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, NhwcConv)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, NhwcFusedConv)>());
 
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DequantizeLinear)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DequantizeBFP)>());

--- a/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/nhwc_schema_defs.cc
@@ -387,10 +387,9 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
 ONNX_MS_OPERATOR_SET_SCHEMA(NhwcFusedConv, 1,
                             OpSchema()
                                 .SetDoc(R"DOC(
-NhwcFusedConv is a float16 Conv operator with optional activation and add operators fused in.
-It also processes both NHWC and NCHW format.
+NhwcFusedConv is a Conv operator with optional activation and add operators fused in.
+Only has fp16 implementation as of 2023/04/15.
 )DOC")
-                                .Attr("channels_last", "0(default) when input tensor is NCHW, else the input is NHWC", AttributeProto::INT, static_cast<int64_t>(0))
                                 .Attr("auto_pad", "", AttributeProto::STRING, std::string("NOTSET"))
                                 .Attr("kernel_shape", "", AttributeProto::INTS, OPTIONAL_VALUE)
                                 .Attr("dilations", "", AttributeProto::INTS, OPTIONAL_VALUE)
@@ -405,18 +404,9 @@ It also processes both NHWC and NCHW format.
                                 .Input(3, "Z", "Tensor to be added to the output, must be the same shape and format as the output tensor.", "T", OpSchema::Optional)
                                 .Output(0, "Y", "", "T")
                                 .TypeConstraint("T", {"tensor(float16)"}, "Constrain input and output types to float tensors")
-                                //.TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-                                //  ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-                                //  ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
-                                //}));
                                 .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
                                   ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 0, 0);
-
-                                  if (getAttribute(ctx, "channels_last", 0) == 0) {
-                                    ONNX_NAMESPACE::convPoolShapeInference(ctx, true, false, 0, 1);
-                                  } else {
-                                    onnxruntime::contrib::convPoolShapeInferenceNhwc(ctx, true, false, 0, 1);
-                                  }
+                                  convPoolShapeInferenceNhwc(ctx, true, false, 0, 1);
                                 }));
 
 }  // namespace contrib

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1437,18 +1437,20 @@ public:
 };
 
 /**
- * @brief Half precision activation functions
+ * @brief Half precision activation functions, with optional sum tensor.
+ * Supplied sum tensor must be the same layout as the GEMM output tensor.
+ * And the supplied sum tensor will be added to the final result.
 */
-class MLAS_HALF_GEMM_ACTIVATION_PROCESSOR : public MLAS_HALF_GEMM_POSTPROCESSOR {
-public:
+class MLAS_HALF_GEMM_ACTIVATION_PROCESSOR : public MLAS_HALF_GEMM_POSTPROCESSOR
+{
+  public:
     MLAS_HALF_GEMM_ACTIVATION_PROCESSOR(
-        const MLAS_ACTIVATION& Activation
-        ) :
-            Activation_(Activation)
+        const MLAS_ACTIVATION& Activation,
+        const MLAS_FP16* SumBuf = nullptr)
+       : Activation_(Activation), SumBuf_(SumBuf)
     {}
 
-    void
-    Process(
+    void Process(
         MLAS_FP16* C,
         size_t StartM,
         size_t StartN,
@@ -1457,8 +1459,9 @@ public:
         size_t ldc
         ) const override;
 
-private:
+  private:
     const MLAS_ACTIVATION& Activation_;
+    const MLAS_FP16* SumBuf_;
 };
 
 inline

--- a/onnxruntime/core/mlas/lib/activate_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/activate_fp16.cpp
@@ -25,6 +25,20 @@ Abstract:
 template<MLAS_ACTIVATION_KIND ActivationKind>
 struct MLAS_HALF_ACTIVATION_FUNCTION;
 
+template <>
+struct MLAS_HALF_ACTIVATION_FUNCTION<MlasIdentityActivation> {
+    MLAS_HALF_ACTIVATION_FUNCTION(const MLAS_ACTIVATION& Activation)
+    {
+        MLAS_UNREFERENCED_PARAMETER(Activation);
+    }
+
+    MLAS_FLOAT16X8 Activate(MLAS_FLOAT16X8 Value) { return Value; }
+
+    MLAS_FLOAT16X4 Activate(MLAS_FLOAT16X4 Value) { return Value; }
+
+    float Activate(float Value) { return Value; }
+};
+
 template<>
 struct MLAS_HALF_ACTIVATION_FUNCTION<MlasReluActivation>
 {
@@ -582,7 +596,7 @@ inline
 void
 MlasActivationKernel(
     const MLAS_ACTIVATION& Activation,
-    MLAS_FP16* Buffer,
+    _mlas_fp16_* Buffer,
     size_t StartM,
     size_t StartN,
     size_t CountM,
@@ -592,8 +606,7 @@ MlasActivationKernel(
 {
     MLAS_HALF_ACTIVATION_FUNCTION<ActivationKind> ActivationFunction(Activation);
 
-    auto* CRow = reinterpret_cast<_mlas_fp16_*>(Buffer);
-    CRow += StartM * ldc + StartN;
+    auto* CRow = Buffer + StartM * ldc + StartN;
 
     while (CountM-- > 0) {
         _mlas_fp16_* buffer = CRow;
@@ -629,7 +642,7 @@ inline
 void
 MlasActivationKernel<MlasIdentityActivation>(
     const MLAS_ACTIVATION& Activation,
-    MLAS_FP16* Buffer,
+    _mlas_fp16_* Buffer,
     size_t StartM,
     size_t StartN,
     size_t CountM,
@@ -651,6 +664,68 @@ MlasActivationKernel<MlasIdentityActivation>(
 }
 
 
+template<MLAS_ACTIVATION_KIND ActivationKind>
+MLAS_FORCEINLINE
+void
+MlasActivationKernel(
+    const MLAS_ACTIVATION& Activation,
+    _mlas_fp16_* Buffer,
+    const _mlas_fp16_* Addon,
+    size_t StartM,
+    size_t StartN,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc
+    )
+{
+    MLAS_HALF_ACTIVATION_FUNCTION<ActivationKind> ActivationFunction(Activation);
+
+    auto* CRow = Buffer + StartM * ldc + StartN;
+    const auto* ARow = Addon + StartM * ldc + StartN;
+
+    while (CountM-- > 0) {
+        auto* buffer = CRow;
+        const auto* addsrc = ARow;
+        size_t n = CountN;
+
+        while (n >= 8) {
+            MLAS_FLOAT16X8 Vector = MlasLoadFloat16x8(buffer);
+            MLAS_FLOAT16X8 AVec = MlasLoadFloat16x8(addsrc);
+            addsrc += 8;
+            Vector = ActivationFunction.Activate(Vector);
+            Vector = MlasAddFloat16x8(Vector, AVec);
+            MlasStoreFloat16x8(buffer, Vector);
+            buffer += 8;
+            n -= 8;
+        }
+
+        if (n >= 4) {
+            MLAS_FLOAT16X4 Vector = MlasLoadFloat16x4(buffer);
+            MLAS_FLOAT16X4 AVec = MlasLoadFloat16x4(addsrc);
+            addsrc += 4;
+            Vector = ActivationFunction.Activate(Vector);
+            Vector = MlasAddFloat16x4(Vector, AVec);
+            MlasStoreFloat16x4(buffer, Vector);
+            buffer += 4;
+            n -= 4;
+        }
+
+        if (n > 0) {
+            MLAS_FLOAT16X4 buf;
+            std::memcpy(&buf, buffer, n * sizeof(_mlas_fp16_));
+            MLAS_FLOAT16X4 addbuf;
+            std::memcpy(&addbuf, addsrc, n * sizeof(_mlas_fp16_));
+            MLAS_FLOAT16X4 res = ActivationFunction.Activate(buf);
+            res = MlasAddFloat16x4(res, addbuf);
+            MlasStorePartialFloat16x4(buffer, res, n);
+        }
+
+        CRow += ldc;
+        ARow += ldc;
+    }
+}
+
+
 void
 MLAS_HALF_GEMM_ACTIVATION_PROCESSOR::Process(
     MLAS_FP16* C,
@@ -661,46 +736,89 @@ MLAS_HALF_GEMM_ACTIVATION_PROCESSOR::Process(
     size_t ldc
     ) const
 {
+    auto* Buffer = reinterpret_cast<_mlas_fp16_*>(C);
     switch (Activation_.ActivationKind) {
         case MlasIdentityActivation: {
-            MlasActivationKernel<MlasIdentityActivation>(Activation_, C, StartM, StartN, CountM,
-                                                         CountN, ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasIdentityActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasIdentityActivation>(Activation_, Buffer, StartM, StartN,
+                                                             CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasReluActivation: {
-            MlasActivationKernel<MlasReluActivation>(Activation_, C, StartM, StartN, CountM, CountN,
-                                                     ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasReluActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasReluActivation>(Activation_, Buffer, StartM, StartN,
+                                                         CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasLeakyReluActivation: {
-            MlasActivationKernel<MlasLeakyReluActivation>(Activation_, C, StartM, StartN, CountM,
-                                                          CountN, ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasLeakyReluActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasLeakyReluActivation>(Activation_, Buffer, StartM, StartN,
+                                                              CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasTanhActivation: {
-            MlasActivationKernel<MlasTanhActivation>(Activation_, C, StartM, StartN, CountM, CountN,
-                                                     ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasTanhActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasTanhActivation>(Activation_, Buffer, StartM, StartN,
+                                                         CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasLogisticActivation: {
-            MlasActivationKernel<MlasLogisticActivation>(Activation_, C, StartM, StartN, CountM,
-                                                         CountN, ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasLogisticActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasLogisticActivation>(Activation_, Buffer, StartM, StartN,
+                                                             CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasClipActivation: {
-            MlasActivationKernel<MlasClipActivation>(Activation_, C, StartM, StartN, CountM, CountN,
-                                                     ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasClipActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasClipActivation>(Activation_, Buffer, StartM, StartN,
+                                                         CountM, CountN, ldc);
+            }
             break;
         }
 
         case MlasHardSigmoidActivation: {
-            MlasActivationKernel<MlasHardSigmoidActivation>(Activation_, C, StartM, StartN, CountM,
-                                                            CountN, ldc);
+            if (SumBuf_) {
+                MlasActivationKernel<MlasHardSigmoidActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasHardSigmoidActivation>(Activation_, Buffer, StartM, StartN,
+                                                                CountM, CountN, ldc);
+            }
             break;
         }
 
@@ -744,10 +862,20 @@ MLAS_HALF_GEMM_ACTIVATION_PROCESSOR::Process(
     proc.Process(C, StartM, StartN, CountM, CountN, ldc);
 
     _mlas_fp16_* Output = reinterpret_cast<_mlas_fp16_*>(C);
-    const auto* CRow = buffer.data();
+    auto* CRow = buffer.data();
+    const _mlas_fp16_* CAdd = nullptr;
+    if (SumBuf_) {
+        CAdd = reinterpret_cast<const _mlas_fp16_*>(SumBuf_) + StartM * ldc + StartN;
+    }
     Output += StartM * ldc + StartN;
 
     while (CountM-- > 0) {
+        if (CAdd) {
+            for (size_t n = 0; n < CountN; n++) {
+                CRow[n] += MLAS_Half2Float(CAdd[n]);
+            }
+            CAdd += ldc;
+        }
         CvtFloat2Half(Output, CRow, CountN);
         CRow += CountN;
         Output += ldc;

--- a/onnxruntime/core/providers/cpu/fp16/fp16_conv.cc
+++ b/onnxruntime/core/providers/cpu/fp16/fp16_conv.cc
@@ -34,16 +34,15 @@ using ConvPadVector = ConvAttributes::ConvPadVector;
  *
  * Add is performed BEFORE activation.
  *
- * The implementation runs faster with NHWC. By default, it converts NCHW to NHWC
- * before processing, and convert the result back. It can take NHWC tensors directly.
- * Use operator attribute 'channels_last' to specify that the data layout is NHWC.
+ * The implementation runs faster with NHWC. In base class, where channel_last_ is
+ * false, it converts NCHW to NHWC before processing, and convert the result back.
+ * In the derived NHWC class, where channel_last_ is true, it takes NHWC tensors directly.
  *
 */
-class FusedConvFp16 final : public OpKernel {
+class FusedConvFp16 : public OpKernel {
  public:
   FusedConvFp16(const OpKernelInfo& info) : OpKernel(info), conv_attrs_(info) {
     ORT_ENFORCE(GetFusedActivationAttr(info, activation_).IsOK());
-    channels_last_ = (info.GetAttrOrDefault<int64_t>("channels_last", static_cast<int64_t>(0)) != 0);
   }
 
   Status Compute(OpKernelContext* context) const override;
@@ -54,6 +53,9 @@ class FusedConvFp16 final : public OpKernel {
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
+
+ protected:
+  bool channels_last_{false};
 
  private:
 
@@ -89,7 +91,6 @@ class FusedConvFp16 final : public OpKernel {
 
   MLAS_ACTIVATION activation_;
   ConvAttributes conv_attrs_;
-  bool channels_last_{false};
   TensorShape W_shape_;
   BufferUniquePtr packed_W_buffer_;
   size_t packed_W_size_{0};
@@ -239,7 +240,7 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
   // TODO!!
   // This tensor should be added to the result before activation is applied
   // We need to augment the post processor to accept an addition operation.
-  // const Tensor* Sum = num_inputs >= 4 ? context->Input<Tensor>(3) : nullptr;
+  const Tensor* Sum = num_inputs >= 4 ? context->Input<Tensor>(3) : nullptr;
 
   const int64_t N = X->Shape()[0];
   const int64_t M = W_shape[0];
@@ -281,6 +282,13 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
   // Bail out early if one of the dimensions is zero.
   if (Y->Shape().Size() == 0) {
     return Status::OK();
+  }
+  if (Sum) {
+    if (Sum->Shape() != Y->Shape()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Z shape does not match output shape.",
+                             " Z: ", Sum->Shape().ToString().c_str(),
+                             " Output: ", Y->Shape().ToString().c_str());
+    }    
   }
 
   const int64_t input_image_size = input_shape.Size();
@@ -332,6 +340,7 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
   const auto* Xdata = X->Data<MLFloat16>();
   const auto* Bdata = B != nullptr ? B->Data<MLFloat16>() : nullptr;
   auto* Ydata = Y->MutableData<MLFloat16>();
+  const auto* SumData = Sum != nullptr ? Sum->Data<MLFloat16>() : nullptr;
 
   BufferUniquePtr transpose_input_buffer;
   BufferUniquePtr transpose_output_buffer;
@@ -403,6 +412,7 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
   for (int64_t image_id = 0; image_id < N; ++image_id) {
     const auto* input_data = Xdata;
     auto* output_data = Ydata;
+    const auto* add_src = SumData; 
 
     if (!channels_last_) {
       // Transpose the input from channels first (CHW) to channels last (HWC).
@@ -413,6 +423,7 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
           static_cast<size_t>(input_image_size));
       input_data = static_cast<MLFloat16*>(transpose_input_buffer.get());
       output_data = static_cast<MLFloat16*>(transpose_output_buffer.get());
+      add_src = nullptr;
     }
 
     // Threaded implementation of ND convolution is not yet supported, so
@@ -459,10 +470,11 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
       }
 
       auto* worker_output = output_data + output_start * M;
+      const auto* worker_addsrc = add_src == nullptr ? nullptr : add_src + output_start * M;
 
       if (is_depthwise_conv) {
         // TODO!! add Sum tensor to activation
-        MLAS_HALF_GEMM_ACTIVATION_PROCESSOR act(activation_);
+        MLAS_HALF_GEMM_ACTIVATION_PROCESSOR act(activation_, worker_addsrc);
         MlasConvDepthwise(
             worker_indirection_buffer,
             reordered_W,
@@ -532,7 +544,8 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
           }
 
           // TODO!! add Sum tensor to activation
-          MLAS_HALF_GEMM_ACTIVATION_PROCESSOR act(activation_);
+          const auto* gemm_add = add_src == nullptr ? nullptr : worker_addsrc + group_id * group_output_channels;
+          MLAS_HALF_GEMM_ACTIVATION_PROCESSOR act(activation_, gemm_add);
           MLAS_HALF_GEMM_DATA_PARAMS gemm_params;
           gemm_params.A = AData;
           gemm_params.lda = lda;
@@ -567,10 +580,21 @@ Status FusedConvFp16::Compute(OpKernelContext* context) const {
           Ydata,
           static_cast<size_t>(output_image_size),
           static_cast<size_t>(M));
+      if (SumData != nullptr) {
+        MLAS_ACTIVATION activation;
+        activation.ActivationKind = MlasIdentityActivation;
+        MLAS_HALF_GEMM_ACTIVATION_PROCESSOR proc(activation, SumData);
+        proc.Process(Ydata, 0, 0, static_cast<size_t>(M),
+                     static_cast<size_t>(output_image_size),
+                     static_cast<size_t>(output_image_size));
+      }
     }
 
     Xdata += X_offset;
     Ydata += Y_offset;
+    if (SumData != nullptr) {
+      SumData += Y_offset;
+    }
   }
 
   return Status::OK();
@@ -586,14 +610,24 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
 
 
 #ifndef DISABLE_CONTRIB_OPS
+
+class NHWCFusedConvFp16 final : public FusedConvFp16 {
+ public:
+  NHWCFusedConvFp16(const OpKernelInfo& info) : FusedConvFp16(info) {
+    channels_last_ = true;
+  }
+};
+
 namespace contrib {
-    ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
-        FusedConv,
-        1,
-        MLFloat16,
-        KernelDefBuilder()
-            .TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
-        FusedConvFp16);
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    FusedConv,
+    kMSInternalNHWCDomain,
+    1,
+    MLFloat16,
+    kCpuExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+    NHWCFusedConvFp16);
 }  // namespace contrib
 #endif
 

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -40,7 +40,6 @@ void TestConvFp16Op(const ConvOpAndTestAttributes& attributes,
   std::unique_ptr<OpTester> tester;
   if (!attributes.activation.empty()) {
     tester = std::make_unique<OpTester>("NhwcFusedConv", 1, onnxruntime::kMSDomain);
-    tester->AddAttribute("channels_last", int64_t(1));
     tester->AddAttribute("activation", attributes.activation);
 
     if (!attributes.activation_parameters.empty()) {

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -39,7 +39,7 @@ void TestConvFp16Op(const ConvOpAndTestAttributes& attributes,
                 int opset = 11) {
   std::unique_ptr<OpTester> tester;
   if (!attributes.activation.empty()) {
-    tester = std::make_unique<OpTester>("FusedConv", 1, onnxruntime::kMSDomain);
+    tester = std::make_unique<OpTester>("FusedConv", 1, onnxruntime::kMSInternalNHWCDomain);
     tester->AddAttribute("activation", attributes.activation);
 
     if (!attributes.activation_parameters.empty()) {
@@ -68,12 +68,14 @@ void TestConvFp16Op(const ConvOpAndTestAttributes& attributes,
   }
 
 
-  ORT_ENFORCE(inputs.size() <= 3, "Our name array is only setup to handle 3 inputs");
-  const char* szNames[] = {"X", "W", "B"};
+  ORT_ENFORCE(inputs.size() <= 4, "Our name array is only setup to handle 4 inputs");
+  const char* szNames[] = {"X", "W", "B", "Z"};
   tester->AddInput<MLFloat16>(szNames[0], input_shapes[0], inputs[0]);
   tester->AddInput<MLFloat16>(szNames[1], input_shapes[1], inputs[1], weight_is_initializer);
-  if (inputs.size() == 3)
+  if (inputs.size() >= 3)
     tester->AddInput<MLFloat16>(szNames[2], input_shapes[2], inputs[2]);
+  if (inputs.size() >= 4)
+    tester->AddInput<MLFloat16>(szNames[3], input_shapes[3], inputs[3]);
 
   tester->AddOutput<MLFloat16>("Y", expected_output_shape, expected_output, /*no sort*/ false, 0.002f, 0.0f);
 
@@ -506,86 +508,6 @@ TEST(ConvFp16Test, Conv2D_AutoPad2) {
   TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape, true);
 }
 
-#ifndef DISABLE_CONTRIB_OPS
-TEST(ConvFp16Test, Conv2D_HardSigmoid) {
-  ConvOpAndTestAttributes attrs = {
-      "",                           // auto_pad
-      vector<int64_t>{1, 1},        // dilations
-      1,                            // group
-      vector<int64_t>{2, 2},        // kernel_shape
-      vector<int64_t>{0, 0, 0, 0},  // pads
-      vector<int64_t>{1, 1},        // strides
-      {},                           // excluded EPs
-      "HardSigmoid",                // activation
-      vector<float>{0.2f, 0.5f}     // activation_parameters
-  };
-
-  vector<MLFloat16> X = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
-                         MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
-                         MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
-  vector<int64_t> X_shape = {1, 1, 3, 3};
-  vector<MLFloat16> W = {MLFloat16(0.125f), MLFloat16(0.125f), MLFloat16(0.125f), MLFloat16(0.125f),
-                         MLFloat16(-0.125f), MLFloat16(-0.125f), MLFloat16(-0.125f), MLFloat16(-0.125f)};
-  vector<int64_t> W_shape = {2, 1, 2, 2};
-  vector<int64_t> Y_shape = {1, 2, 2, 2};
-  auto expected_vals = {MLFloat16(0.8f), MLFloat16(0.9f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(0.2f), MLFloat16(0.1f), MLFloat16(0.0f), MLFloat16(0.0f)};
-  TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
-}
-
-TEST(ConvFp16Test, Conv2D_Relu) {
-  ConvOpAndTestAttributes attrs = {
-      "",                           // auto_pad
-      vector<int64_t>{1, 1},        // dilations
-      1,                            // group
-      vector<int64_t>{2, 2},        // kernel_shape
-      vector<int64_t>{0, 0, 0, 0},  // pads
-      vector<int64_t>{1, 1},        // strides
-      {},                           // excluded EPs
-      "Relu"                        // activation
-  };
-
-  vector<MLFloat16> X = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
-                         MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
-                         MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
-  vector<int64_t> X_shape = {1, 1, 3, 3};
-  vector<MLFloat16> W = {MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f),
-                         MLFloat16(-1.0f), MLFloat16(-1.0f), MLFloat16(-1.0f), MLFloat16(-1.0f)};
-  vector<int64_t> W_shape = {2, 1, 2, 2};
-  vector<int64_t> Y_shape = {1, 2, 2, 2};
-  auto expected_vals = {MLFloat16(12.0f), MLFloat16(16.0f), MLFloat16(24.0f), MLFloat16(28.0f),
-                        MLFloat16(0.0f), MLFloat16(0.0f), MLFloat16(0.0f), MLFloat16(0.0f)};
-  TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
-}
-
-TEST(ConvFp16Test, Conv2D_Bias_Relu) {
-  ConvOpAndTestAttributes attrs = {
-      "",                           // auto_pad
-      vector<int64_t>{1, 1},        // dilations
-      1,                            // group
-      vector<int64_t>{2, 2},        // kernel_shape
-      vector<int64_t>{0, 0, 0, 0},  // pads
-      vector<int64_t>{1, 1},        // strides
-      {},                           // excluded EPs
-      "Relu"                        // activation
-  };
-
-  vector<MLFloat16> X = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
-                         MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
-                         MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
-  vector<int64_t> X_shape = {1, 1, 3, 3};
-  vector<MLFloat16> W = {MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f),
-                         MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f)};
-  vector<int64_t> W_shape = {2, 1, 2, 2};
-  vector<int64_t> Y_shape = {1, 2, 2, 2};
-  vector<MLFloat16> B = {MLFloat16(1.0f), MLFloat16(-1.0f)};
-  vector<int64_t> B_shape = {2};
-  auto expected_vals = {MLFloat16(13.0f), MLFloat16(17.0f), MLFloat16(25.0f), MLFloat16(29.0f),
-                        MLFloat16(11.0f), MLFloat16(15.0f), MLFloat16(23.0f), MLFloat16(27.0f)};
-  TestConvFp16Op(attrs, {X, W, B}, {X_shape, W_shape, B_shape}, expected_vals, Y_shape);
-}
-#endif // CONTRIB_OPS
-
-
 TEST(ConvFp16Test, Conv3D_1) {
   ConvOpAndTestAttributes attrs = {
       "",                                 // auto_pad
@@ -978,29 +900,91 @@ TEST(ConvFp16Test, Pointwise_Relu) {
   };
 
   vector<MLFloat16> X = {
-      MLFloat16(-9.f), MLFloat16(1.f), MLFloat16(2.f),
-      MLFloat16(-5.f), MLFloat16(3.f), MLFloat16(-2.f),
-      MLFloat16(5.f), MLFloat16(-3.f), MLFloat16(1.f),
-      MLFloat16(1.f), MLFloat16(8.f), MLFloat16(-4.f),
-      MLFloat16(-1.f), MLFloat16(6.f), MLFloat16(7.f),
-      MLFloat16(-1.f), MLFloat16(4.f), MLFloat16(-5.f),
-      MLFloat16(-9.f), MLFloat16(1.f), MLFloat16(2.f),
-      MLFloat16(-5.f), MLFloat16(3.f), MLFloat16(-2.f),
-      MLFloat16(5.f), MLFloat16(-3.f), MLFloat16(1.f)};
+      MLFloat16(-9.f), MLFloat16(1.f), MLFloat16(-9.f),
+      MLFloat16(1.f), MLFloat16(8.f), MLFloat16(1.f),
+      MLFloat16(2.f), MLFloat16(-4.f), MLFloat16(2.f),
+      MLFloat16(-5.f), MLFloat16(-1.f), MLFloat16(-5.f),
+      MLFloat16(3.f), MLFloat16(6.f), MLFloat16(3.f),
+      MLFloat16(-2.f), MLFloat16(7.f), MLFloat16(-2.f),
+      MLFloat16(5.f), MLFloat16(-1.f), MLFloat16(5.f),
+      MLFloat16(-3.f), MLFloat16(4.f), MLFloat16(-3.f),
+      MLFloat16(1.f), MLFloat16(-5.f), MLFloat16(1.f)};
   vector<int64_t> X_shape = {1, 3, 3, 3};
   vector<MLFloat16> W = {MLFloat16(2.f), MLFloat16(-3.f), MLFloat16(0.5f),
                          MLFloat16(0.25f), MLFloat16(-2.f), MLFloat16(-0.75f)};
   vector<int64_t> W_shape = {2, 3, 1, 1};
-  vector<int64_t> Y_shape = {1, 2, 3, 3};
+  vector<int64_t> Y_shape = {1, 3, 3, 2};
   auto expected_vals = {
-      MLFloat16(0.f), MLFloat16(0.f), MLFloat16(17.f),
-      MLFloat16(0.f), MLFloat16(0.f), MLFloat16(0.f),
-      MLFloat16(15.5f), MLFloat16(0.f), MLFloat16(17.5f),
-      MLFloat16(2.5f), MLFloat16(0.f), MLFloat16(7.f),
-      MLFloat16(4.5f), MLFloat16(0.f), MLFloat16(0.f),
-      MLFloat16(0.f), MLFloat16(0.f), MLFloat16(9.5f)};
+      MLFloat16(0.f), MLFloat16(2.5f),
+      MLFloat16(0.f), MLFloat16(0.f),
+      MLFloat16(17.f), MLFloat16(7.f),
+      MLFloat16(0.f), MLFloat16(4.5f), 
+      MLFloat16(0.f), MLFloat16(0.f),
+      MLFloat16(0.f), MLFloat16(0.f),
+      MLFloat16(15.5f), MLFloat16(0.f),
+      MLFloat16(0.f), MLFloat16(0.f),
+      MLFloat16(17.5f), MLFloat16(9.5f)};
 
   TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+}
+
+TEST(ConvFp16Test, Conv2D_HardSigmoid) {
+  ConvOpAndTestAttributes attrs = {
+      "",                           // auto_pad
+      vector<int64_t>{1, 1},        // dilations
+      1,                            // group
+      vector<int64_t>{2, 2},        // kernel_shape
+      vector<int64_t>{0, 0, 0, 0},  // pads
+      vector<int64_t>{1, 1},        // strides
+      {},                           // excluded EPs
+      "HardSigmoid",                // activation
+      vector<float>{0.2f, 0.5f}     // activation_parameters
+  };
+
+  vector<MLFloat16> X = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
+                         MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
+                         MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
+  vector<int64_t> X_shape = {1, 3, 3, 1};
+  vector<MLFloat16> W = {MLFloat16(0.125f), MLFloat16(0.125f), MLFloat16(0.125f), MLFloat16(0.125f),
+                         MLFloat16(-0.125f), MLFloat16(-0.125f), MLFloat16(-0.125f), MLFloat16(-0.125f)};
+  vector<int64_t> W_shape = {2, 1, 2, 2};
+  vector<int64_t> Y_shape = {1, 2, 2, 2};
+  auto expected_vals = {
+      MLFloat16(0.8f), MLFloat16(0.2f),
+      MLFloat16(0.9f), MLFloat16(0.1f),
+      MLFloat16(1.0f), MLFloat16(0.0f),
+      MLFloat16(1.0f), MLFloat16(0.0f)};
+  TestConvFp16Op(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+}
+
+
+TEST(ConvFp16Test, Conv2D_Bias_Z_Relu) {
+  ConvOpAndTestAttributes attrs = {
+      "",                           // auto_pad
+      vector<int64_t>{1, 1},        // dilations
+      1,                            // group
+      vector<int64_t>{2, 2},        // kernel_shape
+      vector<int64_t>{0, 0, 0, 0},  // pads
+      vector<int64_t>{1, 1},        // strides
+      {},                           // excluded EPs
+      "Relu"                        // activation
+  };
+
+  vector<MLFloat16> X = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
+                         MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
+                         MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
+  vector<int64_t> X_shape = {1, 3, 3, 1};
+  vector<MLFloat16> W = {MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f),
+                         MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f), MLFloat16(1.0f)};
+  vector<int64_t> W_shape = {2, 1, 2, 2};
+  vector<int64_t> Y_shape = {1, 2, 2, 2};
+  vector<MLFloat16> B = {MLFloat16(1.0f), MLFloat16(-1.0f)};
+  vector<int64_t> B_shape = {2};
+  vector<MLFloat16> Z = {MLFloat16(-1.0f), MLFloat16(0.0f), MLFloat16(0.0f), MLFloat16(0.0f),
+                         MLFloat16(0.0f), MLFloat16(0.0f), MLFloat16(0.0f), MLFloat16(1.0f)};
+  vector<int64_t> Z_shape = {1, 2, 2, 2};
+  auto expected_vals = {MLFloat16(12.0f), MLFloat16(11.0f), MLFloat16(17.0f), MLFloat16(15.0f), MLFloat16(25.0f), MLFloat16(23.0f), MLFloat16(29.0f), MLFloat16(28.0f)};
+  TestConvFp16Op(attrs, {X, W, B, Z}, {X_shape, W_shape, B_shape, Z_shape}, expected_vals, Y_shape);
 }
 
 #endif  // CONTRIB_OPS

--- a/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_fp16_test.cc
@@ -39,7 +39,8 @@ void TestConvFp16Op(const ConvOpAndTestAttributes& attributes,
                 int opset = 11) {
   std::unique_ptr<OpTester> tester;
   if (!attributes.activation.empty()) {
-    tester = std::make_unique<OpTester>("FusedConv", 1, onnxruntime::kMSInternalNHWCDomain);
+    tester = std::make_unique<OpTester>("NhwcFusedConv", 1, onnxruntime::kMSDomain);
+    tester->AddAttribute("channels_last", int64_t(1));
     tester->AddAttribute("activation", attributes.activation);
 
     if (!attributes.activation_parameters.empty()) {


### PR DESCRIPTION
### Description
Adding 'Add' functionality to FP16 Conv operator. It takes a tensor that has the same shape of the output tensor, and add it to the result tensor.


### Motivation and Context
Needed to run Resnet 50


