### PR TITLE
[ROCm] update ROCm/MIGraphX CI to ROCm5.5

### DIFF
--- a/orttraining/tools/ci_test/results/ci-mi100.huggingface.bert-large-rocm5.5.json
+++ b/orttraining/tools/ci_test/results/ci-mi100.huggingface.bert-large-rocm5.5.json
@@ -53,5 +53,5 @@
             "loss": 1.5511
         }
     ],
-    "samples_per_second": 24.863899999999997
+    "samples_per_second": 24.029
 }

--- a/orttraining/tools/ci_test/results/ci-mi100.huggingface.bert-large-rocm5.5.json
+++ b/orttraining/tools/ci_test/results/ci-mi100.huggingface.bert-large-rocm5.5.json
@@ -2,56 +2,56 @@
     "steps": [
         {
             "step": 20,
-            "loss": 4.5144
+            "loss": 2.0312
         },
         {
             "step": 40,
-            "loss": 1.7498
+            "loss": 1.8506
         },
         {
             "step": 60,
-            "loss": 1.642
+            "loss": 1.7430
         },
         {
             "step": 80,
-            "loss": 1.6069
+            "loss": 1.6562
         },
         {
             "step": 100,
-            "loss": 1.5877
+            "loss": 1.6689
         },
         {
             "step": 120,
-            "loss": 1.5781
+            "loss": 1.6786
         },
         {
             "step": 140,
-            "loss": 1.5696
+            "loss": 1.6278
         },
         {
             "step": 160,
-            "loss": 1.5635
+            "loss": 1.6780
         },
         {
             "step": 180,
-            "loss": 1.5589
+            "loss": 1.6239
         },
         {
             "step": 200,
-            "loss": 1.5554
+            "loss": 1.6224
         },
         {
             "step": 220,
-            "loss": 1.5535
+            "loss": 1.6468
         },
         {
             "step": 240,
-            "loss": 1.5525
+            "loss": 1.5370
         },
         {
             "step": 260,
-            "loss": 1.5512
+            "loss": 1.5511
         }
     ],
-    "samples_per_second": 27.246
+    "samples_per_second": 24.863899999999997
 }

--- a/orttraining/tools/ci_test/results/ci-mi100.huggingface.distilbert-base-rocm5.5.json
+++ b/orttraining/tools/ci_test/results/ci-mi100.huggingface.distilbert-base-rocm5.5.json
@@ -2,56 +2,56 @@
     "steps": [
         {
             "step": 20,
-            "loss": 2.0638
+            "loss": 2.4705
         },
         {
             "step": 40,
-            "loss": 1.8575
+            "loss": 2.1767
         },
         {
             "step": 60,
-            "loss": 1.7383
+            "loss": 2.0828
         },
         {
             "step": 80,
-            "loss": 1.6672
+            "loss": 2.0703
         },
         {
             "step": 100,
-            "loss": 1.6656
+            "loss": 2.0184
         },
         {
             "step": 120,
-            "loss": 1.6705
+            "loss": 2.0505
         },
         {
             "step": 140,
-            "loss": 1.6273
+            "loss": 2.0649
         },
         {
             "step": 160,
-            "loss": 1.6861
+            "loss": 1.9914
         },
         {
             "step": 180,
-            "loss": 1.6111
+            "loss": 1.9979
         },
         {
             "step": 200,
-            "loss": 1.625
+            "loss": 1.9386
         },
         {
             "step": 220,
-            "loss": 1.6463
+            "loss": 1.9731
         },
         {
             "step": 240,
-            "loss": 1.527
+            "loss": 1.9630
         },
         {
             "step": 260,
-            "loss": 1.5424
+            "loss": 1.9678
         }
     ],
-    "samples_per_second": 24.029
+    "samples_per_second": 157.404
 }

