### PR TITLE
Get rid of g_host singleton to resolve initialisation order fiasco

### DIFF
--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -248,7 +248,7 @@ constexpr const char* kAzureExecutionProvider = "AzureExecutionProvider";
 template <typename T>
 using IAllocatorUniquePtr = std::unique_ptr<T, std::function<void(T*)> >;
 
-inline OrtStatus* CreateStatus(OrtErrorCode code, _In_ const char* msg) noexcept { return g_host->CreateStatus(code, msg); }
+inline OrtStatus* CreateStatus(OrtErrorCode code, _In_ const char* msg) noexcept { return Provider_GetHost()->CreateStatus(code, msg); }
 
 std::unique_ptr<IAllocator> CreateCPUAllocator(const OrtMemoryInfo& memory_info);
 std::unique_ptr<IAllocator> CreateCUDAAllocator(int16_t device_id, const char* name);

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -76,8 +76,7 @@ namespace onnxruntime {
 // "Global initializer calls a non-constexpr function."
 #pragma warning(disable : 26426)
 #endif
-ProviderHost* g_host = Provider_GetHost();
-ProviderHostCPU& g_host_cpu = g_host->GetProviderHostCPU();
+ProviderHostCPU& g_host_cpu = Provider_GetHost()->GetProviderHostCPU();
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
 #endif
@@ -105,19 +104,19 @@ struct OnUnload {
 
 } g_on_unload;
 
-void* CPUAllocator::Alloc(size_t size) { return g_host->CPUAllocator__Alloc(this, size); }
-void CPUAllocator::Free(void* p) { g_host->CPUAllocator__Free(this, p); }
+void* CPUAllocator::Alloc(size_t size) { return Provider_GetHost()->CPUAllocator__Alloc(this, size); }
+void CPUAllocator::Free(void* p) { Provider_GetHost()->CPUAllocator__Free(this, p); }
 
 AllocatorPtr CreateAllocator(const AllocatorCreationInfo& info) {
-  return g_host->CreateAllocator(info);
+  return Provider_GetHost()->CreateAllocator(info);
 }
 
 void AllocatorManager::InsertAllocator(AllocatorPtr allocator) {
-  return g_host->AllocatorManager__InsertAllocator(this, allocator);
+  return Provider_GetHost()->AllocatorManager__InsertAllocator(this, allocator);
 }
 
 AllocatorPtr AllocatorManager::GetAllocator(OrtMemType mem_type, OrtDevice device) const {
-  return g_host->AllocatorManager__GetAllocator(this, mem_type, device);
+  return Provider_GetHost()->AllocatorManager__GetAllocator(this, mem_type, device);
 }
 
 template <>
@@ -216,19 +215,19 @@ MLDataType DataTypeImpl::GetSparseTensorType<MLFloat16>() { return Provider_GetH
 #endif
 
 Status IDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {
-  return g_host->IDataTransfer__CopyTensor(this, src, dst);
+  return Provider_GetHost()->IDataTransfer__CopyTensor(this, src, dst);
 }
 
 Status IDataTransfer::CopyTensors(const std::vector<SrcDstPair>& src_dst_pairs) const {
-  return g_host->IDataTransfer__CopyTensors(this, src_dst_pairs);
+  return Provider_GetHost()->IDataTransfer__CopyTensors(this, src_dst_pairs);
 }
 #if !defined(DISABLE_SPARSE_TENSORS)
 Status IDataTransfer::CopySparseTensors(const std::vector<SparseSrcDstPair>& src_dst_pairs) const {
-  return g_host->IDataTransfer__CopySparseTensors(this, src_dst_pairs);
+  return Provider_GetHost()->IDataTransfer__CopySparseTensors(this, src_dst_pairs);
 }
 #endif
 
-const Node& OpKernel::Node() const { return g_host->OpKernel__Node(this); }
+const Node& OpKernel::Node() const { return Provider_GetHost()->OpKernel__Node(this); }
 
 TensorShape::TensorShape(gsl::span<const int64_t> dims) {
   Allocate(dims.size());
@@ -236,17 +235,17 @@ TensorShape::TensorShape(gsl::span<const int64_t> dims) {
 }
 
 TensorShape& TensorShape::operator=(const TensorShape& other) {
-  g_host->TensorShape__operator_assign(this, other);
+  Provider_GetHost()->TensorShape__operator_assign(this, other);
   return *this;
 }
 
 TensorShape& TensorShape::operator=(TensorShape&& other) noexcept {
-  g_host->TensorShape__operator_move_assign(this, std::move(other));
+  Provider_GetHost()->TensorShape__operator_move_assign(this, std::move(other));
   return *this;
 }
 
 void TensorShape::Allocate(size_t size) {
-  g_host->TensorShape__Allocate(this, size);
+  Provider_GetHost()->TensorShape__Allocate(this, size);
 }
 
 int64_t TensorShape::Size() const {
@@ -256,7 +255,7 @@ int64_t TensorShape::Size() const {
 }
 
 int64_t TensorShape::SizeHelper(size_t start, size_t end) const {
-  return g_host->TensorShape__SizeHelper(this, start, end);
+  return Provider_GetHost()->TensorShape__SizeHelper(this, start, end);
 }
 
 TensorShape TensorShape::Slice(size_t dimstart, size_t dimend) const {
@@ -265,100 +264,100 @@ TensorShape TensorShape::Slice(size_t dimstart, size_t dimend) const {
 }
 
 std::string TensorShape::ToString() const {
-  return g_host->TensorShape__ToString(this);
+  return Provider_GetHost()->TensorShape__ToString(this);
 }
 
-int64_t TensorShape::SizeToDimension(size_t dimension) const { return g_host->TensorShape__SizeToDimension(this, dimension); }
-int64_t TensorShape::SizeFromDimension(size_t dimension) const { return g_host->TensorShape__SizeFromDimension(this, dimension); }
+int64_t TensorShape::SizeToDimension(size_t dimension) const { return Provider_GetHost()->TensorShape__SizeToDimension(this, dimension); }
+int64_t TensorShape::SizeFromDimension(size_t dimension) const { return Provider_GetHost()->TensorShape__SizeFromDimension(this, dimension); }
 
-std::ostream& operator<<(std::ostream& out, const TensorShape& shape) { return g_host->operator_left_shift(out, shape); }
+std::ostream& operator<<(std::ostream& out, const TensorShape& shape) { return Provider_GetHost()->operator_left_shift(out, shape); }
 
 AllocatorPtr CreateAllocator(AllocatorCreationInfo info) {
-  return g_host->CreateAllocator(info);
+  return Provider_GetHost()->CreateAllocator(info);
 }
 
 std::unique_ptr<IAllocator> CreateCPUAllocator(const OrtMemoryInfo& info) {
-  return g_host->CreateCPUAllocator(info);
+  return Provider_GetHost()->CreateCPUAllocator(info);
 }
 
 bool IAllocator::CalcMemSizeForArrayWithAlignment(size_t nmemb, size_t size, size_t alignment, size_t* out) noexcept {
-  return g_host->IAllocator__CalcMemSizeForArrayWithAlignment(nmemb, size, alignment, out);
+  return Provider_GetHost()->IAllocator__CalcMemSizeForArrayWithAlignment(nmemb, size, alignment, out);
 }
 
 AllocatorPtr IExecutionProvider::GetAllocator(OrtMemType mem_type) const {
-  return g_host->IExecutionProvider__GetAllocator(this, mem_type);
+  return Provider_GetHost()->IExecutionProvider__GetAllocator(this, mem_type);
 }
 
 void IExecutionProvider::InsertAllocator(AllocatorPtr allocator) {
-  g_host->IExecutionProvider__InsertAllocator(this, allocator);
+  Provider_GetHost()->IExecutionProvider__InsertAllocator(this, allocator);
 }
 
 std::vector<std::unique_ptr<ComputeCapability>> IExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer,
                                                                                   const IKernelLookup& kernel_lookup) const {
-  return g_host->IExecutionProvider__GetCapability(this, graph_viewer, kernel_lookup);
+  return Provider_GetHost()->IExecutionProvider__GetCapability(this, graph_viewer, kernel_lookup);
 }
 common::Status IExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
                                            std::vector<NodeComputeInfo>& node_compute_funcs) {
-  return g_host->IExecutionProvider__Compile(this, fused_nodes_and_graphs, node_compute_funcs);
+  return Provider_GetHost()->IExecutionProvider__Compile(this, fused_nodes_and_graphs, node_compute_funcs);
 }
 
 int IExecutionProvider::GenerateMetaDefId(const onnxruntime::GraphViewer& graph_viewer, HashValue& model_hash) const {
-  return g_host->IExecutionProvider__GenerateMetaDefId(this, graph_viewer, model_hash);
+  return Provider_GetHost()->IExecutionProvider__GenerateMetaDefId(this, graph_viewer, model_hash);
 }
 
 void IExecutionProvider::RegisterAllocator(AllocatorManager& allocator_manager) {
-  return g_host->IExecutionProvider__RegisterAllocator(this, allocator_manager);
+  return Provider_GetHost()->IExecutionProvider__RegisterAllocator(this, allocator_manager);
 }
 
 #ifdef USE_TENSORRT
 std::unique_ptr<IAllocator> CreateCUDAAllocator(int16_t device_id, const char* name) {
-  return g_host->CreateCUDAAllocator(device_id, name);
+  return Provider_GetHost()->CreateCUDAAllocator(device_id, name);
 }
 
 std::unique_ptr<IAllocator> CreateCUDAPinnedAllocator(int16_t device_id, const char* name) {
-  return g_host->CreateCUDAPinnedAllocator(device_id, name);
+  return Provider_GetHost()->CreateCUDAPinnedAllocator(device_id, name);
 }
 
 std::unique_ptr<IDataTransfer> CreateGPUDataTransfer() {
-  return g_host->CreateGPUDataTransfer();
+  return Provider_GetHost()->CreateGPUDataTransfer();
 }
 #endif
 
 #ifdef USE_MIGRAPHX
 std::unique_ptr<IAllocator> CreateROCMAllocator(int16_t device_id, const char* name) {
-  return g_host->CreateROCMAllocator(device_id, name);
+  return Provider_GetHost()->CreateROCMAllocator(device_id, name);
 }
 
 std::unique_ptr<IAllocator> CreateROCMPinnedAllocator(int16_t device_id, const char* name) {
-  return g_host->CreateROCMPinnedAllocator(device_id, name);
+  return Provider_GetHost()->CreateROCMPinnedAllocator(device_id, name);
 }
 
 std::unique_ptr<IDataTransfer> CreateGPUDataTransfer() {
-  return g_host->CreateGPUDataTransfer();
+  return Provider_GetHost()->CreateGPUDataTransfer();
 }
 #endif
 
 std::string GetEnvironmentVar(const std::string& var_name) {
-  return g_host->GetEnvironmentVar(var_name);
+  return Provider_GetHost()->GetEnvironmentVar(var_name);
 }
 
 std::unordered_set<NodeIndex> GetCpuPreferredNodes(const onnxruntime::GraphViewer& graph,
                                                    const IExecutionProvider::IKernelLookup& kernel_lookup,
                                                    gsl::span<const NodeIndex> tentative_nodes) {
-  return g_host->GetCpuPreferredNodes(graph, kernel_lookup, tentative_nodes);
+  return Provider_GetHost()->GetCpuPreferredNodes(graph, kernel_lookup, tentative_nodes);
 }
 
 namespace profiling {
 
-std::string demangle(const char* name) { return g_host->demangle(name); }
-std::string demangle(const std::string& name) { return g_host->demangle(name); }
+std::string demangle(const char* name) { return Provider_GetHost()->demangle(name); }
+std::string demangle(const std::string& name) { return Provider_GetHost()->demangle(name); }
 
 }  // namespace profiling
 
 namespace logging {
 
-unsigned int GetThreadId() { return g_host->GetThreadId(); }
-unsigned int GetProcessId() { return g_host->GetProcessId(); }
+unsigned int GetThreadId() { return Provider_GetHost()->GetThreadId(); }
+unsigned int GetProcessId() { return Provider_GetHost()->GetProcessId(); }
 
 const char* Category::onnxruntime = "onnxruntime";
 
@@ -395,7 +394,7 @@ const std::string& Status::ErrorMessage() const noexcept {
   return IsOK() ? EmptyString() : state_->msg;
 }
 
-std::string Status::ToString() const { return g_host->Status__ToString(this); }
+std::string Status::ToString() const { return Provider_GetHost()->Status__ToString(this); }
 
 const std::string& Status::EmptyString() noexcept {
   static std::string s_empty;
@@ -405,8 +404,8 @@ const std::string& Status::EmptyString() noexcept {
 }  // namespace common
 
 namespace math {
-uint16_t floatToHalf(float f) { return g_host->math__floatToHalf(f); }
-float halfToFloat(uint16_t h) { return g_host->math__halfToFloat(h); }
+uint16_t floatToHalf(float f) { return Provider_GetHost()->math__floatToHalf(f); }
+float halfToFloat(uint16_t h) { return Provider_GetHost()->math__halfToFloat(h); }
 
 }  // namespace math
 
@@ -415,23 +414,23 @@ namespace sparse_utils {
 #if !defined(ORT_MINIMAL_BUILD)
 Status DenseTensorToSparseCsr(const DataTransferManager& data_manager, const Tensor& src, const AllocatorPtr& cpu_allocator,
                               const AllocatorPtr& dst_allocator, SparseTensor& dst) {
-  return g_host->sparse_utils__DenseTensorToSparseCsr(data_manager, src, cpu_allocator, dst_allocator, dst);
+  return Provider_GetHost()->sparse_utils__DenseTensorToSparseCsr(data_manager, src, cpu_allocator, dst_allocator, dst);
 }
 
 Status SparseCsrToDenseTensor(const DataTransferManager& data_manager, const SparseTensor& src, const AllocatorPtr& cpu_allocator,
                               const AllocatorPtr& dst_allocator, Tensor& dst) {
-  return g_host->sparse_utils__SparseCsrToDenseTensor(data_manager, src, cpu_allocator, dst_allocator, dst);
+  return Provider_GetHost()->sparse_utils__SparseCsrToDenseTensor(data_manager, src, cpu_allocator, dst_allocator, dst);
 }
 
 Status SparseCooToDenseTensor(const DataTransferManager& data_manager, const SparseTensor& src, const AllocatorPtr& cpu_allocator,
                               const AllocatorPtr& dst_allocator, Tensor& dst) {
-  return g_host->sparse_utils__SparseCooToDenseTensor(data_manager, src, cpu_allocator, dst_allocator, dst);
+  return Provider_GetHost()->sparse_utils__SparseCooToDenseTensor(data_manager, src, cpu_allocator, dst_allocator, dst);
 }
 #endif  // !ORT_MINIMAL_BUILD
 
 Status DenseTensorToSparseCoo(const DataTransferManager& data_manager, const Tensor& src, const AllocatorPtr& cpu_allocator,
                               const AllocatorPtr& dst_allocator, bool linear_indexs, SparseTensor& dst) {
-  return g_host->sparse_utils__DenseTensorToSparseCoo(data_manager, src, cpu_allocator, dst_allocator, linear_indexs, dst);
+  return Provider_GetHost()->sparse_utils__DenseTensorToSparseCoo(data_manager, src, cpu_allocator, dst_allocator, linear_indexs, dst);
 }
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
@@ -441,42 +440,42 @@ float MLFloat16::ToFloat() const {
   return math::halfToFloat(val);
 }
 
-std::vector<std::string> GetStackTrace() { return g_host->GetStackTrace(); }
+std::vector<std::string> GetStackTrace() { return Provider_GetHost()->GetStackTrace(); }
 
 void LogRuntimeError(uint32_t session_id, const common::Status& status,
                      const char* file, const char* function, uint32_t line) {
-  return g_host->LogRuntimeError(session_id, status, file, function, line);
+  return Provider_GetHost()->LogRuntimeError(session_id, status, file, function, line);
 }
 
 std::unique_ptr<OpKernelInfo> CopyOpKernelInfo(const OpKernelInfo& info) {
-  return g_host->CopyOpKernelInfo(info);
+  return Provider_GetHost()->CopyOpKernelInfo(info);
 }
 
 namespace utils {
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ bool* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ bool* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ float* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ float* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ double* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ double* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ MLFloat16* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ MLFloat16* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int8_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int8_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint8_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint8_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int16_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int16_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint16_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint16_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int32_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int32_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint32_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint32_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int64_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ int64_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint64_t* p_data, size_t expected_size) { return g_host->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len, /*out*/ uint64_t* p_data, size_t expected_size) { return Provider_GetHost()->UnpackTensor(tensor, raw_data, raw_data_len, p_data, expected_size); }
 
 }  // namespace utils
 
@@ -528,7 +527,7 @@ Status ConcatBase::PrepareForCompute(OpKernelContext* ctx, const ConcatBase::Inl
   return g_host_cpu.ConcatBase__PrepareForCompute(this, ctx, reinterpret_cast<const ConcatBase_InlinedTensorsVector&>(input_tensors), p);
 }
 
-PhiloxGenerator& PhiloxGenerator::Default() { return g_host->PhiloxGenerator__Default(); }
+PhiloxGenerator& PhiloxGenerator::Default() { return Provider_GetHost()->PhiloxGenerator__Default(); }
 
 Status Einsum::Compute(OpKernelContext* context) const { return g_host_cpu.Einsum__Compute(this, context); }
 
@@ -635,7 +634,7 @@ Status Scan<8>::SetupSubgraphExecutionInfo(const SessionState& session_state, co
 template <>
 Status Scan<9>::SetupSubgraphExecutionInfo(const SessionState& session_state, const std::string& attribute_name, const SessionState& subgraph_session_state) { return g_host_cpu.Scan__SetupSubgraphExecutionInfo(this, session_state, attribute_name, subgraph_session_state); }
 
-void* AllocateBufferWithOptions(IAllocator& allocator, size_t size, bool use_reserve, Stream* stream, WaitNotificationFn wait_fn) { return g_host->Allocator__AllocateBufferWithOptions(allocator, size, use_reserve, stream, wait_fn); }
+void* AllocateBufferWithOptions(IAllocator& allocator, size_t size, bool use_reserve, Stream* stream, WaitNotificationFn wait_fn) { return Provider_GetHost()->Allocator__AllocateBufferWithOptions(allocator, size, use_reserve, stream, wait_fn); }
 
 #ifdef ENABLE_TRAINING_OPS
 namespace contrib {
@@ -657,28 +656,28 @@ Status YieldOp::Compute(OpKernelContext* context) const { return g_host_cpu.cont
 
 #ifdef ENABLE_TRAINING_TORCH_INTEROP
 namespace contrib {
-void PythonOpBase::Init(const OpKernelInfo& info) { return g_host->contrib__PythonOpBase__Init(this, info); }
-void PythonOpBase::Clear() { return g_host->contrib__PythonOpBase__Clear(this); }
+void PythonOpBase::Init(const OpKernelInfo& info) { return Provider_GetHost()->contrib__PythonOpBase__Init(this, info); }
+void PythonOpBase::Clear() { return Provider_GetHost()->contrib__PythonOpBase__Clear(this); }
 void PythonOpBase::RunForward(OpKernelContext* context, void** diff_ctx, std::vector<OrtValue>& returned_ortvalues) const {
-  return g_host->contrib__PythonOpBase__RunForward(this, context, diff_ctx, returned_ortvalues);
+  return Provider_GetHost()->contrib__PythonOpBase__RunForward(this, context, diff_ctx, returned_ortvalues);
 }
 void PythonOpBase::SetOutputs(OpKernelContext* context, void* diff_ctx, std::vector<OrtValue>& returned_args) const {
-  return g_host->contrib__PythonOpBase__SetOutputs(this, context, diff_ctx, returned_args);
+  return Provider_GetHost()->contrib__PythonOpBase__SetOutputs(this, context, diff_ctx, returned_args);
 }
 
-void PythonOpGradBase::Init(const OpKernelInfo& info) { return g_host->contrib__PythonOpGradBase__Init(this, info); }
+void PythonOpGradBase::Init(const OpKernelInfo& info) { return Provider_GetHost()->contrib__PythonOpGradBase__Init(this, info); }
 void PythonOpGradBase::RunBackward(OpKernelContext* context, std::vector<OrtValue>& returned_ortvalues) const {
-  return g_host->contrib__PythonOpGradBase__RunBackward(this, context, returned_ortvalues);
+  return Provider_GetHost()->contrib__PythonOpGradBase__RunBackward(this, context, returned_ortvalues);
 }
 void PythonOpGradBase::SetOutputs(OpKernelContext* context, std::vector<OrtValue>& returned_args) const {
-  return g_host->contrib__PythonOpGradBase__SetOutputs(this, context, returned_args);
+  return Provider_GetHost()->contrib__PythonOpGradBase__SetOutputs(this, context, returned_args);
 }
 }  // namespace contrib
 
 namespace language_interop_ops {
 namespace torch {
 void RefCountTracker::DumpDetails(const std::string& phase_name) const {
-  return g_host->RefCountTracker__DumpDetails(this, phase_name);
+  return Provider_GetHost()->RefCountTracker__DumpDetails(this, phase_name);
 }
 
 }  // namespace torch
@@ -689,26 +688,26 @@ void RefCountTracker::DumpDetails(const std::string& phase_name) const {
 #endif
 
 #if defined(USE_CANN)
-RandomGenerator& RandomGenerator::Default() { return g_host->RandomGenerator__Default(); }
+RandomGenerator& RandomGenerator::Default() { return Provider_GetHost()->RandomGenerator__Default(); }
 void* AllocateBufferWithOptions(IAllocator& allocator, size_t size, bool use_reserve, Stream* stream,
                                 WaitNotificationFn wait_fn) {
-  return g_host->Allocator__AllocateBufferWithOptions(allocator, size, use_reserve, stream, wait_fn);
+  return Provider_GetHost()->Allocator__AllocateBufferWithOptions(allocator, size, use_reserve, stream, wait_fn);
 }
 
 namespace cann {
 std::unique_ptr<Model> CreateModel(const GraphViewer& graph_viewer, const logging::Logger& logger) {
-  return g_host->cann__CreateModel(graph_viewer, logger);
+  return Provider_GetHost()->cann__CreateModel(graph_viewer, logger);
 }
 }  // namespace cann
 #endif
 
 void MurmurHash3::x86_128(const void* key, int len, uint32_t seed, void* out) {
-  return g_host->MurmurHash3__x86_128(key, len, seed, out);
+  return Provider_GetHost()->MurmurHash3__x86_128(key, len, seed, out);
 }
 
 #ifdef _WIN32
 std::string ToUTF8String(const std::wstring& s) {
-  return g_host->ToUTF8String(s);
+  return Provider_GetHost()->ToUTF8String(s);
 }
 #endif
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -3,17 +3,16 @@
 
 namespace onnxruntime {
 
-extern ProviderHost* g_host;
 using ProviderType = const std::string&;
 
 struct CPUIDInfo final {
-  static const CPUIDInfo& GetCPUIDInfo() { return g_host->CPUIDInfo__GetCPUIDInfo(); }
+  static const CPUIDInfo& GetCPUIDInfo() { return Provider_GetHost()->CPUIDInfo__GetCPUIDInfo(); }
 
-  bool HasAVX2() const { return g_host->CPUIDInfo__HasAVX2(this); }
-  bool HasAVX512f() const { return g_host->CPUIDInfo__HasAVX512f(this); }
-  bool HasAVX512_BF16() const { return g_host->CPUIDInfo__HasAVX512_BF16(this); }
-  bool HasAMX_BF16() const { return g_host->CPUIDInfo__HasAMX_BF16(this); }
-  bool HasAVX512Skylake() const { return g_host->CPUIDInfo__HasAVX512Skylake(this); }
+  bool HasAVX2() const { return Provider_GetHost()->CPUIDInfo__HasAVX2(this); }
+  bool HasAVX512f() const { return Provider_GetHost()->CPUIDInfo__HasAVX512f(this); }
+  bool HasAVX512_BF16() const { return Provider_GetHost()->CPUIDInfo__HasAVX512_BF16(this); }
+  bool HasAMX_BF16() const { return Provider_GetHost()->CPUIDInfo__HasAMX_BF16(this); }
+  bool HasAVX512Skylake() const { return Provider_GetHost()->CPUIDInfo__HasAVX512Skylake(this); }
 
   PROVIDER_DISALLOW_ALL(CPUIDInfo)
 };
@@ -21,23 +20,23 @@ struct CPUIDInfo final {
 namespace logging {
 
 struct Logger final {
-  bool OutputIsEnabled(Severity severity, DataType data_type) const noexcept { return g_host->logging__Logger__OutputIsEnabled(this, severity, data_type); }
+  bool OutputIsEnabled(Severity severity, DataType data_type) const noexcept { return Provider_GetHost()->logging__Logger__OutputIsEnabled(this, severity, data_type); }
 
   PROVIDER_DISALLOW_ALL(Logger)
 };
 
 struct LoggingManager final {
-  static const Logger& DefaultLogger() { return g_host->logging__LoggingManager__DefaultLogger(); }
+  static const Logger& DefaultLogger() { return Provider_GetHost()->logging__LoggingManager__DefaultLogger(); }
 
   PROVIDER_DISALLOW_ALL(LoggingManager)
 };
 
 struct Capture final {
   static std::unique_ptr<Capture> Create(const Logger& logger, logging::Severity severity, const char* category,
-                                         logging::DataType dataType, const CodeLocation& location) { return g_host->logging__Capture__construct(logger, severity, category, dataType, location); }
-  static void operator delete(void* p) { g_host->logging__Capture__operator_delete(reinterpret_cast<Capture*>(p)); }
+                                         logging::DataType dataType, const CodeLocation& location) { return Provider_GetHost()->logging__Capture__construct(logger, severity, category, dataType, location); }
+  static void operator delete(void* p) { Provider_GetHost()->logging__Capture__operator_delete(reinterpret_cast<Capture*>(p)); }
 
-  std::ostream& Stream() noexcept { return g_host->logging__Capture__Stream(this); }
+  std::ostream& Stream() noexcept { return Provider_GetHost()->logging__Capture__Stream(this); }
 
   Capture() = delete;
   Capture(const Capture&) = delete;
@@ -49,34 +48,34 @@ struct Capture final {
 namespace ONNX_NAMESPACE {
 
 struct int64s final {
-  int size() const { return g_host->int64s__size(this); }
-  const int64_t& Get(int index) const { return g_host->int64s__Get(this, index); }
+  int size() const { return Provider_GetHost()->int64s__size(this); }
+  const int64_t& Get(int index) const { return Provider_GetHost()->int64s__Get(this, index); }
   const int64_t& operator[](int index) const { return Get(index); }
 
   PROVIDER_DISALLOW_ALL(int64s)
 };
 
 struct AttributeProto final {
-  static std::unique_ptr<AttributeProto> Create() { return g_host->AttributeProto__construct(); }
-  void operator=(const AttributeProto& v) { g_host->AttributeProto__operator_assign(this, v); }
-  static void operator delete(void* p) { g_host->AttributeProto__operator_delete(reinterpret_cast<AttributeProto*>(p)); }
+  static std::unique_ptr<AttributeProto> Create() { return Provider_GetHost()->AttributeProto__construct(); }
+  void operator=(const AttributeProto& v) { Provider_GetHost()->AttributeProto__operator_assign(this, v); }
+  static void operator delete(void* p) { Provider_GetHost()->AttributeProto__operator_delete(reinterpret_cast<AttributeProto*>(p)); }
 
-  const std::string& name() const { return g_host->AttributeProto__name(this); }
-  AttributeProto_AttributeType type() const { return g_host->AttributeProto__type(this); }
-  int ints_size() const { return g_host->AttributeProto__ints_size(this); }
-  int floats_size() const { return g_host->AttributeProto__floats_size(this); }
-  int strings_size() const { return g_host->AttributeProto__strings_size(this); }
-  int64_t ints(int i) const { return g_host->AttributeProto__ints(this, i); }
-  float floats(int i) const { return g_host->AttributeProto__floats(this, i); }
-  const std::string& strings(int i) const { return g_host->AttributeProto__strings(this, i); }
-  const int64s& ints() const { return g_host->AttributeProto__ints(this); }
-  int64_t i() const { return g_host->AttributeProto__i(this); }
-  float f() const { return g_host->AttributeProto__f(this); }
-  void set_s(const ::std::string& value) { return g_host->AttributeProto__set_s(this, value); }
-  const ::std::string& s() const { return g_host->AttributeProto__s(this); }
-  void set_name(const ::std::string& value) { return g_host->AttributeProto__set_name(this, value); }
-  void set_type(AttributeProto_AttributeType value) { return g_host->AttributeProto__set_type(this, value); }
-  TensorProto* add_tensors() { return g_host->AttributeProto__add_tensors(this); }
+  const std::string& name() const { return Provider_GetHost()->AttributeProto__name(this); }
+  AttributeProto_AttributeType type() const { return Provider_GetHost()->AttributeProto__type(this); }
+  int ints_size() const { return Provider_GetHost()->AttributeProto__ints_size(this); }
+  int floats_size() const { return Provider_GetHost()->AttributeProto__floats_size(this); }
+  int strings_size() const { return Provider_GetHost()->AttributeProto__strings_size(this); }
+  int64_t ints(int i) const { return Provider_GetHost()->AttributeProto__ints(this, i); }
+  float floats(int i) const { return Provider_GetHost()->AttributeProto__floats(this, i); }
+  const std::string& strings(int i) const { return Provider_GetHost()->AttributeProto__strings(this, i); }
+  const int64s& ints() const { return Provider_GetHost()->AttributeProto__ints(this); }
+  int64_t i() const { return Provider_GetHost()->AttributeProto__i(this); }
+  float f() const { return Provider_GetHost()->AttributeProto__f(this); }
+  void set_s(const ::std::string& value) { return Provider_GetHost()->AttributeProto__set_s(this, value); }
+  const ::std::string& s() const { return Provider_GetHost()->AttributeProto__s(this); }
+  void set_name(const ::std::string& value) { return Provider_GetHost()->AttributeProto__set_name(this, value); }
+  void set_type(AttributeProto_AttributeType value) { return Provider_GetHost()->AttributeProto__set_type(this, value); }
+  TensorProto* add_tensors() { return Provider_GetHost()->AttributeProto__add_tensors(this); }
 
   typedef AttributeProto_AttributeType AttributeType;
   static constexpr AttributeType UNDEFINED = AttributeProto_AttributeType_UNDEFINED;
@@ -102,39 +101,39 @@ struct AttributeProto final {
 };
 
 struct GraphProto final {
-  static void operator delete(void* p) { g_host->GraphProto__operator_delete(reinterpret_cast<GraphProto*>(p)); }
-  void operator=(const GraphProto& v) { return g_host->GraphProto__operator_assign(this, v); }
+  static void operator delete(void* p) { Provider_GetHost()->GraphProto__operator_delete(reinterpret_cast<GraphProto*>(p)); }
+  void operator=(const GraphProto& v) { return Provider_GetHost()->GraphProto__operator_assign(this, v); }
 
-  const ValueInfoProto& input(int index) const { return g_host->GraphProto__input(this, index); }
-  ValueInfoProtos* mutable_input() { return g_host->GraphProto__mutable_input(this); }
-  ValueInfoProto* mutable_input(int index) { return g_host->GraphProto__mutable_input(this, index); }
-  int input_size() const { return g_host->GraphProto__input_size(this); }
+  const ValueInfoProto& input(int index) const { return Provider_GetHost()->GraphProto__input(this, index); }
+  ValueInfoProtos* mutable_input() { return Provider_GetHost()->GraphProto__mutable_input(this); }
+  ValueInfoProto* mutable_input(int index) { return Provider_GetHost()->GraphProto__mutable_input(this, index); }
+  int input_size() const { return Provider_GetHost()->GraphProto__input_size(this); }
 
-  const ValueInfoProtos& output() const { return g_host->GraphProto__output(this); }
-  const ValueInfoProto& output(int index) const { return g_host->GraphProto__output(this, index); }
-  ValueInfoProtos* mutable_output() { return g_host->GraphProto__mutable_output(this); }
+  const ValueInfoProtos& output() const { return Provider_GetHost()->GraphProto__output(this); }
+  const ValueInfoProto& output(int index) const { return Provider_GetHost()->GraphProto__output(this, index); }
+  ValueInfoProtos* mutable_output() { return Provider_GetHost()->GraphProto__mutable_output(this); }
 
-  ValueInfoProtos* mutable_value_info() { return g_host->GraphProto__mutable_value_info(this); }
-  TensorProtos* mutable_initializer() { return g_host->GraphProto__mutable_initializer(this); }
-  NodeProto* add_node() { return g_host->GraphProto__add_node(this); }
+  ValueInfoProtos* mutable_value_info() { return Provider_GetHost()->GraphProto__mutable_value_info(this); }
+  TensorProtos* mutable_initializer() { return Provider_GetHost()->GraphProto__mutable_initializer(this); }
+  NodeProto* add_node() { return Provider_GetHost()->GraphProto__add_node(this); }
 
   GraphProto() = delete;
   GraphProto(const GraphProto&) = delete;
 };
 
 struct ModelProto final {
-  static std::unique_ptr<ModelProto> Create() { return g_host->ModelProto__construct(); }
-  static void operator delete(void* p) { g_host->ModelProto__operator_delete(reinterpret_cast<ModelProto*>(p)); }
+  static std::unique_ptr<ModelProto> Create() { return Provider_GetHost()->ModelProto__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->ModelProto__operator_delete(reinterpret_cast<ModelProto*>(p)); }
 
-  bool SerializeToString(std::string& string) const { return g_host->ModelProto__SerializeToString(this, string); }
-  bool SerializeToOstream(std::ostream& output) const { return g_host->ModelProto__SerializeToOstream(this, output); }
-  bool ParseFromString(const std::string& data) { return g_host->ModelProto__ParseFromString(this, data); }
-  std::string SerializeAsString() const { return g_host->ModelProto__SerializeAsString(this); }
+  bool SerializeToString(std::string& string) const { return Provider_GetHost()->ModelProto__SerializeToString(this, string); }
+  bool SerializeToOstream(std::ostream& output) const { return Provider_GetHost()->ModelProto__SerializeToOstream(this, output); }
+  bool ParseFromString(const std::string& data) { return Provider_GetHost()->ModelProto__ParseFromString(this, data); }
+  std::string SerializeAsString() const { return Provider_GetHost()->ModelProto__SerializeAsString(this); }
 
-  const GraphProto& graph() const { return g_host->ModelProto__graph(this); }
-  GraphProto* mutable_graph() { return g_host->ModelProto__mutable_graph(this); }
+  const GraphProto& graph() const { return Provider_GetHost()->ModelProto__graph(this); }
+  GraphProto* mutable_graph() { return Provider_GetHost()->ModelProto__mutable_graph(this); }
 
-  void set_ir_version(int64_t value) { return g_host->ModelProto__set_ir_version(this, value); }
+  void set_ir_version(int64_t value) { return Provider_GetHost()->ModelProto__set_ir_version(this, value); }
 
   ModelProto() = delete;
   ModelProto(const ModelProto&) = delete;
@@ -142,47 +141,47 @@ struct ModelProto final {
 };
 
 struct NodeProto final {
-  static std::unique_ptr<NodeProto> Create() { return g_host->NodeProto__construct(); }
-  static void operator delete(void* p) { g_host->NodeProto__operator_delete(reinterpret_cast<NodeProto*>(p)); }
-  void operator=(const NodeProto& v) { g_host->NodeProto__operator_assign(this, v); }
-  int attribute_size() { return g_host->NodeProto__attribute_size(this); }
-  const AttributeProto& attribute(int index) const { return g_host->NodeProto__attribute(this, index); }
+  static std::unique_ptr<NodeProto> Create() { return Provider_GetHost()->NodeProto__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->NodeProto__operator_delete(reinterpret_cast<NodeProto*>(p)); }
+  void operator=(const NodeProto& v) { Provider_GetHost()->NodeProto__operator_assign(this, v); }
+  int attribute_size() { return Provider_GetHost()->NodeProto__attribute_size(this); }
+  const AttributeProto& attribute(int index) const { return Provider_GetHost()->NodeProto__attribute(this, index); }
 
   NodeProto() = delete;
   NodeProto(const NodeProto&) = delete;
 };
 
 struct TensorProto final {
-  static std::unique_ptr<TensorProto> Create() { return g_host->TensorProto__construct(); }
-  static void operator delete(void* p) { g_host->TensorProto__operator_delete(reinterpret_cast<TensorProto*>(p)); }
-  void operator=(const TensorProto& v) { g_host->TensorProto__operator_assign(this, v); }
+  static std::unique_ptr<TensorProto> Create() { return Provider_GetHost()->TensorProto__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->TensorProto__operator_delete(reinterpret_cast<TensorProto*>(p)); }
+  void operator=(const TensorProto& v) { Provider_GetHost()->TensorProto__operator_assign(this, v); }
 
-  bool has_name() const { return g_host->TensorProto__has_name(this); }
+  bool has_name() const { return Provider_GetHost()->TensorProto__has_name(this); }
 
-  int dims_size() const { return g_host->TensorProto__dims_size(this); }
-  const int64s& dims() const { return g_host->TensorProto__dims(this); }
+  int dims_size() const { return Provider_GetHost()->TensorProto__dims_size(this); }
+  const int64s& dims() const { return Provider_GetHost()->TensorProto__dims(this); }
 
-  bool has_data_location() const { return g_host->TensorProto__has_data_location(this); }
-  TensorProto_DataLocation data_location() const { return TensorProto_DataLocation(g_host->TensorProto__data_location(this)); }
+  bool has_data_location() const { return Provider_GetHost()->TensorProto__has_data_location(this); }
+  TensorProto_DataLocation data_location() const { return TensorProto_DataLocation(Provider_GetHost()->TensorProto__data_location(this)); }
 
-  bool has_raw_data() const { return g_host->TensorProto__has_raw_data(this); }
-  const std::string& raw_data() const { return g_host->TensorProto__raw_data(this); }
+  bool has_raw_data() const { return Provider_GetHost()->TensorProto__has_raw_data(this); }
+  const std::string& raw_data() const { return Provider_GetHost()->TensorProto__raw_data(this); }
 
-  int32_t data_type() const { return g_host->TensorProto__data_type(this); }
+  int32_t data_type() const { return Provider_GetHost()->TensorProto__data_type(this); }
 
   typedef TensorProto_DataType DataType;
   static constexpr DataType UNDEFINED = TensorProto_DataType_UNDEFINED;
 
-  static bool DataType_IsValid(int value) { return g_host->TensorProto_DataType_IsValid(value); }
+  static bool DataType_IsValid(int value) { return Provider_GetHost()->TensorProto_DataType_IsValid(value); }
 
-  void copy_from(const TensorProto* other) { return g_host->TensorProto__CopyFrom(this, other); }
+  void copy_from(const TensorProto* other) { return Provider_GetHost()->TensorProto__CopyFrom(this, other); }
 
   TensorProto() = delete;
   TensorProto(const TensorProto&) = delete;
 };
 
 struct TensorProtos final {
-  TensorProto* Add() { return g_host->TensorProtos__Add(this); }
+  TensorProto* Add() { return Provider_GetHost()->TensorProtos__Add(this); }
 
   PROVIDER_DISALLOW_ALL(TensorProtos)
 };
@@ -194,50 +193,50 @@ struct TensorShapeProto_Dimension final {
     VALUE_NOT_SET = 0,
   };
 
-  ValueCase value_case() const { return ValueCase(g_host->TensorShapeProto_Dimension__value_case(this)); }
-  const std::string& dim_param() const { return g_host->TensorShapeProto_Dimension__dim_param(this); }
-  int64_t dim_value() const { return g_host->TensorShapeProto_Dimension__dim_value(this); }
-  void set_dim_value(int64_t value) { return g_host->TensorShapeProto_Dimension__set_dim_value(this, value); }
-  bool has_dim_value() const { return g_host->TensorShapeProto_Dimension__has_dim_value(this); }
-  bool has_dim_param() const { return g_host->TensorShapeProto_Dimension__has_dim_param(this); }
-  void clear_dim_value() { return g_host->TensorShapeProto_Dimension__clear_dim_value(this); }
+  ValueCase value_case() const { return ValueCase(Provider_GetHost()->TensorShapeProto_Dimension__value_case(this)); }
+  const std::string& dim_param() const { return Provider_GetHost()->TensorShapeProto_Dimension__dim_param(this); }
+  int64_t dim_value() const { return Provider_GetHost()->TensorShapeProto_Dimension__dim_value(this); }
+  void set_dim_value(int64_t value) { return Provider_GetHost()->TensorShapeProto_Dimension__set_dim_value(this, value); }
+  bool has_dim_value() const { return Provider_GetHost()->TensorShapeProto_Dimension__has_dim_value(this); }
+  bool has_dim_param() const { return Provider_GetHost()->TensorShapeProto_Dimension__has_dim_param(this); }
+  void clear_dim_value() { return Provider_GetHost()->TensorShapeProto_Dimension__clear_dim_value(this); }
 
   PROVIDER_DISALLOW_ALL(TensorShapeProto_Dimension)
 };
 
 struct TensorShapeProto_Dimensions final {
-  IteratorHolder<TensorShapeProto_Dimension_Iterator, const TensorShapeProto_Dimension> begin() const { return g_host->TensorShapeProto_Dimensions__begin(this); }
-  IteratorHolder<TensorShapeProto_Dimension_Iterator, const TensorShapeProto_Dimension> end() const { return g_host->TensorShapeProto_Dimensions__end(this); }
+  IteratorHolder<TensorShapeProto_Dimension_Iterator, const TensorShapeProto_Dimension> begin() const { return Provider_GetHost()->TensorShapeProto_Dimensions__begin(this); }
+  IteratorHolder<TensorShapeProto_Dimension_Iterator, const TensorShapeProto_Dimension> end() const { return Provider_GetHost()->TensorShapeProto_Dimensions__end(this); }
 
   PROVIDER_DISALLOW_ALL(TensorShapeProto_Dimensions)
 };
 
 struct TensorShapeProto final {
-  int dim_size() const { return g_host->TensorShapeProto__dim_size(this); }
-  const TensorShapeProto_Dimensions& dim() const { return g_host->TensorShapeProto__dim(this); }
-  const TensorShapeProto_Dimension& dim(int index) const { return g_host->TensorShapeProto__dim(this, index); }
-  TensorShapeProto_Dimension* mutable_dim(int index) { return g_host->TensorShapeProto__mutable_dim(this, index); }
-  void clear_dim() { return g_host->TensorShapeProto__clear_dim(this); }
-  TensorShapeProto_Dimension* add_dim() { return g_host->TensorShapeProto__add_dim(this); }
+  int dim_size() const { return Provider_GetHost()->TensorShapeProto__dim_size(this); }
+  const TensorShapeProto_Dimensions& dim() const { return Provider_GetHost()->TensorShapeProto__dim(this); }
+  const TensorShapeProto_Dimension& dim(int index) const { return Provider_GetHost()->TensorShapeProto__dim(this, index); }
+  TensorShapeProto_Dimension* mutable_dim(int index) { return Provider_GetHost()->TensorShapeProto__mutable_dim(this, index); }
+  void clear_dim() { return Provider_GetHost()->TensorShapeProto__clear_dim(this); }
+  TensorShapeProto_Dimension* add_dim() { return Provider_GetHost()->TensorShapeProto__add_dim(this); }
 
   PROVIDER_DISALLOW_ALL(TensorShapeProto)
 };
 
 struct TypeProto_Tensor final {
-  bool has_shape() const { return g_host->TypeProto_Tensor__has_shape(this); }
-  const TensorShapeProto& shape() const { return g_host->TypeProto_Tensor__shape(this); }
-  TensorShapeProto* mutable_shape() { return g_host->TypeProto_Tensor__mutable_shape(this); }
-  int32_t elem_type() const { return g_host->TypeProto_Tensor__elem_type(this); }
+  bool has_shape() const { return Provider_GetHost()->TypeProto_Tensor__has_shape(this); }
+  const TensorShapeProto& shape() const { return Provider_GetHost()->TypeProto_Tensor__shape(this); }
+  TensorShapeProto* mutable_shape() { return Provider_GetHost()->TypeProto_Tensor__mutable_shape(this); }
+  int32_t elem_type() const { return Provider_GetHost()->TypeProto_Tensor__elem_type(this); }
 
   PROVIDER_DISALLOW_ALL(TypeProto_Tensor)
 };
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 struct TypeProto_SparseTensor final {
-  bool has_shape() const { return g_host->TypeProto_SparseTensor__has_shape(this); }
-  const TensorShapeProto& shape() const { return g_host->TypeProto_SparseTensor__shape(this); }
-  TensorShapeProto* mutable_shape() { return g_host->TypeProto_SparseTensor__mutable_shape(this); }
-  int32_t elem_type() const { return g_host->TypeProto_SparseTensor__elem_type(this); }
+  bool has_shape() const { return Provider_GetHost()->TypeProto_SparseTensor__has_shape(this); }
+  const TensorShapeProto& shape() const { return Provider_GetHost()->TypeProto_SparseTensor__shape(this); }
+  TensorShapeProto* mutable_shape() { return Provider_GetHost()->TypeProto_SparseTensor__mutable_shape(this); }
+  int32_t elem_type() const { return Provider_GetHost()->TypeProto_SparseTensor__elem_type(this); }
 
   PROVIDER_DISALLOW_ALL(TypeProto_SparseTensor)
 };
@@ -245,36 +244,36 @@ struct TypeProto_SparseTensor final {
 
 #if !defined(DISABLE_OPTIONAL_TYPE)
 struct TypeProto_Optional final {
-  const TypeProto& elem_type() const { return g_host->TypeProto_Optional__elem_type(this); }
-  TypeProto* mutable_elem_type() { return g_host->TypeProto_Optional__mutable_elem_type(this); }
+  const TypeProto& elem_type() const { return Provider_GetHost()->TypeProto_Optional__elem_type(this); }
+  TypeProto* mutable_elem_type() { return Provider_GetHost()->TypeProto_Optional__mutable_elem_type(this); }
   PROVIDER_DISALLOW_ALL(TypeProto_Optional)
 };
 #endif
 
 struct TypeProto_Sequence final {
-  const TypeProto& elem_type() const { return g_host->TypeProto_Sequence__elem_type(this); }
-  TypeProto* mutable_elem_type() { return g_host->TypeProto_Sequence__mutable_elem_type(this); }
+  const TypeProto& elem_type() const { return Provider_GetHost()->TypeProto_Sequence__elem_type(this); }
+  TypeProto* mutable_elem_type() { return Provider_GetHost()->TypeProto_Sequence__mutable_elem_type(this); }
   PROVIDER_DISALLOW_ALL(TypeProto_Sequence)
 };
 
 struct TypeProto final {
-  static std::unique_ptr<TypeProto> Create() { return g_host->TypeProto__construct(); }
+  static std::unique_ptr<TypeProto> Create() { return Provider_GetHost()->TypeProto__construct(); }
 
-  const TypeProto_Tensor& tensor_type() const { return g_host->TypeProto__tensor_type(this); }
-  TypeProto_Tensor* mutable_tensor_type() { return g_host->TypeProto__mutable_tensor_type(this); }
+  const TypeProto_Tensor& tensor_type() const { return Provider_GetHost()->TypeProto__tensor_type(this); }
+  TypeProto_Tensor* mutable_tensor_type() { return Provider_GetHost()->TypeProto__mutable_tensor_type(this); }
 
 #if !defined(DISABLE_SPARSE_TENSORS)
-  const TypeProto_SparseTensor& sparse_tensor_type() const { return g_host->TypeProto__sparse_tensor_type(this); }
-  TypeProto_SparseTensor* mutable_sparse_tensor_type() { return g_host->TypeProto__mutable_sparse_tensor_type(this); }
+  const TypeProto_SparseTensor& sparse_tensor_type() const { return Provider_GetHost()->TypeProto__sparse_tensor_type(this); }
+  TypeProto_SparseTensor* mutable_sparse_tensor_type() { return Provider_GetHost()->TypeProto__mutable_sparse_tensor_type(this); }
 #endif
 
 #if !defined(DISABLE_OPTIONAL_TYPE)
-  const TypeProto_Optional& optional_type() const { return g_host->TypeProto__optional_type(this); }
-  TypeProto_Optional* mutable_optional_type() { return g_host->TypeProto__mutable_optional_type(this); }
+  const TypeProto_Optional& optional_type() const { return Provider_GetHost()->TypeProto__optional_type(this); }
+  TypeProto_Optional* mutable_optional_type() { return Provider_GetHost()->TypeProto__mutable_optional_type(this); }
 #endif
 
-  const TypeProto_Sequence& sequence_type() const { return g_host->TypeProto__sequence_type(this); }
-  TypeProto_Sequence* mutable_sequence_type() { return g_host->TypeProto__mutable_sequence_type(this); }
+  const TypeProto_Sequence& sequence_type() const { return Provider_GetHost()->TypeProto__sequence_type(this); }
+  TypeProto_Sequence* mutable_sequence_type() { return Provider_GetHost()->TypeProto__mutable_sequence_type(this); }
 
   enum ValueCase {
     kTensorType = 1,
@@ -286,19 +285,19 @@ struct TypeProto final {
     VALUE_NOT_SET = 0,
   };
 
-  ValueCase value_case() const { return ValueCase(g_host->TypeProto__value_case(this)); }
+  ValueCase value_case() const { return ValueCase(Provider_GetHost()->TypeProto__value_case(this)); }
 
-  void copy_from(const TypeProto* other) { return g_host->TypeProto__CopyFrom(this, other); }
+  void copy_from(const TypeProto* other) { return Provider_GetHost()->TypeProto__CopyFrom(this, other); }
 
   TypeProto() = delete;
   TypeProto(const TypeProto&) = delete;
 };
 
 struct ValueInfoProto final {
-  const TypeProto& type() const { return g_host->ValueInfoProto__type(this); }
-  TypeProto* mutable_type() { return g_host->ValueInfoProto__mutable_type(this); }
+  const TypeProto& type() const { return Provider_GetHost()->ValueInfoProto__type(this); }
+  TypeProto* mutable_type() { return Provider_GetHost()->ValueInfoProto__mutable_type(this); }
 
-  void operator=(const ValueInfoProto& v) { g_host->ValueInfoProto__operator_assign(this, v); }
+  void operator=(const ValueInfoProto& v) { Provider_GetHost()->ValueInfoProto__operator_assign(this, v); }
 
   ValueInfoProto() = delete;
   ValueInfoProto(const ValueInfoProto&) = delete;
@@ -306,8 +305,8 @@ struct ValueInfoProto final {
 };
 
 struct ValueInfoProtos final {
-  ValueInfoProto* Add() { return g_host->ValueInfoProtos__Add(this); }
-  const ValueInfoProto& operator[](int index) const { return g_host->ValueInfoProtos__operator_array(this, index); }
+  ValueInfoProto* Add() { return Provider_GetHost()->ValueInfoProtos__Add(this); }
+  const ValueInfoProto& operator[](int index) const { return Provider_GetHost()->ValueInfoProtos__operator_array(this, index); }
 
   PROVIDER_DISALLOW_ALL(ValueInfoProtos)
 };
@@ -324,7 +323,7 @@ bool IsDataTypeString(MLDataType dt_type);
 namespace Utils {
 
 struct DataTypeUtils final {
-  static const std::string* ToType(const ONNX_NAMESPACE::TypeProto& type_proto) { return g_host->Utils__DataTypeUtils__ToType(type_proto); }
+  static const std::string* ToType(const ONNX_NAMESPACE::TypeProto& type_proto) { return Provider_GetHost()->Utils__DataTypeUtils__ToType(type_proto); }
 
   PROVIDER_DISALLOW_ALL(DataTypeUtils)
 };
@@ -332,10 +331,10 @@ struct DataTypeUtils final {
 }  // namespace Utils
 
 struct ComputeCapability final {
-  static std::unique_ptr<ComputeCapability> Create(std::unique_ptr<IndexedSubGraph> t_sub_graph) { return g_host->ComputeCapability__construct(std::move(t_sub_graph)); }
-  static void operator delete(void* p) { g_host->ComputeCapability__operator_delete(reinterpret_cast<ComputeCapability*>(p)); }
+  static std::unique_ptr<ComputeCapability> Create(std::unique_ptr<IndexedSubGraph> t_sub_graph) { return Provider_GetHost()->ComputeCapability__construct(std::move(t_sub_graph)); }
+  static void operator delete(void* p) { Provider_GetHost()->ComputeCapability__operator_delete(reinterpret_cast<ComputeCapability*>(p)); }
 
-  std::unique_ptr<IndexedSubGraph>& SubGraph() { return g_host->ComputeCapability__SubGraph(this); }
+  std::unique_ptr<IndexedSubGraph>& SubGraph() { return Provider_GetHost()->ComputeCapability__SubGraph(this); }
 
   ComputeCapability() = delete;
   ComputeCapability(const ComputeCapability&) = delete;
@@ -343,38 +342,38 @@ struct ComputeCapability final {
 };
 
 struct DataTransferManager final {
-  Status CopyTensor(const Tensor& src, Tensor& dst) const { return g_host->DataTransferManager__CopyTensor(this, src, dst); }
+  Status CopyTensor(const Tensor& src, Tensor& dst) const { return Provider_GetHost()->DataTransferManager__CopyTensor(this, src, dst); }
 #if !defined(DISABLE_SPARSE_TENSORS)
-  Status CopySparseTensor(const SparseTensor& src, SparseTensor& dst) const { return g_host->DataTransferManager__CopySparseTensor(this, src, dst); }
-  Status CopySparseTensors(const std::vector<IDataTransfer::SparseSrcDstPair>& src_dst_pairs) const { return g_host->DataTransferManager__CopySparseTensors(this, src_dst_pairs); }
+  Status CopySparseTensor(const SparseTensor& src, SparseTensor& dst) const { return Provider_GetHost()->DataTransferManager__CopySparseTensor(this, src, dst); }
+  Status CopySparseTensors(const std::vector<IDataTransfer::SparseSrcDstPair>& src_dst_pairs) const { return Provider_GetHost()->DataTransferManager__CopySparseTensors(this, src_dst_pairs); }
 #endif
-  const IDataTransfer* GetDataTransfer(const OrtDevice& src_device, const OrtDevice& dst_device) const { return g_host->DataTransferManager__GetDataTransfer(this, src_device, dst_device); }
+  const IDataTransfer* GetDataTransfer(const OrtDevice& src_device, const OrtDevice& dst_device) const { return Provider_GetHost()->DataTransferManager__GetDataTransfer(this, src_device, dst_device); }
 
   PROVIDER_DISALLOW_ALL(DataTransferManager)
 };
 
 struct IndexedSubGraph_MetaDef final {
-  static std::unique_ptr<IndexedSubGraph_MetaDef> Create() { return g_host->IndexedSubGraph_MetaDef__construct(); }
-  static void operator delete(void* p) { g_host->IndexedSubGraph_MetaDef__operator_delete(reinterpret_cast<IndexedSubGraph_MetaDef*>(p)); }
+  static std::unique_ptr<IndexedSubGraph_MetaDef> Create() { return Provider_GetHost()->IndexedSubGraph_MetaDef__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->IndexedSubGraph_MetaDef__operator_delete(reinterpret_cast<IndexedSubGraph_MetaDef*>(p)); }
 
-  const std::string& name() const { return g_host->IndexedSubGraph_MetaDef__name(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  std::string& name() { return g_host->IndexedSubGraph_MetaDef__name(this); }
-  const std::string& domain() const { return g_host->IndexedSubGraph_MetaDef__domain(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  std::string& domain() { return g_host->IndexedSubGraph_MetaDef__domain(this); }
-  int since_version() const { return g_host->IndexedSubGraph_MetaDef__since_version(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  int& since_version() { return g_host->IndexedSubGraph_MetaDef__since_version(this); }
+  const std::string& name() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__name(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  std::string& name() { return Provider_GetHost()->IndexedSubGraph_MetaDef__name(this); }
+  const std::string& domain() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__domain(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  std::string& domain() { return Provider_GetHost()->IndexedSubGraph_MetaDef__domain(this); }
+  int since_version() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__since_version(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  int& since_version() { return Provider_GetHost()->IndexedSubGraph_MetaDef__since_version(this); }
 
-  ONNX_NAMESPACE::OperatorStatus& status() { return g_host->IndexedSubGraph_MetaDef__status(this); }
+  ONNX_NAMESPACE::OperatorStatus& status() { return Provider_GetHost()->IndexedSubGraph_MetaDef__status(this); }
 
-  const std::vector<std::string>& inputs() const { return g_host->IndexedSubGraph_MetaDef__inputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  std::vector<std::string>& inputs() { return g_host->IndexedSubGraph_MetaDef__inputs(this); }
-  const std::vector<std::string>& outputs() const { return g_host->IndexedSubGraph_MetaDef__outputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  const std::vector<std::string>& constant_initializers() const { return g_host->IndexedSubGraph_MetaDef__constant_initializers(const_cast<IndexedSubGraph_MetaDef*>(this)); }
-  std::vector<std::string>& constant_initializers() { return g_host->IndexedSubGraph_MetaDef__constant_initializers(this); }
-  std::vector<std::string>& outputs() { return g_host->IndexedSubGraph_MetaDef__outputs(this); }
-  NodeAttributes& attributes() { return g_host->IndexedSubGraph_MetaDef__attributes(this); }
+  const std::vector<std::string>& inputs() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__inputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  std::vector<std::string>& inputs() { return Provider_GetHost()->IndexedSubGraph_MetaDef__inputs(this); }
+  const std::vector<std::string>& outputs() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__outputs(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  const std::vector<std::string>& constant_initializers() const { return Provider_GetHost()->IndexedSubGraph_MetaDef__constant_initializers(const_cast<IndexedSubGraph_MetaDef*>(this)); }
+  std::vector<std::string>& constant_initializers() { return Provider_GetHost()->IndexedSubGraph_MetaDef__constant_initializers(this); }
+  std::vector<std::string>& outputs() { return Provider_GetHost()->IndexedSubGraph_MetaDef__outputs(this); }
+  NodeAttributes& attributes() { return Provider_GetHost()->IndexedSubGraph_MetaDef__attributes(this); }
 
-  std::string& doc_string() { return g_host->IndexedSubGraph_MetaDef__doc_string(this); }
+  std::string& doc_string() { return Provider_GetHost()->IndexedSubGraph_MetaDef__doc_string(this); }
 
   IndexedSubGraph_MetaDef() = delete;
   IndexedSubGraph_MetaDef(const IndexedSubGraph_MetaDef&) = delete;
@@ -382,13 +381,13 @@ struct IndexedSubGraph_MetaDef final {
 };
 
 struct IndexedSubGraph final {
-  static std::unique_ptr<IndexedSubGraph> Create() { return g_host->IndexedSubGraph__construct(); }
-  static void operator delete(void* p) { g_host->IndexedSubGraph__operator_delete(reinterpret_cast<IndexedSubGraph*>(p)); }
+  static std::unique_ptr<IndexedSubGraph> Create() { return Provider_GetHost()->IndexedSubGraph__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->IndexedSubGraph__operator_delete(reinterpret_cast<IndexedSubGraph*>(p)); }
 
-  std::vector<onnxruntime::NodeIndex>& Nodes() { return g_host->IndexedSubGraph__Nodes(this); }
+  std::vector<onnxruntime::NodeIndex>& Nodes() { return Provider_GetHost()->IndexedSubGraph__Nodes(this); }
 
-  void SetMetaDef(std::unique_ptr<IndexedSubGraph_MetaDef>&& meta_def_) { return g_host->IndexedSubGraph__SetMetaDef(this, std::move(*reinterpret_cast<std::unique_ptr<IndexedSubGraph_MetaDef>*>(&meta_def_))); }
-  const IndexedSubGraph_MetaDef* GetMetaDef() const { return reinterpret_cast<const IndexedSubGraph_MetaDef*>(g_host->IndexedSubGraph__GetMetaDef(this)); }
+  void SetMetaDef(std::unique_ptr<IndexedSubGraph_MetaDef>&& meta_def_) { return Provider_GetHost()->IndexedSubGraph__SetMetaDef(this, std::move(*reinterpret_cast<std::unique_ptr<IndexedSubGraph_MetaDef>*>(&meta_def_))); }
+  const IndexedSubGraph_MetaDef* GetMetaDef() const { return reinterpret_cast<const IndexedSubGraph_MetaDef*>(Provider_GetHost()->IndexedSubGraph__GetMetaDef(this)); }
 
   IndexedSubGraph() = delete;
   IndexedSubGraph(const IndexedSubGraph&) = delete;
@@ -396,13 +395,13 @@ struct IndexedSubGraph final {
 };
 
 struct KernelDef final {
-  static void operator delete(void* p) { g_host->KernelDef__operator_delete(reinterpret_cast<KernelDef*>(p)); }
+  static void operator delete(void* p) { Provider_GetHost()->KernelDef__operator_delete(reinterpret_cast<KernelDef*>(p)); }
 
-  int ExecQueueId() const { return g_host->KernelDef__ExecQueueId(this); }
+  int ExecQueueId() const { return Provider_GetHost()->KernelDef__ExecQueueId(this); }
 
-  void SinceVersion(/*out*/ int* start, /*out*/ int* end) const { g_host->KernelDef__SinceVersion(this, start, end); }
-  const std::string& Domain() const { return g_host->KernelDef__Domain(this); }
-  const std::string& OpName() const { return g_host->KernelDef__OpName(this); }
+  void SinceVersion(/*out*/ int* start, /*out*/ int* end) const { Provider_GetHost()->KernelDef__SinceVersion(this, start, end); }
+  const std::string& Domain() const { return Provider_GetHost()->KernelDef__Domain(this); }
+  const std::string& OpName() const { return Provider_GetHost()->KernelDef__OpName(this); }
 
   KernelDef() = delete;
   KernelDef(const KernelDef*) = delete;
@@ -412,94 +411,94 @@ struct KernelDef final {
 using BuildKernelCreateInfoFn = KernelCreateInfo (*)();
 
 struct KernelDefBuilder final {
-  static std::unique_ptr<KernelDefBuilder> Create() { return g_host->KernelDefBuilder__construct(); }
-  static void operator delete(void* p) { g_host->KernelDefBuilder__operator_delete(reinterpret_cast<KernelDefBuilder*>(p)); }
+  static std::unique_ptr<KernelDefBuilder> Create() { return Provider_GetHost()->KernelDefBuilder__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->KernelDefBuilder__operator_delete(reinterpret_cast<KernelDefBuilder*>(p)); }
 
   KernelDefBuilder& SetName(const char* op_name) {
-    g_host->KernelDefBuilder__SetName(this, op_name);
+    Provider_GetHost()->KernelDefBuilder__SetName(this, op_name);
     return *this;
   }
   KernelDefBuilder& SetDomain(const char* domain) {
-    g_host->KernelDefBuilder__SetDomain(this, domain);
+    Provider_GetHost()->KernelDefBuilder__SetDomain(this, domain);
     return *this;
   }
   KernelDefBuilder& SinceVersion(int since_version) {
-    g_host->KernelDefBuilder__SinceVersion(this, since_version);
+    Provider_GetHost()->KernelDefBuilder__SinceVersion(this, since_version);
     return *this;
   }
   KernelDefBuilder& SinceVersion(int since_version_start, int since_version_end) {
-    g_host->KernelDefBuilder__SinceVersion(this, since_version_start, since_version_end);
+    Provider_GetHost()->KernelDefBuilder__SinceVersion(this, since_version_start, since_version_end);
     return *this;
   }
   KernelDefBuilder& Provider(const char* provider_type) {
-    g_host->KernelDefBuilder__Provider(this, provider_type);
+    Provider_GetHost()->KernelDefBuilder__Provider(this, provider_type);
     return *this;
   }
   KernelDefBuilder& TypeConstraint(const char* arg_name, MLDataType supported_type) {
-    g_host->KernelDefBuilder__TypeConstraint(this, arg_name, supported_type);
+    Provider_GetHost()->KernelDefBuilder__TypeConstraint(this, arg_name, supported_type);
     return *this;
   }
   KernelDefBuilder& TypeConstraint(const char* arg_name, const std::vector<MLDataType>& supported_types) {
-    g_host->KernelDefBuilder__TypeConstraint(this, arg_name, supported_types);
+    Provider_GetHost()->KernelDefBuilder__TypeConstraint(this, arg_name, supported_types);
     return *this;
   }
   KernelDefBuilder& InputMemoryType(OrtMemType type, int input_index) {
-    g_host->KernelDefBuilder__InputMemoryType(this, type, input_index);
+    Provider_GetHost()->KernelDefBuilder__InputMemoryType(this, type, input_index);
     return *this;
   }
   KernelDefBuilder& InputMemoryType(OrtMemType type, const std::vector<int>& input_indexes) {
-    g_host->KernelDefBuilder__InputMemoryType(this, type, input_indexes);
+    Provider_GetHost()->KernelDefBuilder__InputMemoryType(this, type, input_indexes);
     return *this;
   }
   KernelDefBuilder& OutputMemoryType(OrtMemType type, int input_index) {
-    g_host->KernelDefBuilder__OutputMemoryType(this, type, input_index);
+    Provider_GetHost()->KernelDefBuilder__OutputMemoryType(this, type, input_index);
     return *this;
   }
   KernelDefBuilder& ExecQueueId(int queue_id) {
-    g_host->KernelDefBuilder__ExecQueueId(this, queue_id);
+    Provider_GetHost()->KernelDefBuilder__ExecQueueId(this, queue_id);
     return *this;
   }
   KernelDefBuilder& MayInplace(int input_index, int output_index) {
-    g_host->KernelDefBuilder__MayInplace(this, input_index, output_index);
+    Provider_GetHost()->KernelDefBuilder__MayInplace(this, input_index, output_index);
     return *this;
   }
   KernelDefBuilder& Alias(const std::vector<std::pair<int, int>>& aliases) {
-    g_host->KernelDefBuilder__Alias(this, aliases);
+    Provider_GetHost()->KernelDefBuilder__Alias(this, aliases);
     return *this;
   }
   KernelDefBuilder& Alias(int input_index, int output_index) {
-    g_host->KernelDefBuilder__Alias(this, input_index, output_index);
+    Provider_GetHost()->KernelDefBuilder__Alias(this, input_index, output_index);
     return *this;
   }
   KernelDefBuilder& VariadicAlias(int input_offset, int output_offset) {
-    g_host->KernelDefBuilder__VariadicAlias(this, input_offset, output_offset);
+    Provider_GetHost()->KernelDefBuilder__VariadicAlias(this, input_offset, output_offset);
     return *this;
   }
 
   KernelDefBuilder& ExternalOutputs() {
-    g_host->KernelDefBuilder__ExternalOutputs(this);
+    Provider_GetHost()->KernelDefBuilder__ExternalOutputs(this);
     return *this;
   }
 
   KernelDefBuilder& AllocateInputsContiguously() {
-    g_host->KernelDefBuilder__AllocateInputsContiguously(this);
+    Provider_GetHost()->KernelDefBuilder__AllocateInputsContiguously(this);
     return *this;
   }
 
 #ifdef ENABLE_STRIDED_TENSORS
   KernelDefBuilder& MayStridedInput(int input_index) {
-    g_host->KernelDefBuilder__MayStridedInput(this, input_index);
+    Provider_GetHost()->KernelDefBuilder__MayStridedInput(this, input_index);
     return *this;
   }
 
   KernelDefBuilder& MayStridedOutput(int input_index, int output_index) {
-    g_host->KernelDefBuilder__MayStridedOutput(this, input_index, output_index);
+    Provider_GetHost()->KernelDefBuilder__MayStridedOutput(this, input_index, output_index);
     return *this;
   }
 #endif
 
   std::unique_ptr<KernelDef> Build() {
-    return g_host->KernelDefBuilder__Build(this);
+    return Provider_GetHost()->KernelDefBuilder__Build(this);
   }
 
   KernelDefBuilder() = delete;
@@ -508,10 +507,10 @@ struct KernelDefBuilder final {
 };
 
 struct KernelRegistry final {
-  static std::shared_ptr<KernelRegistry> Create() { return g_host->KernelRegistry__construct(); }
-  static void operator delete(void* p) { g_host->KernelRegistry__operator_delete(reinterpret_cast<KernelRegistry*>(p)); }
+  static std::shared_ptr<KernelRegistry> Create() { return Provider_GetHost()->KernelRegistry__construct(); }
+  static void operator delete(void* p) { Provider_GetHost()->KernelRegistry__operator_delete(reinterpret_cast<KernelRegistry*>(p)); }
 
-  Status Register(KernelCreateInfo&& create_info) { return g_host->KernelRegistry__Register(this, std::move(create_info)); }
+  Status Register(KernelCreateInfo&& create_info) { return Provider_GetHost()->KernelRegistry__Register(this, std::move(create_info)); }
 
   KernelRegistry() = delete;
   KernelRegistry(const KernelRegistry&) = delete;
@@ -519,14 +518,14 @@ struct KernelRegistry final {
 };
 
 struct PrimitiveDataTypeBase final {
-  int32_t GetDataType() const { return g_host->PrimitiveDataTypeBase__GetDataType(this); }
+  int32_t GetDataType() const { return Provider_GetHost()->PrimitiveDataTypeBase__GetDataType(this); }
 
   PROVIDER_DISALLOW_ALL(PrimitiveDataTypeBase)
 };
 
 class DataTypeImpl final {
  public:
-  size_t Size() const { return g_host->DataTypeImpl__Size(this); }
+  size_t Size() const { return Provider_GetHost()->DataTypeImpl__Size(this); }
 
   template <typename T>
   static MLDataType GetType();
@@ -539,60 +538,60 @@ class DataTypeImpl final {
 
   static MLDataType GetTypeFromOnnxType(int);
 
-  bool IsTensorType() const { return g_host->DataTypeImpl__IsTensorType(this); }
-  bool IsTensorSequenceType() const { return g_host->DataTypeImpl__IsTensorSequenceType(this); }
+  bool IsTensorType() const { return Provider_GetHost()->DataTypeImpl__IsTensorType(this); }
+  bool IsTensorSequenceType() const { return Provider_GetHost()->DataTypeImpl__IsTensorSequenceType(this); }
 #if !defined(DISABLE_SPARSE_TENSORS)
-  bool IsSparseTensorType() const { return g_host->DataTypeImpl__IsSparseTensorType(this); }
+  bool IsSparseTensorType() const { return Provider_GetHost()->DataTypeImpl__IsSparseTensorType(this); }
 #endif
-  DeleteFunc GetDeleteFunc() const { return g_host->DataTypeImpl__GetDeleteFunc(this); }
+  DeleteFunc GetDeleteFunc() const { return Provider_GetHost()->DataTypeImpl__GetDeleteFunc(this); }
 
-  static const std::vector<MLDataType>& AllFixedSizeTensorTypes() { return g_host->DataTypeImpl__AllFixedSizeTensorTypes(); }
-  static const std::vector<MLDataType>& AllTensorTypes() { return g_host->DataTypeImpl__AllTensorTypes(); }
-  static const std::vector<MLDataType>& AllIEEEFloatTensorTypes() { return g_host->DataTypeImpl__AllIEEEFloatTensorTypes(); }
-  static const std::vector<MLDataType>& AllTensorAndSequenceTensorTypes() { return g_host->DataTypeImpl__AllTensorAndSequenceTensorTypes(); }
-  static const std::vector<MLDataType>& AllFixedSizeTensorAndSequenceTensorTypes() { return g_host->DataTypeImpl__AllFixedSizeTensorAndSequenceTensorTypes(); }
-  static const std::vector<MLDataType>& AllSequenceTensorTypes() { return g_host->DataTypeImpl__AllSequenceTensorTypes(); }
-  static const std::vector<MLDataType>& AllFixedSizeSequenceTensorTypes() { return g_host->DataTypeImpl__AllFixedSizeSequenceTensorTypes(); }
+  static const std::vector<MLDataType>& AllFixedSizeTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllFixedSizeTensorTypes(); }
+  static const std::vector<MLDataType>& AllTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllTensorTypes(); }
+  static const std::vector<MLDataType>& AllIEEEFloatTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllIEEEFloatTensorTypes(); }
+  static const std::vector<MLDataType>& AllTensorAndSequenceTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllTensorAndSequenceTensorTypes(); }
+  static const std::vector<MLDataType>& AllFixedSizeTensorAndSequenceTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllFixedSizeTensorAndSequenceTensorTypes(); }
+  static const std::vector<MLDataType>& AllSequenceTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllSequenceTensorTypes(); }
+  static const std::vector<MLDataType>& AllFixedSizeSequenceTensorTypes() { return Provider_GetHost()->DataTypeImpl__AllFixedSizeSequenceTensorTypes(); }
 
-  const PrimitiveDataTypeBase* AsPrimitiveDataType() const { return g_host->DataTypeImpl__AsPrimitiveDataType(this); }
+  const PrimitiveDataTypeBase* AsPrimitiveDataType() const { return Provider_GetHost()->DataTypeImpl__AsPrimitiveDataType(this); }
 
-  static const char* ToString(MLDataType type) { return g_host->DataTypeImpl__ToString(type); }
+  static const char* ToString(MLDataType type) { return Provider_GetHost()->DataTypeImpl__ToString(type); }
 
   PROVIDER_DISALLOW_ALL(DataTypeImpl)
 };
 
 struct Function final {
-  const Graph& Body() const { return g_host->Function__Body(this); }
+  const Graph& Body() const { return Provider_GetHost()->Function__Body(this); }
 
   PROVIDER_DISALLOW_ALL(Function)
 };
 
 struct Node final {
-  const std::string& Name() const noexcept { return g_host->Node__Name(this); }
-  const std::string& Description() const noexcept { return g_host->Node__Description(this); }
-  const std::string& Domain() const noexcept { return g_host->Node__Domain(this); }
-  const std::string& OpType() const noexcept { return g_host->Node__OpType(this); }
+  const std::string& Name() const noexcept { return Provider_GetHost()->Node__Name(this); }
+  const std::string& Description() const noexcept { return Provider_GetHost()->Node__Description(this); }
+  const std::string& Domain() const noexcept { return Provider_GetHost()->Node__Domain(this); }
+  const std::string& OpType() const noexcept { return Provider_GetHost()->Node__OpType(this); }
 
-  int SinceVersion() const noexcept { return g_host->Node__SinceVersion(this); }
+  int SinceVersion() const noexcept { return Provider_GetHost()->Node__SinceVersion(this); }
 
-  const Function* GetFunctionBody() const noexcept { return g_host->Node__GetFunctionBody(this); }
-  ProviderType GetExecutionProviderType() const noexcept { return g_host->Node__GetExecutionProviderType(this); }
+  const Function* GetFunctionBody() const noexcept { return Provider_GetHost()->Node__GetFunctionBody(this); }
+  ProviderType GetExecutionProviderType() const noexcept { return Provider_GetHost()->Node__GetExecutionProviderType(this); }
 
-  ConstPointerContainer<std::vector<NodeArg*>> ImplicitInputDefs() const noexcept { return g_host->Node__ImplicitInputDefs(this); }
+  ConstPointerContainer<std::vector<NodeArg*>> ImplicitInputDefs() const noexcept { return Provider_GetHost()->Node__ImplicitInputDefs(this); }
 
-  const std::vector<int>& InputArgCount() const noexcept { return g_host->Node__InputArgCount(this); }
+  const std::vector<int>& InputArgCount() const noexcept { return Provider_GetHost()->Node__InputArgCount(this); }
 
-  ConstPointerContainer<std::vector<NodeArg*>> InputDefs() const noexcept { return g_host->Node__InputDefs(this); }
-  ConstPointerContainer<std::vector<NodeArg*>> OutputDefs() const noexcept { return g_host->Node__OutputDefs(this); }
-  NodeIndex Index() const noexcept { return g_host->Node__Index(this); }
+  ConstPointerContainer<std::vector<NodeArg*>> InputDefs() const noexcept { return Provider_GetHost()->Node__InputDefs(this); }
+  ConstPointerContainer<std::vector<NodeArg*>> OutputDefs() const noexcept { return Provider_GetHost()->Node__OutputDefs(this); }
+  NodeIndex Index() const noexcept { return Provider_GetHost()->Node__Index(this); }
 
-  std::vector<gsl::not_null<const Graph*>> GetSubgraphs() const noexcept { return g_host->Node__GetSubgraphs(this); }
+  std::vector<gsl::not_null<const Graph*>> GetSubgraphs() const noexcept { return Provider_GetHost()->Node__GetSubgraphs(this); }
 
-  void ToProto(ONNX_NAMESPACE::NodeProto& proto, bool update_subgraphs = false) const { return g_host->Node__ToProto(this, proto, update_subgraphs); }
+  void ToProto(ONNX_NAMESPACE::NodeProto& proto, bool update_subgraphs = false) const { return Provider_GetHost()->Node__ToProto(this, proto, update_subgraphs); }
 
-  const NodeAttributes& GetAttributes() const noexcept { return g_host->Node__GetAttributes(this); }
-  size_t GetInputEdgesCount() const noexcept { return g_host->Node__GetInputEdgesCount(this); }
-  size_t GetOutputEdgesCount() const noexcept { return g_host->Node__GetOutputEdgesCount(this); }
+  const NodeAttributes& GetAttributes() const noexcept { return Provider_GetHost()->Node__GetAttributes(this); }
+  size_t GetInputEdgesCount() const noexcept { return Provider_GetHost()->Node__GetInputEdgesCount(this); }
+  size_t GetOutputEdgesCount() const noexcept { return Provider_GetHost()->Node__GetOutputEdgesCount(this); }
 
   struct NodeConstIterator {
     NodeConstIterator(std::unique_ptr<Node__NodeIterator> p) : impl_{std::move(p)} {}
@@ -607,11 +606,11 @@ struct Node final {
     std::unique_ptr<Node__NodeIterator> impl_;
   };
 
-  NodeConstIterator InputNodesBegin() const noexcept { return g_host->Node__InputNodesBegin(this); }
-  NodeConstIterator InputNodesEnd() const noexcept { return g_host->Node__InputNodesEnd(this); }
+  NodeConstIterator InputNodesBegin() const noexcept { return Provider_GetHost()->Node__InputNodesBegin(this); }
+  NodeConstIterator InputNodesEnd() const noexcept { return Provider_GetHost()->Node__InputNodesEnd(this); }
 
-  NodeConstIterator OutputNodesBegin() const noexcept { return g_host->Node__OutputNodesBegin(this); }
-  NodeConstIterator OutputNodesEnd() const noexcept { return g_host->Node__OutputNodesEnd(this); }
+  NodeConstIterator OutputNodesBegin() const noexcept { return Provider_GetHost()->Node__OutputNodesBegin(this); }
+  NodeConstIterator OutputNodesEnd() const noexcept { return Provider_GetHost()->Node__OutputNodesEnd(this); }
 
   struct EdgeConstIterator {
     EdgeConstIterator(std::unique_ptr<Node__EdgeIterator> p) : impl_{std::move(p)} {}
@@ -626,53 +625,53 @@ struct Node final {
     std::unique_ptr<Node__EdgeIterator> impl_;
   };
 
-  EdgeConstIterator OutputEdgesBegin() const noexcept { return g_host->Node__OutputEdgesBegin(this); }
-  EdgeConstIterator OutputEdgesEnd() const noexcept { return g_host->Node__OutputEdgesEnd(this); }
+  EdgeConstIterator OutputEdgesBegin() const noexcept { return Provider_GetHost()->Node__OutputEdgesBegin(this); }
+  EdgeConstIterator OutputEdgesEnd() const noexcept { return Provider_GetHost()->Node__OutputEdgesEnd(this); }
 
-  void ForEachDef(std::function<void(const NodeArg&, bool is_input)> func, bool include_missing_optional_defs = false) const { g_host->Node__ForEachDef(this, func, std::move(include_missing_optional_defs)); }
+  void ForEachDef(std::function<void(const NodeArg&, bool is_input)> func, bool include_missing_optional_defs = false) const { Provider_GetHost()->Node__ForEachDef(this, func, std::move(include_missing_optional_defs)); }
 
   PROVIDER_DISALLOW_ALL(Node)
 };
 
 struct NodeArg final {
-  const std::string& Name() const noexcept { return g_host->NodeArg__Name(this); }
-  const ONNX_NAMESPACE::TensorShapeProto* Shape() const { return g_host->NodeArg__Shape(this); }
-  ONNX_NAMESPACE::DataType Type() const noexcept { return g_host->NodeArg__Type(this); }
-  const NodeArgInfo& ToProto() const noexcept { return g_host->NodeArg__ToProto(this); }
-  bool Exists() const noexcept { return g_host->NodeArg__Exists(this); }
-  const ONNX_NAMESPACE::TypeProto* TypeAsProto() const noexcept { return g_host->NodeArg__TypeAsProto(this); }
+  const std::string& Name() const noexcept { return Provider_GetHost()->NodeArg__Name(this); }
+  const ONNX_NAMESPACE::TensorShapeProto* Shape() const { return Provider_GetHost()->NodeArg__Shape(this); }
+  ONNX_NAMESPACE::DataType Type() const noexcept { return Provider_GetHost()->NodeArg__Type(this); }
+  const NodeArgInfo& ToProto() const noexcept { return Provider_GetHost()->NodeArg__ToProto(this); }
+  bool Exists() const noexcept { return Provider_GetHost()->NodeArg__Exists(this); }
+  const ONNX_NAMESPACE::TypeProto* TypeAsProto() const noexcept { return Provider_GetHost()->NodeArg__TypeAsProto(this); }
 
   PROVIDER_DISALLOW_ALL(NodeArg)
 };
 
 struct NodeAttributes final {
-  static std::unique_ptr<NodeAttributes> Create() { return g_host->NodeAttributes__construct(); }
-  void operator=(const NodeAttributes& v) { return g_host->NodeAttributes__operator_assign(this, v); }
-  static void operator delete(void* p) { g_host->NodeAttributes__operator_delete(reinterpret_cast<NodeAttributes*>(p)); }
+  static std::unique_ptr<NodeAttributes> Create() { return Provider_GetHost()->NodeAttributes__construct(); }
+  void operator=(const NodeAttributes& v) { return Provider_GetHost()->NodeAttributes__operator_assign(this, v); }
+  static void operator delete(void* p) { Provider_GetHost()->NodeAttributes__operator_delete(reinterpret_cast<NodeAttributes*>(p)); }
 
-  size_t size() const { return g_host->NodeAttributes__size(this); }
-  void clear() noexcept { g_host->NodeAttributes__clear(this); }
-  size_t count(const std::string& keyval) const { return g_host->NodeAttributes__count(this, keyval); }
-  ONNX_NAMESPACE::AttributeProto& operator[](const std::string& string) { return g_host->NodeAttributes__operator_array(this, string); }
-  const ONNX_NAMESPACE::AttributeProto& at(const std::string& string) const { return g_host->NodeAttributes__at(this, string); }
+  size_t size() const { return Provider_GetHost()->NodeAttributes__size(this); }
+  void clear() noexcept { Provider_GetHost()->NodeAttributes__clear(this); }
+  size_t count(const std::string& keyval) const { return Provider_GetHost()->NodeAttributes__count(this, keyval); }
+  ONNX_NAMESPACE::AttributeProto& operator[](const std::string& string) { return Provider_GetHost()->NodeAttributes__operator_array(this, string); }
+  const ONNX_NAMESPACE::AttributeProto& at(const std::string& string) const { return Provider_GetHost()->NodeAttributes__at(this, string); }
 
-  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> begin() const { return g_host->NodeAttributes__begin(this); }
-  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> end() const { return g_host->NodeAttributes__end(this); }
-  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> find(const std::string& key) const { return g_host->NodeAttributes__find(this, key); }
-  void insert(const NodeAttributes& v) { return g_host->NodeAttributes__insert(this, v); }
-  void emplace(const std::string& k, const ONNX_NAMESPACE::AttributeProto& v) { g_host->NodeAttributes__emplace(this, k, v); }
-  void reserve(size_t size) { g_host->NodeAttributes__reserve(this, size); }
+  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> begin() const { return Provider_GetHost()->NodeAttributes__begin(this); }
+  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> end() const { return Provider_GetHost()->NodeAttributes__end(this); }
+  IteratorHolder<NodeAttributes_Iterator, std::pair<const std::string, ONNX_NAMESPACE::AttributeProto>> find(const std::string& key) const { return Provider_GetHost()->NodeAttributes__find(this, key); }
+  void insert(const NodeAttributes& v) { return Provider_GetHost()->NodeAttributes__insert(this, v); }
+  void emplace(const std::string& k, const ONNX_NAMESPACE::AttributeProto& v) { Provider_GetHost()->NodeAttributes__emplace(this, k, v); }
+  void reserve(size_t size) { Provider_GetHost()->NodeAttributes__reserve(this, size); }
 
   NodeAttributes() = delete;
   NodeAttributes(const NodeAttributes&) = delete;
 };
 
 struct Model final {
-  static void operator delete(void* p) { g_host->Model__operator_delete(reinterpret_cast<Model*>(p)); }
+  static void operator delete(void* p) { Provider_GetHost()->Model__operator_delete(reinterpret_cast<Model*>(p)); }
 
-  Graph& MainGraph() { return g_host->Model__MainGraph(this); }
+  Graph& MainGraph() { return Provider_GetHost()->Model__MainGraph(this); }
 
-  std::unique_ptr<ONNX_NAMESPACE::ModelProto> ToProto() { return g_host->Model__ToProto(this); }
+  std::unique_ptr<ONNX_NAMESPACE::ModelProto> ToProto() { return Provider_GetHost()->Model__ToProto(this); }
 
   Model() = delete;
   Model(const Model&) = delete;
@@ -680,64 +679,64 @@ struct Model final {
 };
 
 struct Graph final {
-  std::unique_ptr<GraphViewer> CreateGraphViewer() const { return g_host->Graph__CreateGraphViewer(this); }
-  std::unique_ptr<ONNX_NAMESPACE::GraphProto> ToGraphProto() const { return g_host->Graph__ToGraphProto(this); }
+  std::unique_ptr<GraphViewer> CreateGraphViewer() const { return Provider_GetHost()->Graph__CreateGraphViewer(this); }
+  std::unique_ptr<ONNX_NAMESPACE::GraphProto> ToGraphProto() const { return Provider_GetHost()->Graph__ToGraphProto(this); }
 
-  NodeArg& GetOrCreateNodeArg(const std::string& name, const ONNX_NAMESPACE::TypeProto* p_arg_type) { return g_host->Graph__GetOrCreateNodeArg(this, name, p_arg_type); }
+  NodeArg& GetOrCreateNodeArg(const std::string& name, const ONNX_NAMESPACE::TypeProto* p_arg_type) { return Provider_GetHost()->Graph__GetOrCreateNodeArg(this, name, p_arg_type); }
 
-  Status Resolve() { return g_host->Graph__Resolve(this); }
-  void AddInitializedTensor(const ONNX_NAMESPACE::TensorProto& tensor) { return g_host->Graph__AddInitializedTensor(this, tensor); }
-  Node& AddNode(const std::string& name, const std::string& op_type, const std::string& description, gsl::span<NodeArg* const> input_args, gsl::span<NodeArg* const> output_args, const NodeAttributes* attributes, const std::string& domain) { return g_host->Graph__AddNode(this, name, op_type, description, input_args, output_args, attributes, domain); }
+  Status Resolve() { return Provider_GetHost()->Graph__Resolve(this); }
+  void AddInitializedTensor(const ONNX_NAMESPACE::TensorProto& tensor) { return Provider_GetHost()->Graph__AddInitializedTensor(this, tensor); }
+  Node& AddNode(const std::string& name, const std::string& op_type, const std::string& description, gsl::span<NodeArg* const> input_args, gsl::span<NodeArg* const> output_args, const NodeAttributes* attributes, const std::string& domain) { return Provider_GetHost()->Graph__AddNode(this, name, op_type, description, input_args, output_args, attributes, domain); }
 
-  const std::vector<const NodeArg*>& GetOutputs() const noexcept { return g_host->Graph__GetOutputs(this); }
-  void SetOutputs(gsl::span<const NodeArg* const> outputs) { return g_host->Graph__SetOutputs(this, outputs); }
+  const std::vector<const NodeArg*>& GetOutputs() const noexcept { return Provider_GetHost()->Graph__GetOutputs(this); }
+  void SetOutputs(gsl::span<const NodeArg* const> outputs) { return Provider_GetHost()->Graph__SetOutputs(this, outputs); }
 
-  const std::vector<const NodeArg*>& GetInputs() const noexcept { return g_host->Graph__GetInputs(this); }
+  const std::vector<const NodeArg*>& GetInputs() const noexcept { return Provider_GetHost()->Graph__GetInputs(this); }
 
-  bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const { return g_host->Graph__GetInitializedTensor(this, tensor_name, value); }
+  bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const { return Provider_GetHost()->Graph__GetInitializedTensor(this, tensor_name, value); }
 
-  const Node* ParentNode() const { return g_host->Graph__ParentNode(this); }
-  const Graph* ParentGraph() const { return g_host->Graph__ParentGraph(this); }
-  const std::string& Name() const noexcept { return g_host->Graph__Name(this); }
-  const Path& ModelPath() const { return g_host->Graph__ModelPath(this); }
-  const std::vector<const NodeArg*>& GetInputsIncludingInitializers() const noexcept { return g_host->Graph__GetInputsIncludingInitializers(this); }
-  bool IsSubgraph() const { return g_host->Graph__IsSubgraph(this); }
+  const Node* ParentNode() const { return Provider_GetHost()->Graph__ParentNode(this); }
+  const Graph* ParentGraph() const { return Provider_GetHost()->Graph__ParentGraph(this); }
+  const std::string& Name() const noexcept { return Provider_GetHost()->Graph__Name(this); }
+  const Path& ModelPath() const { return Provider_GetHost()->Graph__ModelPath(this); }
+  const std::vector<const NodeArg*>& GetInputsIncludingInitializers() const noexcept { return Provider_GetHost()->Graph__GetInputsIncludingInitializers(this); }
+  bool IsSubgraph() const { return Provider_GetHost()->Graph__IsSubgraph(this); }
 
   PROVIDER_DISALLOW_ALL(Graph)
 };
 
 struct GraphViewer final {
-  static void operator delete(void* p) { g_host->GraphViewer__operator_delete(reinterpret_cast<GraphViewer*>(p)); }
+  static void operator delete(void* p) { Provider_GetHost()->GraphViewer__operator_delete(reinterpret_cast<GraphViewer*>(p)); }
 
-  std::unique_ptr<Model> CreateModel(const logging::Logger& logger) const { return g_host->GraphViewer__CreateModel(this, logger); }
+  std::unique_ptr<Model> CreateModel(const logging::Logger& logger) const { return Provider_GetHost()->GraphViewer__CreateModel(this, logger); }
 
-  const std::string& Name() const noexcept { return g_host->GraphViewer__Name(this); }
-  const Path& ModelPath() const noexcept { return g_host->GraphViewer__ModelPath(this); }
+  const std::string& Name() const noexcept { return Provider_GetHost()->GraphViewer__Name(this); }
+  const Path& ModelPath() const noexcept { return Provider_GetHost()->GraphViewer__ModelPath(this); }
 
-  const Node* GetNode(NodeIndex node_index) const { return g_host->GraphViewer__GetNode(this, node_index); }
-  const NodeArg* GetNodeArg(const std::string& name) const { return g_host->GraphViewer__GetNodeArg(this, name); }
+  const Node* GetNode(NodeIndex node_index) const { return Provider_GetHost()->GraphViewer__GetNode(this, node_index); }
+  const NodeArg* GetNodeArg(const std::string& name) const { return Provider_GetHost()->GraphViewer__GetNodeArg(this, name); }
 
-  bool IsSubgraph() const { return g_host->GraphViewer__IsSubgraph(this); }
-  const Graph& GetGraph() const { return g_host->GraphViewer__GetGraph(this); }
-  bool IsConstantInitializer(const std::string& name, bool check_outer_scope) const { return g_host->GraphViewer__IsConstantInitializer(this, name, check_outer_scope); }
-  const Node* ParentNode() const { return g_host->GraphViewer__ParentNode(this); }
+  bool IsSubgraph() const { return Provider_GetHost()->GraphViewer__IsSubgraph(this); }
+  const Graph& GetGraph() const { return Provider_GetHost()->GraphViewer__GetGraph(this); }
+  bool IsConstantInitializer(const std::string& name, bool check_outer_scope) const { return Provider_GetHost()->GraphViewer__IsConstantInitializer(this, name, check_outer_scope); }
+  const Node* ParentNode() const { return Provider_GetHost()->GraphViewer__ParentNode(this); }
 
-  int NumberOfNodes() const noexcept { return g_host->GraphViewer__NumberOfNodes(this); }
-  int MaxNodeIndex() const noexcept { return g_host->GraphViewer__MaxNodeIndex(this); }
+  int NumberOfNodes() const noexcept { return Provider_GetHost()->GraphViewer__NumberOfNodes(this); }
+  int MaxNodeIndex() const noexcept { return Provider_GetHost()->GraphViewer__MaxNodeIndex(this); }
 
-  const std::vector<const NodeArg*>& GetInputs() const noexcept { return g_host->GraphViewer__GetInputs(this); }
-  const std::vector<const NodeArg*>& GetOutputs() const noexcept { return g_host->GraphViewer__GetOutputs(this); }
-  const std::unordered_set<const NodeArg*>& GetValueInfo() const noexcept { return g_host->GraphViewer__GetValueInfo(this); }
+  const std::vector<const NodeArg*>& GetInputs() const noexcept { return Provider_GetHost()->GraphViewer__GetInputs(this); }
+  const std::vector<const NodeArg*>& GetOutputs() const noexcept { return Provider_GetHost()->GraphViewer__GetOutputs(this); }
+  const std::unordered_set<const NodeArg*>& GetValueInfo() const noexcept { return Provider_GetHost()->GraphViewer__GetValueInfo(this); }
 
-  const InitializedTensorSet& GetAllInitializedTensors() const noexcept { return g_host->GraphViewer__GetAllInitializedTensors(this); }
-  bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const { return g_host->GraphViewer__GetInitializedTensor(this, tensor_name, value); }
+  const InitializedTensorSet& GetAllInitializedTensors() const noexcept { return Provider_GetHost()->GraphViewer__GetAllInitializedTensors(this); }
+  bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const { return Provider_GetHost()->GraphViewer__GetInitializedTensor(this, tensor_name, value); }
 
-  const std::unordered_map<std::string, int>& DomainToVersionMap() const noexcept { return g_host->GraphViewer__DomainToVersionMap(this); }
+  const std::unordered_map<std::string, int>& DomainToVersionMap() const noexcept { return Provider_GetHost()->GraphViewer__DomainToVersionMap(this); }
 
-  const std::vector<NodeIndex>& GetNodesInTopologicalOrder() const { return g_host->GraphViewer__GetNodesInTopologicalOrder(this); }
-  const std::vector<const NodeArg*>& GetInputsIncludingInitializers() const noexcept { return g_host->GraphViewer__GetInputsIncludingInitializers(this); }
+  const std::vector<NodeIndex>& GetNodesInTopologicalOrder() const { return Provider_GetHost()->GraphViewer__GetNodesInTopologicalOrder(this); }
+  const std::vector<const NodeArg*>& GetInputsIncludingInitializers() const noexcept { return Provider_GetHost()->GraphViewer__GetInputsIncludingInitializers(this); }
 
-  void ToProto(ONNX_NAMESPACE::GraphProto& graph_proto, bool include_initializers, bool include_outer_scope_args) const { g_host->GraphViewer__ToProto(this, graph_proto, include_initializers, include_outer_scope_args); }
+  void ToProto(ONNX_NAMESPACE::GraphProto& graph_proto, bool include_initializers, bool include_outer_scope_args) const { Provider_GetHost()->GraphViewer__ToProto(this, graph_proto, include_initializers, include_outer_scope_args); }
 
   GraphViewer() = delete;
   GraphViewer(const GraphViewer&) = delete;
@@ -745,9 +744,9 @@ struct GraphViewer final {
 };
 
 struct Path final {
-  PathString ToPathString() const noexcept { return g_host->Path__ToPathString(this); }
-  const std::vector<PathString>& GetComponents() const noexcept { return g_host->Path__GetComponents(this); }
-  bool IsEmpty() const noexcept { return g_host->Path__IsEmpty(this); }
+  PathString ToPathString() const noexcept { return Provider_GetHost()->Path__ToPathString(this); }
+  const std::vector<PathString>& GetComponents() const noexcept { return Provider_GetHost()->Path__GetComponents(this); }
+  bool IsEmpty() const noexcept { return Provider_GetHost()->Path__IsEmpty(this); }
 
   PROVIDER_DISALLOW_ALL(Path)
 };
@@ -755,74 +754,74 @@ struct Path final {
 struct OpKernelContext final {
   template <typename T>
   const T& RequiredInput(int index) const;
-  Tensor& RequiredOutput(int index, const TensorShape& shape) { return g_host->OpKernelContext__RequiredOutput(this, index, shape); }
+  Tensor& RequiredOutput(int index, const TensorShape& shape) { return Provider_GetHost()->OpKernelContext__RequiredOutput(this, index, shape); }
 
   template <typename T>
   const T* Input(int index) const;
-  int InputCount() const { return g_host->OpKernelContext__InputCount(this); }
+  int InputCount() const { return Provider_GetHost()->OpKernelContext__InputCount(this); }
 
-  MLDataType InputType(int index) const { return g_host->OpKernelContext__InputType(this, index); }
+  MLDataType InputType(int index) const { return Provider_GetHost()->OpKernelContext__InputType(this, index); }
 
   template <typename T>
   T* Output(int index);
 
-  Tensor* Output(int index, const TensorShape& shape) { return g_host->OpKernelContext__Output(this, index, shape); }
+  Tensor* Output(int index, const TensorShape& shape) { return Provider_GetHost()->OpKernelContext__Output(this, index, shape); }
 #if !defined(DISABLE_SPARSE_TENSORS)
-  SparseTensor* OutputSparse(int index, const TensorShape& shape) { return g_host->OpKernelContext__OutputSparse(this, index, shape); }
+  SparseTensor* OutputSparse(int index, const TensorShape& shape) { return Provider_GetHost()->OpKernelContext__OutputSparse(this, index, shape); }
 #endif
-  int OutputCount() const { return g_host->OpKernelContext__OutputCount(this); }
+  int OutputCount() const { return Provider_GetHost()->OpKernelContext__OutputCount(this); }
 
-  Status GetTempSpaceAllocator(AllocatorPtr* output) const { return g_host->OpKernelContext__GetTempSpaceAllocator(this, output); }
+  Status GetTempSpaceAllocator(AllocatorPtr* output) const { return Provider_GetHost()->OpKernelContext__GetTempSpaceAllocator(this, output); }
 
-  Status GetTempSpaceCPUAllocator(AllocatorPtr* output) const { return g_host->OpKernelContext__GetTempSpaceCPUAllocator(this, output); }
+  Status GetTempSpaceCPUAllocator(AllocatorPtr* output) const { return Provider_GetHost()->OpKernelContext__GetTempSpaceCPUAllocator(this, output); }
 
-  bool GetUseDeterministicCompute() const { return g_host->OpKernelContext__GetUseDeterministicCompute(this); }
+  bool GetUseDeterministicCompute() const { return Provider_GetHost()->OpKernelContext__GetUseDeterministicCompute(this); }
 
-  bool TryGetInferredOutputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredOutputShape(this, index, shape); }
-  bool TryGetInferredInputShape(int index, TensorShape& shape) const { return g_host->OpKernelContext__TryGetInferredInputShape(this, index, shape); }
-  Stream* GetComputeStream() const { return g_host->OpKernelContext__GetComputeStream(this); }
+  bool TryGetInferredOutputShape(int index, TensorShape& shape) const { return Provider_GetHost()->OpKernelContext__TryGetInferredOutputShape(this, index, shape); }
+  bool TryGetInferredInputShape(int index, TensorShape& shape) const { return Provider_GetHost()->OpKernelContext__TryGetInferredInputShape(this, index, shape); }
+  Stream* GetComputeStream() const { return Provider_GetHost()->OpKernelContext__GetComputeStream(this); }
 
   PROVIDER_DISALLOW_ALL(OpKernelContext)
 };
 
 template <>
 inline const Tensor* OpKernelContext::Input<Tensor>(int index) const {
-  return g_host->OpKernelContext__Input_Tensor(this, index);
+  return Provider_GetHost()->OpKernelContext__Input_Tensor(this, index);
 }
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 template <>
 inline const SparseTensor* OpKernelContext::Input<SparseTensor>(int index) const {
-  return g_host->OpKernelContext__Input_SparseTensor(this, index);
+  return Provider_GetHost()->OpKernelContext__Input_SparseTensor(this, index);
 }
 #endif
 
 template <>
 inline const TensorSeq* OpKernelContext::Input<TensorSeq>(int index) const {
-  return g_host->OpKernelContext__Input_TensorSeq(this, index);
+  return Provider_GetHost()->OpKernelContext__Input_TensorSeq(this, index);
 }
 
 template <>
 inline Tensor* OpKernelContext::Output<Tensor>(int index) {
-  return g_host->OpKernelContext__Output_Tensor(this, index);
+  return Provider_GetHost()->OpKernelContext__Output_Tensor(this, index);
 }
 
 template <>
 inline TensorSeq* OpKernelContext::Output<TensorSeq>(int index) {
-  return g_host->OpKernelContext__Output_TensorSeq(this, index);
+  return Provider_GetHost()->OpKernelContext__Output_TensorSeq(this, index);
 }
 
 template <>
 inline const Tensor& OpKernelContext::RequiredInput(int index) const {
-  return g_host->OpKernelContext__RequiredInput_Tensor(this, index);
+  return Provider_GetHost()->OpKernelContext__RequiredInput_Tensor(this, index);
 }
 
 struct OpKernelInfo final {
-  static void operator delete(void* p) { g_host->OpKernelInfo__operator_delete(reinterpret_cast<OpKernelInfo*>(p)); }
+  static void operator delete(void* p) { Provider_GetHost()->OpKernelInfo__operator_delete(reinterpret_cast<OpKernelInfo*>(p)); }
 
-  AllocatorPtr GetAllocator(OrtMemType mem_type) const { return g_host->OpKernelInfo__GetAllocator(this, mem_type); }
+  AllocatorPtr GetAllocator(OrtMemType mem_type) const { return Provider_GetHost()->OpKernelInfo__GetAllocator(this, mem_type); }
 
-  const IExecutionProvider* GetExecutionProvider() const noexcept { return g_host->OpKernelInfo__GetExecutionProvider(this); }
+  const IExecutionProvider* GetExecutionProvider() const noexcept { return Provider_GetHost()->OpKernelInfo__GetExecutionProvider(this); }
 
   template <typename T>
   Status GetAttr(const std::string& name, T* value) const;
@@ -855,15 +854,15 @@ struct OpKernelInfo final {
 
   TensorShapeVector GetAttrsOrDefault(const std::string& name, const TensorShapeVector& default_value = TensorShapeVector{}) const;
 
-  bool TryGetConstantInput(int input_index, const Tensor** constant_input_value) const { return g_host->OpKernelInfo__TryGetConstantInput(this, input_index, constant_input_value); }
+  bool TryGetConstantInput(int input_index, const Tensor** constant_input_value) const { return Provider_GetHost()->OpKernelInfo__TryGetConstantInput(this, input_index, constant_input_value); }
 
-  const DataTransferManager& GetDataTransferManager() const noexcept { return g_host->OpKernelInfo__GetDataTransferManager(this); }
-  const KernelDef& GetKernelDef() const { return g_host->OpKernelInfo__GetKernelDef(this); }
+  const DataTransferManager& GetDataTransferManager() const noexcept { return Provider_GetHost()->OpKernelInfo__GetDataTransferManager(this); }
+  const KernelDef& GetKernelDef() const { return Provider_GetHost()->OpKernelInfo__GetKernelDef(this); }
 
-  uint32_t GetInputCount() const { return g_host->OpKernelInfo__GetInputCount(this); }
-  uint32_t GetOutputCount() const { return g_host->OpKernelInfo__GetOutputCount(this); }
+  uint32_t GetInputCount() const { return Provider_GetHost()->OpKernelInfo__GetInputCount(this); }
+  uint32_t GetOutputCount() const { return Provider_GetHost()->OpKernelInfo__GetOutputCount(this); }
 
-  const Node& node() const noexcept { return g_host->OpKernelInfo__node(this); }
+  const Node& node() const noexcept { return Provider_GetHost()->OpKernelInfo__node(this); }
 
   OpKernelInfo() = delete;
   OpKernelInfo(const OpKernelInfo&) = delete;
@@ -871,21 +870,21 @@ struct OpKernelInfo final {
 };
 
 template <>
-inline Status OpKernelInfo::GetAttr<int64_t>(const std::string& name, int64_t* value) const { return g_host->OpKernelInfo__GetAttr_int64(this, name, value); }
+inline Status OpKernelInfo::GetAttr<int64_t>(const std::string& name, int64_t* value) const { return Provider_GetHost()->OpKernelInfo__GetAttr_int64(this, name, value); }
 template <>
-inline Status OpKernelInfo::GetAttr<float>(const std::string& name, float* value) const { return g_host->OpKernelInfo__GetAttr_float(this, name, value); }
+inline Status OpKernelInfo::GetAttr<float>(const std::string& name, float* value) const { return Provider_GetHost()->OpKernelInfo__GetAttr_float(this, name, value); }
 template <>
-inline Status OpKernelInfo::GetAttr<std::string>(const std::string& name, std::string* value) const { return g_host->OpKernelInfo__GetAttr_string(this, name, value); }
+inline Status OpKernelInfo::GetAttr<std::string>(const std::string& name, std::string* value) const { return Provider_GetHost()->OpKernelInfo__GetAttr_string(this, name, value); }
 template <>
-inline Status OpKernelInfo::GetAttr<ONNX_NAMESPACE::TensorProto>(const std::string& name, ONNX_NAMESPACE::TensorProto* value) const { return g_host->OpKernelInfo__GetAttr_TensorProto(this, name, value); }
+inline Status OpKernelInfo::GetAttr<ONNX_NAMESPACE::TensorProto>(const std::string& name, ONNX_NAMESPACE::TensorProto* value) const { return Provider_GetHost()->OpKernelInfo__GetAttr_TensorProto(this, name, value); }
 template <>
-inline Status OpKernelInfo::GetAttrs<int64_t>(const std::string& name, std::vector<int64_t>& values) const { return g_host->OpKernelInfo__GetAttrs(this, name, values); }
+inline Status OpKernelInfo::GetAttrs<int64_t>(const std::string& name, std::vector<int64_t>& values) const { return Provider_GetHost()->OpKernelInfo__GetAttrs(this, name, values); }
 template <>
-inline Status OpKernelInfo::GetAttrs<float>(const std::string& name, std::vector<float>& values) const { return g_host->OpKernelInfo__GetAttrs(this, name, values); }
+inline Status OpKernelInfo::GetAttrs<float>(const std::string& name, std::vector<float>& values) const { return Provider_GetHost()->OpKernelInfo__GetAttrs(this, name, values); }
 template <>
-inline Status OpKernelInfo::GetAttrs<std::string>(const std::string& name, std::vector<std::string>& values) const { return g_host->OpKernelInfo__GetAttrs(this, name, values); }
+inline Status OpKernelInfo::GetAttrs<std::string>(const std::string& name, std::vector<std::string>& values) const { return Provider_GetHost()->OpKernelInfo__GetAttrs(this, name, values); }
 template <>
-inline Status OpKernelInfo::GetAttrsAsSpan<int64_t>(const std::string& name, gsl::span<const int64_t>& values) const { return g_host->OpKernelInfo__GetAttrsAsSpan(this, name, values); }
+inline Status OpKernelInfo::GetAttrsAsSpan<int64_t>(const std::string& name, gsl::span<const int64_t>& values) const { return Provider_GetHost()->OpKernelInfo__GetAttrsAsSpan(this, name, values); }
 
 inline Status OpKernelInfo::GetAttrs(const std::string& name, TensorShapeVector& out) const {
   gsl::span<const int64_t> span;
@@ -904,24 +903,24 @@ inline TensorShapeVector OpKernelInfo::GetAttrsOrDefault(const std::string& name
 
 class SessionState {
  public:
-  const DataTransferManager& GetDataTransferMgr() const noexcept { return g_host->SessionState__GetDataTransferMgr(this); }
+  const DataTransferManager& GetDataTransferMgr() const noexcept { return Provider_GetHost()->SessionState__GetDataTransferMgr(this); }
 
   PROVIDER_DISALLOW_ALL(SessionState)
 };
 
 struct Tensor final {
-  static std::unique_ptr<Tensor> CreateDefault() { return g_host->Tensor__construct_default(); }
-  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) { return g_host->Tensor__construct(p_type, shape, std::move(allocator)); }
-  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset = 0) { return g_host->Tensor__construct(p_type, shape, p_data, alloc, offset); }
+  static std::unique_ptr<Tensor> CreateDefault() { return Provider_GetHost()->Tensor__construct_default(); }
+  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator) { return Provider_GetHost()->Tensor__construct(p_type, shape, std::move(allocator)); }
+  static std::unique_ptr<Tensor> Create(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& alloc, ptrdiff_t offset = 0) { return Provider_GetHost()->Tensor__construct(p_type, shape, p_data, alloc, offset); }
 
-  static void operator delete(void* p) noexcept { g_host->Tensor__operator_delete(reinterpret_cast<Tensor*>(p)); }
+  static void operator delete(void* p) noexcept { Provider_GetHost()->Tensor__operator_delete(reinterpret_cast<Tensor*>(p)); }
 
   static void InitOrtValue(MLDataType elt_type, const TensorShape& shape, std::shared_ptr<IAllocator> allocator, OrtValue& ort_value) {
-    g_host->Tensor__InitOrtValue(elt_type, shape, std::move(allocator), ort_value);
+    Provider_GetHost()->Tensor__InitOrtValue(elt_type, shape, std::move(allocator), ort_value);
   }
 
   static void InitOrtValue(MLDataType p_type, const TensorShape& shape, void* p_data, const OrtMemoryInfo& location, OrtValue& ort_value) {
-    g_host->Tensor__InitOrtValue(p_type, shape, p_data, location, ort_value);
+    Provider_GetHost()->Tensor__InitOrtValue(p_type, shape, p_data, location, ort_value);
   }
 
   template <typename T>
@@ -933,28 +932,28 @@ struct Tensor final {
   template <typename T>
   gsl::span<const T> DataAsSpan() const;
 
-  void* MutableDataRaw(MLDataType type) { return g_host->Tensor__MutableDataRaw(this, type); }
-  const void* DataRaw(MLDataType type) const { return g_host->Tensor__DataRaw(this, type); }
+  void* MutableDataRaw(MLDataType type) { return Provider_GetHost()->Tensor__MutableDataRaw(this, type); }
+  const void* DataRaw(MLDataType type) const { return Provider_GetHost()->Tensor__DataRaw(this, type); }
 
-  void* MutableDataRaw() noexcept { return g_host->Tensor__MutableDataRaw(this); }
-  const void* DataRaw() const noexcept { return g_host->Tensor__DataRaw(this); }
+  void* MutableDataRaw() noexcept { return Provider_GetHost()->Tensor__MutableDataRaw(this); }
+  const void* DataRaw() const noexcept { return Provider_GetHost()->Tensor__DataRaw(this); }
 
-  const TensorShape& Shape() const { return g_host->Tensor__Shape(this); }
-  void Reshape(const TensorShape& new_shape) { g_host->Tensor__Reshape(this, new_shape); }
-  void SetByteOffset(ptrdiff_t byte_offset) { return g_host->Tensor__SetByteOffset(this, byte_offset); }
-  ptrdiff_t ByteOffset() const { return g_host->Tensor__ByteOffset(this); }
-  size_t SizeInBytes() const { return g_host->Tensor__SizeInBytes(this); }
-  const OrtMemoryInfo& Location() const { return g_host->Tensor__Location(this); }
+  const TensorShape& Shape() const { return Provider_GetHost()->Tensor__Shape(this); }
+  void Reshape(const TensorShape& new_shape) { Provider_GetHost()->Tensor__Reshape(this, new_shape); }
+  void SetByteOffset(ptrdiff_t byte_offset) { return Provider_GetHost()->Tensor__SetByteOffset(this, byte_offset); }
+  ptrdiff_t ByteOffset() const { return Provider_GetHost()->Tensor__ByteOffset(this); }
+  size_t SizeInBytes() const { return Provider_GetHost()->Tensor__SizeInBytes(this); }
+  const OrtMemoryInfo& Location() const { return Provider_GetHost()->Tensor__Location(this); }
 
-  int32_t GetElementType() const { return g_host->Tensor__GetElementType(this); }
-  MLDataType DataType() const { return g_host->Tensor__DataType(this); }
-  bool IsDataTypeString() const { return g_host->Tensor__IsDataTypeString(this); }
+  int32_t GetElementType() const { return Provider_GetHost()->Tensor__GetElementType(this); }
+  MLDataType DataType() const { return Provider_GetHost()->Tensor__DataType(this); }
+  bool IsDataTypeString() const { return Provider_GetHost()->Tensor__IsDataTypeString(this); }
 
 #ifdef ENABLE_STRIDED_TENSORS
-  gsl::span<const int64_t> Strides() const noexcept { return g_host->Tensor__Strides(this); }
-  bool IsContiguous() const { return g_host->Tensor__IsContiguous(this); }
+  gsl::span<const int64_t> Strides() const noexcept { return Provider_GetHost()->Tensor__Strides(this); }
+  bool IsContiguous() const { return Provider_GetHost()->Tensor__IsContiguous(this); }
   void SetShapeAndStrides(const TensorShape& new_shape, gsl::span<const int64_t> new_strides) {
-    return g_host->Tensor__SetShapeAndStrides(this, new_shape, new_strides);
+    return Provider_GetHost()->Tensor__SetShapeAndStrides(this, new_shape, new_strides);
   }
 #endif
 
@@ -965,115 +964,115 @@ struct Tensor final {
   Tensor(const Tensor&) = delete;
   void operator=(const Tensor&) = delete;
   Tensor& operator=(Tensor&& o) noexcept {
-    g_host->Tensor__move_assign(*this, std::move(o));
+    Provider_GetHost()->Tensor__move_assign(*this, std::move(o));
     return *this;
   }
 };
 
 template <>
-inline bool Tensor::IsDataType<bool>() const { return g_host->Tensor__IsDataType_bool(this); }
+inline bool Tensor::IsDataType<bool>() const { return Provider_GetHost()->Tensor__IsDataType_bool(this); }
 template <>
-inline bool Tensor::IsDataType<int8_t>() const { return g_host->Tensor__IsDataType_int8(this); }
+inline bool Tensor::IsDataType<int8_t>() const { return Provider_GetHost()->Tensor__IsDataType_int8(this); }
 template <>
-inline bool Tensor::IsDataType<uint8_t>() const { return g_host->Tensor__IsDataType_uint8(this); }
+inline bool Tensor::IsDataType<uint8_t>() const { return Provider_GetHost()->Tensor__IsDataType_uint8(this); }
 template <>
-inline bool Tensor::IsDataType<int16_t>() const { return g_host->Tensor__IsDataType_int16(this); }
+inline bool Tensor::IsDataType<int16_t>() const { return Provider_GetHost()->Tensor__IsDataType_int16(this); }
 template <>
-inline bool Tensor::IsDataType<uint16_t>() const { return g_host->Tensor__IsDataType_uint16(this); }
+inline bool Tensor::IsDataType<uint16_t>() const { return Provider_GetHost()->Tensor__IsDataType_uint16(this); }
 template <>
-inline bool Tensor::IsDataType<int32_t>() const { return g_host->Tensor__IsDataType_int32(this); }
+inline bool Tensor::IsDataType<int32_t>() const { return Provider_GetHost()->Tensor__IsDataType_int32(this); }
 template <>
-inline bool Tensor::IsDataType<uint32_t>() const { return g_host->Tensor__IsDataType_uint32(this); }
+inline bool Tensor::IsDataType<uint32_t>() const { return Provider_GetHost()->Tensor__IsDataType_uint32(this); }
 template <>
-inline bool Tensor::IsDataType<int64_t>() const { return g_host->Tensor__IsDataType_int64(this); }
+inline bool Tensor::IsDataType<int64_t>() const { return Provider_GetHost()->Tensor__IsDataType_int64(this); }
 template <>
-inline bool Tensor::IsDataType<uint64_t>() const { return g_host->Tensor__IsDataType_uint64(this); }
+inline bool Tensor::IsDataType<uint64_t>() const { return Provider_GetHost()->Tensor__IsDataType_uint64(this); }
 template <>
-inline bool Tensor::IsDataType<float>() const { return g_host->Tensor__IsDataType_float(this); }
+inline bool Tensor::IsDataType<float>() const { return Provider_GetHost()->Tensor__IsDataType_float(this); }
 template <>
-inline bool Tensor::IsDataType<double>() const { return g_host->Tensor__IsDataType_double(this); }
+inline bool Tensor::IsDataType<double>() const { return Provider_GetHost()->Tensor__IsDataType_double(this); }
 template <>
-inline bool Tensor::IsDataType<MLFloat16>() const { return g_host->Tensor__IsDataType_MLFloat16(this); }
+inline bool Tensor::IsDataType<MLFloat16>() const { return Provider_GetHost()->Tensor__IsDataType_MLFloat16(this); }
 template <>
-inline bool Tensor::IsDataType<BFloat16>() const { return g_host->Tensor__IsDataType_BFloat16(this); }
+inline bool Tensor::IsDataType<BFloat16>() const { return Provider_GetHost()->Tensor__IsDataType_BFloat16(this); }
 
 template <>
-inline bool* Tensor::MutableData<bool>() { return g_host->Tensor__MutableData_bool(this); }
+inline bool* Tensor::MutableData<bool>() { return Provider_GetHost()->Tensor__MutableData_bool(this); }
 template <>
-inline int8_t* Tensor::MutableData<int8_t>() { return g_host->Tensor__MutableData_int8(this); }
+inline int8_t* Tensor::MutableData<int8_t>() { return Provider_GetHost()->Tensor__MutableData_int8(this); }
 template <>
-inline uint8_t* Tensor::MutableData<uint8_t>() { return g_host->Tensor__MutableData_uint8(this); }
+inline uint8_t* Tensor::MutableData<uint8_t>() { return Provider_GetHost()->Tensor__MutableData_uint8(this); }
 template <>
-inline int16_t* Tensor::MutableData<int16_t>() { return g_host->Tensor__MutableData_int16(this); }
+inline int16_t* Tensor::MutableData<int16_t>() { return Provider_GetHost()->Tensor__MutableData_int16(this); }
 template <>
-inline uint16_t* Tensor::MutableData<uint16_t>() { return g_host->Tensor__MutableData_uint16(this); }
+inline uint16_t* Tensor::MutableData<uint16_t>() { return Provider_GetHost()->Tensor__MutableData_uint16(this); }
 template <>
-inline int32_t* Tensor::MutableData<int32_t>() { return g_host->Tensor__MutableData_int32(this); }
+inline int32_t* Tensor::MutableData<int32_t>() { return Provider_GetHost()->Tensor__MutableData_int32(this); }
 template <>
-inline uint32_t* Tensor::MutableData<uint32_t>() { return g_host->Tensor__MutableData_uint32(this); }
+inline uint32_t* Tensor::MutableData<uint32_t>() { return Provider_GetHost()->Tensor__MutableData_uint32(this); }
 template <>
-inline int64_t* Tensor::MutableData<int64_t>() { return g_host->Tensor__MutableData_int64(this); }
+inline int64_t* Tensor::MutableData<int64_t>() { return Provider_GetHost()->Tensor__MutableData_int64(this); }
 template <>
-inline uint64_t* Tensor::MutableData<uint64_t>() { return g_host->Tensor__MutableData_uint64(this); }
+inline uint64_t* Tensor::MutableData<uint64_t>() { return Provider_GetHost()->Tensor__MutableData_uint64(this); }
 template <>
-inline float* Tensor::MutableData<float>() { return g_host->Tensor__MutableData_float(this); }
+inline float* Tensor::MutableData<float>() { return Provider_GetHost()->Tensor__MutableData_float(this); }
 template <>
-inline double* Tensor::MutableData<double>() { return g_host->Tensor__MutableData_double(this); }
+inline double* Tensor::MutableData<double>() { return Provider_GetHost()->Tensor__MutableData_double(this); }
 template <>
-inline BFloat16* Tensor::MutableData<BFloat16>() { return g_host->Tensor__MutableData_BFloat16(this); }
+inline BFloat16* Tensor::MutableData<BFloat16>() { return Provider_GetHost()->Tensor__MutableData_BFloat16(this); }
 template <>
-inline MLFloat16* Tensor::MutableData<MLFloat16>() { return g_host->Tensor__MutableData_MLFloat16(this); }
+inline MLFloat16* Tensor::MutableData<MLFloat16>() { return Provider_GetHost()->Tensor__MutableData_MLFloat16(this); }
 
 template <>
-inline const bool* Tensor::Data<bool>() const { return g_host->Tensor__Data_bool(this); }
+inline const bool* Tensor::Data<bool>() const { return Provider_GetHost()->Tensor__Data_bool(this); }
 template <>
-inline const int8_t* Tensor::Data<int8_t>() const { return g_host->Tensor__Data_int8(this); }
+inline const int8_t* Tensor::Data<int8_t>() const { return Provider_GetHost()->Tensor__Data_int8(this); }
 template <>
-inline const uint8_t* Tensor::Data<uint8_t>() const { return g_host->Tensor__Data_uint8(this); }
+inline const uint8_t* Tensor::Data<uint8_t>() const { return Provider_GetHost()->Tensor__Data_uint8(this); }
 template <>
-inline const int16_t* Tensor::Data<int16_t>() const { return g_host->Tensor__Data_int16(this); }
+inline const int16_t* Tensor::Data<int16_t>() const { return Provider_GetHost()->Tensor__Data_int16(this); }
 template <>
-inline const uint16_t* Tensor::Data<uint16_t>() const { return g_host->Tensor__Data_uint16(this); }
+inline const uint16_t* Tensor::Data<uint16_t>() const { return Provider_GetHost()->Tensor__Data_uint16(this); }
 template <>
-inline const int32_t* Tensor::Data<int32_t>() const { return g_host->Tensor__Data_int32(this); }
+inline const int32_t* Tensor::Data<int32_t>() const { return Provider_GetHost()->Tensor__Data_int32(this); }
 template <>
-inline const uint32_t* Tensor::Data<uint32_t>() const { return g_host->Tensor__Data_uint32(this); }
+inline const uint32_t* Tensor::Data<uint32_t>() const { return Provider_GetHost()->Tensor__Data_uint32(this); }
 template <>
-inline const int64_t* Tensor::Data<int64_t>() const { return g_host->Tensor__Data_int64(this); }
+inline const int64_t* Tensor::Data<int64_t>() const { return Provider_GetHost()->Tensor__Data_int64(this); }
 template <>
-inline const uint64_t* Tensor::Data<uint64_t>() const { return g_host->Tensor__Data_uint64(this); }
+inline const uint64_t* Tensor::Data<uint64_t>() const { return Provider_GetHost()->Tensor__Data_uint64(this); }
 template <>
-inline const float* Tensor::Data<float>() const { return g_host->Tensor__Data_float(this); }
+inline const float* Tensor::Data<float>() const { return Provider_GetHost()->Tensor__Data_float(this); }
 template <>
-inline const double* Tensor::Data<double>() const { return g_host->Tensor__Data_double(this); }
+inline const double* Tensor::Data<double>() const { return Provider_GetHost()->Tensor__Data_double(this); }
 template <>
-inline const BFloat16* Tensor::Data<BFloat16>() const { return g_host->Tensor__Data_BFloat16(this); }
+inline const BFloat16* Tensor::Data<BFloat16>() const { return Provider_GetHost()->Tensor__Data_BFloat16(this); }
 template <>
-inline const MLFloat16* Tensor::Data<MLFloat16>() const { return g_host->Tensor__Data_MLFloat16(this); }
+inline const MLFloat16* Tensor::Data<MLFloat16>() const { return Provider_GetHost()->Tensor__Data_MLFloat16(this); }
 
 // SparseTensor
 #if !defined(DISABLE_SPARSE_TENSORS)
 struct SparseTensor final {
-  const TensorShape& DenseShape() const noexcept { return g_host->SparseTensor__DenseShape(this); }
-  Status Copy(const DataTransferManager& dtm, SparseTensor& dst) const { return g_host->SparseTensor__Copy(this, dtm, dst); }
+  const TensorShape& DenseShape() const noexcept { return Provider_GetHost()->SparseTensor__DenseShape(this); }
+  Status Copy(const DataTransferManager& dtm, SparseTensor& dst) const { return Provider_GetHost()->SparseTensor__Copy(this, dtm, dst); }
 };
 #endif
 
 // TensorSeq
 class TensorSeq final {
 public:
-  MLDataType DataType() const noexcept { return g_host->TensorSeq__DataType(this); }
-  void SetType(MLDataType elem_type) { g_host->TensorSeq__SetType(this, elem_type); }
-  size_t Size() const noexcept { return g_host->TensorSeq__Size(this); }
-  const Tensor& Get(size_t i) const { return g_host->TensorSeq__Get(this, i); }
-  const OrtValue& GetAt(size_t i) const { return g_host->TensorSeq__GetAt(this, i); }
-  void Add(const OrtValue& tensor) { g_host->TensorSeq__Add(this, tensor); }
-  void Add(OrtValue&& tensor) { g_host->TensorSeq__Add(this, std::move(tensor)); }
-  void Add(Tensor&& tensor) { g_host->TensorSeq__Add(this, std::move(tensor)); }
-  void Reserve(size_t capacity) { g_host->TensorSeq__Reserve(this, capacity); }
+  MLDataType DataType() const noexcept { return Provider_GetHost()->TensorSeq__DataType(this); }
+  void SetType(MLDataType elem_type) { Provider_GetHost()->TensorSeq__SetType(this, elem_type); }
+  size_t Size() const noexcept { return Provider_GetHost()->TensorSeq__Size(this); }
+  const Tensor& Get(size_t i) const { return Provider_GetHost()->TensorSeq__Get(this, i); }
+  const OrtValue& GetAt(size_t i) const { return Provider_GetHost()->TensorSeq__GetAt(this, i); }
+  void Add(const OrtValue& tensor) { Provider_GetHost()->TensorSeq__Add(this, tensor); }
+  void Add(OrtValue&& tensor) { Provider_GetHost()->TensorSeq__Add(this, std::move(tensor)); }
+  void Add(Tensor&& tensor) { Provider_GetHost()->TensorSeq__Add(this, std::move(tensor)); }
+  void Reserve(size_t capacity) { Provider_GetHost()->TensorSeq__Reserve(this, capacity); }
 };
 
 template <>
-inline gsl::span<const int64_t> Tensor::DataAsSpan() const { return g_host->Tensor__DataAsSpan_int64(this); }
+inline gsl::span<const int64_t> Tensor::DataAsSpan() const { return Provider_GetHost()->Tensor__DataAsSpan_int64(this); }
 
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

Call Provider_GetHost() directly without caching it in global variable.


### Motivation and Context
When we link onnxruntime_provider_cuda statically, using global singleton causes initialization order fiasco / dereferencing null-pointer.

This happens because there is no more guarantree that this statement

```
ProviderHost* g_host = Provider_GetHost();
```

will be executed before any of the numerous methods provided by `onnxruntime/core/providers/shared_library`.

This PR resolves the issue without breaking anything.
Related to #14986.


