### PR TITLE
Petermca/whisper dedup

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -5,6 +5,7 @@ from onnx import TensorProto, helper, GraphProto, ModelProto, TensorProto
 from transformers import WhisperConfig
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from onnx_model import OnnxModel  # noqa: E402
+from convert_generation import get_shared_initializers, remove_shared_initializers
 
 def add_attention_mask(model):
     # Add attention mask - required by BeamSearch but unused in Pytorch
@@ -12,113 +13,6 @@ def add_attention_mask(model):
         "encoder_attention_mask", TensorProto.INT32, shape=["batch", "feature_size", "sequence"]
     )
     model.graph.input.insert(1, mask)
-
-
-def get_shared_initializers(encoder_model: ModelProto, decoder_model: ModelProto):
-    encoder = OnnxModel(encoder_model)
-    decoder = OnnxModel(decoder_model)
-    encoder.add_prefix_to_names("e_")
-    decoder.add_prefix_to_names("d_")
-    encoder.remove_duplicated_initializer()
-    decoder.remove_duplicated_initializer()
-    initializers = remove_shared_initializers(encoder.model.graph, decoder.model.graph, "s_")
-    return initializers
-
-def remove_shared_initializers(
-    graph1: GraphProto,
-    graph2: GraphProto,
-    shared_prefix: str = "shared_",
-    min_elements: int = 1024,
-):
-    """Remove initializers with same value from two graphs.
-    Args:
-        graph1 (GraphProto): the first graph to process
-        graph2 (GraphProto): the second graph to process
-        shared_prefix (str): add prefix to the shared initializers among two graphs
-        min_elements (int, optional): minimal number of elements for initializers to be considered. Defaults to 1024.
-    """
-
-    mapping_initializers_1 = {}
-    mapping_initializers_2 = {}
-    shared_initializers_1 = []
-    shared_initializers_2 = []
-    shared_initializers_names = []
-
-    for initializer1 in graph1.initializer:
-        if not (initializer1.dims and sum(initializer1.dims) >= min_elements):
-            continue
-
-        for initializer2 in graph2.initializer:
-            if not (initializer2.dims and sum(initializer2.dims) >= min_elements):
-                continue
-
-            if OnnxModel.has_same_value(initializer1, initializer2):
-                mapping_initializers_1[initializer1.name] = shared_prefix + initializer2.name
-                shared_initializers_1.append(initializer1)
-
-                if initializer2.name not in mapping_initializers_2:
-                    shared_name = shared_prefix + initializer2.name
-                    mapping_initializers_2[initializer2.name] = shared_name
-                    shared_initializers_2.append(initializer2)
-                    shared_initializers_names.append(shared_name)
-                break
-
-    # Make sure new name does not exist in graph 1
-    for node in graph1.node:
-        for j in range(len(node.input)):
-            if node.input[j] in shared_initializers_names:
-                raise RuntimeError(f"name is found in graph 1: {node.input[j]}")
-
-    # Make sure new name does not exist in graph 2
-    for node in graph2.node:
-        for j in range(len(node.input)):
-            if node.input[j] in shared_initializers_names:
-                raise RuntimeError(f"name is found in graph 2: {node.input[j]}")
-
-    # Remove shared initializers from graph 2
-    for initializer in shared_initializers_2:
-        graph2.initializer.remove(initializer)
-
-    # Rename value info for old names in graph 2
-    for value_info in graph2.value_info:
-        if value_info.name in mapping_initializers_2:
-            value_info.name = mapping_initializers_2[value_info.name]
-
-    # Rename nodes inputs in graph 2:
-    for node in graph2.node:
-        for j in range(len(node.input)):
-            if node.input[j] in mapping_initializers_2:
-                new_name = mapping_initializers_2[node.input[j]]
-                node.input[j] = new_name
-
-    #  Remove shared initializers from graph 1
-    for initializer in shared_initializers_1:
-        graph1.initializer.remove(initializer)
-
-    # Rename value info for old names in graph 1
-    for value_info in graph1.value_info:
-        if value_info.name in mapping_initializers_1:
-            value_info.name = mapping_initializers_1[value_info.name]
-
-    # Rename nodes inputs in graph 1:
-    for node in graph1.node:
-        for j in range(len(node.input)):
-            if node.input[j] in mapping_initializers_1:
-                new_name = mapping_initializers_1[node.input[j]]
-                node.input[j] = new_name
-
-    # Rename shared initializers in graph 2
-    for initializer in shared_initializers_2:
-        initializer.name = mapping_initializers_2[initializer.name]
-
-    for initializer in shared_initializers_2:
-        shape = onnx.numpy_helper.to_array(initializer).shape
-        value_info = onnx.helper.make_tensor_value_info(initializer.name, initializer.data_type, shape)
-        # Need add value_info for initializers moved to parent graph. Otherwise, ORT will fail.
-        graph1.value_info.append(value_info)
-        graph2.value_info.append(value_info)
-
-    return shared_initializers_2
 
 def chain_model(args):
     # Load encoder/decoder and insert necessary (but unused) graph inputs expected by BeamSearch op

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -5,7 +5,7 @@ from onnx import TensorProto, helper, GraphProto, ModelProto, TensorProto
 from transformers import WhisperConfig
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from onnx_model import OnnxModel  # noqa: E402
-from convert_generation import get_shared_initializers, remove_shared_initializers
+from convert_generation import get_shared_initializers
 
 def add_attention_mask(model):
     # Add attention mask - required by BeamSearch but unused in Pytorch

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -1,7 +1,10 @@
 import onnx
