### PR TITLE
[JS/Web] Fixed the output indexing in the shader code when the output is 1-dim.

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -102,26 +102,27 @@ const createReduceProgramInfo =
       };
     };
 
-const createReduceAttributesFromInput = (input: TensorView, attributes: ReduceAttributes): ReduceAttributes => {
-  const axes: number[] = [];
-  // Handle empty axes, zero-sized input and zero input.
-  const sum = input.dims.reduce((sum, v) => sum + v, 0);
-  const prod = input.dims.reduce((prod, v) => prod * v, 1);
-  if (prod > 0 && sum > 0) {
-    input.getBigInt64Array().forEach(v => axes.push(Number(v)));
-  } else {
-    axes.push(...attributes.axes);
-  }
-  const noopWithEmptyAxes = attributes.noopWithEmptyAxes;
-  const keepDims = (noopWithEmptyAxes && sum === 0) || attributes.keepDims;
-  return createAttributeWithCacheKey({axes, keepDims, noopWithEmptyAxes});
-};
+const createReduceAttributesFromInputs =
+    (inputs: readonly TensorView[], attributes: ReduceAttributes): ReduceAttributes => {
+      const axes: number[] = [];
+      // Handle empty axes, zero-sized input and zero input.
+      const sum = inputs[1].dims.reduce((sum, v) => sum + v, 0);
+      const prod = inputs[1].dims.reduce((prod, v) => prod * v, 1);
+      if (prod > 0 && sum > 0) {
+        inputs[1].getBigInt64Array().forEach(v => axes.push(Number(v)));
+      } else {
+        axes.push(...attributes.axes);
+      }
+      const noopWithEmptyAxes = attributes.noopWithEmptyAxes;
+      const keepDims = (noopWithEmptyAxes && sum === 0) || attributes.keepDims;
+      return createAttributeWithCacheKey({axes, keepDims, noopWithEmptyAxes});
+    };
 
 const createReduceProgramInfoLoader =
     (inputs: readonly TensorView[], name: string, attributes: ReduceAttributes, reduceOp: ReduceOp):
         ProgramInfoLoader => {
           const updatedAttributes: ReduceAttributes =
-              inputs.length === 1 ? attributes : createReduceAttributesFromInput(inputs[1], attributes);
+              inputs.length === 1 ? attributes : createReduceAttributesFromInputs(inputs, attributes);
           const metadata:
               ProgramMetadata = {name, inputTypes: [GpuDataType.default], cacheHint: updatedAttributes.cacheKey};
           return {

--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -36,6 +36,7 @@ const createReduceProgramInfo =
       const idxCopy: string[] = [];  // copy output indexes to input indexes
 
       const axes = ShapeUtil.normalizeAxes(attributes.axes, inputs[0].dims.length);
+      const outputDimsLength = inputs[0].dims.length - (attributes.keepDims === true ? 0 : axes.length);
       const ops = reduceOp(inputs, axes);
       const inputIndicesHelper = createIndicesHelper('input', inputShape);
       const initInputIdx = (ops[1] === '') ? '' : `let inputIdx = ${inputIndicesHelper.i2oExpression('inputIndices')};`;
@@ -56,7 +57,11 @@ const createReduceProgramInfo =
                             ${reduceOps}
                           }`;
         } else {
-          idxCopy.push(`inputIndices[${k}] = outputIndices[${outputShape.length}];`);
+          if (outputDimsLength > 1) {
+            idxCopy.push(`inputIndices[${k}] = outputIndices[${outputShape.length}];`);
+          } else {
+            idxCopy.push(`inputIndices[${k}] = outputIndices;`);
+          }
           outputShape.push(inputs[0].dims[k]);
         }
       }

--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -36,7 +36,7 @@ const createReduceProgramInfo =
       const idxCopy: string[] = [];  // copy output indexes to input indexes
 
       const axes = ShapeUtil.normalizeAxes(attributes.axes, inputs[0].dims.length);
-      const outputDimsLength = inputs[0].dims.length - (attributes.keepDims === true ? 0 : axes.length);
+      const outputDimsLength = inputs[0].dims.length - (attributes.keepDims ? 0 : axes.length);
       const ops = reduceOp(inputs, axes);
       const inputIndicesHelper = createIndicesHelper('input', inputShape);
       const initInputIdx = (ops[1] === '') ? '' : `let inputIdx = ${inputIndicesHelper.i2oExpression('inputIndices')};`;
@@ -47,7 +47,7 @@ const createReduceProgramInfo =
       for (let k = 0; k < inputs[0].dims.length; k++) {
         // if this axis is reduced
         if (axes.indexOf(k) >= 0 || axes.length === 0) {
-          if (attributes.keepDims === true) {
+          if (attributes.keepDims) {
             outputShape.push(1);
           }  // else { remove the axis from outputShape; }
 

--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -120,13 +120,15 @@ const createReduceAttributesFromInput = (input: TensorView, attributes: ReduceAt
 const createReduceProgramInfoLoader =
     (inputs: readonly TensorView[], name: string, attributes: ReduceAttributes, reduceOp: ReduceOp):
         ProgramInfoLoader => {
-          const metadata: ProgramMetadata = {name, inputTypes: [GpuDataType.default], cacheHint: attributes.cacheKey};
+          const updatedAttributes: ReduceAttributes =
+              inputs.length === 1 ? attributes : createReduceAttributesFromInput(inputs[1], attributes);
+          const metadata:
+              ProgramMetadata = {name, inputTypes: [GpuDataType.default], cacheHint: updatedAttributes.cacheKey};
           return {
             ...metadata,
             get: () => createReduceProgramInfo(
-                metadata, [inputs[0]],
-                (inputs.length === 1) ? attributes : createReduceAttributesFromInput(inputs[1], attributes),
-                attributes.noopWithEmptyAxes && attributes.axes.length === 0 ? noOp : reduceOp)
+                metadata, [inputs[0]], updatedAttributes,
+                updatedAttributes.noopWithEmptyAxes && updatedAttributes.axes.length === 0 ? noOp : reduceOp)
           };
         };
 

--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -20,9 +20,9 @@ const validateInputs = (inputs: readonly TensorView[]): void => {
 };
 
 export interface ReduceAttributes extends AttributeWithCacheKey {
-  axes: number[];
   keepDims: boolean;
   noopWithEmptyAxes: boolean;
+  axes: number[];
 }
 
 type ReduceOp = (inputs: readonly TensorView[], axes: number[]) => string[];

--- a/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/reduce.ts
@@ -113,7 +113,7 @@ const createReduceAttributesFromInputs =
         inputs[1].getBigInt64Array().forEach(v => axes.push(Number(v)));
       }
       return createAttributeWithCacheKey(
-          {axes: axes, keepDims: attributes.keepDims, noopWithEmptyAxes: attributes.noopWithEmptyAxes});
+          {axes, keepDims: attributes.keepDims, noopWithEmptyAxes: attributes.noopWithEmptyAxes});
     };
 
 const createReduceProgramInfoLoader =


### PR DESCRIPTION
### Description
Modified indexing into outputIndices in the shader code. When the output is 1-dim the outputIndices is not a vector and indexing results in error.



### Motivation and Context
Fix the problem in the Reduce Ops implementation in WebGPU.
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


