### PR TITLE
fix error unqualified call to 'std::move'

### DIFF
--- a/orttraining/orttraining/models/mnist/mnist_data_provider.cc
+++ b/orttraining/orttraining/models/mnist/mnist_data_provider.cc
@@ -23,14 +23,14 @@ pair<vector<vector<float>>, vector<vector<float>>> NormalizeData(const vector<Im
         normalized_image[j] = 1.0f;
       }
     }
-    normalized_images.emplace_back(move(normalized_image));
+    normalized_images.emplace_back(std::move(normalized_image));
   }
 
   vector<vector<float>> one_hot_labels;
   for (size_t i = 0; i < labels.size(); i++) {
     vector<float> one_hot_label(10, 0.0f);
     one_hot_label[labels[i]] = 1.0f;  //one hot
-    one_hot_labels.emplace_back(move(one_hot_label));
+    one_hot_labels.emplace_back(std::move(one_hot_label));
   }
   return make_pair(normalized_images, one_hot_labels);
 }

--- a/orttraining/orttraining/models/runner/training_util.cc
+++ b/orttraining/orttraining/models/runner/training_util.cc
@@ -36,7 +36,7 @@ common::Status DataSet::AddData(DataSet::SampleType&& single_sample) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "DataSet::AddData failed");
   }
 
-  data_.emplace_back(move(single_sample));
+  data_.emplace_back(std::move(single_sample));
   return Status::OK();
 }
 
@@ -59,7 +59,7 @@ common::Status DataSet::AddData(const vector<ONNX_NAMESPACE::TensorProto>& featu
     ortvalue_buffers_.emplace_back(std::move(buffer));
   }
 
-  data_.emplace_back(move(sample));
+  data_.emplace_back(std::move(sample));
   return Status::OK();
 }
 


### PR DESCRIPTION
### Description
Specify `std` namespace to call function `move`.



### Motivation and Context
Currently `move` is called  without the std:: qualifier, but the compiler cannot find a function named `move` in the current namespace or any namespaces that have been imported using using directives and failed to fall back to looking for the function in the std namespace.

Resulted in this error:

```
/path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc:39:22: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  data_.emplace_back(move(single_sample));
                     ^
                     std::
/path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc:62:22: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
  data_.emplace_back(move(sample));
                     ^
                     std::
[ 74%] Linking CXX executable onnxruntime_test_trainer.js
2 errors generated.
em++: error: '/path/to/onnxruntime/cmake/external/emsdk/upstream/bin/clang++ -target wasm32-unknown-emscripten -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -D__EMSCRIPTEN_major__=3 -D__EMSCRIPTEN_minor__=1 -D__EMSCRIPTEN_tiny__=19 -I/path/to/onnxruntime/cmake/external/emsdk/upstream/emscripten/cache/sysroot/include/SDL --sysroot=/path/to/onnxruntime/cmake/external/emsdk/upstream/emscripten/cache/sysroot -Xclang -iwithsysroot/include/compat -DBUILD_MLAS_NO_ONNXRUNTIME -DEIGEN_MPL2_ONLY -DEIGEN_USE_THREADS -DENABLE_ATEN -DENABLE_STRIDED_TENSORS -DENABLE_TRAINING -DENABLE_TRAINING_APIS -DENABLE_TRAINING_CORE -DENABLE_TRAINING_OPS -DJSON_DIAGNOSTICS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DNSYNC_ATOMIC_CPP11 -DONNX_ML=1 -DONNX_NAMESPACE=onnx -DONNX_USE_LITE_PROTO=1 -DORT_ENABLE_STREAM -DPLATFORM_POSIX -D__ONNX_NO_DOC_STRINGS -I/path/to/onnxruntime/include/onnxruntime -I/path/to/onnxruntime/include/onnxruntime/core/session -I/path/to/onnxruntime/orttraining/orttraining/training_api/include -I/path/to/onnxruntime/build/Linux/Debug/_deps/google_nsync-src/public -I/path/to/onnxruntime/build/Linux/Debug -I/path/to/onnxruntime/onnxruntime -I/path/to/onnxruntime/build/Linux/Debug/_deps/abseil_cpp-src -I/path/to/onnxruntime/orttraining -I/path/to/onnxruntime/build/Linux/Debug/_deps/safeint-src -I/path/to/onnxruntime/build/Linux/Debug/_deps/gsl-src/include -I/path/to/onnxruntime/build/Linux/Debug/_deps/onnx-src -I/path/to/onnxruntime/build/Linux/Debug/_deps/onnx-build -I/path/to/onnxruntime/build/Linux/Debug/_deps/protobuf-src/src -I/path/to/onnxruntime/build/Linux/Debug/_deps/flatbuffers-src/include -I/path/to/onnxruntime/build/Linux/Debug/_deps/mp11-src/include -I/path/to/onnxruntime/build/Linux/Debug/_deps/eigen-src -I/path/to/onnxruntime/build/Linux/Debug/_deps/nlohmann_json-src/single_include -ffunction-sections -fdata-sections -g0 -std=gnu++17 -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-copy -Wno-tautological-pointer-compare -Wno-ambiguous-reversed-operator -Wno-deprecated-anon-enum-enum-conversion -Wno-undefined-var-template -Wno-deprecated-builtins -Werror -MD -MT CMakeFiles/onnxruntime_training_runner.dir/path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc.o -MF CMakeFiles/onnxruntime_training_runner.dir/path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc.o.d -c /path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc -o CMakeFiles/onnxruntime_training_runner.dir/path/to/onnxruntime/orttraining/orttraining/models/runner/training_util.cc.o' failed (returned 1)
```

when running these build commands:

```
./build.sh --build_wasm --parallel $(expr `nproc` - 1) --enable_training --enable_training_ops --skip_submodule_sync --skip_tests
./build.sh --build_wasm --enable_wasm_simd --parallel $(expr `nproc` - 1) --enable_training --enable_training_ops --skip_submodule_sync --skip_tests
./build.sh --build_wasm --enable_wasm_threads --parallel $(expr `nproc` - 1) --enable_training --enable_training_ops --skip_submodule_sync --skip_tests
./build.sh --build_wasm --enable_wasm_simd --enable_wasm_threads --parallel $(expr `nproc` - 1) --enable_training --enable_training_ops --skip_submodule_sync --skip_tests
```

emcc 3.1.3