### PR TITLE
Pass EnvironmentCreationOptions by reference

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtEnv.shared.cs
@@ -276,7 +276,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="options"></param>
         /// <returns></returns>
         /// <exception cref="OnnxRuntimeException">if the singleton has already been created</exception>
-        public static OrtEnv CreateInstanceWithOptions(EnvironmentCreationOptions options)
+        public static OrtEnv CreateInstanceWithOptions(ref EnvironmentCreationOptions options)
         {
             // Non-thread safe, best effort hopefully helpful check.
             // Environment is usually created once per process, so this should be fine.

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtEnvTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/OrtEnvTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 logLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL
             };
 
-            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(envOptions);
+            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.True(OrtEnv.IsCreated);
             Assert.Equal(OrtLoggingLevel.ORT_LOGGING_LEVEL_FATAL, ortEnvInstance.EnvLogLevel);
 
@@ -92,7 +92,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 logId = "CSharpOnnxRuntimeTestLogid"
             };
 
-            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(envOptions);
+            ortEnvInstance = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.Equal(OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING, ortEnvInstance.EnvLogLevel);
 
             // Change and see if this takes effect
@@ -118,7 +118,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 };
 
                 // Make sure we start anew
-                var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+                var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
                 Assert.True(OrtEnv.IsCreated);
             }
         }
@@ -164,7 +164,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
             LoggingInvokes = 0;
 
-            var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+            var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
             Assert.True(OrtEnv.IsCreated);
 
             var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");
@@ -199,7 +199,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 LoggingInvokes = 0;
 
-                var env = OrtEnv.CreateInstanceWithOptions(envOptions);
+                var env = OrtEnv.CreateInstanceWithOptions(ref envOptions);
                 Assert.True(OrtEnv.IsCreated);
 
                 var model = TestDataLoader.LoadModelFromEmbeddedResource("squeezenet.onnx");


### PR DESCRIPTION
### Description
Pass Environment creation struct by reference as the structure is big.

### Motivation and Context
Avoid extra copy and promote good practices.
This is not performance critical, but if it is to be changed, better be before the release.