### PR TITLE
Fix cmake install when xnnpack is enabled

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1759,11 +1759,6 @@ if (onnxruntime_USE_XNNPACK)
 
   add_dependencies(onnxruntime_providers_xnnpack onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
   set_target_properties(onnxruntime_providers_xnnpack PROPERTIES FOLDER "ONNXRuntime")
-
-  install(DIRECTORY ${ONNXRUNTIME_INCLUDE_DIR}/core/providers/xnnpack
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers
-  )
-
   set_target_properties(onnxruntime_providers_xnnpack PROPERTIES LINKER_LANGUAGE CXX)
 
   if (NOT onnxruntime_BUILD_SHARED_LIB)


### PR DESCRIPTION
### Description
https://github.com/microsoft/onnxruntime/pull/11798 removed the `include/core/providers/xnnpack` folder, it shall not be installed.

### Motivation and Context
Fix cmake install when xnnpack is enabled

