### PR TITLE
Fix: Some fields in OrtCUDAProviderOptionsV2 struct are not initialized 

### DIFF
--- a/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
+++ b/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
@@ -14,21 +14,21 @@
 /// User can only get the instance of OrtCUDAProviderOptionsV2 via CreateCUDAProviderOptions.
 /// </summary>
 struct OrtCUDAProviderOptionsV2 {
-  int device_id;                                           // cuda device id.
-  int has_user_compute_stream;                             // indicator of user specified CUDA compute stream.
-  void* user_compute_stream;                               // user specified CUDA compute stream.
-  int do_copy_in_default_stream;                           // flag specifying if the default stream is to be used for copying.
-  OrtCudnnConvAlgoSearch cudnn_conv_algo_search;           // cudnn algo search enum.
-  size_t gpu_mem_limit;                                    // BFC Arena memory limit for CUDA.
-                                                           // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
-  onnxruntime::ArenaExtendStrategy arena_extend_strategy;  // BFC Arena extension strategy.
-                                                           // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
-  OrtArenaCfg* default_memory_arena_cfg;                   // BFC Arena config flags.
-  int cudnn_conv_use_max_workspace;                        // flag specifying if maximum workspace can be used in cudnn conv algo search.
-  int enable_cuda_graph;                                   // flag specifying if the CUDA graph is to be captured for the model.
-  int cudnn_conv1d_pad_to_nc1d;                            // flag specifying if pad Conv1D's input [N,C,D] to [N,C,1,D] or [N,C,D,1].
-  int tunable_op_enable;                                   // flag specifying if TunableOp is enabled.
-  int tunable_op_tuning_enable;                            // flag specifying if TunableOp is enabled for tuning, this relies on TunableOp is enabled.
-  int enable_skip_layer_norm_strict_mode;                  // flag specifying if SkipLayerNorm is in strict mode. If true, use LayerNormalization kernel.
-                                                           // The strict mode has better accuracy but lower performance.
+  int device_id = 0;                                                                                           // cuda device id.
+  int has_user_compute_stream = 0;                                                                             // indicator of user specified CUDA compute stream.
+  void* user_compute_stream = nullptr;                                                                         // user specified CUDA compute stream.
+  int do_copy_in_default_stream = 0;                                                                           // flag specifying if the default stream is to be used for copying.
+  OrtCudnnConvAlgoSearch cudnn_conv_algo_search = OrtCudnnConvAlgoSearchDefault;                               // cudnn algo search enum.
+  size_t gpu_mem_limit = 0;                                                                                    // BFC Arena memory limit for CUDA.
+                                                                                                               // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
+  onnxruntime::ArenaExtendStrategy arena_extend_strategy = onnxruntime::ArenaExtendStrategy::kNextPowerOfTwo;  // BFC Arena extension strategy.
+                                                                                                               // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
+  OrtArenaCfg* default_memory_arena_cfg = nullptr;                                                             // BFC Arena config flags.
+  int cudnn_conv_use_max_workspace = 0;                                                                        // flag specifying if maximum workspace can be used in cudnn conv algo search.
+  int enable_cuda_graph = 0;                                                                                   // flag specifying if the CUDA graph is to be captured for the model.
+  int cudnn_conv1d_pad_to_nc1d = 0;                                                                            // flag specifying if pad Conv1D's input [N,C,D] to [N,C,1,D] or [N,C,D,1].
+  int tunable_op_enable = 0;                                                                                   // flag specifying if TunableOp is enabled.
+  int tunable_op_tuning_enable = 0;                                                                            // flag specifying if TunableOp is enabled for tuning, this relies on TunableOp is enabled.
+  int enable_skip_layer_norm_strict_mode = 0;                                                                  // flag specifying if SkipLayerNorm is in strict mode. If true, use LayerNormalization kernel.
+                                                                                                               // The strict mode has better accuracy but lower performance.
 };

