### PR TITLE
fix protobuf copyfrom 2G limit

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -17,7 +17,7 @@ from onnx import ModelProto, TensorProto, helper, numpy_helper
 
 import onnxruntime
 
-from .quant_utils import apply_plot, load_model, smooth_distribution
+from .quant_utils import apply_plot, load_model_with_shape_infer, smooth_distribution
 
 
 class CalibrationMethod(Enum):
@@ -63,9 +63,9 @@ class CalibraterBase:
         :param use_external_data_format: use external data format to store model which size is >= 2Gb
         """
         if isinstance(model_path, str):
-            self.model = load_model(Path(model_path), False)
+            self.model = load_model_with_shape_infer(Path(model_path))
         elif isinstance(model_path, Path):
-            self.model = load_model(model_path, False)
+            self.model = load_model_with_shape_infer(model_path)
         else:
             raise ValueError("model_path should be model path.")
 

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -9,7 +9,7 @@ import itertools
 import uuid
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import onnx
@@ -17,7 +17,7 @@ from onnx import ModelProto, TensorProto, helper, numpy_helper
 
 import onnxruntime
 
-from .quant_utils import apply_plot, clone_model_with_shape_infer, load_model, smooth_distribution
+from .quant_utils import apply_plot, load_model, smooth_distribution
 
 
 class CalibrationMethod(Enum):
@@ -49,27 +49,25 @@ class CalibrationDataReader(metaclass=abc.ABCMeta):
 class CalibraterBase:
     def __init__(
         self,
-        model,
+        model_path: Union[str, Path],
         op_types_to_calibrate: Optional[Sequence[str]] = None,
         augmented_model_path="augmented_model.onnx",
         symmetric=False,
         use_external_data_format=False,
     ):
         """
-        :param model: ONNX model to calibrate. It can be a ModelProto or a model path
+        :param model_path: ONNX model to calibrate. It should be a model file path
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         :param symmetric: make range of tensor symmetric (central point is 0).
         :param use_external_data_format: use external data format to store model which size is >= 2Gb
         """
-        if isinstance(model, str):
-            self.model = load_model(Path(model), False)
-        elif isinstance(model, Path):
-            self.model = load_model(model, False)
-        elif isinstance(model, ModelProto):
-            self.model = model
+        if isinstance(model_path, str):
+            self.model = load_model(Path(model_path), False)
+        elif isinstance(model_path, Path):
+            self.model = load_model(model_path, False)
         else:
-            raise ValueError("model should be either model path or onnx.ModelProto.")
+            raise ValueError("model_path should be model path.")
 
         self.op_types_to_calibrate = op_types_to_calibrate
         self.augmented_model_path = augmented_model_path
@@ -99,9 +97,9 @@ class CalibraterBase:
             providers=self.execution_providers,
         )
 
-    def select_tensors_to_calibrate(self, model):
+    def select_tensors_to_calibrate(self, model: ModelProto):
         """
-        select all quantization_candidates op type nodes' input/output tensors.
+        select input/output tensors of candidate nodes to calibrate.
         returns:
             tensors (set): set of tensor name.
             value_infos (dict): tensor name to value info.
@@ -130,15 +128,15 @@ class CalibraterBase:
 
     def get_augment_model(self):
         """
-        return: augmented onnx model
+        return: augmented onnx model. Call after calling augment_graph
         """
-        return self.augment_model
+        return self.model
 
     def augment_graph(self):
         """
         abstract method: augment the input model to prepare for collecting data. It will:
-            1. save augmented model to augmented_model_path.
-            2. set the self.augment_model
+            1. augment the model to be able to collect desired statistics data
+            2. save augmented model to augmented_model_path
         """
         raise NotImplementedError
 
