### PR TITLE
[js/common] refactor tensor type in onnxruntime-common

### DIFF
--- a/js/common/lib/tensor-conversion-impl.ts
+++ b/js/common/lib/tensor-conversion-impl.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {Tensor} from './tensor';
+import {TensorToDataUrlOptions, TensorToImageDataOptions} from './tensor-conversion';
+
+/**
+ * implementation of Tensor.toDataURL()
+ */
+export const tensorToDataURL = (tensor: Tensor, options?: TensorToDataUrlOptions): string => {
+  const canvas = document.createElement('canvas');
+  canvas.width = tensor.dims[3];
+  canvas.height = tensor.dims[2];
+  const pixels2DContext = canvas.getContext('2d');
+
+  if (pixels2DContext != null) {
+    // Default values for height and width & format
+    let width: number;
+    let height: number;
+    if (options?.tensorLayout !== undefined && options.tensorLayout === 'NHWC') {
+      width = tensor.dims[2];
+      height = tensor.dims[3];
+    } else {  // Default layout is NCWH
+      width = tensor.dims[3];
+      height = tensor.dims[2];
+    }
+
+    const inputformat = options?.format !== undefined ? options.format : 'RGB';
+
+    const norm = options?.norm;
+    let normMean: [number, number, number, number];
+    let normBias: [number, number, number, number];
+    if (norm === undefined || norm.mean === undefined) {
+      normMean = [255, 255, 255, 255];
+    } else {
+      if (typeof (norm.mean) === 'number') {
+        normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
+      } else {
+        normMean = [norm.mean[0], norm.mean[1], norm.mean[2], 0];
+        if (norm.mean[3] !== undefined) {
+          normMean[3] = norm.mean[3];
+        }
+      }
+    }
+    if (norm === undefined || norm.bias === undefined) {
+      normBias = [0, 0, 0, 0];
+    } else {
+      if (typeof (norm.bias) === 'number') {
+        normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
+      } else {
+        normBias = [norm.bias[0], norm.bias[1], norm.bias[2], 0];
+        if (norm.bias[3] !== undefined) {
+          normBias[3] = norm.bias[3];
+        }
+      }
+    }
+
+    const stride = height * width;
+    // Default pointer assignments
+    let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
+
+    // Updating the pointer assignments based on the input image format
+    if (inputformat === 'RGBA') {
+      rTensorPointer = 0;
+      gTensorPointer = stride;
+      bTensorPointer = stride * 2;
+      aTensorPointer = stride * 3;
+    } else if (inputformat === 'RGB') {
+      rTensorPointer = 0;
+      gTensorPointer = stride;
+      bTensorPointer = stride * 2;
+    } else if (inputformat === 'RBG') {
+      rTensorPointer = 0;
+      bTensorPointer = stride;
+      gTensorPointer = stride * 2;
+    }
+
+    for (let i = 0; i < height; i++) {
+      for (let j = 0; j < width; j++) {
+        const R = ((tensor.data[rTensorPointer++] as number) - normBias[0]) * normMean[0];  // R value
+        const G = ((tensor.data[gTensorPointer++] as number) - normBias[1]) * normMean[1];  // G value
+        const B = ((tensor.data[bTensorPointer++] as number) - normBias[2]) * normMean[2];  // B value
+        const A = aTensorPointer === -1 ?
+            255 :
+            ((tensor.data[aTensorPointer++] as number) - normBias[3]) * normMean[3];  // A value
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        pixels2DContext.fillStyle = 'rgba(' + R + ',' + G + ',' + B + ',' + A + ')';
+        pixels2DContext.fillRect(j, i, 1, 1);
+      }
+    }
+    return canvas.toDataURL();
+  } else {
+    throw new Error('Can not access image data');
+  }
+};
+
+/**
+ * implementation of Tensor.toImageData()
+ */
+export const tensorToImageData = (tensor: Tensor, options?: TensorToImageDataOptions): ImageData => {
+  const pixels2DContext = document.createElement('canvas').getContext('2d');
+  let image: ImageData;
+  if (pixels2DContext != null) {
+    // Default values for height and width & format
+    let width: number;
+    let height: number;
+    let channels: number;
+    if (options?.tensorLayout !== undefined && options.tensorLayout === 'NHWC') {
+      width = tensor.dims[2];
+      height = tensor.dims[1];
+      channels = tensor.dims[3];
+    } else {  // Default layout is NCWH
+      width = tensor.dims[3];
+      height = tensor.dims[2];
+      channels = tensor.dims[1];
+    }
+    const inputformat = options !== undefined ? (options.format !== undefined ? options.format : 'RGB') : 'RGB';
+
+    const norm = options?.norm;
+    let normMean: [number, number, number, number];
+    let normBias: [number, number, number, number];
+    if (norm === undefined || norm.mean === undefined) {
+      normMean = [255, 255, 255, 255];
+    } else {
+      if (typeof (norm.mean) === 'number') {
+        normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
+      } else {
+        normMean = [norm.mean[0], norm.mean[1], norm.mean[2], 255];
+        if (norm.mean[3] !== undefined) {
+          normMean[3] = norm.mean[3];
+        }
+      }
+    }
+    if (norm === undefined || norm.bias === undefined) {
+      normBias = [0, 0, 0, 0];
+    } else {
+      if (typeof (norm.bias) === 'number') {
+        normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
+      } else {
+        normBias = [norm.bias[0], norm.bias[1], norm.bias[2], 0];
+        if (norm.bias[3] !== undefined) {
+          normBias[3] = norm.bias[3];
+        }
+      }
+    }
+
+    const stride = height * width;
+    if (options !== undefined) {
+      if (options.format !== undefined && (channels === 4 && options.format !== 'RGBA') ||
+          (channels === 3 && (options.format !== 'RGB' && options.format !== 'BGR'))) {
+        throw new Error('Tensor format doesn\'t match input tensor dims');
+      }
+    }
+
+    // Default pointer assignments
+    const step = 4;
+    let rImagePointer = 0, gImagePointer = 1, bImagePointer = 2, aImagePointer = 3;
+    let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
+
+    // Updating the pointer assignments based on the input image format
+    if (inputformat === 'RGBA') {
+      rTensorPointer = 0;
+      gTensorPointer = stride;
+      bTensorPointer = stride * 2;
+      aTensorPointer = stride * 3;
+    } else if (inputformat === 'RGB') {
+      rTensorPointer = 0;
+      gTensorPointer = stride;
+      bTensorPointer = stride * 2;
+    } else if (inputformat === 'RBG') {
+      rTensorPointer = 0;
+      bTensorPointer = stride;
+      gTensorPointer = stride * 2;
+    }
+
+    image = pixels2DContext.createImageData(width, height);
+
+    for (let i = 0; i < height * width;
+         rImagePointer += step, gImagePointer += step, bImagePointer += step, aImagePointer += step, i++) {
+      image.data[rImagePointer] = ((tensor.data[rTensorPointer++] as number) - normBias[0]) * normMean[0];  // R value
+      image.data[gImagePointer] = ((tensor.data[gTensorPointer++] as number) - normBias[1]) * normMean[1];  // G value
+      image.data[bImagePointer] = ((tensor.data[bTensorPointer++] as number) - normBias[2]) * normMean[2];  // B value
+      image.data[aImagePointer] = aTensorPointer === -1 ?
+          255 :
+          ((tensor.data[aTensorPointer++] as number) - normBias[3]) * normMean[3];  // A value
+    }
+
+  } else {
+    throw new Error('Can not access image data');
+  }
+  return image;
+};

