### PR TITLE
Use node name to uniquify the subgraph nodes.

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4015,9 +4015,8 @@ Status Graph::InlineFunction(Node& callnode) {
   // create a uniq_identifier to append to every node name and intermediate input\outputs
   // to make sure there are no unintended duplicates
   std::stringstream ss;
-  ss << "_" << static_cast<const void*>(&callnode) << "_" << callnode.Name() << "_";
-  auto uniq_identifier = ss.str();
-
+  ss << "_" << callnode.Name() << "_" << callnode.OpType();
+  auto uniq_identifier = GenerateNodeName(ss.str());
   // Replace a (function-call) node by an inlined graph.
   if (!callnode.GetFunctionBody()) {
     // This is the normal use-case: inlining a FunctionProto (representing

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4015,7 +4015,7 @@ Status Graph::InlineFunction(Node& callnode) {
   // create a uniq_identifier to append to every node name and intermediate input\outputs
   // to make sure there are no unintended duplicates
   std::stringstream ss;
-  ss << "_" << callnode.Name() << "_" << callnode.OpType();
+  ss << "_inline_" << callnode.OpType();
   auto uniq_identifier = GenerateNodeName(ss.str());
   // Replace a (function-call) node by an inlined graph.
   if (!callnode.GetFunctionBody()) {

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4015,7 +4015,7 @@ Status Graph::InlineFunction(Node& callnode) {
   // create a uniq_identifier to append to every node name and intermediate input\outputs
   // to make sure there are no unintended duplicates
   std::stringstream ss;
-  ss << "_" << static_cast<const void*>(&callnode) << "_";
+  ss << "_" << static_cast<const void*>(&callnode) << "_" << callnode.Name() << "_";
   auto uniq_identifier = ss.str();
 
   // Replace a (function-call) node by an inlined graph.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Use the unique name of the function node name to uniquify the subgraph node names.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
Prevent duplicate node names in the graph.
- If it fixes an open issue, please link to the issue here. -->

https://github.com/microsoft/onnxruntime/issues/15849
