### PR TITLE
Objective-C binding for ORT training 

### DIFF
--- a/cmake/onnxruntime_objectivec.cmake
+++ b/cmake/onnxruntime_objectivec.cmake
@@ -40,6 +40,16 @@ file(GLOB onnxruntime_objc_srcs CONFIGURE_DEPENDS
     "${OBJC_ROOT}/*.m"
     "${OBJC_ROOT}/*.mm")
 
+if(NOT onnxruntime_ENABLE_TRAINING_APIS)
+    list(REMOVE_ITEM onnxruntime_objc_headers
+        "${OBJC_ROOT}/include/ort_checkpoint.h")
+
+    list(REMOVE_ITEM onnxruntime_objc_srcs
+        "${OBJC_ROOT}/ort_checkpoint_internal.h"
+        "${OBJC_ROOT}/ort_checkpoint.mm")
+endif()
+
+
 source_group(TREE "${OBJC_ROOT}" FILES
     ${onnxruntime_objc_headers}
     ${onnxruntime_objc_srcs})
@@ -111,6 +121,12 @@ if(onnxruntime_BUILD_UNIT_TESTS)
         "${OBJC_ROOT}/test/*.h"
         "${OBJC_ROOT}/test/*.m"
         "${OBJC_ROOT}/test/*.mm")
+
+    if(NOT onnxruntime_ENABLE_TRAINING_APIS)
+        list(REMOVE_ITEM onnxruntime_objc_test_srcs
+            "${OBJC_ROOT}/test/ort_checkpoint_test.mm")
+
+    endif()
 
     source_group(TREE "${OBJC_ROOT}" FILES ${onnxruntime_objc_test_srcs})
 

--- a/cmake/onnxruntime_objectivec.cmake
+++ b/cmake/onnxruntime_objectivec.cmake
@@ -61,6 +61,13 @@ if(onnxruntime_USE_COREML)
             "${ONNXRUNTIME_INCLUDE_DIR}/core/providers/coreml")
 endif()
 