@@ -158,7 +156,7 @@ class CalibraterBase:
 class MinMaxCalibrater(CalibraterBase):
     def __init__(
         self,
-        model,
+        model_path: Union[str, Path],
         op_types_to_calibrate: Optional[Sequence[str]] = None,
         augmented_model_path="augmented_model.onnx",
         symmetric=False,
@@ -167,7 +165,7 @@ class MinMaxCalibrater(CalibraterBase):
         averaging_constant=0.01,
     ):
         """
-        :param model: ONNX model to calibrate. It can be a ModelProto or a model path
+        :param model_path: ONNX model to calibrate. It is a model path
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         :param symmetric: make range of tensor symmetric (central point is 0).
@@ -176,7 +174,7 @@ class MinMaxCalibrater(CalibraterBase):
         :param averaging_constant: constant smoothing factor to use when computing the moving average.
         """
         super().__init__(
-            model,
+            model_path,
             op_types_to_calibrate=op_types_to_calibrate,
             augmented_model_path=augmented_model_path,
             symmetric=symmetric,
@@ -197,12 +195,10 @@ class MinMaxCalibrater(CalibraterBase):
         model and ensures their outputs are stored as part of the graph output
         :return: augmented ONNX model
         """
-        model = clone_model_with_shape_infer(self.model)
-
-        tensors, _ = self.select_tensors_to_calibrate(model)
+        tensors, _ = self.select_tensors_to_calibrate(self.model)
         reshape_shape_name = str(uuid.uuid4())
         reshape_shape = numpy_helper.from_array(np.array([1], dtype=np.int64), reshape_shape_name)
-        model.graph.initializer.append(reshape_shape)
+        self.model.graph.initializer.append(reshape_shape)
 
         def add_reduce_min_max(tensor_name, reduce_op_name):
             # When doing ReduceMax/ReduceMin, ORT can't reduce on dim with value of 0 if 'keepdims' is false.
@@ -223,19 +219,18 @@ class MinMaxCalibrater(CalibraterBase):
                 name=intermediate_output,
             )
 
-            model.graph.node.extend([reduce_node, reshape_node])
-            model.graph.output.append(helper.make_tensor_value_info(reduce_output, TensorProto.FLOAT, [1]))
+            self.model.graph.node.extend([reduce_node, reshape_node])
+            self.model.graph.output.append(helper.make_tensor_value_info(reduce_output, TensorProto.FLOAT, [1]))
 
         for tensor in tensors:
             add_reduce_min_max(tensor, "ReduceMin")
             add_reduce_min_max(tensor, "ReduceMax")
 
         onnx.save(
-            model,
+            self.model,
             self.augmented_model_path,
             save_as_external_data=self.use_external_data_format,
         )
-        self.augment_model = model
 
     def clear_collected_data(self):
         self.intermediate_outputs = []
@@ -328,7 +323,7 @@ class MinMaxCalibrater(CalibraterBase):
 class HistogramCalibrater(CalibraterBase):
     def __init__(
         self,
-        model,
+        model_path: Union[str, Path],
         op_types_to_calibrate: Optional[Sequence[str]] = None,
         augmented_model_path="augmented_model.onnx",
         use_external_data_format=False,
@@ -339,7 +334,7 @@ class HistogramCalibrater(CalibraterBase):
         percentile=99.999,
     ):
         """
-        :param model: ONNX model to calibrate. It can be a ModelProto or a model path
+        :param model_path: ONNX model to calibrate. It is a model path.
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         :param use_external_data_format: use external data format to store model which size is >= 2Gb
@@ -350,7 +345,7 @@ class HistogramCalibrater(CalibraterBase):
         :param percentile: A float number between [0, 100]. Default 99.99.
         """
         super().__init__(
-            model,
+            model_path,
             op_types_to_calibrate=op_types_to_calibrate,
             augmented_model_path=augmented_model_path,
             symmetric=symmetric,
@@ -372,19 +367,16 @@ class HistogramCalibrater(CalibraterBase):
         make all quantization_candidates op type nodes as part of the graph output.
         :return: augmented ONNX model
         """
-        model = clone_model_with_shape_infer(self.model)
-
-        self.tensors_to_calibrate, value_infos = self.select_tensors_to_calibrate(model)
+        self.tensors_to_calibrate, value_infos = self.select_tensors_to_calibrate(self.model)
         for tensor in self.tensors_to_calibrate:
             if tensor not in self.model_original_outputs:
-                model.graph.output.append(value_infos[tensor])
+                self.model.graph.output.append(value_infos[tensor])
 
         onnx.save(
-            model,
+            self.model,
             self.augmented_model_path,
             save_as_external_data=self.use_external_data_format,
         )
-        self.augment_model = model
 
     def clear_collected_data(self):
         self.intermediate_outputs = []
@@ -440,7 +432,7 @@ class HistogramCalibrater(CalibraterBase):
 class EntropyCalibrater(HistogramCalibrater):
     def __init__(
         self,
-        model,
+        model_path: Union[str, Path],
         op_types_to_calibrate: Optional[Sequence[str]] = None,
         augmented_model_path="augmented_model.onnx",
         use_external_data_format=False,
@@ -450,7 +442,7 @@ class EntropyCalibrater(HistogramCalibrater):
         num_quantized_bins=128,
     ):
         """
-        :param model: ONNX model to calibrate. It can be a ModelProto or a model path
+        :param model_path: ONNX model to calibrate. It is a model path
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         :param use_external_data_format: use external data format to store model which size is >= 2Gb
@@ -460,7 +452,7 @@ class EntropyCalibrater(HistogramCalibrater):
         :param num_quantized_bins: number of quantized bins. Default 128.
         """
         super().__init__(
-            model,
+            model_path,
             op_types_to_calibrate,
             augmented_model_path,
             use_external_data_format,
@@ -474,7 +466,7 @@ class EntropyCalibrater(HistogramCalibrater):
 class PercentileCalibrater(HistogramCalibrater):
     def __init__(
         self,
-        model,
+        model_path: Union[str, Path],
         op_types_to_calibrate: Optional[Sequence[str]] = None,
         augmented_model_path="augmented_model.onnx",
         use_external_data_format=False,
@@ -484,7 +476,7 @@ class PercentileCalibrater(HistogramCalibrater):
         percentile=99.999,
     ):
         """
-        :param model: ONNX model to calibrate. It can be a ModelProto or a model path
+        :param model_path: ONNX model to calibrate. It is a model path
         :param op_types_to_calibrate: operator types to calibrate. By default, calibrate all the float32/float16 tensors.
         :param augmented_model_path: save augmented model to this path.
         :param use_external_data_format: use external data format to store model which size is >= 2Gb
@@ -494,7 +486,7 @@ class PercentileCalibrater(HistogramCalibrater):
         :param percentile: A float number between [0, 100]. Default 99.99.
         """
         super().__init__(
-            model,
+            model_path,
             op_types_to_calibrate,
             augmented_model_path,
             use_external_data_format,
@@ -840,7 +832,7 @@ class HistogramCollector(CalibrationDataCollector):
 
 
 def create_calibrator(
-    model,
+    model: Union[str, Path],
     op_types_to_calibrate: Optional[Sequence[str]] = None,
     augmented_model_path="augmented_model.onnx",
     calibrate_method=CalibrationMethod.MinMax,

--- a/onnxruntime/python/tools/quantization/qdq_loss_debug.py
+++ b/onnxruntime/python/tools/quantization/qdq_loss_debug.py
@@ -42,7 +42,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import numpy
 import onnx
-from onnx import ModelProto, TensorProto, helper, numpy_helper
+from onnx import TensorProto, helper, numpy_helper
 
 import onnxruntime
 

--- a/onnxruntime/python/tools/quantization/qdq_loss_debug.py
+++ b/onnxruntime/python/tools/quantization/qdq_loss_debug.py
@@ -23,13 +23,8 @@ Example Usage:
 
     input_data_reader = ExampleDataReader()
 
-    aug_model = modify_model_output_intermediate_tensors (path_to_onnx_model)
     augmented_model_path = str(Path(self._tmp_model_dir.name).joinpath("augmented_model.onnx"))
-    onnx.save(
-        aug_model,
-        augmented_model_path,
-        save_as_external_data=False,
-    )
+    modify_model_output_intermediate_tensors (path_to_onnx_model, augmented_model_path)
 
     tensor_dict = collect_activations(augmented_model_path, input_data_reader)
 ```
@@ -59,7 +54,7 @@ from .quant_utils import (
     QUANT_INPUT_SUFFIX,
     TENSOR_NAME_QUANT_SUFFIX,
     find_by_name,
-    load_model,
+    load_model_with_shape_infer,
 )
 
 _TENSOR_SAVE_POSTFIX = "_ReshapedSavedOutput"
@@ -67,15 +62,18 @@ _TENSOR_SAVE_POSTFIX_LEN = len(_TENSOR_SAVE_POSTFIX)
 
 
 def modify_model_output_intermediate_tensors(
-    onnx_model: Union[str, Path], op_types_for_saving: Optional[Sequence[str]] = None
-) -> ModelProto:
+    input_model_path: Union[str, Path],
+    output_model_path: Union[str, Path],
+    op_types_for_saving: Optional[Sequence[str]] = None,
+    save_as_external_data: bool = False,
+) -> None:
     """Augment a given ONNX model to save node input/output tensors.
 
     Add all input/output tensors of operator nodes to model outputs
     so that their values can be retrieved for debugging purposes.
 
     Args:
-        onnx_model: the path to load the model.
+        input_model: the path to load the model.
         op_types_for_saving: Operator types for which the
                 input/output should be saved. By default, saving all the
                 float32/float16 tensors.
@@ -86,12 +84,12 @@ def modify_model_output_intermediate_tensors(
 
     if op_types_for_saving is None:
         op_types_for_saving = []
-    saver = CalibraterBase(onnx_model, op_types_to_calibrate=op_types_for_saving)
-    model = saver.model
-    tensors, _ = saver.select_tensors_to_calibrate(model)
+    saver = CalibraterBase(input_model_path, op_types_to_calibrate=op_types_for_saving)
+    model_to_augment = saver.model
+    tensors, _ = saver.select_tensors_to_calibrate(model_to_augment)
     reshape_shape_name = "LinearReshape_" + str(time.time())
     reshape_shape = numpy_helper.from_array(numpy.array([-1], dtype=numpy.int64), reshape_shape_name)
-    model.graph.initializer.append(reshape_shape)
+    model_to_augment.graph.initializer.append(reshape_shape)
 
     for tensor_name in tensors:
         reshape_output = tensor_name + _TENSOR_SAVE_POSTFIX
@@ -101,10 +99,15 @@ def modify_model_output_intermediate_tensors(
             outputs=[reshape_output],
             name=reshape_output,
         )
-        model.graph.node.append(reshape_node)
+        model_to_augment.graph.node.append(reshape_node)
         reshape_output_value_info = helper.make_tensor_value_info(reshape_output, TensorProto.FLOAT, [-1])
-        model.graph.output.append(reshape_output_value_info)
-    return model
+        model_to_augment.graph.output.append(reshape_output_value_info)
+
+    onnx.save(
+        model_to_augment,
+        output_model_path,
+        save_as_external_data=save_as_external_data,
+    )
 
 
 def collect_activations(
@@ -280,8 +283,8 @@ def create_weight_matching(float_model_path: str, qdq_model_path: str) -> Dict[s
         print(qdq_weight_cmp['activation1']['dequantized'])
         ```
     """
-    float_onnx_model = ONNXModel(load_model(Path(float_model_path), need_optimize=False))
-    qdq_onnx_model = ONNXModel(load_model(Path(qdq_model_path), need_optimize=False))
+    float_onnx_model = ONNXModel(load_model_with_shape_infer(Path(float_model_path)))
+    qdq_onnx_model = ONNXModel(load_model_with_shape_infer(Path(qdq_model_path)))
 
     matched_weights: Dict[str, Dict[str, numpy.ndarray]] = {}
     initializers = qdq_onnx_model.initializer()

--- a/onnxruntime/python/tools/quantization/qdq_loss_debug.py
+++ b/onnxruntime/python/tools/quantization/qdq_loss_debug.py
@@ -31,7 +31,7 @@ Example Usage:
         save_as_external_data=False,
     )
 
-    tensor_dict = collect_activations(augmented_model_path, data_reader)
+    tensor_dict = collect_activations(augmented_model_path, input_data_reader)
 ```
 
 `tensor_dict` points to a dictionary where the keys are tensor names and each value
@@ -58,7 +58,6 @@ from .quant_utils import (
     DEQUANT_OUTPUT_SUFFIX,
     QUANT_INPUT_SUFFIX,
     TENSOR_NAME_QUANT_SUFFIX,
-    clone_model_with_shape_infer,
     find_by_name,
     load_model,
 )
@@ -68,7 +67,7 @@ _TENSOR_SAVE_POSTFIX_LEN = len(_TENSOR_SAVE_POSTFIX)
 
 
 def modify_model_output_intermediate_tensors(
-    onnx_model: Union[str, Path, ModelProto], op_types_for_saving: Optional[Sequence[str]] = None
+    onnx_model: Union[str, Path], op_types_for_saving: Optional[Sequence[str]] = None
 ) -> ModelProto:
     """Augment a given ONNX model to save node input/output tensors.
 
@@ -76,7 +75,7 @@ def modify_model_output_intermediate_tensors(
     so that their values can be retrieved for debugging purposes.
 
     Args:
-        model: An ONNX model or the path to load the model.
+        onnx_model: the path to load the model.
         op_types_for_saving: Operator types for which the
                 input/output should be saved. By default, saving all the
                 float32/float16 tensors.
@@ -88,7 +87,7 @@ def modify_model_output_intermediate_tensors(
     if op_types_for_saving is None:
         op_types_for_saving = []
     saver = CalibraterBase(onnx_model, op_types_to_calibrate=op_types_for_saving)
-    model: ModelProto = clone_model_with_shape_infer(saver.model)
+    model = saver.model
     tensors, _ = saver.select_tensors_to_calibrate(model)
     reshape_shape_name = "LinearReshape_" + str(time.time())
     reshape_shape = numpy_helper.from_array(numpy.array([-1], dtype=numpy.int64), reshape_shape_name)

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import numpy
 import onnx
-from onnx import external_data_helper
+from onnx import ModelProto, TensorProto, external_data_helper
 from onnx import onnx_pb as onnx_proto
 
 from onnxruntime import GraphOptimizationLevel, InferenceSession, SessionOptions
@@ -511,7 +511,7 @@ def optimize_model(model_path: Path, opt_model_path: Path):
     _ = InferenceSession(model_path.as_posix(), sess_option, providers=["CPUExecutionProvider"], **kwargs)
 
 
-def add_pre_process_metadata(model):
+def add_pre_process_metadata(model: ModelProto):
     """Tag the model that it went through quantization pre-processing"""
     metadata_props = {"onnx.quant.pre_process": "onnxruntime.quant"}
     if model.metadata_props:
@@ -520,7 +520,7 @@ def add_pre_process_metadata(model):
     onnx.helper.set_model_props(model, metadata_props)
 
 
-def model_has_pre_process_metadata(model):
+def model_has_pre_process_metadata(model: ModelProto) -> bool:
     """Check the model whether it went through quantization pre-processing"""
     if model.metadata_props:
         for prop in model.metadata_props:
@@ -529,7 +529,7 @@ def model_has_pre_process_metadata(model):
     return False
 
 
-def add_infer_metadata(model):
+def add_infer_metadata(model: ModelProto):
     metadata_props = {"onnx.infer": "onnxruntime.quant"}
     if model.metadata_props:
         for p in model.metadata_props:
@@ -537,7 +537,7 @@ def add_infer_metadata(model):
     onnx.helper.set_model_props(model, metadata_props)
 
 
-def model_has_infer_metadata(model):
+def model_has_infer_metadata(model: ModelProto) -> bool:
     if model.metadata_props:
         for p in model.metadata_props:
             if p.key == "onnx.infer" and p.value == "onnxruntime.quant":
@@ -545,7 +545,7 @@ def model_has_infer_metadata(model):
     return False
 
 
-def load_model_with_shape_infer(model_path: Path):
+def load_model_with_shape_infer(model_path: Path) -> ModelProto:
     inferred_model_path = generate_identified_filename(model_path, "-inferred")
     onnx.shape_inference.infer_shapes_path(str(model_path), str(inferred_model_path))
     model = onnx.load(inferred_model_path.as_posix())
@@ -553,7 +553,7 @@ def load_model_with_shape_infer(model_path: Path):
     return model
 
 
-def load_model(model_path: Path, need_optimize: bool):
+def load_model(model_path: Path, need_optimize: bool) -> ModelProto:
     with tempfile.TemporaryDirectory(prefix="ort.quant.") as quant_tmp_dir:
         if need_optimize and not model_has_external_data(model_path):
             opt_model_path = Path(quant_tmp_dir).joinpath("model.onnx")
@@ -565,7 +565,7 @@ def load_model(model_path: Path, need_optimize: bool):
         return model
 
 
-def save_and_reload_model(model):
+def save_and_reload_model(model: ModelProto) -> ModelProto:
     with tempfile.TemporaryDirectory(prefix="ort.quant.") as quant_tmp_dir:
         model_path = Path(quant_tmp_dir).joinpath("model.onnx")
         onnx.external_data_helper.convert_model_to_external_data(model, all_tensors_to_one_file=True)
@@ -573,16 +573,7 @@ def save_and_reload_model(model):
         return load_model(model_path, False)
 
 
-def clone_model_with_shape_infer(model):
-    if model_has_infer_metadata(model):
-        cloned_model = onnx_proto.ModelProto()
-        cloned_model.CopyFrom(model)
-    else:
-        cloned_model = save_and_reload_model(model)
-    return cloned_model
-
-
-def tensor_proto_to_array(initializer):
+def tensor_proto_to_array(initializer: TensorProto) -> numpy.ndarray:
     if initializer.data_type == onnx_proto.TensorProto.FLOAT:
         return onnx.numpy_helper.to_array(initializer)
 
@@ -591,25 +582,25 @@ def tensor_proto_to_array(initializer):
     )
 
 
-def add_quant_suffix(tensor_name):
+def add_quant_suffix(tensor_name: str) -> str:
     return tensor_name + "_QuantizeLinear"
 
 
-def add_quant_input_suffix(tensor_name):
+def add_quant_input_suffix(tensor_name: str) -> str:
     return tensor_name + QUANT_INPUT_SUFFIX
 
 
-def add_quant_output_suffix(tensor_name):
+def add_quant_output_suffix(tensor_name) -> str:
     return tensor_name + "_QuantizeLinear_Output"
 
 
-def add_dequant_suffix(tensor_name):
+def add_dequant_suffix(tensor_name) -> str:
     return tensor_name + "_DequantizeLinear"
 
 
-def add_dequant_input_suffix(tensor_name):
+def add_dequant_input_suffix(tensor_name) -> str:
     return tensor_name + "_DequantizeLinear_Input"
 
 
-def add_dequant_output_suffix(tensor_name):
+def add_dequant_output_suffix(tensor_name) -> str:
     return tensor_name + DEQUANT_OUTPUT_SUFFIX

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from .calibrate import CalibrationDataReader, CalibrationMethod, create_calibrator
 from .onnx_quantizer import ONNXQuantizer
 from .qdq_quantizer import QDQQuantizer
-from .quant_utils import QuantFormat, QuantizationMode, QuantType, load_model, model_has_pre_process_metadata
+from .quant_utils import (
+    QuantFormat,
+    QuantizationMode,
+    QuantType,
+    load_model_with_shape_infer,
+    model_has_pre_process_metadata,
+)
 from .registry import IntegerOpsRegistry, QDQRegistry, QLinearOpsRegistry
 
 
@@ -24,7 +30,6 @@ class QuantConfig:
         nodes_to_exclude=None,
         per_channel=False,
         reduce_range=False,
-        optimize_model=True,
         use_external_data_format=False,
     ):
         """
@@ -54,8 +59,6 @@ class QuantConfig:
             reduce_range:
                 quantize weights with 7-bits. It may improve the accuracy for some models running on non-VNNI machine,
                 especially for per-channel mode
-            optimize_model: Deprecating Soon! Optimize model before quantization. NOT recommended, optimization will
-                change the computation graph, making debugging of quantization loss difficult.
             use_external_data_format: option used for large size (>2GB) model. Set to False by default.
         """
 
@@ -69,7 +72,6 @@ class QuantConfig:
         self.activation_type = activation_type
         self.nodes_to_quantize = nodes_to_quantize
         self.nodes_to_exclude = nodes_to_exclude
-        self.optimize_model = optimize_model
         self.use_external_data_format = use_external_data_format
 
 
@@ -86,7 +88,6 @@ class StaticQuantConfig(QuantConfig):
         nodes_to_exclude=None,
         per_channel=False,
         reduce_range=False,
-        optimize_model=True,
         use_external_data_format=False,
         extra_options=None,
     ):
@@ -157,7 +158,6 @@ class StaticQuantConfig(QuantConfig):
             nodes_to_exclude=nodes_to_exclude,
             per_channel=per_channel,
             reduce_range=reduce_range,
-            optimize_model=optimize_model,
             use_external_data_format=use_external_data_format,
         )
         self.calibration_data_reader = calibration_data_reader
@@ -175,7 +175,6 @@ class DynamicQuantConfig(QuantConfig):
         nodes_to_exclude=None,
         per_channel=False,
         reduce_range=False,
-        optimize_model=True,
         use_external_data_format=False,
         extra_options=None,
     ):
@@ -208,7 +207,6 @@ class DynamicQuantConfig(QuantConfig):
             weight_type=weight_type,
             nodes_to_quantize=nodes_to_quantize,
             nodes_to_exclude=nodes_to_exclude,
-            optimize_model=optimize_model,
             use_external_data_format=use_external_data_format,
         )
         self.extra_options = extra_options or {}
