### PR TITLE
Refactor prepack buffer code

### DIFF
--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -121,7 +121,9 @@ class OpKernel {
   // @param prepacked_buffers: The pre-packed buffers to be used by this kernel for the provided input index
   //                           (Sometimes a single constant initializer may have multiple pre-packed buffers associated
   //                            with it and it upto the kernel developer to store it in any order of their choice in PrePack()
-  //                            and must use the same order for retrieval in UseSharedPrePackedBuffers().
+  //                            and must use the same order for retrieval in UseSharedPrePackedBuffers(). Though each element
+  //                           of this vector is a BufferUniquePtr, the deleter of the BufferUniquePtr is NULL. So actually they
+  //                           are raw pointers.
   // @param input_idx: The input index of the tensor in this kernel
   // @param used_shared_buffers: Boolean flag set by the kernel implementation indicating
   // that the provided weight has been used by the kernel.

--- a/onnxruntime/contrib_ops/cpu/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/attention.cc
@@ -8,6 +8,7 @@
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
 #include "core/common/safeint.h"
+#include "core/common/span_utils.h"
 #include "core/platform/threadpool.h"
 
 using onnxruntime::narrow;
@@ -15,7 +16,7 @@ using onnxruntime::concurrency::ThreadPool;
 namespace onnxruntime {
 namespace contrib {
 
-static void FreePackedWeights(BufferUniquePtr* array, size_t array_size) {
+static void FreePackedWeights(gsl::span<IAllocatorUniquePtr<void>> array, size_t array_size) {
   for (size_t i = 0; i < array_size; i++) {
     array[i].reset();
   }
@@ -41,7 +42,7 @@ class Attention : public OpKernel, public AttentionCPUBase {
                                size_t input_hidden_size, const T* weights_data,
                                size_t weight_matrix_col_size, PrePackedWeights* prepacked_weights);
 
-  BufferUniquePtr packed_weights_[3];
+  std::array<IAllocatorUniquePtr<void>, 3> packed_weights_;
   size_t packed_weights_size_[3] = {0, 0, 0};
   bool is_prepack_ = false;
   TensorShape weight_shape_;
@@ -76,15 +77,14 @@ bool Attention<T>::IsPackWeightsSuccessful(int qkv_index,
   }
 
   size_t loop_len = narrow<size_t>(num_heads_);
-  size_t packed_weights_data_size = packb_size * loop_len;  // The same size would be computed by AllocArray() below
-  auto* packed_weights_data = static_cast<uint8_t*>(alloc->AllocArray(packb_size, loop_len));
-
+  size_t packed_weights_data_size = SafeInt<size_t>(packb_size) * loop_len;
+  packed_weights_[qkv_index] = IAllocator::MakeUniquePtr<void>(alloc, packed_weights_data_size, true);
+  packed_weights_size_[qkv_index] = packb_size;
+  std::byte* packed_weights_data = static_cast<std::byte*>(packed_weights_[qkv_index].get());
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we do not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(packed_weights_data, 0, packed_weights_data_size);
-  packed_weights_[qkv_index] = BufferUniquePtr(packed_weights_data, BufferDeleter(std::move(alloc)));
-  packed_weights_size_[qkv_index] = packb_size;
 
   for (size_t i = 0; i < loop_len; i++) {
     MlasGemmPackB(CblasNoTrans, head_size, input_hidden_size, weights_data, weight_matrix_col_size, packed_weights_data);

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -32,7 +32,7 @@ class QAttention : public OpKernel, public AttentionCPUBase {
                                    /*out*/ bool& used_shared_buffers) override;
 
  private:
-  BufferUniquePtr packed_weights_;
+  IAllocatorUniquePtr<void> packed_weights_;
   size_t packed_weights_size_;
   TensorShape weight_shape_;
   bool weights_is_signed_;
@@ -90,14 +90,14 @@ Status QAttention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr
 
   const size_t loop_len = 3 * static_cast<size_t>(num_heads_);
   size_t packed_weights_data_size = packed_weights_size_ * loop_len;
-  auto* packed_weights_data = static_cast<uint8_t*>(alloc->Alloc(packed_weights_data_size));
+
+  packed_weights_ = IAllocator::MakeUniquePtr<void>(alloc, packed_weights_data_size, true);
+  std::byte* packed_weights_data = static_cast<std::byte*>(packed_weights_.get());
 
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we don not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(packed_weights_data, 0, packed_weights_data_size);
-
-  packed_weights_ = BufferUniquePtr(packed_weights_data, BufferDeleter(std::move(alloc)));
 
   for (size_t i = 0; i < loop_len; i++) {
     MlasGemmPackB(head_size, input_hidden_size, weights_data, hidden_size_x3, false /*AIsSigned*/, weights_is_signed_, packed_weights_data);

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -59,15 +59,17 @@ Status DynamicQuantizeLSTM::TryPackWeights(const Tensor& weights, PackedWeights&
     return Status::OK();
   }
 
-  size_t packed_weights_data_size = SafeInt<size_t>(packed_weights_size * num_directions_);
-  auto* packed_weights_data = alloc->Alloc(packed_weights_data_size);
+  size_t packed_weights_data_size = SafeInt<size_t>(packed_weights_size) * num_directions_;
+
+  packed_weights.buffer_ = IAllocator::MakeUniquePtr<void>(alloc, packed_weights_data_size, true);
+
+  auto* packed_weights_data = packed_weights.buffer_.get();
 
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we don not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(packed_weights_data, 0, packed_weights_data_size);
 
-  packed_weights.buffer_ = BufferUniquePtr(packed_weights_data, BufferDeleter(alloc));
   packed_weights.buffer_size_ = packed_weights_data_size;
   packed_weights.weights_size_ = packed_weights_size;
   packed_weights.shape_ = shape;

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -47,14 +47,14 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
     bool a_is_signed = a->IsDataType<int8_t>();
     const uint8_t* a_data = static_cast<const uint8_t*>(a->DataRaw());
 
-    std::unique_ptr<Tensor> a_trans_buffer;
+    std::optional<Tensor> a_trans_buffer;
     if (trans_A_ == CblasTrans) {
       a_data = quantization::TransPoseInputData(a_data, a_trans_buffer, allocator, K, M);
     }
 
     bool b_is_signed;
     const uint8_t* b_data = nullptr;
-    std::unique_ptr<Tensor> b_trans_buffer;
+    std::optional<Tensor> b_trans_buffer;
     if (nullptr == b) {
       b_data = static_cast<const uint8_t*>(packed_b_.get());
       b_is_signed = b_is_signed_;
@@ -71,11 +71,11 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
 
     // prepare output buffer of GEMM
     int32_t* gemm_output_data = nullptr;
-    std::unique_ptr<Tensor> gemm_output_buffer;
+    std::optional<Tensor> gemm_output_buffer;
     bool need_requant = y_scale != nullptr;
     if (need_requant) {
       TensorShape outputshape{static_cast<int64_t>(M), static_cast<int64_t>(N)};
-      gemm_output_buffer = std::make_unique<Tensor>(DataTypeImpl::GetType<int32_t>(), outputshape, allocator);
+      gemm_output_buffer.emplace(DataTypeImpl::GetType<int32_t>(), outputshape, allocator);
       gemm_output_data = gemm_output_buffer->MutableData<int32_t>();
     } else {
       gemm_output_data = static_cast<int32_t*>(y->MutableDataRaw());
@@ -103,8 +103,8 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
     gemm_param.PerColumnZeroPoints = !IsScalarOr1ElementVector(b_zp);
 
     std::vector<float> output_scales = ComputeOutputScale(a_scale, b_scale, y_scale);
-    std::unique_ptr<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR> scale_bias_proc_ptr;
-    std::unique_ptr<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR> requant_proc_ptr;
+    std::optional<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR> scale_bias_proc_ptr;
+    std::optional<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR> requant_proc_ptr;
     SetPostProcessor(y_zp, N, output_scales, y, gemm_param, scale_bias_proc_ptr, requant_proc_ptr);
 
     MlasGemmBatch(gemm_shape, &gemm_param, 1, context->GetOperatorThreadPool());
@@ -181,12 +181,12 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
                                const std::vector<float>& output_scales,
                                Tensor* y,
                                MLAS_GEMM_QUANT_DATA_PARAMS& gemm_param,
-                               std::unique_ptr<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR>& scale_bias_proc_ptr,
-                               std::unique_ptr<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR>& requant_proc_ptr) {
+                               std::optional<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR>& scale_bias_proc_ptr,
+                               std::optional<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR>& requant_proc_ptr) {
     if (nullptr != y_zp) {
       bool is_y_signed = y->IsDataType<int8_t>();
       int32_t y_zero_point = is_y_signed ? *y_zp->Data<int8_t>() : *y_zp->Data<uint8_t>();
-      requant_proc_ptr = std::make_unique<MLAS_QGEMM_REQUANT_OUTPUT_PROCESSOR>(
+      requant_proc_ptr.emplace(
           y->MutableDataRaw(),
           out_lda,
           nullptr,
@@ -194,16 +194,16 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
           output_scales.size() > 1,
           y_zero_point,
           is_y_signed);
-      gemm_param.OutputProcessor = requant_proc_ptr.get();
+      gemm_param.OutputProcessor = &*requant_proc_ptr;
     } else {
-      scale_bias_proc_ptr = std::make_unique<MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR>(
+      scale_bias_proc_ptr.emplace(
           static_cast<float*>(y->MutableDataRaw()),
           out_lda,
           output_scales.data(),
           nullptr,
           MLAS_QGEMM_OUTPUT_MODE::ZeroMode,
           output_scales.size() > 1 ? MLAS_QUANTIZATION_GRANULARITY::PerColumn : MLAS_QUANTIZATION_GRANULARITY::PerMatrix);
-      gemm_param.OutputProcessor = scale_bias_proc_ptr.get();
+      gemm_param.OutputProcessor = &*scale_bias_proc_ptr;
     }
   }
 };

--- a/onnxruntime/core/framework/prepacked_weights.h
+++ b/onnxruntime/core/framework/prepacked_weights.h
@@ -16,8 +16,8 @@ struct PrePackedWeights final {
   // Hence we hold them in container. It is upto the developer implementing each PrePack()
   // method to define what gets stored in which position of the container.
 
-  std::vector<IAllocatorUniquePtr<void>> buffers_;             // cache pre-packed buffers associated with the kernel
-  std::vector<size_t> buffer_sizes_;                           // cache sizes of pre-packed buffers (in bytes)
+  std::vector<IAllocatorUniquePtr<void>> buffers_;  // cache pre-packed buffers associated with the kernel
+  std::vector<size_t> buffer_sizes_;                // cache sizes of pre-packed buffers (in bytes)
 
   // Produces a hash of the buffers stored in the given instance of this class
   HashValue GetHash() const;

--- a/onnxruntime/core/framework/prepacked_weights.h
+++ b/onnxruntime/core/framework/prepacked_weights.h
@@ -16,7 +16,7 @@ struct PrePackedWeights final {
   // Hence we hold them in container. It is upto the developer implementing each PrePack()
   // method to define what gets stored in which position of the container.
 
-  std::vector<std::unique_ptr<void, BufferDeleter>> buffers_;  // cache pre-packed buffers associated with the kernel
+  std::vector<IAllocatorUniquePtr<void>> buffers_;             // cache pre-packed buffers associated with the kernel
   std::vector<size_t> buffer_sizes_;                           // cache sizes of pre-packed buffers (in bytes)
 
   // Produces a hash of the buffers stored in the given instance of this class

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -75,7 +75,7 @@ ONNX_CPU_OPERATOR_TYPED_KERNEL(
 bool GemmPackBFp32(AllocatorPtr& alloc,
                    const Tensor& tensor_b,
                    bool trans_b,
-                   BufferUniquePtr& packed_b,
+                   IAllocatorUniquePtr<void>& packed_b,
                    size_t& packed_b_size,
                    TensorShape& b_shape) {
   // Only handle the common case of a 2D weight matrix. Additional matrices
@@ -93,14 +93,14 @@ bool GemmPackBFp32(AllocatorPtr& alloc,
     return false;
   }
 
-  auto* packed_b_data = alloc->Alloc(packed_b_size);
+  packed_b = IAllocator::MakeUniquePtr<void>(alloc, packed_b_size, true);
+  auto* packed_b_data = packed_b.get();
 
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we don not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(packed_b_data, 0, packed_b_size);
 
-  packed_b = BufferUniquePtr(packed_b_data, BufferDeleter(alloc));
   MlasGemmPackB(trans_b ? CblasTrans : CblasNoTrans,
                 N,
                 K,

--- a/onnxruntime/core/providers/cpu/math/gemm.h
+++ b/onnxruntime/core/providers/cpu/math/gemm.h
@@ -39,7 +39,7 @@ class Gemm : protected GemmBase, public OpKernel {
 
  protected:
   TensorShape b_shape_;
-  BufferUniquePtr packed_b_;
+  IAllocatorUniquePtr<void> packed_b_;
 
   // For fused gemm + activation
   std::unique_ptr<functors::ElementWiseRangedTransform<T>> activation_;

--- a/onnxruntime/core/providers/cpu/math/gemm_matmul_common.h
+++ b/onnxruntime/core/providers/cpu/math/gemm_matmul_common.h
@@ -10,7 +10,7 @@ namespace onnxruntime {
 bool GemmPackBFp32(AllocatorPtr& alloc,
                    const Tensor& tensor_b,
                    bool trans_b,
-                   BufferUniquePtr& packed_b,
+                   IAllocatorUniquePtr<void>& packed_b,
                    size_t& packed_b_size,
                    TensorShape& b_shape);
 

--- a/onnxruntime/core/providers/cpu/math/matmul.h
+++ b/onnxruntime/core/providers/cpu/math/matmul.h
@@ -40,7 +40,7 @@ class MatMul<float> final : public OpKernel {
 
  private:
   TensorShape b_shape_;
-  BufferUniquePtr packed_b_;
+  IAllocatorUniquePtr<void> packed_b_;
 
   // For FusedMatMul contrib ops
   float alpha_attr_;

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
@@ -37,7 +37,7 @@ class MatMulIntegerBase : public OpKernel {
 
       const auto* b_data = static_cast<const uint8_t*>(tensor.DataRaw());
 
-      std::unique_ptr<Tensor> b_trans_buffer;
+      std::optional<Tensor> b_trans_buffer;
       if (IsBTransposed()) {
         std::swap(K, N);
         b_data = quantization::TransPoseInputData(b_data, b_trans_buffer, alloc, N, K);
@@ -47,15 +47,12 @@ class MatMulIntegerBase : public OpKernel {
         return Status::OK();
       }
 
-      auto* packed_b_data = alloc->Alloc(packed_b_size);
-
+      packed_b_ = IAllocator::MakeUniquePtr<void>(alloc, packed_b_size, true);
       // Initialize memory to 0 as there could be some padding associated with pre-packed
       // buffer memory and we don not want it uninitialized and generate different hashes
       // if and when we try to cache this pre-packed buffer for sharing between sessions.
-      memset(packed_b_data, 0, packed_b_size);
-
-      packed_b_ = BufferUniquePtr(packed_b_data, BufferDeleter(std::move(alloc)));
-      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_data);
+      memset(packed_b_.get(), 0, packed_b_size);
+      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get());
 
       bool share_prepacked_weights = (prepacked_weights != nullptr);
       if (share_prepacked_weights) {
@@ -129,7 +126,7 @@ class MatMulIntegerBase : public OpKernel {
 
   bool b_is_signed_{true};
   TensorShape b_shape_;
-  BufferUniquePtr packed_b_;
+  IAllocatorUniquePtr<void> packed_b_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -290,9 +290,9 @@ class QLinearConv : public OpKernel {
 
   ConvAttributes conv_attrs_;
   TensorShape W_shape_;
-  BufferUniquePtr packed_W_buffer_;
+  IAllocatorUniquePtr<void> packed_W_buffer_;
   size_t packed_W_size_{0};
-  BufferUniquePtr reordered_W_buffer_;
+  IAllocatorUniquePtr<void> reordered_W_buffer_;
   bool is_W_signed_{false};
   bool is_W_packed_{false};
   bool is_symmetric_conv_{false};
@@ -421,22 +421,21 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
                                        is_W_signed_);
     if (packed_W_size_ != 0) {
       size_t packed_W_data_size = SafeInt<size_t>(group_count) * packed_W_size_;
-      auto* packed_W = static_cast<uint8_t*>(alloc->Alloc(packed_W_data_size));
+      packed_W_buffer_ = IAllocator::MakeUniquePtr<void>(alloc, packed_W_data_size, true);
+      auto* packed_W = static_cast<uint8_t*>(packed_W_buffer_.get());
 
       // Initialize memory to 0 as there could be some padding associated with pre-packed
       // buffer memory and we don not want it uninitialized and generate different hashes
       // if and when we try to cache this pre-packed buffer for sharing between sessions.
       memset(packed_W, 0, packed_W_data_size);
 
-      packed_W_buffer_ = BufferUniquePtr(packed_W, BufferDeleter(alloc));
-
       // Allocate a temporary buffer to hold the reordered oihw->hwio filter for
       // a single group.
       //
       // Note: The size of this buffer is less than or equal to the size of the original
       // weight tensor, so the allocation size is guaranteed to fit inside size_t.
-      auto* group_reordered_W = static_cast<uint8_t*>(alloc->Alloc(group_output_channels * group_input_channels * kernel_size));
-      BufferUniquePtr group_reordered_W_buffer(group_reordered_W, BufferDeleter(alloc));
+      auto group_reordered_W_buffer = IAllocator::MakeUniquePtr<void>(alloc, group_output_channels * group_input_channels * kernel_size, true);
+      auto* group_reordered_W = static_cast<uint8_t*>(group_reordered_W_buffer.get());
 
       const size_t W_offset = group_output_channels * kernel_dim;
 
@@ -470,14 +469,13 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
   }
 
   size_t reordered_w_data_size = SafeInt<size_t>(sizeof(uint8_t)) * output_channels * group_input_channels * kernel_size;
-  auto* reordered_W = static_cast<uint8_t*>(alloc->Alloc(reordered_w_data_size));
+  reordered_W_buffer_ = IAllocator::MakeUniquePtr<void>(alloc, reordered_w_data_size, true);
+  uint8_t* reordered_W = static_cast<uint8_t*>(reordered_W_buffer_.get());
 
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we don not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(reordered_W, 0, reordered_w_data_size);
-
-  reordered_W_buffer_ = BufferUniquePtr(reordered_W, BufferDeleter(alloc));
 
   ReorderFilter(Wdata, reordered_W, output_channels, group_input_channels, kernel_size);
 

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -195,14 +195,15 @@ Status DeepCpuLstmOp::TryPackWeights(const Tensor& weights, PackedWeights& packe
   }
 
   size_t packed_weights_data_size = SafeInt<size_t>(packed_weights_size) * num_directions_;
-  auto* packed_weights_data = alloc->Alloc(packed_weights_data_size);
+  packed_weights.buffer_ = IAllocator::MakeUniquePtr<void>(alloc, packed_weights_data_size, true);
+
+  auto* packed_weights_data = packed_weights.buffer_.get();
 
   // Initialize memory to 0 as there could be some padding associated with pre-packed
   // buffer memory and we don not want it uninitialized and generate different hashes
   // if and when we try to cache this pre-packed buffer for sharing between sessions.
   memset(packed_weights_data, 0, packed_weights_data_size);
 
-  packed_weights.buffer_ = BufferUniquePtr(packed_weights_data, BufferDeleter(alloc));
   packed_weights.buffer_size_ = packed_weights_data_size;
   packed_weights.weights_size_ = packed_weights_size;
   packed_weights.shape_ = shape;

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.h
@@ -163,7 +163,7 @@ void ComputeGemm(const int M,
 }
 
 struct PackedWeights {
-  BufferUniquePtr buffer_;
+  IAllocatorUniquePtr<void> buffer_;
   size_t buffer_size_;
   size_t weights_size_;
   TensorShape shape_;

--- a/onnxruntime/core/quantization/quantization.h
+++ b/onnxruntime/core/quantization/quantization.h
@@ -5,7 +5,7 @@
 
 #include <cmath>
 #include <vector>
-
+#include <optional>
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/mlas/inc/mlas.h"
@@ -188,12 +188,12 @@ void Dequantize(const std::vector<T>& values,
 
 // Transpose the input and store it to a new allocated buffer.
 inline uint8_t* TransPoseInputData(const uint8_t* input,
-                                   std::unique_ptr<Tensor>& buffer_holder,
+                                   std::optional<Tensor>& buffer_holder,
                                    AllocatorPtr& allocator,
                                    size_t M,
                                    size_t N) {
   TensorShape outputshape{static_cast<int64_t>(M), static_cast<int64_t>(N)};
-  buffer_holder = std::make_unique<Tensor>(DataTypeImpl::GetType<uint8_t>(), outputshape, allocator);
+  buffer_holder.emplace(DataTypeImpl::GetType<uint8_t>(), outputshape, allocator);
   uint8_t* output = buffer_holder->MutableData<uint8_t>();
   MlasTranspose(input, output, M, N);
   return output;

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -346,14 +346,15 @@ class PrePackingTestOpKernel : public OpKernel {
     ORT_UNUSED_PARAMETER(tensor);
     ORT_UNUSED_PARAMETER(input_idx);
 
-    weight_packed_ = BufferUniquePtr(alloc->Alloc(8), BufferDeleter(alloc));
+    size_t weight_packed_len = 8;
+    weight_packed_ = IAllocator::MakeUniquePtr<void>(alloc, weight_packed_len, true);
     float* data_weights_packed = reinterpret_cast<float*>(weight_packed_.get());
     data_weights_packed[0] = 1.2345f;
     data_weights_packed[1] = data_weights_packed[0] * 2.f;
 
     if (prepacked_weights != nullptr) {
       prepacked_weights->buffers_.push_back(std::move(weight_packed_));
-      prepacked_weights->buffer_sizes_.push_back(8);
+      prepacked_weights->buffer_sizes_.push_back(weight_packed_len);
     }
 
     is_packed = true;
@@ -363,7 +364,7 @@ class PrePackingTestOpKernel : public OpKernel {
 
   int prepack_calls_count = 0;
   int store_pre_packed_weight_calls_count = 0;
-  BufferUniquePtr weight_packed_;
+  IAllocatorUniquePtr<void> weight_packed_;
 };
 
 static void CreateSimpleGraph(Graph& graph) {


### PR DESCRIPTION
### Description
1. Use IAllocatorUniquePtr to replace BufferUniquePtr. It will ensure that the deleter is always right. 
2. Change some std::unique_ptr to std::optional
3. Bypass Arena allocator when allocating the prepack buffers for mlas. In this special case, Arena doesn't help any. And this change is just an internal implementation change, it doesn't affect our public interface. 

### Motivation and Context



