### PR TITLE
[js/rn] Fix extensions header include issue

### DIFF
--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -8,11 +8,10 @@
 #import <React/RCTLog.h>
 
 // Note: Using below syntax for including ort c api and ort extensions headers to resolve a compiling error happened
-// in an expo react native ios app when ort extensions enabled (a redefinition error of multiple object types defined within
-// ORT C API header). It's an edge case that compiler allows both ort c api headers to be included when #include syntax
-// doesn't match.
-// For the case when extensions not enabled, it still requires a onnxruntime prefix directory for searching paths.
-// Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
+// in an expo react native ios app when ort extensions enabled (a redefinition error of multiple object types defined
+// within ORT C API header). It's an edge case that compiler allows both ort c api headers to be included when #include
+// syntax doesn't match. For the case when extensions not enabled, it still requires a onnxruntime prefix directory for
+// searching paths. Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
 // https://google.github.io/styleguide/objcguide.html#import-and-include
 // https://microsoft.github.io/objc-guide/Headers/ImportAndInclude.html
 #ifdef ORT_ENABLE_EXTENSIONS

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -7,15 +7,19 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
 
-// Note: DO NOT CHANGE the following line for including ORT C API headers.
-// Switched from using syntax `#import <onnxruntime/onnxruntime_cxx_api.h>` to using below syntax for including headers
-// so as to match how we include the ort c api headers in other places. Otherwise, it will trigger an edge case when compiling
-// a react native ios app with ort extensions included and cause the compiler to allow both ORT C APIs to be included.
-// (can lead to a redefinition error of multiple types defined within ORT C API header.)
-#include "onnxruntime_cxx_api.h"
-
+// Note: Using below syntax for including ort c api and ort extensions headers to resolve a compiling error happened
+// in an expo react native ios app when ort extensions enabled (a redefinition error of multiple object types defined within
+// ORT C API header). It's an edge case that compiler allows both ort c api headers to be included when #include syntax
+// doesn't match.
+// For the case when extensions not enabled, it still requires a onnxruntime prefix directory for searching paths.
+// Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
+// https://google.github.io/styleguide/objcguide.html#import-and-include
+// https://microsoft.github.io/objc-guide/Headers/ImportAndInclude.html
 #ifdef ORT_ENABLE_EXTENSIONS
+#include "onnxruntime_cxx_api.h"
 #include "onnxruntime_extensions.h"
+#else
+#include "onnxruntime/onnxruntime_cxx_api.h"
 #endif
 
 @implementation OnnxruntimeModule

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -7,7 +7,13 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
 
+// Note: DO NOT CHANGE the following line for including ORT C API headers.
+// Switched from using syntax `#import <onnxruntime/onnxruntime_cxx_api.h>` to using below syntax for including headers
+// so as to match how we include the ort c api headers in other places. Otherwise, it will trigger an edge case when compiling
+// a react native ios app with ort extensions included and cause the compiler to allow both ORT C APIs to be included.
+// (can lead to a redefinition error of multiple types defined within ORT C API header.)
 #include "onnxruntime_cxx_api.h"
+
 #ifdef ORT_ENABLE_EXTENSIONS
 #include "onnxruntime_extensions.h"
 #endif

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -6,18 +6,10 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
-#import <onnxruntime/onnxruntime_cxx_api.h>
 
+#include "onnxruntime_cxx_api.h"
 #ifdef ORT_ENABLE_EXTENSIONS
-extern "C" {
-// Note: Declared in onnxruntime_extensions.h but forward declared here to resolve a build issue:
-// (A compilation error happened while building an expo react native ios app, onnxruntime_c_api.h header
-// included in the onnxruntime_extensions.h leads to a redefinition conflicts with multiple object defined in the ORT C
-// API.) So doing a forward declaration here instead of #include "onnxruntime_extensions.h" as a workaround for now
-// before we have a fix.
-// TODO: Investigate if we can include onnxruntime_extensions.h here
-OrtStatus *RegisterCustomOps(OrtSessionOptions *options, const OrtApiBase *api);
-} // Extern C
+#include "onnxruntime_extensions.h"
 #endif
 
 @implementation OnnxruntimeModule

--- a/js/react_native/ios/TensorHelper.h
+++ b/js/react_native/ios/TensorHelper.h
@@ -5,7 +5,7 @@
 #define TensorHelper_h
 
 #import <Foundation/Foundation.h>
