### PR TITLE
pause caching docker image in pipeline cache in Linux Aten Pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-aten-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-aten-pipeline.yml
@@ -34,8 +34,8 @@ jobs:
       Context: tools/ci_build/github/linux/docker
       DockerBuildArgs: "--build-arg BUILD_UID=$( id -u )"
       Repository: 'onnxruntimecpubuildaten'
-      UseImageCacheContainerRegistry: false
-      UsePipelineCache: true
+      UseImageCacheContainerRegistry: true
+      UsePipelineCache: false
 
   - task: Cache@2
     inputs:


### PR DESCRIPTION
### Description
Pause caching the docker images in pipeline cache in Linux Aten Pipeline.

### Motivation and Context
We need to work out a better way to reduce the storage.


