### PR TITLE
Make "--cuda_version" build arg optional

### DIFF
--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -372,6 +372,9 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if (WIN32)
+    # parallel build
+    # These compiler opitions cannot be forwarded to NVCC, so cannot use add_compiler_options
+    string(APPEND CMAKE_CXX_FLAGS " /MP")
     # required to be set explicitly to enable Eigen-Unsupported SpecialFunctions
     string(APPEND CMAKE_CXX_FLAGS " -DEIGEN_HAS_C99_MATH")
 elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake/adjust_global_compile_flags.cmake
+++ b/cmake/adjust_global_compile_flags.cmake
@@ -372,9 +372,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if (WIN32)
-    # parallel build
-    # These compiler opitions cannot be forwarded to NVCC, so cannot use add_compiler_options
-    string(APPEND CMAKE_CXX_FLAGS " /MP")
     # required to be set explicitly to enable Eigen-Unsupported SpecialFunctions
     string(APPEND CMAKE_CXX_FLAGS " -DEIGEN_HAS_C99_MATH")
 elseif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -286,7 +286,13 @@ if (WIN32)
     endif()
     get_filename_component(CUDNN_DLL_NAME ${CUDNN_DLL_PATH} NAME_WE)
     string(REPLACE "cudnn64_" "" CUDNN_VERSION "${CUDNN_DLL_NAME}")
-
+    if(NOT onnxruntime_CUDA_VERSION)
+      message("Reading json file ${onnxruntime_CUDA_HOME}/version.json")
+      set(CUDA_SDK_JSON_FILE_PATH "${onnxruntime_CUDA_HOME}/version.json")
+      file(READ ${CUDA_SDK_JSON_FILE_PATH} CUDA_SDK_JSON_CONTENT)
+      string(JSON onnxruntime_CUDA_VERSION GET ${CUDA_SDK_JSON_CONTENT} "cuda" "version")
+      message("onnxruntime_CUDA_VERSION=${onnxruntime_CUDA_VERSION}")
+    endif()
     file(APPEND "${VERSION_INFO_FILE}"
       "cuda_version = \"${onnxruntime_CUDA_VERSION}\"\n"
       "cudnn_version = \"${CUDNN_VERSION}\"\n"
@@ -648,7 +654,7 @@ if (NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_EXTENDED_MINIMAL_BUILD
                                   AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS"
                                   AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Android")
                                   AND NOT onnxruntime_USE_ROCM
-				  AND NOT onnxruntime_BUILD_WEBASSEMBLY)
+                                  AND NOT onnxruntime_BUILD_WEBASSEMBLY)
   add_custom_command(
     TARGET onnxruntime_pybind11_state POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention_v2.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention_v2.h
@@ -18,6 +18,11 @@
 // Modified based on FasterTransformer 5.2
 #pragma once
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+// Global initializer accesses extern object cubin_fmha_v2_fp16_Causal_64_40_sm86_cu_cubin_len
+#pragma warning(disable : 26427)
+#endif
 #include "contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention.h"
 #include <cstdint>
 
@@ -3233,3 +3238,6 @@ inline const FusedMultiHeadAttentionXMMAKernelV2* getXMMAKernelsV2(Data_type typ
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1071,7 +1071,6 @@ Status UpdateDecoderFeeds(
     CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(input_ids_data, beam_next_tokens.data(), beam_next_tokens.size_bytes(),
                                          cudaMemcpyHostToDevice, cuda_stream));
   } else {
-    int32_t* input_ids_data = input_ids.GetMutable<Tensor>()->MutableData<int32_t>();
     for (int i = 0; i < batch_beam_size; i++) {
       gsl::span<const int32_t> sequence = sequences.GetSequence(i);
       const int32_t* sequence_data = sequence.data();

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -116,7 +116,7 @@ static void TestDFTInvertible(bool complex) {
     for (int64_t signal_dim1 = 2; signal_dim1 <= 5; signal_dim1 += 1) {
       for (int64_t signal_dim2 = 2; signal_dim2 <= 5; signal_dim2 += 1) {
         DFTInvertibleTester test(axis);
-        vector<int64_t> input_shape{num_batches, signal_dim1, signal_dim2, 1 + complex};
+        vector<int64_t> input_shape{num_batches, signal_dim1, signal_dim2, 1 + (complex ? 1 : 0)};
         vector<float> input_data = random.Uniform<float>(input_shape, -100.f, 100.f);
         test.AddInput("input", input_shape, input_data);
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1310,9 +1310,6 @@ def generate_build_tree(
     if args.use_azure:
         add_default_definition(cmake_extra_defines, "onnxruntime_USE_AZURE", "ON")
 
-    if is_windows():
-        add_default_definition(cmake_extra_defines, "CMake_MSVC_PARALLEL", "ON")
-
     cmake_args += [f"-D{define}" for define in cmake_extra_defines]
 
     cmake_args += cmake_extra_args

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1310,6 +1310,9 @@ def generate_build_tree(
     if args.use_azure:
         add_default_definition(cmake_extra_defines, "onnxruntime_USE_AZURE", "ON")
 
+    if is_windows():
+        add_default_definition(cmake_extra_defines, "CMake_MSVC_PARALLEL", "ON")
+
     cmake_args += [f"-D{define}" for define in cmake_extra_defines]
 
     cmake_args += cmake_extra_args
@@ -2482,6 +2485,8 @@ def main():
                     toolset = "host=" + host_arch
                 if args.cuda_version:
                     toolset += ",cuda=" + args.cuda_version
+                elif args.cuda_home:
+                    toolset += ",cuda=" + args.cuda_home
                 cmake_extra_args = ["-A", target_arch, "-T", toolset, "-G", args.cmake_generator]
             if args.enable_wcos:
                 cmake_extra_defines.append("CMAKE_USER_MAKE_RULES_OVERRIDE=wcos_rules_override.cmake")
@@ -2520,12 +2525,6 @@ def main():
         if args.enable_pybind and is_windows():
             install_python_deps(args.numpy_version)
 
-        if args.use_cuda and args.cuda_version is None:
-            if is_windows():
-                # cuda_version is used while generating version_info.py on Windows.
-                raise BuildError("cuda_version must be specified on Windows.")
-            else:
-                args.cuda_version = ""
         if args.use_rocm and args.rocm_version is None:
             args.rocm_version = ""
 


### PR DESCRIPTION
### Description
This change will allow us building CUDA EP without installing CUDA SDK on Windows.  

### Motivation and Context
Nvidia's CUDA installer comes with a VS extension. In the past, we require installing the extension. It is a little bit inconvenient since:
1.  Visual Studio must be installed before CUDA SDK. CUDA's installer will not install the extension if your machine doesn't have Visual Studio. 
2.  We need to install CUDA SDK on our build machines, instead of just downloading it and using it.

After this change, we will not need to install CUDA SDK on our build machines. So it will be easier to add a support for a different CUDA version.

Also, fix two PreFast warnings.