### PR TITLE
[ROCm] Add clean step for ROCm CI pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -263,6 +263,6 @@ jobs:
         fi
       workingDirectory: $(Build.SourcesDirectory)
     displayName: 'Umount dataset'
-    condition: succeededOrFailed()
+    condition: always()
 
   - template: templates/explicitly-defined-final-tasks.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -26,6 +26,10 @@ jobs:
       value: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
 
   steps:
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()
+
   - checkout: self
     clean: true
     submodules: recursive
@@ -260,3 +264,5 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)
     displayName: 'Umount dataset'
     condition: succeededOrFailed()
+
+  - template: templates/explicitly-defined-final-tasks.yml

--- a/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-pai-ci-pipeline.yml
@@ -265,4 +265,11 @@ jobs:
     displayName: 'Umount dataset'
     condition: always()
 
-  - template: templates/explicitly-defined-final-tasks.yml
+  - template: templates/component-governance-component-detection-steps.yml
+    parameters :
+      condition : 'succeeded'
+
+  - script: docker image prune -f
+    displayName: Clean docker images
+    condition: eq(variables['Agent.OS'], 'Linux')
+    continueOnError: true


### PR DESCRIPTION
1. Add clean step for ROCm CI pipeline
2. Fix error "device or resource busy" bug by setting umount dataset step as `always()` step.