+if (onnxruntime_ENABLE_TRAINING_APIS)
+    target_include_directories(onnxruntime_objc
+        PRIVATE
+            "${ORTTRAINING_SOURCE_DIR}/training_api/include/")
+
+endif()
+
 find_library(FOUNDATION_LIB Foundation REQUIRED)
 
 target_link_libraries(onnxruntime_objc
@@ -124,6 +131,7 @@ if(onnxruntime_BUILD_UNIT_TESTS)
     add_custom_command(TARGET onnxruntime_objc_test POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             "${OBJC_ROOT}/test/testdata"
+            "${ONNXRUNTIME_ROOT}/test/testdata/training_api"
             "$<TARGET_BUNDLE_CONTENT_DIR:onnxruntime_objc_test>/Resources")
 
     xctest_add_test(XCTest.onnxruntime_objc_test onnxruntime_objc_test)

--- a/objectivec/cxx_api.h
+++ b/objectivec/cxx_api.h
@@ -11,24 +11,26 @@
 #endif  // defined(__clang__)
 
 // paths are different when building the Swift Package Manager package as the headers come from the iOS pod archive
+// clang-format off
 #define STRINGIFY(x) #x
 #ifdef SPM_BUILD
-#define HEADER_FILE_PATH(x) STRINGIFY(onnxruntime / x)
+#define ORT_C_CXX_HEADER_FILE_PATH(x) STRINGIFY(onnxruntime/x)
 #else
-#define HEADER_FILE_PATH(x) STRINGIFY(x)
+#define ORT_C_CXX_HEADER_FILE_PATH(x) STRINGIFY(x)
 #endif
+// clang-format on
 
 #ifndef ENABLE_TRAINING_APIS
-#include HEADER_FILE_PATH(onnxruntime_c_api.h)
-#include HEADER_FILE_PATH(onnxruntime_cxx_api.h)
+#include ORT_C_CXX_HEADER_FILE_PATH(onnxruntime_c_api.h)
+#include ORT_C_CXX_HEADER_FILE_PATH(onnxruntime_cxx_api.h)
 #else
-#include HEADER_FILE_PATH(onnxruntime_training_c_api.h)
-#include HEADER_FILE_PATH(onnxruntime_training_cxx_api.h)
+#include ORT_C_CXX_HEADER_FILE_PATH(onnxruntime_training_c_api.h)
+#include ORT_C_CXX_HEADER_FILE_PATH(onnxruntime_training_cxx_api.h)
 #endif
 
-#if __has_include(HEADER_FILE_PATH(coreml_provider_factory.h))
+#if __has_include(ORT_C_CXX_HEADER_FILE_PATH(coreml_provider_factory.h))
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 1
-#include HEADER_FILE_PATH(coreml_provider_factory.h)
+#include ORT_C_CXX_HEADER_FILE_PATH(coreml_provider_factory.h)
 #else
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 0
 #endif

--- a/objectivec/cxx_api.h
+++ b/objectivec/cxx_api.h
@@ -12,41 +12,26 @@
 
 // paths are different when building the Swift Package Manager package as the headers come from the iOS pod archive
 #ifdef SPM_BUILD
-
-#ifndef ENABLE_TRAINING_APIS
-#include "onnxruntime/onnxruntime_c_api.h"
-#include "onnxruntime/onnxruntime_cxx_api.h"
+#define HEADER_DIR "onnxruntime/"
 #else
-#include "onnxruntime/onnxruntime_training_c_api.h"
-#include "onnxruntime/onnxruntime_training_cxx_api.h"
+#define HEADER_DIR ""
 #endif
 
-#if __has_include("onnxruntime/coreml_provider_factory.h")
+#ifndef ENABLE_TRAINING_APIS
+#include HEADER_DIR "onnxruntime_c_api.h"
+#include HEADER_DIR "onnxruntime_cxx_api.h"
+#else
+#include HEADER_DIR "onnxruntime_training_c_api.h"
+#include HEADER_DIR "onnxruntime_training_cxx_api.h"
+#endif
+
+#if __has_include(HEADER_DIR "coreml_provider_factory.h")
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 1
-#include "onnxruntime/coreml_provider_factory.h"
+#include HEADER_DIR "coreml_provider_factory.h"
 #else
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 0
 #endif
 
-#else
-
-#ifndef ENABLE_TRAINING_APIS
-#include "onnxruntime_c_api.h"
-#include "onnxruntime_cxx_api.h"
-#else
-#include "onnxruntime_training_c_api.h"
-#include "onnxruntime_training_cxx_api.h"
-#endif
-
-#if __has_include("coreml_provider_factory.h")
-#define ORT_OBJC_API_COREML_EP_AVAILABLE 1
-#include "coreml_provider_factory.h"
-#else
-#define ORT_OBJC_API_COREML_EP_AVAILABLE 0
-
-#endif
-
-#endif
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/objectivec/cxx_api.h
+++ b/objectivec/cxx_api.h
@@ -11,27 +11,27 @@
 #endif  // defined(__clang__)
 
 // paths are different when building the Swift Package Manager package as the headers come from the iOS pod archive
+#define STRINGIFY(x) #x
 #ifdef SPM_BUILD
-#define HEADER_DIR "onnxruntime/"
+#define HEADER_FILE_PATH(x) STRINGIFY(onnxruntime / x)
 #else
-#define HEADER_DIR ""
+#define HEADER_FILE_PATH(x) STRINGIFY(x)
 #endif
 
 #ifndef ENABLE_TRAINING_APIS
-#include HEADER_DIR "onnxruntime_c_api.h"
-#include HEADER_DIR "onnxruntime_cxx_api.h"
+#include HEADER_FILE_PATH(onnxruntime_c_api.h)
+#include HEADER_FILE_PATH(onnxruntime_cxx_api.h)
 #else
-#include HEADER_DIR "onnxruntime_training_c_api.h"
-#include HEADER_DIR "onnxruntime_training_cxx_api.h"
+#include HEADER_FILE_PATH(onnxruntime_training_c_api.h)
+#include HEADER_FILE_PATH(onnxruntime_training_cxx_api.h)
 #endif
 
-#if __has_include(HEADER_DIR "coreml_provider_factory.h")
+#if __has_include(HEADER_FILE_PATH(coreml_provider_factory.h))
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 1
-#include HEADER_DIR "coreml_provider_factory.h"
+#include HEADER_FILE_PATH(coreml_provider_factory.h)
 #else
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 0
 #endif
-
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/objectivec/cxx_api.h
+++ b/objectivec/cxx_api.h
@@ -12,8 +12,14 @@
 
 // paths are different when building the Swift Package Manager package as the headers come from the iOS pod archive
 #ifdef SPM_BUILD
+
+#ifndef ENABLE_TRAINING_APIS
 #include "onnxruntime/onnxruntime_c_api.h"
 #include "onnxruntime/onnxruntime_cxx_api.h"
+#else
+#include "onnxruntime/onnxruntime_training_c_api.h"
+#include "onnxruntime/onnxruntime_training_cxx_api.h"
+#endif
 
 #if __has_include("onnxruntime/coreml_provider_factory.h")
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 1
@@ -23,8 +29,14 @@
 #endif
 
 #else
+
+#ifndef ENABLE_TRAINING_APIS
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_cxx_api.h"
+#else
+#include "onnxruntime_training_c_api.h"
+#include "onnxruntime_training_cxx_api.h"
+#endif
 
 #if __has_include("coreml_provider_factory.h")
 #define ORT_OBJC_API_COREML_EP_AVAILABLE 1

--- a/objectivec/error_utils.h
+++ b/objectivec/error_utils.h
@@ -10,6 +10,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 void ORTSaveCodeAndDescriptionToError(int code, const char* description, NSError** error);
+void ORTSaveCodeAndDescriptionToError(int code, NSString* description, NSError** error);
 void ORTSaveOrtExceptionToError(const Ort::Exception& e, NSError** error);
 void ORTSaveExceptionToError(const std::exception& e, NSError** error);
 

--- a/objectivec/error_utils.mm
+++ b/objectivec/error_utils.mm
@@ -18,6 +18,14 @@ void ORTSaveCodeAndDescriptionToError(int code, const char* descriptionCstr, NSE
                            userInfo:@{NSLocalizedDescriptionKey : description}];
 }
 
