### PR TITLE
Xnnpack QDQ test

### DIFF
--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -211,7 +211,7 @@ static void RunModelTestWithPath(const ORTCHAR_T* ort_model_path, const char* gr
   RandomValueGenerator generator;
   TensorShape input_shape_x{input_shape};
   std::vector<float> input_x = generator.Uniform<float>(input_shape_x.GetDims(),
-                                                        -64, 64);
+                                                        -10, 24);
   OrtValue ml_value_x;
   CreateMLValue<float>(input_shape_x.GetDims(), input_x.data(), OrtMemoryInfo(), &ml_value_x);
   NameMLValMap feeds;

--- a/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ci-pipeline.yml
@@ -3,5 +3,5 @@ stages:
   parameters:
     AllowReleasedOpsetOnly: 0
     BuildForAllArchs: false
-    AdditionalBuildFlags: --build_objc --enable_language_interop_ops --build_wheel
+    AdditionalBuildFlags: --build_objc --enable_language_interop_ops --build_wheel --use_xnnpack
     WithCache: true

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -24,13 +24,6 @@ jobs:
               CCACHE_DIR: $(PROTO_CACHE_DIR)
 
     - template: templates/use-xcode-version.yml
-      # TODO figure out XNNPACK EP test failures
-      # Failing tests:
-      #   -[XnnpackEP TestConvTranspose_qdq]
-      #   -[XnnpackEP TestQDQConvS8S8_per_channel]
-      #parameters:
-      #  xcodeVersion: "13.1"
-
     - template: templates/mac-build-step-with-cache.yml
       parameters:
         WithCache: true

--- a/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-ci-pipeline.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: iOS_CI_on_Mac
   pool:
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   variables:
     PROTO_CACHE_DIR: $(Pipeline.Workspace)/proto_ccache
     ORT_CACHE_DIR: $(Pipeline.Workspace)/ort_ccache
@@ -28,8 +28,8 @@ jobs:
       # Failing tests:
       #   -[XnnpackEP TestConvTranspose_qdq]
       #   -[XnnpackEP TestQDQConvS8S8_per_channel]
-      parameters:
-        xcodeVersion: "13.1"
+      #parameters:
+      #  xcodeVersion: "13.1"
 
     - template: templates/mac-build-step-with-cache.yml
       parameters:


### PR DESCRIPTION
### Description
A few QDQ tests failed on XNNPACK EP.

The reason should be the range of input_data doesn't fit for scale and zero_point.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


