### PR TITLE
gather OP with scalar indice in NNAPI EP

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
@@ -121,14 +121,14 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
                                       {output}, {output_operand_type});
   }
 
-  std::string intermidiate_output = model_builder.GetUniqueName(node_unit.Name() + "_need_squeeze");
-  shaper.AddShape(intermidiate_output, output_shape);
+  std::string intermediate_output = model_builder.GetUniqueName(node_unit.Name() + "_need_squeeze");
+  shaper.AddShape(intermediate_output, output_shape);
 
   ORT_RETURN_IF_ERROR(model_builder.AddOperation(ANEURALNETWORKS_GATHER, input_indices,
-                                                 {intermidiate_output}, {output_operand_type}));
+                                                 {intermediate_output}, {output_operand_type}));
 
   std::string squeeze_op_name = model_builder.GetUniqueName(node_unit.Name() + "_squeeze");
-  return op_builder_helpers::AddSqueezeOp(model_builder, squeeze_op_name, intermidiate_output, {output}, {axis});
+  return op_builder_helpers::AddSqueezeOp(model_builder, squeeze_op_name, intermediate_output, {output}, {axis});
 }
 
 // Operator support related

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
@@ -128,7 +128,7 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
                                                  {intermediate_output}, {output_operand_type}));
 
   std::string squeeze_op_name = model_builder.GetUniqueName(node_unit.Name() + "_squeeze");
-  return op_builder_helpers::AddSqueezeOp(model_builder, squeeze_op_name, intermediate_output, {output}, {axis});
+  return op_builder_helpers::AddSqueezeOp(model_builder, squeeze_op_name, intermediate_output, output, {axis});
 }
 
 // Operator support related

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/gather_op_builder.cc
@@ -71,6 +71,8 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
   input_indices.push_back(operand_indices.at(input1));
   ADD_SCALAR_OPERAND(model_builder, input_indices, axis);
 
+  auto output_shape = shaper[output];
+  bool need_squeeze = false;
   int32_t indices_data_type;
   GetType(node_unit.Inputs()[1].node_arg, indices_data_type);
   if (Contains(model_builder.GetInitializerTensors(), input2) &&
@@ -98,14 +100,35 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const
       indices.assign(indice_span.begin(), indice_span.end());
     }
 
+    // If indices is a scalar, insert a dimension of 1
+    // ONNX spec says that indices can be q-D tensor, q could be any value >= 0
+    // When indices is a scalar, output shape would be automatically squeezed.
+    // Add a fake output dimension to avoid NNAPI error.
+    if (indices_dimen.empty()) {
+      indices_dimen.push_back(1);
+      output_shape.insert(output_shape.begin() + axis, 1);
+      need_squeeze = true;
+    }
+
     OperandType indices_operand_type(Type::TENSOR_INT32, indices_dimen);
     ORT_RETURN_IF_ERROR(model_builder.AddOperandFromPersistMemoryBuffer(input2, indices.data(), indices_operand_type));
   }
   input_indices.push_back(operand_indices.at(input2));
 
-  const OperandType output_operand_type(operand_types.at(input1).type, shaper[output]);
-  return model_builder.AddOperation(ANEURALNETWORKS_GATHER, input_indices,
-                                    {output}, {output_operand_type});
+  const OperandType output_operand_type(operand_types.at(input1).type, output_shape);
+  if (!need_squeeze) {
+    return model_builder.AddOperation(ANEURALNETWORKS_GATHER, input_indices,
+                                      {output}, {output_operand_type});
+  }
+
+  std::string intermidiate_output = model_builder.GetUniqueName(node_unit.Name() + "_need_squeeze");
+  shaper.AddShape(intermidiate_output, output_shape);
+
+  ORT_RETURN_IF_ERROR(model_builder.AddOperation(ANEURALNETWORKS_GATHER, input_indices,
+                                                 {intermidiate_output}, {output_operand_type}));
+
+  std::string squeeze_op_name = model_builder.GetUniqueName(node_unit.Name() + "_squeeze");
+  return op_builder_helpers::AddSqueezeOp(model_builder, squeeze_op_name, intermidiate_output, {output}, {axis});
 }
 
 // Operator support related

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -599,7 +599,6 @@ TEST(NnapiExecutionProviderTest, ActivationOutsideOfPartition) {
   ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 1);
 }
 
-
 }  // namespace test
 }  // namespace onnxruntime
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
+++ b/onnxruntime/test/providers/nnapi/nnapi_basic_test.cc
@@ -518,6 +518,31 @@ TEST(NnapiExecutionProviderTest, DISABLED_TestCast) {
   RunQDQModelTest(build_func, "nnapi_qdq_test_graph_cast", {ExpectedEPNodeAssignment::None});
 }
 
+TEST(NnapiExecutionProviderTest, TestGather) {
+  auto BuildGatherTestCase = [](const std::vector<int64_t>& input_shape,
+                                bool scalar_indices) {
+    return [input_shape, scalar_indices](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<float>(input_shape,
+                                                 std::numeric_limits<float>::min(),
+                                                 std::numeric_limits<float>::max());
+      auto* output_arg = builder.MakeOutput();
+      auto* indices = builder.MakeScalarInitializer<int64_t>(1);
+      if (!scalar_indices) {
+        indices = builder.Make1DInitializer<int64_t>({1});
+      }
+      auto& gather_node = builder.AddNode("Gather", {input_arg, indices}, {output_arg});
+      gather_node.AddAttribute("axis", int64_t(1));
+    };
+  };
+
+  RunQDQModelTest(BuildGatherTestCase({10, 5, 5} /* input_shape */, true /* scalar_indices */),
+                  "nnapi_test_graph_gather_scalar", {ExpectedEPNodeAssignment::All});
+
+  RunQDQModelTest(BuildGatherTestCase({10, 5, 5} /* input_shape */, false /* not scalar_indices */),
+                  "nnapi_test_graph_gather",
+                  {ExpectedEPNodeAssignment::All});
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 
 TEST(NnapiExecutionProviderTest, NNAPIFlagsTest) {
@@ -573,6 +598,7 @@ TEST(NnapiExecutionProviderTest, ActivationOutsideOfPartition) {
   // expect one NNAPI partition
   ASSERT_EQ(CountAssignedNodes(session_object.GetGraph(), kNnapiExecutionProvider), 1);
 }
+
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

NNAPI Doesn't support the indices input of Gather to be a scalar.
To workaround it.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


