### PR TITLE
int32_t and uint32_t Clip Kernels

### DIFF
--- a/onnxruntime/core/providers/cpu/math/clip.cc
+++ b/onnxruntime/core/providers/cpu/math/clip.cc
@@ -23,7 +23,7 @@ ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES(
     float);
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPES(
     kCpuExecutionProvider, kOnnxDomain, Clip, 12, Input, 0,
-    float, double, int8_t, uint8_t, int64_t, uint64_t);
+    float, double, int8_t, uint8_t, int32_t, uint32_t, int64_t, uint64_t);
 }  // namespace op_kernel_type_control
 
 using EnabledClip11Types = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST(

--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -123,6 +123,44 @@ TEST(MathOpTest, Clip_Default_uint64) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+TEST(MathOpTest, Clip_int32) {
+  OpTester test("Clip", 12);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<int32_t>("X", dims,
+                        {-1, 0, 1,
+                        -16, 12, -6,
+                        -5, 2, 16});
+  test.AddInput<int32_t>("min", {}, {-10});
+  test.AddInput<int32_t>("max", {}, {10});
+  test.AddOutput<int32_t>("Y", dims,
+                        {-1, 0, 1,
+                          -10, 10, -6,
+                          -5, 2, 10});
+
+  // TensorRT does not support Clip opset 12 yet.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(MathOpTest, Clip_uint32) {
+  OpTester test("Clip", 12);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<uint32_t>("X", dims,
+                        {0, 0, 1,
+                        5, 12, 3,
+                        2, 7, 16});
+  test.AddInput<uint32_t>("min", {}, {3});
+  test.AddInput<uint32_t>("max", {}, {10});
+  test.AddOutput<uint32_t>("Y", dims,
+                        {3, 3, 3,
+                          5, 10, 3,
+                          3, 7, 10});
+
+  // TensorRT does not support Clip opset 12 yet.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
 TEST(MathOpTest, Clip) {
   // To test NNAPI EP, we need the min/max to be in initializers
   auto run_test = [](bool min_max_are_initializer) {


### PR DESCRIPTION
### Description
This adds support for `int32_t` and `uint32_t` clip operator, introduced in Opset 12. It also closes https://github.com/microsoft/onnxruntime/issues/15304.



### Motivation and Context
- Closes https://github.com/microsoft/onnxruntime/issues/15304


