### PR TITLE
Add link to doc for lintrunner in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
               echo ""
-              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. To set up lintrunner locally, see https://github.com/microsoft/onnxruntime/blob/docs/Coding_Conventions_and_Standards.md#linting.\e[0m"
+              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. To set up lintrunner locally, see https://github.com/microsoft/onnxruntime/blob/446c478fbd87c85a0815f14a3b2ff055000cd7d5/docs/Coding_Conventions_and_Standards.md#linting .\e[0m"
               exit 1
           fi
       - name: Produce SARIF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
               echo ""
-              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. To set up lintrunner locally, see https://github.com/microsoft/onnxruntime/blob/446c478fbd87c85a0815f14a3b2ff055000cd7d5/docs/Coding_Conventions_and_Standards.md#linting .\e[0m"
+              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. To set up lintrunner locally, see https://github.com/microsoft/onnxruntime/blob/main/docs/Coding_Conventions_and_Standards.md#linting .\e[0m"
               exit 1
           fi
       - name: Produce SARIF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
               echo ""
-              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
+              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`. To set up lintrunner locally, see https://github.com/microsoft/onnxruntime/blob/docs/Coding_Conventions_and_Standards.md#linting.\e[0m"
               exit 1
           fi
       - name: Produce SARIF


### PR DESCRIPTION
Add a link to point to the doc where users can find instructions to set up lintrunner should there be any lint issues in CI.