--- a/js/common/lib/tensor-conversion.ts
+++ b/js/common/lib/tensor-conversion.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {OptionsFormat, OptionsNormalizationParameters, OptionsTensorLayout} from './tensor-factory';
+
+export interface TensorToDataUrlOptions extends OptionsTensorLayout, OptionsFormat, OptionsNormalizationParameters {}
+
+export interface TensorToImageDataOptions extends OptionsTensorLayout, OptionsFormat, OptionsNormalizationParameters {}
+
+export interface ConversionUtils {
+  /**
+   * creates a DataURL instance from tensor
+   *
+   * @param options - An optional object representing options for creating a DataURL instance from the tensor.
+   *
+   * The following default settings will be applied:
+   * - `format`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * @returns a DataURL string representing the image converted from tensor data
+   */
+  toDataURL(options?: TensorToDataUrlOptions): string;
+
+  /**
+   * creates an ImageData instance from tensor
+   *
+   * @param options - An optional object representing options for creating an ImageData instance from the tensor.
+   *
+   * The following default settings will be applied:
+   * - `format`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * @returns an ImageData instance representing the image converted from tensor data
+   */
+  toImageData(options?: TensorToImageDataOptions): ImageData;
+}

--- a/js/common/lib/tensor-factory-impl.ts
+++ b/js/common/lib/tensor-factory-impl.ts
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {Tensor, TypedTensor} from './tensor';
+import {OptionsDimensions, OptionsFormat, OptionsNormalizationParameters, OptionsTensorFormat, OptionsTensorLayout, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromUrlOptions} from './tensor-factory';
+
+interface BufferToTensorOptions extends OptionsDimensions, OptionsTensorLayout, OptionsNormalizationParameters,
+                                        OptionsFormat, OptionsTensorFormat {}
+
+/**
+ * Create a new tensor object from image object
+ *
+ * @param buffer - Extracted image buffer data - assuming RGBA format
+ * @param imageFormat - input image configuration - required configurations height, width, format
+ * @param tensorFormat - output tensor configuration - Default is RGB format
+ */
+export const bufferToTensor =
+    (buffer: Uint8ClampedArray|undefined, options: BufferToTensorOptions): TypedTensor<'float32'>|
+    TypedTensor<'uint8'> => {
+      if (buffer === undefined) {
+        throw new Error('Image buffer must be defined');
+      }
+      if (options.height === undefined || options.width === undefined) {
+        throw new Error('Image height and width must be defined');
+      }
+      if (options.tensorLayout === 'NHWC') {
+        throw new Error('NHWC Tensor layout is not supported yet');
+      }
+
+      const {height, width} = options;
+
+      const norm = options.norm ?? {mean: 255, bias: 0};
+      let normMean: [number, number, number, number];
+      let normBias: [number, number, number, number];
+
+      if (typeof (norm.mean) === 'number') {
+        normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
+      } else {
+        normMean = [norm.mean![0], norm.mean![1], norm.mean![2], norm.mean![3] ?? 255];
+      }
+
+      if (typeof (norm.bias) === 'number') {
+        normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
+      } else {
+        normBias = [norm.bias![0], norm.bias![1], norm.bias![2], norm.bias![3] ?? 0];
+      }
+
+      const inputformat = options.format !== undefined ? options.format : 'RGBA';
+      // default value is RGBA since imagedata and HTMLImageElement uses it
+
+      const outputformat = options.tensorFormat !== undefined ?
+          (options.tensorFormat !== undefined ? options.tensorFormat : 'RGB') :
+          'RGB';
+      const stride = height * width;
+      const float32Data = outputformat === 'RGBA' ? new Float32Array(stride * 4) : new Float32Array(stride * 3);
+
+      // Default pointer assignments
+      let step = 4, rImagePointer = 0, gImagePointer = 1, bImagePointer = 2, aImagePointer = 3;
+      let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
+
+      // Updating the pointer assignments based on the input image format
+      if (inputformat === 'RGB') {
+        step = 3;
+        rImagePointer = 0;
+        gImagePointer = 1;
+        bImagePointer = 2;
+        aImagePointer = -1;
+      }
+
+      // Updating the pointer assignments based on the output tensor format
+      if (outputformat === 'RGBA') {
+        aTensorPointer = stride * 3;
+      } else if (outputformat === 'RBG') {
+        rTensorPointer = 0;
+        bTensorPointer = stride;
+        gTensorPointer = stride * 2;
+      } else if (outputformat === 'BGR') {
+        bTensorPointer = 0;
+        gTensorPointer = stride;
+        rTensorPointer = stride * 2;
+      }
+
+      for (let i = 0; i < stride;
+           i++, rImagePointer += step, bImagePointer += step, gImagePointer += step, aImagePointer += step) {
+        float32Data[rTensorPointer++] = (buffer[rImagePointer] + normBias[0]) / normMean[0];
+        float32Data[gTensorPointer++] = (buffer[gImagePointer] + normBias[1]) / normMean[1];
+        float32Data[bTensorPointer++] = (buffer[bImagePointer] + normBias[2]) / normMean[2];
+        if (aTensorPointer !== -1 && aImagePointer !== -1) {
+          float32Data[aTensorPointer++] = (buffer[aImagePointer] + normBias[3]) / normMean[3];
+        }
+      }
+
+      // Float32Array -> ort.Tensor
+      const outputTensor = outputformat === 'RGBA' ? new Tensor('float32', float32Data, [1, 4, height, width]) :
+                                                     new Tensor('float32', float32Data, [1, 3, height, width]);
+      return outputTensor;
+    };
+
+/**
+ * implementation of Tensor.fromImage().
+ */
+export const tensorFromImage = async(
+    image: ImageData|HTMLImageElement|ImageBitmap|string,
+    options?: TensorFromImageDataOptions|TensorFromImageElementOptions|TensorFromImageBitmapOptions|
+    TensorFromUrlOptions): Promise<TypedTensor<'float32'>|TypedTensor<'uint8'>> => {
+  // checking the type of image object
+  const isHTMLImageEle = typeof (HTMLImageElement) !== 'undefined' && image instanceof HTMLImageElement;
+  const isImageDataEle = typeof (ImageData) !== 'undefined' && image instanceof ImageData;
+  const isImageBitmap = typeof (ImageBitmap) !== 'undefined' && image instanceof ImageBitmap;
+  const isString = typeof image === 'string';
+
+  let data: Uint8ClampedArray|undefined;
+  let bufferToTensorOptions: BufferToTensorOptions = options ?? {};
+
+  // filling and checking image configuration options
+  if (isHTMLImageEle) {
+    // HTMLImageElement - image object - format is RGBA by default
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const pixels2DContext = canvas.getContext('2d');
+
+    if (pixels2DContext != null) {
+      let height = image.height;
+      let width = image.width;
+      if (options !== undefined && options.resizedHeight !== undefined && options.resizedWidth !== undefined) {
+        height = options.resizedHeight;
+        width = options.resizedWidth;
+      }
+
+      if (options !== undefined) {
+        bufferToTensorOptions = options;
+        if (options.tensorFormat !== undefined) {
+          throw new Error('Image input config format must be RGBA for HTMLImageElement');
+        } else {
+          bufferToTensorOptions.tensorFormat = 'RGBA';
+        }
+        bufferToTensorOptions.height = height;
+        bufferToTensorOptions.width = width;
+      } else {
+        bufferToTensorOptions.tensorFormat = 'RGBA';
+        bufferToTensorOptions.height = height;
+        bufferToTensorOptions.width = width;
+      }
+
+      pixels2DContext.drawImage(image, 0, 0);
+      data = pixels2DContext.getImageData(0, 0, width, height).data;
+    } else {
+      throw new Error('Can not access image data');
+    }
+  } else if (isImageDataEle) {
+    let height: number;
+    let width: number;
+
+    if (options !== undefined && options.resizedWidth !== undefined && options.resizedHeight !== undefined) {
+      height = options.resizedHeight;
+      width = options.resizedWidth;
+    } else {
+      height = image.height;
+      width = image.width;
+    }
+
+    if (options !== undefined) {
+      bufferToTensorOptions = options;
+    }
+    bufferToTensorOptions.format = 'RGBA';
+    bufferToTensorOptions.height = height;
+    bufferToTensorOptions.width = width;
+
+    if (options !== undefined) {
+      const tempCanvas = document.createElement('canvas');
+
+      tempCanvas.width = width;
+      tempCanvas.height = height;
+
+      const pixels2DContext = tempCanvas.getContext('2d');
+
+      if (pixels2DContext != null) {
+        pixels2DContext.putImageData(image, 0, 0);
+        data = pixels2DContext.getImageData(0, 0, width, height).data;
+      } else {
+        throw new Error('Can not access image data');
+      }
+    } else {
+      data = image.data;
+    }
+  } else if (isImageBitmap) {
+    // ImageBitmap - image object - format must be provided by user
+    if (options === undefined) {
+      throw new Error('Please provide image config with format for Imagebitmap');
+    }
+
+    const pixels2DContext = document.createElement('canvas').getContext('2d');
+
+    if (pixels2DContext != null) {
+      const height = image.height;
+      const width = image.width;
+      pixels2DContext.drawImage(image, 0, 0, width, height);
+      data = pixels2DContext.getImageData(0, 0, width, height).data;
+      bufferToTensorOptions.height = height;
+      bufferToTensorOptions.width = width;
+      return bufferToTensor(data, bufferToTensorOptions);
+    } else {
+      throw new Error('Can not access image data');
+    }
+  } else if (isString) {
+    return new Promise((resolve, reject) => {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      if (!image || !context) {
+        return reject();
+      }
+      const newImage = new Image();
+      newImage.crossOrigin = 'Anonymous';
+      newImage.src = image;
+      newImage.onload = () => {
+        canvas.width = newImage.width;
+        canvas.height = newImage.height;
+        context.drawImage(newImage, 0, 0, canvas.width, canvas.height);
+        const img = context.getImageData(0, 0, canvas.width, canvas.height);
+
+        bufferToTensorOptions.height = canvas.height;
+        bufferToTensorOptions.width = canvas.width;
+        resolve(bufferToTensor(img.data, bufferToTensorOptions));
+      };
+    });
+  } else {
+    throw new Error('Input data provided is not supported - aborted tensor creation');
+  }
+
+  if (data !== undefined) {
+    return bufferToTensor(data, bufferToTensorOptions);
+  } else {
+    throw new Error('Input data provided is not supported - aborted tensor creation');
+  }
+};

