### PR TITLE
[QNN EP] Support Equal, Less, LessOrGreater, Greater, GreaterOrEqual operators on HTP backend

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.cc
@@ -373,6 +373,19 @@ bool BatchNormalizationNodeGroupSelector::Check(const GraphViewer& graph_viewer,
   return true;
 }
 
+bool LogicalComparisonNodeGroupSelector::Check(const GraphViewer& graph_viewer,
+                                               const Node& node,
+                                               const std::vector<const Node*>& dq_nodes,
+                                               const std::vector<const Node*>& q_nodes) const {
+  if (!CheckQDQNodes(graph_viewer, node, dq_nodes, q_nodes, -1, true)) {
+    return false;
+  }
+
+  int32_t dt_input_1 = dq_nodes[0]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+  int32_t dt_input_2 = dq_nodes[1]->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
+  return dt_input_1 == dt_input_2;
+}
+
 }  // namespace QDQ
 }  // namespace onnxruntime
 

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h
@@ -160,6 +160,14 @@ class BatchNormalizationNodeGroupSelector : public NodeGroupSelector {
   bool int8_allowed_;
 };
 
+// 2 DQ nodes providing input -> node with bool output tensor.
+// Example: Equal, Less, Greater.
+class LogicalComparisonNodeGroupSelector : public NodeGroupSelector {
+  bool Check(const GraphViewer& graph_viewer, const Node& node,
+             const std::vector<const Node*>& dq_nodes,
+             const std::vector<const Node*>& q_nodes) const override;
+};
+
 /*
  * NodeSelector instances for use in the QDQ::SelectorActionTransformer.
  */

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -92,7 +92,9 @@ static const OpVersionsAndSelector::OpVersionsMap GetBatchNormalizationOpVersion
 static const OpVersionsAndSelector::OpVersionsMap GetLogicalComparisonOpVersionsMap() {
   return {{"Equal", {}},
           {"Greater", {}},
-          {"Less", {}}};
+          {"GreaterOrEqual", {}},
+          {"Less", {}},
+          {"LessOrEqual", {}}};
 }
 
 /* Selector rules registration related */

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -89,6 +89,11 @@ static const OpVersionsAndSelector::OpVersionsMap GetInstanceNormalizationOpVers
 static const OpVersionsAndSelector::OpVersionsMap GetBatchNormalizationOpVersionsMap() {
   return {{"BatchNormalization", {}}};
 }
+static const OpVersionsAndSelector::OpVersionsMap GetLogicalComparisonOpVersionsMap() {
+  return {{"Equal", {}},
+          {"Greater", {}},
+          {"Less", {}}};
+}
 
 /* Selector rules registration related */
 void RegisterMiscSelectors(Selectors& qdq_selectors) {
@@ -162,6 +167,13 @@ void RegisterBatchNormalizationSelector(Selectors& qdq_selectors) {
                                  std::move(selector));
 }
 
