### PR TITLE
Add compute capacity to trtep engine cache file

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -1994,11 +1994,11 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
     std::unique_ptr<nvinfer1::ICudaEngine> trt_engine;
     std::unique_ptr<nvinfer1::IExecutionContext> trt_context;
 
-    // Name the engine cache based on GPU compute capacity to prevent user from loading an incompatible cache
+    // Name the engine cache based on GPU compute capacity and reduce the chance of loading an incompatible cache
+    // Note: Engine cache generated on a GPU with large memory might not be loadable on a GPU with smaller memory, even if they share the same compute capacity
     cudaDeviceProp prop;
-    std::string compute_capability = "";
     CUDA_CALL_THROW(cudaGetDeviceProperties(&prop, device_id_));
-    compute_capability = GetComputeCapacity(prop);
+    std::string compute_capability = GetComputeCapacity(prop);
 
     if (!has_dynamic_shape) {
       const std::string cache_path = GetCachePath(cache_path_, trt_node_name_with_precision);
@@ -2240,9 +2240,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
 
       // Name the engine cache based on GPU compute capacity to prevent user from loading an incompatible cache
       cudaDeviceProp prop;
-      std::string compute_capability = "";
       CUDA_CALL_THROW(cudaGetDeviceProperties(&prop, device_id_));
-      compute_capability = GetComputeCapacity(prop);
+      std::string compute_capability = GetComputeCapacity(prop);
 
       // Load serialized engine
       const std::string cache_path = GetCachePath(trt_state->engine_cache_path, trt_state->trt_node_name_with_precision);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2238,7 +2238,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
       Ort::ThrowOnError(api->KernelContext_GetGPUComputeStream(context, &cuda_stream));
       cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
 
-      // Name the engine cache based on GPU compute capacity to prevent user from loading an incompatible cache
+      // Name the engine cache based on GPU compute capacity and reduce the chance of loading an incompatible cache
+      // Note: Engine cache generated on a GPU with large memory might not be loadable on a GPU with smaller memory, even if they share the same compute capacity
       cudaDeviceProp prop;
       CUDA_CALL_THROW(cudaGetDeviceProperties(&prop, device_id_));
       std::string compute_capability = GetComputeCapacity(prop);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2246,8 +2246,8 @@ common::Status TensorrtExecutionProvider::Compile(const std::vector<FusedNodeAnd
 
       // Load serialized engine
       const std::string cache_path = GetCachePath(trt_state->engine_cache_path, trt_state->trt_node_name_with_precision);
-      const std::string engine_cache_path = cache_path + compute_capability + ".engine";
-      const std::string profile_cache_path = cache_path + compute_capability + ".profile";
+      const std::string engine_cache_path = cache_path + "_sm" + compute_capability + ".engine";
+      const std::string profile_cache_path = cache_path + "_sm" + compute_capability + ".profile";
       std::string timing_cache_path = "";
       if (timing_cache_enable_) {
         timing_cache_path = GetTimingCachePath(cache_path_, prop);

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -447,7 +447,7 @@ std::string GetCachePath(const std::string& root, const std::string& name) {
  * Get compute capability
  *
  */
-std::string GetComputeCapacity(cudaDeviceProp prop) {
+std::string GetComputeCapacity(const cudaDeviceProp& prop) {
   const std::string compute_capability = std::to_string(prop.major * 10 + prop.minor);
   return compute_capability;
 }

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -444,13 +444,22 @@ std::string GetCachePath(const std::string& root, const std::string& name) {
 }
 
 /*
+ * Get compute capability
+ *
+ */
+std::string GetComputeCapacity(cudaDeviceProp prop) {
+  const std::string compute_capability = std::to_string(prop.major * 10 + prop.minor);
+  return compute_capability;
+}
+
+/*
  * Get Timing by compute capability
  *
  */
 std::string GetTimingCachePath(const std::string& root, cudaDeviceProp prop) {
   // append compute capability of the GPU as this invalidates the cache and TRT will throw when loading the cache
   const std::string timing_cache_name = "TensorrtExecutionProvider_cache_cc" +
-                                        std::to_string(prop.major * 10 + prop.minor) + ".timing";
+                                        GetComputeCapacity(prop) + ".timing";
   return GetCachePath(root, timing_cache_name);
 }
 

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -458,7 +458,7 @@ std::string GetComputeCapacity(const cudaDeviceProp& prop) {
  */
 std::string GetTimingCachePath(const std::string& root, cudaDeviceProp prop) {
   // append compute capability of the GPU as this invalidates the cache and TRT will throw when loading the cache
-  const std::string timing_cache_name = "TensorrtExecutionProvider_cache_cc" +
+  const std::string timing_cache_name = "TensorrtExecutionProvider_cache_sm" +
                                         GetComputeCapacity(prop) + ".timing";
   return GetCachePath(root, timing_cache_name);
 }


### PR DESCRIPTION
### Description

Add "_smXX" to trtep engine cache file name, which "sm" stands for "Streaming Multiprocessor".

> The GPU compute capability version is prefixed with "SM" because NVIDIA typically improves and updates the SM in each new GPU architecture.

### Motivation and Context

Github issue: https://github.com/microsoft/onnxruntime/issues/15982

Reduce the chance of misusing incompatible engine cache, when user is switching GPU devices with different compute capacity

* The prevention can't be 100%, as model size & GPU memory size could be another factor to make cache incompatible