### PR TITLE
Remove NETSTANDARD1.1 moniker and NETSTD1.1 specific code

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/Microsoft.ML.OnnxRuntime.csproj
@@ -21,7 +21,7 @@
   -->
   <PropertyGroup>
     <SelectedTargets>PreNet6</SelectedTargets>
-    <BaseTargets>netstandard1.1;netstandard2.0;netcoreapp3.1;net6.0</BaseTargets>
+    <BaseTargets>netstandard2.0;netcoreapp3.1;net6.0</BaseTargets>
   </PropertyGroup>
 
   <!-- only set the Xamarin mobile targets if we're building an ORT package,
@@ -305,7 +305,7 @@
           Visible="false"
     />
     <None Include="targets\netstandard\$(PackageId).targets"
-          PackagePath="build\netstandard1.1\$(PackageId).targets;build\netstandard2.0\$(PackageId).targets"
+          PackagePath="build\netstandard2.0\$(PackageId).targets"
           Pack="true"
           Visible="false"
     />


### PR DESCRIPTION
### Description

Remove NETSTANDARD1.1 moniker and NETSTD1.1 specific code. We no longer target this platform.

### Motivation and Context
NETSTANDARD1.1 target constraints the development and the modern libraries we would like to use in the code while it is apparently no longer required by customers.

