### PR TITLE
Allow compilation using clang when using cuda.

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/qordered_ops/qordered_qdq.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/qordered_ops/qordered_qdq.cc
@@ -1,5 +1,6 @@
 
 
+#include "core/framework/tensor_shape.h"
 #include "contrib_ops/cuda/quantization/qordered_ops/qordered_qdq.h"
 #include "contrib_ops/cuda/quantization/qordered_ops/qordered_qdq_impl.h"
 #include "gsl/gsl"


### PR DESCRIPTION
### Description
Currently compiling with clang + cuda leads to:

```
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/common/make_string.h:33:6: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
  ss << t;
     ^
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/common/make_string.h:39:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<gsl::span<const long, 18446744073709551615>>' requested here
  MakeStringImpl(ss, args...);
  ^
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/common/make_string.h:46:3: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, gsl::span<const long, 18446744073709551615>>' requested here
  MakeStringImpl(ss, args...);
  ^
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/common/make_string.h:93:18: note: in instantiation of function template specialization 'onnxruntime::detail::MakeStringImpl<const char *, gsl::span<const long, 18446744073709551615>>' requested here
  return detail::MakeStringImpl(detail::if_char_array_make_ptr_t<Args const&>(args)...);
                 ^
/code/build/_deps/onnxruntime-src/onnxruntime/contrib_ops/cuda/quantization/qordered_ops/qordered_qdq.cc:73:12: note: in instantiation of function template specialization 'onnxruntime::MakeString<char[39], gsl::span<const long, 18446744073709551615>>' requested here
    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Shape not meet clean tile requirement!", dims);
           ^
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/common/common.h:188:48: note: expanded from macro 'ORT_MAKE_STATUS'
                                ::onnxruntime::MakeString(__VA_ARGS__))
                                               ^
/code/build/_deps/onnxruntime-src/include/onnxruntime/core/framework/tensor_shape.h:201:15: note: 'operator<<' should be declared prior to the call site or in namespace 'gsl'
std::ostream& operator<<(std::ostream& out, const TensorShape& shape);
              ^
1 error generated.
```



### Motivation and Context
Fixes the above issue by including the `ostream<<` definition before using it.
