### PR TITLE
Implement two easier random tensor generator (RTG) for flaky tests

### DIFF
--- a/onnxruntime/test/common/random_generator_test.cc
+++ b/onnxruntime/test/common/random_generator_test.cc
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/common/tensor_op_test_utils.h"
+#include<vector>
+
+namespace onnxruntime {
+namespace test {
+
+TEST(RandomTensorGenerator, DiscreteFloat) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {2, 3};
+  std::vector<float> data = random.Discrete<float>(shape, {-1.f, 0.f, 1.f});
+
+  ASSERT_EQ(data.size(), 6);
+  for (float value : data) {
+    EXPECT_TRUE(value == -1.f || value == 0.f || value == 1.f);
+  }
+}
+
+TEST(RandomTensorGenerator, DiscreteInt) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {2, 3};
+  std::vector<int> data = random.Discrete<int>(shape, {-1, 0, 1});
+
+  ASSERT_EQ(data.size(), 6);
+  for (int value : data) {
+    EXPECT_TRUE(value == -1 || value == 0 || value == 1);
+  }
+}
+
+TEST(RandomTensorGenerator, DiscreteBool) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {2, 3};
+  std::vector<bool> data = random.Discrete<bool>(shape, {false, true});
+
+  ASSERT_EQ(data.size(), 6);
+  for (bool value : data) {
+    EXPECT_TRUE(value == false || value == true);
+  }
+}
+
+// Tests for Circular
+TEST(RandomTensorGenerator, CircularFloat) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {3, 2};
+  std::vector<float> data = random.Circular<float>(shape, {-1.f, 0.f, 1.f});
+
+  ASSERT_EQ(data.size(), 6);
+  EXPECT_EQ(data[0], -1.f);
+  EXPECT_EQ(data[1], 0.f);
+  EXPECT_EQ(data[2], 1.f);
+  EXPECT_EQ(data[3], -1.f);
+  EXPECT_EQ(data[4], 0.f);
+  EXPECT_EQ(data[5], 1.f);
+}
+
+TEST(RandomTensorGenerator, CircularInt) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {3, 2};
+  std::vector<int> data = random.Circular<int>(shape, {-1, 0, 1});
+
+  ASSERT_EQ(data.size(), 6);
+  EXPECT_EQ(data[0], -1);
+  EXPECT_EQ(data[1], 0);
+  EXPECT_EQ(data[2], 1);
+  EXPECT_EQ(data[3], -1);
+  EXPECT_EQ(data[4], 0);
+  EXPECT_EQ(data[5], 1);
+}
+
+TEST(RandomTensorGenerator, CircularBool) {
+  RandomValueGenerator random{};
+  const std::vector<int64_t> shape = {3, 2};
+  std::vector<bool> data = random.Circular<bool>(shape, {false, true});
+
+  ASSERT_EQ(data.size(), 6);
+  EXPECT_EQ(data[0], false);
+  EXPECT_EQ(data[1], true);
+  EXPECT_EQ(data[2], false);
+  EXPECT_EQ(data[3], true);
+  EXPECT_EQ(data[4], false);
+  EXPECT_EQ(data[5], true);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/common/random_generator_test.cc
+++ b/onnxruntime/test/common/random_generator_test.cc
@@ -30,17 +30,6 @@ TEST(RandomTensorGenerator, DiscreteInt) {
   }
 }
 