--- a/js/common/lib/tensor-factory.ts
+++ b/js/common/lib/tensor-factory.ts
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {TypedTensor} from './tensor';
+
+export type ImageFormat = 'RGB'|'RGBA'|'BGR'|'RBG';
+export type ImageTensorLayout = 'NHWC'|'NCHW';
+
+// the following session contains type definitions of each individual options.
+// the tensor factory functions use a composition of those options as the parameter type.
+
+// #region Options fields
+
+export interface OptionsFormat {
+  /**
+   * Describes the image format represented in RGBA color space.
+   */
+  format?: ImageFormat;
+}
+
+export interface OptionsTensorFormat {
+  /**
+   * Describes the image format of the tensor.
+   *
+   * NOTE: this is different from option 'format'. While option 'format' represents the original image, 'tensorFormat'
+   * represents the target format of the tensor. A transpose will be performed if they are different.
+   */
+  tensorFormat?: ImageFormat;
+}
+
+export interface OptionsTensorDataType {
+  /**
+   * Describes the data type of the tensor.
+   */
+  dataType?: 'float32'|'uint8';
+}
+
+export interface OptionsTensorLayout {
+  /**
+   * Describes the tensor layout when representing data of one or more image(s).
+   */
+  tensorLayout?: ImageTensorLayout;
+}
+
+export interface OptionsDimensions {
+  /**
+   * Describes the image height in pixel
+   */
+  height?: number;
+  /**
+   * Describes the image width in pixel
+   */
+  width?: number;
+}
+
+export interface OptionResizedDimensions {
+  /**
+   * Describes the resized height. If omitted, original height will be used.
+   */
+  resizedHeight?: number;
+  /**
+   * Describes resized width - can be accessed via tensor dimensions as well
+   */
+  resizedWidth?: number;
+}
+
+export interface OptionsNormalizationParameters {
+  /**
+   * Describes normalization parameters when preprocessing the image as model input.
+   *
+   * Data element are ranged from 0 to 255.
+   */
+  norm?: {
+    /**
+     * The 'bias' value for image normalization.
+     * - If omitted, use default value 0.
+     * - If it's a single number, apply to each channel
+     * - If it's an array of 3 or 4 numbers, apply element-wise. Number of elements need to match the number of channels
+     * for the corresponding image format
+     */
+    bias?: number|[number, number, number]|[number, number, number, number];
+    /**
+     * The 'mean' value for image normalization.
+     * - If omitted, use default value 255.
+     * - If it's a single number, apply to each channel
+     * - If it's an array of 3 or 4 numbers, apply element-wise. Number of elements need to match the number of channels
+     * for the corresponding image format
+     */
+    mean?: number | [number, number, number] | [number, number, number, number];
+  };
+}
+
+// #endregion
+
+export interface TensorFromImageDataOptions extends OptionResizedDimensions, OptionsTensorFormat, OptionsTensorLayout,
+                                                    OptionsTensorDataType, OptionsNormalizationParameters {}
+
+export interface TensorFromImageElementOptions extends OptionResizedDimensions, OptionsTensorFormat,
+                                                       OptionsTensorLayout, OptionsTensorDataType,
+                                                       OptionsNormalizationParameters {}
+
+export interface TensorFromUrlOptions extends OptionsDimensions, OptionResizedDimensions, OptionsTensorFormat,
+                                              OptionsTensorLayout, OptionsTensorDataType,
+                                              OptionsNormalizationParameters {}
+
+export interface TensorFromImageBitmapOptions extends OptionResizedDimensions, OptionsTensorFormat, OptionsTensorLayout,
+                                                      OptionsTensorDataType, OptionsNormalizationParameters {}
+
+export interface TensorFactory {
+  /**
+   * create a tensor from an ImageData object
+   *
+   * @param imageData - the ImageData object to create tensor from
+   * @param options - An optional object representing options for creating tensor from ImageData.
+   *
+   * The following default settings will be applied:
+   * - `tensorFormat`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * - `dataType`: `'float32'`
+   * @returns A promise that resolves to a tensor object
+   */
+  fromImage(imageData: ImageData, options?: TensorFromImageDataOptions):
+      Promise<TypedTensor<'float32'>|TypedTensor<'uint8'>>;
+
+  /**
+   * create a tensor from a HTMLImageElement object
+   *
+   * @param imageElement - the HTMLImageElement object to create tensor from
+   * @param options - An optional object representing options for creating tensor from HTMLImageElement.
+   *
+   * The following default settings will be applied:
+   * - `tensorFormat`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * - `dataType`: `'float32'`
+   * @returns A promise that resolves to a tensor object
+   */
+  fromImage(imageElement: HTMLImageElement, options?: TensorFromImageElementOptions):
+      Promise<TypedTensor<'float32'>|TypedTensor<'uint8'>>;
+
+  /**
+   * create a tensor from URL
+   *
+   * @param urlSource - a string as a URL to the image or a data URL containing the image data.
+   * @param options - An optional object representing options for creating tensor from URL.
+   *
+   * The following default settings will be applied:
+   * - `tensorFormat`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * - `dataType`: `'float32'`
+   * @returns A promise that resolves to a tensor object
+   */
+  fromImage(urlSource: string, options?: TensorFromUrlOptions): Promise<TypedTensor<'float32'>|TypedTensor<'uint8'>>;
+
+  /**
+   * create a tensor from an ImageBitmap object
+   *
+   * @param bitMap - the ImageBitmap object to create tensor from
+   * @param options - An optional object representing options for creating tensor from URL.
+   *
+   * The following default settings will be applied:
+   * - `tensorFormat`: `'RGB'`
+   * - `tensorLayout`: `'NCHW'`
+   * - `dataType`: `'float32'`
+   * @returns A promise that resolves to a tensor object
+   */
+  fromImage(bitmap: ImageBitmap, options: TensorFromImageBitmapOptions):
+      Promise<TypedTensor<'float32'>|TypedTensor<'uint8'>>;
+}

