### PR TITLE
[QNN EP]Add UT for cached Qnn context binary

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -22,7 +22,10 @@ constexpr const char* QNN = "QNN";
 
 std::string GetFileNameFromModelPath(onnxruntime::Path model_path) {
   auto model_path_components = model_path.GetComponents();
-  ORT_ENFORCE(!model_path_components.empty(), "Model path not valid!");
+  // There's no model path if model loaded from buffer stead of file
+  if (model_path_components.empty()) {
+    return "";
+  }
   return PathToUTF8String(model_path_components.back());
 }
 
@@ -489,7 +492,7 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
       // dump fused_node.OpType() as metadata in context cache binary file, so that we can validate it in GetCapability
       ORT_RETURN_IF_ERROR(qnn_backend_manager_->DumpQnnContext(context_cache_pathstring,
                                                                GetFileNameFromModelPath(graph_viewer.ModelPath()),
-                                                               fused_node.OpType()));
+                                                               graph_viewer.Name()));
     }
     return Status::OK();
   }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -488,8 +488,8 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
     } else {
       // Load and execute from Onnx model if not exit and dump the context
       ORT_RETURN_IF_ERROR(CompileFromOrtGraph(fused_nodes_and_graphs, node_compute_funcs, logger));
-      // fused_node.OpType() is generated in GetCapability, e.g QNN_[hash_id]_[id]
-      // dump fused_node.OpType() as metadata in context cache binary file, so that we can validate it in GetCapability
+      // graph_viewer.Name() is generated in GetCapability, e.g QNN_[hash_id]_[id]
+      // dump graph_viewer.Name() as metadata in context cache binary file, so that we can validate it in GetCapability
       ORT_RETURN_IF_ERROR(qnn_backend_manager_->DumpQnnContext(context_cache_pathstring,
                                                                GetFileNameFromModelPath(graph_viewer.ModelPath()),
                                                                graph_viewer.Name()));

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -117,7 +117,7 @@ TEST_F(QnnHTPBackendTests, ContextBinaryCacheTest) {
   const std::string context_binary_file = "./qnn_context_binary_test.bin";
   provider_options["qnn_context_cache_path"] = context_binary_file;
 
-  // Runs model with DQ-> InstanceNorm -> Q and compares the outputs of the CPU and QNN EPs.
+  // Runs model with DQ-> Atan-> Q and compares the outputs of the CPU and QNN EPs.
   // 1st run will generate the Qnn context cache binary file
   RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>({1, 2, 3}, "Atan", kOnnxDomain),
                   provider_options,

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -96,7 +96,7 @@ TEST_F(QnnHTPBackendTests, TestQDQHardSwishTest) {
   RunQDQSingleInputOpTest({1, 2, 3}, "HardSwish", "TestQDQGeluTest", 14, ExpectedEPNodeAssignment::All, 1);
 }
 
-// Check that QNN compiles DQ -> HardSwish -> Q as a single unit.
+// Check that QNN compiles DQ -> Atan -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQAtanTest) {
   RunQDQSingleInputOpTest({1, 2, 3}, "Atan", "TestQDQGeluTest", 11, ExpectedEPNodeAssignment::All, 1);


### PR DESCRIPTION
### Description
1. Add UT for cached Qnn context binary
2. Minor change: set model path to "" if model_path is not available since the model could be loaded from buffer instead of Onnx file

### Motivation and Context
support more scenario


