### PR TITLE
Expose build information in dynamic lib

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1229,6 +1229,15 @@ if (onnxruntime_USE_VITISAI)
   endif()
 endif()
 
+execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+    OUTPUT_VARIABLE ORT_GIT_COMMIT)
+string(STRIP ${ORT_GIT_COMMIT} ORT_GIT_COMMIT)
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE ORT_GIT_BRANCH)
+string(STRIP ${ORT_GIT_BRANCH} ORT_GIT_BRANCH)
+set(ORT_BUILD_INFO "ORT Build Info: git-branch=${ORT_GIT_BRANCH}, git-commit-id=${ORT_GIT_COMMIT}")
+string(APPEND ORT_BUILD_INFO ", build type=${CMAKE_BUILD_TYPE}")
+string(APPEND ORT_BUILD_INFO ", cmake cxx flags: ${CMAKE_CXX_FLAGS}")
 configure_file(onnxruntime_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime_config.h)
 if (WIN32)
   configure_file(../requirements.txt.in ${CMAKE_CURRENT_BINARY_DIR}/Debug/requirements.txt)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1229,21 +1229,18 @@ if (onnxruntime_USE_VITISAI)
   endif()
 endif()
 
-# If the build envs have no git, ORT_GIT_COMMIT and ORT_GIT_BRANCH will be set to "Not-Available".
-execute_process(COMMAND git log -1 --format=%h
-    OUTPUT_VARIABLE ORT_GIT_COMMIT)
-string(STRIP "${ORT_GIT_COMMIT}" ORT_GIT_COMMIT)
-if ("${ORT_GIT_COMMIT}" STREQUAL "")
-  set(ORT_GIT_COMMIT "Not-Available")
+set(ORT_BUILD_INFO "ORT Build Info: ")
+find_package(Git)
+if (Git_FOUND)
+  execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+      OUTPUT_VARIABLE ORT_GIT_COMMIT)
+  string(STRIP "${ORT_GIT_COMMIT}" ORT_GIT_COMMIT)
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+      OUTPUT_VARIABLE ORT_GIT_BRANCH)
+  string(STRIP "${ORT_GIT_BRANCH}" ORT_GIT_BRANCH)
+  string(APPEND ORT_BUILD_INFO "git-branch=${ORT_GIT_BRANCH}, git-commit-id=${ORT_GIT_COMMIT}, ")
 endif()
-execute_process(COMMAND git rev-parse --abbrev-ref HEAD
-    OUTPUT_VARIABLE ORT_GIT_BRANCH)
-string(STRIP "${ORT_GIT_BRANCH}" ORT_GIT_BRANCH)
-if ("${ORT_GIT_BRANCH}" STREQUAL "")
-  set(ORT_GIT_BRANCH "Not-Available")
-endif()
-set(ORT_BUILD_INFO "ORT Build Info: git-branch=${ORT_GIT_BRANCH}, git-commit-id=${ORT_GIT_COMMIT}")
-string(APPEND ORT_BUILD_INFO ", build type=${CMAKE_BUILD_TYPE}")
+string(APPEND ORT_BUILD_INFO "build type=${CMAKE_BUILD_TYPE}")
 string(APPEND ORT_BUILD_INFO ", cmake cxx flags: ${CMAKE_CXX_FLAGS}")
 configure_file(onnxruntime_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/onnxruntime_config.h)
 if (WIN32)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1229,12 +1229,19 @@ if (onnxruntime_USE_VITISAI)
   endif()
 endif()
 
+# If the build envs have no git, ORT_GIT_COMMIT and ORT_GIT_BRANCH will be set to "Not-Available".
 execute_process(COMMAND git log -1 --format=%h
     OUTPUT_VARIABLE ORT_GIT_COMMIT)
 string(STRIP "${ORT_GIT_COMMIT}" ORT_GIT_COMMIT)
+if ("${ORT_GIT_COMMIT}" STREQUAL "")
+  set(ORT_GIT_COMMIT "Not-Available")
+endif()
 execute_process(COMMAND git rev-parse --abbrev-ref HEAD
     OUTPUT_VARIABLE ORT_GIT_BRANCH)
 string(STRIP "${ORT_GIT_BRANCH}" ORT_GIT_BRANCH)
