### PR TITLE
Improve marshalling of strings in CreateStringTensor

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -1827,11 +1827,6 @@ namespace Microsoft.ML.OnnxRuntime
 #endregion
     } //class NativeMethods
 
-    internal static class EmptyArray<T>
-    {
-        public static readonly T[] Value = new T[0];
-    }
-
     internal unsafe struct MarshaledString : IDisposable
     {
         // Ported from dotnet/clangsharp tag v15.0.2
@@ -1849,7 +1844,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             else
             {
-                var valueBytes = (input.Length != 0) ? Encoding.UTF8.GetBytes(input) : EmptyArray<byte>.Value;
+                var valueBytes = (input.Length != 0) ? Encoding.UTF8.GetBytes(input) : ArrayUtilities.GetEmpty<byte>();
                 length = valueBytes.Length;
                 value = Marshal.AllocHGlobal(length + 1);
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/Tensors/ArrayUtilities.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Tensors/ArrayUtilities.shared.cs
@@ -256,5 +256,20 @@ namespace Microsoft.ML.OnnxRuntime.Tensors
 
             return transformIndex;
         }
+
+        public static T[] GetEmpty<T>()
+        {
+            // Match the implementation of Array.GetEmpty<T>()
+            // from dotnet/runtime. Having it as a static in a
+            // nested class ensures we only allocate the empty
+            // array once and only when actually necessary.
+
+            return EmptyArray<T>.Value;
+        }
+
+        private static class EmptyArray<T>
+        {
+            public static readonly T[] Value = new T[0];
+        }
     }
 }


### PR DESCRIPTION
This should resolve https://github.com/dotnet/machinelearning/issues/6620

The previous logic was correct, but it was creating `tensor.Length` managed arrays and `tensor.Length` GCHandles on top of that to ensure pinning. Disposal of GCHandles can be quite expensive as can having all of these short lived allocations in the form of the arrays as it increases GC pressure.

This new approach changes to using a `MarshaledString` and `MarshaledStringArray` helper. This ends up doing native allocations instead which means they are implicitly pinned, doesn't increase GC pressure, and doesn't require costly GCHandles.

From local testing, @michaelgsharp saw that this was between 2-5x faster.

This isn't necessarily the "best" it could be. Depending on exactly what's being done, it could be more optimal to allocate 1x big native allocation and converting all the strings to it sequentially. We could likewise transcode the data directly to the native memory rather than doing it in managed and then copying.

It looks like `OrtFillStringTensor` is basically just copying all the individual strings into a linearized buffer and so is effectively doing the "1x big native allocation" and so some other considerations may be "even better", but as is this should significantly helper the perf of the scenario in question.

There may be other places that are doing similar things with marshalling that could be switched over.