### PR TITLE
Skip DNNL's opset18 tests

### DIFF
--- a/onnxruntime/test/providers/cpu/model_tests.cc
+++ b/onnxruntime/test/providers/cpu/model_tests.cc
@@ -118,10 +118,12 @@ TEST_P(ModelTest, Run) {
     return;
   }
 
-  if (model_info->GetONNXOpSetVersion() == 10 && provider_name == "dnnl") {
+  if ((model_info->GetONNXOpSetVersion() == 10 || model_info->GetONNXOpSetVersion() >= 18) && provider_name == "dnnl") {
     // DNNL can run most of the model tests, but only part of
     // them is enabled here to save CI build time.
-    SkipTest(" dnnl doesn't support opset 10");
+    std::ostringstream oss;
+    oss << " dnnl doesn't support opset " << model_info->GetONNXOpSetVersion();
+    SkipTest(oss.str());
     return;
   }
 


### PR DESCRIPTION
### Description
DNNL EP doesn't support opset18 yet. So, let it skip such tests so that we could still test the other EPs. 

The models mentioned above are ONNX node tests that live in github.com/onnx/onnx 
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


