### PR TITLE
make nuget workflow easy to debug.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -32,8 +32,8 @@ parameters:
 
 - name: runId
   displayName: Specific Artifact's RunId
-  type: number
-  default: 0
+  type: string
+  default: '0'
 
 resources:
   repositories:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -25,13 +25,13 @@ parameters:
   default: false
 
 # these 2 parameters are used for debugging.
-- name: specificArtifact
-  displayName: Use Specific Artifact
+- name: SpecificArtifact
+  displayName: Use Specific Artifact (Debugging only)
   type: boolean
   default: false
 
-- name: runId
-  displayName: Specific Artifact's RunId
+- name: BuildId
+  displayName: Pipeline BuildId, you could find it in the URL
   type: string
   default: '0'
 
@@ -48,10 +48,10 @@ resources:
     ref: aead4d751c2101e23336aa73f2380df83e7a13f3
 
 variables:
-  - name: sepcificArtifact
-    value: ${{ parameters.specificArtifact }}
+  - name: specificArtifact
+    value: ${{ parameters.SpecificArtifact }}
   - name: otherRunId
-    value: ${{ parameters.runId }}
+    value: ${{ parameters.BuildId }}
 
 stages:
 - template: templates/c-api-cpu.yml

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -58,6 +58,8 @@ stages:
     AdditionalBuildFlags: ''
     AdditionalWinBuildFlags: '--enable_onnx_tests --enable_wcos'
     BuildVariant: 'default'
+    specificArtifact: ${{ parameters.specificArtifact }}
+    runId: ${{ parameters.runId }}
 
 - stage: Linux_C_API_Packaging_GPU_x64
   dependsOn: []

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -705,6 +705,8 @@ stages:
     AgentPool : Onnxruntime-Linux-GPU
     ArtifactSuffix: 'GPU'
     NugetPackageName : 'Microsoft.ML.OnnxRuntime.Gpu'
+    specificArtifact: ${{ parameters.specificArtifact}}
+    runId: ${{ parameters.runId}}
 
 - template: nuget/templates/dml-vs-2019.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -47,6 +47,12 @@ resources:
     name: pypa/manylinux
     ref: aead4d751c2101e23336aa73f2380df83e7a13f3
 
+variables:
+  - name: sepcificArtifact
+    value: ${{ parameters.specificArtifact }}
+  - name: otherRunId
+    value: ${{ parameters.runId }}
+
 stages:
 - template: templates/c-api-cpu.yml
   parameters:
@@ -58,8 +64,6 @@ stages:
     AdditionalBuildFlags: ''
     AdditionalWinBuildFlags: '--enable_onnx_tests --enable_wcos'
     BuildVariant: 'default'
-    specificArtifact: ${{ parameters.specificArtifact }}
-    runId: ${{ parameters.runId }}
 
 - stage: Linux_C_API_Packaging_GPU_x64
   dependsOn: []
@@ -166,24 +170,18 @@ stages:
         stepName: 'Download Pipeline Artifact - Win x64'
         artifactName: 'drop-onnxruntime-java-win-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-win-x64'
