### PR TITLE
Modify CANN EP to align with the EP API refactor and fix CANN CI 

### DIFF
--- a/onnxruntime/core/providers/cann/cann_execution_provider.h
+++ b/onnxruntime/core/providers/cann/cann_execution_provider.h
@@ -65,6 +65,10 @@ class CANNExecutionProvider : public IExecutionProvider {
     return CANNExecutionProviderInfo::ToProviderOptions(info_);
   }
 
+  static AllocatorPtr CreateCannAllocator(OrtDevice::DeviceId device_id, size_t npu_mem_limit,
+                                          ArenaExtendStrategy arena_extend_strategy,
+                                          OrtArenaCfg* default_memory_arena_cfg);
+
   void RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry, AllocatorMap&) const override;
 
   OrtDevice GetOrtDeviceByMemType(OrtMemType mem_type) const override;


### PR DESCRIPTION
Modify CANN EP `CANNExecutionProvider::CreatePreferredAllocators`, `CANNExecutionProvider::CreateCannAllocator`
 to align with the EP API refactor and fix CANN CI  for https://github.com/microsoft/onnxruntime/pull/15833#issuecomment-1601568295 in this [PR](https://github.com/microsoft/onnxruntime/pull/15833)






