### PR TITLE
Download protoc.exe from nuget when cross-compiling

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GoogleTestAdapter" version="0.17.1" targetFramework="net46" />
   <package id="Microsoft.AI.DirectML" version="1.10.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.201201.7" targetFramework="native" />
+  <package id="google.protobuf.tools" version="3.21.12" targetFramework="native" />
 </packages>

--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -29,7 +29,7 @@ jobs:
   variables:
     EnvSetupScript: setup_env.bat
     buildArch: x64
-    CommonBuildArgs: '--parallel --config ${{ parameters.BuildConfig }} --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wasm --use_xnnpack --emsdk_version releases-29ad1037cd6b99e5d8a1bd75bc188c1e9a6fda8d-64bit ${{ parameters.ExtraBuildArgs }} --path_to_protoc_exe $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed\bin\protoc.exe'
+    CommonBuildArgs: '--parallel --config ${{ parameters.BuildConfig }} --skip_submodule_sync --cmake_generator "Visual Studio 16 2019" --build_wasm --use_xnnpack --emsdk_version releases-29ad1037cd6b99e5d8a1bd75bc188c1e9a6fda8d-64bit ${{ parameters.ExtraBuildArgs }}'
     runCodesignValidationInjection: false
   timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
   workspace:
@@ -72,13 +72,6 @@ jobs:
      python -m pip install -q setuptools wheel numpy ninja
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'Install python modules'
-
-  - task: PowerShell@2
-    displayName: 'Install ONNX'
-    inputs:
-      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_protoc.ps1'
-      workingDirectory: '$(Build.BinariesDirectory)'
-      arguments: -cpu_arch x64 -install_prefix $(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\installed -build_config ${{ parameters.BuildConfig }}
 
   - task: PythonScript@0
     displayName: 'Build and test (node)'

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -44,18 +44,11 @@ jobs:
       addToPath: true
       architecture: $(buildArch)
      
-  - task: PowerShell@2
-    displayName: 'Install Protoc for ARM64'
-    inputs:
-      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/windows/install_protoc.ps1'
-      workingDirectory: '$(Build.BinariesDirectory)'
-      arguments: -cpu_arch arm64 -install_prefix $(Build.BinariesDirectory)\$(BuildConfig)\installed -build_config $(BuildConfig)
-
   - task: PythonScript@0
     displayName: 'Generate cmake config'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--arm64 --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --cmake_generator "Visual Studio 16 2019" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel --path_to_protoc_exe $(Build.BinariesDirectory)\$(BuildConfig)\installed\bin\protoc'
+      arguments: '--arm64 --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --cmake_generator "Visual Studio 16 2019" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: 'Generate cmake config'
     inputs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--arm64 --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --cmake_generator "Visual Studio 16 2019" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel
+      arguments: '--arm64 --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --cmake_generator "Visual Studio 16 2019" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel'
       workingDirectory: '$(Build.BinariesDirectory)'
 
   - task: VSBuild@1

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -43,6 +43,10 @@ jobs:
       versionSpec: '3.x'
       addToPath: true
       architecture: $(buildArch)
+
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: 6.4.x
      
   - task: PythonScript@0
     displayName: 'Generate cmake config'


### PR DESCRIPTION
### Description
1. The protoc package on nuget.org contains binaries for Windows_x86/Windows_x64/Linux_x86/Linux_x64/MacOS_x64, which can cover most use cases. Though it doesn't have binaries for AMR64, they are only needed when we cross-compile for Intel CPUs on ARM CPUs. It is rare. When you have such a need, you always can build protoc from source by yourself and pass it to build.py as "--path_to_protoc_exe".  Or if you have security concerns that you don't want to use prebuilt binaries from outside, you can do the same thing.

2. Remove GoogleTestAdapter related thing. That part of code is out of maintain.
### Motivation and Context
Because I deleted the cmake/external/protobuf folder in PR #15190. 
