### PR TITLE
[Java] CheckpointState AddProperty & GetProperty support 

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtTrainingSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtTrainingSession.java
@@ -221,6 +221,72 @@ public final class OrtTrainingSession implements AutoCloseable {
     return evalOutputNames;
   }
 
+  /**
+   * Adds a float property to this training session checkpoint.
+   *
+   * @param name The property name.
+   * @param value The property value.
+   * @throws OrtException If the call failed.
+   */
+  public void addProperty(String name, float value) throws OrtException {
+    checkpoint.addProperty(name, value);
+  }
+
+  /**
+   * Adds a int property to this training session checkpoint.
+   *
+   * @param name The property name.
+   * @param value The property value.
+   * @throws OrtException If the call failed.
+   */
+  public void addProperty(String name, int value) throws OrtException {
+    checkpoint.addProperty(name, value);
+  }
+
+  /**
+   * Adds a String property to this training session checkpoint.
+   *
+   * @param name The property name.
+   * @param value The property value.
+   * @throws OrtException If the call failed.
+   */
+  public void addProperty(String name, String value) throws OrtException {
+    checkpoint.addProperty(name, value);
+  }
+
+  /**
+   * Gets a float property from this training session checkpoint.
+   *
+   * @param name The property name.
+   * @return The property value.
+   * @throws OrtException If the property does not exist, or is of the wrong type.
+   */
+  public float getFloatProperty(String name) throws OrtException {
+    return checkpoint.getFloatProperty(allocator, name);
+  }
+
+  /**
+   * Gets a int property from this training session checkpoint.
+   *
+   * @param name The property name.
+   * @return The property value.
+   * @throws OrtException If the property does not exist, or is of the wrong type.
+   */
+  public int getIntProperty(String name) throws OrtException {
+    return checkpoint.getIntProperty(allocator, name);
+  }
+
+  /**
+   * Gets a String property from this training session checkpoint.
+   *
+   * @param name The property name.
+   * @return The property value.
+   * @throws OrtException If the property does not exist, or is of the wrong type.
+   */
+  public String getStringProperty(String name) throws OrtException {
+    return checkpoint.getStringProperty(allocator, name);
+  }
+
   /** Checks if the OrtTrainingSession is closed, if so throws {@link IllegalStateException}. */
   private void checkClosed() {
     if (closed) {
@@ -927,6 +993,93 @@ public final class OrtTrainingSession implements AutoCloseable {
           saveOptimizer);
     }
 
+    /**
+     * Adds a float property to this checkpoint.
+     *
+     * @param name The property name.
+     * @param value The property value.
+     * @throws OrtException If the call failed.
+     */
+    public void addProperty(String name, float value) throws OrtException {
+      addProperty(
+          OnnxRuntime.ortApiHandle, OnnxRuntime.ortTrainingApiHandle, nativeHandle, name, value);
+    }
+
+    /**
+     * Adds a int property to this checkpoint.
+     *
+     * @param name The property name.
+     * @param value The property value.
+     * @throws OrtException If the call failed.
+     */
+    public void addProperty(String name, int value) throws OrtException {
+      addProperty(
+          OnnxRuntime.ortApiHandle, OnnxRuntime.ortTrainingApiHandle, nativeHandle, name, value);
+    }
+
+    /**
+     * Adds a String property to this checkpoint.
+     *
+     * @param name The property name.
+     * @param value The property value.
+     * @throws OrtException If the call failed.
+     */
+    public void addProperty(String name, String value) throws OrtException {
+      addProperty(
+          OnnxRuntime.ortApiHandle, OnnxRuntime.ortTrainingApiHandle, nativeHandle, name, value);
+    }
+
+    /**
+     * Gets a float property from this checkpoint.
+     *
+     * @param allocator The allocator.
+     * @param name The property name.
+     * @return The property value.
+     * @throws OrtException If the property does not exist, or is of the wrong type.
+     */
+    public float getFloatProperty(OrtAllocator allocator, String name) throws OrtException {
+      return getFloatProperty(
+          OnnxRuntime.ortApiHandle,
+          OnnxRuntime.ortTrainingApiHandle,
+          nativeHandle,
+          allocator.handle,
+          name);
+    }
+
+    /**
+     * Gets a int property from this checkpoint.
+     *
+     * @param allocator The allocator.
+     * @param name The property name.
+     * @return The property value.
+     * @throws OrtException If the property does not exist, or is of the wrong type.
+     */
+    public int getIntProperty(OrtAllocator allocator, String name) throws OrtException {
+      return getIntProperty(
+          OnnxRuntime.ortApiHandle,
+          OnnxRuntime.ortTrainingApiHandle,
+          nativeHandle,
+          allocator.handle,
+          name);
+    }
+
+    /**
+     * Gets a String property from this checkpoint.
+     *
+     * @param allocator The allocator.
+     * @param name The property name.
+     * @return The property value.
+     * @throws OrtException If the property does not exist, or is of the wrong type.
+     */
+    public String getStringProperty(OrtAllocator allocator, String name) throws OrtException {
+      return getStringProperty(
+          OnnxRuntime.ortApiHandle,
+          OnnxRuntime.ortTrainingApiHandle,
+          nativeHandle,
+          allocator.handle,
+          name);
+    }
+
     @Override
     public void close() {
       close(OnnxRuntime.ortTrainingApiHandle, nativeHandle);
@@ -967,6 +1120,88 @@ public final class OrtTrainingSession implements AutoCloseable {
      */
     private native void saveCheckpoint(
         long apiHandle, long trainingHandle, long nativeHandle, String path, boolean saveOptimizer)
+        throws OrtException;
+
+    /* \brief Adds the given property to the checkpoint state.
+     *
+     * Runtime properties such as epoch, training step, best score, and others can be added to the checkpoint
+     * state by the user if they desire by calling this function with the appropriate property name and
+     * value. The given property name must be unique to be able to successfully add the property.
+     *
+     * \param[in] checkpoint_state The checkpoint state which should hold the property.
+     * \param[in] property_name Unique name of the property being added.
+     * \param[in] property_type Type of the property associated with the given name.
+     * \param[in] property_value Property value associated with the given name.
+     *
+     * \snippet{doc} snippets.dox OrtStatus Return Value
+     *
+    ORT_API2_STATUS(AddProperty, _Inout_ OrtCheckpointState* checkpoint_state,
+                    _In_ const char* property_name, _In_ enum OrtPropertyType property_type,
+                    _In_ void* property_value);
+     */
+    private native void addProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        String propertyName,
+        int propertyValue)
+        throws OrtException;
+
+    private native void addProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        String propertyName,
+        float propertyValue)
+        throws OrtException;
+
+    private native void addProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        String propertyName,
+        String propertyValue)
+        throws OrtException;
+
+    /* \brief Gets the property value associated with the given name from the checkpoint state.
+     *
+     * Gets the property value from an existing entry in the checkpoint state. The property must
+     * exist in the checkpoint state to be able to retrieve it successfully.
+     *
+     * \param[in] checkpoint_state The checkpoint state that is currently holding the property.
+     * \param[in] property_name Unique name of the property being retrieved.
+     * \param[in] allocator Allocator used to allocate the memory for the property_value.
+     * \param[out] property_type Type of the property associated with the given name.
+     * \param[out] property_value Property value associated with the given name.
+     *
+     * \snippet{doc} snippets.dox OrtStatus Return Value
+     *
+    ORT_API2_STATUS(GetProperty, _In_ const OrtCheckpointState* checkpoint_state,
+                    _In_ const char* property_name, _Inout_ OrtAllocator* allocator,
+                    _Out_ enum OrtPropertyType* property_type, _Outptr_ void** property_value);
+     */
+    private native int getIntProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        long allocatorHandle,
+        String propertyName)
+        throws OrtException;
+
+    private native float getFloatProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        long allocatorHandle,
+        String propertyName)
+        throws OrtException;
+
+    private native String getStringProperty(
+        long apiHandle,
+        long trainingHandle,
+        long nativeHandle,
+        long allocatorHandle,
+        String propertyName)
         throws OrtException;
 
     private native void close(long trainingApiHandle, long nativeHandle);

