### PR TITLE
fix transpose optimizer on GPU EP

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -913,7 +913,7 @@ PostLayoutTransformCostCheck(const api::GraphRef& graph, const api::NodeRef& nod
 Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvider& execution_provider,
                             const DebugGraphFn& debug_graph_fn) {
   // sub graph recurse will be added later
-  auto api_graph = MakeApiGraph(graph, execution_provider.GetAllocator(OrtMemTypeDefault), nullptr);
+  auto api_graph = MakeApiGraph(graph, execution_provider.GetAllocator(OrtMemTypeCPU), nullptr);
   const auto& layout_sensitive_ops = GetORTLayoutSensitiveOps();
 
   for (auto& node : api_graph->Nodes()) {

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -914,9 +914,9 @@ Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvid
                             const DebugGraphFn& debug_graph_fn) {
   // sub graph recurse will be added later
   auto cpu_allocator = execution_provider.GetAllocator(OrtMemTypeDefault);
-  if (cpu_allocator->Info().device.device_type != OrtDevice::CPU) {
+  if (cpu_allocator->Info().device.Type() != OrtDevice::CPU) {
     cpu_allocator = execution_provider.GetAllocator(OrtMemTypeCPU);
-    if (!cpu_allocator || cpu_allocator->Info().device.device_type != OrtDevice::CPU) {
+    if (!cpu_allocator || cpu_allocator->Info().device.Type() != OrtDevice::CPU) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get CPU allocator from EP: ",
                              execution_provider.Type());
     }

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_api_impl.cc
@@ -911,16 +911,7 @@ PostLayoutTransformCostCheck(const api::GraphRef& graph, const api::NodeRef& nod
 }
 
 Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvider& execution_provider,
-                            const DebugGraphFn& debug_graph_fn) {
-  // sub graph recurse will be added later
-  auto cpu_allocator = execution_provider.GetAllocator(OrtMemTypeDefault);
-  if (cpu_allocator->Info().device.Type() != OrtDevice::CPU) {
-    cpu_allocator = execution_provider.GetAllocator(OrtMemTypeCPU);
-    if (!cpu_allocator || cpu_allocator->Info().device.Type() != OrtDevice::CPU) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to get CPU allocator from EP: ",
-                             execution_provider.Type());
-    }
-  }
+                            AllocatorPtr cpu_allocator, const DebugGraphFn& debug_graph_fn) {
   auto api_graph = MakeApiGraph(graph, cpu_allocator, nullptr);
   const auto& layout_sensitive_ops = GetORTLayoutSensitiveOps();
 

--- a/onnxruntime/core/optimizer/transpose_optimizer/optimizer_utils.h
+++ b/onnxruntime/core/optimizer/transpose_optimizer/optimizer_utils.h
@@ -84,11 +84,12 @@ const std::unordered_set<std::string_view>& GetORTLayoutSensitiveOps();
 /// <param name="graph">graph to transform</param>
 /// <param name="modified">indicates whether the graph is modified during transformation</param>
 /// <param name="execution_provider">execution provider for which the transformation needs to be performed</param>
+/// <param name="cpu_allocator">a CPU allocator used in layout transformation.
 /// <param name="debug_graph_fn">Optional functor to debug the graph produced during layout transformation.
 /// This is called after layout transformation if new nodes are inserted, and again after those are optimized.
 /// </param>
 Status TransformLayoutForEP(Graph& graph, bool& modified, const IExecutionProvider& execution_provider,
-                            const DebugGraphFn& debug_graph_fn = {});
+                            AllocatorPtr cpu_allocator, const DebugGraphFn& debug_graph_fn = {});
 
 /// <summary>
 /// Checks if the opset of the Graph is supported by the layout transformer.

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -157,7 +157,11 @@ TEST_P(SessionStateTestP, TestInitializerProcessing) {
 
   GraphPartitioner partitioner(krm, execution_providers);
   status = partitioner.Partition(graph, session_state.GetMutableFuncMgr(),
-                                 layout_transformer::TransformLayoutForEP);
+                                 [&execution_providers](Graph& graph, bool& modified,
+                                                        const IExecutionProvider& execution_provider,
+                                                        const layout_transformer::DebugGraphFn& debug_graph_fn) -> Status {
+                                   return layout_transformer::TransformLayoutForEP(graph, modified, execution_provider, execution_providers.GetDefaultCpuAllocator(), debug_graph_fn);
+                                 });
   ASSERT_TRUE(status.IsOK()) << status;
 
   ASSERT_STATUS_OK(session_state.FinalizeSessionState(oss.str(), krm));
@@ -231,7 +235,11 @@ TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
     // Partition the graph
     GraphPartitioner partitioner(krm, execution_providers);
     status = partitioner.Partition(graph, session_state.GetMutableFuncMgr(),
-                                   layout_transformer::TransformLayoutForEP);
+                                   [&execution_providers](Graph& graph, bool& modified,
+                                                          const IExecutionProvider& execution_provider,
+                                                          const layout_transformer::DebugGraphFn& debug_graph_fn) -> Status {
+                                     return layout_transformer::TransformLayoutForEP(graph, modified, execution_provider, execution_providers.GetDefaultCpuAllocator(), debug_graph_fn);
+                                   });
     ASSERT_TRUE(status.IsOK()) << status;
     ASSERT_STATUS_OK(session_state.FinalizeSessionState(oss.str(), krm));
 
@@ -282,7 +290,11 @@ TEST(SessionStateTest, TestInitializerMemoryAllocatedUsingNonArenaMemory) {
     // Partition the graph
     GraphPartitioner partitioner(krm, execution_providers);
     status = partitioner.Partition(graph, session_state.GetMutableFuncMgr(),
-                                   layout_transformer::TransformLayoutForEP);
+                                   [&execution_providers](Graph& graph, bool& modified,
+                                                          const IExecutionProvider& execution_provider,
+                                                          const layout_transformer::DebugGraphFn& debug_graph_fn) -> Status {
+                                     return layout_transformer::TransformLayoutForEP(graph, modified, execution_provider, execution_providers.GetDefaultCpuAllocator(), debug_graph_fn);
+                                   });
     ASSERT_TRUE(status.IsOK()) << status;
 
     // Finalize the session state


### PR DESCRIPTION
### Description
because of #15618 , the default allocator changed to device allocator, which will be GPU instead of CPU. in transpose optimizer we expect to read data from initializers so a CPU allocator is required here.

this change fixes transpose optimizer on GPU EP

Fixes the issue referred to in #15869, #15796