### PR TITLE
Remove azure build to unblock PRs

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-ci-pipeline.yml
@@ -190,23 +190,3 @@ stages:
         WITH_CACHE: true
         MachinePool: 'onnxruntime-Win2019-CPU-training'
 
-- stage: x64_release_azure
-  dependsOn: []
-  jobs:
-    - template: templates/win-ci-vs-2019.yml
-      parameters:
-        BuildConfig: 'RelWithDebInfo'
-        EnvSetupScript: setup_env_azure.bat
-        buildArch: x64
-        additionalBuildFlags: --use_azure
-        msbuildPlatform: x64
-        isX86: false
-        job_name_suffix: x64_release_azure
-        RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
-        RunStaticCodeAnalysis: false
-        EnablePython: false
-        isTraining: false
-        ORT_EP_NAME: CPU
-        GenerateDocumentation: false
-        WITH_CACHE: true
-        MachinePool: 'Win-CPU-2019'


### PR DESCRIPTION
Temporarily remove Azure build check to unblock PR(s).
We need to investigate the sudden build failure and reenable.

