### PR TITLE
[QNN EP]fix bug in DlError

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -32,7 +32,7 @@ class QnnBackendManager {
   ~QnnBackendManager();
   char* DlError() {
 #ifdef _WIN32
-    return nullptr;
+    return "";
 #else
     return ::dlerror();
 #endif


### PR DESCRIPTION
### Description
fix bug in DlError. nullptr returned from  DlError() will cause crash.