@@ -240,7 +238,6 @@ def quantize_static(
     weight_type=QuantType.QInt8,
     nodes_to_quantize=None,
     nodes_to_exclude=None,
-    optimize_model=True,
     use_external_data_format=False,
     calibrate_method=CalibrationMethod.MinMax,
     extra_options=None,
@@ -289,8 +286,6 @@ def quantize_static(
         nodes_to_exclude:
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
-        optimize_model: Deprecating Soon! Optimize model before quantization. NOT recommended, optimization will
-            change the computation graph, making debugging of quantization loss difficult.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
         extra_options:
             key value pair dictionary for various options in different case. Current used:
@@ -343,12 +338,12 @@ def quantize_static(
         qdq_ops = list(QDQRegistry.keys())
         op_types_to_quantize = list(set(q_linear_ops + qdq_ops))
 
-    model = load_model(Path(model_input), optimize_model)
+    model = load_model_with_shape_infer(Path(model_input))
 
     pre_processed: bool = model_has_pre_process_metadata(model)
     if not pre_processed:
-        logging.info(
-            "Please consider pre-processing before quantization. See "
+        logging.warning(
+            "Please consider to run pre-processing before quantization. Refer to example: "
             "https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification"
             "/cpu/ReadMe.md "
         )
@@ -427,7 +422,6 @@ def quantize_dynamic(
     weight_type=QuantType.QInt8,
     nodes_to_quantize=None,
     nodes_to_exclude=None,
-    optimize_model=True,
     use_external_data_format=False,
     extra_options=None,
 ):
@@ -457,8 +451,6 @@ def quantize_dynamic(
         nodes_to_exclude:
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
-        optimize_model: Deprecating Soon! Optimize model before quantization. NOT recommended, optimization will
-            change the computation graph, making debugging of quantization loss difficult.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
         extra_options:
             key value pair dictionary for various options in different case. Current used:
@@ -485,7 +477,15 @@ def quantize_dynamic(
     if not op_types_to_quantize or len(op_types_to_quantize) == 0:
         op_types_to_quantize = list(IntegerOpsRegistry.keys())
 
-    model = load_model(Path(model_input), optimize_model)
+    model = load_model_with_shape_infer(Path(model_input))
+
+    pre_processed: bool = model_has_pre_process_metadata(model)
+    if not pre_processed:
+        logging.warning(
+            "Please consider to run pre-processing before quantization. Refer to example: "
+            "https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification"
+            "/cpu/ReadMe.md "
+        )
 
     if "MatMulConstBOnly" not in extra_options:
         extra_options["MatMulConstBOnly"] = True
@@ -536,7 +536,6 @@ def quantize(
             nodes_to_exclude=quant_config.nodes_to_exclude,
             per_channel=quant_config.per_channel,
             reduce_range=quant_config.reduce_range,
-            optimize_model=quant_config.optimize_model,
             use_external_data_format=quant_config.use_external_data_format,
             extra_options=quant_config.extra_options,
         )
@@ -551,7 +550,6 @@ def quantize(
             nodes_to_exclude=quant_config.nodes_to_exclude,
             per_channel=quant_config.per_channel,
             reduce_range=quant_config.reduce_range,
-            optimize_model=quant_config.optimize_model,
             use_external_data_format=quant_config.use_external_data_format,
             extra_options=quant_config.extra_options,
         )

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -347,7 +347,7 @@ def quantize_static(
 
     pre_processed: bool = model_has_pre_process_metadata(model)
     if not pre_processed:
-        logging.warning(
+        logging.info(
             "Please consider pre-processing before quantization. See "
             "https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification"
             "/cpu/ReadMe.md "
@@ -364,7 +364,7 @@ def quantize_static(
 
     with tempfile.TemporaryDirectory(prefix="ort.quant.") as quant_tmp_dir:
         calibrator = create_calibrator(
-            model,
+            Path(model_input),
             op_types_to_quantize,
             augmented_model_path=Path(quant_tmp_dir).joinpath("augmented_model.onnx").as_posix(),
             calibrate_method=calibrate_method,

--- a/onnxruntime/test/python/quantization/test_op_attention.py
+++ b/onnxruntime/test/python/quantization/test_op_attention.py
@@ -75,7 +75,9 @@ class TestOpAttention(unittest.TestCase):
             [output_tensor],
             initializer=initializers,
         )
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("com.microsoft", 1)]
+        )
         model.ir_version = onnx.IR_VERSION
 
         onnx.save(model, output_model_path)

--- a/onnxruntime/test/python/quantization/test_op_embed_layernorm.py
+++ b/onnxruntime/test/python/quantization/test_op_embed_layernorm.py
@@ -105,7 +105,9 @@ class TestOpEmbedLayerNormalization(unittest.TestCase):
         )
 
         graph = helper.make_graph(nodes, graph_name, inputs, outputs, initializer=initializers)
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 14), helper.make_opsetid("com.microsoft", 1)]
+        )
         model.ir_version = 7  # use stable onnx ir version
         onnx.save(model, model_path)
 

--- a/onnxruntime/test/python/quantization/test_op_where.py
+++ b/onnxruntime/test/python/quantization/test_op_where.py
@@ -50,7 +50,9 @@ class TestWhereModel(unittest.TestCase):
             [out_put],
             initializer=initializers,
         )
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 16)])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 16), helper.make_opsetid("com.microsoft", 1)]
+        )
         save(model, model_path)
 
     def quantize_where_test(self, activation_type, weight_type, extra_options={}):  # noqa: B006

