### PR TITLE
increase web CI timeout

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
   variables:
     runCodesignValidationInjection: false
-  timeoutInMinutes: 30
+  timeoutInMinutes: 60
   workspace:
     clean: all
   steps:
@@ -62,7 +62,7 @@ jobs:
      git checkout -- js/**
      git checkout -- .gitattributes
     workingDirectory: '$(Build.SourcesDirectory)'
-    displayName: 'Testing: force EOL to lf on windows for /js/**' 
+    displayName: 'Testing: force EOL to lf on windows for /js/**'
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'


### PR DESCRIPTION
### Description
The CI is extremely slow on downloading source code (~1MB/sec) so the web CI went timeout. This is blocking the PR/checks.

Increase the timeout temporarily.