### PR TITLE
Accelerate GemmBroadcastBias with parallelization

### DIFF
--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -1934,14 +1934,9 @@ void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFun
 // Variant of UntypedBroadcastTwo that will parallelize.
 // Operator usage is the same as the parallelization is opaque to the operator.
 // unit_cost must be a valid cost value.
-void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFuncs& funcs, double unit_cost,
-                         void* user_data) {
-  const Tensor& input0_tensor = *context.Input<Tensor>(0);
-  const Tensor& input1_tensor = *context.Input<Tensor>(1);
-  InputBroadcaster input_broadcaster(input0_tensor, input1_tensor);
-
-  Tensor& output_tensor = *context.Output(0, input_broadcaster.GetOutputShape());
-
+void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFuncs& funcs,
+                         InputBroadcaster& input_broadcaster, Tensor& output_tensor,
+                         double unit_cost, void* user_data) {
   size_t span_size = input_broadcaster.GetSpanSize();
   size_t output_size = static_cast<ptrdiff_t>(output_tensor.Shape().Size());
 
@@ -1981,6 +1976,19 @@ void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFun
           BroadcastLooper(segment_helper, funcs);
         });
   }
+}
+
+// Variant of UntypedBroadcastTwo that will parallelize.
+// Operator usage is the same as the parallelization is opaque to the operator.
+// unit_cost must be a valid cost value.
+void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFuncs& funcs, double unit_cost,
+                         void* user_data) {
+  const Tensor& input0_tensor = *context.Input<Tensor>(0);
+  const Tensor& input1_tensor = *context.Input<Tensor>(1);
+  InputBroadcaster input_broadcaster(input0_tensor, input1_tensor);
+  Tensor& output_tensor = *context.Output(0, input_broadcaster.GetOutputShape());
+
+  UntypedBroadcastTwo(context, funcs, input_broadcaster, output_tensor, unit_cost, user_data);
 }
 
 // allocate_tensor should allocate a tensor of the output type with the given shape

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.h
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.h
@@ -991,6 +991,14 @@ void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFun
 //
 // Operator usage is the same as the parallelization is opaque to the operator.
 // unit_cost must be a valid cost value.
+void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFuncs& funcs,
+                         InputBroadcaster& input_broadcaster, Tensor& output_tensor,
+                         double unit_cost, void* user_data = nullptr);
+
+// Broadcast two inputs with parallelization.
+//
+// Operator usage is the same as the parallelization is opaque to the operator.
+// unit_cost must be a valid cost value.
 void UntypedBroadcastTwo(OpKernelContext& context, const ProcessBroadcastSpanFuncs& funcs, double unit_cost,
                          void* user_data = nullptr);
 

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -282,7 +282,7 @@ Status Gemm<float>::Compute(OpKernelContext* context) const {
     ComputeGemm(trans_A_, trans_B_, M, N, K, alpha_, A->Data<float>(), B->Data<float>(), beta_,
                 c_data, c_shape, y_data, thread_pool);
   } else {
-    GemmBroadcastBias(M, N, beta_, c_data, c_shape, y_data);
+    GemmBroadcastBias<float>(*context, *C, *Y);
     MlasGemm(
         trans_A_,
         static_cast<size_t>(M),

--- a/onnxruntime/core/providers/cpu/math/gemm_helper.h
+++ b/onnxruntime/core/providers/cpu/math/gemm_helper.h
@@ -101,19 +101,19 @@ void GemmBroadcastBias(int64_t M, int64_t N, float beta,
 // Broadcast bias with parallelization
 template <typename T>
 void GemmBroadcastBias(OpKernelContext& context, const Tensor& C, Tensor& Y) {
-    ProcessBroadcastSpanFuncs funcs{
-        [](BroadcastHelper& per_iter_bh) {
-          per_iter_bh.OutputEigen<T>().setConstant(per_iter_bh.ScalarInput0<T>());
-        },
-        [](BroadcastHelper& per_iter_bh) {
-          per_iter_bh.OutputEigen<T>() = per_iter_bh.EigenInput0<T>();
-        },
-        [](BroadcastHelper& per_iter_bh) {
-          per_iter_bh.OutputEigen<T>() = per_iter_bh.EigenInput0<T>();
+  ProcessBroadcastSpanFuncs funcs{
+      [](BroadcastHelper& per_iter_bh) {
+        per_iter_bh.OutputEigen<T>().setConstant(per_iter_bh.ScalarInput0<T>());
+      },
+      [](BroadcastHelper& per_iter_bh) {
+        per_iter_bh.OutputEigen<T>() = per_iter_bh.EigenInput0<T>();
+      },
+      [](BroadcastHelper& per_iter_bh) {
+        per_iter_bh.OutputEigen<T>() = per_iter_bh.EigenInput0<T>();
       }};
 
-    InputBroadcaster inputBroadcaster(C, Y);
-    UntypedBroadcastTwo(context, funcs, inputBroadcaster, Y, 1.);
+  InputBroadcaster inputBroadcaster(C, Y);
+  UntypedBroadcastTwo(context, funcs, inputBroadcaster, Y, 1.);
 }
 
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Accelerate GemmBroadcastBias with parallelization:
- Add new function entry for `UntypedBroadcastTwo` to accept `InputBroadcaster` and `output_tensor`;
- Leverage `UntypedBroadcastTwo` to accelerate GemmBroadcastBias.

TODO:
- Currently, the parallelization is only enabled for `Gemm<float>`. Should also figure out how to fix for general GemmCompute.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

GemmBroadcastBias is single threaded and slow. For example, we have a Gemm operation with (M = 300^2, K = 96, N = 1024) and with Bias tensor C (N=1024):
![MicrosoftTeams-image](https://github.com/microsoft/onnxruntime/assets/2187096/07cdc326-88bd-47db-86e7-d31a7efc2776)

The bias broadcast cost is even longer that the actual computation cost (invoking MlasGemm).
