### PR TITLE
build.py: Fix --parallel 1 option when using Ninja

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1429,7 +1429,10 @@ def build_targets(args, cmake_path, build_dir, configs, num_parallel_jobs, targe
             cmd_args.extend(["--target", target])
 
         build_tool_args = []
-        if num_parallel_jobs != 1:
+        # We do not pass any parallel jobs related option if num_parallel_jobs is 1 as that is the default 
+        # number of jobs in most generators, unless the cmake generator is ninja (as in the ninja case 
+        # the default number of jobs is not 1)
+        if num_parallel_jobs != 1 or args.cmake_generator == "Ninja":
             if is_windows() and args.cmake_generator != "Ninja" and not args.build_wasm:
                 build_tool_args += [
                     f"/maxcpucount:{num_parallel_jobs}",


### PR DESCRIPTION
### Description

This PR ensures that the `--parallel 1` option of `tools/ci_build/build.py` is passed correctly even if the CMake generator used is Ninja.


### Motivation and Context

The option `--parallel 1` was effectively ignored by the `build.py` script, as 1 build job is the default in most CMake generators. However, the default number of jobs for Ninja is not 1, so in the Ninja case it make sense to explicitly pass `--parallel 1` to the ninja invocation.


