### PR TITLE
[js/web] disable node fallback in webpack

### DIFF
--- a/js/web/webpack.config.js
+++ b/js/web/webpack.config.js
@@ -49,7 +49,7 @@ function defaultTerserPluginOptions(target) {
         passes: 2
       },
       mangle: {
-        reserved: ["_scriptDir","startWorker"]
+        reserved: ["_scriptDir", "startWorker"]
       }
     }
   };
@@ -111,6 +111,7 @@ function buildConfig({ filename, format, target, mode, devtool, build_defs }) {
       }]
     },
     mode,
+    node: false,
     devtool
   };
 
@@ -268,8 +269,9 @@ function buildTestRunnerConfig({
         type: 'asset/source'
       }]
     },
-    mode: mode,
-    devtool: devtool,
+    mode,
+    node: false,
+    devtool,
   };
 
   if (mode === 'production') {


### PR DESCRIPTION
### Description
disable webpack's polyfill for node's `global`, `__filename` and `__dirname` in web build. This will confuse emscripten generated environment detection.

see https://webpack.js.org/configuration/node/