### PR TITLE
Use lowest float for causal mask

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
@@ -10,7 +10,7 @@ namespace attention_softmax_cuda {
 template <typename T>
 Status ComputeSoftmax(cudaStream_t stream, const int all_sequence_length, const int sequence_length,
                       const int batch_size, const int num_heads, const T* rel_pos_bias,
-                      const bool broadcast_rel_pos_bias, T* input, T* output, bool is_unidirectional);
+                      const bool broadcast_rel_pos_bias, T* input, T* output, bool causal);
 
 template <typename T>
 Status ComputeSoftmaxWithCumSeqLength(
@@ -35,7 +35,7 @@ Status ComputeSoftmaxWithMask1D(cudaStream_t stream,
                                 const bool broadcast_rel_pos_bias,
                                 const T* input,
                                 T* output,
-                                const bool is_unidirectional);
+                                const bool causal);
 
 template <typename T>
 Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
@@ -49,7 +49,7 @@ Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
                                  const bool broadcast_rel_pos_bias,
                                  const T* input,
                                  T* output,
-                                 const bool is_unidirectional,
+                                 const bool causal,
                                  const float rsqrt_head_size,
                                  const int mask_dimension,
                                  const int max_sequence_length,

--- a/onnxruntime/contrib_ops/rocm/bert/attention_softmax.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention_softmax.h
@@ -109,7 +109,7 @@ __device__ inline void SoftmaxSmall(const int all_sequence_length,
                                     const T* add_before_softmax,
                                     const T* input,
                                     T* output,
-                                    bool is_unidirectional) {
+                                    bool causal) {
   using BlockReduce = hipcub::BlockReduce<float, TPB>;
   __shared__ typename BlockReduce::TempStorage tmp_storage;
 
@@ -122,21 +122,16 @@ __device__ inline void SoftmaxSmall(const int all_sequence_length,
 
   bool is_valid = false;  // whether it has attention mask == 1.
 
-  // Update end position for unidirectional.
+  // Update end position for causal.
   int end = valid_end;
-  if (is_unidirectional) {
-    int end_unid = all_sequence_length - sequence_length + (blockIdx.x % sequence_length) + 1;
-    if (end_unid <= valid_start) {
-      // In this situation, mask of [0, end_unid) and [valid_start, valid_end) has -10000,
-      //              and [end_unid, valid_start) and [valid_end, all_seq_len) has -20000.
-      // So [0, end_unid) will also have value after softmax.
-      is_valid = threadIdx.x < end_unid;
-    } else {
-      end = min(valid_end, end_unid);
+  if (causal) {
+    const int end_causal = all_sequence_length - sequence_length + (blockIdx.x % sequence_length) + 1;
+    if (end_causal < end) {
+      end = end_causal;
     }
   }
 
-  is_valid = is_valid || (threadIdx.x >= valid_start && threadIdx.x < end);
+  is_valid = (threadIdx.x >= valid_start && threadIdx.x < end);
 
   // e^x is represented as infinity if x is large enough, like 100.f.
   // Infinity divided by Infinity is a NAN. Thus, softmax gets a NAN if one or more item are large enough.
@@ -169,7 +164,7 @@ __device__ inline void SoftmaxSmall(const int all_sequence_length,
 
   // threadIdx.x might be larger than all_sequence_length due to alignment to 32x.
   if (threadIdx.x < all_sequence_length) {
-    output[index] = T(thread_data_exp * sum_reverse_block);
+    output[index] = is_valid ? T(thread_data_exp * sum_reverse_block) : T(0.f);
   }
 }
 
@@ -186,7 +181,7 @@ __global__ void SoftmaxWithRawMaskSmallKernel(
     const T* add_before_softmax,
     const T* input,
     T* output,
-    const bool is_unidirectional,
+    const bool causal,
     const float rsqrt_head_size,
     const bool skip_softmax,
     const float mask_filter_value) {
@@ -207,10 +202,10 @@ __global__ void SoftmaxWithRawMaskSmallKernel(
     thread_data = float(input[index]) * rsqrt_head_size;
 
     const int sequence_index = blockIdx.x % sequence_length;
-    if (is_unidirectional) {
+    if (causal) {
       int from_index = all_sequence_length - sequence_length + sequence_index;  // offset in all sequence length.
       if (threadIdx.x > from_index) {
-        thread_data = mask_filter_value;
+        thread_data = -ROCMRT_INF_F;
       }
     }
 
@@ -269,9 +264,9 @@ __global__ void SoftmaxWithRawMaskSmallKernel(
 
 template <typename T, unsigned TPB>
 __global__ void SoftmaxKernelSmall(const int all_sequence_length, const int sequence_length,
-                                   const T* add_before_softmax, const T* input, T* output, bool is_unidirectional) {
+                                   const T* add_before_softmax, const T* input, T* output, bool causal) {
   SoftmaxSmall<T, TPB>(all_sequence_length, sequence_length, all_sequence_length, 0,
-                       add_before_softmax, input, output, is_unidirectional);
+                       add_before_softmax, input, output, causal);
 }
 
 template <typename T, unsigned TPB>
@@ -283,33 +278,33 @@ template <typename T>
 Status ComputeSoftmax(
     hipStream_t stream,
     const int all_sequence_length, const int sequence_length, const int batch_size, const int num_heads,
-    const T* add_before_softmax, const T* input, T* output, bool is_unidirectional) {
+    const T* add_before_softmax, const T* input, T* output, bool causal) {
   const dim3 grid(sequence_length * num_heads, batch_size, 1);
   if (all_sequence_length <= 32) {
     const int blockSize = 32;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
   } else if (all_sequence_length <= 64) {
     const int blockSize = 64;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
   } else if (all_sequence_length <= 128) {
     const int blockSize = 128;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
   } else if (all_sequence_length <= 256) {
     const int blockSize = 256;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
   } else if (all_sequence_length <= 512) {
     const int blockSize = 512;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
   } else if (all_sequence_length <= 1024) {
     const int blockSize = 1024;
     SoftmaxKernelSmall<T, blockSize><<<grid, blockSize, 0, stream>>>(
-        all_sequence_length, sequence_length, add_before_softmax, input, output, is_unidirectional);
-  } else if (!is_unidirectional) {
+        all_sequence_length, sequence_length, add_before_softmax, input, output, causal);
+  } else if (!causal) {
     const int blockSize = 1024;
     SoftmaxKernel<T, blockSize><<<grid, blockSize, 0, stream>>>(
         all_sequence_length, add_before_softmax, input, output);
@@ -324,7 +319,7 @@ template <typename T, unsigned TPB>
 __global__ void MaskedSoftmaxKernelSmall(const int all_sequence_length, const int sequence_length,
                                          const int* mask_end, const int* mask_start,
                                          const T* add_before_softmax, const T* input, T* output,
-                                         bool is_unidirectional) {
+                                         bool causal) {
   __shared__ int start_position;
   __shared__ int end_position;
 
@@ -342,7 +337,7 @@ __global__ void MaskedSoftmaxKernelSmall(const int all_sequence_length, const in
   __syncthreads();
 
   SoftmaxSmall<T, TPB>(all_sequence_length, sequence_length, end_position, start_position,
-                       add_before_softmax, input, output, is_unidirectional);
+                       add_before_softmax, input, output, causal);
 }
 
 template <typename T, unsigned TPB>
@@ -372,13 +367,13 @@ Status ComputeSoftmaxWithMask1D(
     hipStream_t stream,
     const int all_sequence_length, const int sequence_length, const int batch_size, const int num_heads,
     const int* mask_index, const int* mask_start,
-    const T* add_before_softmax, const T* input, T* output, const bool is_unidirectional) {
+    const T* add_before_softmax, const T* input, T* output, const bool causal) {
   const dim3 grid(sequence_length * num_heads, batch_size, 1);
 
 #define DISPATCH_KERNEL_SMALL_WITH_BLOCKSIZE(block_size)                    \
   MaskedSoftmaxKernelSmall<T, block_size><<<grid, block_size, 0, stream>>>( \
       all_sequence_length, sequence_length, mask_index, mask_start,         \
-      add_before_softmax, input, output, is_unidirectional);
+      add_before_softmax, input, output, causal);
 
   if (all_sequence_length <= 32) {
     DISPATCH_KERNEL_SMALL_WITH_BLOCKSIZE(32);
@@ -392,7 +387,7 @@ Status ComputeSoftmaxWithMask1D(
     DISPATCH_KERNEL_SMALL_WITH_BLOCKSIZE(512);
   } else if (all_sequence_length <= 1024) {
     DISPATCH_KERNEL_SMALL_WITH_BLOCKSIZE(1024);
-  } else if (!is_unidirectional) {
+  } else if (!causal) {
     const int blockSize = 1024;
     MaskedSoftmaxKernel<T, blockSize><<<grid, blockSize, 0, stream>>>(
         all_sequence_length, mask_index, mask_start,
@@ -418,7 +413,7 @@ Status ComputeSoftmaxWithRawMask(hipStream_t stream,
                                  const T* add_before_softmax,
                                  const T* input,
                                  T* output,
-                                 const bool is_unidirectional,
+                                 const bool causal,
                                  const float rsqrt_head_size,
                                  const bool use_persistent_softmax,
                                  T* persistent_softmax_workspace,
@@ -431,7 +426,7 @@ Status ComputeSoftmaxWithRawMask(hipStream_t stream,
   SoftmaxWithRawMaskSmallKernel<T, block_size><<<grid, block_size, 0, stream>>>( \
       all_sequence_length, sequence_length, attention_mask_strides,              \
       attention_mask, key_padding_mask, add_before_softmax, input, out,          \
-      is_unidirectional, rsqrt_head_size,                                        \
+      causal, rsqrt_head_size,                                                   \
       use_persistent_softmax, mask_filter_value);
 
   if (all_sequence_length <= 32) {

--- a/onnxruntime/test/contrib_ops/attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/attention_op_test.cc
@@ -1644,7 +1644,7 @@ TEST(AttentionTest, AttentionUnidirectional3DMask) {
       1, 1};
 
   std::vector<float> output_data = {
-      3.0146f, 0.1142f, 3.9834f, 5.3394f,
+      -4.09f, 0.42f, -0.11f, 0.57f,
       8.69f, -0.13f, 4.25f, 5.65f,
       8.69f, -0.13f, 4.25f, 5.65f,
       3.96967912f, 0.07314367f, 4.25f, 5.65f};
@@ -1686,7 +1686,7 @@ TEST(AttentionTest, AttentionUnidirectionalAttentionMask) {
   std::vector<int32_t> mask_index_data = {0, 1, 1, 1};
 
   std::vector<float> output_data = {
-      3.0146f, 0.1142f, 3.9834f, 5.3394f,
+      -4.09f, 0.42f, -0.11f, 0.57f,
       8.69f, -0.13f, 4.25f, 5.65f,
       8.69f, -0.13f, 4.25f, 5.65f,
       3.96967912f, 0.07314367f, 4.25f, 5.65f};
@@ -1728,7 +1728,7 @@ TEST(AttentionTest, AttentionWithNormFactor) {
   std::vector<int32_t> mask_index_data = {0, 1, 1, 1};
 
   std::vector<float> output_data = {
-      3.0146f, 0.1142f, 3.9834f, 5.3394f,
+      -4.09f, 0.42f, -0.11f, 0.57f,
       8.69f, -0.13f, 4.25f, 5.65f,
       8.69f, -0.13f, 4.25f, 5.65f,
       3.96967912f, 0.07314367f, 4.25f, 5.65f};
@@ -1773,10 +1773,10 @@ TEST(AttentionTest, AttentionWithNeoXRotaryEmbedding) {
   std::vector<int32_t> mask_index_data = {0, 1, 1, 1};
 
   std::vector<float> output_data = {
-      3.0146f, 0.1142f, 3.9834f, 5.3394f,
-      8.69f, -0.13f, 4.25f, 5.65f,
-      8.69f, -0.13f, 4.25f, 5.65f,
-      -1.4697f, 0.3071f, 4.25f, 5.65f};
+      -4.0898f, 0.4199f, -0.1096f, 0.5703f,
+      8.6875f, -0.1299f, 4.25f, 5.6484f,
+      8.6875f, -0.1299f, 4.25f, 5.6484f,
+      -1.4697f, 0.3071f, 4.25f, 5.6484f};
 
   bool use_float16 = true;
   bool is_unidirectional = true;


### PR DESCRIPTION
### Description

Always set causal mask to the lowest float. 

Note that since huggingface transformers v4.21, gpt2 uses lowest half for FP16, and lowest float for FP32:
https://github.com/huggingface/transformers/blob/66fd3a8d626a32989f4569260db32785c6cbf42a/src/transformers/models/gpt2/modeling_gpt2.py#L199
Assume that most fp16 ONNX models are converted from fp32 models. We decided to use lowest float32 for both half and float model for consistency.

The mask_filter_value only applies to raw attention mask (2D, 3D or 4D). For 1D mask, masked item is 0.0 after softmax so mask filter value is the lowest float for 1D mask.
* For BERT model, when users use 1D mask (required by FMHA) and mask_filter_value is not applicable.
* For GPT-2, when environment variable "ORT_ENABLE_FUSED_CAUSAL_ATTENTION=1", we will convert 2D mask to 1D internally.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/onnxruntime/issues/12843
https://github.com/microsoft/onnxruntime/issues/14363