### PR TITLE
[WebNN EP] Add support for Identity operator

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -125,6 +125,7 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"GlobalMaxPool", "maxPool2d"},
     {"AveragePool", "averagePool2d"},
     {"LayerNormalization", "meanVarianceNormalization"},
+    {"Identity", "identity"},
     {"MaxPool", "maxPool2d"},
     {"ReduceMax", "reduceMax"},
     {"ReduceMean", "reduceMean"},

--- a/onnxruntime/core/providers/webnn/builders/impl/identity_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/identity_op_builder.cc
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Intel Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/providers/webnn/builders/model_builder.h"
+#include "core/providers/webnn/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+#include "base_op_builder.h"
+
+namespace onnxruntime {
+namespace webnn {
+
+class IdentityOpBuilder : public BaseOpBuilder {
+  // Add operator related.
+ private:
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
+};
+
+// Add operator related.
+Status IdentityOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
+                                                const Node& node,
+                                                const logging::Logger& logger) const {
+  const auto& input_name = node.InputDefs()[0]->Name();
+  const auto& output_name = node.OutputDefs()[0]->Name();
+  emscripten::val input = model_builder.GetOperand(input_name);
+  emscripten::val output = emscripten::val::object();
+
+  output = model_builder.GetBuilder().call<emscripten::val>("identity", input);
+
+  model_builder.AddOperand(output_name, std::move(output));
+  return Status::OK();
+}
+
+void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<IdentityOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace webnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
@@ -77,6 +77,10 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateGemmOpBuilder("MatMul", op_registrations);
   }
 
+  {  // Identity
+    CreateIdentityOpBuilder("Identity", op_registrations);
+  }
+
   {  // Logical
     CreateLogicalOpBuilder("Equal", op_registrations);
   }

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
@@ -30,6 +30,7 @@ void CreateExpandOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateFlattenOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGatherOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLogicalOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);


### PR DESCRIPTION
### Description
Add Identity for WebNN EP.


### Motivation and Context
Support Identity which is used in SD1.5-unet, SD1.5-VAE-decode.


