### PR TITLE
[js] allow manually release inference session

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -115,6 +115,10 @@ export class InferenceSession implements InferenceSessionInterface {
     return returnValue;
   }
 
+  async release(): Promise<void> {
+    return this.handler.dispose();
+  }
+
   static create(path: string, options?: SessionOptions): Promise<InferenceSessionInterface>;
   static create(buffer: ArrayBufferLike, options?: SessionOptions): Promise<InferenceSessionInterface>;
   static create(buffer: ArrayBufferLike, byteOffset: number, byteLength?: number, options?: SessionOptions):

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -306,6 +306,15 @@ export interface InferenceSession {
 
   // #endregion
 
+  // #region release()
+
+  /**
+   * Release the inference session and the underlying resources.
+   */
+  release(): Promise<void>;
+
+  // #endregion
+
   // #region profiling
 
   /**


### PR DESCRIPTION
### Description
This change adds a new instance function (method) to type `InferenceSession` to allow users to manually release an inference session instance.

#16131 depends on this change to work correctly.