### PR TITLE
Make internal nhwc schema registrations complete

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
+++ b/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
@@ -78,14 +78,14 @@ void OpSet_Internal_NHWC_ONNX::ForEachSchema(const std::function<void(ONNX_NAMES
   // /onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, AveragePool, 11);
 
-  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 9);
-  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 14);
-  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 15);
+  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, BatchNormalization, 9);
+  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, BatchNormalization, 14);
+  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, BatchNormalization, 15);
 
   REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 11);
   REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 13);
 
-  REGISTER_NHWC_SCHEMA(fn, InstanceNormalization, 6);
+  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, InstanceNormalization, 6);
 
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, Conv, 11);
 

--- a/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
+++ b/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_opset.cc
@@ -13,7 +13,7 @@ namespace onnxruntime {
 namespace contrib {
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearAveragePool);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, QLinearConvTranspose);
-}
+}  // namespace contrib
 namespace internal_nhwc_onnx {
 
 using contrib::NhwcInferenceContext;
@@ -73,24 +73,51 @@ void OpSet_Internal_NHWC_ONNX::ForEachSchema(const std::function<void(ONNX_NAMES
   // for the activation parameters.
   // For now we only register operators from opset 11 on. Models can easily have their opset updated using ONNX tools
   // so supporting older opsets is unnecessary.
+
+  // NOTE: This should be in sync with GetLayoutSensitiveOps in
+  // /onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, AveragePool, 11);
+
+  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 9);
+  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 14);
+  REGISTER_NHWC_SCHEMA(fn, BatchNormalization, 15);
+
+  REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 11);
+  REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 13);
+
+  REGISTER_NHWC_SCHEMA(fn, InstanceNormalization, 6);
+
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, Conv, 11);
+
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, ConvTranspose, 11);
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, ConvTranspose, 1);
+
+  REGISTER_NHWC_SCHEMA(fn, GlobalAveragePool, 1);
+  REGISTER_NHWC_SCHEMA(fn, GlobalLpPool, 2);
+  REGISTER_NHWC_SCHEMA(fn, GlobalMaxPool, 1);
+
+  REGISTER_NHWC_SCHEMA(fn, GridSample, 16);
+
+  REGISTER_NHWC_SCHEMA(fn, LRN, 1);
+  REGISTER_NHWC_SCHEMA(fn, LRN, 13);
+
+  REGISTER_NHWC_SCHEMA(fn, LpPool, 11);
+  REGISTER_NHWC_SCHEMA(fn, LpPool, 18);
+
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, MaxPool, 11);
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, MaxPool, 12);
+
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, MaxUnpool, 9);
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, MaxUnpool, 11);
-  REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, AveragePool, 11);
+
   REGISTER_NHWC_SCHEMA(fn, QLinearConv, 10);
+
+  REGISTER_NHWC_SCHEMA(fn, SpaceToDepth, 1);
+  REGISTER_NHWC_SCHEMA(fn, SpaceToDepth, 13);
+
+  // internal QLinear ops
   REGISTER_NHWC_SCHEMA_FROM_MSDOMAIN(fn, QLinearAveragePool, 1);
   REGISTER_NHWC_SCHEMA_FROM_MSDOMAIN(fn, QLinearConvTranspose, 1);
-
-  // TODO: Add other layout sensitive ops when needed. Those are:
-  //   BatchNormalization,
-  //   AveragePool, GlobalAveragePool, GlobalMaxPool,
-  //   LRN,
-  //   GridSample
-  //   DepthToSpace, SpaceToDepth
 
   // not all schema are registered here. For part of layout insensitive ops
   // we will use onnx schema directly, for others, like fused-node/qdq-group

--- a/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/transpose_optimizer.cc
@@ -2168,10 +2168,16 @@ OptimizeResult OptimizeImpl(OptimizerCtx& ctx) {
 const std::unordered_set<std::string_view>& GetLayoutSensitiveOps() {
   // List of all layout sensitive ops defined in ONNX standard.
   static std::unordered_set<std::string_view> layout_sensitive_ops = {
-      "Conv", "QLinearConv", "BatchNormalization",
-      "AveragePool", "GlobalAveragePool", "MaxPool",
-      "GlobalMaxPool", "LRN", "GridSample",
-      "DepthToSpace", "SpaceToDepth", "ConvTranspose", "MaxUnpool", "InstanceNormalization"};
+      "BatchNormalization", "InstanceNormalization",
+
+      "Conv", "QLinearConv", "ConvTranspose",
+
+      "AveragePool", "LpPool", "MaxPool", "MaxUnpool",
+      "GlobalAveragePool", "GlobalLpPool", "GlobalMaxPool",
+
+      "LRN",
+      "GridSample",
+      "DepthToSpace", "SpaceToDepth"};
 
   return layout_sensitive_ops;
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add all the ONNX layout sensitive ops from opset 11 on. 
Make list in transpose optimizer consistent.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When we run L1 optimizers after layout transform in a full build it needs a schema for any layout sensitive ops that get converted to the internal domain. Previously we did not run L1, so we got away without having schemas unless the EP used a static kernel for the nhwc version of the op.