### PR TITLE
Add updated skipped test for multiheadattention Packed KV & QKV

### DIFF
--- a/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
@@ -470,12 +470,14 @@ TEST(MultiHeadAttentionTest, CrossAttention_Batch1_HeadSize32_LeftSidePadding_Ma
 }
 
 TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_NoBias_NoMask_PackedKV) {
+  ROCM_GTEST_SKIP("ROCm MHA does not support Packed KV");
   AttentionTestData data;
   GetCrossAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedKV(data);
   RunMultiHeadAttentionTests(data);
 }
 
 TEST(MultiHeadAttentionTest, SelfAttention_Batch2_HeadSize32_NoBias_NoMask_PackedQKV) {
+  ROCM_GTEST_SKIP("ROCm MHA does not support Packed QKV");
   AttentionTestData data;
   GetSelfAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedQKV(data);
   RunMultiHeadAttentionTests(data);

--- a/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
@@ -27,7 +27,6 @@
 #define MIGX_GTEST_SKIP(message)
 #endif
 
-
 namespace onnxruntime {
 namespace test {
 

--- a/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/multihead_attention_op_test.cc
@@ -21,6 +21,13 @@
 #define ROCM_GTEST_SKIP(message)
 #endif
 
+#if defined(USE_MIGRAPHX)
+#define MIGX_GTEST_SKIP(message) GTEST_SKIP_(message)
+#else
+#define MIGX_GTEST_SKIP(message)
+#endif
+
+
 namespace onnxruntime {
 namespace test {
 
@@ -470,14 +477,14 @@ TEST(MultiHeadAttentionTest, CrossAttention_Batch1_HeadSize32_LeftSidePadding_Ma
 }
 
 TEST(MultiHeadAttentionTest, CrossAttention_Batch2_HeadSize32_NoBias_NoMask_PackedKV) {
-  ROCM_GTEST_SKIP("ROCm MHA does not support Packed KV");
+  MIGX_GTEST_SKIP("MIGX MHA does not support Packed KV");
   AttentionTestData data;
   GetCrossAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedKV(data);
   RunMultiHeadAttentionTests(data);
 }
 
 TEST(MultiHeadAttentionTest, SelfAttention_Batch2_HeadSize32_NoBias_NoMask_PackedQKV) {
-  ROCM_GTEST_SKIP("ROCm MHA does not support Packed QKV");
+  MIGX_GTEST_SKIP("MIGX MHA does not support Packed QKV");
   AttentionTestData data;
   GetSelfAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedQKV(data);
   RunMultiHeadAttentionTests(data);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds skip for ROCM & MIGraphX EP builds for Packed KV and QKV tests in Multi Head attention

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Not supported and causes CI failures when building and testing EPs
