### PR TITLE
Fix nightly ort CI pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
         --rm \
         --volume $(Build.SourcesDirectory)/orttraining/orttraining/test/python:/onnxruntime_src \
         --volume $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly:/requirements_torch_nightly \
-        ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu117-py38-torch200dev \
+        ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu117-py38-torch210dev \
          bash -c "python3 -m pip install -r /requirements_torch_nightly/requirements.txt && python3 -m pytest -sv /onnxruntime_src/orttraining_test_ortmodule_api.py"
     displayName: 'Run ORTModule Tests'
     condition: succeededOrFailed()


### PR DESCRIPTION
This PR changes [night ort CI pipeline](https://dev.azure.com/onnxruntime/onnxruntime/_build?definitionId=198) to pick up the latest night ACPT image, which was changed from torch 2.0.0.dev to torch 2.1.0.dev.