### PR TITLE
Update trtep doc with ort 1.15

### DIFF
--- a/docs/build/eps.md
+++ b/docs/build/eps.md
@@ -95,39 +95,46 @@ See more information on the TensorRT Execution Provider [here](../execution-prov
 {: .no_toc }
 
 * Install [CUDA](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn)
-   * The TensorRT execution provider for ONNX Runtime is built and tested with CUDA 11.0/11.1/11.4/11.6 and cuDNN 8.0/cuDNN 8.2/cuDNN 8.4.
+   * The TensorRT execution provider for ONNX Runtime is built and tested up to CUDA 11.8 and cuDNN 8.9.
    * The path to the CUDA installation must be provided via the CUDA_PATH environment variable, or the `--cuda_home` parameter. The CUDA path should contain `bin`, `include` and `lib` directories.
    * The path to the CUDA `bin` directory must be added to the PATH environment variable so that `nvcc` is found.
-   * The path to the cuDNN installation (path to folder that contains libcudnn.so) must be provided via the cuDNN_PATH environment variable, or `--cudnn_home` parameter.
+   * The path to the cuDNN installation (path to cudnn bin/include/lib) must be provided via the cuDNN_PATH environment variable, or `--cudnn_home` parameter.
+     * On Windows, cuDNN requires [zlibwapi.dll](https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html#install-zlib-windows). Feel free to place this dll under `path_to_cudnn/bin`  
  * Install [TensorRT](https://developer.nvidia.com/tensorrt)
-   * The TensorRT execution provider for ONNX Runtime is built and tested with TensorRT 8.4.1.5.
-   * To use different versions of TensorRT, prior to building, change the onnx-tensorrt submodule to a branch corresponding to the TensorRT version. e.g. To use TensorRT 7.2.x,
-     * cd cmake/external/onnx-tensorrt
-     * git remote update
-     * git checkout 7.2.1
-     * build as usual (but add the --skip_submodule_sync command so it doesn't update the submodule)
+   * The TensorRT execution provider for ONNX Runtime is built and tested up to TensorRT 8.6.
    * The path to TensorRT installation must be provided via the `--tensorrt_home` parameter.
-   * ONNX Runtime also supports using TensorRT built-in parser library (instead of generating the parser library from onnx-tensorrt submodule). 
-     * To enable this build option, add additional `--use_tensorrt_builtin_parser` parameter next to the parameter `--use_tensorrt` in build commands below.
+   * By default, ONNX Runtime uses TensorRT built-in parser library, instead of generating the parser library from open-sourced [onnx-tensorrt](https://github.com/onnx/onnx-tensorrt/tree/main) submodule. 
+     * To update TensorRT parser version, simply linking path to new TensorRT folder when building Onnx Runtime. 
+     * To generate open-sourced parser when building ONNX Runtime, add additional `--use_tensorrt_oss_parser` parameter next to the parameter `--use_tensorrt` in build commands below.
 
 ### Build Instructions
 {: .no_toc }
 
 #### Windows
-```
-.\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home>
+```bash
+# to build with tensorrt built-in parser
+.\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home> --cmake_generator "Visual Studio 17 2022"
+
+# to build with open-sourced parser. e.g. TensorRT 8.6-GA
+cd cmake/external/onnx-tensorrt
+git remote update
+git checkout 8.6-GA
+cd ../../..
+.\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home> --use_tensorrt_oss_parser --cmake_generator "Visual Studio 17 2022" 
 ```
 
 #### Linux
 
-```
-# to build with the latest supported TensorRT version
+```bash
+# to build with tensorrt built-in parser
 ./build.sh --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --tensorrt_home <path to TensorRT home>
-# to build with different version. e.g. TensorRT 7.2.1
+
+# to build with open-sourced parser. e.g. TensorRT 8.6-GA
 cd cmake/external/onnx-tensorrt
 git remote update
-git checkout 7.2.1
-./build.sh  --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --tensorrt_home <path to TensorRT home> --skip_submodule_sync
+git checkout 8.6-GA
+cd ../../..
+./build.sh  --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --use_tensorrt_oss_parser --tensorrt_home <path to TensorRT home> --skip_submodule_sync
 ```
 
 Dockerfile instructions are available [here](https://github.com/microsoft/onnxruntime/tree/main/dockerfiles#tensorrt)

--- a/docs/build/eps.md
+++ b/docs/build/eps.md
@@ -106,6 +106,8 @@ See more information on the TensorRT Execution Provider [here](../execution-prov
    * By default, ONNX Runtime uses TensorRT built-in parser library, instead of generating the parser library from open-sourced [onnx-tensorrt](https://github.com/onnx/onnx-tensorrt/tree/main) submodule. 
      * To update TensorRT parser version, simply linking path to new TensorRT folder when building Onnx Runtime. 
      * To generate open-sourced parser when building ONNX Runtime, add additional `--use_tensorrt_oss_parser` parameter next to the parameter `--use_tensorrt` in build commands below.
+       * The default version of open-sourced onnx-tensorrt parser is encoded in cmake/deps.txt.
+       * To specify a different version, please update the commit link for the onnx-tensorrt repository, and run `sha1sum` command on the onnx-tensorrt zip file to acquire the SHA1 hash
 
 ### Build Instructions
 {: .no_toc }
@@ -115,11 +117,7 @@ See more information on the TensorRT Execution Provider [here](../execution-prov
 # to build with tensorrt built-in parser
 .\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home> --cmake_generator "Visual Studio 17 2022"
 
-# to build with open-sourced parser. e.g. TensorRT 8.6-GA
-cd cmake/external/onnx-tensorrt
-git remote update
-git checkout 8.6-GA
-cd ../../..
+# to build with specific version of open-sourced onnx-tensorrt parser configured in cmake/deps.txt
 .\build.bat --cudnn_home <path to cuDNN home> --cuda_home <path to CUDA home> --use_tensorrt --tensorrt_home <path to TensorRT home> --use_tensorrt_oss_parser --cmake_generator "Visual Studio 17 2022" 
 ```
 
@@ -129,11 +127,7 @@ cd ../../..
 # to build with tensorrt built-in parser
 ./build.sh --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --tensorrt_home <path to TensorRT home>
 
-# to build with open-sourced parser. e.g. TensorRT 8.6-GA
-cd cmake/external/onnx-tensorrt
-git remote update
-git checkout 8.6-GA
-cd ../../..
+# to build with specific version of open-sourced onnx-tensorrt parser configured in cmake/deps.txt
 ./build.sh  --cudnn_home <path to cuDNN e.g. /usr/lib/x86_64-linux-gnu/> --cuda_home <path to folder for CUDA e.g. /usr/local/cuda> --use_tensorrt --use_tensorrt_oss_parser --tensorrt_home <path to TensorRT home> --skip_submodule_sync
 ```
 

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -26,8 +26,9 @@ Pre-built packages and Docker images are available for Jetpack in the [Jetson Zo
 
 |ONNX Runtime|TensorRT|CUDA|
 |---|---|---|
-|main|8.5|11.6|
-|1.14|8.5|11.6|
+|main|8.5|11.8|
+|1.15|8.5|11.8|
+|1.14-1.15|8.5|11.6|
 |1.12-1.13|8.4|11.4|
 |1.11|8.2|11.4|
 |1.10|8.0|11.4|
@@ -409,13 +410,7 @@ This example shows how to run the Faster R-CNN model on TensorRT execution provi
     python symbolic_shape_infer.py --input /path/to/onnx/model/model.onnx --output /path/to/onnx/model/new_model.onnx --auto_merge
     ```
 
-3. Replace the original model with the new model and run the 
-    onnx_test_runner tool under ONNX Runtime build directory.
-    ```bash
-    ./onnx_test_runner -e tensorrt /path/to/onnx/model/
-    ```
-
-4. Run `onnxruntime_perf_test` on your shape-inferred Faster-RCNN model 
+3. Run `onnxruntime_perf_test` on your shape-inferred Faster-RCNN model 
 
    > Download sample test data with model from [model zoo](https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/faster-rcnn), and put test_data_set folder next to your inferred model 
 

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -26,8 +26,7 @@ Pre-built packages and Docker images are available for Jetpack in the [Jetson Zo
 
 |ONNX Runtime|TensorRT|CUDA|
 |---|---|---|
-|main|8.5|11.8|
-|1.15|8.5|11.8|
+|1.15-main|8.6|11.8|
 |1.14|8.5|11.6|
 |1.12-1.13|8.4|11.4|
 |1.11|8.2|11.4|
@@ -410,7 +409,15 @@ This example shows how to run the Faster R-CNN model on TensorRT execution provi
     python symbolic_shape_infer.py --input /path/to/onnx/model/model.onnx --output /path/to/onnx/model/new_model.onnx --auto_merge
     ```
 
-3. Run `onnxruntime_perf_test` on your shape-inferred Faster-RCNN model 
+3. To test model with sample input and verify the output, run `onnx_test_runner` under ONNX Runtime build directory.
+   
+    > Models and test_data_set_ folder need to be stored under the same path. `onnx_test_runner` will test all models under this path.
+
+    ```bash
+    ./onnx_test_runner -e tensorrt /path/to/onnx/model/
+    ```
+
+4. To test on model performance, run `onnxruntime_perf_test` on your shape-inferred Faster-RCNN model 
 
    > Download sample test data with model from [model zoo](https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/faster-rcnn), and put test_data_set folder next to your inferred model 
 

--- a/docs/execution-providers/TensorRT-ExecutionProvider.md
+++ b/docs/execution-providers/TensorRT-ExecutionProvider.md
@@ -28,7 +28,7 @@ Pre-built packages and Docker images are available for Jetpack in the [Jetson Zo
 |---|---|---|
 |main|8.5|11.8|
 |1.15|8.5|11.8|
-|1.14-1.15|8.5|11.6|
+|1.14|8.5|11.6|
 |1.12-1.13|8.4|11.4|
 |1.11|8.2|11.4|
 |1.10|8.0|11.4|


### PR DESCRIPTION
### Description
* TRT/cuda/cuDNN version updated
* Update the instruction of using trt builtin parser (new default option) and using open-sourced onnx-trt parser (non-default)
* Add more comments to examples

Rendered version: 
1. https://yf711.github.io/onnxruntime/docs/build/eps.html#tensorrt
2. https://yf711.github.io/onnxruntime/docs/execution-providers/TensorRT-ExecutionProvider.html


