### PR TITLE
[wasm] optimize default session options parsing

### DIFF
--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -81,66 +81,39 @@ export const setSessionOptions = (options?: InferenceSession.SessionOptions): [n
   appendDefaultOptions(sessionOptions);
 
   try {
-    if (options?.graphOptimizationLevel === undefined) {
-      sessionOptions.graphOptimizationLevel = 'all';
-    }
-    const graphOptimizationLevel = getGraphOptimzationLevel(sessionOptions.graphOptimizationLevel!);
+    const graphOptimizationLevel = getGraphOptimzationLevel(sessionOptions.graphOptimizationLevel ?? 'all');
+    const executionMode = getExecutionMode(sessionOptions.executionMode ?? 'sequential');
+    const logIdDataOffset =
+        typeof sessionOptions.logId === 'string' ? allocWasmString(sessionOptions.logId, allocs) : 0;
 
-    if (options?.enableCpuMemArena === undefined) {
-      sessionOptions.enableCpuMemArena = true;
-    }
-
-    if (options?.enableMemPattern === undefined) {
-      sessionOptions.enableMemPattern = true;
+    const logSeverityLevel = sessionOptions.logSeverityLevel ?? 2;  // Default to 2 - warning
+    if (!Number.isInteger(logSeverityLevel) || logSeverityLevel < 0 || logSeverityLevel > 4) {
+      throw new Error(`log serverity level is not valid: ${logSeverityLevel}`);
     }
 
-    if (options?.executionMode === undefined) {
-      sessionOptions.executionMode = 'sequential';
-    }
-    const executionMode = getExecutionMode(sessionOptions.executionMode!);
-
-    let logIdDataOffset = 0;
-    if (options?.logId !== undefined) {
-      logIdDataOffset = allocWasmString(options.logId, allocs);
+    const logVerbosityLevel = sessionOptions.logVerbosityLevel ?? 0;  // Default to 0 - verbose
+    if (!Number.isInteger(logVerbosityLevel) || logVerbosityLevel < 0 || logVerbosityLevel > 4) {
+      throw new Error(`log verbosity level is not valid: ${logVerbosityLevel}`);
     }
 
-    if (options?.logSeverityLevel === undefined) {
-      sessionOptions.logSeverityLevel = 2;  // Default to warning
-    } else if (
-        typeof options.logSeverityLevel !== 'number' || !Number.isInteger(options.logSeverityLevel) ||
-        options.logSeverityLevel < 0 || options.logSeverityLevel > 4) {
-      throw new Error(`log serverity level is not valid: ${options.logSeverityLevel}`);
-    }
-
-    if (options?.logVerbosityLevel === undefined) {
-      sessionOptions.logVerbosityLevel = 0;  // Default to 0
-    } else if (typeof options.logVerbosityLevel !== 'number' || !Number.isInteger(options.logVerbosityLevel)) {
-      throw new Error(`log verbosity level is not valid: ${options.logVerbosityLevel}`);
-    }
-
-    if (options?.enableProfiling === undefined) {
-      sessionOptions.enableProfiling = false;
-    }
-
-    let optimizedModelFilePathOffset = 0;
-    if (typeof options?.optimizedModelFilePath === 'string') {
-      optimizedModelFilePathOffset = allocWasmString(options.optimizedModelFilePath, allocs);
-    }
+    const optimizedModelFilePathOffset = typeof sessionOptions.optimizedModelFilePath === 'string' ?
+        allocWasmString(sessionOptions.optimizedModelFilePath, allocs) :
+        0;
 
     sessionOptionsHandle = wasm._OrtCreateSessionOptions(
-        graphOptimizationLevel, !!sessionOptions.enableCpuMemArena!, !!sessionOptions.enableMemPattern!, executionMode,
-        !!sessionOptions.enableProfiling!, 0, logIdDataOffset, sessionOptions.logSeverityLevel!,
-        sessionOptions.logVerbosityLevel!, optimizedModelFilePathOffset);
+        graphOptimizationLevel, !!sessionOptions.enableCpuMemArena, !!sessionOptions.enableMemPattern, executionMode,
+        !!sessionOptions.enableProfiling, 0, logIdDataOffset, logSeverityLevel, logVerbosityLevel,
+        optimizedModelFilePathOffset);
     if (sessionOptionsHandle === 0) {
       throw new Error('Can\'t create session options');
     }
 
-    if (options?.executionProviders) {
-      setExecutionProviders(sessionOptionsHandle, options.executionProviders, allocs);
+    if (sessionOptions.executionProviders) {
+      setExecutionProviders(sessionOptionsHandle, sessionOptions.executionProviders, allocs);
     }
 
-    if (options?.extra !== undefined) {
-      iterateExtraOptions(options.extra, '', new WeakSet<Record<string, unknown>>(), (key, value) => {
+    if (sessionOptions.extra !== undefined) {
+      iterateExtraOptions(sessionOptions.extra, '', new WeakSet<Record<string, unknown>>(), (key, value) => {
         const keyDataOffset = allocWasmString(key, allocs);
         const valueDataOffset = allocWasmString(value, allocs);
 

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -56,7 +56,9 @@ export const createSessionFinalize =
         }
       } finally {
         wasm._free(modelData[0]);
-        wasm._OrtReleaseSessionOptions(sessionOptionsHandle);
+        if (sessionOptionsHandle !== 0) {
+          wasm._OrtReleaseSessionOptions(sessionOptionsHandle);
+        }
         allocs.forEach(wasm._free);
       }
 


### PR DESCRIPTION
### Description
optimize default session options parsing.
- do minimal property assignment to the passed in `options` object.
- modify default value of `enableCpuMemArena` and `enableMemPattern` to `false`. We don't get benefits from enabling these 2 flags in web assembly