### PR TITLE
Fix: update hyperlinks to the Jupyter notebooks

### DIFF
--- a/docs/TVM_EP.md
+++ b/docs/TVM_EP.md
@@ -286,7 +286,7 @@ It is also possible to use a precompiled model.
 
 The compiled model can be obtained using the [OctoML platform](https://onnx.octoml.ai)
 or compiled directly (see **Support precompiled model** section in
-[Sample notebook for ResNet50 inference with TVM EP](https://github.com/microsoft/onnxruntime/blob/main/docs/python/inference/notebooks/onnxruntime-tvm-tutorial.ipynb)
+[Sample notebook for ResNet50 inference with TVM EP](https://github.com/microsoft/onnxruntime/blob/main/docs/python/notebooks/onnxruntime-tvm-tutorial.ipynb)
 for more information on model compilation).
 
 In order to use the precompiled model, only need to pass two options:
@@ -302,7 +302,7 @@ You can read more about these options in section [Configuration options](#config
 
 
 ## Samples
-- [Sample notebook for ResNet50 inference with TVM EP](https://github.com/microsoft/onnxruntime/blob/main/docs/python/inference/notebooks/onnxruntime-tvm-tutorial.ipynb)
+- [Sample notebook for ResNet50 inference with TVM EP](https://github.com/microsoft/onnxruntime/blob/main/docs/python/notebooks/onnxruntime-tvm-tutorial.ipynb)
 
 ## Known issues
 - At this moment, the TVM EP has only been verified on UNIX/Linux and Windows systems.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR fixes broken hyperlinks in the documentation that should lead users to Jupyter notebooks. Currently, the hyperlinks are not working as intended. The PR resolves this issue by updating the hyperlinks to correctly direct users to the Jupyter notebooks.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->

It fixes broken hyperlinks leading to the Jupyter notebooks.


