### PR TITLE
Enable Web ci on Linux

### DIFF
--- a/js/web/test/e2e/run.js
+++ b/js/web/test/e2e/run.js
@@ -57,7 +57,7 @@ async function main() {
   // we start here:
 
   // install dev dependencies
-  await runInShell(`npm install"`);
+  await runInShell(`npm install`);
 
   // npm install with "--cache" to install packed packages with an empty cache folder
   await runInShell(`npm install --cache "${NPM_CACHE_FOLDER}" ${PACKAGES_TO_INSTALL.map(i => `"${i}"`).join(' ')}`);

--- a/onnxruntime/test/wasm/karma.conf.js
+++ b/onnxruntime/test/wasm/karma.conf.js
@@ -65,6 +65,10 @@ module.exports = function(config) {
           base: 'ChromeCanary',
           flags: chromeFlags
         },
+        ChromeHeadlessTest: {
+          base: 'ChromeHeadless',
+          flags: chromeFlags
+        },
         EdgeTest: {
           base: 'Edge',
           flags: chromeFlags

--- a/onnxruntime/test/wasm/package.json
+++ b/onnxruntime/test/wasm/package.json
@@ -2,7 +2,7 @@
   "name": "wasm-test-adapter",
   "private": true,
   "scripts": {
-    "test": "karma start --browsers EdgeTest --single-run"
+    "test": "karma start --browsers ChromeHeadlessTest --single-run"
   },
   "devDependencies": {
     "@chiragrupani/karma-chromium-edge-launcher": "^2.2.2",

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -117,19 +117,19 @@ jobs:
         workingDirectory: '$(Build.BinariesDirectory)'
   - ${{ if eq(parameters.SkipPublish, false) }}:
     - script: |
-        copy $(Build.BinariesDirectory)/wasm/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
-        copy $(Build.BinariesDirectory)/wasm_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
-        copy $(Build.BinariesDirectory)/wasm_simd_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
-        copy $(Build.BinariesDirectory)/wasm_simd/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
-        if exist $(Build.BinariesDirectory)/wasm_simd_jsep (
-          copy $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.wasm
-          copy $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.js
-        )
-        if exist $(Build.BinariesDirectory)/wasm_simd_threads_jsep (
-          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.wasm
-          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.js
-          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.worker.js
-        )
+        cp $(Build.BinariesDirectory)/wasm/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        cp $(Build.BinariesDirectory)/wasm_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        cp $(Build.BinariesDirectory)/wasm_simd_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        cp $(Build.BinariesDirectory)/wasm_simd/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        if [ -d exist $(Build.BinariesDirectory)/wasm_simd_jsep ]
+          cp $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.wasm
+          cp $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.js
+        fi
+        if [-d $(Build.BinariesDirectory)/wasm_simd_threads_jsep ]
+          cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.wasm
+          cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.js
+          cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.worker.js
+        fi
       displayName: 'Create Artifacts'
   - ${{ if eq(parameters.SkipPublish, false) }}:
     - task: PublishPipelineArtifact@0

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -30,8 +30,6 @@ jobs:
 - job: build_WASM
   pool:
     name: ${{ parameters.PoolName }}
-    demands:
-      ImageVersionOverride -equals 1.0.318581
   variables:
     EnvSetupScript: setup_env.bat
     buildArch: x64
@@ -121,11 +119,11 @@ jobs:
         cp $(Build.BinariesDirectory)/wasm_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
         cp $(Build.BinariesDirectory)/wasm_simd_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
         cp $(Build.BinariesDirectory)/wasm_simd/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
-        if [ -d exist $(Build.BinariesDirectory)/wasm_simd_jsep ]
+        if [ -d $(Build.BinariesDirectory)/wasm_simd_jsep ]; then
           cp $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.wasm
           cp $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.js
         fi
-        if [-d $(Build.BinariesDirectory)/wasm_simd_threads_jsep ]
+        if [ -d $(Build.BinariesDirectory)/wasm_simd_threads_jsep ]; then
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.wasm
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.js
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.worker.js

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -1,0 +1,152 @@
+parameters:
+- name: CommitOverride
+  type: boolean
+  default: false
+
+- name: BuildConfig
+  type: string
+  default: 'Debug'
+
+- name: ExtraBuildArgs
+  type: string
+  default: ''
+
+- name: PoolName
+  type: string
+  default: 'onnxruntime-Ubuntu2004-AMD-CPU'
+
+- name: SkipPublish
+  type: boolean
+  default: false
+
+- name: TimeoutInMinutes
+  default: 180
+
+- name: BuildJsep
+  type: boolean
+  default: false
+
+jobs:
+- job: build_WASM
+  pool:
+    name: ${{ parameters.PoolName }}
+    demands:
+      ImageVersionOverride -equals 1.0.318581
+  variables:
+    EnvSetupScript: setup_env.bat
+    buildArch: x64
+    CommonBuildArgs: '--parallel --config ${{ parameters.BuildConfig }} --skip_submodule_sync --cmake_generator "Ninja" --build_wasm --use_xnnpack --emsdk_version releases-7c905cfc1ca6699f6ccb288ae174902cfbdcf0a2-64bit ${{ parameters.ExtraBuildArgs }}'
+    runCodesignValidationInjection: false
+  timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: '__commit'
+      path: $(Pipeline.Workspace)
+    displayName: 'Get commit SHA'
+    condition: eq('${{ parameters.CommitOverride }}', 'true')
+  - script: |
+     export __commit__=<$(Pipeline.Workspace)/__commit.txt
+     git fetch origin +$__commit__:refs/remotes/origin/$__commit__
+     git checkout --force $__commit__
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Read commit SHA and checkout'
+    condition: eq('${{ parameters.CommitOverride }}', 'true')
+  - script: |
+     git submodule sync --recursive
+     git submodule update --init --recursive
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Checkout submodules'
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+      architecture: $(buildArch)
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+  - template: download-deps.yml
+
+  - task: PythonScript@0
+    displayName: 'Update deps.txt'
+    inputs:
+      scriptPath: $(Build.SourcesDirectory)/tools/ci_build/replace_urls_in_deps.py
+      arguments: --new_dir $(Build.BinariesDirectory)/deps
+      workingDirectory: $(Build.BinariesDirectory)
+
+  - task: PythonScript@0
+    displayName: 'Build and test (node)'
+    inputs:
+      scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+      arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm'
+      workingDirectory: '$(Build.BinariesDirectory)'
+  - task: PythonScript@0
+    displayName: 'Build and test (node) (threads)'
+    inputs:
+      scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+      arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_threads --enable_wasm_threads'
+      workingDirectory: '$(Build.BinariesDirectory)'
+  - task: PythonScript@0
+    displayName: 'Build and test (browser) (simd + threads)'
+    inputs:
+      scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+      arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_simd_threads --enable_wasm_simd --enable_wasm_threads --wasm_run_tests_in_browser'
+      workingDirectory: '$(Build.BinariesDirectory)'
+  - task: PythonScript@0
+    displayName: 'Build and test (node) (simd)'
+    inputs:
+      scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+      arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_simd --enable_wasm_simd'
+      workingDirectory: '$(Build.BinariesDirectory)'
+  - ${{ if eq(parameters.BuildJsep, true) }}:
+    - task: PythonScript@0
+      displayName: 'Build (simd + JSEP)'
+      inputs:
+        scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+        arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_simd_jsep --enable_wasm_simd --use_jsep --target onnxruntime_webassembly --skip_tests'
+        workingDirectory: '$(Build.BinariesDirectory)'
+  - ${{ if eq(parameters.BuildJsep, true) }}:
+    - task: PythonScript@0
+      displayName: 'Build (simd + threads + JSEP)'
+      inputs:
+        scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
+        arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/wasm_simd_threads_jsep --enable_wasm_simd --enable_wasm_threads --use_jsep --target onnxruntime_webassembly --skip_tests'
+        workingDirectory: '$(Build.BinariesDirectory)'
+  - ${{ if eq(parameters.SkipPublish, false) }}:
+    - script: |
+        copy $(Build.BinariesDirectory)/wasm/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)/wasm_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)/wasm_simd_threads/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        copy $(Build.BinariesDirectory)/wasm_simd/${{ parameters.BuildConfig }}/ort-wasm*.* $(Build.ArtifactStagingDirectory)
+        if exist $(Build.BinariesDirectory)/wasm_simd_jsep (
+          copy $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.wasm
+          copy $(Build.BinariesDirectory)/wasm_simd_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd.jsep.js
+        )
+        if exist $(Build.BinariesDirectory)/wasm_simd_threads_jsep (
+          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.wasm
+          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.js
+          copy $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.worker.js
+        )
+      displayName: 'Create Artifacts'
+  - ${{ if eq(parameters.SkipPublish, false) }}:
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish Pipeline Artifact'
+      inputs:
+        artifactName: '${{ parameters.BuildConfig }}_wasm'
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishTestResults@2
+    displayName: 'Publish unit test results'
+    inputs:
+      testResultsFiles: '**/*.results.xml'
+      searchFolder: '$(Build.BinariesDirectory)'
+      testRunTitle: 'Unit Test Run'
+    condition: and(succeededOrFailed(), eq('${{ parameters.BuildConfig }}', 'Debug'))
+  - template: component-governance-component-detection-steps.yml
+    parameters :
+      condition : 'succeeded'
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
@@ -112,7 +112,7 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)/js'
     displayName: 'Clang-format'
   - script: |