+void ORTSaveCodeAndDescriptionToError(int code, NSString* description, NSError** error) {
+  if (!error) return;
+
+  *error = [NSError errorWithDomain:kOrtErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey : description}];
+}
+
 void ORTSaveOrtExceptionToError(const Ort::Exception& e, NSError** error) {
   ORTSaveCodeAndDescriptionToError(e.GetOrtErrorCode(), e.what(), error);
 }

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Optional error information set if an error occurs.
  * @return The instance, or nil if an error occurs.
  *
- * @note The construction of the checkpoint state requires ORTEnv instance to be created.
- * The intialization may fail if the ORTEnv is not properly initialized.
+ * @warning The construction of the checkpoint state requires instantiation of `ORTEnv`.
+ * The intialization will fail if the `ORTEnv` is not properly initialized.
  */
 - (nullable instancetype)initWithPath:(NSString*)path
                                 error:(NSError**)error NS_DESIGNATED_INITIALIZER;

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param path The path to the checkpoint directory.
  * @param error Optional error information set if an error occurs.
  * @return The instance, or nil if an error occurs.
+ *
+ * @note The construction of the checkpoint state requires ORTEnv instance to be created.
+ * The intialization may fail if the ORTEnv is not properly initialized.
  */
 - (nullable instancetype)initWithPath:(NSString*)path
                                 error:(NSError**)error NS_DESIGNATED_INITIALIZER;

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -25,14 +25,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- * Loads a checkpoint from directory on disk.
+ * Creates a checkpoint from directory on disk.
  *
  * @param path The path to the checkpoint directory.
  * @param error Optional error information set if an error occurs.
  * @return The instance, or nil if an error occurs.
  */
-+ (nullable instancetype)loadCheckpointFromPath:(NSString*)path
-                                          error:(NSError**)error;
+- (nullable instancetype)initWithPath:(NSString*)path
+                                error:(NSError**)error NS_DESIGNATED_INITIALIZER;
 
 /**
  * Saves a checkpoint to directory on disk.

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef ENABLE_TRAINING_APIS
 #import <Foundation/Foundation.h>
 #include <stdint.h>
 
@@ -120,3 +121,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // ENABLE_TRAINING_APIS

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Adds a int property to this checkpoint.
  *
  * @param name The name of the property.
- * @param value The value of the property.
+ * @param intValue The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Adds a float property to this checkpoint.
  *
  * @param name The name of the property.
- * @param value The value of the property.
+ * @param floatValue The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Adds a string property to this checkpoint.
  *
  * @param name The name of the property.
- * @param value The value of the property.
+ * @param stringValue The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #import <Foundation/Foundation.h>
+#include <stdint.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
  * This class holds the entire training session state that includes model parameters,
  * their gradients, optimizer parameters, and user properties. The ORTTrainingSession leverages the
  * ORTCheckpointState by accessing and updating the contained training state.
+ *
+ * Available since v1.16.0.
  *
  * @note Note that the training session created with a checkpoint state uses this state to store the entire training
  * state (including model parameters, its gradients, the optimizer states and the properties). The ORTTraingSession
@@ -34,8 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Saves a checkpoint to directory on disk.
  *
- * @param checkpoint The checkpoint to save.
  * @param path The path to the checkpoint directory.
+ * @param includeOptimizerState Flag to indicate whether to save the optimizer state or not.
  * @param error Optional error information set if an error occurs.
  * @return Whether the checkpoint was saved successfully.
  */
@@ -44,48 +47,48 @@ NS_ASSUME_NONNULL_BEGIN
                        error:(NSError**)error;
 
 /**
- * Adds a int property to this checkpoint.
+ * Adds an int property to this checkpoint.
  *
  * @param name The name of the property.
- * @param intValue The value of the property.
+ * @param value The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */
-- (BOOL)addPropertyWithName:(NSString*)name
-                   intValue:(int64_t)value
-                      error:(NSError**)error;
+- (BOOL)addIntPropertyWithName:(NSString*)name
+                         value:(int64_t)value
+                         error:(NSError**)error;
 
 /**
  * Adds a float property to this checkpoint.
  *
  * @param name The name of the property.
- * @param floatValue The value of the property.
+ * @param value The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */
-- (BOOL)addPropertyWithName:(NSString*)name
-                 floatValue:(float)value
-                      error:(NSError**)error;
+- (BOOL)addFloatPropertyWithName:(NSString*)name
+                           value:(float)value
+                           error:(NSError**)error;
 
 /**
  * Adds a string property to this checkpoint.
  *
  * @param name The name of the property.
- * @param stringValue The value of the property.
+ * @param value The value of the property.
  * @param error Optional error information set if an error occurs.
  * @return Whether the property was added successfully.
  */
 
