### PR TITLE
Fix error in post-merge pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci-vs-2019.yml
@@ -232,7 +232,7 @@ jobs:
         CCACHE_DIR: $(ORT_CACHE_DIR)
 
   - powershell: |
-      Get-Volume D
+      Get-Volume $("$(Build.BinariesDirectory)")[0]
     displayName: check disk size
 
   - task: DeleteFiles@1
@@ -243,7 +243,7 @@ jobs:
         **/*.obj
 
   - powershell: |
-      Get-Volume D
+      Get-Volume $("$(Build.BinariesDirectory)")[0]
     displayName: check disk size
 
   - ${{ if eq(parameters.EnablePython, true) }}:


### PR DESCRIPTION
### Description
Get the right drive letter on Windows


### Motivation and Context
Build Directory might be in drive C