-     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run /"npm run format/"?)/n'+a)"
+     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run \"npm run format\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)/js'
     displayName: 'Check unformatted files'
   - script: |
@@ -120,7 +120,7 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)/js/web'
     displayName: 'Generating documents'
   - script: |
-     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run /"npm run build:doc/"?)/n'+a)"
+     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run \"npm run build:doc\"?)\n'+a)"
     workingDirectory: '$(Build.SourcesDirectory)/js/web'
     displayName: 'Check out of dated documents'
   - task: PowerShell@2

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
@@ -58,7 +58,7 @@ jobs:
   - script: |
      echo.>>.gitattributes
      echo /js/** text=auto eol=lf>>.gitattributes
-     rd /s /q js
+     rm -rf js
      git checkout -- js/**
      git checkout -- .gitattributes
     workingDirectory: '$(Build.SourcesDirectory)'

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
@@ -1,0 +1,176 @@
+parameters:
+- name: CommitOverride
+  type: boolean
+  default: false
+
+- name: BuildConfig
+  type: string
+  default: 'Debug'
+
+- name: NpmPackagingMode
+  type: string
+  default: 'dev'
+
+- name: PoolName
+  type: string
+  default: 'onnxruntime-Ubuntu2004-AMD-CPU'
+
+- name: PackageName
+  displayName: 'Package name'
+  type: string
+  default: 'NPM_packages'
+
+jobs:
+- job: build_onnxruntime_web
+  pool: ${{ parameters.PoolName }}
+
+  variables:
+    runCodesignValidationInjection: false
+  timeoutInMinutes: 60
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    submodules: false
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: '__commit'
+      path: $(Pipeline.Workspace)
+    displayName: 'Get commit SHA'
+    condition: eq('${{ parameters.CommitOverride }}', 'true')
+  - script: |
+     export __commit__=<$(Pipeline.Workspace)/__commit.txt
+     git fetch origin +$__commit__:refs/remotes/origin/$__commit__
+     git checkout --force $__commit__
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Read commit SHA and checkout'
+    condition: eq('${{ parameters.CommitOverride }}', 'true')
+  - script: |
+     echo.$(Build.SourceVersion)>$(Pipeline.Workspace)/__commit.txt
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Write commit SHA to __commit.txt'
+    condition: ne('${{ parameters.CommitOverride }}', 'true')
+  - script: |
+     git submodule sync -- cmake/external/onnx
+     git submodule update --init -- cmake/external/onnx
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Checkout submodule onnx'
+  - script: |
+     echo.>>.gitattributes
+     echo /js/** text=auto eol=lf>>.gitattributes
+     rd /s /q js
+     git checkout -- js/**
+     git checkout -- .gitattributes
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Testing: force EOL to lf on windows for /js/**'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      patterns: '${{ parameters.BuildConfig }}_*/**/*'
+      path: $(Pipeline.Workspace)/artifacts
+    displayName: 'Download WebAssembly artifacts'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/artifacts
+      contents: |
+        **/*.wasm
+      targetFolder: $(Build.SourcesDirectory)/js/web/dist
+      flattenFolders: true
+    displayName: 'Binplace dist files'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/artifacts
+      contents: |
+        **/*.js
+      targetFolder: $(Build.SourcesDirectory)/js/web/lib/wasm/binding
+      flattenFolders: true
+    displayName: 'Binplace js files'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'npm ci /js/'
+  - script: |
+     npm run lint
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'run ESLint without TS type populated'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js/common'
+    displayName: 'npm ci /js/common/'
+  - script: |
+     npm ci
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'npm ci /js/web/'
+  - script: |
+     npm run lint
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'run ESLint'
+  - script: |
+     npm run format
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'Clang-format'
+  - script: |
+     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following source files are not formatted: (did you run /"npm run format/"?)/n'+a)"
+    workingDirectory: '$(Build.SourcesDirectory)/js'
+    displayName: 'Check unformatted files'
+  - script: |
+     npm run build:doc
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Generating documents'
+  - script: |
+     node -e "a=require('child_process').execSync('git diff --name-only').toString();if(a)throw new Error('Following documents are not up-to-date: (did you run /"npm run build:doc/"?)/n'+a)"
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Check out of dated documents'
+  - task: PowerShell@2
+    inputs:
+      filePath: '$(Build.SourcesDirectory)/tools/ci_build/github/js/pack-npm-packages.ps1'
+      arguments: '$(NpmPackagingMode) $(Build.SourcesDirectory) web'
+      workingDirectory: $(Build.BinariesDirectory)
+      errorActionPreference: stop
+    displayName: 'Pack NPM packages'
+  - script: |
+     npm test
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Run ort-web tests'
+  - script: |
+     npm test -- --webgl-texture-pack-mode -b=webgl
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Run ort-web tests - WebGL: packed mode'
+  - script: |
+     npm test -- --wasm-enable-proxy -b=wasm
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'Run ort-web tests - WebAssembly: proxy'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - script: |
+      npm run test:e2e
+    workingDirectory: '$(Build.SourcesDirectory)/js/web'
+    displayName: 'E2E package consuming test'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/js/common
+      contents: onnxruntime-common-*.tgz
+      targetFolder: $(Build.ArtifactStagingDirectory)
+    displayName: 'Create Artifacts (onnxruntime-common)'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/js/web
+      contents: onnxruntime-web-*.tgz
+      targetFolder: $(Build.ArtifactStagingDirectory)
+    displayName: 'Create Artifacts (onnxruntime-web)'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: '${{ parameters.PackageName }}'
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+    displayName: 'Publish Pipeline Artifact'
+    condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - template: component-governance-component-detection-steps.yml
+    parameters :
+      condition : 'succeeded'
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -55,12 +55,12 @@ stages:
 - stage: Build_wasm_Debug
   dependsOn: Extract_commit
   jobs:
-  - template: win-wasm-ci.yml
+  - template: linux-wasm-ci.yml
     parameters:
       CommitOverride: true
       BuildConfig: 'Debug'
       ExtraBuildArgs: '--use_extensions --cmake_extra_defines onnxruntime_WEBASSEMBLY_DEFAULT_EXTENSION_FLAGS=ON ${{ parameters.ExtraBuildArgs }}'
-      PoolName: ${{ parameters.PoolName }}
+      PoolName: onnxruntime-Ubuntu2004-AMD-CPU
       BuildJsep: ${{ parameters.BuildJsep }}
 
 - stage: Build_web_Debug

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -24,6 +24,13 @@ parameters:
   type: boolean
   default: true
 
+- name: WASMTemplate
+  type: string
+  default: win-wasm-ci.yml
+- name: WebTemplate
+  type: string
+  default: win-web-ci.yml
+
 - name: ExtraBuildArgs
   displayName: 'Extra build command line arguments'
   type: string
@@ -55,18 +62,18 @@ stages:
 - stage: Build_wasm_Debug
   dependsOn: Extract_commit
   jobs:
-  - template: linux-wasm-ci.yml
+  - template: ${{ parameters.WASMTemplate }}
     parameters:
       CommitOverride: true
       BuildConfig: 'Debug'
       ExtraBuildArgs: '--use_extensions --cmake_extra_defines onnxruntime_WEBASSEMBLY_DEFAULT_EXTENSION_FLAGS=ON ${{ parameters.ExtraBuildArgs }}'
-      PoolName: onnxruntime-Ubuntu2004-AMD-CPU
+      PoolName: ${{ parameters.PoolName }}
       BuildJsep: ${{ parameters.BuildJsep }}
 
 - stage: Build_web_Debug
   dependsOn: Build_wasm_Debug
   jobs:
-  - template: win-web-ci.yml
+  - template: ${{ parameters.WebTemplate }}
     parameters:
       CommitOverride: true
       BuildConfig: 'Debug'
@@ -77,7 +84,7 @@ stages:
 - stage: Build_wasm_Release
   dependsOn: Extract_commit
   jobs:
-  - template: win-wasm-ci.yml
+  - template: ${{ parameters.WASMTemplate }}
     parameters:
       CommitOverride: true
       BuildConfig: 'Release'
@@ -89,7 +96,7 @@ stages:
   - stage: Build_wasm_Release_static_library
     dependsOn: Extract_commit
     jobs:
-    - template: win-wasm-ci.yml
+    - template: ${{ parameters.WASMTemplate }}
       parameters:
         CommitOverride: true
         BuildConfig: 'Release'
@@ -101,7 +108,7 @@ stages:
 - stage: Build_web_Release
   dependsOn: Build_wasm_Release
   jobs:
-  - template: win-web-ci.yml
+  - template: ${{ parameters.WebTemplate }}
     parameters:
       CommitOverride: true
       BuildConfig: 'Release'

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -40,7 +40,7 @@ stages:
 - stage: Extract_commit
   jobs:
   - job: Extract_commit
-    pool: ${{ parameters.PoolName }}
+    pool: onnxruntime-Win-CPU-2022-web
     variables:
       runCodesignValidationInjection: false
     timeoutInMinutes: 30

--- a/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/web-ci-pipeline.yml
@@ -28,6 +28,8 @@ stages:
   parameters:
     NpmPackagingMode: ${{ variables.NpmPackagingMode }}
     IsReleasePipeline: false
-    PoolName: 'onnxruntime-Win-CPU-2022-web'
+    PoolName: 'onnxruntime-Ubuntu2004-AMD-CPU'
     BuildStaticLib: true
     ExtraBuildArgs: $(ExtraBuildArgs)
+    WASMTemplate: linux-wasm-ci.yml
+    WebTemplate: linux-web-ci.yml


### PR DESCRIPTION
### Description
1. Enable Web ci on Linux

### Motivation and Context
1. speed up web ci, the duration can be reduced from 160 minutes to 130 minutes, saving of 20% has been achived.
2. It's the prerequisite to enable compilation in the next step.