+if ("${ORT_GIT_BRANCH}" STREQUAL "")
+  set(ORT_GIT_BRANCH "Not-Available")
+endif()
 set(ORT_BUILD_INFO "ORT Build Info: git-branch=${ORT_GIT_BRANCH}, git-commit-id=${ORT_GIT_COMMIT}")
 string(APPEND ORT_BUILD_INFO ", build type=${CMAKE_BUILD_TYPE}")
 string(APPEND ORT_BUILD_INFO ", cmake cxx flags: ${CMAKE_CXX_FLAGS}")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1229,12 +1229,12 @@ if (onnxruntime_USE_VITISAI)
   endif()
 endif()
 
-execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+execute_process(COMMAND git log -1 --format=%h
     OUTPUT_VARIABLE ORT_GIT_COMMIT)
-string(STRIP ${ORT_GIT_COMMIT} ORT_GIT_COMMIT)
-execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+string(STRIP "${ORT_GIT_COMMIT}" ORT_GIT_COMMIT)
+execute_process(COMMAND git rev-parse --abbrev-ref HEAD
     OUTPUT_VARIABLE ORT_GIT_BRANCH)
-string(STRIP ${ORT_GIT_BRANCH} ORT_GIT_BRANCH)
+string(STRIP "${ORT_GIT_BRANCH}" ORT_GIT_BRANCH)
 set(ORT_BUILD_INFO "ORT Build Info: git-branch=${ORT_GIT_BRANCH}, git-commit-id=${ORT_GIT_COMMIT}")
 string(APPEND ORT_BUILD_INFO ", build type=${CMAKE_BUILD_TYPE}")
 string(APPEND ORT_BUILD_INFO ", cmake cxx flags: ${CMAKE_CXX_FLAGS}")

--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -22,3 +22,6 @@
 #cmakedefine HAS_BITWISE_INSTEAD_OF_LOGICAL
 #cmakedefine HAS_REALLOCARRAY
 #cmakedefine ORT_VERSION "@ORT_VERSION@"
+#cmakedefine ORT_GIT_COMMIT "@ORT_GIT_COMMIT@"
+#cmakedefine ORT_GIT_BRANCH "@ORT_GIT_BRANCH@"
+#cmakedefine ORT_BUILD_INFO "@ORT_BUILD_INFO@"

--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -22,6 +22,4 @@
 #cmakedefine HAS_BITWISE_INSTEAD_OF_LOGICAL
 #cmakedefine HAS_REALLOCARRAY
 #cmakedefine ORT_VERSION "@ORT_VERSION@"
