### PR TITLE
add maybe unused attribute to vars only used for logging

### DIFF
--- a/onnxruntime/core/optimizer/compute_optimizer/upstream_transformer_base.cc
+++ b/onnxruntime/core/optimizer/compute_optimizer/upstream_transformer_base.cc
@@ -50,8 +50,9 @@ Status UpStreamGraphTransformerBase<T1, T2>::ApplyImpl(Graph& graph, bool& modif
   const auto& order = graph_viewer.GetNodesInTopologicalOrder();
   const auto& graph_outputs = graph.GetOutputs();
 
-  size_t reordered_node_count = 0;  // For summary
-  size_t passthrough_count = 0;
+  [[maybe_unused]] size_t reordered_node_count = 0;  // For summary
+  [[maybe_unused]] size_t passthrough_count = 0;
+
   for (const auto index : order) {
     auto* node_ptr = graph.GetNode(index);
     if (!node_ptr)

--- a/orttraining/orttraining/core/optimizer/compute_optimizer/sceloss_compute_optimization.cc
+++ b/orttraining/orttraining/core/optimizer/compute_optimizer/sceloss_compute_optimization.cc
@@ -82,7 +82,7 @@ Status InsertGatherBeforeSceLoss::ApplyImpl(Graph& graph, bool& modified, int /*
   LOG_DEBUG_INFO(logger, "Enter InsertGatherBeforeSceLoss");
 
   GraphViewer graph_viewer(graph);
-  size_t handled_sce_node_count = 0;  // For summary
+  [[maybe_unused]] size_t handled_sce_node_count = 0;  // For summary
   const auto& order = graph_viewer.GetNodesInTopologicalOrder();
   for (const auto index : order) {
     auto* node_ptr = graph.GetNode(index);


### PR DESCRIPTION
### Description
Add maybe_unused attribute to variables that are only used for logging



### Motivation and Context
Building ORT with training using Xcode 14.3 causes` -Wunused-but-set-variable` error as some variables are created and  exclusively used for debug logging. Adding maybe_unused suppresses warnings on unused variables when logging is disabled and fixes the local build.