-        specificArtifact: ${{ parameters.specificArtifact }}
-        runId: ${{ parameters.runId }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-cuda'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64'
-        specificArtifact: ${{ parameters.specificArtifact }}
-        runId: ${{ parameters.runId }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64-tensorrt'
-        specificArtifact: ${{ parameters.specificArtifact }}
-        runId: ${{ parameters.runId }}
 
     - task: PowerShell@2
       displayName: 'PowerShell Script'
@@ -707,8 +705,6 @@ stages:
     AgentPool : Onnxruntime-Linux-GPU
     ArtifactSuffix: 'GPU'
     NugetPackageName : 'Microsoft.ML.OnnxRuntime.Gpu'
-    specificArtifact: ${{ parameters.specificArtifact}}
-    runId: ${{ parameters.runId}}
 
 - template: nuget/templates/dml-vs-2019.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -32,8 +32,8 @@ parameters:
 
 - name: runId
   displayName: Specific Artifact's RunId
-  type: string
-  default: '0'
+  type: number
+  default: 0
 
 resources:
   repositories:

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -165,6 +165,7 @@ stages:
         artifactName: 'drop-onnxruntime-java-win-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-win-x64'
         specificArtifact: ${{ parameters.specificArtifact }}
+        runId: ${{ parameters.runId }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
@@ -172,6 +173,7 @@ stages:
         artifactName: 'drop-onnxruntime-java-linux-x64-cuda'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64'
         specificArtifact: ${{ parameters.specificArtifact }}
+        runId: ${{ parameters.runId }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
@@ -179,6 +181,7 @@ stages:
         artifactName: 'drop-onnxruntime-java-linux-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64-tensorrt'
         specificArtifact: ${{ parameters.specificArtifact }}
+        runId: ${{ parameters.runId }}
 
     - task: PowerShell@2
       displayName: 'PowerShell Script'

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -24,6 +24,17 @@ parameters:
   type: boolean
   default: false
 
+# these 2 parameters are used for debugging.
+- name: specificArtifact
+  displayName: Use Specific Artifact
+  type: boolean
+  default: false
+
+- name: runId
+  displayName: Specific Artifact's RunId
+  type: number
+  default: 0
+
 resources:
   repositories:
   - repository: onnxruntime-inference-examples # The name used to reference this repository in the checkout step
@@ -148,26 +159,26 @@ stages:
       submodules: false
     - template: templates/set-version-number-variables-step.yml
 
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Pipeline Artifact - Win x64'
-      inputs:
-        buildType: 'current'
+    - template: templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        stepName: 'Download Pipeline Artifact - Win x64'
         artifactName: 'drop-onnxruntime-java-win-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-win-x64'
+        speificArtifact: ${{ parameters.specificArtifact }}
 
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Pipeline Artifact - Linux x64'
-      inputs:
-        buildType: 'current'
+    - template: templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-cuda'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64'
+        speificArtifact: ${{ parameters.specificArtifact }}
 
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Pipeline Artifact - Linux x64'
-      inputs:
-        buildType: 'current'
+    - template: templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64-tensorrt'
+        speificArtifact: ${{ parameters.specificArtifact }}
 
     - task: PowerShell@2
       displayName: 'PowerShell Script'
@@ -837,31 +848,31 @@ stages:
                 rename %%~ni.nupkg %%~ni.zip
                 unzip %%~ni.zip -d %%~ni
                 del /Q %%~ni.zip
-        
+
                 unzip win-dml-x86.zip -d win-x86
                 mkdir %%~ni\runtimes\win-x86
                 mkdir %%~ni\runtimes\win-x86\native
-        
+
                 move win-x86\runtimes\win-x86\native\onnxruntime.dll %%~ni\runtimes\win-x86\native\onnxruntime.dll
                 move win-x86\runtimes\win-x86\native\onnxruntime.lib %%~ni\runtimes\win-x86\native\onnxruntime.lib
                 move win-x86\runtimes\win-x86\native\onnxruntime.pdb %%~ni\runtimes\win-x86\native\onnxruntime.pdb
-        
+
                 unzip win-dml-arm64.zip -d win-arm64
                 mkdir %%~ni\runtimes\win-arm64
                 mkdir %%~ni\runtimes\win-arm64\native
-        
+
                 move win-arm64\runtimes\win-arm64\native\onnxruntime.dll %%~ni\runtimes\win-arm64\native\onnxruntime.dll
                 move win-arm64\runtimes\win-arm64\native\onnxruntime.lib %%~ni\runtimes\win-arm64\native\onnxruntime.lib
                 move win-arm64\runtimes\win-arm64\native\onnxruntime.pdb %%~ni\runtimes\win-arm64\native\onnxruntime.pdb
-        
+
                 unzip win-dml-arm.zip -d win-arm
                 mkdir %%~ni\runtimes\win-arm
                 mkdir %%~ni\runtimes\win-arm\native
-        
+
                 move win-arm\runtimes\win-arm\native\onnxruntime.dll %%~ni\runtimes\win-arm\native\onnxruntime.dll
                 move win-arm\runtimes\win-arm\native\onnxruntime.lib %%~ni\runtimes\win-arm\native\onnxruntime.lib
                 move win-arm\runtimes\win-arm\native\onnxruntime.pdb %%~ni\runtimes\win-arm\native\onnxruntime.pdb
-        
+
                 pushd %%~ni
                 zip -r ..\%%~ni.zip .
                 popd

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -164,21 +164,21 @@ stages:
         stepName: 'Download Pipeline Artifact - Win x64'
         artifactName: 'drop-onnxruntime-java-win-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-win-x64'
-        speificArtifact: ${{ parameters.specificArtifact }}
+        specificArtifact: ${{ parameters.specificArtifact }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-cuda'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64'
-        speificArtifact: ${{ parameters.specificArtifact }}
+        specificArtifact: ${{ parameters.specificArtifact }}
 
     - template: templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Pipeline Artifact - Linux x64'
         artifactName: 'drop-onnxruntime-java-linux-x64-tensorrt'
         targetPath: '$(Build.BinariesDirectory)\java-artifact\onnxruntime-java-linux-x64-tensorrt'
-        speificArtifact: ${{ parameters.specificArtifact }}
+        specificArtifact: ${{ parameters.specificArtifact }}
 
     - task: PowerShell@2
       displayName: 'PowerShell Script'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -2,8 +2,6 @@ parameters:
   AgentPool: 'aiinfra-Linux-CPU'
   ArtifactSuffix: ''
   NugetPackageName : ''
-  specificArtifact: false
-  runId: '0'
 
 stages:
 - stage: NuGet_Test_Linux_${{ parameters.ArtifactSuffix }}
@@ -29,16 +27,12 @@ stages:
         stepName: 'Download Signed NuGet'
         artifactName: drop-signed-nuget-${{ parameters.ArtifactSuffix }}
         targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
-        specificArtifact: ${{ parameters.specificArtifact }}
-        runId: ${{ parameters.runId }}
 
     - template: ../../templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Linux CustomOp TestData'
         artifactName: 'onnxruntime-linux-x64'
         targetPath: '$(Build.BinariesDirectory)/testdata'
-        specificArtifact: ${{ parameters.specificArtifact }}
-        runId: ${{ parameters.runId }}
 
     - template: get-nuget-package-version-as-variable.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -22,7 +22,11 @@ stages:
     variables:
     - name: OnnxRuntimeBuildDirectory
       value: '$(Build.BinariesDirectory)'
+
     steps:
+    - script: |
+        echo {{ parameters.runId }}
+      displayName: 'Echo Run Id'
 
     - template: ../../templates/flex-downloadPipelineArtifact.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -3,7 +3,7 @@ parameters:
   ArtifactSuffix: ''
   NugetPackageName : ''
   specificArtifact: false
-  runID: 0
+  runId: 0
 
 stages:
 - stage: NuGet_Test_Linux_${{ parameters.ArtifactSuffix }}

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -25,7 +25,7 @@ stages:
 
     steps:
     - script: |
-        echo {{ parameters.runId }}
+        echo ${{ parameters.runId }}
       displayName: 'Echo Run Id'
 
     - template: ../../templates/flex-downloadPipelineArtifact.yml

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -2,6 +2,8 @@ parameters:
   AgentPool: 'aiinfra-Linux-CPU'
   ArtifactSuffix: ''
   NugetPackageName : ''
+  specificArtifact: false
+  runID: 0
 
 stages:
 - stage: NuGet_Test_Linux_${{ parameters.ArtifactSuffix }}
@@ -22,17 +24,21 @@ stages:
       value: '$(Build.BinariesDirectory)'
     steps:
 
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download Signed NuGet'
-      inputs:
+    - template: ../../templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        stepName: 'Download Signed NuGet'
         artifactName: drop-signed-nuget-${{ parameters.ArtifactSuffix }}
         targetPath: '$(Build.BinariesDirectory)/nuget-artifact'
+        specificArtifact: ${{ parameters.specificArtifact }}
+        runId: ${{ parameters.runId }}
 
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download Linux CustomOp TestData'
-      inputs:
+    - template: ../../templates/flex-downloadPipelineArtifact.yml
+      parameters:
+        stepName: 'Download Linux CustomOp TestData'
         artifactName: 'onnxruntime-linux-x64'
         targetPath: '$(Build.BinariesDirectory)/testdata'
+        specificArtifact: ${{ parameters.specificArtifact }}
+        runId: ${{ parameters.runId }}
 
     - template: get-nuget-package-version-as-variable.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -24,10 +24,6 @@ stages:
       value: '$(Build.BinariesDirectory)'
 
     steps:
-    - script: |
-        echo ${{ parameters.runId }}
-      displayName: 'Echo Run Id'
-
     - template: ../../templates/flex-downloadPipelineArtifact.yml
       parameters:
         stepName: 'Download Signed NuGet'

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/test_linux.yml
@@ -3,7 +3,7 @@ parameters:
   ArtifactSuffix: ''
   NugetPackageName : ''
   specificArtifact: false
-  runId: 0
+  runId: '0'
 
 stages:
 - stage: NuGet_Test_Linux_${{ parameters.ArtifactSuffix }}

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -38,16 +38,6 @@ parameters:
   type: string
   default: 'default'
 
-- name: specificArtifact
-  displayName: Use Specific Artifact
-  type: boolean
-  default: false
-
-- name: runId
-  displayName: Specific Artifact's RunId
-  type: string
-  default: '0'
-
 stages:
 - template: linux-cpu-packaging-pipeline.yml
   parameters:
@@ -780,8 +770,6 @@ stages:
     AgentPool : aiinfra-Linux-CPU
     NugetPackageName : 'Microsoft.ML.OnnxRuntime'
     ArtifactSuffix: 'CPU'
-    specificArtifact: ${{ parameters.specificArtifact }}
-    runId: ${{ parameters.runId }}
 
 - template: ../nuget/templates/test_macos.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -780,6 +780,8 @@ stages:
     AgentPool : aiinfra-Linux-CPU
     NugetPackageName : 'Microsoft.ML.OnnxRuntime'
     ArtifactSuffix: 'CPU'
+    specificArtifact: ${{ parameters.specificArtifact }}
+    runId: ${{ parameters.runId }}
 
 - template: ../nuget/templates/test_macos.yml
   parameters:
@@ -795,8 +797,6 @@ stages:
   parameters:
     AgentPool : 'aiinfra-Linux-CPU'
     StageSuffix : 'Linux_CPU_x64'
-    specificArtifact: ${{ parameters.specificArtifact }}
-    runId: ${{ parameters.runId }}
 
 - template: ../nodejs/templates/test_macos.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -38,6 +38,16 @@ parameters:
   type: string
   default: 'default'
 
+- name: specificArtifact
+  displayName: Use Specific Artifact
+  type: boolean
+  default: false
+
+- name: runId
+  displayName: Specific Artifact's RunId
+  type: string
+  default: '0'
+
 stages:
 - template: linux-cpu-packaging-pipeline.yml
   parameters:
@@ -785,6 +795,8 @@ stages:
   parameters:
     AgentPool : 'aiinfra-Linux-CPU'
     StageSuffix : 'Linux_CPU_x64'
+    specificArtifact: ${{ parameters.specificArtifact }}
+    runId: ${{ parameters.runId }}
 
 - template: ../nodejs/templates/test_macos.yml
   parameters:
@@ -918,5 +930,3 @@ stages:
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()
-
-

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -1,0 +1,31 @@
+parameters:
+  - name: stepName
+    type: string
+
+  - name: artifactName
+    type: string
+
+  - name: targetPath
+    type: string
+
+  - name: specificArtifact
+    type: boolean
+    default: false
+
+  - name: runId
+    type: string
+    default: ''
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Pipeline Artifact - Win x64'
+  inputs:
+    artifactName: ${{ parameters.artifactName}}
+    targetPath: '${{ parameters.targetPath }}'
+    ${{ if eq(parameters.specificArtifact, false)}}:
+      buildType: 'current'
+    ${{ else }}:
+        source: 'specific'
+        project: $(System.TeamProject)
+        pipeline: $(Build.DefinitionName)
+        runVersion: 'specific'
+        runId: ${{ parameters.runId }}

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -13,8 +13,8 @@ parameters:
     default: false
 
   - name: runId
-    type: number
-    default: 0
+    type: string
+    default: '0'
 
 steps:
   - task: DownloadPipelineArtifact@2

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -16,16 +16,17 @@ parameters:
     type: string
     default: ''
 
-- task: DownloadPipelineArtifact@2
-  displayName: 'Download Pipeline Artifact - Win x64'
-  inputs:
-    artifactName: ${{ parameters.artifactName}}
-    targetPath: '${{ parameters.targetPath }}'
-    ${{ if eq(parameters.specificArtifact, false)}}:
-      buildType: 'current'
-    ${{ else }}:
-        source: 'specific'
-        project: $(System.TeamProject)
-        pipeline: $(Build.DefinitionName)
-        runVersion: 'specific'
-        runId: ${{ parameters.runId }}
+steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download Pipeline Artifact - Win x64'
+    inputs:
+      artifactName: ${{ parameters.artifactName}}
+      targetPath: '${{ parameters.targetPath }}'
+      ${{ if eq(parameters.specificArtifact, false)}}:
+        buildType: 'current'
+      ${{ else }}:
+          source: 'specific'
+          project: $(System.TeamProject)
+          pipeline: $(Build.DefinitionName)
+          runVersion: 'specific'
+          runId: ${{ parameters.runId }}

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -8,25 +8,17 @@ parameters:
   - name: targetPath
     type: string
 
-  - name: specificArtifact
-    type: boolean
-    default: false
-
-  - name: runId
-    type: string
-    default: '0'
-
 steps:
   - task: DownloadPipelineArtifact@2
     displayName: ${{ parameters.stepName }}}
     inputs:
       artifactName: ${{ parameters.artifactName}}
       targetPath: '${{ parameters.targetPath }}'
-      ${{ if eq(parameters.specificArtifact, false)}}:
+      ${{ if eq(variables.specificArtifact, false)}}:
         buildType: 'current'
       ${{ else }}:
           source: 'specific'
           project: $(System.TeamProject)
           pipeline: $(Build.DefinitionName)
           runVersion: 'specific'
-          runId: ${{ parameters.runId }}
+          runId: $(otherRunId)

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -13,8 +13,8 @@ parameters:
     default: false
 
   - name: runId
-    type: string
-    default: ''
+    type: number
+    default: 0
 
 steps:
   - task: DownloadPipelineArtifact@2

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -17,11 +17,6 @@ parameters:
     default: ''
 
 steps:
-  - script: |
-      set -ex
-      echo $(System.TeamProject)
-    displayName : Test step
-
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Pipeline Artifact - Win x64'
     inputs:
@@ -31,7 +26,7 @@ steps:
         buildType: 'current'
       ${{ else }}:
           source: 'specific'
-          project: 'Lotus'
+          project: $(System.TeamProject)
           pipeline: $(Build.DefinitionName)
           runVersion: 'specific'
           runId: ${{ parameters.runId }}

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -18,6 +18,7 @@ parameters:
 
 steps:
   - script: |
+      set -ex
       echo $(System.TeamProject)
     displayName : Test step
 
@@ -30,7 +31,7 @@ steps:
         buildType: 'current'
       ${{ else }}:
           source: 'specific'
-          project: 'lotus'
+          project: 'Lotus'
           pipeline: $(Build.DefinitionName)
           runVersion: 'specific'
           runId: ${{ parameters.runId }}

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -18,7 +18,7 @@ parameters:
 
 steps:
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download Pipeline Artifact - Win x64'
+    displayName: ${{ parameters.stepName }}}
     inputs:
       artifactName: ${{ parameters.artifactName}}
       targetPath: '${{ parameters.targetPath }}'

--- a/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/flex-downloadPipelineArtifact.yml
@@ -17,6 +17,10 @@ parameters:
     default: ''
 
 steps:
+  - script: |
+      echo $(System.TeamProject)
+    displayName : Test step
+
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Pipeline Artifact - Win x64'
     inputs:
@@ -26,7 +30,7 @@ steps:
         buildType: 'current'
       ${{ else }}:
           source: 'specific'
-          project: $(System.TeamProject)
+          project: 'lotus'
           pipeline: $(Build.DefinitionName)
           runVersion: 'specific'
           runId: ${{ parameters.runId }}


### PR DESCRIPTION
### Description
Add parameters to make some stages could use other run's intermediate output.

### Motivation and Context
nuget workflow has 38 stages of 4 layers.
We had to run the whole workflow from begining to test one stage.
It could make life easier to run only one stage for testing.
like
![image](https://user-images.githubusercontent.com/16190118/234453721-e6e9a4bd-5e0b-4101-a18e-d5cf60615c9f.png)

### N.B.
In this PR, Nuget_Test_Linux_CPU, Nuget_Test_LinuxGPU and Jar_Packaging_GPU are enabled as the first step.
So I can start to move tests from Linux host to container


