### PR TITLE
Support SCELoss(Grad)/Slice(Grad) for larger size input

### DIFF
--- a/docs/ORTModule_Training_Guidelines.md
+++ b/docs/ORTModule_Training_Guidelines.md
@@ -158,6 +158,17 @@ inspection results to standard outputs.
 	export ORTMODULE_PRINT_INPUT_DENSITY=0 # Disable
 	```
 
+#### ORTMODULE_PRINT_MEMORY_STATS
+
+- **Feature Area**: *ORTMODULE/RuntimeInspector*
+- **Description**: By default, this is disabled. This env var can be used for print the memory inspection results
+to standard outputs.
+
+	```bash
+	export ORTMODULE_PRINT_MEMORY_STATS=1 # Enable
+	export ORTMODULE_PRINT_MEMORY_STATS=0 # Disable
+	```
+
 ### 2.2 Memory Optimization
 
 Q: *Want to run a bigger batch size?*

--- a/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
+++ b/onnxruntime/core/providers/cuda/shared_inc/fast_divmod.h
@@ -14,12 +14,38 @@
 namespace onnxruntime {
 namespace cuda {
 
+// DivMod is a helper class for fast integer division and modulo operation.
+// There is a fast version for int type and a slow version for other type.
+template <typename T>
+struct DivMod {
+  DivMod(T d = 1) {
+    d_ = d == 0 ? 1 : d;
+    ORT_ENFORCE(d_ >= 1 && d_ <= std::numeric_limits<T>::max());
+  }
+
+  __host__ __device__ inline T div(T n) const {
+    return n / d_;
+  }
+
+  __host__ __device__ inline T mod(T n) const {
+    return n % d_;
+  }
+
+  __host__ __device__ inline void divmod(T n, T& q, T& r) const {
+    q = div(n);
+    r = n - q * d_;
+  }
+
+  T d_;  // divisor
+};
+
 // The code below is based on section 4 Unsigned division of paper https://gmplib.org/~tege/divcnst-pldi94.pdf
 // In current ORT, fast_divmod is used for calculating the position of a element in tensor,
 // so unsigned integer division from the paper is good enough for ORT. The advantage is that div is very simple,
 // then GPU compiler can do loop unroll easilly when divmod is called in a loop.
-struct fast_divmod {
-  fast_divmod(int d = 1) {
+template <>
+struct DivMod<int> {
+  DivMod(int d = 1) {
     d_ = d == 0 ? 1 : d;
     ORT_ENFORCE(d_ >= 1 && d_ <= static_cast<uint32_t>(std::numeric_limits<int>::max()));
 
@@ -57,6 +83,8 @@ struct fast_divmod {
   uint32_t M_;  // m' in the paper.
   uint32_t l_;  // l_ = ceil(log2(d_))
 };
+
+typedef DivMod<int> fast_divmod;  // Keep the old name for backward compatibility.
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/slice.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice.h
@@ -35,7 +35,7 @@ class Slice : public CudaKernel, public SliceBase {
 
   virtual Status CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                               const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,
-                              const TArray<fast_divmod>& output_strides, OpKernelContext* ctx,
+                              const TArray<DivMod<uint64_t>>& output_strides, OpKernelContext* ctx,
                               const TensorShape& output_shape) const;
 };
 }  // namespace cuda

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.cu
@@ -20,11 +20,11 @@ constexpr int kNumThreadsPerBlock = GridDim::maxThreadsPerBlock;
 
 template <bool is_grad, int DIMS, typename T>
 __global__ void _SliceKernel(const TArray<int64_t> starts, const TArray<int64_t> steps,
-                             const TArray<int64_t> input_strides, const TArray<fast_divmod> output_strides,
-                             const T* input_data, T* output_data, const CUDA_LONG N) {
-  CUDA_LONG start = kNumElementsPerThread * kNumThreadsPerBlock * blockIdx.x + threadIdx.x;
+                             const TArray<int64_t> input_strides, const TArray<DivMod<uint64_t>> output_strides,
+                             const T* input_data, T* output_data, const uint64_t N) {
+  uint64_t start = kNumElementsPerThread * kNumThreadsPerBlock * blockIdx.x + threadIdx.x;
   T values[kNumElementsPerThread];
-  CUDA_LONG id;
+  uint64_t id;
   if (is_grad) {
     id = start;
 #pragma unroll
@@ -40,9 +40,9 @@ __global__ void _SliceKernel(const TArray<int64_t> starts, const TArray<int64_t>
 #pragma unroll
   for (int i = 0; i < kNumElementsPerThread; ++i) {
     if (id < N) {
-      CUDA_LONG input_index = 0;
-      int div;
-      int mod = id;
+      uint64_t input_index = 0;
+      uint64_t div;
+      uint64_t mod = id;
       int dim = 0;
 #pragma unroll
       for (; dim < DIMS - 1; ++dim) {
@@ -74,8 +74,8 @@ __global__ void _SliceKernel(const TArray<int64_t> starts, const TArray<int64_t>
 template <bool is_grad>
 Status SliceImplEx(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
                    const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
-                   const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data,
-                   const size_t N) {
+                   const TArray<DivMod<uint64_t>>& output_strides, const void* input_data, void* output_data,
+                   const uint64_t N) {
   int blocksPerGrid = static_cast<int>(CeilDiv(N, kNumThreadsPerBlock * kNumElementsPerThread));
   switch (element_size) {
 #define HANDLE_DIMS(ELEMENT_TYPE, DIMS)                                                           \
@@ -83,7 +83,7 @@ Status SliceImplEx(cudaStream_t stream, const size_t element_size, const int32_t
     _SliceKernel<is_grad, DIMS, ELEMENT_TYPE><<<blocksPerGrid, kNumThreadsPerBlock, 0, stream>>>( \
         starts, steps, input_strides, output_strides,                                             \
         reinterpret_cast<const ToCudaType<ELEMENT_TYPE>::MappedType*>(input_data),                \
-        reinterpret_cast<ToCudaType<ELEMENT_TYPE>::MappedType*>(output_data), (CUDA_LONG)N);      \
+        reinterpret_cast<ToCudaType<ELEMENT_TYPE>::MappedType*>(output_data), N);                 \
   } break
 #define HANDLE_ELEMENT_TYPE(ELEMENT_TYPE) \
   case sizeof(ELEMENT_TYPE): {            \
@@ -113,7 +113,7 @@ Status SliceImplEx(cudaStream_t stream, const size_t element_size, const int32_t
 
 Status SliceImpl(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
                  const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
-                 const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data, const size_t N) {
+                 const TArray<DivMod<uint64_t>>& output_strides, const void* input_data, void* output_data, const uint64_t N) {
   return SliceImplEx<false>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides,
                             input_data, output_data, N);
 }
@@ -121,8 +121,8 @@ Status SliceImpl(cudaStream_t stream, const size_t element_size, const int32_t d
 #ifdef ENABLE_TRAINING_OPS
 Status SliceImplGrad(cudaStream_t stream, const size_t element_size, const int32_t dimension_count,
                      const TArray<int64_t>& starts, const TArray<int64_t>& steps, const TArray<int64_t>& input_strides,
-                     const TArray<fast_divmod>& output_strides, const void* input_data, void* output_data,
-                     const size_t N) {
+                     const TArray<DivMod<uint64_t>>& output_strides, const void* input_data, void* output_data,
+                     const uint64_t N) {
   return SliceImplEx<true>(stream, element_size, dimension_count, starts, steps, input_strides, output_strides,
                            input_data, output_data, N);
 }

--- a/onnxruntime/core/providers/cuda/tensor/slice_impl.h
+++ b/onnxruntime/core/providers/cuda/tensor/slice_impl.h
@@ -14,10 +14,10 @@ Status SliceImpl(cudaStream_t stream,
                  const TArray<int64_t>& starts,
                  const TArray<int64_t>& steps,
                  const TArray<int64_t>& input_strides,
-                 const TArray<fast_divmod>& output_strides,
+                 const TArray<DivMod<uint64_t>>& output_strides,
                  const void* input_data,
                  void* output_data,
-                 const size_t N);
+                 const uint64_t N);
 
 #ifdef ENABLE_TRAINING_OPS
 Status SliceImplGrad(cudaStream_t stream,
@@ -26,10 +26,10 @@ Status SliceImplGrad(cudaStream_t stream,
                      const TArray<int64_t>& starts,
                      const TArray<int64_t>& steps,
                      const TArray<int64_t>& input_strides,
-                     const TArray<fast_divmod>& output_strides,
+                     const TArray<DivMod<uint64_t>>& output_strides,
                      const void* input_data,
                      void* output_data,
-                     const size_t N);
+                     const uint64_t N);
 #endif  // ENABLE_TRAINING_OPS
 
 }  // namespace cuda

--- a/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
+++ b/orttraining/orttraining/python/training/ortmodule/_runtime_inspector.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+from enum import IntEnum
 from logging import Logger
 from typing import List, Tuple, Union
 
@@ -10,6 +11,27 @@ import onnx
 import torch
 from onnx import ModelProto, helper
 from onnx import onnx_pb as onnx_proto
+
+
+class Phase(IntEnum):
+    INVALID = -1
+    PRE_FORWARD = 0
+    POST_FORWARD = 1
+    PRE_BACKWARD = 2  # not applicable for inference
+    POST_BACKWARD = 3  # not applicable for inference
+
+
+def _convert_phase_to_string(phase: Phase) -> str:
+    if phase == Phase.PRE_FORWARD:
+        return "pre_forward"
+    elif phase == Phase.POST_FORWARD:
+        return "post_forward"
+    elif phase == Phase.PRE_BACKWARD:
+        return "pre_backward"
+    elif phase == Phase.POST_BACKWARD:
+        return "post_backward"
+    else:
+        return "invalid"
 
 
 class RuntimeInspector:
@@ -23,6 +45,7 @@ class RuntimeInspector:
         self._logger = logger
 
         self.input_density_ob: Union[InputDensityObserver, None] = None
+        self.memory_ob: Union[MemoryObserver, None] = None
 
     def enable_input_inspector(self, model: ModelProto, user_input_names: List[str]) -> None:
         """
@@ -63,6 +86,28 @@ class RuntimeInspector:
         """Disable input density inspector."""
         self.input_density_ob = None
 
+    def enable_memory_inspector(self, module: torch.nn.Module):
+        """
+        Enable memory inspector for ORTModule.
+
+        Args:
+            module: ORTModule.
+        """
+        if self.memory_ob is None:
+            self.memory_ob = MemoryObserver(module, self._logger)
+        else:
+            raise RuntimeError("Memory observer is already enabled.")
+
+    def inspect_memory(self, phase: Phase) -> None:
+        """
+        Inspect memory usage and print statistics.
+
+        Args:
+            phase: Phase to inspect.
+        """
+        if self.memory_ob is not None:
+            self.memory_ob.inspect_memory(phase)
+
 
 class InputDensityObserver:
     """
@@ -89,8 +134,7 @@ class InputDensityObserver:
         self._tensor_to_node_map = {}
 
     def initialize(self, model: ModelProto, user_input_names: List[str]) -> None:
-        """
-        Initialize data observer from the given ONNX model and user input names.
+        """Initialize data observer from the given ONNX model and user input names.
 
         For embedding input (e.g. ATen embedding), try to parse the padding_idx from the ONNX model, if padding_idx is
         valid, register it in _embedding_graph_input_to_padding_idx_map.
@@ -283,8 +327,7 @@ class InputDensityObserver:
             )
 
     def inspect_from_input_data(self, name: str, inp) -> Tuple[bool, float, float]:
-        """
-        Inspect input data and print statistics.
+        """Inspect input data and print statistics.
 
         Args:
             name: User input name.
@@ -379,7 +422,7 @@ class InputDensityObserver:
             stat += "\t| {:<10} | {:<10} | {:<15} | {:<10} | {:<10} | {:<15} | {:<15} | {:<15} |\n".format(
                 "STEP",
                 "INPUT TYPE",
-                " INPUT NAME",
+                "INPUT NAME",
                 "PAD IDX",
                 "DENSITY",
                 "VALID TOKENS",
@@ -422,3 +465,87 @@ class InputDensityObserver:
             return None
         value = onnx.numpy_helper.to_array(tensor)
         return value
+
+
+class MemoryObserver:
+    """Memory inspector across the training lifetime.
+
+    On different training/inference phases, `inspect_memory` is called to print out the memory usage, including
+    current/peak memory usage, current/peak inactive and non-releasable memory.
+    """
+
+    NORMALIZER_FATOR = float(1024 * 1024)
+    NORMALIZER_UNIT = "MiB"
+
+    def __init__(self, m: torch.nn.Module, logger: Logger):
+        self._logger = logger
+        self._current_step = 0
+        self._rank = 0
+        self._world_size = 1
+        if torch.distributed.is_initialized():
+            self._rank = torch.distributed.get_rank()
+            self._world_size = torch.distributed.get_world_size()
+
+        self._rank_info = f"[{self._rank}/{self._world_size}]"
+        self._pre_phase = Phase.INVALID
+        self._last_pahse = Phase.POST_BACKWARD if m.training else Phase.POST_FORWARD
+
+        self._is_first_inspect = True
+
+    def inspect_memory(self, cur_phase: Phase):
+        if not torch.cuda.is_available():
+            return
+
+        if self._is_first_inspect:
+            # Clean the memory cache and memory stats before the first time run forward pass, FOR EVERY RANK.
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+            self._is_first_inspect = False
+
+        if self._rank != 0:
+            return
+
+        if cur_phase < Phase.PRE_FORWARD or cur_phase > self._last_pahse:
+            raise RuntimeError(f"Invalid phase detected: {cur_phase}")
+
+        if (cur_phase - self._pre_phase) != 1:
+            raise RuntimeError(f"Invalid phase transition detected: {self._pre_phase} -> {cur_phase}")
+
+        cur_mem_allocated = self._normalize(torch.cuda.memory_allocated())
+        max_mem_allocated = self._normalize(torch.cuda.max_memory_allocated())
+        cur_mem_cached = self._normalize(torch.cuda.memory_reserved())
+        max_mem_cached = self._normalize(torch.cuda.max_memory_reserved())
+        torch_mem_stat = torch.cuda.memory_stats()
+        cur_mem_inactive = self._normalize(torch_mem_stat.get("inactive_split_bytes.all.current", 0))
+        max_mem_inactive = self._normalize(torch_mem_stat.get("inactive_split_bytes.all.peak", 0))
+
+        mem_stats = [
+            ["phase", _convert_phase_to_string(cur_phase)],
+            ["allocated", cur_mem_allocated],  # current memory alloeated for tensors
+            ["max allocated", max_mem_allocated],  # peak memory allocated for tensors
+            ["cached", cur_mem_cached],  # current memory cached for caching allocator
+            ["max cached", max_mem_cached],  # peak memory cached for caching allocator.
+            ["inactive", cur_mem_inactive],  # amount of inactive, non-releasable memory
+            ["max inactive", max_mem_inactive],  # peak of inactive, non-releasable memory
+        ]
+
+        summ = f"{self._rank_info} step {self._current_step} memory ({MemoryObserver.NORMALIZER_UNIT})"
+        for stat in mem_stats:
+            summ += f" | {stat[0]}: {stat[1]}"
+
+        # For the 10+ steps, only print when it is power of 2.
+        if self._current_step < 10 or (self._current_step & (self._current_step - 1) == 0):
+            print(summ)
+
+        if cur_phase == self._last_pahse:
+            self._increase_step()
+            self._pre_phase = Phase.INVALID
+            return
+
+        self._pre_phase = cur_phase
+
+    def _increase_step(self):
+        self._current_step += 1
+
+    def _normalize(self, mem_size_in_bytes: Union[float, int]):
+        return f"{float(mem_size_in_bytes) / MemoryObserver.NORMALIZER_FATOR:.0f}"

--- a/orttraining/orttraining/training_ops/cpu/loss/softmax_cross_entropy_loss.cc
+++ b/orttraining/orttraining/training_ops/cpu/loss/softmax_cross_entropy_loss.cc
@@ -291,11 +291,11 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
     const T1* weight_data = weight.template Data<T1>();
 
     if (reduction_ == ReductionType::NONE) {
-      for (int i = 0; i < n_d; i++) {
+      for (int64_t i = 0; i < N_D; i++) {
         T2 label_sample = label_data[i];
         T1 weight_smaple = weight_data[label_sample] * dY_data[i];
-        for (int j = 0; j < c; j++) {
-          int index = i * c + j;
+        for (int64_t j = 0; j < C; j++) {
+          int64_t index = i * C + j;
           if (ignore_index == label_sample) {
             d_logit_data[index] = 0;
           } else {
@@ -308,7 +308,7 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
       T1 dY_scaled = *dY_data;
       if (reduction_ == ReductionType::MEAN) {
         T1 sum_weight = (T1)0;
-        for (int i = 0; i < n_d; i++) {
+        for (int64_t i = 0; i < N_D; i++) {
           if (ignore_index != label_data[i]) {
             sum_weight += weight_data[label_data[i]];
           }
@@ -319,11 +319,11 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
         }
       }
 
-      for (int i = 0; i < n_d; i++) {
+      for (int64_t i = 0; i < N_D; i++) {
         T2 label_sample = label_data[i];
         T1 weight_smaple = weight_data[label_sample] * dY_scaled;
-        for (int j = 0; j < c; j++) {
-          int index = i * c + j;
+        for (int64_t j = 0; j < C; j++) {
+          int64_t index = i * C + j;
           if (ignore_index == label_sample) {
             d_logit_data[index] = 0;
           } else {
@@ -334,10 +334,10 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
     }
   } else {
     if (reduction_ == ReductionType::NONE) {
-      for (int i = 0; i < n_d; i++) {
+      for (int64_t i = 0; i < N_D; i++) {
         T2 label_sample = label_data[i];
-        for (int j = 0; j < c; j++) {
-          int index = i * c + j;
+        for (int64_t j = 0; j < C; j++) {
+          int64_t index = i * C + j;
           if (ignore_index == label_sample) {
             d_logit_data[index] = 0;
           } else {
@@ -348,7 +348,7 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
     } else {
       T1 dY_scaled = *dY_data;
       int unignored_sample_count = 0;
-      for (int i = 0; i < n_d; i++) {
+      for (int64_t i = 0; i < N_D; i++) {
         if (ignore_index != label_data[i]) {
           unignored_sample_count += 1;
         }
@@ -358,10 +358,10 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
         dY_scaled = *dY_data / unignored_sample_count;
       }
 
-      for (int i = 0; i < n_d; i++) {
+      for (int64_t i = 0; i < N_D; i++) {
         T2 label_sample = label_data[i];
-        for (int j = 0; j < c; j++) {
-          int index = i * c + j;
+        for (int64_t j = 0; j < C; j++) {
+          int64_t index = i * c + j;
           if (ignore_index == label_sample) {
             d_logit_data[index] = 0;
           } else {
@@ -391,7 +391,7 @@ Status SoftmaxCrossEntropyLossGrad<T1, T2>::Compute(OpKernelContext* context) co
   if (p_bias) {
     ORT_ENFORCE(probability_shape.Size() == p_bias->Shape().Size());
     const T1* bias_data = p_bias->Data<T1>();
-    for (size_t i = 0; i < static_cast<size_t>(probability_shape.Size()); ++i) {
+    for (int64_t i = 0; i < probability_shape.Size(); ++i) {
       d_logit_data[i] += bias_data[i];
     }
   }

--- a/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.cc
@@ -49,7 +49,7 @@ Status SliceGrad::FillInputVectors(OpKernelContext* ctx, TensorShapeVector& inpu
 
 Status SliceGrad::CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                                const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,
-                               const TArray<fast_divmod>& output_strides, OpKernelContext* ctx,
+                               const TArray<DivMod<uint64_t>>& output_strides, OpKernelContext* ctx,
                                const TensorShape& output_shape) const {
   Tensor* gradient_out_tensor = GetOutputGradientTensor(ctx);
   CUDA_RETURN_IF_ERROR(cudaMemsetAsync(gradient_out_tensor->MutableDataRaw(), 0, gradient_out_tensor->SizeInBytes(), Stream(ctx)));

--- a/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/slice_grad.h
@@ -17,7 +17,7 @@ class SliceGrad final : public Slice<true> {
 
   Status CallSliceImp(size_t element_size, size_t dimension_count, const TArray<int64_t>& starts_buffer,
                       const TArray<int64_t>& steps_buffer, const TArray<int64_t>& input_strides,
-                      const TArray<fast_divmod>& output_strides, OpKernelContext* ctx, const TensorShape& output_shape)
+                      const TArray<DivMod<uint64_t>>& output_strides, OpKernelContext* ctx, const TensorShape& output_shape)
       const override;
 };
 }  // namespace cuda


### PR DESCRIPTION
### Support SCELoss/SCELossGrad/Slice/SliceGrad run with bigger sized input

For Bloom560M model, ORT has potential to run bigger batch size from initialally 6 to now 10.
SCELoss/SCELossGrad's input size is Bsz X 1023 * 250680. When Bsz is bigger than 8, totoal element count cannot be represented by int32_t, which those kernels are using to passing total elem count. There is silent overflow causing other indirectly exceptions, or wrong mistake without errors. 

This PR is to use uint64_t to pass all element count and element index for the ops mentioned above.

A challenge for adding a UT is: our CPU kernels are not efficient enough to handle the large size tensor, it will take very very very long time to finish, so may defer adding such a case until the CPU kernel latency is acceptable for CI runs. 


