### PR TITLE
Fix symbolic shape infer empty value_info

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -491,12 +491,13 @@ class SymbolicShapeInference:
 
         for i_o in range(len(node.output)):
             o = node.output[i_o]
-            vi = self.out_mp_.graph.value_info.add()
-            if not skip_infer:
-                vi.CopyFrom(self.tmp_mp_.graph.output[i_o])
-            else:
-                vi.name = o
-            self.known_vi_[o] = vi
+            if o:  # skip optional output
+                vi = self.out_mp_.graph.value_info.add()
+                if not skip_infer:
+                    vi.CopyFrom(self.tmp_mp_.graph.output[i_o])
+                else:
+                    vi.name = o
+                self.known_vi_[o] = vi
 
     def _onnx_infer_subgraph(self, node, subgraph, use_node_input=True, inc_subgraph_id=True):
         if self.verbose_ > 2:

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -644,12 +644,17 @@ class OnnxModel:
                 if model_with_shape is not None:
                     name_vi = {}
                     for vi in model_with_shape.graph.value_info:
-                        vi_copy = ValueInfoProto()
-                        vi_copy.CopyFrom(vi)
-                        if hasattr(vi_copy.type, "tensor_type") and hasattr(vi_copy.type.tensor_type, "shape"):
-                            vi_copy.type.tensor_type.ClearField("shape")
-                        name_vi[vi.name] = vi_copy
-
+                        if (
+                            hasattr(vi.type, "tensor_type")
+                            and hasattr(vi.type.tensor_type, "elem_type")
+                            and vi.type.tensor_type.elem_type != TensorProto.UNDEFINED
+                            and vi.name
+                        ):
+                            vi_copy = ValueInfoProto()
+                            vi_copy.CopyFrom(vi)
+                            if hasattr(vi_copy.type.tensor_type, "shape"):
+                                vi_copy.type.tensor_type.ClearField("shape")
+                            name_vi[vi.name] = vi_copy
                     for vi in model.graph.value_info:
                         if vi.name in name_vi:
                             del name_vi[vi.name]


### PR DESCRIPTION
### Description
When node output is optional, symbolic shape infer might add an empty value_info item. Add some checking to avoid this.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- 
Stable diffusion optimized model reported invalid data type 0 during inference.


