### PR TITLE
Update build option for training in java to enable_training_api

### DIFF
--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -47,7 +47,7 @@ file(GLOB onnxruntime4j_native_src
     "${JAVA_ROOT}/src/main/native/*.c"
     "${JAVA_ROOT}/src/main/native/*.h"
     "${REPO_ROOT}/include/onnxruntime/core/session/*.h"
-    "${REPO_ROOT}/orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h"
+    "${REPO_ROOT}/orttraining/orttraining/training_api/include/*.h"
     )
 # Build the JNI library
 onnxruntime_add_shared_library_module(onnxruntime4j_jni ${onnxruntime4j_native_src})
@@ -193,7 +193,7 @@ endif()
 # Append relevant native build flags to gradle command
 set(GRADLE_ARGS ${GRADLE_ARGS} ${ORT_PROVIDER_FLAGS})
 if (onnxruntime_ENABLE_TRAINING_APIS)
-    set(GRADLE_ARGS ${GRADLE_ARGS} "-DENABLE_TRAINING=1")
+    set(GRADLE_ARGS ${GRADLE_ARGS} "-DENABLE_TRAINING_APIS=1")
 endif()
 
 message(STATUS "GRADLE_ARGS: ${GRADLE_ARGS}")
@@ -208,6 +208,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
   # Copy onnxruntime.so and onnxruntime4j_jni.so for building Android AAR package
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime>)
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime4j_jni> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime4j_jni>)
+
+  set(JAVA_ENABLE_TRAINING_APIS "")
+  if (onnxruntime_ENABLE_TRAINING_APIS)
+    set(JAVA_ENABLE_TRAINING_APIS "-DENABLE_TRAINING_APIS=1")
+  endif()
+
   # Generate the Android AAR package
   add_custom_command(TARGET onnxruntime4j_jni
     POST_BUILD
@@ -217,6 +223,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
       -b build-android.gradle -c settings-android.gradle
       -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR}
       -DminSdkVer=${ANDROID_MIN_SDK} -DheadersDir=${ANDROID_HEADERS_DIR}
+      ${JAVA_ENABLE_TRAINING_APIS}
       --stacktrace
     WORKING_DIRECTORY ${JAVA_ROOT})
 

--- a/cmake/onnxruntime_java.cmake
+++ b/cmake/onnxruntime_java.cmake
@@ -209,11 +209,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime>)
   add_custom_command(TARGET onnxruntime4j_jni POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:onnxruntime4j_jni> ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime4j_jni>)
 
-  set(JAVA_ENABLE_TRAINING_APIS "")
-  if (onnxruntime_ENABLE_TRAINING_APIS)
-    set(JAVA_ENABLE_TRAINING_APIS "-DENABLE_TRAINING_APIS=1")
-  endif()
-
   # Generate the Android AAR package
   add_custom_command(TARGET onnxruntime4j_jni
     POST_BUILD
@@ -223,7 +218,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Android")
       -b build-android.gradle -c settings-android.gradle
       -DjniLibsDir=${ANDROID_PACKAGE_JNILIBS_DIR} -DbuildDir=${ANDROID_PACKAGE_OUTPUT_DIR}
       -DminSdkVer=${ANDROID_MIN_SDK} -DheadersDir=${ANDROID_HEADERS_DIR}
-      ${JAVA_ENABLE_TRAINING_APIS}
+      $<$<BOOL:${onnxruntime_ENABLE_TRAINING_APIS}>:-DENABLE_TRAINING_APIS=1>
       --stacktrace
     WORKING_DIRECTORY ${JAVA_ROOT})
 

--- a/cmake/onnxruntime_java_unittests.cmake
+++ b/cmake/onnxruntime_java_unittests.cmake
@@ -8,7 +8,7 @@ FILE(TO_NATIVE_PATH ${BIN_DIR} BINDIR_NATIVE_PATH)
 message(STATUS "GRADLE_TEST_EP_FLAGS: ${ORT_PROVIDER_FLAGS}")
 if (onnxruntime_ENABLE_TRAINING_APIS)
     message(STATUS "Running ORT Java training tests")
