### PR TITLE
Introduce register-efficient warp-wise Softmax

### DIFF
--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -27,7 +27,7 @@ Status SoftMaxComputeHelper(
   auto Y_data = reinterpret_cast<CudaT_OUT*>(Y);
   auto X_data = reinterpret_cast<const CudaT_IN*>(X);
 
-  if (D <= 1024 && D * sizeof(T) <= 4096) {
+  if (D <= 2048 && D * sizeof(T) <= 4096) {
     return dispatch_warpwise_softmax_forward<
         CudaT_IN, CudaT_OUT, AccumulationType_t<CudaT_ACCUM>, is_log_softmax>(
         stream, Y_data, X_data, gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(N));

--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -26,9 +26,13 @@ Status SoftMaxComputeHelper(
   int64_t D = input_shape.SizeFromDimension(axis);
   auto Y_data = reinterpret_cast<CudaT_OUT*>(Y);
   auto X_data = reinterpret_cast<const CudaT_IN*>(X);
-  // according to nsigh compute, softmax_warp_forward_resource_efficient is better than dispatch_blockwise_softmax_forward when 1024 < D <=2048 and N >= 8192
+#ifdef USE_ROCM
+  if (D <= 1024 && D * sizeof(T) <= 4096) {
+#else
+  // According to nsight compute profiling, softmax_warp_forward_resource_efficient is better than dispatch_blockwise_softmax_forward when 1024 < D <=2048 and N >= 8192.
   const bool use_softmax_warp_forward_resource_efficient = 1024 < D && D <= 2048 && D * sizeof(T) <= 4096 && N >= 8192;
   if ((D <= 1024 && D * sizeof(T) <= 4096) or use_softmax_warp_forward_resource_efficient) {
+#endif
     return dispatch_warpwise_softmax_forward<
         CudaT_IN, CudaT_OUT, AccumulationType_t<CudaT_ACCUM>, is_log_softmax>(
         stream, Y_data, X_data, gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(N));

--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -26,13 +26,9 @@ Status SoftMaxComputeHelper(
   int64_t D = input_shape.SizeFromDimension(axis);
   auto Y_data = reinterpret_cast<CudaT_OUT*>(Y);
   auto X_data = reinterpret_cast<const CudaT_IN*>(X);
-#ifdef USE_ROCM
-  if (D <= 1024 && D * sizeof(T) <= 4096) {
-#else
   // According to nsight compute profiling, softmax_warp_forward_resource_efficient is better than dispatch_blockwise_softmax_forward when 1024 < D <=2048 and N >= 8192.
   const bool use_softmax_warp_forward_resource_efficient = 1024 < D && D <= 2048 && D * sizeof(T) <= 4096 && N >= 8192;
   if ((D <= 1024 && D * sizeof(T) <= 4096) or use_softmax_warp_forward_resource_efficient) {
-#endif
     return dispatch_warpwise_softmax_forward<
         CudaT_IN, CudaT_OUT, AccumulationType_t<CudaT_ACCUM>, is_log_softmax>(
         stream, Y_data, X_data, gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(D), gsl::narrow_cast<int>(N));

--- a/onnxruntime/core/providers/cuda/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/softmax_impl.cu
@@ -39,73 +39,50 @@ Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, con
 
     // This value must match the WARP_SIZE constexpr value computed inside softmax_warp_forward.
     int warp_size = (next_power_of_two < GPU_WARP_SIZE_HOST) ? next_power_of_two : GPU_WARP_SIZE_HOST;
-
-    // This value must match the WARP_BATCH constexpr value computed inside softmax_warp_forward.
-    int batches_per_warp = 1;
-
-    // use 128 threads per block to maximimize gpu utilization
-    constexpr int threads_per_block = 32; // one block only has 1 warp
-
+    int batches_per_warp, threads_per_block, shared_memory_size;
+    // there are 2 options to save one row of the input matrix: register or shared memory
+    // when the number of elements is small, we use register; otherwise, we use shared memory;
+    if (log2_elements <= 10){
+      // This value must match the WARP_BATCH constexpr value computed inside softmax_warp_forward.
+      batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
+      // use 128 threads per block to maximimize gpu utilization
+      threads_per_block = 128;
+      shared_memory_size = 0;
+    } else{
+      // when the number of elements is large, one cuda block will only process 1 row of the input matrix(to avoid high shared memory usage and hurt warp occupancy), so hardcode the following values
+      batches_per_warp = 1;
+      threads_per_block = 32;
+      // use shared memory to contain one row of elements
+      // TODO: one more optimization can be done here: we actually not need to save next_power_of_two elements, we can just save the valid elements
+      shared_memory_size = next_power_of_two * sizeof(input_t);
+    }
     int warps_per_block = (threads_per_block / warp_size);
     int batches_per_block = warps_per_block * batches_per_warp;
     int blocks = (batch_count + batches_per_block - 1) / batches_per_block;
-    // use shared memory to contain one row of elements
-    int shared_memory_size = next_power_of_two * sizeof(input_t);
     dim3 threads(warp_size, warps_per_block, 1);
     // Launch code would be more elegant if C++ supported FOR CONSTEXPR
     switch (log2_elements) {
-      case 0:  // 1
-        softmax_warp_forward<input_t, output_t, acc_t, 0, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 1:  // 2
-        softmax_warp_forward<input_t, output_t, acc_t, 1, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 2:  // 4
-        softmax_warp_forward<input_t, output_t, acc_t, 2, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 3:  // 8
-        softmax_warp_forward<input_t, output_t, acc_t, 3, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 4:  // 16
-        softmax_warp_forward<input_t, output_t, acc_t, 4, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 5:  // 32
-        softmax_warp_forward<input_t, output_t, acc_t, 5, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 6:  // 64
-        softmax_warp_forward<input_t, output_t, acc_t, 6, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 7:  // 128
-        softmax_warp_forward<input_t, output_t, acc_t, 7, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 8:  // 256
-        softmax_warp_forward<input_t, output_t, acc_t, 8, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 9:  // 512
-        softmax_warp_forward<input_t, output_t, acc_t, 9, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 10:  // 1024
-        softmax_warp_forward<input_t, output_t, acc_t, 10, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      case 11:  // 2048
-        softmax_warp_forward<input_t, output_t, acc_t, 11, is_log_softmax>
-            <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
-        break;
-      default:
-        break;
-    }
-  }
+#define CASE_LOG2_ELEMENTS(log2_elements_value, impl_version) \
+  case log2_elements_value: { \
+    softmax_warp_forward##impl_version<input_t, output_t, acc_t, log2_elements_value, is_log_softmax> \
+      <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements); \
+  } break
+
+        CASE_LOG2_ELEMENTS(0, 1);
+        CASE_LOG2_ELEMENTS(1, 1);
+        CASE_LOG2_ELEMENTS(2, 1);
+        CASE_LOG2_ELEMENTS(3, 1);
+        CASE_LOG2_ELEMENTS(4, 1);
+        CASE_LOG2_ELEMENTS(5, 1);
+        CASE_LOG2_ELEMENTS(6, 1);
+        CASE_LOG2_ELEMENTS(7, 1);
+        CASE_LOG2_ELEMENTS(8, 1);
+        CASE_LOG2_ELEMENTS(9, 1);
+        CASE_LOG2_ELEMENTS(10, 1);
+        CASE_LOG2_ELEMENTS(11, 2); // start from here, using shared memory will have better performance namely the second version implementation
+#undef CASE_LOG2_ELEMENTS
+    } // switch
+  } // else
   return CUDA_CALL(cudaGetLastError());
 }
 

--- a/onnxruntime/core/providers/cuda/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/softmax_impl.cu
@@ -62,24 +62,33 @@ Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, con
     dim3 threads(warp_size, warps_per_block, 1);
     // Launch code would be more elegant if C++ supported FOR CONSTEXPR
     switch (log2_elements) {
-#define CASE_LOG2_ELEMENTS(log2_elements_value, impl_version) \
-  case log2_elements_value: { \
-    softmax_warp_forward##impl_version<input_t, output_t, acc_t, log2_elements_value, is_log_softmax> \
-      <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements); \
+
+#define LAUNCH_KERNEL(kernel_name, log2_elements_value)                                                                  \
+  kernel_name<input_t, output_t, acc_t, log2_elements_value, is_log_softmax>                                             \
+    <<<blocks, threads, shared_memory_size, stream>>>(dst, src, batch_count, softmax_elements_stride, softmax_elements);
+
+#define CASE_LOG2_ELEMENTS(log2_elements_value)                                                                          \
+  case log2_elements_value: {                                                                                            \
+    if (log2_elements_value <= 10) {                                                                                     \
+      LAUNCH_KERNEL(softmax_warp_forward, log2_elements_value)                                                           \
+    } else {                                                                                                             \
+      LAUNCH_KERNEL(softmax_warp_forward_resource_efficient, log2_elements_value)                                        \
+    }                                                                                                                    \
   } break
 
-        CASE_LOG2_ELEMENTS(0, 1);
-        CASE_LOG2_ELEMENTS(1, 1);
-        CASE_LOG2_ELEMENTS(2, 1);
-        CASE_LOG2_ELEMENTS(3, 1);
-        CASE_LOG2_ELEMENTS(4, 1);
-        CASE_LOG2_ELEMENTS(5, 1);
-        CASE_LOG2_ELEMENTS(6, 1);
-        CASE_LOG2_ELEMENTS(7, 1);
-        CASE_LOG2_ELEMENTS(8, 1);
-        CASE_LOG2_ELEMENTS(9, 1);
-        CASE_LOG2_ELEMENTS(10, 1);
-        CASE_LOG2_ELEMENTS(11, 2); // start from here, using shared memory will have better performance namely the second version implementation
+        CASE_LOG2_ELEMENTS(0);
+        CASE_LOG2_ELEMENTS(1);
+        CASE_LOG2_ELEMENTS(2);
+        CASE_LOG2_ELEMENTS(3);
+        CASE_LOG2_ELEMENTS(4);
+        CASE_LOG2_ELEMENTS(5);
+        CASE_LOG2_ELEMENTS(6);
+        CASE_LOG2_ELEMENTS(7);
+        CASE_LOG2_ELEMENTS(8);
+        CASE_LOG2_ELEMENTS(9);
+        CASE_LOG2_ELEMENTS(10);
+        CASE_LOG2_ELEMENTS(11); // start to use softmax_warp_forward_resource_efficient instead of softmax_warp_forward for better performance
+#undef LAUNCH_KERNEL
 #undef CASE_LOG2_ELEMENTS
     } // switch
   } // else

--- a/onnxruntime/core/providers/cuda/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/softmax_impl.cu
@@ -49,8 +49,8 @@ Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, con
       threads_per_block = 128;
       shared_memory_size = 0;
     } else{
-      // 1 warp(32 threads) per block, so the index offset calculations in cuda kernel will be easier
-      // under this setting, the cuda block number will be equal to batch size and contains one warp only
+      // setting the number of threads per block to 32 will make index offset calculations easier,
+      // under this setting, the cuda block number will be equal to batch size.
       threads_per_block = 32;
       // use shared memory to contain one row of elements
       // TODO: one more optimization can be done here: we actually not need to save next_power_of_two elements, we can just save the valid elements

--- a/onnxruntime/core/providers/cuda/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/softmax_impl.cu
@@ -69,7 +69,7 @@ Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, con
 
 #define CASE_LOG2_ELEMENTS(log2_elements_value)                                                                          \
   case log2_elements_value: {                                                                                            \
-    if (log2_elements_value <= 10) {                                                                                     \
+    if constexpr (log2_elements_value <= 10) {                                                                                     \
       LAUNCH_KERNEL(softmax_warp_forward, log2_elements_value)                                                           \
     } else {                                                                                                             \
       LAUNCH_KERNEL(softmax_warp_forward_resource_efficient, log2_elements_value)                                        \

--- a/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
@@ -170,7 +170,7 @@ template <typename input_t, typename output_t, typename acc_t, int log2_elements
 __global__ void softmax_warp_forward_resource_efficient(output_t* dst, const input_t* src, int batch_size, int stride, int element_count) {
   // 1 cuda block only processes one row and contains 1 cuda warp only.
   constexpr int next_power_of_two = 1 << log2_elements;
-  constexpr int WARP_SIZE = 32;
+  constexpr int WARP_SIZE = (next_power_of_two < GPU_WARP_SIZE) ? next_power_of_two : GPU_WARP_SIZE;
   constexpr int WARP_ITERATIONS = next_power_of_two / WARP_SIZE;
 
   int local_idx = threadIdx.x;

--- a/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
@@ -74,7 +74,97 @@ __device__ __forceinline__ void warp_reduce(acc_t* sum) {
 // input_t_float, acc_t=float, output_t=half  => read float tensor, float accumulators, write half tensor.
 
 template <typename input_t, typename output_t, typename acc_t, int log2_elements, bool is_log_softmax>
-__global__ void softmax_warp_forward(output_t* dst, const input_t* src, int batch_size, int stride, int element_count) {
+__global__ void softmax_warp_forward1(output_t* dst, const input_t* src, int batch_size, int stride, int element_count) {
+  // WARP_SIZE and WARP_BATCH must match the return values batches_per_warp and warp_size of method warp_softmax_forward_kernel.
+  constexpr int next_power_of_two = 1 << log2_elements;
+  constexpr int WARP_SIZE = (next_power_of_two < GPU_WARP_SIZE) ? next_power_of_two : GPU_WARP_SIZE;
+  constexpr int WARP_ITERATIONS = next_power_of_two / WARP_SIZE;
+  constexpr int WARP_BATCH = (next_power_of_two <= 128) ? 2 : 1;
+
+  int first_batch = (blockDim.y * blockIdx.x + threadIdx.y) * WARP_BATCH;
+
+  // batch_size might not be a multiple of WARP_BATCH. Check how
+  // many batches have to computed within this WARP.
+  int local_batches = batch_size - first_batch;
+  if (local_batches > WARP_BATCH)
+    local_batches = WARP_BATCH;
+
+  // there might be multiple batches per warp. compute the index within the batch
+  int local_idx = threadIdx.x;
+
+  src += first_batch * stride + local_idx;
+  dst += first_batch * stride + local_idx;
+
+  // The nested loops over WARP_BATCH and then WARP_ITERATIONS can be simplified to one loop,
+  // but I think doing so would obfuscate the logic of the algorithm, thus I chose to keep
+  // the nested loops.
+  // This should have no impact on performance because the loops are unrolled anyway.
+
+  // load data from global memory
+  acc_t elements[WARP_BATCH][WARP_ITERATIONS];
+  for (int i = 0; i < WARP_BATCH; ++i) {
+    int batch_element_count = (i >= local_batches) ? 0 : element_count;
+    for (int it = 0; it < WARP_ITERATIONS; ++it) {
+      int element_index = local_idx + it * WARP_SIZE;
+      if (element_index < batch_element_count) {
+        elements[i][it] = src[i * element_count + it * WARP_SIZE];
+      } else {
+        elements[i][it] = -std::numeric_limits<acc_t>::infinity();
+      }
+    }
+  }
+
+  // compute max_value
+  acc_t max_value[WARP_BATCH];
+#pragma unroll
+  for (int i = 0; i < WARP_BATCH; ++i) {
+    max_value[i] = elements[i][0];
+#pragma unroll
+    for (int it = 1; it < WARP_ITERATIONS; ++it) {
+      max_value[i] = (max_value[i] > elements[i][it]) ? max_value[i] : elements[i][it];
+    }
+  }
+  warp_reduce<acc_t, WARP_BATCH, WARP_SIZE, Max>(max_value);
+
+  acc_t sum[WARP_BATCH]{0.0f};
+#pragma unroll
+  for (int i = 0; i < WARP_BATCH; ++i) {
+#pragma unroll
+    for (int it = 0; it < WARP_ITERATIONS; ++it) {
+      if (is_log_softmax) {
+        sum[i] += std::exp((float)(elements[i][it] - max_value[i]));
+      } else {
+        elements[i][it] = std::exp((float)(elements[i][it] - max_value[i]));
+        sum[i] += elements[i][it];
+      }
+    }
+  }
+  warp_reduce<acc_t, WARP_BATCH, WARP_SIZE, Add>(sum);
+
+// store result
+#pragma unroll
+  for (int i = 0; i < WARP_BATCH; ++i) {
+    if (i >= local_batches)
+      break;
+    if (is_log_softmax) sum[i] = max_value[i] + std::log((float)(sum[i]));
+#pragma unroll
+    for (int it = 0; it < WARP_ITERATIONS; ++it) {
+      int element_index = local_idx + it * WARP_SIZE;
+      if (element_index < element_count) {
+        if (is_log_softmax) {
+          dst[i * element_count + it * WARP_SIZE] = elements[i][it] - sum[i];
+        } else {
+          dst[i * element_count + it * WARP_SIZE] = elements[i][it] / sum[i];
+        }
+      } else {
+        break;
+      }
+    }
+  }
+}
+
+template <typename input_t, typename output_t, typename acc_t, int log2_elements, bool is_log_softmax>
+__global__ void softmax_warp_forward2(output_t* dst, const input_t* src, int batch_size, int stride, int element_count) {
   // WARP_SIZE and WARP_BATCH must match the return values batches_per_warp and warp_size of method warp_softmax_forward_kernel.
   constexpr int next_power_of_two = 1 << log2_elements;
   constexpr int WARP_SIZE = (next_power_of_two < GPU_WARP_SIZE) ? next_power_of_two : GPU_WARP_SIZE;

--- a/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
@@ -164,8 +164,10 @@ __global__ void softmax_warp_forward(output_t* dst, const input_t* src, int batc
 }
 
 
-// softmax_warp_forward use register to store data and the dtype is fp32, which will result resource oversubscription and thus hurt kernel performance.
-// softmax_warp_forward_resource_efficient is implemneted to solve the issues.
+// softmax_warp_forward uses register to store data in fp32 even when data is fp16, which will cause register resource oversubscription when data is large,
+// and will lead to low CUDA warp occupancy and thus a poor kernel performance.
+// softmax_warp_forward_resource_efficient is implemneted to solve the issue, it cache data in original dtype, and cast it into fp32 when needed,
+// the idea is like we use recomputation to save resource usage.
 template <typename input_t, typename output_t, typename acc_t, int log2_elements, bool is_log_softmax>
 __global__ void softmax_warp_forward_resource_efficient(output_t* dst, const input_t* src, int batch_size, int stride, int element_count) {
   // 1 cuda block only processes one row and contains 1 cuda warp only.


### PR DESCRIPTION
improve softmax forward when number of elem to do softmax is between (1024,2048]

several optimizations done in the PR:
1. originally ort will call softmax_block_forward when shape is 1500, this will cause 5.53ms, however ort has another implementation called softmax_warp_forward, this function will only need 4.74ms, so i modified the function selection logic to call the faster version.
2. softmax_warp_forward will use register to cache the input in fp32 mode, this will consume many registers when data number is large and will make warp occupancy quite low, also compiler can do some of its optimizations, so the pr implements another version of softmax_warp_forward, it will use shared memory instead of register to cache the input; also when the for loop in the function has many iterations, actually disable loop unrolling will make kernel faster further.

the perf table between softmax_warp_forward1(the original version) and softmax_warp_forward2
![image](https://user-images.githubusercontent.com/43435212/228491963-cf87e3b3-e69e-454c-bab6-7e62a25bf76b.png)


in open-ai whisper case, the kernel gain will be 5.53ms/3.03ms = 82% (softmax_block_forward vs softmax_warp_forward2)

























































