### PR TITLE
[QNN EP] Properly skip HTP test on x64

### DIFF
--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -20,7 +20,7 @@ namespace test {
 // It has to be QDQ model, because the DQ node with initializer on Conv gets processed first
 // and DQ node requires its node unit to be processed
 // So, Conv gets processed before Mul node
-TEST_F(QnnCPUBackendTests, Test_QDQConvWithDynamicWeightsFromMul) {
+TEST_F(QnnHTPBackendTests, Test_QDQConvWithDynamicWeightsFromMul) {
   ProviderOptions provider_options;
 
 #if defined(_WIN32)


### PR DESCRIPTION
### Description
Fixes a typo that prevents skipping a test that targets the QNN HTP backend on Windows x64.



### Motivation and Context
- Windows x64 machines cannot load/run the QNN HTP backend. Therefore, we need to skip such tests on Windows x64.
- Fixes the QNN_Nuget_Windows pipeline.