### PR TITLE
Cleanup InferenceSession code

### DIFF
--- a/onnxruntime/core/framework/allocatormgr.cc
+++ b/onnxruntime/core/framework/allocatormgr.cc
@@ -62,29 +62,27 @@ AllocatorPtr CreateAllocator(const AllocatorCreationInfo& info) {
 
     if (info.use_stream_aware_arena) {
 #ifdef ORT_ENABLE_STREAM
-      return AllocatorPtr(
-          std::make_unique<StreamAwareArena>(std::move(device_allocator),
-                                             max_mem,
-                                             info.enable_cross_stream_reusing,
-                                             arena_extend_str,
-                                             initial_chunk_size_bytes,
-                                             max_dead_bytes_per_chunk,
-                                             initial_growth_chunk_size_bytes));
+      return std::make_shared<StreamAwareArena>(std::move(device_allocator),
+                                                max_mem,
+                                                info.enable_cross_stream_reusing,
+                                                arena_extend_str,
+                                                initial_chunk_size_bytes,
+                                                max_dead_bytes_per_chunk,
+                                                initial_growth_chunk_size_bytes);
 #else
       ORT_THROW("StreamAwareArena should be transparent to minimal build.");
 #endif
     } else {
-      return AllocatorPtr(
-          std::make_unique<BFCArena>(std::move(device_allocator),
-                                     max_mem,
-                                     arena_extend_str,
-                                     initial_chunk_size_bytes,
-                                     max_dead_bytes_per_chunk,
-                                     initial_growth_chunk_size_bytes,
-                                     max_power_of_two_extend_bytes));
+      return std::make_shared<BFCArena>(std::move(device_allocator),
+                                        max_mem,
+                                        arena_extend_str,
+                                        initial_chunk_size_bytes,
+                                        max_dead_bytes_per_chunk,
+                                        initial_growth_chunk_size_bytes,
+                                        max_power_of_two_extend_bytes);
     }
   } else {
-    return device_allocator;
+    return std::move(device_allocator);
   }
 }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -407,14 +407,6 @@ InferenceSession::InferenceSession(const SessionOptions& session_options, const 
   ConstructorCommon(session_options, session_env);
 }
 
-#ifdef _WIN32
-InferenceSession::InferenceSession(const SessionOptions& session_options,
-                                   const Environment& session_env,
-                                   const std::string& model_uri)
-    : InferenceSession(session_options, session_env, ToPathString(model_uri)) {
-}
-#endif
-
 InferenceSession::InferenceSession(const SessionOptions& session_options, const Environment& session_env,
                                    std::istream& model_istream)
     : graph_transformer_mgr_(session_options.max_num_graph_transformation_steps),
