### PR TITLE
Add Compliation Cache in CoreML pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -1,5 +1,7 @@
 jobs:
 - job: CoreML_CI
+  workspace:
+    clean: all
   pool:
     vmImage: 'macOS-12'
   variables:

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
 
   - template: templates/mac-build-step-with-cache.yml
     parameters:
+      Today: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)}]'
       AddtionalKey: coreml
       BuildStep:
         - script: |

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -10,6 +10,19 @@ jobs:
     displayName: Install coreutils and ninja
 
   - script: |
+      brew install ccache
+      echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
+    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+
+  - task: Cache@2
+    inputs:
+      key:  ' "$(TODAY)" | coreml | "$(Build.SourceVersion)" '
+      path: $(CCACHE_DIR)
+      restoreKeys: |
+        "$(TODAY)" | coreml
+    displayName: ccache task
+
+  - script: |
       python3 tools/ci_build/build.py \
       --build_dir build \
       --skip_submodule_sync \
@@ -19,3 +32,8 @@ jobs:
       --config Debug \
       --use_coreml
     displayName: CoreML EP, Build and Test on macOS
+
+  - script: |
+      ccache -s
+      ccache -z
+    displayName: Show Cache stats and Clear stats.

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -4,8 +4,6 @@ jobs:
     vmImage: 'macOS-12'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
-    CCACHE_DIR: $(Pipeline.Workspace)/ccache
-    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja
@@ -16,26 +14,17 @@ jobs:
       echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
-  - task: Cache@2
-    inputs:
-      key:  ' "$(TODAY)" | coreml | "$(Build.SourceVersion)" '
-      path: $(CCACHE_DIR)
-      restoreKeys: |
-        "$(TODAY)" | coreml
-    displayName: ccache task
-
-  - script: |
-      python3 tools/ci_build/build.py \
-      --build_dir build \
-      --skip_submodule_sync \
-      --cmake_generator=Ninja \
-      --parallel \
-      --build_shared_lib \
-      --config Debug \
-      --use_coreml
-    displayName: CoreML EP, Build and Test on macOS
-
-  - script: |
-      ccache -s
-      ccache -z
-    displayName: Show Cache stats and Clear stats.
+  - template: templates/mac-build-step-with-cache.yml
+    parameters:
+      AddtionalKey: coreml
+      BuildStep:
+        - script: |
+            python3 tools/ci_build/build.py \
+            --build_dir build \
+            --skip_submodule_sync \
+            --cmake_generator=Ninja \
+            --parallel \
+            --build_shared_lib \
+            --config Debug \
+            --use_coreml
+          displayName: CoreML EP, Build and Test on macOS

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -19,8 +19,10 @@ jobs:
             python3 tools/ci_build/build.py \
             --build_dir build \
             --skip_submodule_sync \
+            --cmake_generator=Ninja \
             --parallel \
             --build_shared_lib \
             --config Debug \
+            --use_cache \
             --use_coreml
           displayName: CoreML EP, Build and Test on macOS

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -28,3 +28,5 @@ jobs:
             --use_cache \
             --use_coreml
           displayName: CoreML EP, Build and Test on macOS
+          env:
+            CCACHE_COMPILERCHECK: content

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
   - template: templates/mac-build-step-with-cache.yml
     parameters:
       TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-      AddtionalKey: coreml
+      AdditionalKey: coreml
       BuildStep:
         - script: |
             python3 tools/ci_build/build.py \

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: 'macOS-12'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
+    Today: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)}]'
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja
@@ -16,7 +17,7 @@ jobs:
 
   - template: templates/mac-build-step-with-cache.yml
     parameters:
-      Today: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)}]'
+      Today: $(Today)
       AddtionalKey: coreml
       BuildStep:
         - script: |

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -19,7 +19,6 @@ jobs:
             python3 tools/ci_build/build.py \
             --build_dir build \
             --skip_submodule_sync \
-            --cmake_generator=Ninja \
             --parallel \
             --build_shared_lib \
             --config Debug \

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -7,6 +7,7 @@ jobs:
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
+    CCACHE_DIR: '$(Pipeline.Workspace)/ccache'
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja
@@ -16,6 +17,7 @@ jobs:
     parameters:
       TODAY: $(TODAY)
       AdditionalKey: coreml
+      CCACHE_DIR: $(CCACHE_DIR)
       BuildStep:
         - script: |
             python3 tools/ci_build/build.py \

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -4,7 +4,6 @@ jobs:
     vmImage: 'macOS-12'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
-    Today: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)}]'
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja
@@ -17,7 +16,7 @@ jobs:
 
   - template: templates/mac-build-step-with-cache.yml
     parameters:
-      Today: $(Today)
+      TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
       AddtionalKey: coreml
       BuildStep:
         - script: |

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -4,19 +4,15 @@ jobs:
     vmImage: 'macOS-12'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
+    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja
     displayName: Install coreutils and ninja
 
-  - script: |
-      brew install ccache
-      echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
-    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
-
   - template: templates/mac-build-step-with-cache.yml
     parameters:
-      TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
+      TODAY: $(TODAY)
       AdditionalKey: coreml
       BuildStep:
         - script: |

--- a/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-coreml-ci-pipeline.yml
@@ -4,6 +4,8 @@ jobs:
     vmImage: 'macOS-12'
   variables:
     MACOSX_DEPLOYMENT_TARGET: '10.14'
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 120
   steps:
   - script: brew install coreutils ninja

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -22,10 +22,10 @@ steps:
 
   - task: Cache@2
     inputs:
