### PR TITLE
Fix a misaligned error in CUDA GEMM

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul_helper.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_helper.h
@@ -373,7 +373,7 @@ class MatMulComputeHelper {
 
   static bool IsAligned(const std::vector<size_t>& offsets) {
     constexpr size_t alignment = 16;
-    auto len = offsets.size();
+    const auto len = offsets.size();
     for (size_t i = 0; i < len; i++) {
       if ((offsets[i] % alignment) != 0) {
         return false;
@@ -388,7 +388,7 @@ class MatMulComputeHelper {
 
   template <typename T>
   static void OffsetToArrays(T* p, const std::vector<size_t>& offsets, gsl::span<T*> arrays) {
-    auto len = offsets.size();
+    const auto len = offsets.size();
     ORT_ENFORCE(arrays.size() == len);
     for (size_t i = 0; i < len; i++) {
       arrays[i] = p + offsets[i];
@@ -397,7 +397,7 @@ class MatMulComputeHelper {
 
   template <typename T>
   static void OffsetToArrays(const T* p, const std::vector<size_t>& offsets, gsl::span<const T*> arrays) {
-    auto len = offsets.size();
+    const auto len = offsets.size();
     ORT_ENFORCE(arrays.size() == len);
     for (size_t i = 0; i < len; i++) {
       arrays[i] = p + offsets[i];

--- a/onnxruntime/core/providers/cpu/math/matmul_helper.h
+++ b/onnxruntime/core/providers/cpu/math/matmul_helper.h
@@ -371,6 +371,21 @@ class MatMulComputeHelper {
     return right_zp_offsets_;
   }
 
+  static bool IsAligned(const std::vector<size_t>& offsets) {
+    constexpr size_t alignment = 16;
+    auto len = offsets.size();
+    for (size_t i = 0; i < len; i++) {
+      if ((offsets[i] % alignment) != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool IsBatchedGemmAligned() const {
+    return IsAligned(left_offsets_) && IsAligned(right_offsets_) && IsAligned(output_offsets_);
+  }
+
   template <typename T>
   static void OffsetToArrays(T* p, const std::vector<size_t>& offsets, gsl::span<T*> arrays) {
     auto len = offsets.size();

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -180,10 +180,13 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu(ctx->GetComputeStream()));
   ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu(ctx->GetComputeStream()));
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
-  cublasMath_t mode = (device_prop.major >= 8 && helper.IsBatchedGemmAligned()) ? CUBLAS_TF32_TENSOR_OP_MATH : CUBLAS_DEFAULT_MATH;
+  // TF32 provides a huge performance gain for training and inference while preserving FP32 levels of accuracy.
+  // It requires Ampere or newer GPU, and pointers of matrics shall be aligned (ideal alignment is 16-byte).
+  // Assume that start memory of input/output tensor is aligned, we only check offsets of sub-matrix per batch here.
+  cublasMath_t mode = (std::is_same<T, float>::value && device_prop.major >= 8 && helper.IsBatchedGemmAligned())
+                          ? CUBLAS_TF32_TENSOR_OP_MATH
+                          : CUBLAS_DEFAULT_MATH;
   CublasMathModeSetter math_mode_setter(device_prop, GetCublasHandle(ctx), mode);
-#endif
 
   // note that onnxruntime OrtValue is row major, while cublas is column major,
   // so swap left/right operands

--- a/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fpgeneric.h
@@ -185,13 +185,7 @@ inline cublasStatus_t cublasGemmBatchedHelper(cublasHandle_t handle,
                                               const float* beta,
                                               float* Carray[], int ldc,
                                               int batch_count,
-                                              const cudaDeviceProp& prop) {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
-  onnxruntime::cuda::CublasMathModeSetter math_mode_setter(prop, handle, CUBLAS_TF32_TENSOR_OP_MATH);
-#else
-  ORT_UNUSED_PARAMETER(prop);
-#endif
-
+                                              const cudaDeviceProp&) {
   return cublasSgemmBatched(handle,
                             transa,
                             transb,


### PR DESCRIPTION
### Description

See #15981 for error description.

The underlaying issue comes from the CublasMathModeSetter class. It uses the device's CUDA cuda compute capability's major version to determine which code path to go, and our team's build service only have T4 and M60 GPUs. The highest major  compute capability version we tested is 7. This is the main reason why this issue went unnoticed so long. And the code with fine with CUDA 11.6 since at the time when CUDA 11.6 was released tensor core wasn't a thing. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


