### PR TITLE
Support re2 == 2023-06-02

### DIFF
--- a/onnxruntime/contrib_ops/cpu/tokenizer.cc
+++ b/onnxruntime/contrib_ops/cpu/tokenizer.cc
@@ -242,7 +242,7 @@ Status Tokenizer::SeparatorExpressionTokenizer(OpKernelContext* ctx,
                                   token_len, utf8_chars);
             if (!valid) {
               return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                            "Match contains invalid utf8 chars: " + submatch.as_string());
+                            "Match contains invalid utf8 chars: " + std::string{submatch});
             }
             if (utf8_chars >= size_t(mincharnum_)) {
               tokens.emplace_back(text.data() + start_pos, token_len);
@@ -384,7 +384,7 @@ Status Tokenizer::TokenExpression(OpKernelContext* ctx,
         utf8_chars = 0;
         if (!utf8_len(reinterpret_cast<const unsigned char*>(submatch.data()), token_len, utf8_chars)) {
           return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                        "Match contains invalid utf8 chars: " + submatch.as_string());
+                        "Match contains invalid utf8 chars: " + std::string{submatch});
         }
         if (utf8_chars >= size_t(mincharnum_)) {
           row.push_back(submatch);


### PR DESCRIPTION
### Description

google/re2 [was switched](https://github.com/google/re2/commit/49d776b9d29d79b6e2876d5f091d2207d8123dfa) to absl::string_view in version 2023-06-02.

As `absl::string_view` is a drop-in replacement for `std::string_view` it does not have `as_string()` method.
This PR ensures the forward compatibility with the newest versions of re2 library.

