### PR TITLE
Set onnxruntime-c local pod path environment variable for react native e2e tests on ci

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -268,6 +268,9 @@ stages:
       displayName: Bootstrap Android and iOS e2e tests
 
     - script: |
+        # Mobile build:
+        # ORT_MOBILE_C_LOCAL_POD_PATH=$(Build.BinariesDirectory)/staging/onnxruntime-mobile-c \
+        ORT_C_LOCAL_POD_PATH=$(Build.BinariesDirectory)/staging/onnxruntime-c \
         pod install
       workingDirectory: '$(Build.SourcesDirectory)/js/react_native/e2e/ios'
       displayName: Pod install for onnxruntime react native ios e2e tests


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Set onnxruntime-c local pod path environment variable for react native e2e tests on react-native-ci.yml


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Previously the E2E test project is not properly consuming a local built onnxruntime-c version pod. 

https://github.com/microsoft/onnxruntime/pull/16411#issuecomment-1598512816
