### PR TITLE
[CANN] Add IOBinding Support For CANN EP

### DIFF
--- a/onnxruntime/core/providers/cann/cann_execution_provider.cc
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.cc
@@ -1434,6 +1434,28 @@ Status CANNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fuse
   return Status::OK();
 }
 
+AllocatorPtr CANNExecutionProvider::CreateCannAllocator(OrtDevice::DeviceId device_id, size_t npu_mem_limit,
+                                                        ArenaExtendStrategy arena_extend_strategy,
+                                                        OrtArenaCfg* default_memory_arena_cfg) {
+  AllocatorCreationInfo default_memory_info(
+      [](OrtDevice::DeviceId id) {
+        return std::make_unique<CANNAllocator>(id, CANN);
+      },
+      device_id,
+      true,
+      {default_memory_arena_cfg ? *default_memory_arena_cfg
+                                : OrtArenaCfg(npu_mem_limit,
+                                              static_cast<int>(arena_extend_strategy),
+                                              -1,
+                                              -1,
+                                              -1,
+                                              -1L)},
+      true,
+      false);
+
+  return CreateAllocator(default_memory_info);
+}
+
 void CANNExecutionProvider::RegisterAllocator(AllocatorManager& allocator_manager) {
   OrtDevice cann_device{OrtDevice::NPU, OrtDevice::MemType::DEFAULT, info_.device_id};
   OrtDevice pinned_device{OrtDevice::CPU, OrtDevice::MemType::CANN_PINNED, DEFAULT_CPU_ALLOCATOR_DEVICE_ID};
@@ -1444,23 +1466,8 @@ void CANNExecutionProvider::RegisterAllocator(AllocatorManager& allocator_manage
     cann_alloc = allocator_manager.GetAllocator(OrtMemTypeDefault, cann_device);
 
     if (!cann_alloc) {
-      AllocatorCreationInfo default_memory_info(
-          [](OrtDevice::DeviceId id) {
-            return std::make_unique<CANNAllocator>(id, CANN);
-          },
-          cann_device.Id(),
-          true,
-          {info_.default_memory_arena_cfg ? *info_.default_memory_arena_cfg
-                                          : OrtArenaCfg(info_.npu_mem_limit,
-                                                        static_cast<int>(info_.arena_extend_strategy),
-                                                        -1,
-                                                        -1,
-                                                        -1,
-                                                        -1)},
-          true,
-          false);
-
-      cann_alloc = CreateAllocator(default_memory_info);
+      cann_alloc = CreateCannAllocator(info_.device_id, info_.npu_mem_limit, info_.arena_extend_strategy,
+                                       info_.default_memory_arena_cfg);
       allocator_manager.InsertAllocator(cann_alloc);
     }
 

--- a/onnxruntime/core/providers/cann/cann_execution_provider.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.h
@@ -81,6 +81,9 @@ class CANNExecutionProvider : public IExecutionProvider {
     return CANNExecutionProviderInfo::ToProviderOptions(info_);
   }
 
+  static AllocatorPtr CreateCannAllocator(OrtDevice::DeviceId device_id, size_t npu_mem_limit,
+                                          ArenaExtendStrategy arena_extend_strategy,
+                                          OrtArenaCfg* arena_cfg);
   void RegisterAllocator(AllocatorManager& allocator_manager) override;
 
   void RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry) const override;

--- a/onnxruntime/core/providers/cann/cann_provider_factory.h
+++ b/onnxruntime/core/providers/cann/cann_provider_factory.h
@@ -10,14 +10,24 @@
 #include "core/providers/cann/cann_provider_options.h"
 
 namespace onnxruntime {
+class IAllocator;
+class IDataTransfer;
 struct IExecutionProviderFactory;
 struct CANNExecutionProviderInfo;
+enum class ArenaExtendStrategy : int32_t;
 
 struct ProviderInfo_CANN {
+  virtual int cannGetDeviceCount() = 0;
+
+  virtual void cannMemcpy_HostToDevice(void* dst, const void* src, size_t count) = 0;
+  virtual void cannMemcpy_DeviceToHost(void* dst, const void* src, size_t count) = 0;
   virtual void CANNExecutionProviderInfo__FromProviderOptions(const onnxruntime::ProviderOptions& options,
                                                               onnxruntime::CANNExecutionProviderInfo& info) = 0;
   virtual std::shared_ptr<onnxruntime::IExecutionProviderFactory>
   CreateExecutionProviderFactory(const onnxruntime::CANNExecutionProviderInfo& info) = 0;
+  virtual std::shared_ptr<onnxruntime::IAllocator>
+  CreateCannAllocator(int16_t device_id, size_t npu_mem_limit, onnxruntime::ArenaExtendStrategy arena_extend_strategy,
+                      OrtArenaCfg* default_memory_arena_cfg) = 0;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -20,6 +20,8 @@ if typing.TYPE_CHECKING:
 def get_ort_device_type(device_type: str, device_index) -> C.OrtDevice:
     if device_type == "cuda":
         return C.OrtDevice.cuda()
+    elif device_type == "cann":
+        return C.OrtDevice.cann()
     elif device_type == "cpu":
         return C.OrtDevice.cpu()
     elif device_type == "ort":
@@ -487,7 +489,7 @@ class IOBinding:
     def bind_input(self, name, device_type, device_id, element_type, shape, buffer_ptr):
         """
         :param name: input name
-        :param device_type: e.g. cpu, cuda
+        :param device_type: e.g. cpu, cuda, cann
         :param device_id: device id, e.g. 0
         :param element_type: input element type
         :param shape: input shape
@@ -526,7 +528,7 @@ class IOBinding:
     ):
         """
         :param name: output name
-        :param device_type: e.g. cpu, cuda, cpu by default
+        :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
         :param element_type: output element type
         :param shape: output shape
@@ -626,7 +628,7 @@ class OrtValue:
         A copy of the data in the Numpy object is held by the OrtValue only if the device is NOT cpu
 
         :param numpy_obj: The Numpy object to construct the OrtValue from
-        :param device_type: e.g. cpu, cuda, cpu by default
+        :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
         """
         # Hold a reference to the numpy object (if device_type is 'cpu') as the OrtValue
@@ -651,7 +653,7 @@ class OrtValue:
 
         :param shape: List of integers indicating the shape of the OrtValue
         :param element_type: The data type of the elements in the OrtValue (numpy type)
-        :param device_type: e.g. cpu, cuda, cpu by default
+        :param device_type: e.g. cpu, cuda, cann, cpu by default
         :param device_id: device id, e.g. 0
         """
         if shape is None or element_type is None:
@@ -691,7 +693,7 @@ class OrtValue:
 
     def device_name(self):
         """
-        Returns the name of the device where the OrtValue's data buffer resides e.g. cpu, cuda
+        Returns the name of the device where the OrtValue's data buffer resides e.g. cpu, cuda, cann
         """
         return self._ortvalue.device_name().lower()
 

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.h
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.h
@@ -74,6 +74,20 @@ std::unique_ptr<IDataTransfer> GetGPUDataTransfer();
 
 #endif
 
+#ifdef USE_CANN
+
+void CpuToCannMemCpy(void* dst, const void* src, size_t num_bytes);
+
+void CannToCpuMemCpy(void* dst, const void* src, size_t num_bytes);
+
+const std::unordered_map<OrtDevice::DeviceType, MemCpyFunc>* GetCannToHostMemCpyFunction();
+
+bool IsCannDeviceIdValid(const onnxruntime::logging::Logger& logger, int id);
+
+AllocatorPtr GetCannAllocator(OrtDevice::DeviceId id);
+
+#endif
+
 #ifdef USE_ROCM
 
 bool IsRocmDeviceIdValid(const onnxruntime::logging::Logger& logger, int id);

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -151,7 +151,11 @@ const char* GetDeviceName(const OrtDevice& device) {
     case OrtDevice::FPGA:
       return "FPGA";
     case OrtDevice::NPU:
+#ifdef USE_CANN
       return CANN;
+#else
+      return "NPU";
+#endif
     default:
       ORT_THROW("Unknown device type: ", device.Type());
   }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -151,7 +151,7 @@ const char* GetDeviceName(const OrtDevice& device) {
     case OrtDevice::FPGA:
       return "FPGA";
     case OrtDevice::NPU:
-      return "NPU";
+      return CANN;
     default:
       ORT_THROW("Unknown device type: ", device.Type());
   }
@@ -1143,6 +1143,7 @@ void addObjectMethods(py::module& m, ExecutionProviderRegistrationFn ep_registra
       .def("device_type", &OrtDevice::Type, R"pbdoc(Device Type.)pbdoc")
       .def_static("cpu", []() { return OrtDevice::CPU; })
       .def_static("cuda", []() { return OrtDevice::GPU; })
+      .def_static("cann", []() { return OrtDevice::NPU; })
       .def_static("fpga", []() { return OrtDevice::FPGA; })
       .def_static("npu", []() { return OrtDevice::NPU; })
       .def_static("default_memory", []() { return OrtDevice::MemType::DEFAULT; });


### PR DESCRIPTION
### Description
Add IOBinding Support For CANN EP

### Motivation and Context
Now, Users can use IOBinding feature to speed up the inference on CANN.
