### PR TITLE
Increase the timeout value of win-wasm-ci.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -20,7 +20,7 @@ parameters:
   default: false
 
 - name: TimeoutInMinutes
-  default: 150
+  default: 180
 
 jobs:
 - job: build_WASM


### PR DESCRIPTION
### Description
Increase the timeout value of win-wasm-ci.yml because I just reduced the number of vCPUs of each machine from 16 to 8. If I didn't do so, the pipeline's test code would randomly fail. 


### Motivation and Context