--- a/orttraining/tools/ci_test/results/ci-mi100.huggingface.gpt2-rocm5.5.json
+++ b/orttraining/tools/ci_test/results/ci-mi100.huggingface.gpt2-rocm5.5.json
@@ -2,56 +2,56 @@
     "steps": [
         {
             "step": 20,
-            "loss": 2.4707
+            "loss": 4.5223
         },
         {
             "step": 40,
-            "loss": 2.1768
+            "loss": 1.7494
         },
         {
             "step": 60,
-            "loss": 2.0827
+            "loss": 1.6407
         },
         {
             "step": 80,
-            "loss": 2.0703
+            "loss": 1.6060
         },
         {
             "step": 100,
-            "loss": 2.0185
+            "loss": 1.5880
         },
         {
             "step": 120,
-            "loss": 2.0503
+            "loss": 1.5776
         },
         {
             "step": 140,
-            "loss": 2.0647
+            "loss": 1.5700
         },
         {
             "step": 160,
-            "loss": 1.9912
+            "loss": 1.5634
         },
         {
             "step": 180,
-            "loss": 1.998
+            "loss": 1.5581
         },
         {
             "step": 200,
-            "loss": 1.9384
+            "loss": 1.5555
         },
         {
             "step": 220,
-            "loss": 1.973
+            "loss": 1.5534
         },
         {
             "step": 240,
-            "loss": 1.963
+            "loss": 1.5523
         },
         {
             "step": 260,
-            "loss": 1.9678
+            "loss": 1.5505
         }
     ],
-    "samples_per_second": 154.103
+    "samples_per_second": 27.793
 }

--- a/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-migraphx-ci-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
     - name: render
       value: 109
     - name: RocmVersion
-      value: 5.4
+      value: 5.5
 
   steps:
   - checkout: self

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     - name: onnxruntimeBuildSucceeded
       value: false
     - name: RocmVersion
-      value: 5.4
+      value: 5.5
     - name: CCACHE_DIR
       value: $(Pipeline.Workspace)/ccache
     - name: TODAY

--- a/tools/ci_build/github/linux/docker/migraphx-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/linux/docker/migraphx-ci-pipeline-env.Dockerfile
@@ -1,7 +1,7 @@
-FROM rocm/pytorch:rocm5.4_ubuntu20.04_py3.7_pytorch_1.12.1
+FROM rocm/pytorch:rocm5.5_ubuntu20.04_py3.8_pytorch_1.12.1
 
 # MIGraphX version should be the same as ROCm version
-ARG MIGRAPHX_VERSION=rocm-5.4.0
+ARG MIGRAPHX_VERSION=rocm-5.5.0
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV MIGRAPHX_DISABLE_FAST_GELU=1

--- a/tools/ci_build/github/linux/docker/migraphx-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/linux/docker/migraphx-ci-pipeline-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm5.5_ubuntu20.04_py3.8_pytorch_1.12.1
+FROM rocm/pytorch:rocm5.5_ubuntu20.04_py3.8_pytorch_1.13.1
 
 # MIGraphX version should be the same as ROCm version
 ARG MIGRAPHX_VERSION=rocm-5.5.0

--- a/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
+++ b/tools/ci_build/github/pai/rocm-ci-pipeline-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm5.4_ubuntu20.04_py3.7_pytorch_1.12.1
+FROM rocm/pytorch:rocm5.5_ubuntu20.04_py3.8_pytorch_1.13.1
 
 WORKDIR /stage
 
@@ -29,7 +29,7 @@ RUN git clone https://github.com/microsoft/huggingface-transformers.git &&\
       pip install -e .
 
 RUN pip install \
-      numpy \
+      numpy==1.24.1 \
       onnx \
       cerberus \
       sympy \
@@ -38,7 +38,7 @@ RUN pip install \
       requests \
       sacrebleu==1.5.1 \
       sacremoses \
-      scipy \
+      scipy==1.10.0 \
       scikit-learn \
       tokenizers \
       sentencepiece \


### PR DESCRIPTION
update ROCm/MIGraphX CI to ROC5.5.

TODO:
two PR to fix failure on orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
- test_gradient_correctness_minmax/test_gradient_correctness_argmax_unfold/test_gradient_correctness_argmax_diagonal  (https://github.com/microsoft/onnxruntime/pull/15903)
- test_ortmodule_attribute_name_collision_warning (https://github.com/microsoft/onnxruntime/pull/15884)




