### PR TITLE
Use fixed version of Android NDK in binary size checks pipeline.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-binary-size-check-stage.yml
@@ -37,6 +37,8 @@ stages:
       clean: true
       submodules: none
 
+    - template: use-android-ndk.yml
+
     - template: get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cpu


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use fixed version of Android NDK in binary size checks pipeline.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Ensure that we build with a known version of NDK and are not surprised when the default version on the build machine changes.

A similar change was made for other Android build pipelines previously, but this one was missed.