### PR TITLE
Unblock Linux MultiGPU TensorRT CI

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_tensorrt
@@ -2,7 +2,7 @@
 # Label: com.nvidia.cuda.version: 11.8.0
 # Label: com.nvidia.cudnn.version: 8.7.0
 # Ubuntu 20.04
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04@sha256:b754c43fe9d62e88862d168c4ab9282618a376dbc54871467870366cacfa456e
 
 ARG PYTHON_VERSION=3.8
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description
Revert docker base image to nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04@sha256:b754c43fe9d62e88862d168c4ab9282618a376dbc54871467870366cacfa456e



### Motivation and Context
The default img env of nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04 has minor upgrade, which make Linux MultiGPU TensorRT CI (NV12 instance with Maxwell GPU) fail on three [CApiTestGlobalThreadPoolsWithProvider tests](https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=320245&view=logs&j=8c952c3b-dbd4-5685-50d1-7e2a31304cbf&t=ab7852eb-c27a-552f-5934-55aea3e695cb&l=40460) (these three tests have higher error which are above the tolerance)

That minor upgrade includes cudnn 8.7.0->8.9.0, which might be a factor that make maxwell GPU generator higher error. CIs with T4 GPU are not affected.