### PR TITLE
make package.json more rebost

### DIFF
--- a/js/web/package.json
+++ b/js/web/package.json
@@ -69,17 +69,17 @@
   "exports": {
     ".": {
       "node": {
-        "default": "./dist/ort-web.node.js",
-        "types": "./types.d.ts"
+        "types": "./types.d.ts",
+        "default": "./dist/ort-web.node.js"
       },
       "default": {
-        "default": "./dist/ort.min.js",
-        "types": "./types.d.ts"
+        "types": "./types.d.ts",
+        "default": "./dist/ort.min.js"
       }
     },
     "./webgpu": {
-      "default": "./dist/ort.webgpu.min.js",
-      "types": "./types.d.ts"
+      "types": "./types.d.ts",
+      "default": "./dist/ort.webgpu.min.js"
     }
   },
   "types": "./types.d.ts",


### PR DESCRIPTION
"default" should be last element for exports.
This fixes "Module not found: Error: Default condition should be last one" when importing the onnxruntime-web package in some conditions.