### PR TITLE
Address performance regression with duplicate initializers across DML partitions

### DIFF
--- a/onnxruntime/core/optimizer/constant_sharing.cc
+++ b/onnxruntime/core/optimizer/constant_sharing.cc
@@ -35,7 +35,6 @@ using SupportedTypeList = boost::mp11::mp_list<MLFloat16, float, double, int32_t
 // TODO(pengwa): we can gradually increase this threshold if we see more benefits (memory saving
 // or more CSE optimizations triggered). Should be careful to cover test cases that assume initializer
 // name did not change after transformation then.
-static constexpr int64_t TENSOR_ELEM_COUNT_THRESHOLD = 8;
 static constexpr char SHARED_INITIALIZER_PREFIX[] = "ortshared_";
 
 bool IsAllowedToShare(const ONNX_NAMESPACE::TensorShapeProto* input_shape,
@@ -52,12 +51,12 @@ bool IsAllowedToShare(const ONNX_NAMESPACE::TensorShapeProto* input_shape,
 
     int64_t dim_value = dim.dim_value();
     num_elements *= dim_value;
-    if (num_elements > TENSOR_ELEM_COUNT_THRESHOLD) {
+    if (num_elements > ConstantSharing::TENSOR_ELEM_COUNT_THRESHOLD) {
       return false;
     }
   }
 
-  if (num_elements > 0 && num_elements <= TENSOR_ELEM_COUNT_THRESHOLD) {
+  if (num_elements > 0 && num_elements <= ConstantSharing::TENSOR_ELEM_COUNT_THRESHOLD) {
     return true;
   }
 

--- a/onnxruntime/core/optimizer/constant_sharing.h
+++ b/onnxruntime/core/optimizer/constant_sharing.h
@@ -29,6 +29,8 @@ class ConstantSharing : public GraphTransformer {
         excluded_initializers_(excluded_initializers) {
   }
 
+  static constexpr int64_t TENSOR_ELEM_COUNT_THRESHOLD = 8;
+
  private:
   Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
 


### PR DESCRIPTION
This addresses a DML performance regression introduced by the constant sharing pass.  

The constant sharing pass identifies small initializer tensors which contain identical values and merges them.  This could have the effect of causing DML to treat those tensors as non-constant and skip certain optimization.  

To prevent this, there is now an element count threshold below which the DML EP will enable this optimization, even though it results in duplicate work uploading and pre-processing the common tensor at multiple operators.