### PR TITLE
Fix issues on Windows for Vitis AI

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
+++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
@@ -50,7 +50,7 @@ void addGlobalSchemaFunctions(pybind11::module& m) {
             onnxruntime::MIGraphXProviderFactoryCreator::Create(0),
 #endif
 #ifdef USE_VITISAI
-            onnxruntime::VitisAIProviderFactoryCreator::Create(),
+            onnxruntime::VitisAIProviderFactoryCreator::Create(ProviderOptions{}),
 #endif
 #ifdef USE_ACL
             onnxruntime::ACLProviderFactoryCreator::Create(0),

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -762,7 +762,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
   } else if (type == kVitisAIExecutionProvider) {
 #if USE_VITISAI
     const auto it = provider_options_map.find(type);
-    if (it != provider_options_map.end()) {
+    if (it == provider_options_map.end()) {
       LOGS_DEFAULT(FATAL) << "cannot find provider options for VitisAIExecutionProvider";
     }
     const auto& vitis_option_map = it->second;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix two errors that is only encountered on windows


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
For onnxruntime::VitisAIProviderFactoryCreator::Create, it would cause the compile error.
For if (it == provider_options_map.end()), it would cause an error but execute as normal

