### PR TITLE
[C-API] Fallible compute for custom operators

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4292,7 +4292,7 @@ struct OrtCustomOp {
   // Fallible kernel creation
   OrtStatusPtr(ORT_API_CALL* CreateKernelFallible)(_In_ const struct OrtCustomOp* op, _In_ const OrtApi* api,
 						   _In_ const OrtKernelInfo* info,
-						   _Out_ void* kernel);
+						   _Out_ void** kernel);
 
   // Fallible compute call
   OrtStatusPtr(ORT_API_CALL* KernelComputeFallible)(_In_ void* op_kernel, _In_ OrtKernelContext* context);

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4289,6 +4289,11 @@ struct OrtCustomOp {
   // Applicable only for custom ops that have a variadic output.
   int(ORT_API_CALL* GetVariadicOutputHomogeneity)(_In_ const struct OrtCustomOp* op);
 
+  // Fallible kernel creation
+  OrtStatusPtr(ORT_API_CALL* CreateKernelFallible)(_In_ const struct OrtCustomOp* op, _In_ const OrtApi* api,
+						   _In_ const OrtKernelInfo* info,
+						   _Out_ void* kernel);
+
   // Fallible compute call
   OrtStatusPtr(ORT_API_CALL* KernelComputeFallible)(_In_ void* op_kernel, _In_ OrtKernelContext* context);
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -37,7 +37,7 @@
  *
  * This value is used by some API functions to behave as this version of the header expects.
  */
-#define ORT_API_VERSION 15
+#define ORT_API_VERSION 16
 
 #ifdef __cplusplus
 extern "C" {
@@ -4288,6 +4288,10 @@ struct OrtCustomOp {
   // and false (zero) otherwise.
   // Applicable only for custom ops that have a variadic output.
   int(ORT_API_CALL* GetVariadicOutputHomogeneity)(_In_ const struct OrtCustomOp* op);
+
+  // Fallible compute call
+  OrtStatusPtr(ORT_API_CALL* KernelComputeFallible)(_In_ void* op_kernel, _In_ OrtKernelContext* context);
+
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2026,7 +2026,7 @@ struct CustomOpBase : OrtCustomOp {
     OrtCustomOp::GetVariadicOutputMinArity = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetVariadicOutputMinArity(); };
     OrtCustomOp::GetVariadicOutputHomogeneity = [](const OrtCustomOp* this_) { return static_cast<int>(static_cast<const TOp*>(this_)->GetVariadicOutputHomogeneity()); };
     if constexpr(Fallible) {
-      OrtCustomOp::CreateKernelFallible = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info, void* op_kernel) -> OrtStatusPtr {
+      OrtCustomOp::CreateKernelFallible = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info, void** op_kernel) -> OrtStatusPtr {
 	return static_cast<const TOp*>(this_)->CreateKernelFallible(*api, info, &op_kernel);
       };
       OrtCustomOp::KernelComputeFallible = [](void* op_kernel, OrtKernelContext* context) -> OrtStatusPtr {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2027,7 +2027,7 @@ struct CustomOpBase : OrtCustomOp {
     OrtCustomOp::GetVariadicOutputHomogeneity = [](const OrtCustomOp* this_) { return static_cast<int>(static_cast<const TOp*>(this_)->GetVariadicOutputHomogeneity()); };
     if constexpr(Fallible) {
       OrtCustomOp::CreateKernelFallible = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info, void** op_kernel) -> OrtStatusPtr {
-	return static_cast<const TOp*>(this_)->CreateKernelFallible(*api, info, &op_kernel);
+	return static_cast<const TOp*>(this_)->CreateKernelFallible(*api, info, op_kernel);
       };
       OrtCustomOp::KernelComputeFallible = [](void* op_kernel, OrtKernelContext* context) -> OrtStatusPtr {
 	return static_cast<TKernel*>(op_kernel)->ComputeFallible(context);

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -2014,8 +2014,8 @@ inline std::vector<std::string> GetAvailableProviders() {
   return available_providers;
 }
 
-template <typename TOp, typename TKernel>
-void CustomOpBase<TOp, TKernel>::GetSessionConfigs(std::unordered_map<std::string, std::string>& out,
+  template <typename TOp, typename TKernel, bool Fallible>
+  void CustomOpBase<TOp, TKernel, Fallible>::GetSessionConfigs(std::unordered_map<std::string, std::string>& out,
                                                    ConstSessionOptions options) const {
   const TOp* derived = static_cast<const TOp*>(this);
   std::vector<std::string> keys = derived->GetSessionConfigKeys();

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -403,6 +403,11 @@ struct CustomOpKernel : OpKernel {
   ~CustomOpKernel() override { op_.KernelDestroy(op_kernel_); }
 
   Status Compute(OpKernelContext* ctx) const override {
+    if (op_.version > 15 && op_.KernelCompute == 0) {
+      auto status_ptr = op_.KernelComputeFallible(op_kernel_, reinterpret_cast<OrtKernelContext*>(ctx));
+      return ToStatus(status_ptr);
+    }
+
     op_.KernelCompute(op_kernel_, reinterpret_cast<OrtKernelContext*>(ctx));
     return Status::OK();
   }

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -67,8 +67,8 @@ struct KernelTwo {
 };
 
 struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne, true> {
-  OrtStatusPtr CreateKernelFallible(const OrtApi& /* api */, const OrtKernelInfo* /* info */, void* op_kernel) const {
-    op_kernel = reinterpret_cast<void*>(std::make_unique<KernelOne>().release());
+  OrtStatusPtr CreateKernelFallible(const OrtApi& /* api */, const OrtKernelInfo* /* info */, void** op_kernel) const {
+    *op_kernel = reinterpret_cast<void*>(std::make_unique<KernelOne>().release());
     return nullptr;
   };
 

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -67,8 +67,9 @@ struct KernelTwo {
 };
 
 struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne, true> {
-  void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* /* info */) const {
-    return std::make_unique<KernelOne>().release();
+  OrtStatusPtr CreateKernelFallible(const OrtApi& /* api */, const OrtKernelInfo* /* info */, void* op_kernel) const {
+    op_kernel = reinterpret_cast<void*>(std::make_unique<KernelOne>().release());
+    return nullptr;
   };
 
   const char* GetName() const { return "CustomOpOne"; };


### PR DESCRIPTION
### Description
This PR implements a backwards compatible way to define custom operators with fallible compute functions. The C++ API templated gained an optional `Fallible` argument.  Closes #14287 

### Motivation and Context
#14287 contains more context. The gist is that the current C-API defines compute operations of custom operators as functions returning `void` rather than an `OrtStatusPtr`.