### PR TITLE
update docs for a new cuda provider option: enable_skip_layer_norm_strict_mode

### DIFF
--- a/docs/execution-providers/CUDA-ExecutionProvider.md
+++ b/docs/execution-providers/CUDA-ExecutionProvider.md
@@ -103,6 +103,12 @@ This flag is only supported from the V2 version of the provider options struct w
 
 Default value: 0
 
+### enable_skip_layer_norm_strict_mode
+Whether to use strict mode in SkipLayerNormalization cuda implementation. The default and recommanded setting is false. If enabled, accuracy improvement and performance drop can be expected. 
+This flag is only supported from the V2 version of the provider options struct when used using the C API. The V2 provider options struct can be created using [this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a0d29cbf555aa806c050748cf8d2dc172) and updated using [this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a4710fc51f75a4b9a75bde20acbfa0783).
+
+Default value: 0
+
 ## Performance Tuning
 The [I/O Binding feature](../performance/tune-performance/iobinding.md) should be utilized to avoid overhead resulting from copies on inputs and outputs. 
 

--- a/docs/performance/transformers-optimization.md
+++ b/docs/performance/transformers-optimization.md
@@ -141,7 +141,7 @@ The first command will generate ONNX models (both before and after optimizations
 
 If you remove -o parameter, optimizer script is not used in benchmark.
 
-If your GPU (like V100 or T4) has TensorCore, you can append `-p fp16` to the above commands to enable mixed precision.
+If your GPU (like V100 or T4) has TensorCore, you can append `-p fp16` to the above commands to enable mixed precision. In some decoder-only(e.g GPT2) based generative models, you can enable [strict mode](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#enable_skip_layer_norm_strict_mode) for SkipLayerNormalization Op on CUDA EP to achieve better accuray. However, the performance will drop a bit.
 
 If you want to benchmark on CPU, you can remove -g option in the commands.
 

--- a/docs/performance/transformers-optimization.md
+++ b/docs/performance/transformers-optimization.md
@@ -141,7 +141,7 @@ The first command will generate ONNX models (both before and after optimizations
 
 If you remove -o parameter, optimizer script is not used in benchmark.
 
-If your GPU (like V100 or T4) has TensorCore, you can append `-p fp16` to the above commands to enable mixed precision. In some decoder-only(e.g GPT2) based generative models, you can enable [strict mode](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#enable_skip_layer_norm_strict_mode) for SkipLayerNormalization Op on CUDA EP to achieve better accuray. However, the performance will drop a bit.
+If your GPU (like V100 or T4) has TensorCore, you can append `-p fp16` to the above commands to enable mixed precision. In some decoder-only(e.g GPT2) based generative models, you can enable [strict mode](../execution-providers/CUDA-ExecutionProvider.md#enable_skip_layer_norm_strict_mode) for SkipLayerNormalization Op on CUDA EP to achieve better accuray. However, the performance will drop a bit.
 
 If you want to benchmark on CPU, you can remove -g option in the commands.
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

update docs for a new cuda provider option: enable_skip_layer_norm_strict_mode used in decoder-only based generative models

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


