### PR TITLE
Rename onnxruntime-Linux-CPU-2019 machine pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-ci-pipeline.yml
@@ -17,7 +17,7 @@ stages:
         skipComponentGovernanceDetection: true
         ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
         TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-      pool: onnxruntime-Linux-CPU-2019
+      pool: onnxruntime-Ubuntu2004-AMD-CPU
       steps:
       - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
         displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-aten-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-aten-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   variables:
     CCACHE_DIR: $(Agent.TempDirectory)/ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-  pool: onnxruntime-Linux-CPU-2019
+  pool: onnxruntime-Ubuntu2004-AMD-CPU
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-eager-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-eager-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  pool: onnxruntime-Linux-CPU-2019
+  pool: onnxruntime-Ubuntu2004-AMD-CPU
   steps:
   - checkout: self
     clean: true

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
   timeoutInMinutes: 120
   workspace:
     clean: all
-  pool: onnxruntime-Linux-CPU-2019
+  pool: onnxruntime-Linux-CPU-For-Android-CI
   variables:
     ORT_CACHE_DIR: $(Pipeline.Workspace)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]

--- a/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-gpu-ci-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
   workspace:
     clean: all
-  pool: onnxruntime-Linux-CPU-2019
+  pool: onnxruntime-Ubuntu2004-AMD-CPU
   steps:
   - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
     displayName: 'Clean Agent Directories'

--- a/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-react-native-ci-pipeline.yml
@@ -32,4 +32,4 @@ stages:
   parameters:
     NpmPackagingMode: ${{ variables.NpmPackagingMode }}
     BuildConfig: 'Release'
-    PoolName: 'onnxruntime-Linux-CPU-2019'
+    PoolName: 'onnxruntime-Linux-CPU-For-Android-CI'

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-ortmodule-test-clear-cache-pipeline.yml
@@ -4,7 +4,7 @@ jobs:
 - job: Onnxruntime_Linux_GPU_ORTTraining_Clear_Cache
 
   timeoutInMinutes: 15
-  pool: 'onnxruntime-Linux-CPU-2019'
+  pool: 'onnxruntime-Ubuntu2004-AMD-CPU'
 
   steps:
   - checkout: self

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -9,7 +9,7 @@ variables:
 - name: LINUX_CPU_BUILD_MACHINE_POOL_NAME  # name of a variable
   # The public ADO project
   ${{ if startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/onnxruntime/') }}:
-    value: 'onnxruntime-Linux-CPU-2019'
+    value: 'onnxruntime-Ubuntu2004-AMD-CPU'
   # The private ADO project
   ${{ if or(startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/aiinfra/'),startsWith(variables['System.CollectionUri'], 'https://aiinfra.visualstudio.com/')) }}:
     value: 'aiinfra-Linux-CPU'

--- a/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-ci.yml
@@ -1,5 +1,5 @@
 parameters:
-  AgentPool : 'onnxruntime-Linux-CPU-2019'
+  AgentPool : 'onnxruntime-Ubuntu2004-AMD-CPU'
   StageName : 'Linux_CI_Dev'
   SubmoduleCheckoutMode: ''
   RunDockerBuildArgs: '-o ubuntu20.04 -d cpu -x "--build_wheel"'


### PR DESCRIPTION
### Description
Rename onnxruntime-Linux-CPU-2019 machine pool to "onnxruntime-Ubuntu2004-AMD-CPU". The old one has an internal error and stuck there. I cannot make any change to it. It has been like this for more than 1 week. So I created a new pool with the same setting except the name is different. 
Also, move some android pipelines to "onnxruntime-Linux-CPU-For-Android-CI" which uses a standard image from https://github.com/actions/runner-images



