### PR TITLE
[QNN EP] test coverage for MaxPool

### DIFF
--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -290,7 +290,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_HTP_u8) {
 }
 
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Floor_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Floor_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
                        {3, 3},        // kernel_shape
                        {3, 3},        // strides
@@ -302,7 +302,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Floor_HTP_u8) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Floor_HTP_u8");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Floor_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Floor_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -222,7 +222,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Floor) {
+TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
   RunMaxPoolOpTest({1, 2, 3, 3},  // shape
                        {3, 3},        // kernel_shape
                        {3, 3},        // strides
@@ -231,10 +231,10 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Floor) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Floor");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Floor) {
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Ceil) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -243,7 +243,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Floor) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Floor");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Ceil");
 }
 
 
@@ -290,7 +290,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_HTP_u8) {
 }
 
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Floor_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
                        {3, 3},        // kernel_shape
                        {3, 3},        // strides
@@ -299,10 +299,10 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Floor_HTP_u8) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Floor_HTP_u8");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Floor_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -311,7 +311,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Floor_HTP_u8) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Floor_HTP_u8");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Ceil_HTP_u8");
 }
 
 

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -222,7 +222,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
                    ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
+TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Ceil) {
   RunMaxPoolOpTest({1, 2, 3, 3},  // shape
                    {3, 3},        // kernel_shape
                    {3, 3},        // strides
@@ -234,7 +234,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
                    ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2_Ceil) {
+TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
                    {2, 2},             // kernel_shape
                    {2, 2},             // strides
@@ -263,7 +263,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input_HTP_u8) {
+TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 125, 8, 56},  // shape
                                {2, 2},           // kernel_shape
                                {2, 2},           // strides
@@ -275,7 +275,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_HTP_u8) {
+TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                                {2, 2},             // kernel_shape
                                {2, 2},             // strides
@@ -299,7 +299,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_Ceil_HTP_u8) {
+TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                                {2, 2},             // kernel_shape
                                {2, 2},             // strides

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -18,13 +18,13 @@ namespace test {
 
 // Returns a function that creates a graph with a single MaxPool operator.
 static GetTestModelFn BuildMaxPoolTestCase(const std::vector<int64_t>& shape,
-                                               const std::vector<int64_t>& kernel_shape,
-                                               const std::vector<int64_t>& strides,
-                                               const std::vector<int64_t>& pads,
-											   const std::vector<int64_t>& dilations,
-											   int64_t ceil_mode,
-											   int64_t storage_order,
-                                               const std::string& auto_pad = "NOTSET") {
+                                           const std::vector<int64_t>& kernel_shape,
+                                           const std::vector<int64_t>& strides,
+                                           const std::vector<int64_t>& pads,
+                                           const std::vector<int64_t>& dilations,
+                                           int64_t ceil_mode,
+                                           int64_t storage_order,
+                                           const std::string& auto_pad = "NOTSET") {
   return [shape, kernel_shape, strides, pads, dilations,
           ceil_mode, storage_order, auto_pad](ModelTestBuilder& builder) {
     // Random input data
@@ -53,7 +53,7 @@ static GetTestModelFn BuildMaxPoolTestCase(const std::vector<int64_t>& shape,
       pool_node.AddAttribute("ceil_mode", ceil_mode);
     }
 
-	if (storage_order > 0) {
+    if (storage_order > 0) {
       pool_node.AddAttribute("storage_order", storage_order);
     }
   };
@@ -62,13 +62,13 @@ static GetTestModelFn BuildMaxPoolTestCase(const std::vector<int64_t>& shape,
 // Returns a function that creates a graph with a QDQ MaxPool operator.
 template <typename QuantType>
 GetQDQTestCaseFn BuildMaxPoolQDQTestCase(const std::vector<int64_t>& shape,
-                                             const std::vector<int64_t>& kernel_shape,
-                                             const std::vector<int64_t>& strides,
-                                             const std::vector<int64_t>& pads,
-											 const std::vector<int64_t>& dilations,
-											 int64_t ceil_mode,
-											 int64_t storage_order,
-                                             const std::string& auto_pad = "NOTSET") {
+                                         const std::vector<int64_t>& kernel_shape,
+                                         const std::vector<int64_t>& strides,
+                                         const std::vector<int64_t>& pads,
+                                         const std::vector<int64_t>& dilations,
+                                         int64_t ceil_mode,
+                                         int64_t storage_order,
+                                         const std::string& auto_pad = "NOTSET") {
   return [shape, kernel_shape, strides, pads, dilations,
           ceil_mode, storage_order, auto_pad](ModelTestBuilder& builder) {
     float dq_scale = 0.0038f;
@@ -106,7 +106,7 @@ GetQDQTestCaseFn BuildMaxPoolQDQTestCase(const std::vector<int64_t>& shape,
       pool_node.AddAttribute("ceil_mode", ceil_mode);
     }
 
-	if (storage_order > 0) {
+    if (storage_order > 0) {
       pool_node.AddAttribute("storage_order", storage_order);
     }
 
@@ -126,15 +126,15 @@ GetQDQTestCaseFn BuildMaxPoolQDQTestCase(const std::vector<int64_t>& shape,
 // Runs an MaxPool model on the QNN CPU backend. Checks the graph node assignment, and that inference
 // outputs for QNN and CPU match.
 static void RunMaxPoolOpTest(const std::vector<int64_t>& shape,
-                                 const std::vector<int64_t>& kernel_shape,
-                                 const std::vector<int64_t>& strides,
-                                 const std::vector<int64_t>& pads,
-								 const std::vector<int64_t>& dilations,
-								 int64_t ceil_mode,
-								 int64_t storage_order,
-                                 const std::string& auto_pad,
-                                 ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
-                                 int opset = 18) {
+                             const std::vector<int64_t>& kernel_shape,
+                             const std::vector<int64_t>& strides,
+                             const std::vector<int64_t>& pads,
+                             const std::vector<int64_t>& dilations,
+                             int64_t ceil_mode,
+                             int64_t storage_order,
+                             const std::string& auto_pad,
+                             ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                             int opset = 18) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnCpu.dll";
@@ -155,15 +155,15 @@ static void RunMaxPoolOpTest(const std::vector<int64_t>& shape,
 // outputs for QNN and CPU match.
 template <typename QuantType>
 static void RunQDQMaxPoolOpTest(const std::vector<int64_t>& shape,
-                                    const std::vector<int64_t>& kernel_shape,
-                                    const std::vector<int64_t>& strides,
-                                    const std::vector<int64_t>& pads,
-								    const std::vector<int64_t>& dilations,
-								    int64_t ceil_mode,
-								    int64_t storage_order,
-                                    const std::string& auto_pad,
-                                    ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
-                                    int opset = 18, float fp32_abs_err = 1e-5f) {
+                                const std::vector<int64_t>& kernel_shape,
+                                const std::vector<int64_t>& strides,
+                                const std::vector<int64_t>& pads,
+                                const std::vector<int64_t>& dilations,
+                                int64_t ceil_mode,
+                                int64_t storage_order,
+                                const std::string& auto_pad,
+                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                int opset = 18, float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnHtp.dll";
@@ -188,65 +188,63 @@ static void RunQDQMaxPoolOpTest(const std::vector<int64_t>& shape,
 // MaxPool with kernel size equal to the spatial dimension of input tensor.
 TEST_F(QnnCPUBackendTests, TestMaxPool_Global) {
   RunMaxPoolOpTest({1, 2, 3, 3},  // shape
-                       {3, 3},        // kernel_shape
-                       {3, 3},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
+                   {3, 3},        // kernel_shape
+                   {3, 3},        // strides
+                   {0, 0, 0, 0},  // pads
+                   {1, 1},        // dialations
+                   0,             // ceil_mode
+                   0,             // storage_order
+                   "NOTSET",      // auto_pad
+                   ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input) {
   RunMaxPoolOpTest({1, 125, 8, 56},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input");
+                   {2, 2},           // kernel_shape
+                   {2, 2},           // strides
+                   {0, 0, 0, 0},     // pads
+                   {1, 1},           // dialations
+                   0,                // ceil_mode
+                   0,                // storage_order
+                   "NOTSET",         // auto_pad
+                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input");
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
+                   {2, 2},             // kernel_shape
+                   {2, 2},             // strides
+                   {0, 0, 0, 0},       // pads
+                   {1, 1},             // dialations
+                   0,                  // ceil_mode
+                   0,                  // storage_order
+                   "NOTSET",           // auto_pad
+                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
   RunMaxPoolOpTest({1, 2, 3, 3},  // shape
-                       {3, 3},        // kernel_shape
-                       {3, 3},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   1,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
+                   {3, 3},        // kernel_shape
+                   {3, 3},        // strides
+                   {0, 0, 0, 0},  // pads
+                   {1, 1},        // dialations
+                   1,             // ceil_mode
+                   0,             // storage_order
+                   "NOTSET",      // auto_pad
+                   ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2_Ceil) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   1,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil");
+                   {2, 2},             // kernel_shape
+                   {2, 2},             // strides
+                   {0, 0, 0, 0},       // pads
+                   {1, 1},             // dialations
+                   1,                  // ceil_mode
+                   0,                  // storage_order
+                   "NOTSET",           // auto_pad
+                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil");
 }
-
-
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
@@ -255,65 +253,63 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2_Ceil) {
 // QDQ MaxPool with kernel size equal to the spatial dimension of input tensor.
 TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
-                       {3, 3},        // kernel_shape
-                       {3, 3},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
+                               {3, 3},        // kernel_shape
+                               {3, 3},        // strides
+                               {0, 0, 0, 0},  // pads
+                               {1, 1},        // dialations
+                               0,             // ceil_mode
+                               0,             // storage_order
+                               "NOTSET",      // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
 }
 
 TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 125, 8, 56},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
+                               {2, 2},           // kernel_shape
+                               {2, 2},           // strides
+                               {0, 0, 0, 0},     // pads
+                               {1, 1},           // dialations
+                               0,                // ceil_mode
+                               0,                // storage_order
+                               "NOTSET",         // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
 }
 
 TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   0,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_HTP_u8");
+                               {2, 2},             // kernel_shape
+                               {2, 2},             // strides
+                               {0, 0, 0, 0},       // pads
+                               {1, 1},             // dialations
+                               0,                  // ceil_mode
+                               0,                  // storage_order
+                               "NOTSET",           // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_HTP_u8");
 }
-
 
 TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
-                       {3, 3},        // kernel_shape
-                       {3, 3},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   1,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
+                               {3, 3},        // kernel_shape
+                               {3, 3},        // strides
+                               {0, 0, 0, 0},  // pads
+                               {1, 1},        // dialations
+                               1,             // ceil_mode
+                               0,             // storage_order
+                               "NOTSET",      // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
 }
 
 TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
-                       {2, 2},        // kernel_shape
-                       {2, 2},        // strides
-                       {0, 0, 0, 0},  // pads
-					   {1, 1},        // dialations
-					   1,             // ceil_mode
-					   0,             // storage_order
-                       "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil_HTP_u8");
+                               {2, 2},             // kernel_shape
+                               {2, 2},             // strides
+                               {0, 0, 0, 0},       // pads
+                               {1, 1},             // dialations
+                               1,                  // ceil_mode
+                               0,                  // storage_order
+                               "NOTSET",           // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil_HTP_u8");
 }
-
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -198,7 +198,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Global) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel) {
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input) {
   RunMaxPoolOpTest({1, 125, 8, 56},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -207,10 +207,10 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel) {
 					   0,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2) {
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -219,7 +219,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2) {
 					   0,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
@@ -234,7 +234,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Ceil) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
 }
 
-TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Ceil) {
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2_Ceil) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -243,7 +243,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Ceil) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Ceil");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil");
 }
 
 
@@ -265,7 +265,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 125, 8, 56},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -274,10 +274,10 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel_HTP_u8) {
 					   0,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel_HTP_u8");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -286,7 +286,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_HTP_u8) {
 					   0,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_HTP_u8");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_HTP_u8");
 }
 
 
