### PR TITLE
Enable RUFF as a formatter

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -64,36 +64,6 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     '--requirement=requirements-lintrunner.txt',
 ]
-
-[[linter]]
-code = 'RUFF-FIX'
-include_patterns = [
-    '**/*.py',
-    '**/*.pyi',
-]
-exclude_patterns = [
-    'cmake/external/**',
-    # ignore generated flatbuffers code
-    'onnxruntime/core/flatbuffers/ort_flatbuffers_py/**',
-]
-command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'ruff_fix_linter',
-    '--config=pyproject.toml',
-    '@{{PATHSFILE}}'
-]
-init_command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'pip_init',
-    '--dry-run={{DRYRUN}}',
-    '--requirement=requirements-lintrunner.txt',
-]
 is_formatter = true
 
 

--- a/docs/Coding_Conventions_and_Standards.md
+++ b/docs/Coding_Conventions_and_Standards.md
@@ -167,7 +167,13 @@ If you want to see what lintrunner init will install, run
 To lint local changes:
 
 ```bash
-lintrunner -m main
+lintrunner
+```
+
+To format files and apply suggestions:
+
+```bash
+lintrunner -a
 ```
 
 To lint all files:
@@ -176,10 +182,10 @@ To lint all files:
 lintrunner --all-files
 ```
 
-To format files:
+To show help text:
 
 ```bash
-lintrunner -a --all-files
+lintrunner -h
 ```
 
 To read more about lintrunner, see [wiki](https://github.com/pytorch/pytorch/wiki/lintrunner).

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,5 +1,5 @@
 # This file is auto updated by dependabot
-lintrunner-adapters
+lintrunner-adapters>=0.8.0
 # RUFF, RUFF-FIX
 ruff==0.0.261
 # BLACK-ISORT


### PR DESCRIPTION
### Description

RUFF can now format since lintrunner-adapters v0.8. Removed the RUFF-FIX linter.



### Motivation and Context

Better engineering


