### PR TITLE
Remove some D2D memcpy in T5 BeamSearch

### DIFF
--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -859,14 +859,14 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
   const dim3 grid(batch_size * beam_width, num_heads, sequence_length);
 
 #ifndef USE_ROCM
-  if (head_size % 4 == 0) {
+  if ((head_size % 4) == 0) {
     using vec_type = typename TypeMapper<T, 4>::Type;
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(key_cache),
                                                         reinterpret_cast<vec_type*>(key_cache_expanded),
                                                         beam_width,
                                                         max_seq_length,
                                                         head_size / 4);
-  } else if (head_size & 1 == 0) {
+  } else if ((head_size & 1) == 0) {
     using vec_type = typename TypeMapper<T, 2>::Type;
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(key_cache),
                                                         reinterpret_cast<vec_type*>(key_cache_expanded),
@@ -943,13 +943,13 @@ void BufferExpansionKernelLauncher(const T* input,
   const dim3 block(128);
 
 #ifndef USE_ROCM
-  if (chunk_size % 4 == 0) {
+  if ((chunk_size % 4) == 0) {
     using vec_type = typename TypeMapper<T, 4>::Type;
     const dim3 grid(batch_size, beam_width, (chunk_size / 4 + block.x - 1) / block.x);
     BufferExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(input),
                                                       reinterpret_cast<vec_type*>(output),
                                                       chunk_size / 4);
-  } else if (chunk_size & 1 == 0) {
+  } else if ((chunk_size & 1) == 0) {
     using vec_type = typename TypeMapper<T, 2>::Type;
     const dim3 grid(batch_size, beam_width, (chunk_size / 2 + block.x - 1) / block.x);
     BufferExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(input),

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -807,6 +807,7 @@ void UpdateDecoderMaskedMultiHeadAttentionCacheIndirection(int32_t* tgt_indir_ca
                                                                                           current_length);
 }
 
+#ifndef USE_ROCM
 namespace {
 template <typename T, size_t size>
 struct TypeMapper : public V_vec_m_<T, size> {};
@@ -821,6 +822,7 @@ struct TypeMapper<int32_t, 4> {
   using Type = uint4;
 };
 }  // namespace
+#endif
 
 template <typename T>
 __global__ void KeyCacheExpansionKernel(const T* input,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -857,12 +857,12 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
                                      int max_seq_length,
                                      int head_size,
                                      cudaStream_t stream) {
-  const dim3 block(256);
   const dim3 grid(batch_size * beam_width, num_heads, sequence_length);
 
   int equiv_head_size = (head_size & 1) == 0 ? (head_size >> 1) : head_size;
   equiv_head_size = (equiv_head_size & 1) == 0 ? (equiv_head_size >> 1) : equiv_head_size;
 
+  // Here we know head_size is smaller than max_thread_num_per_block
   int tpb = std::max(32, equiv_head_size);
 
   // round up tpb to power of 2
@@ -877,6 +877,7 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
 #ifndef USE_ROCM
   if ((head_size % 4) == 0) {
     using vec_type = typename TypeMapper<T, 4>::Type;
+    const dim3 block(tpb);
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(key_cache),
                                                         reinterpret_cast<vec_type*>(key_cache_expanded),
                                                         beam_width,
@@ -884,6 +885,7 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
                                                         equiv_head_size);
   } else if ((head_size & 1) == 0) {
     using vec_type = typename TypeMapper<T, 2>::Type;
+    const dim3 block(tpb);
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(key_cache),
                                                         reinterpret_cast<vec_type*>(key_cache_expanded),
                                                         beam_width,
@@ -891,6 +893,7 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
                                                         equiv_head_size);
   } else {
 #endif
+    const dim3 block(tpb);
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(key_cache,
                                                         key_cache_expanded,
                                                         beam_width,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.cu
@@ -858,6 +858,7 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
   const dim3 block(256);
   const dim3 grid(batch_size * beam_width, num_heads, sequence_length);
 
+#ifndef USE_ROCM
   if (head_size % 4 == 0) {
     using vec_type = typename TypeMapper<T, 4>::Type;
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(reinterpret_cast<const vec_type*>(key_cache),
@@ -873,12 +874,15 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
                                                         max_seq_length,
                                                         head_size / 2);
   } else {
+#endif
     KeyCacheExpansionKernel<<<grid, block, 0, stream>>>(key_cache,
                                                         key_cache_expanded,
                                                         beam_width,
                                                         max_seq_length,
                                                         head_size);
+#ifndef USE_ROCM
   }
+#endif
 }
 
 template void KeyCacheExpansionKernelLauncher(const float* key_cache,
@@ -938,6 +942,7 @@ void BufferExpansionKernelLauncher(const T* input,
                                    cudaStream_t stream) {
   const dim3 block(128);
 
+#ifndef USE_ROCM
   if (chunk_size % 4 == 0) {
     using vec_type = typename TypeMapper<T, 4>::Type;
     const dim3 grid(batch_size, beam_width, (chunk_size / 4 + block.x - 1) / block.x);
@@ -951,11 +956,14 @@ void BufferExpansionKernelLauncher(const T* input,
                                                       reinterpret_cast<vec_type*>(output),
                                                       chunk_size / 2);
   } else {
+#endif
     const dim3 grid(batch_size, beam_width, (chunk_size + block.x - 1) / block.x);
     BufferExpansionKernel<<<grid, block, 0, stream>>>(input,
                                                       output,
                                                       chunk_size);
+#ifndef USE_ROCM
   }
+#endif
 }
 
 template void BufferExpansionKernelLauncher(const float* input,

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
@@ -119,6 +119,17 @@ void UpdateDecoderMaskedMultiHeadAttentionCacheIndirection(int32_t* tgt_indir_ca
                                                            int current_length,
                                                            cudaStream_t stream);
 
+template <typename T>
+void KeyCacheExpansionKernelLauncher(const T* key_cache,
+                                     T* key_cache_expanded,
+                                     int batch_size,
+                                     int beam_width,
+                                     int num_heads,
+                                     int sequence_length,
+                                     int max_seq_length,
+                                     int head_size,
+                                     cudaStream_t stream);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_cuda_impl.h
@@ -130,6 +130,14 @@ void KeyCacheExpansionKernelLauncher(const T* key_cache,
                                      int head_size,
                                      cudaStream_t stream);
 
+template <typename T>
+void BufferExpansionKernelLauncher(const T* input,
+                                   T* output,
+                                   int batch_size,
+                                   int beam_width,
+                                   int chunk_size,
+                                   cudaStream_t stream);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1207,9 +1207,9 @@ Status ExpandBuffer(Stream* ort_stream,
 
     cuda::BufferExpansionKernelLauncher<CudaT>(reinterpret_cast<const CudaT*>(input_data),
                                                reinterpret_cast<CudaT*>(expanded_data),
-                                               batch_size,
+                                               static_cast<int>(batch_size),
                                                num_beams,
-                                               chunk_size,
+                                               static_cast<int>(chunk_size),
                                                cuda_stream);
     return Status::OK();
   }
@@ -1222,12 +1222,12 @@ Status ExpandBuffer(Stream* ort_stream,
 
   cuda::KeyCacheExpansionKernelLauncher<CudaT>(reinterpret_cast<const CudaT*>(input_data),
                                                reinterpret_cast<CudaT*>(expanded_data),
-                                               batch_size,
+                                               static_cast<int>(batch_size),
                                                num_beams,
-                                               num_heads,
-                                               sequence_length,
+                                               static_cast<int>(num_heads),
+                                               static_cast<int>(sequence_length),
                                                max_sequence_length,
-                                               head_size,
+                                               static_cast<int>(head_size),
                                                cuda_stream);
 
   return Status::OK();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

replace D2D memcpy with cuda kernels in creating decoder initial feeds
before:
![image](https://user-images.githubusercontent.com/52801275/234746326-209110e3-1cd4-4e8c-a488-515dd34c06c7.png)


after:
![image](https://user-images.githubusercontent.com/52801275/234736352-0bd027a0-e382-47d7-a1c5-ae9fbc9f1c9d.png)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