@@ -302,7 +302,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
 }
 
-TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Ceil_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Input2_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                        {2, 2},        // kernel_shape
                        {2, 2},        // strides
@@ -311,7 +311,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_Ceil_HTP_u8) {
 					   1,             // ceil_mode
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
-                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Ceil_HTP_u8");
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil_HTP_u8");
 }
 
 

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <unordered_map>
+
+#include "test/optimizer/qdq_test_utils.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "onnx/onnx_pb.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Returns a function that creates a graph with a single MaxPool operator.
+static GetTestModelFn BuildMaxPoolTestCase(const std::vector<int64_t>& shape,
+                                               const std::vector<int64_t>& kernel_shape,
+                                               const std::vector<int64_t>& strides,
+                                               const std::vector<int64_t>& pads,
+											   const std::vector<int64_t>& dilations,
+											   int64_t ceil_mode,
+											   int64_t storage_order,
+                                               const std::string& auto_pad = "NOTSET") {
+  return [shape, kernel_shape, strides, pads, dilations,
+          ceil_mode, storage_order, auto_pad](ModelTestBuilder& builder) {
+    // Random input data
+    auto input = builder.MakeInput<float>(shape, 0.0f, 10.0f);
+
+    auto* output = builder.MakeOutput();
+    Node& pool_node = builder.AddNode("MaxPool", {input}, {output});
+
+    pool_node.AddAttribute("kernel_shape", kernel_shape);
+
+    if (!strides.empty()) {
+      pool_node.AddAttribute("strides", strides);
+    }
+
+    if (!dilations.empty()) {
+      pool_node.AddAttribute("dilations", dilations);
+    }
+
+    pool_node.AddAttribute("auto_pad", auto_pad);
+
+    if (!pads.empty() && auto_pad == "NOTSET") {
+      pool_node.AddAttribute("pads", pads);
+    }
+
+    if (ceil_mode > 0) {
+      pool_node.AddAttribute("ceil_mode", ceil_mode);
+    }
+
+	if (storage_order > 0) {
+      pool_node.AddAttribute("storage_order", storage_order);
+    }
+  };
+}
+
+// Returns a function that creates a graph with a QDQ MaxPool operator.
+template <typename QuantType>
+GetQDQTestCaseFn BuildMaxPoolQDQTestCase(const std::vector<int64_t>& shape,
+                                             const std::vector<int64_t>& kernel_shape,
+                                             const std::vector<int64_t>& strides,
+                                             const std::vector<int64_t>& pads,
+											 const std::vector<int64_t>& dilations,
+											 int64_t ceil_mode,
+											 int64_t storage_order,
+                                             const std::string& auto_pad = "NOTSET") {
+  return [shape, kernel_shape, strides, pads, dilations,
+          ceil_mode, storage_order, auto_pad](ModelTestBuilder& builder) {
+    float dq_scale = 0.0038f;
+    float pool_output_scale = 0.0038f;
+    float q_scale = 0.0038f;
+    QuantType dq_zp = std::numeric_limits<QuantType>::max() / 2;
+    QuantType pool_output_zp = std::numeric_limits<QuantType>::max() / 2;
+    QuantType q_zp = std::numeric_limits<QuantType>::max() / 2;
+
+    auto* input_arg = builder.MakeInput<float>(shape, -1.0f, 1.0f);
+    auto* output_arg = builder.MakeOutput();
+
+    // add QDQ + MaxPool
+    auto* dq_output = AddQDQNodePair<QuantType>(builder, input_arg, dq_scale, dq_zp);
+    auto* MaxPool_output = builder.MakeIntermediate();
+    Node& pool_node = builder.AddNode("MaxPool", {dq_output}, {MaxPool_output});
+
+    pool_node.AddAttribute("kernel_shape", kernel_shape);
+
+    if (!strides.empty()) {
+      pool_node.AddAttribute("strides", strides);
+    }
+
+    if (!dilations.empty()) {
+      pool_node.AddAttribute("dilations", dilations);
+    }
+
+    pool_node.AddAttribute("auto_pad", auto_pad);
+
+    if (!pads.empty() && auto_pad == "NOTSET") {
+      pool_node.AddAttribute("pads", pads);
+    }
+
+    if (ceil_mode > 0) {
+      pool_node.AddAttribute("ceil_mode", ceil_mode);
+    }
+
+	if (storage_order > 0) {
+      pool_node.AddAttribute("storage_order", storage_order);
+    }
+
+    // add QDQ output
+    auto* q_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<QuantType>(MaxPool_output,
+                                             pool_output_scale,
+                                             pool_output_zp,
+                                             q_output);
+    builder.AddDequantizeLinearNode<QuantType>(q_output,
+                                               q_scale,
+                                               q_zp,
+                                               output_arg);
+  };
+}
+
+// Runs an MaxPool model on the QNN CPU backend. Checks the graph node assignment, and that inference
+// outputs for QNN and CPU match.
+static void RunMaxPoolOpTest(const std::vector<int64_t>& shape,
+                                 const std::vector<int64_t>& kernel_shape,
+                                 const std::vector<int64_t>& strides,
+                                 const std::vector<int64_t>& pads,
+								 const std::vector<int64_t>& dilations,
+								 int64_t ceil_mode,
+								 int64_t storage_order,
+                                 const std::string& auto_pad,
+                                 ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                 int opset = 18) {
+  ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnCpu.dll";
+#else
+  provider_options["backend_path"] = "libQnnCpu.so";
+#endif
+
+  constexpr int expected_nodes_in_partition = 1;
+  RunQnnModelTest(BuildMaxPoolTestCase(shape, kernel_shape, strides, pads, dilations, ceil_mode, storage_order, auto_pad),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  expected_nodes_in_partition,
+                  test_description);
+}
+
+// Runs a QDQ MaxPool model on the QNN HTP backend. Checks the graph node assignment, and that inference
+// outputs for QNN and CPU match.
+template <typename QuantType>
+static void RunQDQMaxPoolOpTest(const std::vector<int64_t>& shape,
+                                    const std::vector<int64_t>& kernel_shape,
+                                    const std::vector<int64_t>& strides,
+                                    const std::vector<int64_t>& pads,
+								    const std::vector<int64_t>& dilations,
+								    int64_t ceil_mode,
+								    int64_t storage_order,
+                                    const std::string& auto_pad,
+                                    ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                    int opset = 18, float fp32_abs_err = 1e-5f) {
+  ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnHtp.dll";
+#else
+  provider_options["backend_path"] = "libQnnHtp.so";
+#endif
+
+  constexpr int expected_nodes_in_partition = 1;
+  RunQnnModelTest(BuildMaxPoolQDQTestCase<QuantType>(shape, kernel_shape, strides, pads, dilations, ceil_mode, storage_order, auto_pad),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  expected_nodes_in_partition,
+                  test_description,
+                  fp32_abs_err);
+}
+
+//
+// CPU tests:
+//
+
+// MaxPool with kernel size equal to the spatial dimension of input tensor.
+TEST_F(QnnCPUBackendTests, TestMaxPool_Global) {
+  RunMaxPoolOpTest({1, 2, 3, 3},  // shape
+                       {3, 3},        // kernel_shape
+                       {3, 3},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
+}
+
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+//
+// HTP tests:
+//
+
+// QDQ MaxPool with kernel size equal to the spatial dimension of input tensor.
+TEST_F(QnnCPUBackendTests, TestMaxPool_Global_HTP_u8) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
+                       {3, 3},        // kernel_shape
+                       {3, 3},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
+}
+
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -198,14 +198,62 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Global) {
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
 }
 
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel) {
+  RunMaxPoolOpTest({1, 125, 8, 56},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel");
+}
+
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2) {
+  RunMaxPoolOpTest({1, 128, 16, 113},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2");
+}
+
+TEST_F(QnnCPUBackendTests, TestMaxPool_Floor) {
+  RunMaxPoolOpTest({1, 2, 3, 3},  // shape
+                       {3, 3},        // kernel_shape
+                       {3, 3},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   1,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Floor");
+}
+
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Floor) {
+  RunMaxPoolOpTest({1, 128, 16, 113},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   1,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Floor");
+}
+
+
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
 //
-
 // QDQ MaxPool with kernel size equal to the spatial dimension of input tensor.
-TEST_F(QnnCPUBackendTests, TestMaxPool_Global_HTP_u8) {
+TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
                        {3, 3},        // kernel_shape
                        {3, 3},        // strides
@@ -215,6 +263,55 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Global_HTP_u8) {
 					   0,             // storage_order
                        "NOTSET",      // auto_pad
                        ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
+}
+
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel_HTP_u8) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 125, 8, 56},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel_HTP_u8");
+}
+
+TEST_F(QnnHTPBackendTests, TestMaxPool_Large_Kernel2_HTP_u8) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   0,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_HTP_u8");
+}
+
+
+TEST_F(QnnCPUBackendTests, TestMaxPool_Floor_HTP_u8) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 2, 3, 3},  // shape
+                       {3, 3},        // kernel_shape
+                       {3, 3},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   1,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Floor_HTP_u8");
+}
+
+TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Kernel2_Floor_HTP_u8) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
+                       {2, 2},        // kernel_shape
+                       {2, 2},        // strides
+                       {0, 0, 0, 0},  // pads
+					   {1, 1},        // dialations
+					   1,             // ceil_mode
+					   0,             // storage_order
+                       "NOTSET",      // auto_pad
+                       ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Kernel2_Floor_HTP_u8");
 }
 
 


### PR DESCRIPTION
### Description
Added MaxPool tests to show the issues with MaxPool and also provide test coverage

The following tests are currently Failing:
 ./onnxruntime_test_all --gtest_filter=*.TestMaxPool*

[  FAILED  ] 5 tests, listed below:
[  FAILED  ] QnnCPUBackendTests.TestMaxPool_Ceil
[  FAILED  ] QnnCPUBackendTests.TestMaxPool_Large_Input2_Ceil
[  FAILED  ] QnnHTPBackendTests.TestMaxPool_Large_Input_HTP_u8
[  FAILED  ] QnnHTPBackendTests.TestMaxPool_Large_Input2_HTP_u8
[  FAILED  ] QnnHTPBackendTests.TestMaxPool_Large_Input2_Ceil_HTP_u8


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
Provide test coverage for MaxPool and debug model related issues.