### PR TITLE
[js/webgpu] fix buffer size when download

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -195,12 +195,13 @@ class GpuDataManagerImpl implements GpuDataManager {
 
     const commandEncoder = this.backend.getCommandEncoder();
     this.backend.endComputePass();
+    const bufferSize = calcNormalizedBufferSize(cachedData.originalSize);
     const gpuReadBuffer = this.backend.device.createBuffer(
         // eslint-disable-next-line no-bitwise
-        {size: cachedData.originalSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+        {size: bufferSize, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
     commandEncoder.copyBufferToBuffer(
         cachedData.gpuData.buffer /* source buffer */, 0 /* source offset */, gpuReadBuffer /* destination buffer */,
-        0 /* destination offset */, cachedData.originalSize /* size */
+        0 /* destination offset */, bufferSize /* size */
     );
     this.backend.flush();
 


### PR DESCRIPTION
### Description
 fix buffer size when download. buffer size should always be padded to multiple of 4.

resolved issue described in #15796

> ![Image](https://user-images.githubusercontent.com/26504141/239093785-9417dffc-6f00-47b2-956d-402b43bdb0a9.png)