### PR TITLE
[QNN EP] Add tests for large inputs that trigger memory alloc errors

### DIFF
--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -230,6 +230,20 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8U8S32_large_input2_bias_initial
   RunHTPConvOpTest<uint8_t, uint8_t, int32_t, uint8_t>({1, 128, 8, 56}, {32, 128, 1, 1}, true, {1, 1}, {0, 0, 0, 0}, {1, 1}, "NOTSET", ExpectedEPNodeAssignment::All,
                                                        "TestQDQConvU8U8S32_large_input2_bias_initializer");
 }
+
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
+TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8U8S32_LargeInput_Dilations_Pads) {
+  RunHTPConvOpTest<uint8_t, uint8_t, int32_t, uint8_t>(
+      {1, 3, 768, 1152},  // input_shape
+      {64, 3, 7, 7},      // weights_shape
+      true,               // is_bias_initializer
+      {2, 2},             // strides
+      {3, 3, 3, 3},       // pads
+      {1, 1},             // dilations
+      "NOTSET",           // auto_pad
+      ExpectedEPNodeAssignment::All,
+      "TestQDQConvU8U8S32_large_input2_bias_initializer");
+}
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -222,6 +222,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
                    ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
 }
 
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Ceil) {
   RunMaxPoolOpTest({1, 2, 3, 3},  // shape
                    {3, 3},        // kernel_shape
@@ -234,6 +235,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Ceil) {
                    ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
 }
 
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil) {
   RunMaxPoolOpTest({1, 128, 16, 113},  // shape
                    {2, 2},             // kernel_shape
@@ -263,6 +265,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
 }
 
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 125, 8, 56},  // shape
                                {2, 2},           // kernel_shape
