### PR TITLE
[java] Allow the creation of boolean tensors from ByteBuffer

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -542,7 +542,8 @@ public final class OrtUtil {
           break;
         default:
           throw new IllegalStateException(
-              "Impossible to reach here, managed to cast a buffer as an incorrect type, found " + type);
+              "Impossible to reach here, managed to cast a buffer as an incorrect type, found "
+                  + type);
       }
       data.position(origPosition);
       tmp.rewind();

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -494,7 +494,7 @@ public final class OrtUtil {
    */
   static BufferTuple prepareBuffer(Buffer data, OnnxJavaType type) {
     if (type == OnnxJavaType.STRING || type == OnnxJavaType.UNKNOWN) {
-      throw new IllegalStateException("Cannot create a String tensor from a buffer, or an unknown tensor of any kind");
+      throw new IllegalStateException("Cannot create a " + type + " tensor from a buffer");
     }
     int bufferPos;
     long bufferSizeLong = data.remaining() * (long) type.size;

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -542,7 +542,7 @@ public final class OrtUtil {
           break;
         default:
           throw new IllegalStateException(
-              "Impossible to reach here, managed to cast a buffer as an incorrect type");
+              "Impossible to reach here, managed to cast a buffer as an incorrect type, found " + type);
       }
       data.position(origPosition);
       tmp.rewind();

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -493,6 +493,9 @@ public final class OrtUtil {
    * @return The prepared buffer tuple.
    */
   static BufferTuple prepareBuffer(Buffer data, OnnxJavaType type) {
+    if (type == OnnxJavaType.STRING || type == OnnxJavaType.UNKNOWN) {
+      throw new IllegalStateException("Cannot create a String tensor from a buffer, or an unknown tensor of any kind");
+    }
     int bufferPos;
     long bufferSizeLong = data.remaining() * (long) type.size;
     if (bufferSizeLong > (Integer.MAX_VALUE - (8 * type.size))) {
@@ -522,6 +525,7 @@ public final class OrtUtil {
         case DOUBLE:
           tmp = buffer.asDoubleBuffer().put((DoubleBuffer) data);
           break;
+        case BOOL:
         case UINT8:
         case INT8:
           // buffer is already a ByteBuffer, no cast needed.
@@ -536,9 +540,6 @@ public final class OrtUtil {
         case INT64:
           tmp = buffer.asLongBuffer().put((LongBuffer) data);
           break;
-        case BOOL:
-        case STRING:
-        case UNKNOWN:
         default:
           throw new IllegalStateException(
               "Impossible to reach here, managed to cast a buffer as an incorrect type");


### PR DESCRIPTION
### Description
The tensor creation code now allows the creation of boolean tensors from non-direct `ByteBuffer` instances. It previously only allowed them from arrays and direct `ByteBuffer` instances and this fixes that inconsistency. The boolean tensor test has been updated to cover all three cases.

### Motivation and Context
Fixes #15509.

