### PR TITLE
Fix no contrib tests in TVM CI

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -32,6 +32,8 @@ namespace test {
 
 #define MODEL_FOLDER ORT_TSTR("testdata/transform/")
 
+#ifndef DISABLE_CONTRIB_OPS
+
 TEST_F(GraphTransformationTests, LayerNormFusionTest) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/layer_norm.onnx";
   std::shared_ptr<Model> p_model;
@@ -922,6 +924,8 @@ TEST_F(GraphTransformationTests, EmbedLayerNormFusionMultiple) {
 TEST_F(GraphTransformationTests, EmbedLayerNormFusionMultiple_OpSet13) {
   EmbedLayerNormFusionFormatMultiple(MODEL_FOLDER "fusion/embed_layer_norm_multiple_opset13.onnx", logger_.get());
 }
+
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Fix no contrib tests in TVM CI


Linux_CI / Onnxruntime-TVM 
Windows_CI / Onnxruntime-TVM


```
[----------] Global test environment tear-down
[==========] 2850 tests from 186 test suites ran. (51340 ms total)
[  PASSED  ] 2820 tests.
[  FAILED  ] 30 tests, listed below:
[  FAILED  ] GraphTransformationTests.LayerNormFusionTest
[  FAILED  ] GraphTransformationTests.LayerNormWithCastFusionTest_2
[  FAILED  ] GraphTransformationTests.LayerNormWithCastFusionTest_3
[  FAILED  ] GraphTransformationTests.LayerNormWithCastFusionTest_4
[  FAILED  ] GraphTransformationTests.LayerNormWithCastFusionTest_5
[  FAILED  ] GraphTransformationTests.SimplifiedLayerNormFusionTest
[  FAILED  ] GraphTransformationTests.SimplifiedLayerNormWithCastsFusionTestCudaEp
[  FAILED  ] GraphTransformationTests.SkipLayerNormFusionTest
[  FAILED  ] GraphTransformationTests.SkipLayerNormFusionWithCastTest
[  FAILED  ] GraphTransformationTests.SkipLayerNormFusion_Input_Output_Check
[  FAILED  ] GraphTransformationTests.SkipLayerNormFusion_NoBeta
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat1
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat2
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat3
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat3_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat3NoCast
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat3NoCast_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat4
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat5
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat5_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat6
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat6_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat7
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat7_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat8
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat8_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat9
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionFormat9_OpSet13
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionMultiple
[  FAILED  ] GraphTransformationTests.EmbedLayerNormFusionMultiple_OpSet13
```

Looks related to https://github.com/microsoft/onnxruntime/pull/15844. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


