### PR TITLE
Update OpenVINO Execution Provider doc

### DIFF
--- a/docs/execution-providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution-providers/OpenVINO-ExecutionProvider.md
@@ -50,15 +50,12 @@ pip install onnxruntime-openvino
 
 * **Windows**
 
-   To enable OpenVINO™ Execution Provider with ONNX Runtime on Windows we must install OpenVINO™ separately:
-      ```
-      pip install openvino
-      ```
-   Code to be added in ONNX Runtime Windows Samples:
-      ```
-      import openvino.utils as utils
-      utils.add_openvino_libs_to_path()
-      ```
+   To enable OpenVINO™ Execution Provider with ONNX Runtime on Windows it is must to set up the OpenVINO™ Environment Variables using the full installer package of OpenVINO™.
+   Initialize the OpenVINO™ environment by running the setupvars script as shown below. This is a required step:
+
+   ```
+      C:\ <openvino_install_directory>\setupvars.bat
+   ```
 
 * **Linux**
 


### PR DESCRIPTION
### Description
Update OpenVINO Execution Provider documentation for python


### Motivation and Context
`onnxruntime-openvino` doesn't have dependency on OpenVINO Python API itself, it needs OpenVINO libs.
Moreover, `add_openvino_libs_to_path()` meant to be internal, right now it doesn't work and will be deprecated in the upcoming OpenVINO release.
The recommended way is to install an archive with libraries and run setupvars to add OpenVINO libraries to PATH.

