### PR TITLE
modify olive doc section

### DIFF
--- a/docs/performance/olive.md
+++ b/docs/performance/olive.md
@@ -1,5 +1,5 @@
 ---
-title: Olive 
+title: End to end optimization with Olive
 description: Hardware-aware model optimization tool
 parent: Performance
 nav_order: 5

--- a/docs/performance/olive.md
+++ b/docs/performance/olive.md
@@ -1,0 +1,20 @@
+---
+title: Olive 
+description: Hardware-aware model optimization tool
+parent: Performance
+nav_order: 5
+---
+# Olive - hardware-aware model optimization tool
+
+[Olive](https://github.com/microsoft/Olive) is an easy-to-use hardware-aware model optimization tool that composes industry-leading techniques across 
+model compression, optimization, and compilation. It works with ONNX Runtime as an E2E inference optimization solution. 
+
+Given a model and targeted hardware, Olive composes the best suitable optimization techniques to output 
+the most efficient model(s) and runtime configurations for inferencing with ONNX Runtime, while taking a set of constraints such as accuracy and latency into consideration. Techniques Olive has integrated include ONNX Runtime Transformer optimizations, ONNX Runtime performance tuning, HW-dependent tunable post training quantization, quantize aware training, and more. Olive is the recommended tool for model optimization for ONNX Runtime.
+
+**Examples:**
+1. [BERT optimization on CPU (with post training quantization)](https://github.com/microsoft/Olive/tree/main/examples/bert_ptq_cpu)
+2. [BERT optimization on CPU (with quantization aware training)](https://github.com/microsoft/Olive/tree/main/examples/quantization_aware_training/bert_qat_customized_train_loop_cpu)
+
+
+For more details, pls refer to [Olive repo](https://github.com/microsoft/Olive) and [Olive documentation](https://microsoft.github.io/Olive).

--- a/docs/performance/tune-performance/profiling-tools.md
+++ b/docs/performance/tune-performance/profiling-tools.md
@@ -14,12 +14,6 @@ nav_order: 1
 {:toc}
 
 
-## Olive
-
-[Olive](https://github.com/microsoft/Olive) is an easy-to-use hardware-aware model optimization tool that composes industry-leading techniques across model compression, optimization, and compilation. Given a model and targeted hardware, Olive composes the best suitable optimization techniques to output the most efficient model(s) for inferencing on cloud or edge, while taking a set of constraints such as accuracy and latency into consideration.
-
-As a quickstart, please refer to [documentation](https://microsoft.github.io/Olive) and [examples](https://github.com/microsoft/Olive/tree/main/examples).
-
 ## In-code performance profiling
 
 The onnxruntime_perf_test.exe tool (available from the build drop) can be used to test various knobs. Please find the usage instructions using `onnxruntime_perf_test.exe -h`. The [perf_view tool](https://github.com/microsoft/onnxruntime/tree/main/tools/perf_view) can also be used to render the statistics as a summarized view in the browser.


### PR DESCRIPTION
### Description
Move Olive doc into Performance section. 
Olive v2 is no longer just a profiling tool. It composes industry-leading techniques across model compression, optimization, and compilation. It's better to move into Performance section. 
