### PR TITLE
[js/web] fix terser reserved symbols for worker

### DIFF
--- a/js/web/script/build.ts
+++ b/js/web/script/build.ts
@@ -86,7 +86,7 @@ if (WASM) {
         'npx',
         [
           'terser', WASM_BINDING_THREADED_JS_PATH, '--compress', 'passes=2', '--format', 'comments=false', '--mangle',
-          'reserved=[_scriptDir]', '--module'
+          'reserved=[_scriptDir,startWorker]', '--module'
         ],
         {shell: true, encoding: 'utf-8', cwd: ROOT_FOLDER});
     if (terser.status !== 0) {

--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -49,7 +49,7 @@ function defaultTerserPluginOptions(target) {
         passes: 2
       },
       mangle: {
-        reserved: ["_scriptDir"]
+        reserved: ["_scriptDir","startWorker"]
       }
     }
   };


### PR DESCRIPTION
### Description
due to change from https://github.com/emscripten-core/emscripten/commit/3935cdcc57409e05830be9603e8eb0b906809f40, our minimizer need to be updated to add "startWorker" to reserved symbol.