-from onnx import TensorProto, helper
+import sys
+import os
+from onnx import TensorProto, helper, GraphProto, ModelProto, TensorProto
 from transformers import WhisperConfig
-
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from onnx_model import OnnxModel  # noqa: E402
 
 def add_attention_mask(model):
     # Add attention mask - required by BeamSearch but unused in Pytorch
@@ -11,13 +14,119 @@ def add_attention_mask(model):
     model.graph.input.insert(1, mask)
 
 
+def get_shared_initializers(encoder_model: ModelProto, decoder_model: ModelProto):
+    encoder = OnnxModel(encoder_model)
+    decoder = OnnxModel(decoder_model)
+    encoder.add_prefix_to_names("e_")
+    decoder.add_prefix_to_names("d_")
+    encoder.remove_duplicated_initializer()
+    decoder.remove_duplicated_initializer()
+    initializers = remove_shared_initializers(encoder.model.graph, decoder.model.graph, "s_")
+    return initializers
+
+def remove_shared_initializers(
+    graph1: GraphProto,
+    graph2: GraphProto,
+    shared_prefix: str = "shared_",
+    min_elements: int = 1024,
+):
+    """Remove initializers with same value from two graphs.
+    Args:
+        graph1 (GraphProto): the first graph to process
+        graph2 (GraphProto): the second graph to process
+        shared_prefix (str): add prefix to the shared initializers among two graphs
+        min_elements (int, optional): minimal number of elements for initializers to be considered. Defaults to 1024.
+    """
+
+    mapping_initializers_1 = {}
+    mapping_initializers_2 = {}
+    shared_initializers_1 = []
+    shared_initializers_2 = []
+    shared_initializers_names = []
+
+    for initializer1 in graph1.initializer:
+        if not (initializer1.dims and sum(initializer1.dims) >= min_elements):
+            continue
+
+        for initializer2 in graph2.initializer:
+            if not (initializer2.dims and sum(initializer2.dims) >= min_elements):
+                continue
+
+            if OnnxModel.has_same_value(initializer1, initializer2):
+                mapping_initializers_1[initializer1.name] = shared_prefix + initializer2.name
+                shared_initializers_1.append(initializer1)
+
+                if initializer2.name not in mapping_initializers_2:
+                    shared_name = shared_prefix + initializer2.name
+                    mapping_initializers_2[initializer2.name] = shared_name
+                    shared_initializers_2.append(initializer2)
+                    shared_initializers_names.append(shared_name)
+                break
+
+    # Make sure new name does not exist in graph 1
+    for node in graph1.node:
+        for j in range(len(node.input)):
+            if node.input[j] in shared_initializers_names:
+                raise RuntimeError(f"name is found in graph 1: {node.input[j]}")
+
+    # Make sure new name does not exist in graph 2
+    for node in graph2.node:
+        for j in range(len(node.input)):
+            if node.input[j] in shared_initializers_names:
+                raise RuntimeError(f"name is found in graph 2: {node.input[j]}")
+
+    # Remove shared initializers from graph 2
+    for initializer in shared_initializers_2:
+        graph2.initializer.remove(initializer)
+
+    # Rename value info for old names in graph 2
+    for value_info in graph2.value_info:
+        if value_info.name in mapping_initializers_2:
+            value_info.name = mapping_initializers_2[value_info.name]
+
+    # Rename nodes inputs in graph 2:
+    for node in graph2.node:
+        for j in range(len(node.input)):
+            if node.input[j] in mapping_initializers_2:
+                new_name = mapping_initializers_2[node.input[j]]
+                node.input[j] = new_name
+
+    #  Remove shared initializers from graph 1
+    for initializer in shared_initializers_1:
+        graph1.initializer.remove(initializer)
+
+    # Rename value info for old names in graph 1
+    for value_info in graph1.value_info:
+        if value_info.name in mapping_initializers_1:
+            value_info.name = mapping_initializers_1[value_info.name]
+
+    # Rename nodes inputs in graph 1:
+    for node in graph1.node:
+        for j in range(len(node.input)):
+            if node.input[j] in mapping_initializers_1:
+                new_name = mapping_initializers_1[node.input[j]]
+                node.input[j] = new_name
+
+    # Rename shared initializers in graph 2
+    for initializer in shared_initializers_2:
+        initializer.name = mapping_initializers_2[initializer.name]
+
+    for initializer in shared_initializers_2:
+        shape = onnx.numpy_helper.to_array(initializer).shape
+        value_info = onnx.helper.make_tensor_value_info(initializer.name, initializer.data_type, shape)
+        # Need add value_info for initializers moved to parent graph. Otherwise, ORT will fail.
+        graph1.value_info.append(value_info)
+        graph2.value_info.append(value_info)
+
+    return shared_initializers_2
+
 def chain_model(args):
     # Load encoder/decoder and insert necessary (but unused) graph inputs expected by BeamSearch op
