### PR TITLE
[CoreML EP] Minor changes to allow CoreML EP to handle more nodes and models.

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/helper.cc
+++ b/onnxruntime/core/providers/coreml/builders/helper.cc
@@ -86,12 +86,6 @@ std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewe
   }
 #endif
 
-  const auto& graph_inputs = graph_viewer.GetInputs();
-  if (std::any_of(graph_inputs.begin(), graph_inputs.end(),
-                  [&](const NodeArg* input) { return !IsInputSupported(*input, "graph", logger); })) {
-    return supported_nodes;
-  }
-
   for (const auto& node : graph_viewer.Nodes()) {
     const bool supported = IsNodeSupported(node, graph_viewer, logger);
     LOGS(logger, VERBOSE) << "Operator type: [" << node.OpType()

--- a/onnxruntime/core/providers/coreml/builders/helper.cc
+++ b/onnxruntime/core/providers/coreml/builders/helper.cc
@@ -46,6 +46,11 @@ bool IsNodeSupported(const Node& node, const GraphViewer& graph_viewer, const lo
 }
 
 bool IsInputSupported(const NodeArg& input, const std::string& parent_name, const logging::Logger& logger) {
+  if (!input.Exists()) {
+    // optional input that is not provided
+    return true;
+  }
+
   const auto& input_name = input.Name();
   const auto* shape_proto = input.Shape();
   // We do not support input with no shape


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Minor changes to allow CoreML EP to handle more nodes and models.
- Remove graph input dynamic shape check from coreml::GetSupportedNodes(). Each node input is still checked.
- Add check for optional input in coreml::IsInputSupported(). If an input does not exist it should not be considered unsupported.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Some CoreML EP checks seem too strict now.