--- a/onnxruntime/test/python/quantization/test_qdq.py
+++ b/onnxruntime/test/python/quantization/test_qdq.py
@@ -84,7 +84,7 @@ class TestQDQExtraOptions(unittest.TestCase):
         op_types_to_quantize = ["Add"]
 
         mode = QuantizationMode.QLinearOps
-        model = onnx.load_model(test_model_path, False)
+        model = onnx.load_model(test_model_path)
         quantizer = QDQQuantizer(
             model,
             True,  # per_channel
@@ -185,7 +185,7 @@ class TestQDQExtraOptions(unittest.TestCase):
         op_types_to_quantize = ["Add", "MatMul"]
 
         mode = QuantizationMode.QLinearOps
-        model = onnx.load_model(test_model_path, False)
+        model = onnx.load_model(test_model_path)
         quantizer = QDQQuantizer(
             model,
             True,  # per_channel
@@ -301,7 +301,6 @@ class TestQDQFormatConv(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         qdq_nodes = {
@@ -324,7 +323,6 @@ class TestQDQFormatConv(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         qop_nodes = {"QLinearConv": 1, "QuantizeLinear": 1, "DequantizeLinear": 1}
@@ -409,7 +407,6 @@ class TestQDQFormatConvClip(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         # topo sort check
@@ -440,7 +437,6 @@ class TestQDQFormatConvClip(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         qop_nodes = {"QLinearConv": 1, "QuantizeLinear": 1, "DequantizeLinear": 1}
@@ -579,7 +575,6 @@ class TestQDQFormatConvRelu(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         # topo sort check
@@ -607,7 +602,6 @@ class TestQDQFormatConvRelu(TestQDQFormat):
             reduce_range=per_channel,
             activation_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
             weight_type=QuantType.QInt8 if is_quant_type_int8 else QuantType.QUInt8,
-            optimize_model=False,
         )
         data_reader.rewind()
         qop_nodes = {"QLinearConv": 1, "QuantizeLinear": 1, "DequantizeLinear": 1}
@@ -636,7 +630,6 @@ class TestQDQFormatConvRelu(TestQDQFormat):
             reduce_range=False,
             activation_type=QuantType.QInt8,
             weight_type=QuantType.QInt8,
-            optimize_model=False,
         )
 
 
@@ -690,7 +683,7 @@ class TestQDQRemovableActivation(TestQDQFormat):
         data_reader = self.input_feeds(2, {"input": [1, 3, 1, 3]})
 
         qdq_model_path = str(Path(self._tmp_model_dir.name) / "qdq_relu_convs_model.onnx")
-        quantize_static(float_model_path, qdq_model_path, data_reader, optimize_model=False)
+        quantize_static(float_model_path, qdq_model_path, data_reader)
 
         qop_nodes = {"Clip": 1, "Relu": 1, "QuantizeLinear": 0, "DequantizeLinear": 0}
         check_op_type_count(self, qdq_model_path, **qop_nodes)

--- a/onnxruntime/test/python/quantization/test_qdq_loss_debug.py
+++ b/onnxruntime/test/python/quantization/test_qdq_loss_debug.py
@@ -109,13 +109,7 @@ class TestDataReader(CalibrationDataReader):
 def augment_model_collect_activations(
     model_path: str, augmented_model_path: str, data_reader: TestDataReader
 ) -> Dict[str, List[np.ndarray]]:
-    aug_model = modify_model_output_intermediate_tensors(model_path)
-
-    onnx.save(
-        aug_model,
-        augmented_model_path,
-        save_as_external_data=False,
-    )
+    modify_model_output_intermediate_tensors(model_path, augmented_model_path)
 
     tensor_dict = collect_activations(augmented_model_path, data_reader)
     return tensor_dict
@@ -180,7 +174,6 @@ class TestSaveActivations(unittest.TestCase):
             reduce_range=False,
             activation_type=QuantType.QInt8,
             weight_type=QuantType.QInt8,
-            optimize_model=False,
         )
 
         data_reader.rewind()
@@ -238,7 +231,6 @@ class TestSaveActivations(unittest.TestCase):
             reduce_range=False,
             activation_type=QuantType.QInt8,
             weight_type=QuantType.QInt8,
-            optimize_model=False,
         )
 
         # Call function under test and verify all weights are present
@@ -307,7 +299,6 @@ class TestSaveActivations(unittest.TestCase):
             reduce_range=False,
             activation_type=QuantType.QInt8,
             weight_type=QuantType.QInt8,
-            optimize_model=False,
         )
 
         # Call function under test and verify all weights are present

--- a/onnxruntime/test/python/quantization/test_quant_util.py
+++ b/onnxruntime/test/python/quantization/test_quant_util.py
@@ -13,7 +13,7 @@ import numpy
 import onnx
 from onnx import TensorProto, helper, numpy_helper
 
-from onnxruntime.quantization.quant_utils import compute_scale_zp, load_model, model_has_infer_metadata
+from onnxruntime.quantization.quant_utils import compute_scale_zp, load_model_with_shape_infer, model_has_infer_metadata
 
 
 class TestQuantUtil(unittest.TestCase):
@@ -61,7 +61,7 @@ class TestQuantUtil(unittest.TestCase):
             self.assertFalse(model_has_infer_metadata(model))
             model_file_path = temp_dir + "/test_load_external_model.onnx"
             onnx.save(model, model_file_path, save_as_external_data=True)
-            model_reloaded = load_model(Path(model_file_path), False)
+            model_reloaded = load_model_with_shape_infer(Path(model_file_path))
             self.assertTrue(model_has_infer_metadata(model_reloaded))
 
 

--- a/orttraining/orttraining/test/python/qat_poc_example/quantize.py
+++ b/orttraining/orttraining/test/python/qat_poc_example/quantize.py
@@ -51,13 +51,12 @@ def quantize_static(input_model_dir, output_model_dir):
 
     # Quantize the model
     logging.info(
-        "Invoking onnxruntime.quantization.quantize_static with optimize_model=False, AddQDQPairToWeight=True and QuantizeBias=False.."
+        "Invoking onnxruntime.quantization.quantize_static with AddQDQPairToWeight=True and QuantizeBias=False.."
     )
     logging.info("Quantized model will be saved to %s." % output_model_dir)
     quantization.quantize_static(
         input_model_dir,
         output_model_dir,
         calibration_data_reader,
-        optimize_model=False,
         extra_options=extra_options,
     )


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
protobuf CopyFrom doesn't work for model > 2GB for version 4.23. This PR removes the copy for Calibrator.

Currently Calibrator copies the ModelProto to avoid changing it. The reason is that: quantize_static passes a ModelProto to Calibrator to calibrate quantitation parameters, and then use it for quantization. If calibrator changes the ModelProto, quantizaiton won't work.

This PR changes quantize_static to pass in a model path to Calibrator instead of a ModelProto, and make Calibrator only take in model path as input, which is how it is used in most cases.

This PR also remove the optimization from quantization. User needs to call pre-process to optimize the model