### PR TITLE
[ROCm] add rocm5.5 to python package pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-rocm.yml
@@ -62,15 +62,27 @@ stages:
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.8'
-      RocmVersion: '5.4.2'
+      RocmVersion: '5.5'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.9'
+      RocmVersion: '5.5'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.10'
+      RocmVersion: '5.5'
+  - template: templates/rocm.yml
+    parameters:
+      PythonVersion: '3.8'
+      RocmVersion: '5.5'
       BuildConfig: 'RelWithDebInfo'
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.9'
-      RocmVersion: '5.4.2'
+      RocmVersion: '5.5'
       BuildConfig: 'RelWithDebInfo'
   - template: templates/rocm.yml
     parameters:
       PythonVersion: '3.10'
-      RocmVersion: '5.4.2'
+      RocmVersion: '5.5'
       BuildConfig: 'RelWithDebInfo'

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_rocm
@@ -6,7 +6,7 @@ ARG LD_LIBRARY_PATH_ARG=
 ARG PREPEND_PATH=
 
 FROM $BASEIMAGE AS base_image
-ARG ROCM_VERSION=5.3.2
+ARG ROCM_VERSION=5.5
 
 # Enable epel-release repositories
 RUN yum --enablerepo=extras install -y epel-release


### PR DESCRIPTION
add rocm5.5 to python packaging pipeline.
https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=306082&view=results

TODO:
Remove version 5.2.3, 5.3.2 and 5.4 in the next PR.