-    encoder_model = onnx.load(args.encoder_path, load_external_data=True)
+    encoder_model = onnx.load_model(args.encoder_path, load_external_data=True)
     encoder_model.graph.name = "encoderdecoderinit subgraph"
     add_attention_mask(encoder_model)
 
-    decoder_model = onnx.load(args.decoder_path, load_external_data=True)
+    decoder_model = onnx.load_model(args.decoder_path, load_external_data=True)
     decoder_model.graph.name = "decoder subgraph"
     add_attention_mask(decoder_model)
 
@@ -48,8 +157,6 @@ def chain_model(args):
             helper.make_attribute("no_repeat_ngram_size", args.no_repeat_ngram_size),
             helper.make_attribute("early_stopping", True),
             helper.make_attribute("model_type", 2),
-            helper.make_attribute("decoder", decoder_model.graph),
-            helper.make_attribute("encoder", encoder_model.graph),
         ]
     )
 
@@ -85,7 +192,14 @@ def chain_model(args):
     graph_outputs = [sequences]
 
     # Initializers/opsets
-    initializers = []
+    # Delete shared data between decoder/encoder and move to larger graph initializers
+    initializers = get_shared_initializers(encoder_model, decoder_model)
+    node.attribute.extend(
+        [
+            helper.make_attribute("decoder", decoder_model.graph),
+            helper.make_attribute("encoder", encoder_model.graph),
+        ]
+    )
     opset_import = [helper.make_opsetid(domain="com.microsoft", version=1), helper.make_opsetid(domain="", version=17)]
 
     beam_graph = helper.make_graph([node], "beam-search-test", graph_inputs, graph_outputs, initializers)

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -1,10 +1,13 @@
-import onnx
-import sys
 import os
+import sys
+
+import onnx
 from onnx import TensorProto, helper
 from transformers import WhisperConfig
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-from convert_generation import get_shared_initializers
+from convert_generation import get_shared_initializers  # noqa: E402
+
 
 def add_attention_mask(model):
     # Add attention mask - required by BeamSearch but unused in Pytorch
@@ -12,6 +15,7 @@ def add_attention_mask(model):
         "encoder_attention_mask", TensorProto.INT32, shape=["batch", "feature_size", "sequence"]
     )
     model.graph.input.insert(1, mask)
+
 
 def chain_model(args):
     # Load encoder/decoder and insert necessary (but unused) graph inputs expected by BeamSearch op

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -1,10 +1,9 @@
 import onnx
 import sys
 import os
-from onnx import TensorProto, helper, GraphProto, ModelProto, TensorProto
+from onnx import TensorProto, helper
 from transformers import WhisperConfig
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-from onnx_model import OnnxModel  # noqa: E402
 from convert_generation import get_shared_initializers
 
 def add_attention_mask(model):


### PR DESCRIPTION
### Description
Apply `get_shared_initializers()` to the encoder and decoder subgraphs of Whisper before chaining and exporting the full, final model.


### Motivation and Context
The Whisper export process has some overlap between the encoder and decoder subgraphs due to the format of the BeamSearch contrib op. Consequently, there is some shared model data that is duplicated in the final exported product, which can result in a file size increase of ~40%. This PR takes the methods in `convert_generation.py` and applies them during the whisper export process.


