### PR TITLE
Support overriding most ORT session options via environment variables

### DIFF
--- a/onnxruntime/core/common/path_string.h
+++ b/onnxruntime/core/common/path_string.h
@@ -13,6 +13,15 @@
 #include <cctype>
 #endif
 
+// for converting / printing ORT_TSTR path strings to std::string
+#ifdef _WIN32
+#define ORT_TSTR_CONVERT_TO_PRINTABLE_STRING(X) std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(X)
+#define ORT_TSTR_CONVERT_FROM_STRING(X) std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(X);
+#else
+#define ORT_TSTR_CONVERT_TO_PRINTABLE_STRING(X) X
+#define ORT_TSTR_CONVERT_FROM_STRING(X) X
+#endif
+
 #include "core/common/common.h"
 #include "core/session/onnxruntime_c_api.h"
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -264,8 +264,7 @@ static Status FinalizeSessionOptions(const SessionOptions& user_provided_session
   }
 
   int envVarSession_enable_profiling = ParseEnvironmentVariableWithDefault<int>("ORT_DEBUG_SESSION_ENABLE_PROFILING", -1);
-  if (envVarSession_enable_profiling != -1)
-  {
+  if (envVarSession_enable_profiling != -1) {
     bool envVarSession_enable_profilingBool = envVarSession_enable_profiling == 0 ? false : true;
     if (finalized_session_options.enable_profiling != envVarSession_enable_profilingBool) {
       LOGS(default_logger, INFO) << "Overriding enable_profiling. Original:" << finalized_session_options.enable_profiling << " New:" << envVarSession_enable_profilingBool;
@@ -274,15 +273,14 @@ static Status FinalizeSessionOptions(const SessionOptions& user_provided_session
   }
 
   std::string envVarSession_profile_file_prefix = ParseEnvironmentVariableWithDefault<std::string>("ORT_DEBUG_SESSION_PROFILE_FILE_PREFIX", "");
-  if (envVarSession_profile_file_prefix != "")
-  {
+  if (envVarSession_profile_file_prefix != "") {
     std::basic_string<ORTCHAR_T> profile_file_prefix_ort_string;
 
-    #ifdef _WIN32
+#ifdef _WIN32
     profile_file_prefix_ort_string = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(envVarSession_profile_file_prefix);
-    #else
+#else
     profile_file_prefix_ort_string = envVarSession_profile_file_prefix;
-    #endif
+#endif
 
     LOGS(default_logger, INFO) << "Overriding profile_file_prefix. Original:"
                                << std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(finalized_session_options.profile_file_prefix) << " New:"
@@ -310,8 +308,7 @@ static Status FinalizeSessionOptions(const SessionOptions& user_provided_session
   }
 
   int envVarSession_enable_Cpu_Mem_Arena = ParseEnvironmentVariableWithDefault<int>("ORT_DEBUG_SESSION_ENABLE_CPU_MEM_ARENA", -1);
-  if (envVarSession_enable_Cpu_Mem_Arena != -1)
-  {
+  if (envVarSession_enable_Cpu_Mem_Arena != -1) {
     bool envVarSession_enable_Cpu_Mem_ArenaBool = envVarSession_enable_Cpu_Mem_Arena == 0 ? false : true;
     if (finalized_session_options.enable_cpu_mem_arena != envVarSession_enable_Cpu_Mem_ArenaBool) {
       LOGS(default_logger, INFO) << "Overriding enable_cpu_mem_arena. Original:" << finalized_session_options.enable_cpu_mem_arena << " New:" << envVarSession_enable_Cpu_Mem_ArenaBool;
@@ -320,21 +317,21 @@ static Status FinalizeSessionOptions(const SessionOptions& user_provided_session
   }
 
   int envVarSession_enable_Memory_Pattern = ParseEnvironmentVariableWithDefault<int>("ORT_DEBUG_SESSION_ENABLE_MEMORY_PATTERN", -1);
-  if (envVarSession_enable_Memory_Pattern != -1)
-  {
+  if (envVarSession_enable_Memory_Pattern != -1) {
     bool envVarSession_enable_Memory_PatternBool = envVarSession_enable_Memory_Pattern == 0 ? false : true;
-    if (finalized_session_options.enable_mem_pattern != envVarSession_enable_Memory_PatternBool)
-    LOGS(default_logger, INFO) << "Overriding enable_mem_pattern. Original:" << finalized_session_options.enable_mem_pattern << " New:" << envVarSession_enable_Memory_PatternBool;
-    finalized_session_options.enable_mem_pattern = envVarSession_enable_Memory_PatternBool;
+    if (finalized_session_options.enable_mem_pattern != envVarSession_enable_Memory_PatternBool) {
+      LOGS(default_logger, INFO) << "Overriding enable_mem_pattern. Original:" << finalized_session_options.enable_mem_pattern << " New:" << envVarSession_enable_Memory_PatternBool;
+      finalized_session_options.enable_mem_pattern = envVarSession_enable_Memory_PatternBool;
+    }
   }
 
   int envVarSession_enable_mem_reuse = ParseEnvironmentVariableWithDefault<int>("ORT_DEBUG_SESSION_ENABLE_MEM_REUSE", -1);
-  if (envVarSession_enable_mem_reuse != -1)
-  {
+  if (envVarSession_enable_mem_reuse != -1) {
     bool envVarSession_enable_mem_reuseBool = envVarSession_enable_mem_reuse == 0 ? false : true;
-    if (finalized_session_options.enable_mem_reuse != envVarSession_enable_mem_reuseBool)
-    LOGS(default_logger, INFO) << "Overriding enable_mem_reuse. Original:" << finalized_session_options.enable_mem_reuse << " New:" << envVarSession_enable_mem_reuseBool;
-    finalized_session_options.enable_mem_reuse = envVarSession_enable_mem_reuseBool;
+    if (finalized_session_options.enable_mem_reuse != envVarSession_enable_mem_reuseBool) {
+      LOGS(default_logger, INFO) << "Overriding enable_mem_reuse. Original:" << finalized_session_options.enable_mem_reuse << " New:" << envVarSession_enable_mem_reuseBool;
+      finalized_session_options.enable_mem_reuse = envVarSession_enable_mem_reuseBool;
+    }
   }
 
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -275,16 +275,11 @@ static Status FinalizeSessionOptions(const SessionOptions& user_provided_session
   std::string envVarSession_profile_file_prefix = ParseEnvironmentVariableWithDefault<std::string>("ORT_DEBUG_SESSION_PROFILE_FILE_PREFIX", "");
   if (envVarSession_profile_file_prefix != "") {
     std::basic_string<ORTCHAR_T> profile_file_prefix_ort_string;
-
-#ifdef _WIN32
-    profile_file_prefix_ort_string = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(envVarSession_profile_file_prefix);
-#else
-    profile_file_prefix_ort_string = envVarSession_profile_file_prefix;
-#endif
+    profile_file_prefix_ort_string = ORT_TSTR_CONVERT_FROM_STRING(envVarSession_profile_file_prefix);
 
     LOGS(default_logger, INFO) << "Overriding profile_file_prefix. Original:"
-                               << std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(finalized_session_options.profile_file_prefix) << " New:"
-                               << std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(profile_file_prefix_ort_string);
+                               << ORT_TSTR_CONVERT_TO_PRINTABLE_STRING(finalized_session_options.profile_file_prefix) << " New:"
+                               << ORT_TSTR_CONVERT_TO_PRINTABLE_STRING(profile_file_prefix_ort_string);
     finalized_session_options.profile_file_prefix = profile_file_prefix_ort_string;
   }
 


### PR DESCRIPTION
### Description
Support overriding most ORT session options via environment variables for use in testing, debugging, perf evaluations

### Motivation and Context
ORT Session options are key to controlling ORT behavior. This allows these session options to be overridden at session init time via debug environment variables. This is essential when debugging or investigating performance where a recompile would be burdensome or access to code calling ORT is difficult. This for example allows getting CPU profiling report, testing optimization level, # of threads, logging levels and other options on the fly.