### PR TITLE
Use os.fspath on Path

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -359,11 +359,8 @@ class InferenceSession(Session):
         """
         super().__init__()
 
-        if isinstance(path_or_bytes, str):
-            self._model_path = path_or_bytes
-            self._model_bytes = None
-        elif isinstance(path_or_bytes, os.PathLike):
-            self._model_path = str(path_or_bytes)
+        if isinstance(path_or_bytes, (str, os.PathLike)):
+            self._model_path = os.fspath(path_or_bytes)
             self._model_bytes = None
         elif isinstance(path_or_bytes, bytes):
             self._model_path = None


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Use os.fspath instead of str() on a path object. 

### Motivation and Context

I learned today that os.fspath is the right way to go: https://github.com/charliermarsh/ruff/issues/3675#issuecomment-1494975508
