### PR TITLE
Fix CPUInfo logging

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -3,6 +3,7 @@
 #include "core/common/cpuid_info.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/severity.h"
+#include <iostream>
 
 #ifdef __linux__
 
@@ -132,7 +133,13 @@ void CPUIDInfo::ArmLinuxInit() {
 #ifdef CPUINFO_SUPPORTED
   pytorch_cpuinfo_init_ = cpuinfo_initialize();
   if (!pytorch_cpuinfo_init_) {
-    LOGS_DEFAULT(WARNING) << "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
+    const char* message = "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
+    if (LoggingManager::HasDefaultLogger()) {
+      LOGS_DEFAULT(WARNING) << message;
+    } else {
+      std::cerr << message << std::endl;
+    }
+
     return;
   }
 #else


### PR DESCRIPTION
### Description
Both default logger and CPUInfo are static object, so the initialization might depends on compiler. When CPU Info is initialized, the default logger might or might not exist yet.

Add a check during logging. If there is no default logger yet, print to stderr instead.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

https://github.com/microsoft/onnxruntime/issues/15650 and https://github.com/microsoft/onnxruntime/issues/10038
