### PR TITLE
[DML EP] Massage SkipLayerNorm axes to better target metacommands

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorSkipLayerNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorSkipLayerNormalization.cpp
@@ -23,12 +23,50 @@ public:
             std::nullopt,
             kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0));
 
-        const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
+        constexpr static uint32_t minimumDimensionCount = 4;
 
+        // Pad the input and the output with trailing 1's until they are at least 4D
+        for (uint32_t i = 0; i < kernelCreationContext.GetInputCount(); ++i)
+        {
+            if (m_inputTensorDescs[i].GetDmlDataType() != DML_TENSOR_TYPE_INVALID)
+            {
+                auto sizes = m_inputTensorDescs[i].GetSizes();
+                std::vector<uint32_t> tensorShape(sizes.begin(), sizes.end());
+                tensorShape.resize(std::max<size_t>(tensorShape.size(), minimumDimensionCount), 1);
+
+                std::optional<std::vector<uint32_t>> optionalStrides;
+                if (!m_inputTensorDescs[i].GetStrides().empty())
+                {
+                    auto strides = m_inputTensorDescs[i].GetStrides();
+                    std::vector<uint32_t> tensorStrides(strides.begin(), strides.end());
+                    tensorStrides.resize(std::max<size_t>(tensorStrides.size(), minimumDimensionCount), 0);
+                    optionalStrides = std::move(tensorStrides);
+                }
+
+                m_inputTensorDescs[i] = TensorDesc(
+                    m_inputTensorDescs[i].GetDmlDataType(),
+                    tensorShape,
+                    std::move(optionalStrides));
+            }
+        }
+
+        m_outputTensorDescs[0] = TensorDesc(
+            m_outputTensorDescs[0].GetDmlDataType(),
+            m_inputTensorDescs[0].GetSizes());
+
+        if (m_outputTensorDescs[3].GetDmlDataType() != DML_TENSOR_TYPE_INVALID)
+        {
+            m_outputTensorDescs[3] = TensorDesc(
+                m_outputTensorDescs[3].GetDmlDataType(),
+                m_inputTensorDescs[0].GetSizes());
+        }
+
+        const float epsilon = kernelCreationContext.GetOptionalAttribute<float>(AttrName::Epsilon, DefaultEpsilon);
         int32_t onnxAxis = kernelCreationContext.GetOptionalAttribute<int32_t>(AttrName::Axis, -1);
-        uint32_t inputDimCount = kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
-        onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, inputDimCount);
-        std::vector<uint32_t> onnxAxes(static_cast<size_t>(inputDimCount) - static_cast<size_t>(onnxAxis));
+        uint32_t onnxDimCount = kernelCreationContext.GetTensorShapeDescription().GetInputTensorDimensionCount(0);
+        uint32_t dmlDimCount = m_inputTensorDescs[0].GetDimensionCount();
+        onnxAxis = OperatorHelper::HandleNegativeAxis(onnxAxis, onnxDimCount);
+        std::vector<uint32_t> onnxAxes(static_cast<size_t>(dmlDimCount) - static_cast<size_t>(onnxAxis));
         std::iota(onnxAxes.begin(), onnxAxes.end(), onnxAxis);
 
         assert(m_inputTensorDescs.size() == 5);


### PR DESCRIPTION
DML's MVN metacommand needs all axes except for batch and channel to be reduced. By adding trailing dimensions of 1's and their corresponding axes, the operation stays the same but we are now able to call metacommands.