### PR TITLE
Allow for fallible custom operators through C-API

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4394,6 +4394,15 @@ struct OrtCustomOp {
   // and false (zero) otherwise.
   // Applicable only for custom ops that have a variadic output.
   int(ORT_API_CALL* GetVariadicOutputHomogeneity)(_In_ const struct OrtCustomOp* op);
+
+  // Fallible kernel creation
+  OrtStatusPtr(ORT_API_CALL* CreateKernelFallible)(_In_ const struct OrtCustomOp* op, _In_ const OrtApi* api,
+						   _In_ const OrtKernelInfo* info,
+						   _Out_ void** kernel);
+
+  // Fallible compute call
+  OrtStatusPtr(ORT_API_CALL* KernelComputeFallible)(_In_ void* op_kernel, _In_ OrtKernelContext* context);
+
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1847,11 +1847,11 @@ struct Op : detail::Base<OrtOp> {
               size_t output_count);
 };
 
-template <typename TOp, typename TKernel>
+
+  template <typename TOp, typename TKernel, bool Fallible = false>
 struct CustomOpBase : OrtCustomOp {
   CustomOpBase() {
     OrtCustomOp::version = ORT_API_VERSION;
-    OrtCustomOp::CreateKernel = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info) { return static_cast<const TOp*>(this_)->CreateKernel(*api, info); };
     OrtCustomOp::GetName = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetName(); };
 
     OrtCustomOp::GetExecutionProviderType = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetExecutionProviderType(); };
@@ -1863,7 +1863,6 @@ struct CustomOpBase : OrtCustomOp {
     OrtCustomOp::GetOutputTypeCount = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetOutputTypeCount(); };
     OrtCustomOp::GetOutputType = [](const OrtCustomOp* this_, size_t index) { return static_cast<const TOp*>(this_)->GetOutputType(index); };
 
-    OrtCustomOp::KernelCompute = [](void* op_kernel, OrtKernelContext* context) { static_cast<TKernel*>(op_kernel)->Compute(context); };
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 #pragma warning(disable : 26409)
@@ -1879,6 +1878,22 @@ struct CustomOpBase : OrtCustomOp {
     OrtCustomOp::GetVariadicInputHomogeneity = [](const OrtCustomOp* this_) { return static_cast<int>(static_cast<const TOp*>(this_)->GetVariadicInputHomogeneity()); };
     OrtCustomOp::GetVariadicOutputMinArity = [](const OrtCustomOp* this_) { return static_cast<const TOp*>(this_)->GetVariadicOutputMinArity(); };
     OrtCustomOp::GetVariadicOutputHomogeneity = [](const OrtCustomOp* this_) { return static_cast<int>(static_cast<const TOp*>(this_)->GetVariadicOutputHomogeneity()); };
+    if constexpr(Fallible) {
+      OrtCustomOp::CreateKernelFallible = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info, void** op_kernel) -> OrtStatusPtr {
+	return static_cast<const TOp*>(this_)->CreateKernelFallible(*api, info, op_kernel);
+      };
+      OrtCustomOp::KernelComputeFallible = [](void* op_kernel, OrtKernelContext* context) -> OrtStatusPtr {
+	return static_cast<TKernel*>(op_kernel)->ComputeFallible(context);
+      };
+    } else {
+      OrtCustomOp::CreateKernelFallible = nullptr;
+      OrtCustomOp::KernelComputeFallible = nullptr;
+
+      OrtCustomOp::CreateKernel = [](const OrtCustomOp* this_, const OrtApi* api, const OrtKernelInfo* info) { return static_cast<const TOp*>(this_)->CreateKernel(*api, info); };
+      OrtCustomOp::KernelCompute = [](void* op_kernel, OrtKernelContext* context) {
+	static_cast<TKernel*>(op_kernel)->Compute(context);
+      };
+    }
   }
 
   // Default implementation of GetExecutionProviderType that returns nullptr to default to the CPU provider

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1812,9 +1812,9 @@ inline std::vector<std::string> GetAvailableProviders() {
   return available_providers;
 }
 
