### PR TITLE
repoint amd repo to onnxruntime repo not amd's

### DIFF
--- a/Build2023.html
+++ b/Build2023.html
@@ -61,7 +61,7 @@
                                     <p><a href="https://github.com/microsoft/Olive/tree/main/examples/directml/dolly_v2">Dolly v2 with ONNX Runtime and Olive</a></p>
                                     <p><a href="https://github.com/microsoft/Olive/tree/main/examples/directml/stable_diffusion">Stable diffusion with ONNX Runtime, DirectML, and Olive</a></p>    
                                     <p><a href="https://github.com/onnxruntime/Whisper-HybridLoop-Onnx-Demo">Hydrid AI: Whisper on Windows and Azure</a></p>
-                                    <p><a href="https://github.com/amd/ms-build-demo">Hybrid photo classification on AMD with ONNX Runtime, Vitis AI and the Azure EP</a></p>
+                                    <p><a href="https://github.com/onnxruntime/RyzenAI-Cloud2Client-Onnx-Demo">Hybrid photo classification on AMD with ONNX Runtime, Vitis AI and the Azure EP</a></p>
                                 </div>
                             </div>
                         </div>

--- a/build2023.html
+++ b/build2023.html
@@ -61,7 +61,7 @@
                                     <p><a href="https://github.com/microsoft/Olive/tree/main/examples/directml/dolly_v2">Dolly v2 with ONNX Runtime and Olive</a></p>
                                     <p><a href="https://github.com/microsoft/Olive/tree/main/examples/directml/stable_diffusion">Stable diffusion with ONNX Runtime, DirectML, and Olive</a></p>    
                                     <p><a href="https://github.com/onnxruntime/Whisper-HybridLoop-Onnx-Demo">Hydrid AI: Whisper on Windows and Azure</a></p>
-                                    <p><a href="https://github.com/amd/ms-build-demo">Hybrid photo classification on AMD with ONNX Runtime, Vitis AI and the Azure EP</a></p>
+                                    <p><a href="https://github.com/onnxruntime/RyzenAI-Cloud2Client-Onnx-Demo">Hybrid photo classification on AMD with ONNX Runtime, Vitis AI and the Azure EP</a></p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
changes hosted at:  https://jeffmend.github.io/onnxruntime/build2023
### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


