### PR TITLE
Adust GetVersionString() GetBuildInfoString() signatures and move them to OrtApi

### DIFF
--- a/cmake/onnxruntime_config.h.in
+++ b/cmake/onnxruntime_config.h.in
@@ -21,5 +21,5 @@
 #cmakedefine HAS_FORMAT_TRUNCATION
 #cmakedefine HAS_BITWISE_INSTEAD_OF_LOGICAL
 #cmakedefine HAS_REALLOCARRAY
-#cmakedefine ORT_VERSION "@ORT_VERSION@"
-#cmakedefine ORT_BUILD_INFO "@ORT_BUILD_INFO@"
+#cmakedefine ORT_VERSION u8"@ORT_VERSION@"
+#cmakedefine ORT_BUILD_INFO u8"@ORT_BUILD_INFO@"

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.OnnxRuntime
     public struct OrtApiBase
     {
         public IntPtr GetApi;
+        public IntPtr GetVersionString;
     };
 
     // NOTE: The order of the APIs in this struct should match exactly that in
@@ -286,8 +287,6 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr GetOptionalContainedTypeInfo;
         public IntPtr GetResizedStringTensorElementBuffer;
         public IntPtr KernelContext_GetAllocator;
-        public IntPtr GetVersionString;
-        public IntPtr GetBuildInfoString;
     }
 
     internal static class NativeMethods
@@ -297,12 +296,18 @@ namespace Microsoft.ML.OnnxRuntime
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate ref OrtApi DOrtGetApi(UInt32 version);
 
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr DOrtGetVersionString();
+
+        public static DOrtGetVersionString OrtGetVersionString;
+
         static NativeMethods()
         {
             DOrtGetApi OrtGetApi = (DOrtGetApi)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetApi, typeof(DOrtGetApi));
 
             // TODO: Make this save the pointer, and not copy the whole structure across
             api_ = (OrtApi)OrtGetApi(14 /*ORT_API_VERSION*/);
+            OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetVersionString, typeof(DOrtGetVersionString));
 
             OrtCreateEnv = (DOrtCreateEnv)Marshal.GetDelegateForFunctionPointer(api_.CreateEnv, typeof(DOrtCreateEnv));
             OrtCreateEnvWithCustomLogger = (DOrtCreateEnvWithCustomLogger)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithCustomLogger, typeof(DOrtCreateEnvWithCustomLogger));
@@ -461,7 +466,6 @@ namespace Microsoft.ML.OnnxRuntime
             OrtModelMetadataGetCustomMetadataMapKeys = (DOrtModelMetadataGetCustomMetadataMapKeys)Marshal.GetDelegateForFunctionPointer(api_.ModelMetadataGetCustomMetadataMapKeys, typeof(DOrtModelMetadataGetCustomMetadataMapKeys));
             OrtModelMetadataLookupCustomMetadataMap = (DOrtModelMetadataLookupCustomMetadataMap)Marshal.GetDelegateForFunctionPointer(api_.ModelMetadataLookupCustomMetadataMap, typeof(DOrtModelMetadataLookupCustomMetadataMap));
             OrtReleaseModelMetadata = (DOrtReleaseModelMetadata)Marshal.GetDelegateForFunctionPointer(api_.ReleaseModelMetadata, typeof(DOrtReleaseModelMetadata));
-            OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(api_.GetVersionString, typeof(DOrtGetVersionString));
 
             OrtGetAvailableProviders = (DOrtGetAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.GetAvailableProviders, typeof(DOrtGetAvailableProviders));
             OrtReleaseAvailableProviders = (DOrtReleaseAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.ReleaseAvailableProviders, typeof(DOrtReleaseAvailableProviders));
@@ -1659,11 +1663,6 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseModelMetadata(IntPtr /*(OrtModelMetadata*)*/ modelMetadata);
 
         public static DOrtReleaseModelMetadata OrtReleaseModelMetadata;
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate IntPtr DOrtGetVersionString();
-
-        public static DOrtGetVersionString OrtGetVersionString;
 
         #endregion ModelMetadata API
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -10,7 +10,6 @@ namespace Microsoft.ML.OnnxRuntime
     public struct OrtApiBase
     {
         public IntPtr GetApi;
-        public IntPtr GetVersionString;
     };
 
     // NOTE: The order of the APIs in this struct should match exactly that in
@@ -286,6 +285,9 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr CastTypeInfoToOptionalTypeInfo;
         public IntPtr GetOptionalContainedTypeInfo;
         public IntPtr GetResizedStringTensorElementBuffer;
