### PR TITLE
FIX image building in Linux Multi GPU TensorRT CI Pipeline

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -17,7 +17,7 @@ RUN v="8.6.0.12-1+cuda11.8" &&\
     sudo apt-get install -y libnvinfer8=${v} libnvonnxparsers8=${v} libnvparsers8=${v} libnvinfer-plugin8=${v} libnvinfer-vc-plugin8=${v}\
         libnvinfer-dev=${v} libnvonnxparsers-dev=${v} libnvparsers-dev=${v} libnvinfer-plugin-dev=${v} libnvinfer-vc-plugin-dev=${v}\
         python3-libnvinfer=${v} libnvinfer-samples=${v} libnvinfer-headers-dev=${v} libnvinfer-headers-plugin-dev=${v} libnvinfer-lean-dev=${v}\
-        libnvinfer-dispatch-dev=${v} libnvinfer-headers-plugin-dev=${v}
+        libnvinfer-dispatch-dev=${v} libnvinfer-headers-plugin-dev=${v} libnvinfer-dispatch8=${v} libnvinfer-lean8=${v}
 
 WORKDIR /root
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -16,8 +16,8 @@ RUN v="8.6.0.12-1+cuda11.8" &&\
     apt-get update &&\
     sudo apt-get install -y libnvinfer8=${v} libnvonnxparsers8=${v} libnvparsers8=${v} libnvinfer-plugin8=${v} libnvinfer-vc-plugin8=${v}\
         libnvinfer-dev=${v} libnvonnxparsers-dev=${v} libnvparsers-dev=${v} libnvinfer-plugin-dev=${v} libnvinfer-vc-plugin-dev=${v}\
-        python3-libnvinfer=${v} libnvinfer-samples=${v} libnvinfer-headers-dev=${v} libnvinfer-headers-plugin-dev=${v} libnvinfer-lean-dev=${v} \
-        libnvinfer-lean-dev-cross-amd64=${v} libnvinfer-dispatch-dev=${v} libnvinfer-dispatch-dev-cross-amd64=${v} libnvinfer-headers-plugin-dev=${v}
+        python3-libnvinfer=${v} libnvinfer-samples=${v} libnvinfer-headers-dev=${v} libnvinfer-headers-plugin-dev=${v} libnvinfer-lean-dev=${v}\
+        libnvinfer-dispatch-dev=${v} libnvinfer-headers-plugin-dev=${v}
 
 WORKDIR /root
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -7,6 +7,8 @@ FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
 ARG PYTHON_VERSION=3.8
 ARG DEBIAN_FRONTEND=noninteractive
 
+ENV CUDA_MODULE_LOADING=LAZY
+
 ADD scripts /tmp/scripts
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION && /tmp/scripts/install_os_deps.sh && /tmp/scripts/install_python_deps.sh -p $PYTHON_VERSION && rm -rf /tmp/scripts
 

--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -16,7 +16,8 @@ RUN v="8.6.0.12-1+cuda11.8" &&\
     apt-get update &&\
     sudo apt-get install -y libnvinfer8=${v} libnvonnxparsers8=${v} libnvparsers8=${v} libnvinfer-plugin8=${v} libnvinfer-vc-plugin8=${v}\
         libnvinfer-dev=${v} libnvonnxparsers-dev=${v} libnvparsers-dev=${v} libnvinfer-plugin-dev=${v} libnvinfer-vc-plugin-dev=${v}\
-        python3-libnvinfer=${v} libnvinfer-samples=${v}
+        python3-libnvinfer=${v} libnvinfer-samples=${v} libnvinfer-headers-dev=${v} libnvinfer-headers-plugin-dev=${v} libnvinfer-lean-dev=${v} \
+        libnvinfer-lean-dev-cross-amd64=${v} libnvinfer-dispatch-dev=${v} libnvinfer-dispatch-dev-cross-amd64=${v} libnvinfer-headers-plugin-dev=${v}
 
 WORKDIR /root
 


### PR DESCRIPTION
### Description
1. Add CUDA components
2. Set CUDA_MODULE_LOADING=LAZY


### Motivation and Context
[Linux Multi GPU TensorRT CI Pipeline](https://dev.azure.com/aiinfra/Lotus/_build?definitionId=1016&_a=summary) has been broken since April 13th. 
There's an exception in image building.


