### PR TITLE
Remove codecov from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 black>=22.3
 cerberus
-codecov
 flatbuffers
 isort
 jinja2


### PR DESCRIPTION
### Motivation and Context
It is no longer supported, and we don't really use it.


