### PR TITLE
[ROCm] reduce batch size to fix CI error

### DIFF
--- a/orttraining/tools/ci_test/run_batch_size_test.py
+++ b/orttraining/tools/ci_test/run_batch_size_test.py
@@ -56,7 +56,7 @@ def main():
     configs["MI100_32G"] = [
         Config(True, 128, 192, 20, ""),
         Config(True, 512, 26, 80, ""),
-        Config(False, 128, 108, 20, ""),
+        Config(False, 128, 106, 20, ""),
         Config(False, 512, 16, 80, ""),
     ]
 


### PR DESCRIPTION
ROCm CI batch size test occasionally fail. Try reduce batch size to fix it.

error log:
Non-zero status code returned while running FusedMatMul node. Name:'MatMul_2914_Grad/FusedMatMul_0' Status Message: HIP error hipErrorNotFound:named symbol not found
Non-zero status code returned while running Gemm node. Name:'MatMul_2891_Grad/Gemm_5' Status Message: HIP error hipErrorNotFound:named symbol not found