-#cmakedefine ORT_GIT_COMMIT "@ORT_GIT_COMMIT@"
-#cmakedefine ORT_GIT_BRANCH "@ORT_GIT_BRANCH@"
 #cmakedefine ORT_BUILD_INFO "@ORT_BUILD_INFO@"

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -619,7 +619,7 @@ struct OrtApiBase {
    *   older than the version created with this header file.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
-  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
   const char*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
 typedef struct OrtApiBase OrtApiBase;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -619,8 +619,8 @@ struct OrtApiBase {
    *   older than the version created with this header file.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
-  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
-  const char*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
+  const ORTCHAR_T*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+  const ORTCHAR_T*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
 typedef struct OrtApiBase OrtApiBase;
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -620,6 +620,7 @@ struct OrtApiBase {
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
   const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+  const char*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
 typedef struct OrtApiBase OrtApiBase;
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -91,8 +91,11 @@ extern "C" {
 #ifndef ORT_TSTR
 #ifdef _WIN32
 #define ORT_TSTR(X) L##X
+// When X is a macro, L##X is not defined. In this case, we need to use ORT_TSTR_ON_MACRO.
+#define ORT_TSTR_ON_MACRO(X) L"" X
 #else
 #define ORT_TSTR(X) X
+#define ORT_TSTR_ON_MACRO(X) X
 #endif
 #endif
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -128,6 +128,13 @@ inline const OrtApi& GetApi() noexcept { return *Global<void>::api_; }
 std::string GetVersionString();
 
 /// <summary>
+/// This function returns the onnxruntime build information: including git branch,
+/// git commit id, build type(Debug/Release/RelWithDebInfo) and cmake cpp flags.
+/// </summary>
+/// <returns>string</returns>
+std::string GetBuildInfoString();
+
+/// <summary>
 /// This is a C++ wrapper for OrtApi::GetAvailableProviders() and
 /// returns a vector of strings representing the available execution providers.
 /// </summary>

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -125,14 +125,14 @@ inline const OrtApi& GetApi() noexcept { return *Global<void>::api_; }
 /// This function returns the onnxruntime version string
 /// </summary>
 /// <returns>version string major.minor.rev</returns>
-std::string GetVersionString();
+std::basic_string<ORTCHAR_T> GetVersionString();
 
 /// <summary>
 /// This function returns the onnxruntime build information: including git branch,
 /// git commit id, build type(Debug/Release/RelWithDebInfo) and cmake cpp flags.
 /// </summary>
 /// <returns>string</returns>
-std::string GetBuildInfoString();
+std::basic_string<ORTCHAR_T> GetBuildInfoString();
 
 /// <summary>
 /// This is a C++ wrapper for OrtApi::GetAvailableProviders() and

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1981,8 +1981,13 @@ inline void CustomOpApi::ReleaseKernelInfo(_Frees_ptr_opt_ OrtKernelInfo* info_c
   api_.ReleaseKernelInfo(info_copy);
 }
 
-inline std::string GetVersionString() {
-  std::string result = OrtGetApiBase()->GetVersionString();
+inline std::basic_string<ORTCHAR_T> GetVersionString() {
+  std::basic_string<ORTCHAR_T> result = OrtGetApiBase()->GetVersionString();
+  return result;
+}
+
+inline std::basic_string<ORTCHAR_T> GetBuildInfoString() {
+  std::basic_string<ORTCHAR_T> result = OrtGetApiBase()->GetBuildInfoString();
   return result;
 }
 

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -79,7 +79,7 @@ JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseVersion
   const ORTCHAR_T* version = OrtGetApiBase()->GetVersionString();
   assert(version != NULL);
 #ifdef _WIN32
-  size_t len = wcslen(version);
+  jsize len = (jsize)(wcslen(version));
   jstring versionStr = (*jniEnv)->NewString(jniEnv, (const jchar*)version, len);
 #else
   jstring versionStr = (*jniEnv)->NewStringUTF(jniEnv, version);

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -78,6 +78,11 @@ JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseVersion
   (void)clazz;  // required JNI parameter not needed by functions which don't access their host class.
   const ORTCHAR_T* version = OrtGetApiBase()->GetVersionString();
   assert(version != NULL);
+#ifdef _WIN32
+  size_t len = wcslen(version);
+  jstring versionStr = (*jniEnv)->NewString(jniEnv, (const jchar*)version, len);
+#else
   jstring versionStr = (*jniEnv)->NewStringUTF(jniEnv, version);
+#endif
   return versionStr;
 }

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -76,7 +76,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxRuntime_getAvailableProvi
 JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseVersion
   (JNIEnv * jniEnv, jclass clazz) {
   (void)clazz;  // required JNI parameter not needed by functions which don't access their host class.
-  const char* version = OrtGetApiBase()->GetVersionString();
+  const ORTCHAR_T* version = OrtGetApiBase()->GetVersionString();
   assert(version != NULL);
   jstring versionStr = (*jniEnv)->NewStringUTF(jniEnv, version);
   return versionStr;

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -39,6 +39,7 @@ try:
     from onnxruntime.capi._pybind_state import get_all_providers  # noqa: F401
     from onnxruntime.capi._pybind_state import get_available_providers  # noqa: F401
     from onnxruntime.capi._pybind_state import get_device  # noqa: F401
+    from onnxruntime.capi._pybind_state import get_build_info  # noqa: F401
     from onnxruntime.capi._pybind_state import get_version_string  # noqa: F401
     from onnxruntime.capi._pybind_state import set_default_logger_severity  # noqa: F401
     from onnxruntime.capi._pybind_state import set_default_logger_verbosity  # noqa: F401

--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -38,8 +38,8 @@ try:
     from onnxruntime.capi._pybind_state import enable_telemetry_events  # noqa: F401
     from onnxruntime.capi._pybind_state import get_all_providers  # noqa: F401
     from onnxruntime.capi._pybind_state import get_available_providers  # noqa: F401
-    from onnxruntime.capi._pybind_state import get_device  # noqa: F401
     from onnxruntime.capi._pybind_state import get_build_info  # noqa: F401
+    from onnxruntime.capi._pybind_state import get_device  # noqa: F401
     from onnxruntime.capi._pybind_state import get_version_string  # noqa: F401
     from onnxruntime.capi._pybind_state import set_default_logger_severity  # noqa: F401
     from onnxruntime.capi._pybind_state import set_default_logger_verbosity  # noqa: F401

--- a/onnxruntime/core/framework/tuning_context_impl.h
+++ b/onnxruntime/core/framework/tuning_context_impl.h
@@ -215,13 +215,11 @@ Status TuningResultsValidator::ValidateOrtVersion(const std::string& value) cons
 }
 
 std::string TuningResultsValidator::GetOrtGitCommit() const {
-  // TODO:
-  return "";
+  return ORT_GIT_COMMIT;
 }
 
 Status TuningResultsValidator::ValidateOrtGitCommit(const std::string& value) const {
-  // TODO:
-  ORT_UNUSED_PARAMETER(value);
+  ORT_RETURN_IF(value != ORT_GIT_COMMIT, "onnxruntime git commit mismatch");
   return Status::OK();
 }
 

--- a/onnxruntime/core/framework/tuning_context_impl.h
+++ b/onnxruntime/core/framework/tuning_context_impl.h
@@ -215,11 +215,13 @@ Status TuningResultsValidator::ValidateOrtVersion(const std::string& value) cons
 }
 
 std::string TuningResultsValidator::GetOrtGitCommit() const {
-  return ORT_GIT_COMMIT;
+  // TODO:
+  return "";
 }
 
 Status TuningResultsValidator::ValidateOrtGitCommit(const std::string& value) const {
-  ORT_RETURN_IF(value != ORT_GIT_COMMIT, "onnxruntime git commit mismatch");
+  // TODO:
+  ORT_UNUSED_PARAMETER(value);
   return Status::OK();
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2381,6 +2381,7 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 static constexpr OrtApiBase ort_api_base = {
     &OrtApis::GetApi,
     &OrtApis::GetVersionString,
+    &OrtApis::GetBuildInfoString,
 };
 
 /* Rules on how to add a new Ort API version
@@ -2764,6 +2765,10 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
 
 ORT_API(const char*, OrtApis::GetVersionString) {
   return ORT_VERSION;
+}
+
+ORT_API(const char*, OrtApis::GetBuildInfoString) {
+  return ORT_BUILD_INFO;
 }
 
 const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2764,11 +2764,11 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
 }
 
 ORT_API(const ORTCHAR_T*, OrtApis::GetVersionString) {
-  return ORT_VERSION;
+  return ORT_TSTR(ORT_VERSION);
 }
 
 ORT_API(const ORTCHAR_T*, OrtApis::GetBuildInfoString) {
-  return ORT_BUILD_INFO;
+  return ORT_TSTR(ORT_BUILD_INFO);
 }
 
 const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2764,11 +2764,11 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
 }
 
 ORT_API(const ORTCHAR_T*, OrtApis::GetVersionString) {
-  return ORT_TSTR(ORT_VERSION);
+  return ORT_TSTR_ON_MACRO(ORT_VERSION);
 }
 
 ORT_API(const ORTCHAR_T*, OrtApis::GetBuildInfoString) {
-  return ORT_TSTR(ORT_BUILD_INFO);
+  return ORT_TSTR_ON_MACRO(ORT_BUILD_INFO);
 }
 
 const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2763,11 +2763,11 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
   return nullptr;  // Unsupported version
 }
 
-ORT_API(const char*, OrtApis::GetVersionString) {
+ORT_API(const ORTCHAR_T*, OrtApis::GetVersionString) {
   return ORT_VERSION;
 }
 
-ORT_API(const char*, OrtApis::GetBuildInfoString) {
+ORT_API(const ORTCHAR_T*, OrtApis::GetBuildInfoString) {
   return ORT_BUILD_INFO;
 }
 

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -5,6 +5,7 @@ namespace OrtApis {
 
 ORT_API(const OrtApi*, GetApi, uint32_t version);
 ORT_API(const char*, GetVersionString);
+ORT_API(const char*, GetBuildInfoString);
 
 ORT_API(void, ReleaseEnv, OrtEnv*);
 ORT_API(void, ReleaseStatus, _Frees_ptr_opt_ OrtStatus*);

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -4,8 +4,8 @@
 namespace OrtApis {
 
 ORT_API(const OrtApi*, GetApi, uint32_t version);
-ORT_API(const char*, GetVersionString);
-ORT_API(const char*, GetBuildInfoString);
+ORT_API(const ORTCHAR_T*, GetVersionString);
+ORT_API(const ORTCHAR_T*, GetBuildInfoString);
 
 ORT_API(void, ReleaseEnv, OrtEnv*);
 ORT_API(void, ReleaseStatus, _Frees_ptr_opt_ OrtStatus*);

--- a/onnxruntime/python/onnxruntime_pybind_module.cc
+++ b/onnxruntime/python/onnxruntime_pybind_module.cc
@@ -22,6 +22,7 @@ PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
       "from highest to lowest.");
 
   m.def("get_version_string", []() -> std::string { return ORT_VERSION; });
+  m.def("get_build_info", []() -> std::string { return ORT_BUILD_INFO; });
 }
 }  // namespace python
 }  // namespace onnxruntime

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -29,6 +29,7 @@ using namespace onnxruntime;
 
 namespace {
 void usage() {
+  auto version_string = ToUTF8String(OrtGetApiBase()->GetVersionString());
   printf(
       "onnx_test_runner [options...] <data_root>\n"
       "Options:\n"
@@ -64,7 +65,7 @@ void usage() {
       "\t-h: help\n"
       "\n"
       "onnxruntime version: %s\n",
-      OrtGetApiBase()->GetVersionString());
+      version_string.c_str());
 }
 
 static TestTolerances LoadTestTolerances(bool enable_cuda, bool enable_openvino, bool useCustom, double atol, double rtol) {

--- a/onnxruntime/test/onnx/microbenchmark/activation.cc
+++ b/onnxruntime/test/onnx/microbenchmark/activation.cc
@@ -97,7 +97,7 @@ class MyIExecutionFrame : public IExecutionFrame {
   Status CreateNodeOutputMLValueImpl(OrtValue& /*ort_value*/, int /*ort_value_idx*/, const TensorShape* /*shape*/) override {
     abort();
   }
-  AllocatorPtr GetAllocatorImpl(const OrtMemoryInfo& info) const {
+  AllocatorPtr GetAllocatorImpl(const OrtMemoryInfo& info) const override {
     return a_.GetAllocator(info.mem_type);
   }
 
@@ -126,7 +126,7 @@ class MyIExecutionFrame : public IExecutionFrame {
     return Status::OK();
   }
 
-  Status CopyTensor(const Tensor& /*src*/, Tensor& /*dest*/) const {
+  Status CopyTensor(const Tensor& /*src*/, Tensor& /*dest*/) const override {
     return Status::OK();
   }
 };

--- a/onnxruntime/test/onnx/microbenchmark/batchnorm.cc
+++ b/onnxruntime/test/onnx/microbenchmark/batchnorm.cc
@@ -2,14 +2,14 @@
 #include "core/util/thread_utils.h"
 #include <benchmark/benchmark.h>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 #include "core/common/eigen_common_wrapper.h"
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/onnxruntime/test/onnx/microbenchmark/common.h
+++ b/onnxruntime/test/onnx/microbenchmark/common.h
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cstdlib>
+#ifdef _WIN32
 #include <malloc.h>
+#endif
 #include <new>
 #include <random>
 

--- a/onnxruntime/test/onnx/microbenchmark/eigen.cc
+++ b/onnxruntime/test/onnx/microbenchmark/eigen.cc
@@ -1,4 +1,4 @@
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6
 #pragma GCC diagnostic ignored "-Wignored-attributes"
@@ -25,7 +25,7 @@
 #include <unsupported/Eigen/CXX11/ThreadPool>
 #include <unsupported/Eigen/CXX11/Tensor>
 #include <unsupported/Eigen/CXX11/src/Tensor/TensorDeviceThreadPool.h>
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
 #pragma warning(pop)

--- a/onnxruntime/test/onnx/microbenchmark/gelu.cc
+++ b/onnxruntime/test/onnx/microbenchmark/gelu.cc
@@ -137,10 +137,9 @@ static void BM_ScaledTanhParallelFor(benchmark::State& state) {
   std::unique_ptr<concurrency::ThreadPool> tp(
       concurrency::CreateThreadPool(&onnxruntime::Env::Default(), tpo, concurrency::ThreadPoolType::INTRA_OP));
   const float alpha_ = 0.3f;
-  const float beta_ = 0.6f;
   for (auto _ : state) {
     ThreadPool::TryParallelFor(tp.get(), batch_size, cost,
-                               [alpha_, beta_, data, output](ptrdiff_t first, ptrdiff_t last) {
+                               [alpha_, data, output](ptrdiff_t first, ptrdiff_t last) {
                                  ptrdiff_t len = last - first;
                                  float* output_ptr = output + first;
                                  onnxruntime::ConstEigenVectorArrayMap<float> xm(data + first, len);

--- a/onnxruntime/test/onnx/microbenchmark/tptest.cc
+++ b/onnxruntime/test/onnx/microbenchmark/tptest.cc
@@ -30,7 +30,7 @@ BENCHMARK(BM_CreateThreadPool)
 // On Xeon W-2123 CPU, it takes about 2ns for each iteration
 #ifdef _WIN32
 #pragma optimize("", off)
-#else
+#elif defined(__GNUC__) && !defined(__clang__)
 #pragma GCC push_options
 #pragma GCC optimize("O0")
 #endif
@@ -42,7 +42,7 @@ void SimpleForLoop(ptrdiff_t first, ptrdiff_t last) {
 }
 #ifdef _WIN32
 #pragma optimize("", on)
-#else
+#elif defined(__GNUC__) && !defined(__clang__)
 #pragma GCC pop_options
 #endif
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -71,7 +71,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def testGetBuildInfo(self):  # noqa: N802
         self.assertIsNot(onnxrt.get_build_info(), None)
-        self.assertTrue("Build Info" in onnxrt.get_build_info())
+        self.assertIn("Build Info", onnxrt.get_build_info())
 
     def testModelSerialization(self):  # noqa: N802
         try:

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -69,6 +69,10 @@ class TestInferenceSession(unittest.TestCase):
     def testGetVersionString(self):  # noqa: N802
         self.assertIsNot(onnxrt.get_version_string(), None)
 
+    def testGetBuildInfo(self):  # noqa: N802
+        self.assertIsNot(onnxrt.get_build_info(), None)
+        self.assertTrue("Build Info" in onnxrt.get_build_info())
+
     def testModelSerialization(self):  # noqa: N802
         try:
             so = onnxrt.SessionOptions()

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2209,7 +2209,7 @@ TEST(CApiTest, get_available_providers_cpp) {
 TEST(CApiTest, get_version_string_cpp) {
   std::basic_string<ORTCHAR_T> version_string = Ort::GetVersionString();
   ASSERT_FALSE(version_string.empty());
-  ASSERT_EQ(version_string, std::basic_string<ORTCHAR_T>(ORT_TSTR(ORT_VERSION)));
+  ASSERT_EQ(version_string, std::basic_string<ORTCHAR_T>(ORT_TSTR_ON_MACRO(ORT_VERSION)));
 }
 
 TEST(CApiTest, TestSharedAllocators) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2207,9 +2207,9 @@ TEST(CApiTest, get_available_providers_cpp) {
 }
 
 TEST(CApiTest, get_version_string_cpp) {
-  std::string version_string = Ort::GetVersionString();
+  std::basic_string<ORTCHAR_T> version_string = Ort::GetVersionString();
   ASSERT_FALSE(version_string.empty());
-  ASSERT_EQ(version_string, ORT_VERSION);
+  ASSERT_EQ(version_string, std::basic_string<ORTCHAR_T>(ORT_TSTR(ORT_VERSION)));
 }
 
 TEST(CApiTest, TestSharedAllocators) {

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -360,6 +360,8 @@ PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
 
   m.def("get_version_string", []() -> std::string { return ORT_VERSION; });
 
+  m.def("get_build_info", []() -> std::string { return ORT_BUILD_INFO; });
+
   m.def(
       "clear_training_ep_instances", []() -> void {
         GetTrainingEnv().ClearExecutionProviderInstances();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
1. Add Build Info API to onnx.
2. Fix compile error while building onnxruntime_benchmark in MacOs.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
1. When Onnxruntime lib is serving online, we need a way to detect how this lib is built. This PR helps the developer to get the build information using `strings` such as git branch, git commit id, build type and cmake cxx flags, which is showed as follows.

![image](https://user-images.githubusercontent.com/19584326/233794371-b2f95a2c-27fb-4709-a6dd-bf4bb12b0b5b.png)

![image](https://user-images.githubusercontent.com/19584326/233794360-f96f5d2e-332c-405c-83f1-370ccc2b86f8.png)

If the build env has no git, there will be no git related infor:

![image](https://user-images.githubusercontent.com/19584326/234558596-298c1b01-9a90-41bf-9372-7259a8f8e5be.png)


3. Fix the following compile error while building benchmark in MacOs.
![image](https://user-images.githubusercontent.com/19584326/233793571-c261ac1f-47b2-434d-a293-7e9edc6c8a66.png)


