### PR TITLE
[AMX] Update assembler check

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -17,6 +17,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GRE
     if (_gas_version MATCHES "GNU.[Aa]ssembler.*(2\\.[4-9][0-9])")
         set(MLAS_AMX_SUPPORTED TRUE)
     endif()
+  elseif (CMAKE_ASM_COMPILER_ID STREQUAL "GNU")
+    set(MLAS_AMX_SUPPORTED TRUE)
   endif()
 endif()
 

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -7,18 +7,16 @@ set(MLAS_SRC_DIR ${ONNXRUNTIME_ROOT}/core/mlas/lib)
 set(MLAS_AMX_SUPPORTED FALSE)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
-  # match assembler version, AMX instructions are supported from 2.40
-  if (CMAKE_ASM-ATT_COMPILER_ID STREQUAL "GNU")
+  # match assembler version, AMX instructions are supported from 2.38
+  if (CMAKE_ASM_COMPILER_ID STREQUAL "GNU")
     execute_process(
-        COMMAND ${CMAKE_ASM-ATT_COMPILER} --version
-        OUTPUT_VARIABLE _gas_version
+        COMMAND as --version
+        OUTPUT_VARIABLE _as_version
     )
-    # 2.40 or later
-    if (_gas_version MATCHES "GNU.[Aa]ssembler.*(2\\.[4-9][0-9])")
+    # 2.38 or later
+    if (_as_version MATCHES "GNU.[Aa]ssembler.*(2\\.38|2\\.39|2\\.[4-9][0-9]|[3-9]\\.[0-9][0-9])")
         set(MLAS_AMX_SUPPORTED TRUE)
     endif()
-  elseif (CMAKE_ASM_COMPILER_ID STREQUAL "GNU")
-    set(MLAS_AMX_SUPPORTED TRUE)
   endif()
 endif()
 


### PR DESCRIPTION
A recent commit added an assembler check if the ASM dialect was ATT

This unfortunately broke the AMX build for systems that don't have the ASM-ATT dialect.

This change assumes if the CMAKE_ASM-ATT_COMPILER_ID is not found and the CMAKE_ASM_COMPILER_ID is "GNU" based on all the other already passed checks AMX is supported by the compiler and assembler.

### Description




### Motivation and Context
On my build system the recent change to add the ASM-ATT version check disabled AMX code from the build.


