### PR TITLE
Update pytorch_cpuinfo dependency to 6481e8

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -352,7 +352,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "5916273f79a21551890fd3d56fc5375a78d1598d",
+          "commitHash": "6481e8bef08f606ddd627e4d3be89f64d62e1b8a",
           "repositoryUrl": "https://github.com/pytorch/cpuinfo.git"
         },
         "comments": "pytorch_cpuinfo"

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -30,7 +30,7 @@ protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zi
 psimd;https://github.com/Maratyszcza/psimd/archive/072586a71b55b7f8c584153d223e95687148a900.zip;1f5454b01f06f9656b77e4a5e2e31d7422487013
 pthreadpool;https://github.com/Maratyszcza/pthreadpool/archive/1787867f6183f056420e532eec640cba25efafea.zip;e43e80781560c5ab404a4da20f34d846f5f5d101
 pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.zip;769b6aa67a77f17a770960f604b727645b6f6a13
-pytorch_cpuinfo;https://github.com/pytorch/cpuinfo/archive/5916273f79a21551890fd3d56fc5375a78d1598d.zip;2be4d2ae321fada97cb39eaf4eeba5f8c85597cf
+pytorch_cpuinfo;https://github.com/pytorch/cpuinfo/archive/6481e8bef08f606ddd627e4d3be89f64d62e1b8a.zip;5f917e91a8c3a6def4811dccd2044edd80ec5c2d
 re2;https://github.com/google/re2/archive/refs/tags/2022-06-01.zip;aa77313b76e91b531ee7f3e45f004c6a502a5374
 safeint;https://github.com/dcleblanc/SafeInt/archive/ff15c6ada150a5018c5ef2172401cb4529eac9c0.zip;913a4046e5274d329af2806cb53194f617d8c0ab
 tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -363,12 +363,6 @@ FetchContent_Declare(
 
 if (CPUINFO_SUPPORTED)
   onnxruntime_fetchcontent_makeavailable(pytorch_cpuinfo)
-  if (pytorch_cpuinfo_SOURCE_DIR)
-    # shouldn't need to define these aliases after we use a version of cpuinfo with this commit:
-    # https://github.com/pytorch/cpuinfo/commit/082deffc80ce517f81dc2f3aebe6ba671fcd09c9
-    add_library(cpuinfo::cpuinfo ALIAS cpuinfo)
-    add_library(cpuinfo::clog ALIAS clog)
-  endif()
 endif()
 
 


### PR DESCRIPTION
### Description
Update pytorch_cpuinfo dependency to 6481e8
This is the latest commit compatible with xnnpack (which depends on clog which is removed from pytorch_cpuinfo after this commit) without further changes in the build system

### Motivation and Context
Keep up-to-date dependencies