+void RegisterLogicalComparisonSelectors(Selectors& qdq_selectors) {
+  /* register selectors for logical comparison ops */
+  std::unique_ptr<NodeGroupSelector> selector = std::make_unique<LogicalComparisonNodeGroupSelector>();
+  qdq_selectors.RegisterSelector(GetLogicalComparisonOpVersionsMap(),
+                                 std::move(selector));
+}
+
 void SelectorManager::CreateSelectors() {
   RegisterMiscSelectors(qdq_selectors_);
   RegisterUnarySelectors(qdq_selectors_);
@@ -173,6 +185,7 @@ void SelectorManager::CreateSelectors() {
   RegisterGemmSelector(qdq_selectors_);
   RegisterInstanceNormalizationSelector(qdq_selectors_);
   RegisterBatchNormalizationSelector(qdq_selectors_);
+  RegisterLogicalComparisonSelectors(qdq_selectors_);
 }
 
 void SelectorManager::InitializeSelectorsMap() {

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.h
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.h
@@ -148,9 +148,9 @@ class ModelTestBuilder {
     ONNX_NAMESPACE::TypeProto type_proto;
     type_proto.mutable_tensor_type()->set_elem_type(utils::ToTensorProtoElementType<T>());
     if (shape != std::nullopt) {
-      type_proto.mutable_tensor_type()->mutable_shape();
+      ONNX_NAMESPACE::TensorShapeProto* shape_proto = type_proto.mutable_tensor_type()->mutable_shape();
       for (auto& d : *shape) {
-        auto dim = type_proto.mutable_tensor_type()->mutable_shape()->add_dim();
+        auto dim = shape_proto->add_dim();
         if (d != -1) {
           dim->set_dim_value(d);
         }

--- a/onnxruntime/test/optimizer/graph_transform_test_builder.h
+++ b/onnxruntime/test/optimizer/graph_transform_test_builder.h
@@ -143,6 +143,24 @@ class ModelTestBuilder {
     return &graph_.GetOrCreateNodeArg(name, nullptr);
   }
 
+  template <typename T>
+  NodeArg* MakeOutput(const std::optional<std::vector<int64_t>>& shape) {
+    ONNX_NAMESPACE::TypeProto type_proto;
+    type_proto.mutable_tensor_type()->set_elem_type(utils::ToTensorProtoElementType<T>());
+    if (shape != std::nullopt) {
+      type_proto.mutable_tensor_type()->mutable_shape();
+      for (auto& d : *shape) {
+        auto dim = type_proto.mutable_tensor_type()->mutable_shape()->add_dim();
+        if (d != -1) {
+          dim->set_dim_value(d);
+        }
+      }
+    }
+    std::string name = graph_.GenerateNodeArgName("output");
+    output_names_.push_back(name);
+    return &graph_.GetOrCreateNodeArg(name, &type_proto);
+  }
+
   NodeArg* MakeIntermediate() {
     std::string name = graph_.GenerateNodeArgName("node");
     return &graph_.GetOrCreateNodeArg(name, nullptr);

--- a/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
+++ b/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
@@ -21,7 +21,14 @@ static GetTestModelFn BuildLogicalOpTestCase(const std::string& op_type, const s
   return [op_type, shape](ModelTestBuilder& builder) {
     auto* input0 = builder.MakeInput<float>(shape, 0.0f, 20.0f);
     auto* input1 = builder.MakeInput<float>(shape, 0.0f, 20.0f);
-    auto* output = builder.MakeOutput();
+    NodeArg* output = nullptr;
+
+    // Explicitly set output type/shape for logical comparison ops implemented as functions.
+    if (op_type == "GreaterOrEqual" || op_type == "LessOrEqual") {
+      output = builder.MakeOutput<bool>(shape);
+    } else {
+      output = builder.MakeOutput();
+    }
 
     builder.AddNode(op_type, {input0, input1}, {output});
   };
@@ -36,7 +43,14 @@ static GetTestModelFn BuildQDQLogicalOpTestCase(const std::string& op_type, cons
 
     auto* input0 = builder.MakeInput<float>(shape, -1.0f, 1.0f);
     auto* input1 = builder.MakeInput<float>(shape, -1.0f, 1.0f);
-    auto* output = builder.MakeOutput();
+    NodeArg* output = nullptr;
+
+    // Explicitly set output type/shape for logical comparison ops implemented as functions.
+    if (op_type == "GreaterOrEqual" || op_type == "LessOrEqual") {
+      output = builder.MakeOutput<bool>(shape);
+    } else {
+      output = builder.MakeOutput();
+    }
 
     // input -> Q -> DQ -> Op
     auto* qdq0_output = AddQDQNodePair<InputQType>(builder, input0, qdq_scale, zero_point);
@@ -103,11 +117,7 @@ TEST_F(QnnCPUBackendTests, LogicalOpGreater4D) {
   RunCPULogicalOpTest("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
 }
 
-// TODO: Add support for GreaterOrEqual.
-// According to the ONNX spec, logical operators that are implemented as
-// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
-// We need to handle this uniquely.
-TEST_F(QnnCPUBackendTests, DISABLED_LogicalOpGreaterOrEqual4D) {
+TEST_F(QnnCPUBackendTests, LogicalOpGreaterOrEqual4D) {
   RunCPULogicalOpTest("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
 }
 
@@ -115,11 +125,7 @@ TEST_F(QnnCPUBackendTests, LogicalOpLess4D) {
   RunCPULogicalOpTest("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
 }
 
-// TODO: Add support for LessOrEqual.
-// According to the ONNX spec, logical operators that are implemented as
-// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
-// We need to handle this uniquely.
-TEST_F(QnnCPUBackendTests, DISABLED_LogicalOpLessOrEqual4D) {
+TEST_F(QnnCPUBackendTests, LogicalOpLessOrEqual4D) {
   RunCPULogicalOpTest("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
 }
 
@@ -136,11 +142,7 @@ TEST_F(QnnHTPBackendTests, LogicalOpGreater4D) {
   RunQDQLogicalOpTest<uint8_t>("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
 }
 
-// TODO: Add support for GreaterOrEqual.
-// According to the ONNX spec, logical operators that are implemented as
-// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
-// We need to handle this uniquely.
-TEST_F(QnnHTPBackendTests, DISABLED_LogicalOpGreaterOrEqual4D) {
+TEST_F(QnnHTPBackendTests, LogicalOpGreaterOrEqual4D) {
   RunQDQLogicalOpTest<uint8_t>("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
 }
 
@@ -148,11 +150,7 @@ TEST_F(QnnHTPBackendTests, LogicalOpLess4D) {
   RunQDQLogicalOpTest<uint8_t>("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
 }
 
-// TODO: Add support for LessOrEqual.
-// According to the ONNX spec, logical operators that are implemented as
-// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
-// We need to handle this uniquely.
-TEST_F(QnnHTPBackendTests, DISABLED_LogicalOpLessOrEqual4D) {
+TEST_F(QnnHTPBackendTests, LogicalOpLessOrEqual4D) {
   RunQDQLogicalOpTest<uint8_t>("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
 }
 

--- a/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
+++ b/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <unordered_map>
+
+#include "test/optimizer/qdq_test_utils.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "onnx/onnx_pb.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Creates a graph with a single logical operator (e.g., Equal). Used for testing CPU backend.
+static GetTestModelFn BuildLogicalOpTestCase(const std::string& op_type, const std::vector<int64_t>& shape) {
+  return [op_type, shape](ModelTestBuilder& builder) {
+    auto* input0 = builder.MakeInput<float>(shape, 0.0f, 20.0f);
+    auto* input1 = builder.MakeInput<float>(shape, 0.0f, 20.0f);
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode(op_type, {input0, input1}, {output});
+  };
+}
+
+// Creates a graph with a single Q/DQ logical operator. Used for testing HTP backend.
+template <typename InputQType = uint8_t>
+static GetTestModelFn BuildQDQLogicalOpTestCase(const std::string& op_type, const std::vector<int64_t>& shape) {
+  return [op_type, shape](ModelTestBuilder& builder) {
+    const InputQType zero_point = std::numeric_limits<InputQType>::max() / 2;
+    constexpr float qdq_scale = 0.0038f;
+
+    auto* input0 = builder.MakeInput<float>(shape, -1.0f, 1.0f);
+    auto* input1 = builder.MakeInput<float>(shape, -1.0f, 1.0f);
+    auto* output = builder.MakeOutput();
+
+    // input -> Q -> DQ -> Op
+    auto* qdq0_output = AddQDQNodePair<InputQType>(builder, input0, qdq_scale, zero_point);
+    auto* qdq1_output = AddQDQNodePair<InputQType>(builder, input1, qdq_scale, zero_point);
+
+    // Op -> output
+    builder.AddNode(op_type, {qdq0_output, qdq1_output}, {output});
+  };
+}
+
+// Runs a model with a logical operator on the QNN CPU backend. Checks the graph node assignment, and that inference
+// outputs for QNN EP and CPU EP match.
+static void RunCPULogicalOpTest(const std::string& op_type, const std::vector<int64_t>& shape,
+                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                int opset = 17) {
+  ProviderOptions provider_options;
+
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnCpu.dll";
+#else
+  provider_options["backend_path"] = "libQnnCpu.so";
+  fp32_abs_err = 1.5e-5f;  // On linux we need slightly larger tolerance.
+#endif
+
+  constexpr int expected_nodes_in_partition = 1;
+  RunQnnModelTest(BuildLogicalOpTestCase(op_type, shape),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  expected_nodes_in_partition,
+                  test_description);
+}
+
+// Runs a model with a logical operator on the QNN HTP backend. Checks the graph node assignment, and that inference
+// outputs for QNN EP and CPU EP match.
+template <typename QuantType>
+static void RunQDQLogicalOpTest(const std::string& op_type, const std::vector<int64_t>& shape,
+                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                int opset = 17) {
+  ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnHtp.dll";
+#else
+  provider_options["backend_path"] = "libQnnHtp.so";
+#endif
+
+  constexpr int expected_nodes_in_partition = 1;
+  RunQnnModelTest(BuildQDQLogicalOpTestCase<QuantType>(op_type, shape),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  expected_nodes_in_partition,
+                  test_description);
+}
+
+//
+// CPU tests:
+//
+
+TEST_F(QnnCPUBackendTests, LogicalOpEqual4D) {
+  RunCPULogicalOpTest("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpEqual4D");
+}
+
+TEST_F(QnnCPUBackendTests, LogicalOpGreater4D) {
+  RunCPULogicalOpTest("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
+}
+
+// TODO: Add support for GreaterOrEqual.
+// According to the ONNX spec, logical operators that are implemented as
+// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
+// We need to handle this uniquely.
+TEST_F(QnnCPUBackendTests, DISABLED_LogicalOpGreaterOrEqual4D) {
+  RunCPULogicalOpTest("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
+}
+
+TEST_F(QnnCPUBackendTests, LogicalOpLess4D) {
+  RunCPULogicalOpTest("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
+}
+
+// TODO: Add support for LessOrEqual.
+// According to the ONNX spec, logical operators that are implemented as
+// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
+// We need to handle this uniquely.
+TEST_F(QnnCPUBackendTests, DISABLED_LogicalOpLessOrEqual4D) {
+  RunCPULogicalOpTest("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+//
+// HTP tests:
+//
+
+TEST_F(QnnHTPBackendTests, LogicalOpEqual4D) {
+  RunQDQLogicalOpTest<uint8_t>("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpEqual4D");
+}
+
+TEST_F(QnnHTPBackendTests, LogicalOpGreater4D) {
+  RunQDQLogicalOpTest<uint8_t>("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
+}
+
+// TODO: Add support for GreaterOrEqual.
+// According to the ONNX spec, logical operators that are implemented as
+// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
+// We need to handle this uniquely.
+TEST_F(QnnHTPBackendTests, DISABLED_LogicalOpGreaterOrEqual4D) {
+  RunQDQLogicalOpTest<uint8_t>("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
+}
+
+TEST_F(QnnHTPBackendTests, LogicalOpLess4D) {
+  RunQDQLogicalOpTest<uint8_t>("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
+}
+
+// TODO: Add support for LessOrEqual.
+// According to the ONNX spec, logical operators that are implemented as
+// functions (e.g., LessOrEqual or GreaterOrEqual) do not have output type/shape inference.
+// We need to handle this uniquely.
+TEST_F(QnnHTPBackendTests, DISABLED_LogicalOpLessOrEqual4D) {
+  RunQDQLogicalOpTest<uint8_t>("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
+++ b/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
@@ -58,7 +58,6 @@ static void RunCPULogicalOpTest(const std::string& op_type, const std::vector<in
   provider_options["backend_path"] = "QnnCpu.dll";
 #else
   provider_options["backend_path"] = "libQnnCpu.so";
-  fp32_abs_err = 1.5e-5f;  // On linux we need slightly larger tolerance.
 #endif
 
   constexpr int expected_nodes_in_partition = 1;

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -16,7 +16,7 @@ namespace test {
 
 void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOptions& provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_ep,
-                     const char* test_description, float fp32_abs_err) {
+                     const char* test_description, float fp32_abs_err, logging::Severity log_severity) {
   std::function<void(const Graph&)> graph_verify = [num_nodes_in_ep, test_description](const Graph& graph) -> void {
     ASSERT_EQ(graph.NumberOfNodes(), num_nodes_in_ep) << test_description;
   };
@@ -28,9 +28,12 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOption
   // Add kMSDomain to cover contrib op like Gelu
   const std::unordered_map<std::string, int> domain_to_version = {{"", opset_version}, {kMSDomain, 1}};
 
+  auto& logging_manager = DefaultLoggingManager();
+  logging_manager.SetDefaultLoggerSeverity(log_severity);
+
   onnxruntime::Model model(test_description, false, ModelMetaData(), PathString(),
                            IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
-                           DefaultLoggingManager().DefaultLogger());
+                           logging_manager.DefaultLogger());
   Graph& graph = model.MainGraph();
   ModelTestBuilder helper(graph);
   build_test_case(helper);

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -29,10 +29,12 @@ using GetTestModelFn = std::function<void(ModelTestBuilder& builder)>;
  * \param num_modes_in_ep The expected number of nodes assigned to QNN EP's partition.
  * \param test_description Description of the test for error reporting.
  * \param fp32_abs_err The acceptable error between CPU EP and QNN EP.
+ * \param log_severity The logger's minimum severity level.
  */
 void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOptions& provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_ep,
-                     const char* test_description, float fp32_abs_err = 1e-5f);
+                     const char* test_description, float fp32_abs_err = 1e-5f,
+                     logging::Severity log_severity = logging::Severity::kERROR);
 
 enum class BackendSupport {
   SUPPORT_UNKNOWN,

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -46,6 +46,10 @@ static void VerifyOutputs(const std::vector<std::string>& output_names,
         EXPECT_TRUE(SpanEq(ltensor.DataAsSpan<int8_t>(), rtensor.DataAsSpan<int8_t>()))
             << " mismatch for " << output_names[i];
         break;
+      case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+        EXPECT_TRUE(SpanEq(ltensor.DataAsSpan<bool>(), rtensor.DataAsSpan<bool>()))
+            << " mismatch for " << output_names[i];
+        break;
       case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {
         EXPECT_THAT(ltensor.DataAsSpan<float>(),
                     ::testing::Pointwise(::testing::FloatNear(params.fp32_abs_err), rtensor.DataAsSpan<float>()));


### PR DESCRIPTION
### Description
- Updates QDQ transformer to handle QDQ logical operators (Equal, Less, LessOrEqual, Greater, GreaterOrEqual).
  - Expects 2 DQ inputs and no Qs in the output, which is boolean.

The following can now run on QNN HTP backend.
![image](https://github.com/microsoft/onnxruntime/assets/19691973/87497025-0a15-4ba9-9d8a-8b8101a0354b)

### Motivation and Context
This is needed to enable QDQ models with logical comparison operators to run on QNN EP. 