### PR TITLE
Set proper default values for pool attributes

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -93,8 +93,8 @@ struct PoolAttributes {
   TensorShapeVector strides;
   TensorShapeVector dilations;  // Introduced in MaxPool_10
   // default_dilations is true if dilations is not set or all dilations are 1
-  bool default_dilations;
-  AutoPadType auto_pad;
+  bool default_dilations{false};
+  AutoPadType auto_pad{AutoPadType::NOTSET};
 
   TensorShapeVector SetOutputSize(const TensorShape& input_shape,
                                   int64_t output_channel,


### PR DESCRIPTION
### Description
Setting proper default value for attributes of pool operators


### Motivation and Context
Fixed [AB#14719](https://aiinfra.visualstudio.com/6a833879-cd9b-44a4-a9de-adc2d818f13c/_workitems/edit/14719)

Global pooling and pooling operators usually share the same underlying implementation. When we detect the operator is global, code for setting up the attributes is skipped. This may cause un-deterministic behavior.