-#import <onnxruntime/onnxruntime_cxx_api.h>
+#include "onnxruntime_cxx_api.h"
 
 @interface TensorHelper : NSObject
 

--- a/js/react_native/ios/TensorHelper.h
+++ b/js/react_native/ios/TensorHelper.h
@@ -6,12 +6,20 @@
 
 #import <Foundation/Foundation.h>
 
-// Note: DO NOT CHANGE the following line for including ORT C API headers.
-// Switched from using syntax `#import <onnxruntime/onnxruntime_cxx_api.h>` to using below syntax for including headers
-// so as to match how we include the ort c api headers in other places. Otherwise, it will trigger an edge case when compiling
-// a react native ios app with ort extensions included and cause the compiler to allow both ORT C APIs to be included.
-// (can lead to a redefinition error of multiple types defined within ORT C API header.)
+// Note: Using below syntax for including ort c api and ort extensions headers to resolve a compiling error happened
+// in an expo react native ios app (a redefinition error happened with multiple object types defined within
+// ORT C API header). It's an edge case that the compiler allows both ort c api headers to be included when #include syntax
+// doesn't match.
+// For the case when extensions not enabled, it still requires a onnxruntime prefix directory for searching paths.
+// Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
+// https://google.github.io/styleguide/objcguide.html#import-and-include
+// https://microsoft.github.io/objc-guide/Headers/ImportAndInclude.html
+#ifdef ORT_ENABLE_EXTENSIONS
 #include "onnxruntime_cxx_api.h"
+#include "onnxruntime_extensions.h"
+#else
+#include "onnxruntime/onnxruntime_cxx_api.h"
+#endif
 
 @interface TensorHelper : NSObject
 

--- a/js/react_native/ios/TensorHelper.h
+++ b/js/react_native/ios/TensorHelper.h
@@ -5,6 +5,12 @@
 #define TensorHelper_h
 
 #import <Foundation/Foundation.h>
+
+// Note: DO NOT CHANGE the following line for including ORT C API headers.
+// Switched from using syntax `#import <onnxruntime/onnxruntime_cxx_api.h>` to using below syntax for including headers
+// so as to match how we include the ort c api headers in other places. Otherwise, it will trigger an edge case when compiling
+// a react native ios app with ort extensions included and cause the compiler to allow both ORT C APIs to be included.
+// (can lead to a redefinition error of multiple types defined within ORT C API header.)
 #include "onnxruntime_cxx_api.h"
 
 @interface TensorHelper : NSObject

--- a/js/react_native/ios/TensorHelper.h
+++ b/js/react_native/ios/TensorHelper.h
@@ -8,10 +8,9 @@
 
 // Note: Using below syntax for including ort c api and ort extensions headers to resolve a compiling error happened
 // in an expo react native ios app (a redefinition error happened with multiple object types defined within
-// ORT C API header). It's an edge case that the compiler allows both ort c api headers to be included when #include syntax
-// doesn't match.
-// For the case when extensions not enabled, it still requires a onnxruntime prefix directory for searching paths.
-// Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
+// ORT C API header). It's an edge case that the compiler allows both ort c api headers to be included when #include
+// syntax doesn't match. For the case when extensions not enabled, it still requires a onnxruntime prefix directory for
+// searching paths. Also in general, it's a convention to use #include for C/C++ headers rather then #import. See:
 // https://google.github.io/styleguide/objcguide.html#import-and-include
 // https://microsoft.github.io/objc-guide/Headers/ImportAndInclude.html
 #ifdef ORT_ENABLE_EXTENSIONS

--- a/js/react_native/ios/TensorHelper.h
+++ b/js/react_native/ios/TensorHelper.h
@@ -16,7 +16,6 @@
 // https://microsoft.github.io/objc-guide/Headers/ImportAndInclude.html
 #ifdef ORT_ENABLE_EXTENSIONS
 #include "onnxruntime_cxx_api.h"
-#include "onnxruntime_extensions.h"
 #else
 #include "onnxruntime/onnxruntime_cxx_api.h"
 #endif


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Identified the cause for a `redefinition compilation error` happened in a react native expo app with ort-extensions enabled when running the ios side. Fix the include path now, so we can remove the temporary forward declaration in OnnxruntimeModule.mm file.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix implementation detail.