--- a/java/src/main/native/ai_onnxruntime_OrtTrainingSession_OrtCheckpointState.c
+++ b/java/src/main/native/ai_onnxruntime_OrtTrainingSession_OrtCheckpointState.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -79,6 +79,158 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpoint
   checkOrtStatus(jniEnv, api, trainApi->SaveCheckpoint(checkpointState, cPath, saveOptimizer));
   (*jniEnv)->ReleaseStringUTFChars(jniEnv, outputPath, cPath);
 #endif
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    addProperty
+ * Signature: (JJJLjava/lang/String;I)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_addProperty__JJJLjava_lang_String_2I
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jstring propName, jint propValue) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  checkOrtStatus(jniEnv, api, trainApi->AddProperty(checkpointState, cPropName, OrtIntProperty, &propValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    addProperty
+ * Signature: (JJJLjava/lang/String;F)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_addProperty__JJJLjava_lang_String_2F
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jstring propName, jfloat propValue) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  checkOrtStatus(jniEnv, api, trainApi->AddProperty(checkpointState, cPropName, OrtFloatProperty, &propValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    addProperty
+ * Signature: (JJJLjava/lang/String;Ljava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_addProperty__JJJLjava_lang_String_2Ljava_lang_String_2
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jstring propName, jstring propValue) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  const char* cPropValue = (*jniEnv)->GetStringUTFChars(jniEnv, propValue, NULL);
+  checkOrtStatus(jniEnv, api, trainApi->AddProperty(checkpointState, cPropName, OrtStringProperty, (void*)cPropValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propValue, cPropValue);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    getIntProperty
+ * Signature: (JJJJLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_getIntProperty
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jlong allocatorHandle, jstring propName) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  enum OrtPropertyType type;
+  int* propValue = NULL;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, trainApi->GetProperty(checkpointState, cPropName, allocator, &type, (void**)&propValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+  if (code == ORT_OK) {
+    if (type == OrtIntProperty) {
+      int output = *propValue;
+      checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, propValue));
+      return output;
+    } else {
+      throwOrtException(jniEnv, 2, "Requested an int property but this property is not an int");
+    }
+  }
+  return 0;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    getFloatProperty
+ * Signature: (JJJJLjava/lang/String;)F
+ */
+JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_getFloatProperty
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jlong allocatorHandle, jstring propName) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  enum OrtPropertyType type;
+  float* propValue = NULL;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, trainApi->GetProperty(checkpointState, cPropName, allocator, &type, (void**)&propValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+  if (code == ORT_OK) {
+    if (type == OrtFloatProperty) {
+      float output = *propValue;
+      checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, propValue));
+      return output;
+    } else {
+      throwOrtException(jniEnv, 2, "Requested a float property but this property is not a float");
+    }
+  }
+  return 0.0f;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtTrainingSession_OrtCheckpointState
+ * Method:    getStringProperty
+ * Signature: (JJJJLjava/lang/String;)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OrtTrainingSession_00024OrtCheckpointState_getStringProperty
+  (JNIEnv * jniEnv, jobject jobj, jlong apiHandle, jlong trainingApiHandle, jlong nativeHandle, jlong allocatorHandle, jstring propName) {
+  (void) jobj; // Required JNI parameters not needed by functions which don't need to access their host object.
+  const OrtApi* api = (const OrtApi*) apiHandle;
+  const OrtTrainingApi* trainApi = (const OrtTrainingApi*) trainingApiHandle;
+
+  OrtCheckpointState* checkpointState = (OrtCheckpointState*) nativeHandle;
+
+  OrtAllocator* allocator = (OrtAllocator*) allocatorHandle;
+
+  const char* cPropName = (*jniEnv)->GetStringUTFChars(jniEnv, propName, NULL);
+  enum OrtPropertyType type;
+  char* propValue = NULL;
+  OrtErrorCode code = checkOrtStatus(jniEnv, api, trainApi->GetProperty(checkpointState, cPropName, allocator, &type, (void**)&propValue));
+  (*jniEnv)->ReleaseStringUTFChars(jniEnv, propName, cPropName);
+  if (code == ORT_OK) {
+    if (type == OrtStringProperty) {
+      jstring output = (*jniEnv)->NewStringUTF(jniEnv, propValue);
+      checkOrtStatus(jniEnv, api, api->AllocatorFree(allocator, propValue));
+      return output;
+    } else {
+      throwOrtException(jniEnv, 2, "Requested a string property but this property is not a string");
+    }
+  }
+  return (jstring) 0;
 }
 
 /*


### PR DESCRIPTION
### Description
Adds the Java side methods for CheckpointState AddProperty and GetProperty, mirroring #15720. Also ports across the relevant C# tests from #15720.

### Motivation and Context
Java side support for the new training APIs.

cc @baijumeswani 

