### PR TITLE
LabelEncoder kernel creation improvement

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/label_encoder.h
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.h
@@ -63,9 +63,9 @@ class LabelEncoder_2 final : public OpKernel {
                 "(name: ", info.node().Name(), ") must have the same length. ",
                 "However, the number of key is ", num_keys, " and the number of ",
                 "values is ", num_values, ".");
-
+    _map.reserve(num_keys);
     for (size_t i = 0; i < num_keys; ++i)
-      _map[keys[i]] = values[i];
+      _map.emplace(keys[i], values[i]);
   }
 
   Status Compute(OpKernelContext* context) const override {

--- a/onnxruntime/core/providers/cpu/ml/label_encoder.h
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.h
@@ -98,7 +98,7 @@ class LabelEncoder_2 final : public OpKernel {
   // A collection of key-value pairs. Each (a_key, a_value) pair
   // means that the "a_key" in the input would be mapped to "a_value".
   // If _map doesn't contain "a_key", we use _default_value as its output.
-  absl::flat_hash_map<TKey, TValue> _map;
+  InlinedHashMap<TKey, TValue> _map;
   TValue _default_value;
   // ONNX attribute name to load keys.
   std::string _key_field_name;

--- a/onnxruntime/core/providers/cpu/ml/label_encoder.h
+++ b/onnxruntime/core/providers/cpu/ml/label_encoder.h
@@ -98,7 +98,7 @@ class LabelEncoder_2 final : public OpKernel {
   // A collection of key-value pairs. Each (a_key, a_value) pair
   // means that the "a_key" in the input would be mapped to "a_value".
   // If _map doesn't contain "a_key", we use _default_value as its output.
-  std::unordered_map<TKey, TValue> _map;
+  absl::flat_hash_map<TKey, TValue> _map;
   TValue _default_value;
   // ONNX attribute name to load keys.
   std::string _key_field_name;


### PR DESCRIPTION
### Description
This PR updates the initialisation of the `_map` in `LabelEncoder_2` to be more memory efficient.

1. Firstly, we switch from `std::unordered_map` to [`absl::flat_hash_map`](https://abseil.io/tips/136). The latter has a more compact layout and doesn't have the overhead of maintaining reference validity like `std::unordered_map`, which is a feature we do not need here since we only initialise `_map` once at creation and then perform lookups duing `compute`. Abseil is already used extensively within onnxruntime.
2. Secondly, space is reserved before inserting to prevent rehashing and reallocation.


### Motivation and Context
For very large lookups, the LabelEncoder's kernel creation can require more RAM than necessary. These simple changes in `_map` initialisation improve initialisation speed and memory allocated.


