### PR TITLE
[QNN EP] Update default QNN SDK version to 2.10 for QNN NuGet pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/qnn-ep-nuget-packaging-pipeline.yml
@@ -2,13 +2,13 @@ parameters:
 - name: qnn_sdk_path_win
   displayName: QNN Windows SDK path
   type: string
-  default: C:\data\qnnsdk\qnn-v2.9.0.230327191003_53330_win
+  default: C:\data\qnnsdk\qnn-v2.10.0.230425122932_54038_win
 
 - name: qnn_sdk_info
   displayName: QNN SDK Version Information
   type: string
-  default: qnn-v2.9.0.230327191003_53330_win
-  
+  default: qnn-v2.10.0.230425122932_54038
+
 - name: ort_package_version
   displayName: OnnxRuntime Nuget package version
   type: string


### PR DESCRIPTION
### Description
Updates the default QNN SDK version to 2.10 for the QNN NuGet pipeline.

### Motivation and Context
Ensures that the daily QNN NuGet pipeline builds ORT using the latest QNN SDK by default.