--- a/js/common/lib/tensor-impl.ts
+++ b/js/common/lib/tensor-impl.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {Tensor as TensorInterface, TensorFromImageOptions, TensorToImageDataOptions} from './tensor';
+import {Tensor as TensorInterface} from './tensor';
+import {TensorToDataUrlOptions, TensorToImageDataOptions} from './tensor-conversion';
+import {tensorToDataURL, tensorToImageData} from './tensor-conversion-impl';
+import {TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromUrlOptions} from './tensor-factory';
+import {tensorFromImage} from './tensor-factory-impl';
+import {calculateSize, tensorReshape} from './tensor-utils-impl';
 
 type TensorType = TensorInterface.Type;
 type TensorDataType = TensorInterface.DataType;
@@ -58,25 +63,6 @@ const checkBigInt = () => {
   }
 };
 
-/**
- * calculate size from dims.
- *
- * @param dims the dims array. May be an illegal input.
- */
-const calculateSize = (dims: readonly unknown[]): number => {
-  let size = 1;
-  for (let i = 0; i < dims.length; i++) {
-    const dim = dims[i];
-    if (typeof dim !== 'number' || !Number.isSafeInteger(dim)) {
-      throw new TypeError(`dims[${i}] must be an integer, got: ${dim}`);
-    }
-    if (dim < 0) {
-      throw new RangeError(`dims[${i}] must be a non-negative integer, got: ${dim}`);
-    }
-    size *= dim;
-  }
-  return size;
-};
 
 export class Tensor implements TensorInterface {
   // #region constructors
@@ -178,469 +164,30 @@ export class Tensor implements TensorInterface {
     this.size = size;
   }
   // #endregion
-  /**
-   * Create a new tensor object from image object
-   *
-   * @param buffer - Extracted image buffer data - assuming RGBA format
-   * @param imageFormat - input image configuration - required configurations height, width, format
-   * @param tensorFormat - output tensor configuration - Default is RGB format
-   */
-  private static bufferToTensor(buffer: Uint8ClampedArray|undefined, options: TensorFromImageOptions): Tensor {
-    if (buffer === undefined) {
-      throw new Error('Image buffer must be defined');
-    }
-    if (options.height === undefined || options.width === undefined) {
-      throw new Error('Image height and width must be defined');
-    }
-    if (options.tensorLayout === 'NHWC') {
-      throw new Error('NHWC Tensor layout is not supported yet');
-    }
-
-    const {height, width} = options;
-
-    const norm = options.norm ?? {mean: 255, bias: 0};
-    let normMean: [number, number, number, number];
-    let normBias: [number, number, number, number];
-
-    if (typeof (norm.mean) === 'number') {
-      normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
-    } else {
-      normMean = [norm.mean![0], norm.mean![1], norm.mean![2], norm.mean![3] ?? 255];
-    }
-
-    if (typeof (norm.bias) === 'number') {
-      normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
-    } else {
-      normBias = [norm.bias![0], norm.bias![1], norm.bias![2], norm.bias![3] ?? 0];
-    }
-
-    const inputformat = options.bitmapFormat !== undefined ? options.bitmapFormat : 'RGBA';
-    // default value is RGBA since imagedata and HTMLImageElement uses it
-
-    const outputformat = options.tensorFormat !== undefined ?
-        (options.tensorFormat !== undefined ? options.tensorFormat : 'RGB') :
-        'RGB';
-    const stride = height * width;
-    const float32Data = outputformat === 'RGBA' ? new Float32Array(stride * 4) : new Float32Array(stride * 3);
-
-    // Default pointer assignments
-    let step = 4, rImagePointer = 0, gImagePointer = 1, bImagePointer = 2, aImagePointer = 3;
-    let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
-
-    // Updating the pointer assignments based on the input image format
-    if (inputformat === 'RGB') {
-      step = 3;
-      rImagePointer = 0;
-      gImagePointer = 1;
-      bImagePointer = 2;
-      aImagePointer = -1;
-    }
-
-    // Updating the pointer assignments based on the output tensor format
-    if (outputformat === 'RGBA') {
-      aTensorPointer = stride * 3;
-    } else if (outputformat === 'RBG') {
-      rTensorPointer = 0;
-      bTensorPointer = stride;
-      gTensorPointer = stride * 2;
-    } else if (outputformat === 'BGR') {
-      bTensorPointer = 0;
-      gTensorPointer = stride;
-      rTensorPointer = stride * 2;
-    }
-
-    for (let i = 0; i < stride;
-         i++, rImagePointer += step, bImagePointer += step, gImagePointer += step, aImagePointer += step) {
-      float32Data[rTensorPointer++] = (buffer[rImagePointer] + normBias[0]) / normMean[0];
-      float32Data[gTensorPointer++] = (buffer[gImagePointer] + normBias[1]) / normMean[1];
-      float32Data[bTensorPointer++] = (buffer[bImagePointer] + normBias[2]) / normMean[2];
-      if (aTensorPointer !== -1 && aImagePointer !== -1) {
-        float32Data[aTensorPointer++] = (buffer[aImagePointer] + normBias[3]) / normMean[3];
-      }
-    }
-
-    // Float32Array -> ort.Tensor
-    const outputTensor = outputformat === 'RGBA' ? new Tensor('float32', float32Data, [1, 4, height, width]) :
-                                                   new Tensor('float32', float32Data, [1, 3, height, width]);
-    return outputTensor;
-  }
 
   // #region factory
-  static async fromImage(imageData: ImageData, options?: TensorFromImageOptions): Promise<Tensor>;
-  static async fromImage(imageElement: HTMLImageElement, options?: TensorFromImageOptions): Promise<Tensor>;
-  static async fromImage(bitmap: ImageBitmap, options: TensorFromImageOptions): Promise<Tensor>;
-  static async fromImage(urlSource: string, options?: TensorFromImageOptions): Promise<Tensor>;
+  static async fromImage(imageData: ImageData, options?: TensorFromImageDataOptions): Promise<Tensor>;
+  static async fromImage(imageElement: HTMLImageElement, options?: TensorFromImageElementOptions): Promise<Tensor>;
+  static async fromImage(bitmap: ImageBitmap, options: TensorFromImageBitmapOptions): Promise<Tensor>;
+  static async fromImage(urlSource: string, options?: TensorFromUrlOptions): Promise<Tensor>;
 
-  static async fromImage(image: ImageData|HTMLImageElement|ImageBitmap|string, options?: TensorFromImageOptions):
-      Promise<Tensor> {
-    // checking the type of image object
-    const isHTMLImageEle = typeof (HTMLImageElement) !== 'undefined' && image instanceof HTMLImageElement;
-    const isImageDataEle = typeof (ImageData) !== 'undefined' && image instanceof ImageData;
-    const isImageBitmap = typeof (ImageBitmap) !== 'undefined' && image instanceof ImageBitmap;
-    const isString = typeof image === 'string';
-
-    let data: Uint8ClampedArray|undefined;
-    let tensorConfig: TensorFromImageOptions = options ?? {};
-
-    // filling and checking image configuration options
-    if (isHTMLImageEle) {
-      // HTMLImageElement - image object - format is RGBA by default
-      const canvas = document.createElement('canvas');
-      canvas.width = image.width;
-      canvas.height = image.height;
-      const pixels2DContext = canvas.getContext('2d');
-
-      if (pixels2DContext != null) {
-        let height = image.height;
-        let width = image.width;
-        if (options !== undefined && options.resizedHeight !== undefined && options.resizedWidth !== undefined) {
-          height = options.resizedHeight;
-          width = options.resizedWidth;
-        }
-
-        if (options !== undefined) {
-          tensorConfig = options;
-          if (options.tensorFormat !== undefined) {
-            throw new Error('Image input config format must be RGBA for HTMLImageElement');
-          } else {
-            tensorConfig.tensorFormat = 'RGBA';
-          }
-          if (options.height !== undefined && options.height !== height) {
-            throw new Error('Image input config height doesn\'t match HTMLImageElement height');
-          } else {
-            tensorConfig.height = height;
-          }
-          if (options.width !== undefined && options.width !== width) {
-            throw new Error('Image input config width doesn\'t match HTMLImageElement width');
-          } else {
-            tensorConfig.width = width;
-          }
-        } else {
-          tensorConfig.tensorFormat = 'RGBA';
-          tensorConfig.height = height;
-          tensorConfig.width = width;
-        }
-
-        pixels2DContext.drawImage(image, 0, 0);
-        data = pixels2DContext.getImageData(0, 0, width, height).data;
-      } else {
-        throw new Error('Can not access image data');
-      }
-
-    } else if (isImageDataEle) {
-      // ImageData - image object - format is RGBA by default
-      const format = 'RGBA';
-      let height: number;
-      let width: number;
-
-      if (options !== undefined && options.resizedWidth !== undefined && options.resizedHeight !== undefined) {
-        height = options.resizedHeight;
-        width = options.resizedWidth;
-      } else {
-        height = image.height;
-        width = image.width;
-      }
-
-      if (options !== undefined) {
-        tensorConfig = options;
-        if (options.bitmapFormat !== undefined && options.bitmapFormat !== format) {
-          throw new Error('Image input config format must be RGBA for ImageData');
-        } else {
-          tensorConfig.bitmapFormat = 'RGBA';
-        }
-      } else {
-        tensorConfig.bitmapFormat = 'RGBA';
-      }
-
-      tensorConfig.height = height;
-      tensorConfig.width = width;
-
-      if (options !== undefined) {
-        const tempCanvas = document.createElement('canvas');
-
-        tempCanvas.width = width;
-        tempCanvas.height = height;
-
-        const pixels2DContext = tempCanvas.getContext('2d');
-
-        if (pixels2DContext != null) {
-          pixels2DContext.putImageData(image, 0, 0);
-          data = pixels2DContext.getImageData(0, 0, width, height).data;
-        } else {
-          throw new Error('Can not access image data');
-        }
-      } else {
-        data = image.data;
-      }
-
-    } else if (isImageBitmap) {
-      // ImageBitmap - image object - format must be provided by user
-      if (options === undefined) {
-        throw new Error('Please provide image config with format for Imagebitmap');
-      }
-      if (options.bitmapFormat !== undefined) {
-        throw new Error('Image input config format must be defined for ImageBitmap');
-      }
-
-      const pixels2DContext = document.createElement('canvas').getContext('2d');
-
-      if (pixels2DContext != null) {
-        const height = image.height;
-        const width = image.width;
-        pixels2DContext.drawImage(image, 0, 0, width, height);
-        data = pixels2DContext.getImageData(0, 0, width, height).data;
-        if (options !== undefined) {
-          // using square brackets to avoid TS error - type 'never'
-          if (options.height !== undefined && options.height !== height) {
-            throw new Error('Image input config height doesn\'t match ImageBitmap height');
-          } else {
-            tensorConfig.height = height;
-          }
-          // using square brackets to avoid TS error - type 'never'
-          if (options.width !== undefined && options.width !== width) {
-            throw new Error('Image input config width doesn\'t match ImageBitmap width');
-          } else {
-            tensorConfig.width = width;
-          }
-        } else {
-          tensorConfig.height = height;
-          tensorConfig.width = width;
-        }
-        return Tensor.bufferToTensor(data, tensorConfig);
-      } else {
-        throw new Error('Can not access image data');
-      }
-
-    } else if (isString) {
-      return new Promise((resolve, reject) => {
-        const canvas = document.createElement('canvas');
-        const context = canvas.getContext('2d');
-        if (!image || !context) {
-          return reject();
-        }
-        const newImage = new Image();
-        newImage.crossOrigin = 'Anonymous';
-        newImage.src = image;
-        newImage.onload = () => {
-          canvas.width = newImage.width;
-          canvas.height = newImage.height;
-          context.drawImage(newImage, 0, 0, canvas.width, canvas.height);
-          const img = context.getImageData(0, 0, canvas.width, canvas.height);
-          if (options !== undefined) {
-            if (options.height !== undefined && options.height !== canvas.height) {
-              throw new Error('Image input config height doesn\'t match height');
-            } else {
-              tensorConfig.height = canvas.height;
-            }
-            if (options.width !== undefined && options.width !== canvas.width) {
-              throw new Error('Image input config width doesn\'t match width');
-            } else {
-              tensorConfig.width = canvas.width;
-            }
-          } else {
-            tensorConfig.height = canvas.height;
-            tensorConfig.width = canvas.width;
-          }
-          resolve(Tensor.bufferToTensor(img.data, tensorConfig));
-        };
-      });
-    } else {
-      throw new Error('Input data provided is not supported - aborted tensor creation');
-    }
-
-    if (data !== undefined) {
-      return Tensor.bufferToTensor(data, tensorConfig);
-    } else {
-      throw new Error('Input data provided is not supported - aborted tensor creation');
-    }
+  static async fromImage(
+      image: ImageData|HTMLImageElement|ImageBitmap|string,
+      options?: TensorFromImageDataOptions|TensorFromImageElementOptions|TensorFromImageBitmapOptions|
+      TensorFromUrlOptions): Promise<Tensor> {
+    return tensorFromImage(image, options);
   }
+  // #endregion
 
-  toDataURL(options?: TensorToImageDataOptions): string {
-    const canvas = document.createElement('canvas');
-    canvas.width = this.dims[3];
-    canvas.height = this.dims[2];
-    const pixels2DContext = canvas.getContext('2d');
-
-    if (pixels2DContext != null) {
-      // Default values for height and width & format
-      let width: number;
-      let height: number;
-      if (options?.tensorLayout !== undefined && options.tensorLayout === 'NHWC') {
-        width = this.dims[2];
-        height = this.dims[3];
-      } else {  // Default layout is NCWH
-        width = this.dims[3];
-        height = this.dims[2];
-      }
-
-      const inputformat = options?.format !== undefined ? options.format : 'RGB';
-
-      const norm = options?.norm;
-      let normMean: [number, number, number, number];
-      let normBias: [number, number, number, number];
-      if (norm === undefined || norm.mean === undefined) {
-        normMean = [255, 255, 255, 255];
-      } else {
-        if (typeof (norm.mean) === 'number') {
-          normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
-        } else {
-          normMean = [norm.mean[0], norm.mean[1], norm.mean[2], 0];
-          if (norm.mean[3] !== undefined) {
-            normMean[3] = norm.mean[3];
-          }
-        }
-      }
-      if (norm === undefined || norm.bias === undefined) {
-        normBias = [0, 0, 0, 0];
-      } else {
-        if (typeof (norm.bias) === 'number') {
-          normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
-        } else {
-          normBias = [norm.bias[0], norm.bias[1], norm.bias[2], 0];
-          if (norm.bias[3] !== undefined) {
-            normBias[3] = norm.bias[3];
-          }
-        }
-      }
-
-      const stride = height * width;
-      // Default pointer assignments
-      let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
-
-      // Updating the pointer assignments based on the input image format
-      if (inputformat === 'RGBA') {
-        rTensorPointer = 0;
-        gTensorPointer = stride;
-        bTensorPointer = stride * 2;
-        aTensorPointer = stride * 3;
-      } else if (inputformat === 'RGB') {
-        rTensorPointer = 0;
-        gTensorPointer = stride;
-        bTensorPointer = stride * 2;
-      } else if (inputformat === 'RBG') {
-        rTensorPointer = 0;
-        bTensorPointer = stride;
-        gTensorPointer = stride * 2;
-      }
-
-      for (let i = 0; i < height; i++) {
-        for (let j = 0; j < width; j++) {
-          const R = ((this.data[rTensorPointer++] as number) - normBias[0]) * normMean[0];  // R value
-          const G = ((this.data[gTensorPointer++] as number) - normBias[1]) * normMean[1];  // G value
-          const B = ((this.data[bTensorPointer++] as number) - normBias[2]) * normMean[2];  // B value
-          const A = aTensorPointer === -1 ?
-              255 :
-              ((this.data[aTensorPointer++] as number) - normBias[3]) * normMean[3];  // A value
-          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-          pixels2DContext.fillStyle = 'rgba(' + R + ',' + G + ',' + B + ',' + A + ')';
-          pixels2DContext.fillRect(j, i, 1, 1);
-        }
-      }
-      return canvas.toDataURL();
-    } else {
-      throw new Error('Can not access image data');
-    }
+  // #region conversions
+  toDataURL(options?: TensorToDataUrlOptions): string {
+    return tensorToDataURL(this, options);
   }
 
   toImageData(options?: TensorToImageDataOptions): ImageData {
-    const pixels2DContext = document.createElement('canvas').getContext('2d');
-    let image: ImageData;
-    if (pixels2DContext != null) {
-      // Default values for height and width & format
-      let width: number;
-      let height: number;
-      let channels: number;
-      if (options?.tensorLayout !== undefined && options.tensorLayout === 'NHWC') {
-        width = this.dims[2];
-        height = this.dims[1];
-        channels = this.dims[3];
-      } else {  // Default layout is NCWH
-        width = this.dims[3];
-        height = this.dims[2];
-        channels = this.dims[1];
-      }
-      const inputformat = options !== undefined ? (options.format !== undefined ? options.format : 'RGB') : 'RGB';
-
-      const norm = options?.norm;
-      let normMean: [number, number, number, number];
-      let normBias: [number, number, number, number];
-      if (norm === undefined || norm.mean === undefined) {
-        normMean = [255, 255, 255, 255];
-      } else {
-        if (typeof (norm.mean) === 'number') {
-          normMean = [norm.mean, norm.mean, norm.mean, norm.mean];
-        } else {
-          normMean = [norm.mean[0], norm.mean[1], norm.mean[2], 255];
-          if (norm.mean[3] !== undefined) {
-            normMean[3] = norm.mean[3];
-          }
-        }
-      }
-      if (norm === undefined || norm.bias === undefined) {
-        normBias = [0, 0, 0, 0];
-      } else {
-        if (typeof (norm.bias) === 'number') {
-          normBias = [norm.bias, norm.bias, norm.bias, norm.bias];
-        } else {
-          normBias = [norm.bias[0], norm.bias[1], norm.bias[2], 0];
-          if (norm.bias[3] !== undefined) {
-            normBias[3] = norm.bias[3];
-          }
-        }
-      }
-
-      const stride = height * width;
-      if (options !== undefined) {
-        if (options.height !== undefined && options.height !== height) {
-          throw new Error('Image output config height doesn\'t match tensor height');
-        }
-        if (options.width !== undefined && options.width !== width) {
-          throw new Error('Image output config width doesn\'t match tensor width');
-        }
-        if (options.format !== undefined && (channels === 4 && options.format !== 'RGBA') ||
-            (channels === 3 && (options.format !== 'RGB' && options.format !== 'BGR'))) {
-          throw new Error('Tensor format doesn\'t match input tensor dims');
-        }
-      }
-
-      // Default pointer assignments
-      const step = 4;
-      let rImagePointer = 0, gImagePointer = 1, bImagePointer = 2, aImagePointer = 3;
-      let rTensorPointer = 0, gTensorPointer = stride, bTensorPointer = stride * 2, aTensorPointer = -1;
-
-      // Updating the pointer assignments based on the input image format
-      if (inputformat === 'RGBA') {
-        rTensorPointer = 0;
-        gTensorPointer = stride;
-        bTensorPointer = stride * 2;
-        aTensorPointer = stride * 3;
-      } else if (inputformat === 'RGB') {
-        rTensorPointer = 0;
-        gTensorPointer = stride;
-        bTensorPointer = stride * 2;
-      } else if (inputformat === 'RBG') {
-        rTensorPointer = 0;
-        bTensorPointer = stride;
-        gTensorPointer = stride * 2;
-      }
-
-      image = pixels2DContext.createImageData(width, height);
-
-      for (let i = 0; i < height * width;
-           rImagePointer += step, gImagePointer += step, bImagePointer += step, aImagePointer += step, i++) {
-        image.data[rImagePointer] = ((this.data[rTensorPointer++] as number) - normBias[0]) * normMean[0];  // R value
-        image.data[gImagePointer] = ((this.data[gTensorPointer++] as number) - normBias[1]) * normMean[1];  // G value
-        image.data[bImagePointer] = ((this.data[bTensorPointer++] as number) - normBias[2]) * normMean[2];  // B value
-        image.data[aImagePointer] = aTensorPointer === -1 ?
-            255 :
-            ((this.data[aTensorPointer++] as number) - normBias[3]) * normMean[3];  // A value
-      }
-
-    } else {
-      throw new Error('Can not access image data');
-    }
-    return image;
+    return tensorToImageData(this, options);
   }
+  // #endregion
 
   // #region fields
   readonly dims: readonly number[];
@@ -651,7 +198,7 @@ export class Tensor implements TensorInterface {
 
   // #region tensor utilities
   reshape(dims: readonly number[]): Tensor {
-    return new Tensor(this.type, this.data, dims);
+    return tensorReshape(this, dims);
   }
   // #endregion
 }

--- a/js/common/lib/tensor-utils-impl.ts
+++ b/js/common/lib/tensor-utils-impl.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {Tensor} from './tensor';
+
+/**
+ * calculate size from dims.
+ *
+ * @param dims the dims array. May be an illegal input.
+ */
+export const calculateSize = (dims: readonly unknown[]): number => {
+  let size = 1;
+  for (let i = 0; i < dims.length; i++) {
+    const dim = dims[i];
+    if (typeof dim !== 'number' || !Number.isSafeInteger(dim)) {
+      throw new TypeError(`dims[${i}] must be an integer, got: ${dim}`);
+    }
+    if (dim < 0) {
+      throw new RangeError(`dims[${i}] must be a non-negative integer, got: ${dim}`);
+    }
+    size *= dim;
+  }
+  return size;
+};
+
+/**
+ * implementation of Tensor.reshape()
+ */
+export const tensorReshape = (tensor: Tensor, dims: readonly number[]): Tensor =>
+    new Tensor(tensor.type, tensor.data, dims);

--- a/js/common/lib/tensor-utils.ts
+++ b/js/common/lib/tensor-utils.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {Tensor, TensorToImageDataOptions, TypedTensor} from './tensor';
+import {Tensor, TypedTensor} from './tensor';
+import {ConversionUtils} from './tensor-conversion';
 
 interface Properties {
   /**
@@ -19,23 +20,12 @@ export interface TypedShapeUtils<T extends Tensor.Type> {
   reshape(dims: readonly number[]): TypedTensor<T>;
 }
 
-// TODO: add more tensor utilities
-export interface TypedTensorUtils<T extends Tensor.Type> extends Properties, TypedShapeUtils<T> {
-  /**
-   * creates an DataURL instance from tensor
-   *
-   * @param options - Interface describing tensor instance - Defaults: RGB, 3 channels, 0-255, NHWC
-   * 0-255, NHWC
-   * @returns An DataURL instance which can be used to draw on canvas
-   */
-  toDataURL(options?: TensorToImageDataOptions): string;
+/**
+ * interface `TensorUtils` includes all utility members that does not use the type parameter from their signature.
+ */
+export interface TensorUtils extends Properties, ConversionUtils {}
 
-  /**
-   * creates an ImageData instance from tensor
-   *
-   * @param tensorFormat - Interface describing tensor instance - Defaults: RGB, 3 channels, 0-255, NHWC
-   * 0-255, NHWC
-   * @returns An ImageData instance which can be used to draw on canvas
-   */
-  toImageData(options?: TensorToImageDataOptions): ImageData;
-}
+/**
+ * interface `TypedShapeUtils` includes all utility members that uses the type parameter from their signature.
+ */
+export interface TypedTensorUtils<T extends Tensor.Type> extends TensorUtils, TypedShapeUtils<T> {}

--- a/js/common/lib/tensor.ts
+++ b/js/common/lib/tensor.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import {TensorFactory} from './tensor-factory';
 import {Tensor as TensorImpl} from './tensor-impl';
 import {TypedTensorUtils} from './tensor-utils';
 
@@ -234,128 +235,5 @@ export interface TensorConstructor {
   // #endregion
 }
 
-/**
- * Specify the image format. Assume 'RGBA' if omitted.
- */
-export type ImageFormat = 'RGB'|'RGBA'|'BGR'|'RBG';
-
-/**
- * Describes Tensor configuration to an image data.
- */
-export interface TensorToImageDataOptions {
-  /**
-   * Describes Tensor channels order.
-   */
-  format?: ImageFormat;
-  /**
-   * Tensor channel layout - default is 'NHWC'
-   */
-  tensorLayout?: 'NHWC'|'NCHW';
-  /**
-   * Describes Tensor Height - can be accessed via tensor dimensions as well
-   */
-  height?: number;
-  /**
-   * Describes Tensor Width - can be accessed via tensor dimensions as well
-   */
-  width?: number;
-  /**
-   * Describes normalization parameters to ImageData conversion from tensor - default values - Bias: 0, Mean: 255
-   * Supports computation base on single parameter (extended to all channels) up to value per channel
-   * Example - tesnor.toImageData({norm:{bias:[2/5,3/6,9/17,5/8],mean:[5,6,17,8]}})
-   */
-  norm?: {
-    bias?: number|[number, number, number]|[number, number, number, number];
-    mean?: number | [number, number, number] | [number, number, number, number];
-  };
-}
-/**
- * Describes Tensor and Image configuration to an image data.
- */
-export interface TensorFromImageOptions {
-  /**
-   * Describes image data format - will be used only in the case of ImageBitMap
-   */
-  bitmapFormat?: ImageFormat;
-  /**
-   * Describes Tensor channels order - can differ from original image
-   */
-  tensorFormat?: ImageFormat;
-  /**
-   * Tensor data type - default is 'float32'
-   */
-  dataType?: 'float32'|'uint8';
-  /**
-   * Tensor channel layout - default is 'NCHW' - TODO: add support for 'NHWC'
-   */
-  tensorLayout?: 'NHWC'|'NCHW';
-  /**
-   * Describes Image Height - Required only in the case of ImageBitMap
-   */
-  height?: number;
-  /**
-   * Describes Image Width - Required only in the case of ImageBitMap
-   */
-  width?: number;
-  /**
-   * Describes resized height - can be accessed via tensor dimensions as well
-   */
-  resizedHeight?: number;
-  /**
-   * Describes resized width - can be accessed via tensor dimensions as well
-   */
-  resizedWidth?: number;
-  /**
-   * Describes normalization parameters to tensor conversion from image data - default values - Bias: 0, Mean: 255
-   * Supports computation base on single parameter (extended to all channels) up to value per channel
-   * Example - Tensor.fromImage(img, {norm:{bias:[2,3,9,5],mean:[5,6,17,8]}});
-   */
-  norm?: {
-    bias?: number|[number, number, number]|[number, number, number, number];
-    mean?: number | [number, number, number] | [number, number, number, number];
-  };
-}
-export interface TensorFactory {
-  /**
-   * create a tensor from image object - HTMLImageElement, ImageData, ImageBitmap, URL
-   *
-   * @param imageData - {ImageData} - composed of: Uint8ClampedArray, width. height - uses known pixel format RGBA
-   * @param options - Optional - Interface describing input image & output tensor -
-   * Input Defaults: RGBA, 3 channels, 0-255, NHWC - Output Defaults: same as input parameters
-   * @returns A promise that resolves to a tensor object
-   */
-  fromImage(imageData: ImageData, options?: TensorFromImageOptions): Promise<Tensor>;
-
-  /**
-   * create a tensor from image object - HTMLImageElement, ImageData, ImageBitmap, URL
-   *
-   * @param imageElement - {HTMLImageElement} - since the data is stored as ImageData no need for format parameter
-   * @param options - Optional - Interface describing input image & output tensor -
-   * Input Defaults: RGBA, 3 channels, 0-255, NHWC - Output Defaults: same as input parameters
-   * @returns A promise that resolves to a tensor object
-   */
-  fromImage(imageElement: HTMLImageElement, options?: TensorFromImageOptions): Promise<Tensor>;
-
-  /**
-   * create a tensor from image object - HTMLImageElement, ImageData, ImageBitmap, URL
-   *
-   * @param urlSource - {string} - Assuming the string is a URL to an image or Data URL
-   * @param options - Optional - Interface describing input image & output tensor -
-   * Input Defaults: RGBA, 3 channels, 0-255, NHWC - Output Defaults: same as input parameters
-   * @returns A promise that resolves to a tensor object
-   */
-  fromImage(urlSource: string, options?: TensorFromImageOptions): Promise<Tensor>;
-
-  /**
-   * create a tensor from image object - HTMLImageElement, ImageData, ImageBitmap, URL
-   *
-   * @param bitMap - {ImageBitmap} - since the data is stored as ImageData no need for format parameter
-   * @param options - NOT Optional - Interface describing input image & output tensor -
-   * Output Defaults: same as input parameters
-   * @returns A promise that resolves to a tensor object
-   */
-  fromImage(bitmap: ImageBitmap, options: TensorFromImageOptions): Promise<Tensor>;
-}
-
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const Tensor = TensorImpl as TensorConstructor;
+export const Tensor = TensorImpl as (TensorConstructor & TensorFactory);

--- a/js/web/test/e2e/browser-test-wasm-image-tensor-image.js
+++ b/js/web/test/e2e/browser-test-wasm-image-tensor-image.js
@@ -23,6 +23,15 @@ function compareTensors(tensorA, tensorB, msg){
   }
 }
 
+// TODO: this testing need to be revised
+//
+// work item list:
+// - format the code
+// - remove 'wasm' from file name
+// - test depending on public website (https://media.istockphoto.com/) should be changed to depends on a localhost
+// - the test is composed by 3 different test cases. split them to 3 different cases.
+// - some test cases are wriiten incorrectly.
+//
 it('Browser E2E testing - Tensor <--> Image E2E test', async function () {
 
   // Creating Image HTML Image Element
@@ -56,6 +65,12 @@ it('Browser E2E testing - Tensor <--> Image E2E test', async function () {
     // ImageData to tensor API
     let inputTensorImageData = await ort.Tensor.fromImage(newImage, options={norm:{bias:[2,3,9,5],mean:[5,6,17,8]}});
 
+    // TODO: fix this test case
+    //
+    // the line above does not return as expected because syntax error.
+    // the reason why it does not fail is because it throws exception, and the exception is not caught. the line below is not executed.
+    // to fix this, wrap a try-catch to deal with exceptions.
+
     compareTensors(inputTensorHTML,inputTensorImageData,'BUG in HTML image element & ImageData use case');
   }
 
@@ -68,7 +83,12 @@ it('Browser E2E testing - Tensor <--> Image E2E test', async function () {
   // Tensor to ImageDAta API
   let newImage = inputTensorDataURL.toDataURL({norm:{bias:[1/5,10/7,5/11,0],mean:[5,7,11,0]}});
   // ImageData to tensor API
-  let inputTensorImageData = await ort.Tensor.fromImage(newImage,{format:'RGB', norm:{bias:[1,10,5,0],mean:[5,7,11,0]}});
+  let inputTensorImageData = await ort.Tensor.fromImage(newImage,{format:'RGBA', norm:{bias:[1,10,5,0],mean:[5,7,11,0]}});
+
+  // TODO: fix this
+  // creating tensor from image data should not depend on `options.format`.
+  // data url with type 'image/png' has a determined 'RGBA' format
+
   compareTensors(inputTensorDataURL,inputTensorImageData,'BUG in ImageData & Data URL use case');
 
   // Testing URL --> Tensor --> ImageData --> Tensor


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

refactor tensor type in onnxruntime-common.

### Motivation and Context
There major motivation is that I am doing a local change to address the API part of #15312. And I am doing a refactoring of onnxruntime-common anyway (#15772).

The `tensor.ts` and `tensor-impl.ts` are too large, so I split contents into multiple files to make the type declarations clearer.

The original target of this change is for API only ( ie. do not refactor any implementation.). However, there are a few type/implementation inconsistencies so I also made minimal changes to fix them.

### Changes
- extract `TensorUtils` for non-template interfaces
- extract `TensorFactory` for all overloads of `Tensor.fromImage()`
- refactor options type that used for `Tensor.fromImage()`
  - fix JSDoc comments to make option descriptions consistent with actual type declarations
  - fix an inconsistency for `options.format` and `options.bitmapFormat`; change all `bitmapFormat` to `format`
- extract `ConversionUtils` for `tensor.toDataURL()` and `tensor.toImageData()`
- put implementations into multiple files from `tensor-impl.ts`
- fix a bug that cause unittest fail. put comments for future fix.