### PR TITLE
[DML EP] Add Outer Product Einsum

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
@@ -26,7 +26,8 @@ public:
         }
         inputIndices.resize(bindableInputCount);
 
-        DmlOperator::Initialize(kernelCreationContext, inputIndices, outputIndices);
+        constexpr uint32_t dimCount = 2;
+        DmlOperator::Initialize(kernelCreationContext, inputIndices, outputIndices, std::nullopt, std::nullopt, dimCount);
 
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
@@ -47,12 +48,12 @@ public:
 
         case RecognizedOperatorType::OuterProduct:
             {
-                std::array<uint32_t, 4> aSizes = {1, 1, m_inputTensorDescs[0].GetSizes().back(), 1};
-                TensorDesc& aTensorDesc = TensorDesc(m_inputTensorDescs[0].GetDmlDataType(), aSizes);
+                std::array<uint32_t, 2> aSizes = {m_inputTensorDescs[0].GetSizes().back(), 1};
+                TensorDesc aTensorDesc = TensorDesc(m_inputTensorDescs[0].GetDmlDataType(), aSizes);
                 auto aDmlTensorDesc = aTensorDesc.GetDmlDesc();
 
-                std::array<uint32_t, 4> bSizes = {1, 1, 1, m_inputTensorDescs[1].GetSizes().back()};
-                TensorDesc& bTensorDesc = TensorDesc(m_inputTensorDescs[1].GetDmlDataType(), bSizes);
+                std::array<uint32_t, 2> bSizes = {1, m_inputTensorDescs[1].GetSizes().back()};
+                TensorDesc bTensorDesc = TensorDesc(m_inputTensorDescs[1].GetDmlDataType(), bSizes);
                 auto bDmlTensorDesc = bTensorDesc.GetDmlDesc();
 
                 DML_GEMM_OPERATOR_DESC operatorDesc = {};

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorEinSum.cpp
@@ -31,7 +31,7 @@ public:
         std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
         std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
 
-        static_assert(RecognizedOperatorType::Total == static_cast<RecognizedOperatorType>(11), "Update this switch.");
+        static_assert(RecognizedOperatorType::Total == static_cast<RecognizedOperatorType>(12), "Update this switch.");
         switch (m_recognizedOperatorType)
         {
         case RecognizedOperatorType::Multiply:
@@ -42,6 +42,28 @@ public:
                 operatorDesc.OutputTensor = outputDescs.data();
 
                 SetDmlOperatorDesc({ DML_OPERATOR_ELEMENT_WISE_MULTIPLY, &operatorDesc}, kernelCreationContext);
+            }
+            break;
+
+        case RecognizedOperatorType::OuterProduct:
+            {
+                std::array<uint32_t, 4> aSizes = {1, 1, m_inputTensorDescs[0].GetSizes().back(), 1};
+                TensorDesc& aTensorDesc = TensorDesc(m_inputTensorDescs[0].GetDmlDataType(), aSizes);
+                auto aDmlTensorDesc = aTensorDesc.GetDmlDesc();
+
+                std::array<uint32_t, 4> bSizes = {1, 1, 1, m_inputTensorDescs[1].GetSizes().back()};
+                TensorDesc& bTensorDesc = TensorDesc(m_inputTensorDescs[1].GetDmlDataType(), bSizes);
+                auto bDmlTensorDesc = bTensorDesc.GetDmlDesc();
+
+                DML_GEMM_OPERATOR_DESC operatorDesc = {};
+                operatorDesc.ATensor = &aDmlTensorDesc;
+                operatorDesc.BTensor = &bDmlTensorDesc;
+                operatorDesc.OutputTensor = &outputDescs[0];
+                operatorDesc.Alpha = 1.0;
+                operatorDesc.Beta = 0.0;
+                operatorDesc.FusedActivation = nullptr;
+
+                SetDmlOperatorDesc({ DML_OPERATOR_GEMM, &operatorDesc }, kernelCreationContext);
             }
             break;
 
@@ -253,7 +275,7 @@ void CALLBACK QueryEinSum(IMLOperatorSupportQueryContextPrivate* context, bool* 
     EinSumHelper helper(attributes);
     auto recognizedOperatorType = helper.GetRecognizedOperatorType();
 
-    static_assert(EinSumHelper::RecognizedOperatorType::Total == static_cast<EinSumHelper::RecognizedOperatorType>(11), "Update this function.");
+    static_assert(EinSumHelper::RecognizedOperatorType::Total == static_cast<EinSumHelper::RecognizedOperatorType>(12), "Update this function.");
     *isSupported = (recognizedOperatorType != EinSumHelper::RecognizedOperatorType::None);
 }
 

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp
@@ -1525,6 +1525,7 @@ namespace OperatorHelper
             {RecognizedOperatorType::MatMul,               {2,2,2},{0,1, 1,2, 0,2}}, // ij,jk->ik
             {RecognizedOperatorType::MatMul,               {3,3,3},{0,1,2, 0,2,3, 0,1,3}}, // bij,bjk->bik
             {RecognizedOperatorType::MatMul,               {4,4,4},{0,1,2,3, 0,1,3,4, 0,1,2,4}}, // abij,abjk->abik
+            {RecognizedOperatorType::OuterProduct,         {1,1,2},{0, 1, 0,1}}, // i,j->ij
             {RecognizedOperatorType::MatMulTransposeA,     {2,2,2},{0,1, 0,2, 1,2}}, // ji,jk->ik
             {RecognizedOperatorType::MatMulTransposeA,     {3,3,3},{0,1,2, 0,1,3, 0,2,3}}, // bji,bjk->bik
             {RecognizedOperatorType::MatMulTransposeA,     {4,4,4},{0,1,2,3, 0,1,2,4, 0,1,3,4}}, // abji,abjk->abik
@@ -1615,7 +1616,8 @@ namespace OperatorHelper
 
     bool EinSumHelper::IsMatMulOperatorType() const noexcept
     {
-        return m_recognizedOperatorType == RecognizedOperatorType::MatMul ||
+        return m_recognizedOperatorType == RecognizedOperatorType::OuterProduct ||
+            m_recognizedOperatorType == RecognizedOperatorType::MatMul ||
             m_recognizedOperatorType == RecognizedOperatorType::MatMulTransposeA ||
             m_recognizedOperatorType == RecognizedOperatorType::MatMulTransposeB ||
             m_recognizedOperatorType == RecognizedOperatorType::MatMulNhcw ||

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.h
@@ -746,6 +746,7 @@ public:
         None,
         Identity,
         Multiply,
+        OuterProduct,
         MatMul,
         MatMulTransposeA,
         MatMulTransposeB,


### PR DESCRIPTION
This operator is used in some LLMs to compute the rotary embeddings.