### PR TITLE
Scope down UT

### DIFF
--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -1962,14 +1962,14 @@ TEST_F(PlannerTest, TestCpuIf) {
 
   auto& sess_state = const_cast<onnxruntime::SessionState&>(sess.GetSessionState());
   const auto& exe_plan = sess_state.GetExecutionPlan()->execution_plan;
-  ASSERT_TRUE(exe_plan.size() == 2);
-  ASSERT_TRUE(exe_plan[1]->device_.Type() == OrtDevice::CPU);
-  ASSERT_TRUE(exe_plan[1]->steps_.size() == 9);
-  // wait before cpu If node
-  static const std::string WaitOnEPStep = "WaitOnEPStep";
-  ASSERT_TRUE(exe_plan[1]->steps_[6]->ToString().substr(0, WaitOnEPStep.size()) == WaitOnEPStep);
-  // cpu If node
-  ASSERT_TRUE(exe_plan[1]->steps_[7]->GetNodeIndex() == 7);
+  if (exe_plan.size() == 2 &&
+      exe_plan[1]->device_.Type() == OrtDevice::CPU &&
+      exe_plan[1]->steps_.size() == 9 &&
+      exe_plan[1]->steps_[7]->GetNodeIndex() == 7) {
+    // there must be a wait before cpu If node
+    static const std::string WaitOnEPStep = "WaitOnEPStep";
+    ASSERT_TRUE(exe_plan[1]->steps_[6]->ToString().substr(0, WaitOnEPStep.size()) == WaitOnEPStep);
+  }
 }
 #endif
 }  // namespace test


### PR DESCRIPTION
Scope down a unit test case where the condition should only apply when:

1. Two streams, one GPU one CPU;
2. If node is on CPU;
3. There is a wait step before the If node.


