### PR TITLE
Avoid calling new and delete explicitly, use std::make_unique instead

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_custom_ops.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_custom_ops.h
@@ -31,7 +31,7 @@ struct TensorRTCustomKernel {
 struct TensorRTCustomOp : Ort::CustomOpBase<TensorRTCustomOp, TensorRTCustomKernel> {
   explicit TensorRTCustomOp(const char* provider, void* compute_stream) : provider_(provider), compute_stream_(compute_stream) {}
 
-  void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* info) const { return new TensorRTCustomKernel(info, compute_stream_); };
+  void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* info) const { return make_unique<TensorRTCustomKernel>(info, compute_stream_).get(); };
 
   const char* GetName() const { return name_; };
 

--- a/onnxruntime/test/shared_lib/custom_op_utils.h
+++ b/onnxruntime/test/shared_lib/custom_op_utils.h
@@ -38,7 +38,7 @@ struct MyCustomKernelSecondInputOnCpu {
 
 struct MyCustomOp : Ort::CustomOpBase<MyCustomOp, MyCustomKernel> {
   explicit MyCustomOp(const char* provider) : provider_(provider) {}
-  void* CreateKernel(const OrtApi& api, const OrtKernelInfo* info) const { return new MyCustomKernel(api, info); };
+  void* CreateKernel(const OrtApi& api, const OrtKernelInfo* info) const { return std::make_unique<MyCustomKernel>(api, info).get(); };
   const char* GetName() const { return "Foo"; };
   const char* GetExecutionProviderType() const { return provider_; };
 
@@ -60,7 +60,7 @@ struct MyCustomOpSecondInputOnCpu : Ort::CustomOpBase<MyCustomOpSecondInputOnCpu
       : provider_(provider), compute_stream_(compute_stream) {}
 
   void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* info) const {
-    return new MyCustomKernelSecondInputOnCpu(info, compute_stream_);
+    return std::make_unique<MyCustomKernelSecondInputOnCpu>(info, compute_stream_).get();
   };
 
   const char* GetName() const { return "Foo"; };
@@ -102,7 +102,7 @@ struct MyCustomOpMultipleDynamicInputs : Ort::CustomOpBase<MyCustomOpMultipleDyn
                                                            MyCustomKernelMultipleDynamicInputs> {
   explicit MyCustomOpMultipleDynamicInputs(const char* provider) : provider_(provider) {}
   void* CreateKernel(const OrtApi& api, const OrtKernelInfo* info) const {
-    return new MyCustomKernelMultipleDynamicInputs(api, info);
+    return std::make_unique<MyCustomKernelMultipleDynamicInputs>(api, info).get();
   };
   const char* GetName() const { return "Foo"; };
   const char* GetExecutionProviderType() const { return provider_; };

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -123,7 +123,7 @@ struct MulTopKernelFloat {
 };
 
 struct MulTopOpFloat : Ort::CustomOpBase<MulTopOpFloat, MulTopKernelFloat> {
-  void* CreateKernel(const OrtApi&, const OrtKernelInfo* info) const { return new MulTopKernelFloat(info); }
+  void* CreateKernel(const OrtApi&, const OrtKernelInfo* info) const { return std::make_unique<MulTopKernelFloat>(info).get(); }
   const char* GetName() const { return "MulTop"; }
   const char* GetExecutionProviderType() const { return "CPUExecutionProvider"; }
   size_t GetInputTypeCount() const { return 1; }
@@ -149,7 +149,7 @@ struct MulTopKernelInt32 {
 };
 
 struct MulTopOpInt32 : Ort::CustomOpBase<MulTopOpInt32, MulTopKernelInt32> {
-  void* CreateKernel(const OrtApi&, const OrtKernelInfo* info) const { return new MulTopKernelInt32(info); }
+  void* CreateKernel(const OrtApi&, const OrtKernelInfo* info) const { return std::make_unique<MulTopKernelInt32>(info).get(); }
   const char* GetName() const { return "MulTop"; }
   const char* GetExecutionProviderType() const { return "CPUExecutionProvider"; }
   size_t GetInputTypeCount() const { return 1; }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Replaced new operator with make_unique


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

https://github.com/microsoft/onnxruntime/security/code-scanning/11191
