### PR TITLE
Revert "Retry the step of Start Android simulator (#15584)"

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -180,7 +180,6 @@ stages:
           --start --emulator-extra-args="-partition-size 4096" \
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android Emulator
-      retryCountOnTaskFailure: 2
 
     - script: |
         xcrun simctl create iPhoneRNTest com.apple.CoreSimulator.SimDeviceType.iPhone-13


### PR DESCRIPTION
This reverts commit 64b63921a27d67e6a6c371308d7925669de1f172.



### Motivation and Context
From https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=970086&view=logs&s=28fb2bf2-39c5-5feb-1887-4904233f6193&j=de302ec2-2305-57e0-e8c6-cd89c569f2a3
It's useless to rerun the step.