--- a/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
+++ b/include/onnxruntime/core/providers/cuda/cuda_provider_options.h
@@ -17,14 +17,14 @@ struct OrtCUDAProviderOptionsV2 {
   int device_id = 0;                                                                                           // cuda device id.
   int has_user_compute_stream = 0;                                                                             // indicator of user specified CUDA compute stream.
   void* user_compute_stream = nullptr;                                                                         // user specified CUDA compute stream.
-  int do_copy_in_default_stream = 0;                                                                           // flag specifying if the default stream is to be used for copying.
-  OrtCudnnConvAlgoSearch cudnn_conv_algo_search = OrtCudnnConvAlgoSearchDefault;                               // cudnn algo search enum.
-  size_t gpu_mem_limit = 0;                                                                                    // BFC Arena memory limit for CUDA.
+  int do_copy_in_default_stream = 1;                                                                           // flag specifying if the default stream is to be used for copying.
+  OrtCudnnConvAlgoSearch cudnn_conv_algo_search = OrtCudnnConvAlgoSearchExhaustive;                            // cudnn algo search enum.
+  size_t gpu_mem_limit = std::numeric_limits<size_t>::max();                                                   // BFC Arena memory limit for CUDA.
                                                                                                                // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
   onnxruntime::ArenaExtendStrategy arena_extend_strategy = onnxruntime::ArenaExtendStrategy::kNextPowerOfTwo;  // BFC Arena extension strategy.
                                                                                                                // (will be overridden by contents of `default_memory_arena_cfg` is it exists)
   OrtArenaCfg* default_memory_arena_cfg = nullptr;                                                             // BFC Arena config flags.
-  int cudnn_conv_use_max_workspace = 0;                                                                        // flag specifying if maximum workspace can be used in cudnn conv algo search.
+  int cudnn_conv_use_max_workspace = 1;                                                                        // flag specifying if maximum workspace can be used in cudnn conv algo search.
   int enable_cuda_graph = 0;                                                                                   // flag specifying if the CUDA graph is to be captured for the model.
   int cudnn_conv1d_pad_to_nc1d = 0;                                                                            // flag specifying if pad Conv1D's input [N,C,D] to [N,C,1,D] or [N,C,D,1].
   int tunable_op_enable = 0;                                                                                   // flag specifying if TunableOp is enabled.

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1770,18 +1770,6 @@ ORT_API_STATUS_IMPL(OrtApis::CreateCUDAProviderOptions, _Outptr_ OrtCUDAProvider
   API_IMPL_BEGIN
 #ifdef USE_CUDA
   auto options = std::make_unique<OrtCUDAProviderOptionsV2>();
-  options->device_id = 0;
-  options->cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::OrtCudnnConvAlgoSearchExhaustive;
-  options->gpu_mem_limit = std::numeric_limits<size_t>::max();
-  options->arena_extend_strategy = static_cast<onnxruntime::ArenaExtendStrategy>(0);
-  options->do_copy_in_default_stream = 1;
-  options->has_user_compute_stream = 0;
-  options->user_compute_stream = nullptr;
-  options->default_memory_arena_cfg = nullptr;
-  options->cudnn_conv_use_max_workspace = 1;
-  options->enable_cuda_graph = 0;
-  options->cudnn_conv1d_pad_to_nc1d = 0;
-  options->enable_skip_layer_norm_strict_mode = 0;
   *out = options.release();
   return nullptr;
 #else


### PR DESCRIPTION
### Description
The file include/onnxruntime/core/providers/cuda/cuda_provider_options.h is a C++ file. It is not for C. 

Though OrtCUDAProviderOptionsV2 is defined as a struct. It is a normal C++ class. You can use any C++ grammar there.
C++ class normally use constructors to initialize its member variables. 
C normally use memset or specialized functions(e.g. having a function named InitOrtCUDAProviderOptionsV2)

Whatever, you should provide an initialization function at where you define the data structure, so that whatever people add new members to the data structure they would know they also should update the init function.

### Motivation and Context
Some of the members were definitely not initialized in some cases. 
