### PR TITLE
Add check for DQ producing graph output to DropDQNodeGroupSelector

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -130,17 +130,12 @@ bool DropQDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
   return IsQDQPairSupported(q_node, dq_node, get_const_initializer, graph_viewer.ModelPath());
 }
 
-bool DropDQNodeGroupSelector::CheckDQNodes(const Node& node, const std::vector<const Node*>& dq_nodes) const {
-  int num_dq_inputs = NumActualValues(node, true);
-
-  return num_dq_inputs == gsl::narrow_cast<int>(dq_nodes.size());
-}
-
 bool DropDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
                                     const Node& node,
                                     const std::vector<const Node*>& dq_nodes,
-                                    const std::vector<const Node*>& q_nodes) const {
-  if (!CheckDQNodes(node, dq_nodes)) {
+                                    const std::vector<const Node*>& /*q_nodes*/) const {
+  int num_dq_inputs = NumActualValues(node, true);
+  if (num_dq_inputs != gsl::narrow_cast<int>(dq_nodes.size())) {
     return false;
   }
 
@@ -148,7 +143,6 @@ bool DropDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
     return false;
   }
 
-  (void)q_nodes;
   const Node& dq_node = *dq_nodes.front();
 
   auto get_const_initializer = [&graph_viewer](const std::string& initializer_name) {

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -19,6 +19,18 @@ int NumActualValues(const Node& node, bool input) {
   return gsl::narrow_cast<int>(std::count_if(defs.cbegin(), defs.cend(),
                                              [](const NodeArg* def) { return def && def->Exists(); }));
 }
+
+bool AnyNodeProducesGraphOutput(const GraphViewer& graph_viewer, const std::vector<const Node*>& nodes) {
+  auto does_node_produce_graph_output = [&graph_viewer](const Node* node_ptr) {
+    return graph_viewer.NodeProducesGraphOutput(*node_ptr);
+  };
+
+  if (std::any_of(nodes.begin(), nodes.end(), does_node_produce_graph_output)) {
+    return true;
+  }
+
+  return false;
+}
 }  // namespace
 
 static std::vector<const Node*> FindQDQNodes(const GraphViewer& graph_viewer, const Node& node, bool find_dq_nodes) {
@@ -51,11 +63,7 @@ bool NodeGroupSelector::CheckQDQNodes(const GraphViewer& graph_viewer, const Nod
     return false;
   }
 
-  auto does_node_produce_graph_output = [&graph_viewer](const Node* node_ptr) {
-    return graph_viewer.NodeProducesGraphOutput(*node_ptr);
-  };
-
-  if (std::any_of(dq_nodes.begin(), dq_nodes.end(), does_node_produce_graph_output)) {
+  if (AnyNodeProducesGraphOutput(graph_viewer, dq_nodes)) {
     return false;
   }
 
@@ -96,8 +104,8 @@ std::optional<NodesToOptimizeIndices> BaseSelector::Select(const GraphViewer& gr
   // TODO(edgchen1) update NodeGroup to use InlinedVector
   builder.input_nodes.assign(qdq_group->dq_nodes.begin(), qdq_group->dq_nodes.end());
   builder.output_nodes.assign(qdq_group->q_nodes.begin(), qdq_group->q_nodes.end());
-  //builder.input_nodes = qdq_group->dq_nodes;
-  //builder.output_nodes = qdq_group->q_nodes;
+  // builder.input_nodes = qdq_group->dq_nodes;
+  // builder.output_nodes = qdq_group->q_nodes;
   builder.target_node = qdq_group->target_node;
 
   UpdateBuilder(builder);
@@ -133,6 +141,10 @@ bool DropDQNodeGroupSelector::Check(const GraphViewer& graph_viewer,
                                     const std::vector<const Node*>& dq_nodes,
                                     const std::vector<const Node*>& q_nodes) const {
   if (!CheckDQNodes(node, dq_nodes)) {
+    return false;
+  }
+
+  if (AnyNodeProducesGraphOutput(graph_viewer, dq_nodes)) {
     return false;
   }
 
@@ -317,20 +329,19 @@ void GemmSelector::UpdateBuilder(NodesToOptimizeIndicesBuilder& builder) const {
   builder.input_nodes.resize(3, NodesToOptimizeIndices::kEmptyNodeIndex);
 }
 
-bool WhereNodeGroupSelector::Check(const GraphViewer &graph_viewer, const Node &node,
-                                   const std::vector<const Node *> &dq_nodes,
-                                   const std::vector<const Node *> &q_nodes) const {
+bool WhereNodeGroupSelector::Check(const GraphViewer& graph_viewer, const Node& node,
+                                   const std::vector<const Node*>& dq_nodes,
+                                   const std::vector<const Node*>& q_nodes) const {
   // Where has 1 boolean input and 2 dq inputs
-  if (!CheckQDQNodes(graph_viewer, node, dq_nodes, q_nodes,2)) {
+  if (!CheckQDQNodes(graph_viewer, node, dq_nodes, q_nodes, 2)) {
     return false;
   }
 
-  const int32_t  dt_input_1 = dq_nodes[0]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+  const int32_t dt_input_1 = dq_nodes[0]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
   const int32_t dt_input_2 = dq_nodes[1]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
   const int32_t dt_output = q_nodes[0]->OutputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
   return dt_input_1 == dt_input_2 &&
          dt_input_1 == dt_output;
-
 }
 
 bool InstanceNormalizationNodeGroupSelector::Check(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
@@ -59,9 +59,6 @@ class DropQDQNodeGroupSelector : public NodeGroupSelector {
 
 // Single DQ -> node.
 class DropDQNodeGroupSelector : public NodeGroupSelector {
-  // base check that we have the expected number of DQ inputs.
-  bool CheckDQNodes(const Node& node, const std::vector<const Node*>& dq_nodes) const;
-
   bool Check(const GraphViewer& graph_viewer, const Node& node,
              const std::vector<const Node*>& dq_nodes,
              const std::vector<const Node*>& q_nodes) const override;
@@ -104,14 +101,13 @@ class ConvNodeGroupSelector : public NodeGroupSelector {
 };
 
 class WhereNodeGroupSelector : public NodeGroupSelector {
-public:
-  WhereNodeGroupSelector()= default;
+ public:
+  WhereNodeGroupSelector() = default;
 
-private:
+ private:
   bool Check(const GraphViewer& graph_viewer, const Node& node,
              const std::vector<const Node*>& dq_nodes,
              const std::vector<const Node*>& q_nodes) const override;
-
 };
 
 // 2 DQ nodes for input -> node -> optional Q if QLinearMatMul, MatMulIntegerToFloat if not
@@ -221,7 +217,7 @@ class ConvSelector : public BaseSelector {
   void UpdateBuilder(NodesToOptimizeIndicesBuilder&) const override;
 };
 class WhereSelector : public BaseSelector {
-public:
+ public:
   WhereSelector() : BaseSelector(std::make_unique<WhereNodeGroupSelector>()) {}
 };
 // 2 DQ nodes for input -> node -> optional Q if QLinearMatMul, MatMulIntegerToFloat if not


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Missing check for whether the DQ produces a graph output meant to could be invalidly removed.

TODO: Add unit test.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
#15093 