### PR TITLE
XNNPack: allow users to choose whether enable CPU MEM arena or not

### DIFF
--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -123,9 +123,10 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 using namespace xnnpack;
 
 XnnpackExecutionProvider::XnnpackExecutionProvider(const XnnpackExecutionProviderInfo& info)
-    : IExecutionProvider{kXnnpackExecutionProvider, true} {
+    : IExecutionProvider{kXnnpackExecutionProvider, true}, enable_cpu_mem_arena_(info.session_options ? info.session_options->enable_cpu_mem_arena : false) {
   int xnn_thread_pool_size = info.xnn_thread_pool_size;
   int ort_thread_pool_size = info.session_options ? info.session_options->intra_op_param.thread_pool_size : 1;
+
   bool allow_intra_op_spinning = (info.session_options == nullptr) ||
                                  (info.session_options &&
                                   info.session_options->config_options.GetConfigOrDefault(
@@ -170,7 +171,8 @@ void XnnpackExecutionProvider::RegisterAllocator(AllocatorManager& allocator_man
             // lazy create the allocator
             return std::make_unique<CPUAllocator>(OrtMemoryInfo(kXnnpackExecutionProvider,
                                                                 OrtAllocatorType::OrtDeviceAllocator));
-          });
+          },
+          cpu_device.Id(), enable_cpu_mem_arena_);
       // only the first time we create the allocator do we pass in the xnn_allocator
       cpu_alloc = stored_allocator ? stored_allocator : CreateAllocator(allocator_info);
       // enable sharing of our allocator

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -123,7 +123,8 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 using namespace xnnpack;
 
 XnnpackExecutionProvider::XnnpackExecutionProvider(const XnnpackExecutionProviderInfo& info)
-    : IExecutionProvider{kXnnpackExecutionProvider, true}, enable_cpu_mem_arena_(info.session_options ? info.session_options->enable_cpu_mem_arena : true) {
+    : IExecutionProvider{kXnnpackExecutionProvider, true},
+      enable_cpu_mem_arena_(info.session_options ? info.session_options->enable_cpu_mem_arena : true) {
   int xnn_thread_pool_size = info.xnn_thread_pool_size;
   int ort_thread_pool_size = info.session_options ? info.session_options->intra_op_param.thread_pool_size : 1;
   bool allow_intra_op_spinning = (info.session_options == nullptr) ||

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -123,10 +123,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 using namespace xnnpack;
 
 XnnpackExecutionProvider::XnnpackExecutionProvider(const XnnpackExecutionProviderInfo& info)
-    : IExecutionProvider{kXnnpackExecutionProvider, true}, enable_cpu_mem_arena_(info.session_options ? info.session_options->enable_cpu_mem_arena : false) {
+    : IExecutionProvider{kXnnpackExecutionProvider, true}, enable_cpu_mem_arena_(info.session_options ? info.session_options->enable_cpu_mem_arena : true) {
   int xnn_thread_pool_size = info.xnn_thread_pool_size;
   int ort_thread_pool_size = info.session_options ? info.session_options->intra_op_param.thread_pool_size : 1;
-
   bool allow_intra_op_spinning = (info.session_options == nullptr) ||
                                  (info.session_options &&
                                   info.session_options->config_options.GetConfigOrDefault(

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.h
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.h
@@ -52,6 +52,7 @@ class XnnpackExecutionProvider : public IExecutionProvider {
 
  private:
   pthreadpool* xnnpack_thread_pool_{nullptr};
+  const bool enable_cpu_mem_arena_ = false;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.h
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.h
@@ -52,7 +52,7 @@ class XnnpackExecutionProvider : public IExecutionProvider {
 
  private:
   pthreadpool* xnnpack_thread_pool_{nullptr};
-  const bool enable_cpu_mem_arena_ = false;
+  const bool enable_cpu_mem_arena_;
 };
 
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
XNNPack: allow users to choose whether enable CPU MEM arena or not. Right now it is hardcoded to true and it is not impacted by the on/off switch in SessionOption. We should make it work.

### Motivation and Context
As we have such a switch in SessionOption, it should work as expected.