### PR TITLE
[DML EP] Use ORT node names in DML execution plans

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -194,6 +194,11 @@ namespace Dml
             DML_EXECUTION_FLAGS executionFlags = GetExecutionFlags();
             ORT_THROW_IF_FAILED(dmlDevice1->CompileGraph(&graphDesc, executionFlags, IID_PPV_ARGS(&m_compiledOperator)));
 
+            // Static buffer (might truncate name) to avoid excessive dynamic allocation only for debugging purposes.
+            wchar_t nodeName[512];
+            ORT_THROW_IF_FAILED(kernelInfo.GetNodeWrapperInterface()->GetWideName(sizeof(nodeName), nodeName));
+            ORT_THROW_IF_FAILED(m_compiledOperator->SetName(nodeName));
+
             UINT64 persistentResourceSize = m_compiledOperator->GetBindingProperties().PersistentResourceSize;
             if (persistentResourceSize > 0)
             {


### PR DESCRIPTION
This will allow pix markers to show the corresponding ORT node name in PIX.