### PR TITLE
rust: Add function to expose CUDA execution provider.

### DIFF
--- a/rust/onnxruntime/src/error.rs
+++ b/rust/onnxruntime/src/error.rs
@@ -118,6 +118,12 @@ pub enum OrtError {
     /// Error occurred when checking if ONNXRuntime tensor was properly initialized
     #[error("Failed to check if tensor")]
     IsTensorCheck,
+    /// Error occurred when creating CUDA provider options
+    #[error("Failed to create CUDA provider options: {0}")]
+    CudaProviderOptions(OrtApiError),
+    /// Error occurred when appending CUDA execution provider
+    #[error("Failed to append CUDA execution provider: {0}")]
+    AppendExecutionProviderCuda(OrtApiError),
 }
 
 /// Error used when dimensions of input (from model and from inference call)

--- a/rust/onnxruntime/src/session.rs
+++ b/rust/onnxruntime/src/session.rs
@@ -1,6 +1,6 @@
 //! Module containing session types
 
-use std::{convert::TryFrom, ffi::CString, fmt::Debug, path::Path};
+use std::{convert::TryFrom, ffi::CString, fmt::Debug, path::Path, ptr::null_mut};
 
 #[cfg(not(target_family = "windows"))]
 use std::os::unix::ffi::OsStrExt;
@@ -158,6 +158,37 @@ impl<'a> SessionBuilder<'a> {
     /// Defaults to [`MemType::Default`](../enum.MemType.html#variant.Default)
     pub fn with_memory_type(mut self, memory_type: MemType) -> Result<SessionBuilder<'a>> {
         self.memory_type = memory_type;
+        Ok(self)
+    }
+
+    /// Append a CUDA execution provider
+    pub fn with_execution_provider_cuda(self) -> Result<SessionBuilder<'a>> {
+        let mut cuda_options: *mut sys::OrtCUDAProviderOptionsV2 = null_mut();
+        let status = unsafe {
+            self.env
+                .env()
+                .api()
+                .CreateCUDAProviderOptions
+                .unwrap()(&mut cuda_options)
+        };
+        status_to_result(status).map_err(OrtError::CudaProviderOptions)?;
+
+        let status = unsafe {
+            self.env
+                .env()
+                .api()
+                .SessionOptionsAppendExecutionProvider_CUDA_V2
+                .unwrap()(self.session_options_ptr, cuda_options)
+        };
+        status_to_result(status).map_err(OrtError::AppendExecutionProviderCuda)?;
+
+        unsafe {
+            self.env
+                .env()
+                .api()
+                .ReleaseCUDAProviderOptions
+                .unwrap()(cuda_options);
+        };
         Ok(self)
     }
 


### PR DESCRIPTION
### Description
Expose functions to enable CUDA execution provider in Rust bindings.

### Motivation and Context
To use an nvidia device for hardware acceleration.

This fixes https://github.com/microsoft/onnxruntime/issues/15627