### PR TITLE
Remove now duplicated symbol

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_provider_interface.cc
+++ b/onnxruntime/core/providers/cuda/cuda_provider_interface.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/session/onnxruntime_c_api.h"
+#if !defined(USE_ROCM)
 
 namespace onnxruntime {
 struct Provider;
@@ -15,3 +16,5 @@ ORT_API(onnxruntime::Provider*, GetProvider) {
   return reinterpret_cast<onnxruntime::Provider*>(onnxruntime::GetProvider());
 }
 }
+
+#endif

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
@@ -214,3 +214,10 @@ struct ROCM_Provider : Provider {
 } g_provider;
 
 }  // namespace onnxruntime
+
+extern "C" {
+
+ORT_API(onnxruntime::Provider*, GetProvider) {
+  return &onnxruntime::g_provider;
+}
+}

--- a/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
+++ b/onnxruntime/core/providers/rocm/rocm_provider_factory.cc
@@ -214,10 +214,3 @@ struct ROCM_Provider : Provider {
 } g_provider;
 
 }  // namespace onnxruntime
-
-extern "C" {
-
-ORT_API(onnxruntime::Provider*, GetProvider) {
-  return &onnxruntime::g_provider;
-}
-}


### PR DESCRIPTION
### Description
Change #16161 broke rocm by duplicating this symbol. This removes the duplicate to unblock the tests.