+        public IntPtr KernelContext_GetAllocator;
+        public IntPtr GetVersionString;
+        public IntPtr GetBuildInfoString;
     }
 
     internal static class NativeMethods
@@ -295,18 +297,12 @@ namespace Microsoft.ML.OnnxRuntime
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate ref OrtApi DOrtGetApi(UInt32 version);
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate IntPtr DOrtGetVersionString();
-
-        public static DOrtGetVersionString OrtGetVersionString;
-
         static NativeMethods()
         {
             DOrtGetApi OrtGetApi = (DOrtGetApi)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetApi, typeof(DOrtGetApi));
 
             // TODO: Make this save the pointer, and not copy the whole structure across
             api_ = (OrtApi)OrtGetApi(14 /*ORT_API_VERSION*/);
-            OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetVersionString, typeof(DOrtGetVersionString));
 
             OrtCreateEnv = (DOrtCreateEnv)Marshal.GetDelegateForFunctionPointer(api_.CreateEnv, typeof(DOrtCreateEnv));
             OrtCreateEnvWithCustomLogger = (DOrtCreateEnvWithCustomLogger)Marshal.GetDelegateForFunctionPointer(api_.CreateEnvWithCustomLogger, typeof(DOrtCreateEnvWithCustomLogger));
@@ -465,6 +461,7 @@ namespace Microsoft.ML.OnnxRuntime
             OrtModelMetadataGetCustomMetadataMapKeys = (DOrtModelMetadataGetCustomMetadataMapKeys)Marshal.GetDelegateForFunctionPointer(api_.ModelMetadataGetCustomMetadataMapKeys, typeof(DOrtModelMetadataGetCustomMetadataMapKeys));
             OrtModelMetadataLookupCustomMetadataMap = (DOrtModelMetadataLookupCustomMetadataMap)Marshal.GetDelegateForFunctionPointer(api_.ModelMetadataLookupCustomMetadataMap, typeof(DOrtModelMetadataLookupCustomMetadataMap));
             OrtReleaseModelMetadata = (DOrtReleaseModelMetadata)Marshal.GetDelegateForFunctionPointer(api_.ReleaseModelMetadata, typeof(DOrtReleaseModelMetadata));
+            OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(api_.GetVersionString, typeof(DOrtGetVersionString));
 
             OrtGetAvailableProviders = (DOrtGetAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.GetAvailableProviders, typeof(DOrtGetAvailableProviders));
             OrtReleaseAvailableProviders = (DOrtReleaseAvailableProviders)Marshal.GetDelegateForFunctionPointer(api_.ReleaseAvailableProviders, typeof(DOrtReleaseAvailableProviders));
@@ -1654,7 +1651,6 @@ namespace Microsoft.ML.OnnxRuntime
 
         public static DOrtModelMetadataLookupCustomMetadataMap OrtModelMetadataLookupCustomMetadataMap;
 
-
         /// <summary>
         /// Frees ModelMetadata instance
         /// </summary>
@@ -1663,6 +1659,11 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseModelMetadata(IntPtr /*(OrtModelMetadata*)*/ modelMetadata);
 
         public static DOrtReleaseModelMetadata OrtReleaseModelMetadata;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr DOrtGetVersionString();
+
+        public static DOrtGetVersionString OrtGetVersionString;
 
         #endregion ModelMetadata API
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
@@ -276,7 +276,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="options"></param>
         /// <returns></returns>
         /// <exception cref="OnnxRuntimeException">if the singleton has already been created</exception>
-        public static OrtEnv CreateInstanceWithOptions(EnvironmentCreationOptions options)
+        public static OrtEnv CreateInstanceWithOptions(ref EnvironmentCreationOptions options)
         {
             // Non-thread safe, best effort hopefully helpful check.
             // Environment is usually created once per process, so this should be fine.

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtEnvTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtEnvTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 logLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL
             };
 
-            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(envOptions);
+            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.True(OrtEnv.IsCreated);
             Assert.Equal(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, ortEnvInstance.EnvLogLevel);
 
@@ -92,7 +92,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 logId = "CSharpOnnxRuntimeTestLogid"
             };
 
-            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(envOptions);
+            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.Equal(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, ortEnvInstance.EnvLogLevel);
 
             // Change and see if this takes effect
@@ -118,7 +118,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 };
 
                 // Make sure we start anew
