### PR TITLE
[ROCm] disable composable_kernel and kernel explorer for MIGraphX CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
@@ -49,6 +49,8 @@ jobs:
               --config Release \
               --cmake_extra_defines \
                 CMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+                onnxruntime_BUILD_KERNEL_EXPLORER=OFF \
+                onnxruntime_USE_COMPOSABLE_KERNEL=OFF \
               --mpi_home /opt/ompi \
               --use_migraphx \
               --rocm_version=$(RocmVersion) \


### PR DESCRIPTION
Disable composable_kernel and kernel explorer for MIGraphx CI to save build time. 
Composable_kernel and kernel explorer are tested on ROCm CI.


