### PR TITLE
Add vocab masks to Whisper export with beam search

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/convert_to_onnx.py
@@ -108,6 +108,24 @@ def parse_arguments(argv=None):
     parser.set_defaults(use_specific_logits_processor=False)
 
     parser.add_argument(
+        "-v",
+        "--use_vocab_mask",
+        required=False,
+        action="store_true",
+        help="Use vocab_mask as an extra graph input to enable specific logits processing",
+    )
+    parser.set_defaults(use_vocab_mask=False)
+
+    parser.add_argument(
+        "-u",
+        "--use_prefix_vocab_mask",
+        required=False,
+        action="store_true",
+        help="Use prefix_vocab_mask as an extra graph input to enable specific logits processing",
+    )
+    parser.set_defaults(use_prefix_vocab_mask=False)
+
+    parser.add_argument(
         "-w",
         "--overwrite",
         required=False,
@@ -176,7 +194,7 @@ def parse_arguments(argv=None):
         help="Produce beam search model with chained encdecinit and decoder.",
     )
 
-    parser.add_argument("--no_repeat_ngram_size", type=int, default=3, help="default to 3")
+    parser.add_argument("--no_repeat_ngram_size", type=int, default=0, help="default to 0")
 
     parser.add_argument(
         "--state_dict_path",

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -44,6 +44,7 @@ def chain_model(args):
         beam_inputs.append("logits_processor")
     beam_outputs = ["sequences"]
 
+    input_features_cast_node, len_pen_cast_node, rep_pen_cast_node = None, None, None
     if args.precision == Precision.FLOAT16:
         input_features_cast_node = helper.make_node(
             "Cast",
@@ -143,7 +144,11 @@ def chain_model(args):
 
     opset_import = [helper.make_opsetid(domain="com.microsoft", version=1), helper.make_opsetid(domain="", version=17)]
 
-    graph_nodes = [input_features_cast_node, len_pen_cast_node, rep_pen_cast_node, node] if args.precision == Precision.FLOAT16 else [node]
+    graph_nodes = (
+        [input_features_cast_node, len_pen_cast_node, rep_pen_cast_node, node]
+        if args.precision == Precision.FLOAT16
+        else [node]
+    )
     beam_graph = helper.make_graph(graph_nodes, "beam-search-test", graph_inputs, graph_outputs, initializers)
     beam_model = helper.make_model(beam_graph, producer_name="onnxruntime.transformers", opset_imports=opset_import)
 

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -24,15 +24,15 @@ def chain_model(args):
     config = WhisperConfig.from_pretrained(args.model_name_or_path)
 
     beam_inputs = [
-        "input_features",
+        "input_features_fp16" if args.precision == Precision.FLOAT16 else "input_features",
         "max_length",
         "min_length",
         "num_beams",
         "num_return_sequences",
         "length_penalty",
         "repetition_penalty",
-        "",
-        "",
+        "vocab_mask" if args.use_prefix_vocab_mask else "",
+        "prefix_vocab_mask" if args.use_prefix_vocab_mask else "",
         "",
     ]
     if args.use_forced_decoder_ids:
@@ -43,6 +43,15 @@ def chain_model(args):
     if args.use_logits_processor:
         beam_inputs.append("logits_processor")
     beam_outputs = ["sequences"]
+
+    if args.precision == Precision.FLOAT16:
+        cast_node = helper.make_node(
+            "Cast",
+            inputs=["input_features"],
+            outputs=["input_features_fp16"],
+            name="CastToFp16",
+            to=TensorProto.FLOAT16,
+        )
 
     node = helper.make_node("BeamSearch", inputs=beam_inputs, outputs=beam_outputs, name="BeamSearch_zcode")
     node.domain = "com.microsoft"
@@ -57,13 +66,8 @@ def chain_model(args):
         ]
     )
 
-    # beam graph inputs
-    float_data_type = TensorProto.FLOAT
-    if args.precision != Precision.FLOAT32:
-        float_data_type = TensorProto.FLOAT16
-
     input_features = helper.make_tensor_value_info(
-        "input_features", float_data_type, ["batch_size", "feature_size", "sequence_length"]
+        "input_features", TensorProto.FLOAT, ["batch_size", "feature_size", "sequence_length"]
     )
     max_length = helper.make_tensor_value_info("max_length", TensorProto.INT32, [1])
     min_length = helper.make_tensor_value_info("min_length", TensorProto.INT32, [1])
@@ -91,6 +95,16 @@ def chain_model(args):
         logits_processor = helper.make_tensor_value_info("logits_processor", TensorProto.INT32, [1])
         graph_inputs.append(logits_processor)
 
+    if args.use_vocab_mask:
+        vocab_mask = helper.make_tensor_value_info("vocab_mask", TensorProto.INT32, [config.vocab_size])
+        graph_inputs.append(vocab_mask)
+
+    if args.use_prefix_vocab_mask:
+        prefix_vocab_mask = helper.make_tensor_value_info(
+            "prefix_vocab_mask", TensorProto.INT32, ["batch_size", config.vocab_size]
+        )
+        graph_inputs.append(prefix_vocab_mask)
+
     # graph outputs
     sequences = helper.make_tensor_value_info(
         "sequences", TensorProto.INT32, ["batch_size", "num_return_sequences", "max_length"]
@@ -115,7 +129,8 @@ def chain_model(args):
 
     opset_import = [helper.make_opsetid(domain="com.microsoft", version=1), helper.make_opsetid(domain="", version=17)]
 
-    beam_graph = helper.make_graph([node], "beam-search-test", graph_inputs, graph_outputs, initializers)
+    graph_nodes = ([cast_node] if args.precision == Precision.FLOAT16 else []) + [node]
+    beam_graph = helper.make_graph(graph_nodes, "beam-search-test", graph_inputs, graph_outputs, initializers)
     beam_model = helper.make_model(beam_graph, producer_name="pytorch", opset_imports=opset_import)
 
     onnx.save(


### PR DESCRIPTION
### Description
This PR adds flags for exporting Whisper with vocab masks for logits processing. This PR also sets `input_features` back to FP32 precision for the user and casts `input_features` to FP16 precision when needed.



### Motivation and Context
This helps enable specific logits processing for the exported Whisper model.