### PR TITLE
[ROCm] fix python packaging pipeline and add python10 

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
@@ -21,11 +21,19 @@ stages:
       RocmVersion: '5.2.3'
   - template: templates/rocm.yml
     parameters:
+      PythonVersion: '3.10'
+      RocmVersion: '5.2.3'
+  - template: templates/rocm.yml
+    parameters:
       PythonVersion: '3.8'
       RocmVersion: '5.3.2'
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
+      RocmVersion: '5.3.2'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.10'
       RocmVersion: '5.3.2'
   - template: templates/rocm.yml
     parameters:
@@ -34,6 +42,10 @@ stages:
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
+      RocmVersion: '5.4'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.10'
       RocmVersion: '5.4'
   - template: templates/rocm.yml
     parameters:
@@ -42,6 +54,10 @@ stages:
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
+      RocmVersion: '5.4.2'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.10'
       RocmVersion: '5.4.2'
   - template: templates/rocm.yml
     parameters:
@@ -51,5 +67,10 @@ stages:
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
+      RocmVersion: '5.4.2'
+      BuildConfig: 'RelWithDebInfo'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.10'
       RocmVersion: '5.4.2'
       BuildConfig: 'RelWithDebInfo'

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -150,6 +150,16 @@ COPY build_scripts/ambv-pubkey.txt /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.9.13
 
 
+FROM build_cpython AS build_cpython310
+COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkeys.txt
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.5
+
+
+FROM build_cpython AS build_cpython311
+COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkeys.txt
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.11.2
+
+
 FROM build_cpython AS all_python
 COPY build_scripts/install-pypy.sh \
      build_scripts/pypy.sha256 \
@@ -159,6 +169,8 @@ RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.8 7.3.9
 RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.9 7.3.9
 COPY --from=build_cpython38 /opt/_internal /opt/_internal/
 COPY --from=build_cpython39 /opt/_internal /opt/_internal/
+COPY --from=build_cpython310 /opt/_internal /opt/_internal/
+COPY --from=build_cpython311 /opt/_internal /opt/_internal/
 RUN manylinux-entrypoint /build_scripts/finalize-python.sh
 
 
@@ -171,6 +183,8 @@ COPY build_scripts/finalize.sh \
      build_scripts/python-tag-abi-tag.py \
      build_scripts/requirements3.8.txt \
      build_scripts/requirements3.9.txt \
+     build_scripts/requirements3.10.txt \
+     build_scripts/requirements3.11.txt \
      build_scripts/requirements-base-tools.txt \
      /build_scripts/
 COPY build_scripts/requirements-tools/* /build_scripts/requirements-tools/
@@ -193,6 +207,8 @@ RUN cd /tmp/scripts && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.10 $INSTALL_DEPS_EXTRA_ARGS && \
+    /tmp/scripts/install_python_deps.sh -d gpu -p 3.11 $INSTALL_DEPS_EXTRA_ARGS && \
      rm -rf /tmp/scripts
 
 # remove protobuf to prevent ambiguity which is used for onnxruntime build

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -208,7 +208,6 @@ RUN cd /tmp/scripts && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.8 $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.9 $INSTALL_DEPS_EXTRA_ARGS && \
     /tmp/scripts/install_python_deps.sh -d gpu -p 3.10 $INSTALL_DEPS_EXTRA_ARGS && \
-    /tmp/scripts/install_python_deps.sh -d gpu -p 3.11 $INSTALL_DEPS_EXTRA_ARGS && \
      rm -rf /tmp/scripts
 
 # remove protobuf to prevent ambiguity which is used for onnxruntime build

--- a/tools/ci_build/github/linux/docker/manylinux.patch
+++ b/tools/ci_build/github/linux/docker/manylinux.patch
@@ -65,17 +65,21 @@ index 9ef1e99..ec52833 100755
 +fi
 \ No newline at end of file
 diff --git a/install-runtime-packages.sh b/install-runtime-packages.sh
-index 137d2e2..5b7cc0a 100755
+index 137d2e2..bd329f4 100755
 --- a/install-runtime-packages.sh
 +++ b/install-runtime-packages.sh
-@@ -75,7 +75,12 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
+@@ -73,9 +73,14 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
+ 	if [ "${AUDITWHEEL_ARCH}" == "x86_64" ]; then
+ 		# Software collection (for devtoolset-10)
  		yum -y install centos-release-scl-rh
-- 		# EPEL support (for yasm)
-- 		yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+-		# EPEL support (for yasm)
+-		yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 -		TOOLCHAIN_DEPS="${TOOLCHAIN_DEPS} yasm"
 +               if [[ -d /opt/rocm ]]; then
 +                 TOOLCHAIN_DEPS="devtoolset-10-binutils devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-gcc-gfortran"
 +               else
++                 # EPEL support (for yasm)
++                 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 +                 TOOLCHAIN_DEPS="devtoolset-11-binutils devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-gcc-gfortran"
 +               fi
 +               TOOLCHAIN_DEPS="${TOOLCHAIN_DEPS} yasm"

--- a/tools/ci_build/github/linux/docker/manylinux.patch
+++ b/tools/ci_build/github/linux/docker/manylinux.patch
@@ -23,7 +23,7 @@ index 9c0b02d..2e2919c 100755
 +make -j$(nproc) install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}"
  popd
  rm -rf ${GIT_ROOT} ${GIT_ROOT}.tar.gz
- 
+
 diff --git a/build-openssl.sh b/build-openssl.sh
 index 668deb6..5f3f5d5 100755
 --- a/build-openssl.sh
@@ -42,14 +42,14 @@ index 961e34d..55ae11b 100755
 --- a/build_utils.sh
 +++ b/build_utils.sh
 @@ -52,7 +52,7 @@ function check_sha256sum {
- 
+
  function do_standard_install {
      ./configure "$@" CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" "CXXFLAGS=${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}" > /dev/null
 -    make > /dev/null
 +    make -j$(nproc) > /dev/null
      make install > /dev/null
  }
- 
+
 diff --git a/install-entrypoint.sh b/install-entrypoint.sh
 index 9ef1e99..ec52833 100755
 --- a/install-entrypoint.sh
@@ -70,8 +70,8 @@ index 137d2e2..5b7cc0a 100755
 +++ b/install-runtime-packages.sh
 @@ -75,7 +75,12 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
  		yum -y install centos-release-scl-rh
- 		# EPEL support (for yasm)
- 		yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+- 		# EPEL support (for yasm)
+- 		yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 -		TOOLCHAIN_DEPS="${TOOLCHAIN_DEPS} yasm"
 +               if [[ -d /opt/rocm ]]; then
 +                 TOOLCHAIN_DEPS="devtoolset-10-binutils devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-gcc-gfortran"


### PR DESCRIPTION
rocm python packaging pipeline failed because manylinux version and manylinux.patch update.
1. fix duplicate `epel-release` installation issue, ROCm pipeline install it at the begin of the dockerfile to install rocm libs. remove duplicate installation on install-runtime-packages.sh.
```
/var/tmp/yum-root-sMRl36/epel-release-latest-7.noarch.rpm: does not update installed package.
Error: Nothing to do
```
2. add python10 to fix error below.
```
+ /opt/python/cp310-cp310/bin/python -m venv /opt/_internal/tools
build_scripts/finalize.sh: line 40: /opt/python/cp310-cp310/bin/python: No such file or directory
```
3. add python10 to rocm pipeline.

pipeline link: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=294776&view=results
