### PR TITLE
[DONT REVIEW] create stream id with thread info to fix thread safe bug 15154

### DIFF
--- a/include/onnxruntime/core/framework/stream_handles.h
+++ b/include/onnxruntime/core/framework/stream_handles.h
@@ -31,7 +31,7 @@ class Stream {
   Stream(StreamHandle h, const OrtDevice& d, bool set_id_with_thread_info = false) : handle_(h), device_(d) {
     if (set_id_with_thread_info) {
       std::random_device rd;
-      std::mt19937 gen(rd() + std::hash<std::thread::id>{}(std::this_thread::get_id()));
+      std::mt19937 gen(static_cast<uint32_t>(rd() + std::hash<std::thread::id>{}(std::this_thread::get_id())));
       std::uniform_int_distribution<> distrib(0, INT_MAX);
       id_ = distrib(gen);
     } else {

--- a/onnxruntime/core/framework/bfc_arena.h
+++ b/onnxruntime/core/framework/bfc_arena.h
@@ -101,6 +101,11 @@ class BFCArena : public IAllocator {
 
   ArenaType GetArenaType() const { return arena_type_; }
 
+  // Secure the allocated chunk on the target stream
+  virtual void SecureTheChunk(Stream* /*chunk_stream*/,
+                              Stream* /*target_stream*/,
+                              WaitNotificationFn /*wait_fn*/) const {}
+
  protected:
   void* AllocateRawInternal(size_t num_bytes,
                             bool dump_log_on_failure,
@@ -112,11 +117,6 @@ class BFCArena : public IAllocator {
   // perform coalesce if coalesce_flag is true
   void ResetChunkOnTargetStream(Stream* target_stream, bool coalesce_flag);
   #endif
-  // Secure the allocated chunk on the target stream
-  virtual void SecureTheChunk(Stream* /*chunk_stream*/,
-                              Stream* /*target_stream*/,
-                              WaitNotificationFn /*wait_fn*/) const {}
-
   ArenaType arena_type_;
 
  private:
@@ -536,7 +536,6 @@ class StreamAwareArena : public BFCArena {
     return arena.GetArenaType() == ArenaType::StreamAwareArena ? reinterpret_cast<StreamAwareArena*>(&arena) : nullptr;
   }
 
- protected:
   virtual void SecureTheChunk(Stream* chunk_stream, Stream* target_stream, WaitNotificationFn wait_fn) const override;
 
  private:

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -427,6 +427,7 @@ ExecutionFrame::ExecutionFrame(gsl::span<const int> feed_mlvalue_idxs, gsl::span
               static_activation_memory_sizes_in_byte_[location.name] = peak_size;
 #endif
               // the memory pattern buffer will leave in the whole execution.
+#ifdef ORT_ENABLE_STREAM
               StreamAwareArena* stream_aware_alloc = AsStreamBasedAllocator(alloc);
               if (stream_aware_alloc) {
                 mem_pattern_stream_ = std::make_unique<Stream>(nullptr, OrtDevice(), true);
@@ -437,6 +438,9 @@ ExecutionFrame::ExecutionFrame(gsl::span<const int> feed_mlvalue_idxs, gsl::span
               } else {
                 buffer = alloc->Alloc(peak_size);
               }
+#else
+              buffer = alloc->Alloc(peak_size);
+#endif
               // handle allocator that doesn't throw
               if (buffer == nullptr) {
                 // INFO level as this may fire on every run and there may not be much a user can do

--- a/onnxruntime/core/framework/execution_frame.h
+++ b/onnxruntime/core/framework/execution_frame.h
@@ -239,6 +239,8 @@ class ExecutionFrame final : public IExecutionFrame {
 
   gsl::span<Stream*> device_streams_;
 
+  std::unique_ptr<Stream> mem_pattern_stream_;
+
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
   // Size of virtual memory allocated before any kernel execution.
   // This field is not physical memory size.

--- a/onnxruntime/test/framework/bfc_arena_test.cc
+++ b/onnxruntime/test/framework/bfc_arena_test.cc
@@ -399,10 +399,10 @@ TEST(StreamAwareArenaTest, TestSecureTheChunk) {
   a.Free(p1);
 
   bool waitFunctionInvoked = false;
-  void* p2 = a.AllocOnStream(BFCArena::DEFAULT_INITIAL_CHUNK_SIZE_BYTES, &stream2, 
+  void* p2 = a.AllocOnStream(BFCArena::DEFAULT_INITIAL_CHUNK_SIZE_BYTES, &stream2,
       [&waitFunctionInvoked](Stream&, synchronize::Notification&) { waitFunctionInvoked = true; });
 
-  std::unordered_map<Stream*, uint64_t> syncTable;
+  std::unordered_map<size_t, uint64_t> syncTable;
   stream2.CloneCurrentStreamSyncTable(syncTable);
   EXPECT_EQ(syncTable.size(), 1u) << "stream2 has been updated with stream1's nofitication on the clock";
   EXPECT_TRUE(waitFunctionInvoked) << "wait function should be invoked";


### PR DESCRIPTION
### Description
Introduce id in Stream class and initialize it with thread info which will be used in StreamAwareArena to fix the thread safe issue


### Motivation and Context
This is to fix the bug 15154 https://github.com/microsoft/onnxruntime/issues/15154