-      key:  ' "${{parameters.TODAY}}" | "${{parameters.AdditionalKey}}" | "$(Build.SourceVersion)" '
+      key:  ' "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}} | "$(Build.SourceVersion)" '
       path: "${{parameters.CCACHE_DIR}}"
       restoreKeys: |
-        "${{parameters.TODAY}}" | "${{parameters.AdditionalKey}}"
+        "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}}
     displayName: ccache task
 
   - ${{ parameters.BuildStep }}

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -18,6 +18,7 @@ steps:
   - script: |
       brew install ccache
       echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
+      mkdir -p "${{parameters.CCACHE_DIR}}"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
   - task: Cache@2

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -1,7 +1,7 @@
 # It's used for complication in Mac Host, not including iOS compliation.
 
 parameters:
-- name: Today
+- name: TODAY
   type: string
 
 - name: CCACHE_DIR

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -9,7 +9,7 @@ parameters:
   default: '$(Pipeline.Workspace)/ccache'
 
 - name: BuildStep
-  type: step
+  type: stepList
 
 - name: AdditionalKey
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -4,10 +4,6 @@ parameters:
 - name: TODAY
   type: string
 
-- name: CCACHE_DIR
-  type: string
-  default: '$(Pipeline.Workspace)/ccache'
-
 - name: BuildStep
   type: stepList
 
@@ -18,13 +14,14 @@ steps:
   - script: |
       brew install ccache
       echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
-      mkdir -p "${{parameters.CCACHE_DIR}}"
+      mkdir -p "$(Pipeline.Workspace)/ccache"
+      ls "$(Pipeline.Workspace)"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
   - task: Cache@2
     inputs:
       key:  ' "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}} | "$(Build.SourceVersion)" '
-      path: "${{parameters.CCACHE_DIR}}"
+      path: '$(Pipeline.Workspace)/ccache'
       restoreKeys: |
         "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}}
     displayName: ccache task

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -21,10 +21,12 @@ steps:
   - task: Cache@2
     inputs:
       key:  ' "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}} | "$(Build.SourceVersion)" '
-      path: '$(Pipeline.Workspace)/ccache'
+      path: $(CCACHE_DIR)
       restoreKeys: |
         "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}}
     displayName: ccache task
+    env:
+      CCACHE_DIR: '$(Pipeline.Workspace)/ccache'
 
   - ${{ parameters.BuildStep }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -10,6 +10,9 @@ parameters:
 - name: AdditionalKey
   type: string
 
+- name: CCACHE_DIR
+  type: string
+
 steps:
   - script: |
       brew install ccache
@@ -25,8 +28,7 @@ steps:
         "${{parameters.TODAY}}" | ${{parameters.AdditionalKey}}
     displayName: ccache task
     env:
-      CCACHE_DIR: '$(Pipeline.Workspace)/ccache'
-      CCACHE_COMPILERCHECK: content
+      CCACHE_DIR: ${{parameters.CCACHE_DIR}}
 
   - ${{ parameters.BuildStep }}
 

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -1,0 +1,37 @@
+# It's used for complication in Mac Host, not including iOS compliation.
+
+parameters:
+- name: Today
+  type: string
+  default: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]'
+
+- name: CCACHE_DIR
+  type: string
+  default: '$(Pipeline.Workspace)/ccache'
+
+- name: BuildStep
+  type: step
+
+- name: AdditionalKey
+  type: string
+
+steps:
+  - script: |
+      brew install ccache
+      echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
+    displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
+
+  - task: Cache@2
+    inputs:
+      key:  ' "${{parameters.TODAY}}" | "${{parameters.AdditionalKey}}" | "$(Build.SourceVersion)" '
+      path: "${{parameters.CCACHE_DIR}}"
+      restoreKeys: |
+        "${{parameters.TODAY}}" | "${{parameters.AdditionalKey}}"
+    displayName: ccache task
+
+  - ${{ parameters.BuildStep }}
+
+  - script: |
+      ccache -s
+      ccache -z
+    displayName: Show Cache stats and Clear stats.

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -15,7 +15,6 @@ steps:
       brew install ccache
       echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
       mkdir -p "$(Pipeline.Workspace)/ccache"
-      ls "$(Pipeline.Workspace)"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc
 
   - task: Cache@2
@@ -27,10 +26,14 @@ steps:
     displayName: ccache task
     env:
       CCACHE_DIR: '$(Pipeline.Workspace)/ccache'
+      CCACHE_COMPILERCHECK: content
 
   - ${{ parameters.BuildStep }}
 
   - script: |
+      set -ex
       ccache -s
       ccache -z
+      ls -l $(Pipeline.Workspace)/ccache
+      du -sh $(Pipeline.Workspace)/ccache
     displayName: Show Cache stats and Clear stats.

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -3,7 +3,6 @@
 parameters:
 - name: Today
   type: string
-  default: '$[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]'
 
 - name: CCACHE_DIR
   type: string


### PR DESCRIPTION
### Description
1. move the cache task definition into template
2. In debug mode, the compiler mtime is different in different machine. So, change the CCACHE_COMPILERCHECK to content.


### Motivation and Context
1. Accelerate the CoreML pipeline.
2. Make the cache function easy to use and maintain.


