### PR TITLE
[js/webgpu] fix download failure due to buffer change

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -279,8 +279,12 @@ export class WebGpuBackend {
     this.gpuDataManager.memcpy(src, dst);
   }
 
-  async download(gpuDataId: number, data: Uint8Array): Promise<void> {
+  async download(gpuDataId: number, getTargetBuffer: () => Uint8Array): Promise<void> {
     const arrayBuffer = await this.gpuDataManager.download(gpuDataId);
+
+    // the underlying buffer may be changed after the async function is called. so we use a getter function to make sure
+    // the buffer is up-to-date.
+    const data = getTargetBuffer();
     data.set(new Uint8Array(arrayBuffer));
   }
 

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -124,13 +124,11 @@ export const init = async(module: OrtWasmModule): Promise<void> => {
         // jsepCopyAsync(src, dst, size)
         async(gpuDataId: number, dataOffset: number, size: number):
             Promise<void> => {
-              const data = module.HEAPU8.subarray(dataOffset, dataOffset + size);
-
               LOG_DEBUG(
                   'verbose',
                   () => `[WebGPU] jsepCopyGpuToCpu: gpuDataId=${gpuDataId}, dataOffset=${dataOffset}, size=${size}`);
 
-              await backend.download(gpuDataId, data);
+              await backend.download(gpuDataId, () => module.HEAPU8.subarray(dataOffset, dataOffset + size));
             },
 
         // jsepCreateKernel


### PR DESCRIPTION
### Description
fix download failure due to buffer change.

WebAssembly buffer may change (growth triggered by memory allocation) during an async function call.