### PR TITLE
Disable vendor library tests by default

### DIFF
--- a/onnxruntime/python/tools/kernel_explorer/kernels/batched_gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/batched_gemm_test.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import os
 import sys
 from dataclasses import dataclass
 from itertools import product
@@ -85,6 +86,10 @@ dtypes = ["float32", "float16"]
 all_transabs = list(product([True, False], repeat=2))
 
 
+@pytest.mark.skipif(
+    not int(os.environ.get("KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES", "0")),
+    reason="Export KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES=1 to test vendor libraries.",
+)
 @pytest.mark.parametrize("batch", [1, 64])
 @pytest.mark.parametrize("m, n, k", get_gemm_basic_sizes(full=False) + get_gemm_bert_sizes(full=False))
 @pytest.mark.parametrize("transa, transb", all_transabs)

--- a/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/gemm_test.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import os
 import sys
 from dataclasses import dataclass
 from itertools import product
@@ -71,6 +72,10 @@ dtypes = ["float32", "float16"]
 all_transabs = list(product([True, False], repeat=2))
 
 
+@pytest.mark.skipif(
+    not int(os.environ.get("KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES", "0")),
+    reason="Export KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES=1 to test vendor libraries.",
+)
 @pytest.mark.parametrize("m, n, k", get_gemm_basic_sizes(full=True) + get_gemm_bert_sizes(full=False))
 @pytest.mark.parametrize("transa, transb", all_transabs)
 @pytest.mark.parametrize("dtype", dtypes)

--- a/onnxruntime/python/tools/kernel_explorer/kernels/strided_batched_gemm_test.py
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/strided_batched_gemm_test.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+import os
 import sys
 from dataclasses import dataclass
 from itertools import product
@@ -89,6 +90,10 @@ dtypes = ["float32", "float16"]
 all_transabs = list(product([True, False], repeat=2))
 
 
+@pytest.mark.skipif(
+    not int(os.environ.get("KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES", "0")),
+    reason="Export KERNEL_EXPLORER_TEST_VENDOR_LIBRARIES=1 to test vendor libraries.",
+)
 @pytest.mark.parametrize("batch", [1, 64])
 @pytest.mark.parametrize("m, n, k", get_gemm_basic_sizes(full=False) + get_gemm_bert_sizes(full=False))
 @pytest.mark.parametrize("transa, transb", all_transabs)


### PR DESCRIPTION
Disable vendor library tests to avoid too much time and energy wasting. These libraries should only be tested once and only once iff the vendor library is changed.