@@ -1431,7 +1423,7 @@ common::Status InferenceSession::Initialize() {
 #endif
 
     // now that we have all the execution providers, create the session state
-    session_state_ = std::make_unique<SessionState>(
+    session_state_.emplace(
         model_->MainGraph(),
         execution_providers_,
         GetIntraOpThreadPoolToUse(),

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -155,11 +155,6 @@ class InferenceSession {
   InferenceSession(const SessionOptions& session_options,
                    const Environment& session_env,
                    const PathString& model_uri);
-#ifdef _WIN32
-  InferenceSession(const SessionOptions& session_options,
-                   const Environment& session_env,
-                   const std::string& model_uri);
-#endif
 
   /**
     Create a new InferenceSession
@@ -482,7 +477,7 @@ class InferenceSession {
   const logging::Logger* GetLogger() const { return session_logger_; };
 
   const SessionState& GetSessionState() const {
-    ORT_ENFORCE(session_state_ != nullptr, "Session must be initialized to create session state.");
+    ORT_ENFORCE(session_state_.has_value(), "Session must be initialized to create session state.");
     return *session_state_;
   }
 
@@ -682,7 +677,7 @@ class InferenceSession {
 
   // Immutable state for each op in the model. Shared by all executors.
   // It has a dependency on execution_providers_.
-  std::unique_ptr<SessionState> session_state_;
+  std::optional<SessionState> session_state_;
 
   // Threadpools per session. These are initialized and used for the entire duration of the session
   // when use_per_session_threads is true.

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -236,7 +236,7 @@ struct PyInferenceSession {
       : env_(std::move(env)) {
     if (is_arg_file_name) {
       // Given arg is the file path. Invoke the corresponding ctor().
-      sess_ = std::make_unique<InferenceSession>(so.value, *env_, arg);
+      sess_ = std::make_unique<InferenceSession>(so.value, *env_, ToPathString(arg));
     } else {
       // Given arg is the model content as bytes. Invoke the corresponding ctor().
       std::istringstream buffer(arg);

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -2252,7 +2252,7 @@ TEST(InferenceSessionTests, LoadModelWithValidOrtConfigJson) {
 #endif
 
   SessionOptions so;
-  std::string model_path = "testdata/model_with_valid_ort_config_json.onnx";
+  static constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/model_with_valid_ort_config_json.onnx");
 
   // Create session
   InferenceSession session_object_1{so, GetEnvironment(), model_path};
@@ -2318,7 +2318,7 @@ TEST(InferenceSessionTests, LoadModelWithInValidOrtConfigJson) {
 #endif
 
   SessionOptions so;
-  std::string model_path = "testdata/model_with_invalid_ort_config_json.onnx";
+  static constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/model_with_invalid_ort_config_json.onnx");
 
   // Create session (should throw as the json within the model is invalid/improperly formed)
   ORT_TRY {
@@ -2371,7 +2371,7 @@ TEST(InferenceSessionTests, LoadModelWithNoOrtConfigJson) {
   // Change from default value for one option
   so.intra_op_param.thread_pool_size = 2;
 
-  std::string model_path = "testdata/transform/abs-id-max.onnx";
+  static constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/transform/abs-id-max.onnx");
 
   // Create session
   InferenceSession session_object_1{so, GetEnvironment(), model_path};
@@ -2415,7 +2415,7 @@ TEST(InferenceSessionTests, LoadModelWithEnvVarSetToUnsupportedVal) {
   putenv(env_var_value_set_to_unsupported_val);
 #endif
   SessionOptions so;
-  std::string model_path = "testdata/model_with_valid_ort_config_json.onnx";
+  static constexpr const ORTCHAR_T* model_path = ORT_TSTR("testdata/model_with_valid_ort_config_json.onnx");
 
   // Create session (should throw because of the unsupported value for the env var - ORT_LOAD_CONFIG_FROM_MODEL)
   ORT_TRY {

--- a/onnxruntime/test/shared_lib/custom_op_utils.cc
+++ b/onnxruntime/test/shared_lib/custom_op_utils.cc
@@ -43,7 +43,7 @@ void MyCustomKernel::Compute(OrtKernelContext* context) {
   void* allocated = allocator->Alloc(allocator, 2);
   EXPECT_NE(allocated, nullptr) << "KernelContext_GetAllocator() can successfully allocate some memory";
   allocator->Free(allocator, allocated);
-
+  ort_.ReleaseAllocator(allocator);
   // Do computation
 #ifdef USE_CUDA
   // Launch on stream 0 or user provided stream


### PR DESCRIPTION
### Description
1. Remove the method that loads models from std::string(byte strings instead wide strings) on Windows
2. Fix a memory leak in onnxruntime/core/framework/allocatormgr.cc. BFCArena allocators were never freed.
3. Fix a memory leak in onnxruntime/test/shared_lib/custom_op_utils.cc
4. Change a member variable of InferenceSession from a std::unique_ptr to std::optional to reduce an unnecessary memory allocation.  See https://abseil.io/tips/187 "Common Anti-Pattern: Delayed Initialization“ section. I also got this suggestion from @yuslepukhin . 