-TEST(RandomTensorGenerator, DiscreteBool) {
-  RandomValueGenerator random{};
-  const std::vector<int64_t> shape = {2, 3};
-  std::vector<bool> data = random.Discrete<bool>(shape, {false, true});
-
-  ASSERT_EQ(data.size(), 6);
-  for (bool value : data) {
-    EXPECT_TRUE(value == false || value == true);
-  }
-}
-
 // Tests for Circular
 TEST(RandomTensorGenerator, CircularFloat) {
   RandomValueGenerator random{};

--- a/onnxruntime/test/common/random_generator_test.cc
+++ b/onnxruntime/test/common/random_generator_test.cc
@@ -13,7 +13,7 @@ TEST(RandomTensorGenerator, DiscreteFloat) {
   const std::vector<int64_t> shape = {2, 3};
   std::vector<float> data = random.Discrete<float>(shape, {-1.f, 0.f, 1.f});
 
-  ASSERT_EQ(data.size(), 6);
+  ASSERT_EQ(data.size(), static_cast<size_t>(6));
   for (float value : data) {
     EXPECT_TRUE(value == -1.f || value == 0.f || value == 1.f);
   }
@@ -24,7 +24,7 @@ TEST(RandomTensorGenerator, DiscreteInt) {
   const std::vector<int64_t> shape = {2, 3};
   std::vector<int> data = random.Discrete<int>(shape, {-1, 0, 1});
 
-  ASSERT_EQ(data.size(), 6);
+  ASSERT_EQ(data.size(), static_cast<size_t>(6));
   for (int value : data) {
     EXPECT_TRUE(value == -1 || value == 0 || value == 1);
   }
@@ -36,7 +36,7 @@ TEST(RandomTensorGenerator, CircularFloat) {
   const std::vector<int64_t> shape = {3, 2};
   std::vector<float> data = random.Circular<float>(shape, {-1.f, 0.f, 1.f});
 
-  ASSERT_EQ(data.size(), 6);
+  ASSERT_EQ(data.size(), static_cast<size_t>(6));
   EXPECT_EQ(data[0], -1.f);
   EXPECT_EQ(data[1], 0.f);
   EXPECT_EQ(data[2], 1.f);
@@ -50,7 +50,7 @@ TEST(RandomTensorGenerator, CircularInt) {
   const std::vector<int64_t> shape = {3, 2};
   std::vector<int> data = random.Circular<int>(shape, {-1, 0, 1});
 
-  ASSERT_EQ(data.size(), 6);
+  ASSERT_EQ(data.size(), static_cast<size_t>(6));
   EXPECT_EQ(data[0], -1);
   EXPECT_EQ(data[1], 0);
   EXPECT_EQ(data[2], 1);
@@ -64,7 +64,7 @@ TEST(RandomTensorGenerator, CircularBool) {
   const std::vector<int64_t> shape = {3, 2};
   std::vector<bool> data = random.Circular<bool>(shape, {false, true});
 
-  ASSERT_EQ(data.size(), 6);
+  ASSERT_EQ(data.size(), static_cast<size_t>(6));
   EXPECT_EQ(data[0], false);
   EXPECT_EQ(data[1], true);
   EXPECT_EQ(data[2], false);

--- a/onnxruntime/test/common/random_generator_test.cc
+++ b/onnxruntime/test/common/random_generator_test.cc
@@ -3,13 +3,13 @@
 
 #include "gtest/gtest.h"
 #include "test/common/tensor_op_test_utils.h"
-#include<vector>
+#include <vector>
 
 namespace onnxruntime {
 namespace test {
 
-TEST(RandomTensorGenerator, DiscreteFloat) {
-  RandomValueGenerator random{};
+TEST(TensorGenerator, DiscreteFloat) {
+  FixedPatternValueGenerator random{};
   const std::vector<int64_t> shape = {2, 3};
   std::vector<float> data = random.Discrete<float>(shape, {-1.f, 0.f, 1.f});
 
@@ -19,8 +19,8 @@ TEST(RandomTensorGenerator, DiscreteFloat) {
   }
 }
 
-TEST(RandomTensorGenerator, DiscreteInt) {
-  RandomValueGenerator random{};
+TEST(TensorGenerator, DiscreteInt) {
+  FixedPatternValueGenerator random{};
   const std::vector<int64_t> shape = {2, 3};
   std::vector<int> data = random.Discrete<int>(shape, {-1, 0, 1});
 
@@ -31,8 +31,8 @@ TEST(RandomTensorGenerator, DiscreteInt) {
 }
 
 // Tests for Circular
-TEST(RandomTensorGenerator, CircularFloat) {
-  RandomValueGenerator random{};
+TEST(TensorGenerator, CircularFloat) {
+  FixedPatternValueGenerator random{};
   const std::vector<int64_t> shape = {3, 2};
   std::vector<float> data = random.Circular<float>(shape, {-1.f, 0.f, 1.f});
 
@@ -45,8 +45,8 @@ TEST(RandomTensorGenerator, CircularFloat) {
   EXPECT_EQ(data[5], 1.f);
 }
 
-TEST(RandomTensorGenerator, CircularInt) {
-  RandomValueGenerator random{};
+TEST(TensorGenerator, CircularInt) {
+  FixedPatternValueGenerator random{};
   const std::vector<int64_t> shape = {3, 2};
   std::vector<int> data = random.Circular<int>(shape, {-1, 0, 1});
 
@@ -59,8 +59,8 @@ TEST(RandomTensorGenerator, CircularInt) {
   EXPECT_EQ(data[5], 1);
 }
 
-TEST(RandomTensorGenerator, CircularBool) {
-  RandomValueGenerator random{};
+TEST(TensorGenerator, CircularBool) {
+  FixedPatternValueGenerator random{};
   const std::vector<int64_t> shape = {3, 2};
   std::vector<bool> data = random.Circular<bool>(shape, {false, true});
 

--- a/onnxruntime/test/common/tensor_op_test_utils.cc
+++ b/onnxruntime/test/common/tensor_op_test_utils.cc
@@ -14,5 +14,10 @@ RandomValueGenerator::RandomValueGenerator(optional<RandomSeedType> seed)
       output_trace_{__FILE__, __LINE__, "ORT test random seed: " + std::to_string(random_seed_)} {
 }
 
+FixedPatternValueGenerator::FixedPatternValueGenerator()
+    : generator_{0},
+      output_trace_{__FILE__, __LINE__, "ORT test random seed with fixed pattern tensor generator"} {
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -75,7 +75,9 @@ class RandomValueGenerator {
     //  [-1.5, -1, 0, 1, 1.5]
     //  [-2, -1.5, -1, 0, 1, 1.5, -2]
     for (size_t i = 0; i < values.size(); ++i) {
-      auto index = distribution(generator_);
+      // To maximize stability, use constant_generator_ since
+      // it's always initialized with 0.
+      auto index = distribution(constant_generator_);
       values[i] = value_candidates[index];
     }
     return values;
@@ -214,6 +216,7 @@ class RandomValueGenerator {
 
  private:
   const RandomSeedType random_seed_;
+  RandomEngine constant_generator_{0};
   RandomEngine generator_;
   // while this instance is in scope, output some context information on test failure like the random seed value
   const ::testing::ScopedTrace output_trace_;

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -65,6 +65,46 @@ class RandomValueGenerator {
     return val;
   }
 
+  template <typename TValue>
+  std::vector<TValue>
+  Discrete(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
+    std::vector<TValue> values(detail::SizeFromDims(dims));
+    std::uniform_int_distribution<size_t> distribution(0, value_candidates.size() - 1);
+    // Tier 2 RNG. Use it if `Uniform` method causes large numerical errors
+    // (e.g., when elementwise relative error > 1e-3).
+    //
+    // The generated tensor is more numerically stable than other `Uniform` methods.
+    // If a test constantly fails, it's better to use `Discrete` method. For example,
+    // we call `Discrete` method to generate a tensor with shape [2, 3] and value candidates [-1, 0, 1].
+    // to eliminate the error propagation caused by * and / in matrix multiplication.
+    // To trigger mild error propagation in * and /, try value candidates [-1.5, -1, 0, 1, 1.5].
+    for (size_t i = 0; i < values.size(); ++i) {
+      auto index = distribution(generator_);
+      values[i] = value_candidates[index];
+    }
+    return values;
+  }
+
+  template <typename TValue>
+  std::vector<TValue>
+  Circular(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
+    // Tier 3 RNG. Use it if `Discrete` method causes large numerical errors
+    // (e.g., when elementwise relative error > 1e-3).
+    // Suggested value_candidates to alleviate numerical error (listed from smallest error to largest error):
+    //  [0]
+    //  [1]
+    //  [0, 1]
+    //  [-1, 0, 1]
+    //  [-2, 1, 0, 1, 2]
+    //  [-1.5, -1, 0, 1, 1.5]
+    std::vector<TValue> values(detail::SizeFromDims(dims));
+    for (size_t i = 0; i < values.size(); ++i) {
+      auto index = i % value_candidates.size();
+      values[i] = value_candidates[index];
+    }
+    return values;
+  }
+
   // Random values generated are in the range [min, max).
   template <typename TFloat16>
   typename std::enable_if<

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -71,9 +71,9 @@ class RandomValueGenerator {
     //  [1]
     //  [0, 1]
     //  [-1, 0, 1]
-    //  [-2, 1, 0, 1, 2]
+    //  [-2, -1, 0, 1, 2]
     //  [-1.5, -1, 0, 1, 1.5]
-    //  [-2, -1.5, -1, 0, 1, 1.5, -2]
+    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
     for (size_t i = 0; i < values.size(); ++i) {
       // To maximize stability, use constant_generator_ since
       // it's always initialized with 0.
@@ -94,9 +94,9 @@ class RandomValueGenerator {
     //  [1]
     //  [0, 1]
     //  [-1, 0, 1]
-    //  [-2, 1, 0, 1, 2]
+    //  [-2, -1, 0, 1, 2]
     //  [-1.5, -1, 0, 1, 1.5]
-    //  [-2, -1.5, -1, 0, 1, 1.5, -2]
+    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
     std::vector<TValue> values(detail::SizeFromDims(dims));
     for (size_t i = 0; i < values.size(); ++i) {
       auto index = i % value_candidates.size();

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -51,60 +51,6 @@ class RandomValueGenerator {
     return random_seed_;
   }
 
-  template <typename TValue>
-  std::vector<TValue>
-  Discrete(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
-    std::vector<TValue> values(detail::SizeFromDims(dims));
-    std::uniform_int_distribution<size_t> distribution(0, value_candidates.size() - 1);
-    // Tier 2 RNG. Use it if `Uniform` method causes large numerical errors
-    // (e.g., when elementwise relative error > 1e-3).
-    //
-    // The generated tensor is more numerically stable than other `Uniform` methods.
-    // If a test constantly fails, it's better to use `Discrete` method. For example,
-    // we call `Discrete` method to generate a tensor with shape [2, 3] and value candidates
-    // [-1, 0, 1] to eliminate the error propagation caused by * and / in matrix multiplication.
-    // To trigger mild error propagation in * and /, try value candidates [-1.5, -1, 0, 1, 1.5].
-    //
-    // Suggested value_candidates to alleviate numerical error (listed
-    // from smallest error to largest error):
-    //  [0]
-    //  [1]
-    //  [0, 1]
-    //  [-1, 0, 1]
-    //  [-2, -1, 0, 1, 2]
-    //  [-1.5, -1, 0, 1, 1.5]
-    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
-    for (size_t i = 0; i < values.size(); ++i) {
-      // To maximize stability, use constant_generator_ since
-      // it's always initialized with 0.
-      auto index = distribution(constant_generator_);
-      values[i] = value_candidates[index];
-    }
-    return values;
-  }
-
-  template <typename TValue>
-  std::vector<TValue>
-  Circular(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
-    // Tier 3 RNG. Use it if `Discrete` method causes large numerical errors
-    // (e.g., when elementwise relative error > 1e-3).
-    // Suggested value_candidates to alleviate numerical error (listed
-    // from smallest error to largest error):
-    //  [0]
-    //  [1]
-    //  [0, 1]
-    //  [-1, 0, 1]
-    //  [-2, -1, 0, 1, 2]
-    //  [-1.5, -1, 0, 1, 1.5]
-    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
-    std::vector<TValue> values(detail::SizeFromDims(dims));
-    for (size_t i = 0; i < values.size(); ++i) {
-      auto index = i % value_candidates.size();
-      values[i] = value_candidates[index];
-    }
-    return values;
-  }
-
   // Random values generated are in the range [min, max).
   template <typename TFloat>
   typename std::enable_if<
@@ -219,6 +165,72 @@ class RandomValueGenerator {
   RandomEngine constant_generator_{0};
   RandomEngine generator_;
   // while this instance is in scope, output some context information on test failure like the random seed value
+  const ::testing::ScopedTrace output_trace_;
+};
+
+// This class provides similar functionality as `RandomValueGenerator` but generates `fixed` patterns
+// for given tensor element type and shape. It should be used in unstable tests because
+// `purely random` patterns can easily trigger numerical errors.
+class FixedPatternValueGenerator {
+ public:
+  explicit FixedPatternValueGenerator();
+
+  template <typename TValue>
+  std::vector<TValue>
+  Discrete(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
+    std::vector<TValue> values(detail::SizeFromDims(dims));
+    std::uniform_int_distribution<size_t> distribution(0, value_candidates.size() - 1);
+    // Tier 2 RNG. Use it if `RandomValueGenerator::Uniform` method causes large numerical errors
+    // (e.g., when elementwise relative error > 1e-3).
+    //
+    // The generated tensor is more numerically stable than other `RandomValueGenerator::Uniform` methods.
+    // If a test constantly fails, it's better to use `Discrete` method. For example,
+    // we call `Discrete` method to generate a tensor with shape [2, 3] and value candidates
+    // [-1, 0, 1] to eliminate the error propagation caused by * and / in matrix multiplication.
+    // To trigger mild error propagation in * and /, try value candidates [-1.5, -1, 0, 1, 1.5].
+    //
+    // Suggested value_candidates to alleviate numerical error (listed
+    // from smallest error to largest error):
+    //  [0]
+    //  [1]
+    //  [0, 1]
+    //  [-1, 0, 1]
+    //  [-2, -1, 0, 1, 2]
+    //  [-1.5, -1, 0, 1, 1.5]
+    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
+    for (size_t i = 0; i < values.size(); ++i) {
+      // To maximize stability, use constant_generator_ since
+      // it's always initialized with 0.
+      auto index = distribution(constant_generator_);
+      values[i] = value_candidates[index];
+    }
+    return values;
+  }
+
+  template <typename TValue>
+  std::vector<TValue>
+  Circular(gsl::span<const int64_t> dims, const std::vector<TValue>& value_candidates) {
+    // Tier 3 RNG. Use it if `Discrete` method causes large numerical errors
+    // (e.g., when elementwise relative error > 1e-3).
+    // Suggested value_candidates to alleviate numerical error (listed
+    // from smallest error to largest error):
+    //  [0]
+    //  [1]
+    //  [0, 1]
+    //  [-1, 0, 1]
+    //  [-2, -1, 0, 1, 2]
+    //  [-1.5, -1, 0, 1, 1.5]
+    //  [-2, -1.5, -1, 0, 1, 1.5, 2]
+    std::vector<TValue> values(detail::SizeFromDims(dims));
+    for (size_t i = 0; i < values.size(); ++i) {
+      auto index = i % value_candidates.size();
+      values[i] = value_candidates[index];
+    }
+    return values;
+  }
+
+ private:
+  std::default_random_engine constant_generator_{0};
   const ::testing::ScopedTrace output_trace_;
 };
 

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -200,7 +200,7 @@ class FixedPatternValueGenerator {
     for (size_t i = 0; i < values.size(); ++i) {
       // To maximize stability, use constant_generator_ since
       // it's always initialized with 0.
-      auto index = distribution(constant_generator_);
+      auto index = distribution(generator_);
       values[i] = value_candidates[index];
     }
     return values;
@@ -229,7 +229,7 @@ class FixedPatternValueGenerator {
   }
 
  private:
-  std::default_random_engine constant_generator_{0};
+  std::default_random_engine generator_;
   const ::testing::ScopedTrace output_trace_;
 };
 

--- a/onnxruntime/test/common/tensor_op_test_utils.h
+++ b/onnxruntime/test/common/tensor_op_test_utils.h
@@ -162,7 +162,6 @@ class RandomValueGenerator {
 
  private:
   const RandomSeedType random_seed_;
-  RandomEngine constant_generator_{0};
   RandomEngine generator_;
   // while this instance is in scope, output some context information on test failure like the random seed value
   const ::testing::ScopedTrace output_trace_;


### PR DESCRIPTION
Some math ops have very bad numerical stability and essential randomness (e.g., exp/log with reduction on large elements). To maintain the same test coverage with lower CI failing rate, we can gradually replace flaky tests' RTG with the ones implemented in this PR --- try Discrete first. If still unstable, use Circular.

Overall recommended strategy to handle flaky test
- Find if it uses `Uniform` in `onnxruntime/test/common/tensor_op_test_utils.h`. If yes, replace `Uniform` with `Discrete` implemented in this PR. For `candidate_values`, we can try `[-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2]`, `[-2, -1, 0, 1, 2]`, `[-1, 0, 1]`, and `[0, 1]` and choose the most difficult one among those passing 100 runs.
- If `Discrete` fails to meet the stability requirement, switch to `Circular` and repeat the `candidate_values` selection process.

Let's keep an eye on the two bugs mentioned in https://github.com/microsoft/onnxruntime/pull/15515. If the related unit tests fail again, we can replace the underlying `RandomValueGenerator::Uniform` with `FixedPatternValueGenerator::Descrete` or `FixedPatternValueGenerator::Circular` implemented in this PR.