### PR TITLE
dump tensor statistics

### DIFF
--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.cc
@@ -5,6 +5,7 @@
 
 #include "core/framework/debug_node_inputs_outputs_utils.h"
 #include "core/framework/print_tensor_utils.h"
+#include "core/framework/print_tensor_statistics_utils.h"
 #include <iomanip>
 #include <cctype>
 #include <string>
@@ -60,6 +61,9 @@ bool FilterNode(const NodeDumpOptions& dump_options, const Node& node) {
 template <typename T>
 void DumpTensorToStdOut(const Tensor& tensor, const NodeDumpOptions& dump_options) {
   onnxruntime::utils::PrintCpuTensor<T>(tensor, dump_options.snippet_threshold, dump_options.snippet_edge_items);
+  if (dump_options.dump_flags & NodeDumpOptions::DumpFlags::StatisticsData) {
+    onnxruntime::utils::PrintCpuTensorStats<T>(tensor);
+  }
 }
 
 PathString MakeTensorFileName(const std::string& tensor_name, const NodeDumpOptions& dump_options) {
@@ -375,6 +379,9 @@ const NodeDumpOptions& NodeDumpOptionsFromEnvironmentVariables() {
     }
     if (ParseEnvironmentVariableWithDefault<bool>(env_vars::kDumpNodePlacement, true)) {
       opts.dump_flags |= NodeDumpOptions::DumpFlags::NodePlacement;
+    }
+    if (ParseEnvironmentVariableWithDefault<bool>(env_vars::kDumpStatisticsData, false)) {
+      opts.dump_flags |= NodeDumpOptions::DumpFlags::StatisticsData;
     }
 
     opts.filter.name_pattern = Env::Default().GetEnvironmentVar(env_vars::kNameFilter);

--- a/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
+++ b/onnxruntime/core/framework/debug_node_inputs_outputs_utils.h
@@ -36,6 +36,9 @@ constexpr const char* kDumpNodePlacement = "ORT_DEBUG_NODE_IO_DUMP_NODE_PLACEMEN
 constexpr const char* kDumpInputData = "ORT_DEBUG_NODE_IO_DUMP_INPUT_DATA";
 // set to non-zero to dump node output data
 constexpr const char* kDumpOutputData = "ORT_DEBUG_NODE_IO_DUMP_OUTPUT_DATA";
+// Output statistics data like min, max, count of NaN, count of infinity etc.
+constexpr const char* kDumpStatisticsData = "ORT_DEBUG_NODE_IO_DUMP_STATISTICS_DATA";
+
 // specify a node name filter to limit the nodes that are dumped
 // see NodeDumpOptions::FilterOptions
 constexpr const char* kNameFilter = "ORT_DEBUG_NODE_IO_NAME_FILTER";
@@ -70,7 +73,8 @@ struct NodeDumpOptions {
     InputData = 1 << 1,
     OutputData = 1 << 2,
     NodePlacement = 1 << 3,
-    AllData = Shape | InputData | OutputData | NodePlacement,
+    StatisticsData = 1 << 4,
+    AllData = Shape | InputData | OutputData | NodePlacement | StatisticsData,
   };
 
   // specifies the information to dump per node

--- a/onnxruntime/core/framework/print_tensor_statistics_utils.h
+++ b/onnxruntime/core/framework/print_tensor_statistics_utils.h
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cmath>
+#include "core/framework/print_tensor_utils.h"
+
+namespace onnxruntime {
+namespace utils {
+
+template <typename T>
+int my_fpclassify(const T& val) {
+  return std::fpclassify(val);
+}
+
+template <>
+int my_fpclassify(const MLFloat16& val) {
+  return std::fpclassify(val.ToFloat());
+}
+
+template <>
+int my_fpclassify(const BFloat16& val) {
+  return std::fpclassify(val.ToFloat());
+}
+
+template <typename T>
+void PrintFloatStats(const T* data, size_t count) {
+  size_t inf = 0;
+  size_t nan = 0;
+  size_t zero = 0;
+  size_t subnormal = 0;
+  for (size_t i = 0; i < count; i++) {
+    switch (my_fpclassify(*data)) {
+      case FP_INFINITE:
+        inf++;
+        break;
+      case FP_NAN:
+        nan++;
+        break;
+      case FP_SUBNORMAL:
+        subnormal++;
+        break;
+      case FP_ZERO:
+        zero++;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (inf)
+    std::cout << ",Inf=" << inf;
+  if (nan)
+    std::cout << ",NaN=" << nan;
+  if (zero)
+    std::cout << ",Zero=" << zero;
+  if (subnormal)
+    std::cout << ",SubNormal=" << subnormal;
+}
+
+template <typename T>
+void PrintCommonStats(const T* data, size_t count) {
+  T min = data[0];
+  T max = min;
+  for (size_t i = 1; i < count; i++) {
+    auto value = data[i];
+    if (value > max) {
+      max = value;
+    }
+    if (value < min) {
+      min = value;
+    }
+  }
+
+  std::cout << "Min=";
+  PrintValue(min);
+
+  std::cout << ",Max=";
+  PrintValue(max);
+}
+
+template <typename T>
+void PrintHalfStats(const T* data, size_t count) {
+  float min = data[0].ToFloat();
+  float max = min;
+  for (size_t i = 1; i < count; i++) {
+    float value = data[i].ToFloat();
+    if (value > max) {
+      max = value;
+    }
+
+    if (value < min) {
+      min = value;
+    }
+  }
+
+  std::cout << "Min=";
+  PrintValue(min);
+
+  std::cout << ",Max=";
+  PrintValue(max);
+}
+
+template <typename T>
+void PrintTensorStats(const T* tensor, size_t count) {
+  PrintCommonStats<T>(tensor, count);
+}
+
+template <>
+void PrintTensorStats<float>(const float* tensor, size_t count) {
+  PrintCommonStats<float>(tensor, count);
+  PrintFloatStats<float>(tensor, count);
+}
+
+template <>
+void PrintTensorStats<double>(const double* tensor, size_t count) {
+  PrintCommonStats<double>(tensor, count);
+  PrintFloatStats<double>(tensor, count);
+}
+
+template <>
+void PrintTensorStats<MLFloat16>(const MLFloat16* tensor, size_t count) {
+  PrintHalfStats<MLFloat16>(tensor, count);
+  PrintFloatStats<MLFloat16>(tensor, count);
+}
+
+template <>
+void PrintTensorStats<BFloat16>(const BFloat16* tensor, size_t count) {
+  PrintHalfStats<BFloat16>(tensor, count);
+  PrintFloatStats<BFloat16>(tensor, count);
+}
+
+template <typename T>
+void PrintCpuTensorStats(const Tensor& tensor) {
+  const auto& shape = tensor.Shape();
+  auto num_items = shape.Size();
+  if (num_items == 0) {
+    return;
+  }
+
+  const T* data = tensor.Data<T>();
+  PrintTensorStats<T>(data, num_items);
+  std::cout << std::endl;
+}
+
+template <>
+void PrintCpuTensorStats<std::string>(const Tensor&) {
+}
+
+}  // namespace utils
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description
Dump statistics of input and/or output tensors of each node. It could help to find out why a model outputs NaN.

To use this tool, just add `--cmake_extra_defines onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS=1` when build onnxruntime package. Then set some environment varaibles before running model with onnxruntime:

```
export ORT_DEBUG_NODE_IO_DUMP_INPUT_DATA=1
export ORT_DEBUG_NODE_IO_DUMP_OUTPUT_DATA=1
export ORT_DEBUG_NODE_IO_DUMP_STATISTICS_DATA=1
```

Then statistics data will be appended after the dumping of input and output tensors. 

One possible cause of a FP16 or mixed precision model outputs NaN:  some number exceeds the limit of FP16 (like max FP16 value is 65504). When a fp32 model has value > 65504 in a node output, it will become INF when converting the node to FP16. In this case, you need keep related nodes in FP32 to avoid the issue. You can dump tensor statistics of FP32 model to find out such candidate nodes.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


