### PR TITLE
Support additional op domains in op reduction script.

### DIFF
--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -157,6 +157,7 @@ Status RegisterNchwcKernels(KernelRegistry& kernel_registry) {
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
 Status RegisterFp16Kernels(KernelRegistry& kernel_registry) {
   static const BuildKernelCreateInfoFn function_table[] = {
+      BuildKernelCreateInfo<void>,  // default entry to avoid the list become empty after ops-reducing
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, NhwcFusedConv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, MaxPool)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSInternalNHWCDomain, 11, MLFloat16, AveragePool)>,

--- a/tools/ci_build/op_registration_utils.py
+++ b/tools/ci_build/op_registration_utils.py
@@ -31,6 +31,7 @@ def map_ort_constant_to_domain(ort_constant_name: str, allow_unknown_constant: b
         "kMSDomain": "com.microsoft",
         "kMSExperimentalDomain": "com.microsoft.experimental",
         "kMSNchwcDomain": "com.microsoft.nchwc",
+        "kMSInternalNHWCDomain": "com.ms.internal.nhwc",
         "kMSDmlDomain": "com.microsoft.dml",
         "kNGraphDomain": "com.intel.ai",
         "kVitisAIDomain": "com.xilinx",

--- a/tools/ci_build/op_registration_utils.py
+++ b/tools/ci_build/op_registration_utils.py
@@ -29,6 +29,7 @@ def map_ort_constant_to_domain(ort_constant_name: str, allow_unknown_constant: b
         "kOnnxDomain": "ai.onnx",
         "kMLDomain": "ai.onnx.ml",
         "kMSDomain": "com.microsoft",
+        "kPytorchAtenDomain": "org.pytorch.aten",
         "kMSExperimentalDomain": "com.microsoft.experimental",
         "kMSNchwcDomain": "com.microsoft.nchwc",
         "kMSInternalNHWCDomain": "com.ms.internal.nhwc",

--- a/tools/ci_build/reduce_op_kernels.py
+++ b/tools/ci_build/reduce_op_kernels.py
@@ -146,7 +146,7 @@ class _ExcludingRegistrationProcessor(op_registration_utils.RegistrationProcesso
         )
 
         # convert from the ORT constant name to the domain string used in the config
-        domain = op_registration_utils.map_ort_constant_to_domain(constant_for_domain)
+        domain = op_registration_utils.map_ort_constant_to_domain(constant_for_domain, allow_unknown_constant=False)
 
         exclude = False
         reason = ""


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add support for kMSInternalNHWCDomain and kPytorchAtenDomain op domains to op reduction script.
Make it an error if the op reduction script encounters unknown op domains.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Enable op reduction support for additional op domains.