### PR TITLE
[js/web] fix nodejs detection

### DIFF
--- a/js/web/lib/onnxjs/session.ts
+++ b/js/web/lib/onnxjs/session.ts
@@ -60,7 +60,7 @@ export class Session {
       this._model = new Model();
       if (typeof arg === 'string') {
         const isOrtFormat = arg.endsWith('.ort');
-        if (typeof fetch === 'undefined') {
+        if (typeof process !== 'undefined' && process.versions) {
           // node
           const buf = await promisify(readFile)(arg);
           this.initialize(buf, isOrtFormat);

--- a/js/web/lib/onnxjs/session.ts
+++ b/js/web/lib/onnxjs/session.ts
@@ -60,7 +60,7 @@ export class Session {
       this._model = new Model();
       if (typeof arg === 'string') {
         const isOrtFormat = arg.endsWith('.ort');
-        if (typeof process !== 'undefined' && process.versions) {
+        if (typeof process !== 'undefined' && process.versions && process.versions.node) {
           // node
           const buf = await promisify(readFile)(arg);
           this.initialize(buf, isOrtFormat);

--- a/js/web/lib/wasm/session-handler.ts
+++ b/js/web/lib/wasm/session-handler.ts
@@ -31,7 +31,7 @@ export class OnnxruntimeWebAssemblySessionHandler implements SessionHandler {
     }
 
     if (typeof pathOrBuffer === 'string') {
-      if (typeof fetch === 'undefined') {
+      if (typeof process !== 'undefined' && process.versions) {
         // node
         const model = await promisify(readFile)(pathOrBuffer);
         [this.sessionId, this.inputNames, this.outputNames] = await createSession(model, options);

--- a/js/web/lib/wasm/session-handler.ts
+++ b/js/web/lib/wasm/session-handler.ts
@@ -31,7 +31,7 @@ export class OnnxruntimeWebAssemblySessionHandler implements SessionHandler {
     }
 
     if (typeof pathOrBuffer === 'string') {
-      if (typeof process !== 'undefined' && process.versions) {
+      if (typeof process !== 'undefined' && process.versions && process.versions.node) {
         // node
         const model = await promisify(readFile)(pathOrBuffer);
         [this.sessionId, this.inputNames, this.outputNames] = await createSession(model, options);

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -47,7 +47,7 @@ function fromInternalTensor(tensor: Tensor): ort.Tensor {
 }
 
 async function loadFile(uri: string): Promise<Uint8Array> {
-  if (typeof fetch === 'undefined') {
+  if (typeof process !== 'undefined' && process.versions) {
     // node
     return promisify(readFile)(uri);
   } else {

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 
 import {expect} from 'chai';
-import {readFile} from 'fs';
 import {onnx} from 'onnx-proto';
 import * as ort from 'onnxruntime-common';
 import {extname} from 'path';
-import {inspect, promisify} from 'util';
+import {inspect} from 'util';
 
 import {Attribute} from '../lib/onnxjs/attribute';
 import {InferenceHandler, resolveBackend, SessionHandler} from '../lib/onnxjs/backend';
@@ -16,7 +15,7 @@ import {Operator} from '../lib/onnxjs/operators';
 import {Tensor} from '../lib/onnxjs/tensor';
 import {ProtoUtil} from '../lib/onnxjs/util';
 
-import {base64toBuffer, createMockGraph} from './test-shared';
+import {base64toBuffer, createMockGraph, readFile} from './test-shared';
 import {Test} from './test-types';
 
 // the threshold that used to compare 2 float numbers. See above for TensorResultValidator.floatEqual().
@@ -46,19 +45,8 @@ function fromInternalTensor(tensor: Tensor): ort.Tensor {
   return new ort.Tensor(tensor.type, tensor.data as ort.Tensor.DataType, tensor.dims);
 }
 
-async function loadFile(uri: string): Promise<Uint8Array> {
-  if (typeof process !== 'undefined' && process.versions) {
-    // node
-    return promisify(readFile)(uri);
-  } else {
-    // browser
-    const response = await fetch(uri);
-    return new Uint8Array(await response.arrayBuffer());
-  }
-}
-
 async function loadTensorProto(uriOrData: string|Uint8Array, allowInt64 = false): Promise<Test.NamedTensor> {
-  const buf = (typeof uriOrData === 'string') ? await loadFile(uriOrData) : uriOrData;
+  const buf = (typeof uriOrData === 'string') ? await readFile(uriOrData) : uriOrData;
   const tensorProto = onnx.TensorProto.decode(buf);
 
   let tensor: ort.Tensor;

--- a/js/web/test/test-shared.ts
+++ b/js/web/test/test-shared.ts
@@ -17,7 +17,7 @@ export function bufferToBase64(buffer: Uint8Array): string {
 }
 
 async function readFile(file: string) {
-  if (typeof fetch === 'undefined') {
+  if (typeof process !== 'undefined' && process.versions) {
     // node
     return promisify(fs.readFile)(file);
   } else {

--- a/js/web/test/test-shared.ts
+++ b/js/web/test/test-shared.ts
@@ -16,8 +16,8 @@ export function bufferToBase64(buffer: Uint8Array): string {
   return base64.fromByteArray(buffer);
 }
 
-async function readFile(file: string) {
-  if (typeof process !== 'undefined' && process.versions) {
+export async function readFile(file: string) {
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
     // node
     return promisify(fs.readFile)(file);
   } else {


### PR DESCRIPTION
### Description
We used to use `typeof fetch === 'undefined'` as condition to detect the environment is Node.js or not. Before Node.js v18, this works. However, in Node.js v18, it introduced `fetch` function, so this check does not work any more.

This PR changes the condition to check whether `process`,  `process.versions` and `process.versions.node` exists.

Checking whether `process` exists is not enough. This is because in some configuration, webpack may polyfill nodejs's process.