### PR TITLE
Fix training pipeline

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier.py
@@ -220,7 +220,7 @@ def load_dataset(args):
 
     # Load the dataset into a pandas dataframe.
     df = pd.read_csv(
-        os.path.join(args.data_dir, "in_domain_train.tsv"),
+        os.path.join(args.data_dir if os.path.exists(args.data_dir) else "cola_public/raw", "in_domain_train.tsv"),
         delimiter="\t",
         header=None,
         names=["sentence_source", "label", "label_notes", "sentence"],

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier_autocast.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_bert_classifier_autocast.py
@@ -218,7 +218,7 @@ def load_dataset(args):
 
     # Load the dataset into a pandas dataframe.
     df = pd.read_csv(
-        os.path.join(args.data_dir, "in_domain_train.tsv"),
+        os.path.join(args.data_dir if os.path.exists(args.data_dir) else "cola_public/raw", "in_domain_train.tsv"),
         delimiter="\t",
         header=None,
         names=["sentence_source", "label", "label_notes", "sentence"],


### PR DESCRIPTION
The contents of bert-data folder seems to have been deleted from the container which is resulting in file not found errors.

For now, we can redownload the data on each PR run (while I figure out how the data was deleted and fix that).