-- (BOOL)addPropertyWithName:(NSString*)name
-                stringValue:(NSString*)value
-                      error:(NSError**)error;
+- (BOOL)addStringPropertyWithName:(NSString*)name
+                            value:(NSString*)value
+                            error:(NSError**)error;
 
 /**
- * Gets a int property from this checkpoint.
+ * Gets an int property from this checkpoint.
  *
  * @param name The name of the property.
  * @param error Optional error information set if an error occurs.
- * @return The value of the property.
+ * @return The value of the property or 0 if an error occurs.
  */
 - (int64_t)getIntPropertyWithName:(NSString*)name
                             error:(NSError**)error __attribute__((swift_error(nonnull_error)));
@@ -95,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param name The name of the property.
  * @param error Optional error information set if an error occurs.
- * @return The value of the property.
+ * @return The value of the property or 0.0f if an error occurs.
  */
 - (float)getFloatPropertyWithName:(NSString*)name
                             error:(NSError**)error __attribute__((swift_error(nonnull_error)));

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An ORT checkpoint is a snapshot of the state of a model at a given point in time.
+ *
+ * This class holds the entire training session state that includes model parameters,
+ * their gradients, optimizer parameters, and user properties. The ORTTrainingSession leverages the
+ * ORTCheckpointState by accessing and updating the contained training state.
+ *
+ * @note Note that the training session created with a checkpoint state uses this state to store the entire training
+ * state (including model parameters, its gradients, the optimizer states and the properties). The ORTTraingSession
+ * does not hold a copy of the checkpoint state. Therefore, it is required that the checkpoint state outlive the
+ * lifetime of the training session.
+ */
+@interface ORTCheckpoint : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Loads a checkpoint from directory on disk.
+ *
+ * @param path The path to the checkpoint directory.
+ * @param error Optional error information set if an error occurs.
+ * @return The instance, or nil if an error occurs.
+ */
++ (nullable instancetype)loadCheckpointFromPath:(NSString*)path
+                                          error:(NSError**)error;
+
+/**
+ * Saves a checkpoint to directory on disk.
+ *
+ * @param checkpoint The checkpoint to save.
+ * @param path The path to the checkpoint directory.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the checkpoint was saved successfully.
+ */
+- (BOOL)saveCheckpointToPath:(NSString*)path
+          withOptimizerState:(BOOL)includeOptimizerState
+                       error:(NSError**)error;
+
+/**
+ * Adds a int property to this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param value The value of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the property was added successfully.
+ */
+- (BOOL)addPropertyWithName:(NSString*)name
+                   intValue:(int64_t)value
+                      error:(NSError**)error;
+
+/**
+ * Adds a float property to this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param value The value of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the property was added successfully.
+ */
+- (BOOL)addPropertyWithName:(NSString*)name
+                 floatValue:(float)value
+                      error:(NSError**)error;
+
+/**
+ * Adds a string property to this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param value The value of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the property was added successfully.
+ */
+
+- (BOOL)addPropertyWithName:(NSString*)name
+                stringValue:(NSString*)value
+                      error:(NSError**)error;
+
+/**
+ * Gets a int property from this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return The value of the property.
+ */
+- (int64_t)getIntPropertyWithName:(NSString*)name
+                            error:(NSError**)error __attribute__((swift_error(nonnull_error)));
+
+/**
+ * Gets a float property from this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return The value of the property.
+ */
+- (float)getFloatPropertyWithName:(NSString*)name
+                            error:(NSError**)error __attribute__((swift_error(nonnull_error)));
+
+/**
+ *
+ * Gets a string property from this checkpoint.
+ *
+ * @param name The name of the property.
+ * @param error Optional error information set if an error occurs.
+ * @return The value of the property.
+ */
+- (nullable NSString*)getStringPropertyWithName:(NSString*)name
+                                          error:(NSError**)error __attribute__((swift_error(nonnull_error)));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -73,48 +73,37 @@ NS_ASSUME_NONNULL_BEGIN
   Ort::Property value;
   try {
     value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    if (std::string* str = std::get_if<std::string>(&value)) {
+      return [NSString stringWithUTF8String:str->c_str()];
+    }
+    ORT_CXX_API_THROW("Property is not a string.", ORT_INVALID_ARGUMENT);
+
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
-
-  if (std::holds_alternative<std::string>(value)) {
-    return [NSString stringWithUTF8String:std::get<std::string>(value).c_str()];
-  } else {
-    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a string.", name];
-    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
-    return nil;
-  }
 }
 
 - (int64_t)getIntPropertyWithName:(NSString*)name error:(NSError**)error {
   Ort::Property value;
   try {
     value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    if (int64_t* i = std::get_if<int64_t>(&value)) {
+      return *i;
+    }
+    ORT_CXX_API_THROW("Property is not an integer.", ORT_INVALID_ARGUMENT);
   }
   ORT_OBJC_API_IMPL_CATCH(error, 0)
-
-  if (std::holds_alternative<int64_t>(value)) {
-    return std::get<int64_t>(value);
-  } else {
-    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not an integer.", name];
-    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
-    return 0;
-  }
 }
 
 - (float)getFloatPropertyWithName:(NSString*)name error:(NSError**)error {
   Ort::Property value;
   try {
     value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    if (float* f = std::get_if<float>(&value)) {
+      return *f;
+    }
+    ORT_CXX_API_THROW("Property is not a float.", ORT_INVALID_ARGUMENT);
   }
   ORT_OBJC_API_IMPL_CATCH(error, 0.0f)
-
-  if (std::holds_alternative<float>(value)) {
-    return std::get<float>(value);
-  } else {
-    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a float.", name];
-    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
-    return 0.0f;
-  }
 }
 
 - (Ort::CheckpointState&)CXXAPIOrtCheckpoint {

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -70,9 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable NSString*)getStringPropertyWithName:(NSString*)name error:(NSError**)error {
-  Ort::Property value;
   try {
-    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    Ort::Property value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
     if (std::string* str = std::get_if<std::string>(&value)) {
       return [NSString stringWithUTF8String:str->c_str()];
     }
@@ -82,9 +81,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (int64_t)getIntPropertyWithName:(NSString*)name error:(NSError**)error {
-  Ort::Property value;
   try {
-    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    Ort::Property value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
     if (int64_t* i = std::get_if<int64_t>(&value)) {
       return *i;
     }
@@ -94,9 +92,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (float)getFloatPropertyWithName:(NSString*)name error:(NSError**)error {
-  Ort::Property value;
   try {
-    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+    Ort::Property value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
     if (float* f = std::get_if<float>(&value)) {
       return *f;
     }

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -16,8 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
   std::optional<Ort::CheckpointState> _checkpoint;
 }
 
-- (nullable instancetype)initWithCXXAPIOrtCheckPointFromPath:(NSString*)path
-                                                       error:(NSError**)error {
+- (nullable instancetype)initWithPath:(NSString*)path
+                                error:(NSError**)error {
   if ((self = [super init]) == nil) {
     return nil;
   }
@@ -27,12 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
-}
-
-+ (nullable instancetype)loadCheckpointFromPath:(NSString*)path
-                                          error:(NSError**)error {
-  return [[ORTCheckpoint alloc] initWithCXXAPIOrtCheckPointFromPath:path
-                                                              error:error];
 }
 
 - (BOOL)saveCheckpointToPath:(NSString*)path
@@ -119,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
   } else {
     NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a float.", name];
     ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
-    return 0.0;
+    return 0.0f;
   }
 }
 

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -77,7 +77,6 @@ NS_ASSUME_NONNULL_BEGIN
       return [NSString stringWithUTF8String:str->c_str()];
     }
     ORT_CXX_API_THROW("Property is not a string.", ORT_INVALID_ARGUMENT);
-
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
 }

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef ENABLE_TRAINING_APIS
 #import "ort_checkpoint_internal.h"
 
 #include <optional>
@@ -109,3 +110,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif  // ENABLE_TRAINING_APIS

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -45,9 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
 }
 
-- (BOOL)addPropertyWithName:(NSString*)name
-                   intValue:(int64_t)value
-                      error:(NSError**)error {
+- (BOOL)addIntPropertyWithName:(NSString*)name
+                         value:(int64_t)value
+                         error:(NSError**)error {
   try {
     [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value);
     return YES;
@@ -55,9 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
 }
 
-- (BOOL)addPropertyWithName:(NSString*)name
-                 floatValue:(float)value
-                      error:(NSError**)error {
+- (BOOL)addFloatPropertyWithName:(NSString*)name
+                           value:(float)value
+                           error:(NSError**)error {
   try {
     [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value);
     return YES;
@@ -65,9 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
 }
 
-- (BOOL)addPropertyWithName:(NSString*)name
-                stringValue:(NSString*)value
-                      error:(NSError**)error {
+- (BOOL)addStringPropertyWithName:(NSString*)name
+                            value:(NSString*)value
+                            error:(NSError**)error {
   try {
     [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value.UTF8String);
     return YES;
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [NSString stringWithUTF8String:std::get<std::string>(value).c_str()];
   } else {
     NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a string.", name];
-    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
     return nil;
   }
 }
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
     return std::get<int64_t>(value);
   } else {
     NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not an integer.", name];
-    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
     return 0;
   }
 }
@@ -112,13 +112,13 @@ NS_ASSUME_NONNULL_BEGIN
   try {
     value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
   }
-  ORT_OBJC_API_IMPL_CATCH(error, 0.0)
+  ORT_OBJC_API_IMPL_CATCH(error, 0.0f)
 
   if (std::holds_alternative<float>(value)) {
     return std::get<float>(value);
   } else {
     NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a float.", name];
-    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    ORTSaveCodeAndDescriptionToError(ORT_INVALID_ARGUMENT, errorMessage, error);
     return 0.0;
   }
 }
@@ -130,4 +130,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-// ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode --enable_training --build_objc  --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64

--- a/objectivec/ort_checkpoint.mm
+++ b/objectivec/ort_checkpoint.mm
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import "ort_checkpoint_internal.h"
+
+#include <optional>
+#include <string>
+#include <variant>
+#import "cxx_api.h"
+
+#import "error_utils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation ORTCheckpoint {
+  std::optional<Ort::CheckpointState> _checkpoint;
+}
+
+- (nullable instancetype)initWithCXXAPIOrtCheckPointFromPath:(NSString*)path
+                                                       error:(NSError**)error {
+  if ((self = [super init]) == nil) {
+    return nil;
+  }
+
+  try {
+    _checkpoint = Ort::CheckpointState::LoadCheckpoint(path.UTF8String);
+    return self;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
+}
+
++ (nullable instancetype)loadCheckpointFromPath:(NSString*)path
+                                          error:(NSError**)error {
+  return [[ORTCheckpoint alloc] initWithCXXAPIOrtCheckPointFromPath:path
+                                                              error:error];
+}
+
+- (BOOL)saveCheckpointToPath:(NSString*)path
+          withOptimizerState:(BOOL)includeOptimizerState
+                       error:(NSError**)error {
+  try {
+    Ort::CheckpointState::SaveCheckpoint([self CXXAPIOrtCheckpoint], path.UTF8String, includeOptimizerState);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)addPropertyWithName:(NSString*)name
+                   intValue:(int64_t)value
+                      error:(NSError**)error {
+  try {
+    [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)addPropertyWithName:(NSString*)name
+                 floatValue:(float)value
+                      error:(NSError**)error {
+  try {
+    [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)addPropertyWithName:(NSString*)name
+                stringValue:(NSString*)value
+                      error:(NSError**)error {
+  try {
+    [self CXXAPIOrtCheckpoint].AddProperty(name.UTF8String, value.UTF8String);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (nullable NSString*)getStringPropertyWithName:(NSString*)name error:(NSError**)error {
+  Ort::Property value;
+  try {
+    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
+
+  if (std::holds_alternative<std::string>(value)) {
+    return [NSString stringWithUTF8String:std::get<std::string>(value).c_str()];
+  } else {
+    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a string.", name];
+    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    return nil;
+  }
+}
+
+- (int64_t)getIntPropertyWithName:(NSString*)name error:(NSError**)error {
+  Ort::Property value;
+  try {
+    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+  }
+  ORT_OBJC_API_IMPL_CATCH(error, 0)
+
+  if (std::holds_alternative<int64_t>(value)) {
+    return std::get<int64_t>(value);
+  } else {
+    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not an integer.", name];
+    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    return 0;
+  }
+}
+
+- (float)getFloatPropertyWithName:(NSString*)name error:(NSError**)error {
+  Ort::Property value;
+  try {
+    value = [self CXXAPIOrtCheckpoint].GetProperty(name.UTF8String);
+  }
+  ORT_OBJC_API_IMPL_CATCH(error, 0.0)
+
+  if (std::holds_alternative<float>(value)) {
+    return std::get<float>(value);
+  } else {
+    NSString* errorMessage = [NSString stringWithFormat:@"Property '%@' is not a float.", name];
+    ORTSaveCodeAndDescriptionToError(1, errorMessage, error);
+    return 0.0;
+  }
+}
+
+- (Ort::CheckpointState&)CXXAPIOrtCheckpoint {
+  return *_checkpoint;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+// ./build.sh --config RelWithDebInfo --build_shared_lib --parallel --use_xcode --enable_training --build_objc  --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64

--- a/objectivec/ort_checkpoint_internal.h
+++ b/objectivec/ort_checkpoint_internal.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef ENABLE_TRAINING_APIS
 #import "ort_checkpoint.h"
 
 #import "cxx_api.h"
@@ -14,3 +15,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif  // ENABLE_TRAINING_APIS

--- a/objectivec/ort_checkpoint_internal.h
+++ b/objectivec/ort_checkpoint_internal.h
@@ -11,9 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (Ort::CheckpointState&)CXXAPIOrtCheckpoint;
 
-- (nullable instancetype)initWithCXXAPIOrtCheckPointFromPath:(NSString*)path
-                                                       error:(NSError**)error NS_DESIGNATED_INITIALIZER;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/objectivec/ort_checkpoint_internal.h
+++ b/objectivec/ort_checkpoint_internal.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import "ort_checkpoint.h"
+
+#import "cxx_api.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORTCheckpoint ()
+
+- (Ort::CheckpointState&)CXXAPIOrtCheckpoint;
+
+- (nullable instancetype)initWithCXXAPIOrtCheckPointFromPath:(NSString*)path
+                                                       error:(NSError**)error NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/test/ort_checkpoint_test.mm
+++ b/objectivec/test/ort_checkpoint_test.mm
@@ -34,14 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadCheckpoint {
   NSError* error = nil;
-  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTCheckpoint* checkpoint = [[ORTCheckpoint alloc] initWithPath:[self getCheckpointPath] error:&error];
   ORTAssertNullableResultSuccessful(checkpoint, error);
 }
 
 - (void)testIntProperty {
   NSError* error = nil;
   // Load checkpoint
-  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTCheckpoint* checkpoint = [[ORTCheckpoint alloc] initWithPath:[self getCheckpointPath] error:&error];
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testFloatProperty {
   NSError* error = nil;
   // Load checkpoint
-  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTCheckpoint* checkpoint = [[ORTCheckpoint alloc] initWithPath:[self getCheckpointPath] error:&error];
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testStringProperty {
   NSError* error = nil;
   // Load checkpoint
-  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTCheckpoint* checkpoint = [[ORTCheckpoint alloc] initWithPath:[self getCheckpointPath] error:&error];
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property

--- a/objectivec/test/ort_checkpoint_test.mm
+++ b/objectivec/test/ort_checkpoint_test.mm
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifdef ENABLE_TRAINING_APIS
 #import <XCTest/XCTest.h>
 
 #import "ort_checkpoint.h"
@@ -92,3 +93,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // ENABLE_TRAINING_APIS

--- a/objectivec/test/ort_checkpoint_test.mm
+++ b/objectivec/test/ort_checkpoint_test.mm
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #import <XCTest/XCTest.h>
 
 #import "ort_checkpoint.h"
@@ -29,38 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
   return path;
 }
 
-- (NSString*)createTempDirectory {
-  NSString* temporaryDirectory = NSTemporaryDirectory();
-  NSString* directoryPath = [temporaryDirectory stringByAppendingPathComponent:@"ort-objective-c-training-test"];
-
-  NSError* error = nil;
-  [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:&error];
-
-  if (error) {
-    NSLog(@"Error creating temporary directory: %@", error.localizedDescription);
-    return nil;
-  }
-
-  return directoryPath;
-}
-
-- (void)deleteTempDirectory:(NSString*)directoryPath {
-  NSError* error = nil;
-  NSFileManager* fileManager = [NSFileManager defaultManager];
-
-  // Check if the directory exists
-  BOOL directoryExists = [fileManager fileExistsAtPath:directoryPath];
-
-  if (directoryExists) {
-    // Remove the directory and its contents
-    BOOL success = [fileManager removeItemAtPath:directoryPath error:&error];
-
-    if (!success) {
-      NSLog(@"Error deleting temporary directory: %@", error.localizedDescription);
-    }
-  }
-}
-
 - (void)testLoadCheckpoint {
   NSError* error = nil;
   ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
@@ -74,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property
-  BOOL result = [checkpoint addPropertyWithName:@"test" intValue:314 error:&error];
+  BOOL result = [checkpoint addIntPropertyWithName:@"test" value:314 error:&error];
   ORTAssertBoolResultSuccessful(result, error);
 
   // Get property
@@ -89,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property
-  BOOL result = [checkpoint addPropertyWithName:@"test" floatValue:3.14f error:&error];
+  BOOL result = [checkpoint addFloatPropertyWithName:@"test" value:3.14f error:&error];
   ORTAssertBoolResultSuccessful(result, error);
 
   // Get property
@@ -104,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
   ORTAssertNullableResultSuccessful(checkpoint, error);
 
   // Add property
-  BOOL result = [checkpoint addPropertyWithName:@"test" stringValue:@"hello" error:&error];
+  BOOL result = [checkpoint addStringPropertyWithName:@"test" value:@"hello" error:&error];
   ORTAssertBoolResultSuccessful(result, error);
 
   // Get property

--- a/objectivec/test/ort_checkpoint_test.mm
+++ b/objectivec/test/ort_checkpoint_test.mm
@@ -112,16 +112,6 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqualObjects(value, @"hello");
 }
 
-//- (void)testSaveCheckPoint {
-////  NSError* error = nil;
-////  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
-////  XCTAssertNotNil(checkpoint);
-////  NSString* path = [self createTempDirectory];
-////  BOOL result = [checkpoint saveCheckpointToPath:path withOptimizerState:NO error:&error];
-////  [self deleteTempDirectory:path];
-////  ORTAssertBoolResultSuccessful(result, error);
-//}
-
 - (void)tearDown {
   _ortEnv = nil;
 

--- a/objectivec/test/ort_checkpoint_test.mm
+++ b/objectivec/test/ort_checkpoint_test.mm
@@ -1,0 +1,133 @@
+#import <XCTest/XCTest.h>
+
+#import "ort_checkpoint.h"
+#import "ort_env.h"
+#import "test/assertion_utils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORTCheckpointTest : XCTestCase
+@property(readonly, nullable) ORTEnv* ortEnv;
+@end
+
+@implementation ORTCheckpointTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.continueAfterFailure = NO;
+
+  NSError* err = nil;
+  _ortEnv = [[ORTEnv alloc] initWithLoggingLevel:ORTLoggingLevelWarning
+                                           error:&err];
+  ORTAssertNullableResultSuccessful(_ortEnv, err);
+}
+
+- (NSString*)getCheckpointPath {
+  NSBundle* bundle = [NSBundle bundleForClass:[ORTCheckpointTest class]];
+  NSString* path = [[bundle resourcePath] stringByAppendingPathComponent:@"checkpoint.ckpt"];
+  return path;
+}
+
+- (NSString*)createTempDirectory {
+  NSString* temporaryDirectory = NSTemporaryDirectory();
+  NSString* directoryPath = [temporaryDirectory stringByAppendingPathComponent:@"ort-objective-c-training-test"];
+
+  NSError* error = nil;
+  [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:&error];
+
+  if (error) {
+    NSLog(@"Error creating temporary directory: %@", error.localizedDescription);
+    return nil;
+  }
+
+  return directoryPath;
+}
+
+- (void)deleteTempDirectory:(NSString*)directoryPath {
+  NSError* error = nil;
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+
+  // Check if the directory exists
+  BOOL directoryExists = [fileManager fileExistsAtPath:directoryPath];
+
+  if (directoryExists) {
+    // Remove the directory and its contents
+    BOOL success = [fileManager removeItemAtPath:directoryPath error:&error];
+
+    if (!success) {
+      NSLog(@"Error deleting temporary directory: %@", error.localizedDescription);
+    }
+  }
+}
+
+- (void)testLoadCheckpoint {
+  NSError* error = nil;
+  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTAssertNullableResultSuccessful(checkpoint, error);
+}
+
+- (void)testIntProperty {
+  NSError* error = nil;
+  // Load checkpoint
+  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTAssertNullableResultSuccessful(checkpoint, error);
+
+  // Add property
+  BOOL result = [checkpoint addPropertyWithName:@"test" intValue:314 error:&error];
+  ORTAssertBoolResultSuccessful(result, error);
+
+  // Get property
+  int64_t value = [checkpoint getIntPropertyWithName:@"test" error:&error];
+  XCTAssertEqual(value, 314);
+}
+
+- (void)testFloatProperty {
+  NSError* error = nil;
+  // Load checkpoint
+  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTAssertNullableResultSuccessful(checkpoint, error);
+
+  // Add property
+  BOOL result = [checkpoint addPropertyWithName:@"test" floatValue:3.14f error:&error];
+  ORTAssertBoolResultSuccessful(result, error);
+
+  // Get property
+  float value = [checkpoint getFloatPropertyWithName:@"test" error:&error];
+  XCTAssertEqual(value, 3.14f);
+}
+
+- (void)testStringProperty {
+  NSError* error = nil;
+  // Load checkpoint
+  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+  ORTAssertNullableResultSuccessful(checkpoint, error);
+
+  // Add property
+  BOOL result = [checkpoint addPropertyWithName:@"test" stringValue:@"hello" error:&error];
+  ORTAssertBoolResultSuccessful(result, error);
+
+  // Get property
+  NSString* value = [checkpoint getStringPropertyWithName:@"test" error:&error];
+  XCTAssertEqualObjects(value, @"hello");
+}
+
+//- (void)testSaveCheckPoint {
+////  NSError* error = nil;
+////  ORTCheckpoint* checkpoint = [ORTCheckpoint loadCheckpointFromPath:[self getCheckpointPath] error:&error];
+////  XCTAssertNotNil(checkpoint);
+////  NSString* path = [self createTempDirectory];
+////  BOOL result = [checkpoint saveCheckpointToPath:path withOptimizerState:NO error:&error];
+////  [self deleteTempDirectory:path];
+////  ORTAssertBoolResultSuccessful(result, error);
+//}
+
+- (void)tearDown {
+  _ortEnv = nil;
+
+  [super tearDown];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-mac-ci-pipeline.yml
@@ -3,5 +3,5 @@ stages:
   parameters:
     AllowReleasedOpsetOnly: 0
     BuildForAllArchs: false
-    AdditionalBuildFlags: --enable_training
+    AdditionalBuildFlags: --enable_training --build_objc
     WithCache: true


### PR DESCRIPTION
### Description
Implement Objective-C binding for `ORTCheckPoint`. Additionally, 
- Modify `onnxruntime_objectivec.cmake` to only include training header and sources when training flag is enabled
- Enable objective-c binding for `orttraining-mac-ci-pipeline`

### Motivation and Context
This PR is part of implementing Objective-C bindings for training API. It implements objective-c binding for ORTCheckPoint class. The objective-C API closely resembles the C++ API. 

**Note**: The test for saving checkpoint is skipped as it requires use of training session. It will be added when the objective-c binding for `ORTTrainingSession` is added.