-                var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+                var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
                 Assert.True(OrtEnv.IsCreated);
             }
         }
@@ -164,7 +164,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
             LoggingInvokes = 0;
 
-            var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+            var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.True(OrtEnv.IsCreated);
 
             var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");
@@ -199,7 +199,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 LoggingInvokes = 0;
 
-                var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+                var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
                 Assert.True(OrtEnv.IsCreated);
 
                 var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -631,9 +631,8 @@ struct OrtApiBase {
    *   older than the version created with this header file.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
-  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;         ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
-  const ORTCHAR_T*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
+
 typedef struct OrtApiBase OrtApiBase;
 
 /** \brief The Onnxruntime library's entry point to access the C API
@@ -4194,6 +4193,22 @@ struct OrtApi {
    * \since Version 1.15.
    */
   ORT_API2_STATUS(KernelContext_GetAllocator, _In_ const OrtKernelContext* context, _In_ const OrtMemoryInfo* mem_info, _Outptr_ OrtAllocator** out);
+
+  /** \brief Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+   *
+   *  \return UTF-8 encoded version string. Do not deallocate the returned buffer.
+   *
+   *  \since Version 1.15.
+   */
+  const char*(ORT_API_CALL* GetVersionString)(void);
+
+  /** \brief Returns a null terminated string of the build info including git info and cxx flags
+   *
+   * \return UTF-8 encoded version string. Do not deallocate the returned buffer.
+   *
+   * \since Version 1.15.
+   */
+  const char*(ORT_API_CALL* GetBuildInfoString)(void);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -629,8 +629,17 @@ struct OrtApiBase {
    * \param[in] version Must be ::ORT_API_VERSION
    * \return The ::OrtApi for the version requested, nullptr will be returned if this version is unsupported, for example when using a runtime
    *   older than the version created with this header file.
+   *
+   * One can call GetVersionString() to get the version of the Onnxruntime library for logging
+   * and error reporting purposes.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
+
+  /** \brief Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+   *
+   *  \return UTF-8 encoded version string. Do not deallocate the returned buffer.
+   */
+  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;
 };
 
 typedef struct OrtApiBase OrtApiBase;
@@ -4193,14 +4202,6 @@ struct OrtApi {
    * \since Version 1.15.
    */
   ORT_API2_STATUS(KernelContext_GetAllocator, _In_ const OrtKernelContext* context, _In_ const OrtMemoryInfo* mem_info, _Outptr_ OrtAllocator** out);
-
-  /** \brief Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
-   *
-   *  \return UTF-8 encoded version string. Do not deallocate the returned buffer.
-   *
-   *  \since Version 1.15.
-   */
-  const char*(ORT_API_CALL* GetVersionString)(void);
 
   /** \brief Returns a null terminated string of the build info including git info and cxx flags
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -631,7 +631,7 @@ struct OrtApiBase {
    *   older than the version created with this header file.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
-  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;         ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
   const ORTCHAR_T*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
 typedef struct OrtApiBase OrtApiBase;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -95,6 +95,8 @@ extern "C" {
 #define ORTCHAR_T char
 #endif
 
+/// ORTCHAR_T, ORT_TSTR are reserved specifically for path handling.
+/// All other strings are UTF-8 encoded, use char and std::string
 #ifndef ORT_TSTR
 #ifdef _WIN32
 #define ORT_TSTR(X) L##X
@@ -629,7 +631,7 @@ struct OrtApiBase {
    *   older than the version created with this header file.
    */
   const OrtApi*(ORT_API_CALL* GetApi)(uint32_t version)NO_EXCEPTION;
-  const ORTCHAR_T*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
+  const char*(ORT_API_CALL* GetVersionString)(void)NO_EXCEPTION;    ///< Returns a null terminated string of the version of the Onnxruntime library (eg: "1.8.1")
   const ORTCHAR_T*(ORT_API_CALL* GetBuildInfoString)(void)NO_EXCEPTION;  ///< Returns a null terminated string of the build info including git info and cxx flags
 };
 typedef struct OrtApiBase OrtApiBase;

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -132,7 +132,7 @@ std::string GetVersionString();
 /// git commit id, build type(Debug/Release/RelWithDebInfo) and cmake cpp flags.
 /// </summary>
 /// <returns>string</returns>
-std::basic_string<ORTCHAR_T> GetBuildInfoString();
+std::string GetBuildInfoString();
 
 /// <summary>
 /// This is a C++ wrapper for OrtApi::GetAvailableProviders() and

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -125,7 +125,7 @@ inline const OrtApi& GetApi() noexcept { return *Global<void>::api_; }
 /// This function returns the onnxruntime version string
 /// </summary>
 /// <returns>version string major.minor.rev</returns>
-std::basic_string<ORTCHAR_T> GetVersionString();
+std::string GetVersionString();
 
 /// <summary>
 /// This function returns the onnxruntime build information: including git branch,

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1988,13 +1988,11 @@ inline void CustomOpApi::ReleaseKernelInfo(_Frees_ptr_opt_ OrtKernelInfo* info_c
 }
 
 inline std::string GetVersionString() {
-  std::string result = OrtGetApiBase()->GetVersionString();
-  return result;
+  return GetApi().GetVersionString();
 }
 
-inline std::basic_string<ORTCHAR_T> GetBuildInfoString() {
-  std::basic_string<ORTCHAR_T> result = OrtGetApiBase()->GetBuildInfoString();
-  return result;
+inline std::string GetBuildInfoString() {
+  return GetApi().GetBuildInfoString();
 }
 
 inline std::vector<std::string> GetAvailableProviders() {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1988,7 +1988,7 @@ inline void CustomOpApi::ReleaseKernelInfo(_Frees_ptr_opt_ OrtKernelInfo* info_c
 }
 
 inline std::string GetVersionString() {
-  return GetApi().GetVersionString();
+  return OrtGetApiBase()->GetVersionString();
 }
 
 inline std::string GetBuildInfoString() {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1987,8 +1987,8 @@ inline void CustomOpApi::ReleaseKernelInfo(_Frees_ptr_opt_ OrtKernelInfo* info_c
   api_.ReleaseKernelInfo(info_copy);
 }
 
-inline std::basic_string<ORTCHAR_T> GetVersionString() {
-  std::basic_string<ORTCHAR_T> result = OrtGetApiBase()->GetVersionString();
+inline std::string GetVersionString() {
+  std::string result = OrtGetApiBase()->GetVersionString();
   return result;
 }
 

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -76,7 +76,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxRuntime_getAvailableProvi
 JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseVersion
   (JNIEnv * jniEnv, jclass clazz) {
   (void)clazz;  // required JNI parameter not needed by functions which don't access their host class.
-  const char* version = OrtGetApiBase()->GetVersionString();
+  const char* version = ORT_VERSION;
   assert(version != NULL);
   return (*jniEnv)->NewStringUTF(jniEnv, version);
 }

--- a/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxRuntime.c
@@ -76,13 +76,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_onnxruntime_OnnxRuntime_getAvailableProvi
 JNIEXPORT jstring JNICALL Java_ai_onnxruntime_OnnxRuntime_initialiseVersion
   (JNIEnv * jniEnv, jclass clazz) {
   (void)clazz;  // required JNI parameter not needed by functions which don't access their host class.
-  const ORTCHAR_T* version = OrtGetApiBase()->GetVersionString();
+  const char* version = OrtGetApiBase()->GetVersionString();
   assert(version != NULL);
-#ifdef _WIN32
-  jsize len = (jsize)(wcslen(version));
-  jstring versionStr = (*jniEnv)->NewString(jniEnv, (const jchar*)version, len);
-#else
-  jstring versionStr = (*jniEnv)->NewStringUTF(jniEnv, version);
-#endif
-  return versionStr;
+  return (*jniEnv)->NewStringUTF(jniEnv, version);
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2767,8 +2767,8 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
   return nullptr;  // Unsupported version
 }
 
-ORT_API(const ORTCHAR_T*, OrtApis::GetVersionString) {
-  return ORT_TSTR_ON_MACRO(ORT_VERSION);
+ORT_API(const char*, OrtApis::GetVersionString) {
+  return ORT_VERSION;
 }
 
 ORT_API(const ORTCHAR_T*, OrtApis::GetBuildInfoString) {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2379,10 +2379,7 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 }
 
 static constexpr OrtApiBase ort_api_base = {
-    &OrtApis::GetApi,
-    &OrtApis::GetVersionString,
-    &OrtApis::GetBuildInfoString,
-};
+    &OrtApis::GetApi};
 
 /* Rules on how to add a new Ort API version
 
@@ -2726,7 +2723,9 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::CastTypeInfoToOptionalTypeInfo,
     &OrtApis::GetOptionalContainedTypeInfo,
     &OrtApis::GetResizedStringTensorElementBuffer,
-    &OrtApis::KernelContext_GetAllocator};
+    &OrtApis::KernelContext_GetAllocator,
+    &OrtApis::GetVersionString,
+    &OrtApis::GetBuildInfoString};
 // End of Version 15 - DO NOT MODIFY ABOVE (see above text for more information)
 
 // Asserts to do a some checks to ensure older Versions of the OrtApi never change (will detect an addition or deletion but not if they cancel out each other)
@@ -2747,7 +2746,7 @@ static_assert(offsetof(OrtApi, SessionOptionsAppendExecutionProvider_MIGraphX) /
 static_assert(offsetof(OrtApi, ReleaseKernelInfo) / sizeof(void*) == 218, "Size of version 12 API cannot change");
 static_assert(offsetof(OrtApi, ReleaseCANNProviderOptions) / sizeof(void*) == 224, "Size of version 13 API cannot change");
 static_assert(offsetof(OrtApi, GetSessionConfigEntry) / sizeof(void*) == 238, "Size of version 14 API cannot change");
-static_assert(offsetof(OrtApi, KernelContext_GetAllocator) / sizeof(void*) == 253, "Size of version 15 API cannot change");
+static_assert(offsetof(OrtApi, GetBuildInfoString) / sizeof(void*) == 255, "Size of version 15 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.16.0",
@@ -2771,8 +2770,8 @@ ORT_API(const char*, OrtApis::GetVersionString) {
   return ORT_VERSION;
 }
 
-ORT_API(const ORTCHAR_T*, OrtApis::GetBuildInfoString) {
-  return ORT_TSTR_ON_MACRO(ORT_BUILD_INFO);
+ORT_API(const char*, OrtApis::GetBuildInfoString) {
+  return ORT_BUILD_INFO;
 }
 
 const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2379,7 +2379,8 @@ ORT_API(const OrtTrainingApi*, OrtApis::GetTrainingApi, uint32_t version) {
 }
 
 static constexpr OrtApiBase ort_api_base = {
-    &OrtApis::GetApi};
+    &OrtApis::GetApi,
+    &OrtApis::GetVersionString};
 
 /* Rules on how to add a new Ort API version
 
@@ -2724,7 +2725,6 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::GetOptionalContainedTypeInfo,
     &OrtApis::GetResizedStringTensorElementBuffer,
     &OrtApis::KernelContext_GetAllocator,
-    &OrtApis::GetVersionString,
     &OrtApis::GetBuildInfoString};
 // End of Version 15 - DO NOT MODIFY ABOVE (see above text for more information)
 
@@ -2746,7 +2746,7 @@ static_assert(offsetof(OrtApi, SessionOptionsAppendExecutionProvider_MIGraphX) /
 static_assert(offsetof(OrtApi, ReleaseKernelInfo) / sizeof(void*) == 218, "Size of version 12 API cannot change");
 static_assert(offsetof(OrtApi, ReleaseCANNProviderOptions) / sizeof(void*) == 224, "Size of version 13 API cannot change");
 static_assert(offsetof(OrtApi, GetSessionConfigEntry) / sizeof(void*) == 238, "Size of version 14 API cannot change");
-static_assert(offsetof(OrtApi, GetBuildInfoString) / sizeof(void*) == 255, "Size of version 15 API cannot change");
+static_assert(offsetof(OrtApi, GetBuildInfoString) / sizeof(void*) == 254, "Size of version 15 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.16.0",
@@ -2760,8 +2760,10 @@ ORT_API(const OrtApi*, OrtApis::GetApi, uint32_t version) {
   if (version >= 1 && version <= ORT_API_VERSION)
     return &ort_api_1_to_16;
 
-  fprintf(stderr, "The given version [%u] is not supported, only version 1 to %u is supported in this build.\n",
-          version, ORT_API_VERSION);
+  fprintf(stderr,
+          "The requested API version [%u] is not available, only API versions [1, %u] are supported in this build."
+          " Current ORT Version is: %s\n",
+          version, ORT_API_VERSION, ORT_VERSION);
 
   return nullptr;  // Unsupported version
 }

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -4,8 +4,6 @@
 namespace OrtApis {
 
 ORT_API(const OrtApi*, GetApi, uint32_t version);
-ORT_API(const char*, GetVersionString);
-ORT_API(const ORTCHAR_T*, GetBuildInfoString);
 
 ORT_API(void, ReleaseEnv, OrtEnv*);
 ORT_API(void, ReleaseStatus, _Frees_ptr_opt_ OrtStatus*);
@@ -465,4 +463,8 @@ ORT_API_STATUS_IMPL(GetResizedStringTensorElementBuffer, _Inout_ OrtValue* value
                     _In_ size_t index, _In_ size_t length_in_bytes, _Inout_ char**);
 
 ORT_API_STATUS_IMPL(KernelContext_GetAllocator, _In_ const OrtKernelContext* context, _In_ const OrtMemoryInfo* mem_info, _Outptr_ OrtAllocator** out);
+
+ORT_API(const char*, GetVersionString);
+
+ORT_API(const char*, GetBuildInfoString);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -5,6 +5,8 @@ namespace OrtApis {
 
 ORT_API(const OrtApi*, GetApi, uint32_t version);
 
+ORT_API(const char*, GetVersionString);
+
 ORT_API(void, ReleaseEnv, OrtEnv*);
 ORT_API(void, ReleaseStatus, _Frees_ptr_opt_ OrtStatus*);
 ORT_API(void, ReleaseMemoryInfo, _Frees_ptr_opt_ OrtMemoryInfo*);
@@ -463,8 +465,6 @@ ORT_API_STATUS_IMPL(GetResizedStringTensorElementBuffer, _Inout_ OrtValue* value
                     _In_ size_t index, _In_ size_t length_in_bytes, _Inout_ char**);
 
 ORT_API_STATUS_IMPL(KernelContext_GetAllocator, _In_ const OrtKernelContext* context, _In_ const OrtMemoryInfo* mem_info, _Outptr_ OrtAllocator** out);
-
-ORT_API(const char*, GetVersionString);
 
 ORT_API(const char*, GetBuildInfoString);
 }  // namespace OrtApis

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -4,7 +4,7 @@
 namespace OrtApis {
 
 ORT_API(const OrtApi*, GetApi, uint32_t version);
-ORT_API(const ORTCHAR_T*, GetVersionString);
+ORT_API(const char*, GetVersionString);
 ORT_API(const ORTCHAR_T*, GetBuildInfoString);
 
 ORT_API(void, ReleaseEnv, OrtEnv*);

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -29,7 +29,7 @@ using namespace onnxruntime;
 
 namespace {
 void usage() {
-  auto version_string = ToUTF8String(OrtGetApiBase()->GetVersionString());
+  auto version_string = Ort::GetVersionString();
   printf(
       "onnx_test_runner [options...] <data_root>\n"
       "Options:\n"

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2209,9 +2209,9 @@ TEST(CApiTest, get_available_providers_cpp) {
 }
 
 TEST(CApiTest, get_version_string_cpp) {
-  std::basic_string<ORTCHAR_T> version_string = Ort::GetVersionString();
+  auto version_string = Ort::GetVersionString();
   ASSERT_FALSE(version_string.empty());
-  ASSERT_EQ(version_string, std::basic_string<ORTCHAR_T>(ORT_TSTR_ON_MACRO(ORT_VERSION)));
+  ASSERT_EQ(version_string, std::string(ORT_VERSION));
 }
 
 TEST(CApiTest, TestSharedAllocators) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -2214,6 +2214,12 @@ TEST(CApiTest, get_version_string_cpp) {
   ASSERT_EQ(version_string, std::string(ORT_VERSION));
 }
 
+TEST(CApiTest, get_build_info_string) {
+  auto build_info_string = Ort::GetBuildInfoString();
+  ASSERT_FALSE(build_info_string.empty());
+  ASSERT_EQ(build_info_string, std::string(ORT_BUILD_INFO));
+}
+
 TEST(CApiTest, TestSharedAllocators) {
   OrtEnv* env_ptr = (OrtEnv*)(*ort_env);
 


### PR DESCRIPTION
### Description

This PR partially reverts changes introduced in https://github.com/microsoft/onnxruntime/pull/15643

We make two API return std::string always in UTF-8.

We also move the entry points from OrtApiBase to OrtApi to make them versioned.

### Motivation and Context

`GetVersionString` always returns x.y.z numbers that are not subject to internationalization.
`GetBuildInfoString` can hold international chars, but UTF-8 should be fine to contain those.
We prefix them with u8"" in case the compiler default charset is not UTF-8.
Furthermore, creating platform dependent APIs is discouraged.
`ORTCHAR_T` is platform dependent and was created for paths only.
On non-unix platforms would still produce `std::string` that can only contain UTF-8

The API was introduced after the latest release, and can still be adjusted.