### PR TITLE
Update Link to Olive Example in Vitis-AI-ExecutionProvider.md

### DIFF
--- a/docs/execution-providers/Vitis-AI-ExecutionProvider.md
+++ b/docs/execution-providers/Vitis-AI-ExecutionProvider.md
@@ -128,7 +128,7 @@ See [Vitis AI Model Quantization](https://xilinx.github.io/Vitis-AI/docs/workflo
 
 ### Olive
 
-Experimental support for Microsoft Olive is enabled in this release.  The Vitis AI Quantizer has been integrated as a plugin into Olive and will be upstreamed.  Once this is complete, users can refer to the Vitis AI example(s) provided in the [Olive Vitis AI Example Directory](https://github.com/microsoft/Olive/tree/main/examples/resnet_vitis_ai_ptq_cpu).
+Experimental support for Microsoft Olive is enabled in this release.  The Vitis AI Quantizer has been integrated as a plugin into Olive and will be upstreamed.  Once this is complete, users can refer to the Vitis AI example(s) provided in the [Olive Vitis AI Example Configuration](https://github.com/microsoft/Olive/blob/main/examples/resnet/resnet_vitis_ai_ptq_cpu.json).
 
 ## Runtime Options
 


### PR DESCRIPTION
### Description
update link to Olive Example Config, which was moved / restructured in the other repo.

### Motivation and Context
Link to the Vitis AI Quantization Example leads to a 404 page, so i updated the link to link to the example config file, which was moved.


