### PR TITLE
[React Native] Publish E2E test logs on build failure too.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -300,7 +300,7 @@ stages:
 
     - script: |
         JEST_JUNIT_OUTPUT_FILE=$(Build.SourcesDirectory)/js/react_native/e2e/android-test-results.xml \
-        detox test --record-logs all  --configuration android.emu.release
+        detox test --record-logs all --configuration android.emu.release
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e'
       displayName: Run React Native Detox Android e2e Tests
 
@@ -333,8 +333,10 @@ stages:
 
     - task: PublishPipelineArtifact@1
       inputs:
-        targetPath:  '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
-      displayName: Publish React Native Detox E2E test artifacts
+        artifact: e2e_test_logs
+        targetPath: '$(Build.SourcesDirectory)/js/react_native/e2e/artifacts'
+      condition: succeededOrFailed()
+      displayName: Publish React Native Detox E2E test logs
 
     - script: |
         python3 tools/python/run_android_emulator.py \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Publish E2E test logs on build failure too.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Get more information about intermittent test failures.