### PR TITLE
Fix input typo in Whisper export with beam search

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/convert_to_onnx.py
@@ -405,9 +405,10 @@ def main(argv=None):
         try:
             with torch.no_grad():
                 max_diff = WhisperHelper.verify_onnx(args.model_name_or_path, ort_session, device)
-            logger.info(f"Max difference between PyTorch and ONNX Runtime token ids = {max_diff}")
             if max_diff > 1e-4:
                 logger.warning("PyTorch and ONNX Runtime results are NOT close")
+            else:
+                logger.info("PyTorch and ONNX Runtime results are close")
         except Exception as e:
             logger.warning(
                 f"An error occurred while trying to verify parity between PyTorch and ONNX Runtime: {e}", exc_info=True

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -33,7 +33,7 @@ def chain_model(args):
         "num_beams",
         "num_return_sequences",
         "length_penalty_fp16" if args.precision == Precision.FLOAT16 else "length_penalty",
-        "repetition_penalty_fp16" if args.precision == Precision.FLOAT16 else "input_features",
+        "repetition_penalty_fp16" if args.precision == Precision.FLOAT16 else "repetition_penalty",
         "vocab_mask" if args.use_prefix_vocab_mask else "",
         "prefix_vocab_mask" if args.use_prefix_vocab_mask else "",
         "",  # attention mask

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 def verify_inputs(beam_inputs, graph_inputs):
     # Verify that ONNX graph's inputs match beam search op's inputs
-    beam_required_inputs = list(filter(lambda beam_input: beam_input != "", beam_inputs))
+    beam_required_inputs = list(filter(lambda beam_input: beam_input, beam_inputs))
     assert len(graph_inputs) == len(beam_required_inputs)
-    for (graph_input, beam_input) in zip(graph_inputs, beam_required_inputs):
+    for graph_input, beam_input in zip(graph_inputs, beam_required_inputs):
         # Check if graph_input is in beam_input to handle beam_input names with the "_fp16" suffix
         assert graph_input.name in beam_input
 

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_chain.py
@@ -16,6 +16,15 @@ from convert_generation import (  # noqa: E402
 logger = logging.getLogger(__name__)
 
 
+def verify_inputs(beam_inputs, graph_inputs):
+    # Verify that ONNX graph's inputs match beam search op's inputs
+    beam_required_inputs = list(filter(lambda beam_input: beam_input != "", beam_inputs))
+    assert len(graph_inputs) == len(beam_required_inputs)
+    for (graph_input, beam_input) in zip(graph_inputs, beam_required_inputs):
+        # Check if graph_input is in beam_input to handle beam_input names with the "_fp16" suffix
+        assert graph_input.name in beam_input
+
+
 def chain_model(args):
     # Load encoder/decoder and insert necessary (but unused) graph inputs expected by BeamSearch op
     encoder_model = onnx.load_model(args.encoder_path, load_external_data=True)
@@ -98,16 +107,6 @@ def chain_model(args):
         length_penalty,
         repetition_penalty,
     ]
-    if args.use_forced_decoder_ids:
-        decoder_input_ids = helper.make_tensor_value_info(
-            "decoder_input_ids", TensorProto.INT32, ["batch_size", "initial_sequence_length"]
-        )
-        graph_inputs.append(decoder_input_ids)
-
-    if args.use_logits_processor:
-        logits_processor = helper.make_tensor_value_info("logits_processor", TensorProto.INT32, [1])
-        graph_inputs.append(logits_processor)
-
     if args.use_vocab_mask:
         vocab_mask = helper.make_tensor_value_info("vocab_mask", TensorProto.INT32, [config.vocab_size])
         graph_inputs.append(vocab_mask)
@@ -117,6 +116,16 @@ def chain_model(args):
             "prefix_vocab_mask", TensorProto.INT32, ["batch_size", config.vocab_size]
         )
         graph_inputs.append(prefix_vocab_mask)
+
+    if args.use_forced_decoder_ids:
+        decoder_input_ids = helper.make_tensor_value_info(
+            "decoder_input_ids", TensorProto.INT32, ["batch_size", "initial_sequence_length"]
+        )
+        graph_inputs.append(decoder_input_ids)
+
+    if args.use_logits_processor:
+        logits_processor = helper.make_tensor_value_info("logits_processor", TensorProto.INT32, [1])
+        graph_inputs.append(logits_processor)
 
     # graph outputs
     sequences = helper.make_tensor_value_info(
@@ -148,6 +157,10 @@ def chain_model(args):
         else [node]
     )
     beam_graph = helper.make_graph(graph_nodes, "beam-search-test", graph_inputs, graph_outputs, initializers)
+
+    # Verify graph's inputs match beam search's inputs
+    verify_inputs(beam_inputs, graph_inputs)
+
     assert decoder_model.ir_version == encoder_model.ir_version
     logger.info(f"Using IR version {decoder_model.ir_version} for chained model")
 

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -324,12 +324,18 @@ class WhisperHelper:
 
         if max_diff > 0:
             # For ONNX Runtime INT8 model
-            pt_expected_transcription = " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+            pt_expected_transcription = (
+                " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+            )
             pt_transcription = processor.batch_decode(pt_outputs, skip_special_tokens=True)
-            ort_expected_transcription = " Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel."
+            ort_expected_transcription = (
+                " Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel."
+            )
             ort_transcription = processor.batch_decode(ort_outputs, skip_special_tokens=True)
 
-            parity = pt_expected_transcription == pt_transcription[0] and ort_expected_transcription == ort_transcription[0]
+            parity = (
+                pt_expected_transcription == pt_transcription[0] and ort_expected_transcription == ort_transcription[0]
+            )
             if parity:
                 max_diff = 0
 

--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -320,4 +320,17 @@ class WhisperHelper:
             logger.warning("PyTorch and ONNX Runtime outputs do not have the same shape")
 
         diff = pt_outputs - ort_outputs
-        return max(diff.min(), diff.max(), key=abs)
+        max_diff = max(diff.min(), diff.max(), key=abs)
+
+        if max_diff > 0:
+            # For ONNX Runtime INT8 model
+            pt_expected_transcription = " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+            pt_transcription = processor.batch_decode(pt_outputs, skip_special_tokens=True)
+            ort_expected_transcription = " Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel."
+            ort_transcription = processor.batch_decode(ort_outputs, skip_special_tokens=True)
+
+            parity = pt_expected_transcription == pt_transcription[0] and ort_expected_transcription == ort_transcription[0]
+            if parity:
+                max_diff = 0
+
+        return max_diff


### PR DESCRIPTION
### Description
This PR fixes a typo with assigning the `repetition_penalty` input in the Whisper export with beam search model. It is a follow-up to the [export stabilization PR](https://github.com/microsoft/onnxruntime/pull/16297).


### Motivation and Context
The `repetition_penalty` input should be set to `repetition_penalty` instead of `input_features`.