### PR TITLE
Zhijxu/cast propagation softmax

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -5157,6 +5157,74 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests_Gelu) {
 
 #endif
 
+#ifdef ENABLE_TRAINING_CORE
+TEST_F(GraphTransformationTests, PropagateCastOpsTests_Softmax) {
+  using Strategy = GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy;
+  {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<MLFloat16>({{2, 3, 3, 3}});
+      auto* cast_out_0 = builder.MakeIntermediate();
+      auto* softmax_out = builder.MakeIntermediate();
+      auto* cast_out_1 = builder.MakeIntermediate();
+      auto* identity_out = builder.MakeOutput();
+
+      builder.AddNode("Cast", {input_arg}, {cast_out_0})
+          .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+      builder.AddNode("Softmax", {cast_out_0}, {softmax_out});
+      builder.AddNode("Cast", {softmax_out}, {cast_out_1})
+          .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16));
+      builder.AddNode("Identity", {cast_out_1}, {identity_out});
+    };
+
+    auto pre_graph_checker = [&](Graph& graph) {
+      TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
+      return Status::OK();
+    };
+
+    auto post_graph_checker = [&](Graph& graph) {
+      TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 0);
+      return Status::OK();
+    };
+
+    std::unique_ptr<GraphTransformer> transformer = std::make_unique<PropagateCastOps>(Strategy::FloodFill, 1);
+    ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer), TransformerLevel::Level1, 1,
+                                          pre_graph_checker, post_graph_checker));
+  }
+
+  {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_arg = builder.MakeInput<BFloat16>({{2, -1, 3, -1}});
+      auto* cast_out_0 = builder.MakeIntermediate();
+      auto* softmax_out = builder.MakeIntermediate();
+      auto* cast_out_1 = builder.MakeIntermediate();
+      auto* identity_out = builder.MakeOutput();
+
+      builder.AddNode("Cast", {input_arg}, {cast_out_0})
+          .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+      builder.AddNode("Softmax", {cast_out_0}, {softmax_out});
+      builder.AddNode("Cast", {softmax_out}, {cast_out_1})
+          .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16));
+      builder.AddNode("Identity", {cast_out_1}, {identity_out});
+    };
+
+    auto pre_graph_checker = [&](Graph& graph) {
+      TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
+      return Status::OK();
+    };
+
+    auto post_graph_checker = [&](Graph& graph) {
+      TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
+      return Status::OK();
+    };
+
+    std::unique_ptr<GraphTransformer> transformer = std::make_unique<PropagateCastOps>(Strategy::FloodFill, 1);
+    ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer), TransformerLevel::Level1, 1,
+                                          pre_graph_checker, post_graph_checker));
+  }
+}
+
+#endif
+
 /*
 Test graph include multiple equivalent subgraphs as below.
            graph input [1, 1, 256, 256] (int64_t)

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -5155,13 +5155,10 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests_Gelu) {
   }
 }
 
-#endif
-
-#ifdef ENABLE_TRAINING_CORE
 TEST_F(GraphTransformationTests, PropagateCastOpsTests_Softmax) {
   using Strategy = GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy;
   {
-    auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto build_test_case = [](ModelTestBuilder& builder) {
       auto* input_arg = builder.MakeInput<MLFloat16>({{2, 3, 3, 3}});
       auto* cast_out_0 = builder.MakeIntermediate();
       auto* softmax_out = builder.MakeIntermediate();
@@ -5176,12 +5173,12 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests_Softmax) {
       builder.AddNode("Identity", {cast_out_1}, {identity_out});
     };
 
-    auto pre_graph_checker = [&](Graph& graph) {
+    auto pre_graph_checker = [](Graph& graph) {
       TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
       return Status::OK();
     };
 
-    auto post_graph_checker = [&](Graph& graph) {
+    auto post_graph_checker = [](Graph& graph) {
       TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 0);
       return Status::OK();
     };
@@ -5192,7 +5189,7 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests_Softmax) {
   }
 
   {
-    auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto build_test_case = [](ModelTestBuilder& builder) {
       auto* input_arg = builder.MakeInput<BFloat16>({{2, -1, 3, -1}});
       auto* cast_out_0 = builder.MakeIntermediate();
       auto* softmax_out = builder.MakeIntermediate();
@@ -5207,12 +5204,12 @@ TEST_F(GraphTransformationTests, PropagateCastOpsTests_Softmax) {
       builder.AddNode("Identity", {cast_out_1}, {identity_out});
     };
 
-    auto pre_graph_checker = [&](Graph& graph) {
+    auto pre_graph_checker = [](Graph& graph) {
       TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
       return Status::OK();
     };
 
-    auto post_graph_checker = [&](Graph& graph) {
+    auto post_graph_checker = [](Graph& graph) {
       TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Cast"] == 2);
       return Status::OK();
     };


### PR DESCRIPTION
enhance cast-propagation for "softmax can be put at fp16 when data flow is cast-to-fp32 > softmax > cast-to-fp16"

this optimization can save gpu memory and have performance gain