### PR TITLE
Fix broken GRU tests

### DIFF
--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -13,7 +13,7 @@ using namespace std;
 namespace onnxruntime {
 namespace test {
 
-static const std::vector<string> default_activations = {"sigmoid", "tanh"};
+static const std::vector<string> default_activations = {"Sigmoid", "Tanh"};
 
 static void RunGruTest(const std::vector<float>& X_data,
                        const std::vector<float>& W_data,
@@ -146,11 +146,6 @@ void DefaultActivationsSimpleWeightsNoBias(std::string direction,
 }
 
 TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsNoBiasTwoRows) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.4750208f, 0.450166f, 0.4255575f,
       0.45016602f, 0.40131235f, 0.35434368f,
@@ -169,11 +164,6 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsNoBiasTwoRows) {
 }
 
 TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsNoBiasTwoRows) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.6082785f, 0.50623393f, 0.4426924f,
       0.5803454f, 0.4527356f, 0.36886263f,
@@ -189,11 +179,6 @@ TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsNoBiasTwoRows) {
 }
 
 TEST(GRUTest, BidirectionalDefaultActivationsSimpleWeightsNoBias) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       // forward output for input sequence 0
       0.4750208f, 0.450166f, 0.4255575f,
@@ -224,11 +209,6 @@ TEST(GRUTest, BidirectionalDefaultActivationsSimpleWeightsNoBias) {
 }
 
 TEST(GRUTest, BidirectionalDefaultActivationsSimpleWeightsNoBiasLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       // forward output for input sequence 0
       0.4750208f, 0.450166f, 0.4255575f,
@@ -313,11 +293,6 @@ void DefaultActivationsSimpleWeightsWithBias(std::string direction,
 }
 
 TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasBatchParallel) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.16783132f, -0.11754231f, 0.11977843f,
       0.2046872f, -0.10372487f, 0.15365849f,
@@ -329,11 +304,6 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasBatchParallel) {
 }
 
 TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.15024948f, -0.11097029f, -0.02121867f,
       0.18887489f, -0.09747667f, 0.02093463f,
@@ -346,11 +316,6 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearB
 }
 
 TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.20910699f, -0.18880953f, -0.04005555f,
       0.29700265f, -0.15308119f, 0.04537245f,
@@ -364,11 +329,6 @@ TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsWithBiasBatchParallelLinearB
 
 // test forward !batch_parallel_ path with linear_before_reset
 TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.15024948f, -0.11097029f, -0.02121867f,
       0.19538902f, -0.19016478f, -0.05644283f};
@@ -380,11 +340,6 @@ TEST(GRUTest, ForwardDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset) {
 
 // test reverse !batch_parallel_ path with linear_before_reset
 TEST(GRUTest, ReverseDefaultActivationsSimpleWeightsWithBiasLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   std::vector<float> Y_data{
       0.20910699f, -0.18880953f, -0.04005555f,
       0.12252139f, -0.12032216f, -0.05064924f};
@@ -584,13 +539,8 @@ void DeepCpuGruOpTestContext::RunTest(const std::vector<float>& X,
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBasic) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -607,13 +557,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBasic) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpBackwardBasic) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "reverse";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -631,13 +576,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpBackwardBasic) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpBidirectionalBasic) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -659,13 +599,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpBidirectionalBasic) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpForwardActivation) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"tanh", "sigmoid"};
+  const std::vector<std::string> activations = {"Tanh", "Sigmoid"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -683,13 +618,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardActivation) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpForwardInitialHiddenState) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -707,13 +637,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardInitialHiddenState) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatch) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -739,13 +664,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatch) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatchLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -771,13 +691,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpForwardBatchLinearBeforeReset) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLength) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -816,13 +731,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLength) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLengthLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -861,13 +771,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpGrowBatchSequenceLengthLinearBeforeReset) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeResetB1) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -887,13 +792,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeResetB2) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -912,13 +812,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeReset) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -945,13 +840,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithBidirectionalLinearBeforeRe
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpShorterSeqInMiddle) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -983,13 +873,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpShorterSeqInMiddle) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpZeroSeqInMiddle) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -1021,13 +906,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpZeroSeqInMiddle) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithPartialZero) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -1054,13 +934,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthWithPartialZero) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthShorterThanInputSequenceLength) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "bidirectional";
-  const std::vector<std::string> activations = {"sigmoid", "tanh", "sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh", "Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -1088,13 +963,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthShorterThanInputSequenceLength)
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthAllZeros) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations);
 
@@ -1121,13 +991,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSequenceLengthAllZeros) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUOpSingleBatchMultipleHiddenThreads) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations, true, {}, {}, /*large_hidden*/ true);
 
@@ -1156,13 +1021,8 @@ TEST(GRUTest, ONNXRuntime_TestGRUOpSingleBatchMultipleHiddenThreads) {
 }
 
 TEST(GRUTest, ONNXRuntime_TestGRUPositiveActivationClipping) {
-  // TODO: Unskip when fixed #41968513
-  if (DefaultDmlExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(1817): The parameter is incorrect.";
-  }
-
   const std::string direction = "forward";
-  const std::vector<std::string> activations = {"sigmoid", "tanh"};
+  const std::vector<std::string> activations = {"Sigmoid", "Tanh"};
 
   DeepCpuGruOpTestContext ctx(direction, activations, true, {}, {}, /*large_hidden*/ true);
 


### PR DESCRIPTION
Many GRU Tests were being skipped due to an error in MLOperatorAuthorImpl.cpp.
- Cause of that error was due to the activation functions not being capitalized (e.g. 'sigmoid' instead of 'Sigmoid') which would throw an 'unsupported activation function' error in DMLOperatorRecurrentNeuralNetwork.cpp

This PR fixes the errors by capitalizing the activation function names and reenables the tests.