### PR TITLE
Add explicit 'set +x' before printing a vso[] command to avoid output getting parsed again with a trailing quote.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -83,6 +83,8 @@ stages:
     steps:
     - checkout: none
     - bash: |
+        # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+        set +x
         if [[ "${{ parameters.IsReleaseBuild }}" = True && "${{ parameters.PreReleaseVersionSuffixString }}" != "none"  ]]; then
           if [[ "${{ parameters.PreReleaseVersionSuffixNumber }}" -eq 0 ]]; then
             echo "##vso[task.setvariable variable=ReleaseVersionSuffix;isOutput=true]-${{ parameters.PreReleaseVersionSuffixString }}"

--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -49,6 +49,8 @@ jobs:
     displayName: "Install Python requirements"
 
   - bash: |
+      set -e
+
       BUILD_TYPE="${{ parameters.BuildType }}"
       BASE_VERSION="$(cat ./VERSION_NUMBER)"
       SHORT_COMMIT_HASH="$(git rev-parse --short HEAD)"
@@ -64,6 +66,9 @@ jobs:
         (*)
           echo "Invalid build type: ${BUILD_TYPE}"; exit 1 ;;
       esac
+
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
 
       set_var() {
         local VAR_NAME=${1:?}

--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test.yml
@@ -22,6 +22,8 @@ steps:
   displayName: 'Extract package file name (POSIX)'
   inputs:
     script: |
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "##vso[task.setvariable variable=NpmPackageFilesForTest;]`ls $(Build.BinariesDirectory)/nodejs-artifact/*.tgz | tr '\n' ' '`"
     workingDirectory: '$(Build.BinariesDirectory)/e2e_test'
 

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/get-nuget-package-version-as-variable.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/get-nuget-package-version-as-variable.yml
@@ -37,4 +37,6 @@ steps:
       filenamewithext=$(ls Microsoft.ML.OnnxRuntime.Managed*nupkg)
       filename=${filenamewithext%.*}
       ortversion=${filename:33}
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "##vso[task.setvariable variable=NuGetPackageVersionNumber;]$ortversion"

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-amd-e2e-test-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-gpu-amd-e2e-test-ci-pipeline.yml
@@ -14,6 +14,8 @@ jobs:
     submodules: recursive
 
   - script: |-
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "##vso[task.prependpath]/home/ciagent/conda/bin/"
       echo "##vso[task.prependpath]/home/ciagent/pkg/openmpi-4.0.5/bin/"
       echo '##vso[task.setvariable variable=LD_LIBRARY_PATH]/home/ciagent/pkg/openmpi-4.0.5/lib/'

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -97,6 +97,8 @@ jobs:
     displayName: Show Cache Stats After Building
 
   - bash: |-
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "##vso[task.setvariable variable=onnxruntimeBuildSucceeded]true"
     displayName: 'Set Onnxruntime Build Succeeded'
 

--- a/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-build-step-with-cache.yml
@@ -29,6 +29,8 @@ parameters:
 steps:
   - script: |
       which ccache || brew install ccache
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "##vso[task.prependpath]/usr/local/opt/ccache/libexec"
       mkdir -p "${{ parameters.CacheDir }}"
     displayName: Install ccache and update PATH to use linked versions of gcc, cc, etc

--- a/tools/ci_build/github/azure-pipelines/templates/rocm.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/rocm.yml
@@ -101,6 +101,8 @@ jobs:
   # To view the UTs disabled from this CI - see https://github.com/microsoft/onnxruntime/pull/11945 for examples
 
   - script: |-
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
       echo "Tests will run using HIP_VISIBLES_DEVICES=$HIP_VISIBLE_DEVICES"
       video_gid=$(getent group | awk '/video/ {split($0,a,":"); print(a[3])}')
       echo "Found video_gid=$video_gid; attempting to set as pipeline variable"

--- a/tools/ci_build/github/azure-pipelines/templates/set-version-number-variables-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/set-version-number-variables-step.yml
@@ -10,9 +10,9 @@ steps:
   inputs:
     script: |
         SETLOCAL EnableDelayedExpansion
-        set /p _OnnxRuntimeVersion=<${{parameters.versionFileDirectory}}\VERSION_NUMBER 
+        set /p _OnnxRuntimeVersion=<${{parameters.versionFileDirectory}}\VERSION_NUMBER
         @echo ##vso[task.setvariable variable=OnnxRuntimeVersion;]%_OnnxRuntimeVersion%
-        
+
         FOR /F "tokens=* USEBACKQ" %%F IN (`git rev-parse HEAD`) DO (
             @echo ##vso[task.setvariable variable=OnnxRuntimeGitCommitHash;]%%F
         )
@@ -20,22 +20,25 @@ steps:
         FOR /F "tokens=* USEBACKQ" %%F IN (`git rev-parse --short HEAD`) DO (
             @echo ##vso[task.setvariable variable=OnnxRuntimeGitCommitHashShort;]%%F
         )
-        
-    workingDirectory: ${{parameters.workingDirectory}} 
-  condition: eq(variables['Agent.OS'], 'Windows_NT') 
+
+    workingDirectory: ${{parameters.workingDirectory}}
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: CmdLine@2
   displayName: 'Set version number variables for Unix'
   inputs:
     script: |
-        _OnnxRuntimeVersion=$(head -1 ${{parameters.versionFileDirectory}}/VERSION_NUMBER) 
+        # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+        set +x
+
+        _OnnxRuntimeVersion=$(head -1 ${{parameters.versionFileDirectory}}/VERSION_NUMBER)
         echo "##vso[task.setvariable variable=OnnxRuntimeVersion;]$_OnnxRuntimeVersion"
-        
+
         _OnnxRuntimeGitCommitHash=$(git rev-parse HEAD)
         echo "##vso[task.setvariable variable=OnnxRuntimeGitCommitHash;]$_OnnxRuntimeGitCommitHash"
 
         _OnnxRuntimeGitCommitHash=$(git rev-parse --short=8 HEAD)
         echo "##vso[task.setvariable variable=OnnxRuntimeGitCommitHashShort;]$_OnnxRuntimeGitCommitHash"
 
-    workingDirectory: ${{parameters.workingDirectory}} 
+    workingDirectory: ${{parameters.workingDirectory}}
   condition: not(eq(variables['Agent.OS'], 'Windows_NT'))

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -17,6 +17,9 @@
         exit 1
       fi
 
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
+
       set_var() {
         local VAR_NAME=${1:?}
         local VAR_VALUE=${2:?}


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add explicit 'set +x' before printing a vso[] command to avoid output getting parsed again with a trailing quote.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Here's the motivating issue:
https://github.com/microsoft/azure-pipelines-tasks/issues/10331

Noticed some problems in other repos so also updating usages in ORT.

We may be fine now without it, but this change adds some safeguard against future additions of 'set -x' for debugging.