### PR TITLE
Add new QNN CIs to azp run tool

### DIFF
--- a/tools/python/run_CIs_for_external_pr.py
+++ b/tools/python/run_CIs_for_external_pr.py
@@ -56,7 +56,7 @@ def main():
     # Current pipelines. These change semi-frequently and may need updating.
     pipelines = [
         # windows
-        'Windows ARM64 QNN CI Pipeline',
+        "Windows ARM64 QNN CI Pipeline",
         "Windows CPU CI Pipeline",
         "Windows GPU CI Pipeline",
         "Windows GPU TensorRT CI Pipeline",

--- a/tools/python/run_CIs_for_external_pr.py
+++ b/tools/python/run_CIs_for_external_pr.py
@@ -56,6 +56,7 @@ def main():
     # Current pipelines. These change semi-frequently and may need updating.
     pipelines = [
         # windows
+        'Windows ARM64 QNN CI Pipeline',
         "Windows CPU CI Pipeline",
         "Windows GPU CI Pipeline",
         "Windows GPU TensorRT CI Pipeline",
@@ -66,6 +67,7 @@ def main():
         "Linux GPU CI Pipeline",
         "Linux GPU TensorRT CI Pipeline",
         "Linux OpenVINO CI Pipeline",
+        "Linux QNN CI Pipeline",
         # mac
         "MacOS CI Pipeline",
         # training


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add 2 new QNN CIs to tools/python/run_CIs_for_external_pr.py


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Update tool so it runs all current CIs

