### PR TITLE
Upgrade transformers for ORTModule tests

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly/requirements.txt
@@ -1,4 +1,4 @@
 scikit-learn
 packaging==21.3
-transformers==v4.4.2
+transformers==v4.30.2
 wget

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -2,7 +2,7 @@ pandas
 scikit-learn
 numpy==1.21.6 ; python_version < '3.11'
 numpy==1.24.2 ; python_version >= '3.11'
-transformers==v4.4.2
+transformers==v4.30.2
 rsa==4.9
 tensorboard>=2.2.0,<2.5.0
 h5py


### PR DESCRIPTION
### Description

orttraining-linux-gpu-ci-pipeline is failing with:
2023-06-14T09:07:15.5727446Z =========================== short test summary info ============================
2023-06-14T09:07:15.5727834Z FAILED orttraining_test_ortmodule_api.py::test_bert_inputs_with_dynamic_shape
2023-06-14T09:07:15.5728220Z FAILED orttraining_test_ortmodule_api.py::test_gpu_reserved_memory_with_torch_no_grad
2023-06-14T09:07:15.5728734Z FAILED orttraining_test_ortmodule_api.py::test_dynamic_axes_config - OSError:...
2023-06-14T09:07:15.5729127Z FAILED orttraining_test_ortmodule_api.py::test_hf_model_output_with_tuples[True]
2023-06-14T09:07:15.5729522Z FAILED orttraining_test_ortmodule_api.py::test_hf_model_output_with_tuples[False]
2023-06-14T09:07:15.5730005Z FAILED orttraining_test_ortmodule_api.py::test_hf_save_pretrained - OSError: ...
2023-06-14T09:07:15.5730398Z ===== 6 failed, 1532 passed, 6 skipped, 111 warnings in 474.81s (0:07:54) ======

Not sure it is directly related, transformers PYPI releases a new version few hours ago. A big guess is there are some incompatibilities between old version 4.4.2 with current HF services. Try some luck to see whether it can fix the CI by upgrading transformers versions for ORTModule tests. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


