### PR TITLE
Make docker command fail if bash command fails.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -90,6 +90,7 @@ jobs:
                 -e ORT_BUILD_WITH_CACHE=1 \
                 onnxruntimecpubuild \
                   /bin/bash -c "
+                    set -e -x;
                     /onnxruntime_src/tools/ci_build/github/linux/ort_minimal/build_full_ort_and_create_ort_files.sh /build/1; \
                     ccache -sv; \
                     ccache -z;"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `set -e` so that failing bash commands will cause the containing docker command to fail.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The CI build was reporting a successful step even when a bash command within failed. This can cause later steps to fail with confusing errors.