### PR TITLE
[js/rn] Implement dispose native method

### DIFF
--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -135,6 +135,9 @@ public class OnnxruntimeModuleTest {
           Assert.fail(e.getMessage());
         }
       }
+
+      // test dispose
+      ortModule.dispose(sessionKey);
     } finally {
       mockSession.finishMocking();
     }

--- a/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
+++ b/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
@@ -217,7 +217,7 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
    *
    * @param key a session key representing the session given at loadModel()
    */
-  private void dispose(String key) throws OrtException {
+  public void dispose(String key) throws OrtException {
     OrtSession ortSession = sessionMap.get(key);
     if (ortSession != null) {
       ortSession.close();

--- a/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
+++ b/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
@@ -245,6 +245,7 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
     long startTime = System.currentTimeMillis();
     Map<String, OnnxTensor> feed = new HashMap<>();
     Iterator<String> iterator = ortSession.getInputNames().iterator();
+    Result result = null;
     try {
       while (iterator.hasNext()) {
         String inputName = iterator.next();
@@ -282,7 +283,6 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
       Log.d("Duration", "createInputTensor: " + duration);
 
       startTime = System.currentTimeMillis();
-      Result result = null;
       if (requestedOutputs != null) {
         result = ortSession.run(feed, requestedOutputs, runOptions);
       } else {
@@ -300,6 +300,9 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule implements Lif
 
     } finally {
       OnnxValue.close(feed);
+      if (result != null) {
+        result.close();
+      }
     }
   }
 

--- a/js/react_native/ios/OnnxruntimeModule.h
+++ b/js/react_native/ios/OnnxruntimeModule.h
@@ -14,6 +14,8 @@
 -(NSDictionary*)loadModelFromBuffer:(NSData*)modelData
                             options:(NSDictionary*)options;
 
+-(void)dispose:(NSString*)key;
+
 -(NSDictionary*)run:(NSString*)url
               input:(NSDictionary*)input
              output:(NSArray*)output

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -102,7 +102,7 @@ RCT_EXPORT_METHOD(dispose
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   @try {
-    [self disposeImpl:key];
+    [self dispose:key];
     resolve(nil);
   } @catch (...) {
     reject(@"onnxruntime", @"failed to dispose session", nil);
@@ -220,7 +220,7 @@ RCT_EXPORT_METHOD(run
  *
  * @param key a session key returned from loadModel()
  */
-- (void)disposeImpl:(NSString *)key {
+- (void)dispose:(NSString *)key {
   NSValue *value = [sessionMap objectForKey:key];
   if (value == nil) {
     NSException *exception = [NSException exceptionWithName:@"onnxruntime"
@@ -228,6 +228,7 @@ RCT_EXPORT_METHOD(run
                                                    userInfo:nil];
     @throw exception;
   }
+  [sessionMap removeObjectForKey:key];
   SessionInfo *sessionInfo = (SessionInfo *)[value pointerValue];
   delete sessionInfo;
   sessionInfo = nullptr;
@@ -375,7 +376,7 @@ static NSDictionary *executionModeTable = @{@"sequential" : @(ORT_SEQUENTIAL), @
 - (void)dealloc {
   NSEnumerator *iterator = [sessionMap keyEnumerator];
   while (NSString *key = [iterator nextObject]) {
-    [self disposeImpl:key];
+    [self dispose:key];
   }
 }
 

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -91,6 +91,25 @@ RCT_EXPORT_METHOD(loadModelFromBase64EncodedBuffer
 }
 
 /**
+ * React native binding API to dispose a session using given key from loadModel()
+ *
+ * @param key a model path location given at loadModel()
+ * @param resolve callback for returning output back to react native js
+ * @param reject callback for returning an error back to react native js
+ */
+RCT_EXPORT_METHOD(dispose
+                  : (NSString *)key resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  @try {
+    [self disposeImpl:key];
+    resolve(nil);
+  } @catch (...) {
+    reject(@"onnxruntime", @"failed to dispose session", nil);
+  }
+}
+
+/**
  * React native binding API to run a model using given uri.
  *
  * @param url a model path location given at loadModel()
@@ -194,6 +213,24 @@ RCT_EXPORT_METHOD(run
   resultMap[@"outputNames"] = outputNames;
 
   return resultMap;
+}
+
+/**
+ * Dispose a session given a key.
+ *
+ * @param key a session key returned from loadModel()
+ */
+- (void)disposeImpl:(NSString *)key {
+  NSValue *value = [sessionMap objectForKey:key];
+  if (value == nil) {
+    NSException *exception = [NSException exceptionWithName:@"onnxruntime"
+                                                     reason:@"can't find onnxruntime session"
+                                                   userInfo:nil];
+    @throw exception;
+  }
+  SessionInfo *sessionInfo = (SessionInfo *)[value pointerValue];
+  delete sessionInfo;
+  sessionInfo = nullptr;
 }
 
 /**
@@ -338,10 +375,7 @@ static NSDictionary *executionModeTable = @{@"sequential" : @(ORT_SEQUENTIAL), @
 - (void)dealloc {
   NSEnumerator *iterator = [sessionMap keyEnumerator];
   while (NSString *key = [iterator nextObject]) {
-    NSValue *value = [sessionMap objectForKey:key];
-    SessionInfo *sessionInfo = (SessionInfo *)[value pointerValue];
-    delete sessionInfo;
-    sessionInfo = nullptr;
+    [self disposeImpl:key];
   }
 }
 

--- a/js/react_native/ios/OnnxruntimeModuleTest/OnnxruntimeModuleTest.mm
+++ b/js/react_native/ios/OnnxruntimeModuleTest/OnnxruntimeModuleTest.mm
@@ -87,6 +87,12 @@
     XCTAssertTrue([[resultMap objectForKey:@"output"] isEqualToDictionary:inputTensorMap]);
     XCTAssertTrue([[resultMap2 objectForKey:@"output"] isEqualToDictionary:inputTensorMap]);
   }
+
+  // test dispose
+  {
+    [onnxruntimeModule dispose:sessionKey];
+    [onnxruntimeModule dispose:sessionKey2];
+  }
 }
 
 @end

--- a/js/react_native/lib/backend.ts
+++ b/js/react_native/lib/backend.ts
@@ -85,7 +85,7 @@ class OnnxruntimeSessionHandler implements SessionHandler {
   }
 
   async dispose(): Promise<void> {
-    return Promise.resolve();
+    return this.#inferenceSession.dispose(this.#key);
   }
 
   startProfiling(): void {

--- a/js/react_native/lib/binding.ts
+++ b/js/react_native/lib/binding.ts
@@ -65,6 +65,7 @@ export declare namespace Binding {
   interface InferenceSession {
     loadModel(modelPath: string, options: SessionOptions): Promise<ModelLoadInfoType>;
     loadModelFromBase64EncodedBuffer?(buffer: string, options: SessionOptions): Promise<ModelLoadInfoType>;
+    dispose(key: string): Promise<void>;
     run(key: string, feeds: FeedsType, fetches: FetchesType, options: RunOptions): Promise<ReturnType>;
   }
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Implement `dispose` react native method.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Currently we are not able to release the memory used by model in JS runtime if we don't want to use it anymore, we can do that only by reload app on debug or restart app on release.