-    execute_process(COMMAND cmd /C ${GRADLE_NATIVE_PATH} --console=plain cmakeCheck -DcmakeBuildDir=${BINDIR_NATIVE_PATH} -Dorg.gradle.daemon=false ${ORT_PROVIDER_FLAGS} -DENABLE_TRAINING=1
+    execute_process(COMMAND cmd /C ${GRADLE_NATIVE_PATH} --console=plain cmakeCheck -DcmakeBuildDir=${BINDIR_NATIVE_PATH} -Dorg.gradle.daemon=false ${ORT_PROVIDER_FLAGS} -DENABLE_TRAINING_APIS=1
       WORKING_DIRECTORY ${REPO_ROOT}/java
       RESULT_VARIABLE HAD_ERROR)
 else()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1448,7 +1448,7 @@ if (NOT onnxruntime_BUILD_WEBASSEMBLY)
                           ${JAVA_NATIVE_TEST_DIR}/$<TARGET_LINKER_FILE_NAME:custom_op_library>)
           if (onnxruntime_ENABLE_TRAINING_APIS)
             message(STATUS "Running Java inference and training tests")
-            add_test(NAME onnxruntime4j_test COMMAND ${GRADLE_EXECUTABLE} cmakeCheck -DcmakeBuildDir=${CMAKE_CURRENT_BINARY_DIR} ${ORT_PROVIDER_FLAGS} -DENABLE_TRAINING=1
+            add_test(NAME onnxruntime4j_test COMMAND ${GRADLE_EXECUTABLE} cmakeCheck -DcmakeBuildDir=${CMAKE_CURRENT_BINARY_DIR} ${ORT_PROVIDER_FLAGS} -DENABLE_TRAINING_APIS=1
                           WORKING_DIRECTORY ${REPO_ROOT}/java)
           else()
             message(STATUS "Running Java inference tests only")

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -19,7 +19,7 @@ version = rootProject.file('../VERSION_NUMBER').text.trim()
 def cmakeBuildDir = System.properties['cmakeBuildDir']
 def useCUDA = System.properties['USE_CUDA']
 def useROCM = System.properties['USE_ROCM']
-def enableTraining = System.properties['ENABLE_TRAINING']
+def enableTrainingApis = System.properties['ENABLE_TRAINING_APIS']
 def cmakeJavaDir = "${cmakeBuildDir}/java"
 def cmakeNativeLibDir = "${cmakeJavaDir}/native-lib"
 def cmakeNativeJniDir = "${cmakeJavaDir}/native-jni"
@@ -29,7 +29,7 @@ def cmakeBuildOutputDir = "${cmakeJavaDir}/build"
 def mavenUser = System.properties['mavenUser']
 def mavenPwd = System.properties['mavenPwd']
 
-def tmpArtifactId = enableTraining == null ? project.name : project.name + "-training"
+def tmpArtifactId = enableTrainingApis == null ? project.name : project.name + "-training"
 def mavenArtifactId = (useCUDA == null && useROCM == null) ? tmpArtifactId : tmpArtifactId + "_gpu"
 
 java {
@@ -176,7 +176,7 @@ test {
 	if (cmakeBuildDir != null) {
 		workingDir cmakeBuildDir
 	}
-	systemProperties System.getProperties().subMap(['USE_CUDA', 'USE_ROCM', 'USE_TENSORRT', 'USE_DNNL', 'USE_OPENVINO', 'JAVA_FULL_TEST', 'ENABLE_TRAINING'])
+	systemProperties System.getProperties().subMap(['USE_CUDA', 'USE_ROCM', 'USE_TENSORRT', 'USE_DNNL', 'USE_OPENVINO', 'JAVA_FULL_TEST', 'ENABLE_TRAINING_APIS'])
 	testLogging {
 		events "passed", "skipped", "failed"
 		showStandardStreams = true

--- a/java/src/test/java/ai/onnxruntime/TrainingTest.java
+++ b/java/src/test/java/ai/onnxruntime/TrainingTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /** Tests for the ORT training apis. */
-@EnabledIfSystemProperty(named = "ENABLE_TRAINING", matches = "1")
+@EnabledIfSystemProperty(named = "ENABLE_TRAINING_APIS", matches = "1")
 public class TrainingTest {
 
   private static final OrtEnvironment env = OrtEnvironment.getEnvironment();


### PR DESCRIPTION
### Description
Updating the build option for enabling training in java builds from ENABLE_TRAINING -> ENABLE_TRAINING_APIS.
In the native codebase ENABLE_TRAINING is used for enabling full training and ENABLE_TRAINING_APIS is used for creating the lte builds with training apis. Making the change to sync the naming convention across all the language bindings.

It was a bit confusing to see ENABLE_TRAINING when debugging the android build failures for training. Making this change just to improve readability of logs during debugging.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


