### PR TITLE
Update  cgmanifest.json

### DIFF
--- a/cgmanifests/cgmanifest.json
+++ b/cgmanifests/cgmanifest.json
@@ -563,6 +563,15 @@
             },
             "comments": "python-pillow. Implementation logic for anti-aliasing copied by Resize CPU kernel."
          }
+      },
+      {
+         "component": {
+            "type": "git",
+            "git": {
+               "commitHash": "d10b27fe37736d2944630ecd7557cefa95cf87c9",
+               "repositoryUrl": "https://gitlab.com/libeigen/eigen.git"
+            }            
+         }
       }
    ],
    "Version": 1

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -82,16 +82,6 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "d10b27fe37736d2944630ecd7557cefa95cf87c9",
-          "repositoryUrl": "https://gitlab.com/libeigen/eigen.git"
-        },
-        "comments": "git submodule at cmake/external/eigen"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "commitHash": "b113f24842c6e97fe3e352084db09a6e278593ae",
           "repositoryUrl": "https://github.com/emscripten-core/emsdk.git"
         },
@@ -447,7 +437,7 @@
         },
         "comments": "extensions"
       }
-    }
+    },
     {
       "component": {
         "type": "git",


### PR DESCRIPTION
### Description
In PR #15797, the author manually edited the  cgmanifests/generated/cgmanifest.json file and made an error there that makes the file ill formed. 

The PR also accidentally reverted emsdk submodule to an older version. 

### Motivation and Context



