### PR TITLE
Enable Microsoft.AI.MachineLearning NuGet with WinUI projects

### DIFF
--- a/csharp/src/Microsoft.AI.MachineLearning/Microsoft.AI.MachineLearning.targets
+++ b/csharp/src/Microsoft.AI.MachineLearning/Microsoft.AI.MachineLearning.targets
@@ -32,7 +32,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NuGetProjectStyle)' != 'PackageReference'">
+  <ItemGroup Condition="'$(NuGetProjectStyle)' != 'PackageReference' AND WinAppSDKPackageName == ''">
     <ReferenceCopyLocalPaths Include="$(WindowsAIBinary);" />
   </ItemGroup>
   <ItemGroup Condition="'$(NuGetProjectStyle)' != 'PackageReference' OR '$(TargetPlatformIdentifier)' == 'UAP'">


### PR DESCRIPTION
Microsoft.AI.MachineLearning NuGet fails to build on WinUI projects due to the conflict between the ReferenceCopy of binaries that occurs with managed applications, with the manual binplacement that occurs with native appliactions.

With WinUI, both cases are triggered, and a duplicate binplace is detected as an error.

Fix: Don't rely on the ReferenceCopy for WinUI applications, and manually binplace the Microsoft.AI.MachineLearning dll.