### PR TITLE
Remove C# SessionOptions.RegisterCustomOpsUsingFunction.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -362,7 +362,6 @@ namespace Microsoft.ML.OnnxRuntime
             OrtSetSessionGraphOptimizationLevel = (DOrtSetSessionGraphOptimizationLevel)Marshal.GetDelegateForFunctionPointer(api_.SetSessionGraphOptimizationLevel, typeof(DOrtSetSessionGraphOptimizationLevel));
             OrtRegisterCustomOpsLibrary = (DOrtRegisterCustomOpsLibrary)Marshal.GetDelegateForFunctionPointer(api_.RegisterCustomOpsLibrary, typeof(DOrtRegisterCustomOpsLibrary));
             OrtRegisterCustomOpsLibrary_V2 = (DOrtRegisterCustomOpsLibrary_V2)Marshal.GetDelegateForFunctionPointer(api_.RegisterCustomOpsLibrary_V2, typeof(DOrtRegisterCustomOpsLibrary_V2));
-            OrtRegisterCustomOpsUsingFunction = (DOrtRegisterCustomOpsUsingFunction)Marshal.GetDelegateForFunctionPointer(api_.RegisterCustomOpsUsingFunction, typeof(DOrtRegisterCustomOpsUsingFunction));
             OrtAddSessionConfigEntry = (DOrtAddSessionConfigEntry)Marshal.GetDelegateForFunctionPointer(api_.AddSessionConfigEntry, typeof(DOrtAddSessionConfigEntry));
             OrtAddInitializer = (DOrtAddInitializer)Marshal.GetDelegateForFunctionPointer(api_.AddInitializer, typeof(DOrtAddInitializer));
             SessionOptionsAppendExecutionProvider_TensorRT = (DSessionOptionsAppendExecutionProvider_TensorRT)Marshal.GetDelegateForFunctionPointer(
@@ -1089,18 +1088,6 @@ namespace Microsoft.ML.OnnxRuntime
                                                                                byte[] /*(const ORTCHAR_T*)*/ libraryPath);
 
         public static DOrtRegisterCustomOpsLibrary_V2 OrtRegisterCustomOpsLibrary_V2;
-
-        /// <summary>
-        /// Register custom op library using a function name. ORT will lookup the function name using dlsym.
-        /// Library containing the function must be loaded and the function name must be globally visible.
-        /// </summary>
-        /// <param name="options">Native SessionOptions instance</param>
-        /// <param name="functionName">Function name to call to register the custom ops.</param>
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate IntPtr /*(OrtStatus*)*/DOrtRegisterCustomOpsUsingFunction(IntPtr /*(OrtSessionOptions*) */ options,
-                                                                                  byte[] /*(const char*)*/ functionName);
-
-        public static DOrtRegisterCustomOpsUsingFunction OrtRegisterCustomOpsUsingFunction;
 
         /// <summary>
         /// Add initializer that is shared across Sessions using this SessionOptions (by denotation)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -440,35 +440,6 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
-        /// Register custom ops by calling the C function with functionName. 
-        /// The C function has the signature
-        ///   OrtStatus* RegisterCustomOps(OrtSessionOptions* options, const OrtApiBase* api);
-        /// 
-        /// The function must be available in the global symbols so ONNX Runtime can find it using GetProcAddress or
-        /// dlsym. This will require your app to 'DllImport' the native library containing the function and use 
-        /// Marshal.Prelink to ensure the function is loaded.
-        ///
-        /// Example usage:
-        ///   static class NativeCustomOps {
-        ///     [DllImport("YourLibraryName", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Winapi)]
-        ///     public static extern IntPtr /* OrtStatus* */ 
-        ///         YourRegisterCustomOpsFunctionName(IntPtr /* OrtSessionOptions* */ sessionOptions,
-        ///                                           IntPtr /* OrtApiBase*        */ ortApiBase);
-        ///   }
-        ///   ...
-        ///   var sessionOptions = new SessionOptions();
-        ///   Marshal.Prelink(typeof(NativeCustomOps).GetMethod("YourRegisterCustomOpsFunctionName"));
-        ///   sessionOptions.RegisterCustomOpsUsingFunction("YourRegisterCustomOpsFunctionName");
-        /// 
-        /// </summary>
-        /// <param name="functionName">Function name to call to register custom operators.</param>
-        public void RegisterCustomOpsUsingFunction(string functionName)
-        {
-            var utf8FuncName = NativeOnnxValueHelper.StringToZeroTerminatedUtf8(functionName);
-            NativeApiStatus.VerifySuccess(NativeMethods.OrtRegisterCustomOpsUsingFunction(this.handle, utf8FuncName));
-        }
-
-        /// <summary>
         /// Register the custom operators from the Microsoft.ML.OnnxRuntime.Extensions NuGet package.
         /// A reference to Microsoft.ML.OnnxRuntime.Extensions must be manually added to your project. 
         /// </summary>


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Symbol visibility from DllImport is inconsistent across platforms resulting in the symbol not necessarily being visible to ORT native code that tries to look it up by name.

Best solution is to use DllImport to load the library and to call the registration function directly. That requires the native SessionOptions handle and OrtApiBase struct. We could either make those public, or provide a helper where the user passes in a delegate from their DllImport. Can add when needed.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


