### PR TITLE
Fix lintrunner configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -62,7 +62,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.261',
+    '--requirement=requirements-lintrunner.txt',
 ]
 
 [[linter]]
@@ -92,7 +92,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.261',
+    '--requirement=requirements-lintrunner.txt',
 ]
 is_formatter = true
 
@@ -108,7 +108,7 @@ exclude_patterns = [
     'onnxruntime/core/flatbuffers/**',
 ]
 command = [
-    'python3',
+    'python',
     '-m',
     'lintrunner_adapters',
     'run',
@@ -117,14 +117,13 @@ command = [
     '@{{PATHSFILE}}'
 ]
 init_command = [
-    'python3',
+    'python',
     '-m',
     'lintrunner_adapters',
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'black==23.1.0',
-    'isort==5.10.1',
+    '--requirement=requirements-lintrunner.txt',
 ]
 is_formatter = true
 
@@ -136,7 +135,7 @@ include_patterns = [
 exclude_patterns = [
 ]
 command = [
-    'python3',
+    'python',
     '-m',
     'lintrunner_adapters',
     'run',
@@ -146,13 +145,13 @@ command = [
     '@{{PATHSFILE}}'
 ]
 init_command = [
-    'python3',
+    'python',
     '-m',
     'lintrunner_adapters',
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'pylint==2.15.5',
+    '--requirement=requirements-lintrunner.txt',
 ]
 
 [[linter]]
@@ -208,6 +207,6 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'clang-format==16.0.1',
+    '--requirement=requirements-lintrunner.txt',
 ]
 is_formatter = true

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,0 +1,10 @@
+# This file is auto updated by dependabot
+# RUFF, RUFF-FIX
+ruff==0.0.261
+# BLACK-ISORT
+black==23.3.0
+isort==5.12.0
+# PYLINT
+pylint==2.17.2
+# CLANGFORMAT
+clang-format==16.0.1

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,4 +1,5 @@
 # This file is auto updated by dependabot
+lintrunner-adapters
 # RUFF, RUFF-FIX
 ruff==0.0.261
 # BLACK-ISORT


### PR DESCRIPTION
### Description

- Fix lintrunner configurations to always use `python` instead of `python3`.
- Set up dependabot
- Moved dependencies to requirements-lintrunner to allow dependabot to update it similar to https://github.com/onnx/onnx/pull/5124

