### PR TITLE
[WebNN EP] Support Squeeze Op

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -136,6 +136,7 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"Reshape", "reshape"},
     {"Resize", "resample2d"},
     {"Split", "split"},
+    {"Squeeze", "squeeze"},
     {"Transpose", "transpose"},
     {"Unsqueeze", "unsqueeze"},
 };

--- a/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/squeeze_unsqueeze_op_builder.cc
@@ -16,7 +16,7 @@
 namespace onnxruntime {
 namespace webnn {
 
-class UnsqueezeOpBuilder : public BaseOpBuilder {
+class SqueezeUnsqueezeOpBuilder : public BaseOpBuilder {
   // Add operator related.
  public:
   void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const override;
@@ -32,10 +32,10 @@ class UnsqueezeOpBuilder : public BaseOpBuilder {
 };
 
 // Add operator related.
-void UnsqueezeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
-  // Unsqueeze opset 13 uses input 1 as axes, add it to initializer skip list.
+void SqueezeUnsqueezeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
+  // Squeeze/Unsqueeze opset 13 uses input 1 as axes, add it to initializer skip list.
   const auto& input_defs = node.InputDefs();
-  if (node.SinceVersion() > 12 && input_defs.size() > 1) {
+  if (node.SinceVersion() >= 13 && input_defs.size() > 1) {
     model_builder.AddInitializerToSkip(input_defs[1]->Name());  // "axes"
     model_builder.AddInputToSkip(input_defs[1]->Name());
   }
@@ -43,20 +43,19 @@ void UnsqueezeOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, cons
 
 // Add operator related.
 
-Status UnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
-                                                 const Node& node,
-                                                 const logging::Logger& logger) const {
+Status SqueezeUnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
+                                                        const Node& node,
+                                                        const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
   std::vector<int64_t> input_shape;
   ORT_RETURN_IF_NOT(GetShape(*input_defs[0], input_shape, logger), "Cannot get input shape");
   const auto input_rank = input_shape.size();
 
-  NodeAttrHelper helper(node);
   emscripten::val options = emscripten::val::object();
   std::vector<int32_t> axes_data;
 
-  if (node.SinceVersion() >= 13) {
+  if (node.SinceVersion() >= 13 && input_defs.size() > 1) {
     // Input axes is provided, use axes initializer data.
     const auto& initializers = model_builder.GetInitializerTensors();
     const auto& axes_tensor = *initializers.at(input_defs[1]->Name());
@@ -67,6 +66,7 @@ Status UnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
         axes_data_span.begin(), axes_data_span.end(), std::back_inserter(axes_data),
         [output_rank](int64_t axis) -> int32_t { return HandleNegativeAxis(axis, output_rank); });
   } else {
+    NodeAttrHelper helper(node);
     if (helper.HasAttr("axes")) {
       auto axes = helper.Get("axes", std::vector<int64_t>{});
       const auto output_rank = input_rank + axes.size();
@@ -80,17 +80,23 @@ Status UnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     options.set("axes", emscripten::val::array(axes_data));
   }
 
-  emscripten::val output = model_builder.GetBuilder().call<emscripten::val>("unsqueeze", input, options);
+  emscripten::val output = emscripten::val::undefined();
+  if (node.OpType() == "Squeeze") {
+    output = model_builder.GetBuilder().call<emscripten::val>("squeeze", input, options);
+  } else {  // Unsqueeze
+    output = model_builder.GetBuilder().call<emscripten::val>("unsqueeze", input, options);
+  }
+
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
   return Status::OK();
 }
 
 // Operator support related.
 
-bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
-                                           const Node& node,
-                                           const WebnnDeviceType /* device_type */,
-                                           const logging::Logger& logger) const {
+bool SqueezeUnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                                  const Node& node,
+                                                  const WebnnDeviceType /* device_type */,
+                                                  const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
   if (!GetShape(*input_defs[0], input_shape, logger))
@@ -98,18 +104,34 @@ bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
 
   // Unsqueeze opset 13 uses input 1 as axes, it needs to be an initializer.
   if (node.SinceVersion() >= 13) {
-    if (input_defs.size() < 2) {
-      LOGS(logger, ERROR) << "Input axes of Unsqueeze must be provided";
-      return false;
+    if (node.OpType() == "Squeeze") {
+      if (input_defs.size() < 1) {
+        LOGS(logger, ERROR) << "Squeeze has no input tensor";
+        return false;
+      }
+      // Axes for Squeeze is optional.
+      if (input_defs.size() > 1) {
+        const auto& axes_name = input_defs[1]->Name();
+        if (!Contains(initializers, axes_name)) {
+          LOGS(logger, ERROR) << "Input axes of Squeeze must be provided";
+          return false;
+        }
+      }
+    } else {  // Unsqueeze
+      if (input_defs.size() < 2) {
+        LOGS(logger, ERROR) << "Input axes of Unsqueeze must be provided";
+        return false;
+      }
+      const auto& axes_name = input_defs[1]->Name();
+      if (!Contains(initializers, axes_name)) {
+        LOGS(logger, ERROR) << "Input axes of Unsqueeze must be known";
+        return false;
+      }
     }
-    const auto& axes_name = input_defs[1]->Name();
-    if (!Contains(initializers, axes_name)) {
-      LOGS(logger, ERROR) << "Input axes of Unsqueeze must be known";
-      return false;
-    }
+
   } else {
     if (input_defs.size() < 1) {
-      LOGS(logger, ERROR) << "Unsqueeze has no input tensor";
+      LOGS(logger, ERROR) << node.OpType() << " has no input tensor";
       return false;
     }
   }
@@ -117,9 +139,20 @@ bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
   return true;
 }
 
-void CreateUnsqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
-  op_registrations.builders.push_back(std::make_unique<UnsqueezeOpBuilder>());
-  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+void CreateSqueezeUnsqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  if (op_registrations.op_builder_map.find(op_type) != op_registrations.op_builder_map.cend())
+    return;
+
+  static std::vector<std::string> op_types =
+      {
+          "Squeeze",
+          "Unsqueeze",
+      };
+
+  op_registrations.builders.push_back(std::make_unique<SqueezeUnsqueezeOpBuilder>());
+  for (const auto& type : op_types) {
+    op_registrations.op_builder_map.emplace(type, op_registrations.builders.back().get());
+  }
 }
 
 }  // namespace webnn

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
@@ -122,12 +122,13 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateSplitOpBuilder("Split", op_registrations);
   }
 
-  {  // Transpose
-    CreateTransposeOpBuilder("Transpose", op_registrations);
+  {  // Squeeze/Unsqueeze
+    CreateSqueezeUnsqueezeOpBuilder("Squeeze", op_registrations);
+    CreateSqueezeUnsqueezeOpBuilder("Unsqueeze", op_registrations);
   }
 
-  {  // Unsqueeze
-    CreateUnsqueezeOpBuilder("Unsqueeze", op_registrations);
+  {  // Transpose
+    CreateTransposeOpBuilder("Transpose", op_registrations);
   }
 
   return op_registrations;

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
@@ -39,9 +39,9 @@ void CreateResizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateSliceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSoftmaxOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSplitOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateSqueezeUnsqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateUnaryOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
-void CreateUnsqueezeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 }  // namespace webnn
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds support for the Squeeze Op to WebNN EP.
It shares the similar parameters as Unsqueeze, so they are merged.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable more models to run on WebNN EP.