@@ -275,6 +278,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
 }
 
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                                {2, 2},             // kernel_shape
@@ -299,6 +303,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
 }
 
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
 TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil_HTP_u8) {
   RunQDQMaxPoolOpTest<uint8_t>({1, 128, 16, 113},  // shape
                                {2, 2},             // kernel_shape
@@ -309,6 +314,19 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil_HTP_u8) {
                                0,                  // storage_order
                                "NOTSET",           // auto_pad
                                ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil_HTP_u8");
+}
+
+// TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
+TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_LargeInput_1Pads) {
+  RunQDQMaxPoolOpTest<uint8_t>({1, 64, 384, 576},  // shape
+                               {3, 3},             // kernel_shape
+                               {2, 2},             // strides
+                               {1, 1, 1, 1},       // pads
+                               {1, 1},             // dialations
+                               0,                  // ceil_mode
+                               0,                  // storage_order
+                               "NOTSET",           // auto_pad
+                               ExpectedEPNodeAssignment::All, "TestMaxPool_LargeInput_1Pads");
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -18,6 +18,105 @@ namespace test {
 
 using GetTestModelFn = std::function<void(ModelTestBuilder& builder)>;
 
+// Class that defines an input that can be created with ModelTestBuilder.
+// Defines whether the input is an initializer and if the data should be randomized or if
+// set to an explicit value.
+template <typename T>
+struct TestInputDef {
+  struct RawData {
+    std::vector<T> data;
+  };
+
+  struct RandomData {
+    T min;
+    T max;
+  };
+
+  TestInputDef() : is_initializer_(false) {}
+
+  // Create a random input.
+  TestInputDef(std::vector<int64_t> shape, bool is_initializer, T rand_min, T rand_max)
+      : shape_(std::move(shape)),
+        data_info_(RandomData{rand_min, rand_max}),
+        is_initializer_(is_initializer) {}
+
+  // Create an input with explicit data.
+  TestInputDef(std::vector<int64_t> shape, bool is_initializer, std::vector<T> data)
+      : shape_(std::move(shape)),
+        data_info_(RawData{std::move(data)}),
+        is_initializer_(is_initializer) {}
+
+  TestInputDef(TestInputDef&& other) = default;
+  TestInputDef(const TestInputDef& other) = default;
+
+  TestInputDef& operator=(const TestInputDef& other) = default;
+  TestInputDef& operator=(TestInputDef&& other) = default;
+
+  const std::vector<int64_t>& GetShape() const {
+    return shape_;
+  }
+
+  const bool IsInitializer() const {
+    return is_initializer_;
+  }
+
+  const bool IsRandomData() const {
+    return data_info_.index() == 1;
+  }
+
+  const RandomData& GetRandomDataInfo() const {
+    return std::get<RandomData>(data_info_);
+  }
+
+  const bool IsRawData() const {
+    return data_info_.index() == 0;
+  }
+
+  const std::vector<T>& GetRawData() const {
+    return std::get<RawData>(data_info_).data;
+  }
+
+ private:
+  std::vector<int64_t> shape_;
+  std::variant<RawData, RandomData> data_info_;
+  bool is_initializer_;
+};
+
+/**
+ * Creates and returns an input in a test model graph. The input's characteristics are defined
+ * by the provided input definition.
+ *
+ * \param builder Model builder object used to build the model's inputs, outputs, and nodes.
+ * \param input_def Input definition that describes what kind of input to create.
+ * \return A pointer to the new input.
+ */
+template <typename T>
+inline NodeArg* MakeTestInput(ModelTestBuilder& builder, const TestInputDef<T>& input_def) {
+  NodeArg* input = nullptr;
+  const auto& shape = input_def.GetShape();
+  const bool is_initializer = input_def.IsInitializer();
+
+  if (input_def.IsRawData()) {  // Raw data.
+    const std::vector<T>& raw_data = input_def.GetRawData();
+
+    if (is_initializer) {
+      input = builder.MakeInitializer<T>(shape, raw_data);
+    } else {
+      input = builder.MakeInput<T>(shape, raw_data);
+    }
+  } else {  // Random data
+    const TestInputDef<T>::RandomData& rand_info = input_def.GetRandomDataInfo();
+
+    if (is_initializer) {
+      input = builder.MakeInitializer<T>(shape, rand_info.min, rand_info.max);
+    } else {
+      input = builder.MakeInput<T>(shape, rand_info.min, rand_info.max);
+    }
+  }
+
+  return input;
+}
+
 /**
  * Runs a test model on the QNN EP. Checks the graph node assignment, and that inference
  * outputs for QNN and CPU match.

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -56,11 +56,11 @@ struct TestInputDef {
     return shape_;
   }
 
-  const bool IsInitializer() const {
+  bool IsInitializer() const {
     return is_initializer_;
   }
 
-  const bool IsRandomData() const {
+  bool IsRandomData() const {
     return data_info_.index() == 1;
   }
 
@@ -68,7 +68,7 @@ struct TestInputDef {
     return std::get<RandomData>(data_info_);
   }
 
-  const bool IsRawData() const {
+  bool IsRawData() const {
     return data_info_.index() == 0;
   }
 
@@ -105,7 +105,7 @@ inline NodeArg* MakeTestInput(ModelTestBuilder& builder, const TestInputDef<T>& 
       input = builder.MakeInput<T>(shape, raw_data);
     }
   } else {  // Random data
-    const TestInputDef<T>::RandomData& rand_info = input_def.GetRandomDataInfo();
+    const auto& rand_info = input_def.GetRandomDataInfo();
 
     if (is_initializer) {
       input = builder.MakeInitializer<T>(shape, rand_info.min, rand_info.max);


### PR DESCRIPTION
### Description
Adds tests for operators that return error 1002 (QNN_COMMON_ERROR_MEM_ALLOC) when the call to graphFinalize() fails. This seems to happen for large input sizes.

Operators:
- Sub
- Div
- Conv
- MaxPool



### Motivation and Context
This documents bugs that need to be addressed with unit tests.