-template <typename TOp, typename TKernel>
-void CustomOpBase<TOp, TKernel>::GetSessionConfigs(std::unordered_map<std::string, std::string>& out,
-                                                   ConstSessionOptions options) const {
+template <typename TOp, typename TKernel, bool Fallible>
+void CustomOpBase<TOp, TKernel, Fallible>::GetSessionConfigs(std::unordered_map<std::string, std::string>& out,
+							     ConstSessionOptions options) const {
   const TOp* derived = static_cast<const TOp*>(this);
   std::vector<std::string> keys = derived->GetSessionConfigKeys();
 

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -402,13 +402,32 @@ struct CustomOpKernel : OpKernel {
       ORT_THROW("Unsupported version '" + std::to_string(op_.version) + "' in custom op '" + op.GetName(&op));
     }
 
-    op_kernel_ = op_.CreateKernel(&op_, OrtGetApiBase()->GetApi(op_.version),
-                                  reinterpret_cast<const OrtKernelInfo*>(&info));
+    if (op_.version > 15 && op_.KernelCompute == 0) {
+      op_kernel_ = nullptr;
+      Ort::ThrowOnError(
+			op_.CreateKernelFallible(
+						 &op_,
+						 OrtGetApiBase()->GetApi(op_.version),
+						 reinterpret_cast<const OrtKernelInfo*>(&info),
+						 &op_kernel_
+						 )
+			);
+    } else {
+      op_kernel_ = op_.CreateKernel(&op_, OrtGetApiBase()->GetApi(op_.version),
+				    reinterpret_cast<const OrtKernelInfo*>(&info));
+    }
   }
 
-  ~CustomOpKernel() override { op_.KernelDestroy(op_kernel_); }
+  ~CustomOpKernel() override {
+    op_.KernelDestroy(op_kernel_);
+  }
 
   Status Compute(OpKernelContext* ctx) const override {
+    if (op_.version > 15 && op_.KernelCompute == 0) {
+      auto status_ptr = op_.KernelComputeFallible(op_kernel_, reinterpret_cast<OrtKernelContext*>(ctx));
+      return ToStatus(status_ptr);
+    }
+
     op_.KernelCompute(op_kernel_, reinterpret_cast<OrtKernelContext*>(ctx));
     return Status::OK();
   }

--- a/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
+++ b/onnxruntime/test/testdata/custom_op_library/custom_op_library.cc
@@ -20,7 +20,7 @@ void cuda_add(int64_t, T3*, const T1*, const T2*, cudaStream_t compute_stream);
 static const char* c_OpDomain = "test.customop";
 
 struct KernelOne {
-  void Compute(OrtKernelContext* context) {
+  OrtStatusPtr ComputeFallible(OrtKernelContext* context) {
     // Setup inputs
     Ort::KernelContext ctx(context);
     auto input_X = ctx.GetInput(0);
@@ -45,13 +45,15 @@ struct KernelOne {
       out[i] = X[i] + Y[i];
     }
 #endif
+    return nullptr;
   }
 };
 
-// legacy custom op registration
-struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne> {
-  void* CreateKernel(const OrtApi& /* api */, const OrtKernelInfo* /* info */) const {
-    return std::make_unique<KernelOne>().release();
+// legacy custom op registration with fallible kernel creation and compute function
+struct CustomOpOne : Ort::CustomOpBase<CustomOpOne, KernelOne, true> {
+  OrtStatusPtr CreateKernelFallible(const OrtApi& /* api */, const OrtKernelInfo* /* info */, void** op_kernel) const {
+    *op_kernel = reinterpret_cast<void*>(std::make_unique<KernelOne>().release());
+    return nullptr;
   };
 
   const char* GetName() const { return "CustomOpOne"; };


### PR DESCRIPTION
### Description
This PR implements a backward-compatible way to define custom operators with fallible compute functions. The C++ API templated gained an optional `Fallible` argument.  Closes #14287 

### Motivation and Context
#14287 contains more context. The gist is that the current C-API defines compute operations of custom operators as functions returning `void` rather than an `OrtStatusPtr`. Currently, errors are often propagated across the C-ABI using C++ exceptions. That is very unsafe and undefined behavior. Moreover, it is difficult for languages other than C++ to use this approach even if they wanted to. A C-compliant sound and safe way to propagate errors allows for non-C++ fallible custom operators.

### An example in action
https://github.com/cbourjau/ort-custom-op/pull/6/files is a demonstration of how this PR can be used to write safe and fallible custom operators in Rust.

