### PR TITLE
update target framework to dotnet6.0

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/Microsoft.ML.OnnxRuntime.EndToEndTests.csproj
@@ -14,6 +14,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\OnnxRuntime.snk</AssemblyOriginatorKeyFile>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsLinuxBuild)'=='true'">


### PR DESCRIPTION
### Description
Upgrade dotnet E2E test target framework to dotnet6.0


### Motivation and Context
Fix dotnet3.1 deprecation issue which broke nuget building pipeline.
The error message in NuGet_Test_Linux_CPU was
```
To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=ubuntu.20.04-x64
. Please check the diagnostic logs for more information.
```

Test Run:
https://dev.azure.com/aiinfra/Lotus/_build/results?buildId=300655&view=results.

