### PR TITLE
Avoid repeated GemmSoftmaxGemmPermuteTunableOp<HipT> ctor invocation

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/attention.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention.h
@@ -21,6 +21,11 @@ class Attention final : public RocmKernel, public AttentionBase {
 
  public:
   AttentionType attn_type_;
+
+  // type-erased GemmSoftmaxGemmPermuteTunableOp<HipT>, the reason for this is:
+  //   1. We don't want to include the cuh file where GemmSoftmaxGemmPermuteTunableOp<HipT> is defined.
+  //   2. We don't want to construct the object repeatly (which is expansive) during Compute.
+  std::shared_ptr<void> tunable_op_;
 };
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/multihead_attention.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/multihead_attention.cu
@@ -68,6 +68,10 @@ MultiHeadAttention<T>::MultiHeadAttention(const OpKernelInfo& info)
   scale_ = info.GetAttrOrDefault<float>("scale", 0.0f);
 
   past_present_share_buffer_ = info.GetAttrOrDefault<int64_t>("past_present_share_buffer", 0LL) != 0LL;
+
+  using HipT = typename ToHipType<T>::MappedType;
+  using AttentionTunableOp = GemmSoftmaxGemmPermuteTunableOp<HipT>;
+  tunable_op_ = std::make_shared<AttentionTunableOp>();
 }
 
 template <typename T>
@@ -261,7 +265,7 @@ Status MultiHeadAttention<T>::ComputeInternal(OpKernelContext* context) const {
   }
 
   params.workspace_buffer = reinterpret_cast<HipT*>(workspace.get());
-  return AttentionTunableOp{}(&params);
+  return (*std::static_pointer_cast<AttentionTunableOp>(tunable_op_))(&params);
 }
 
 }  // namespace rocm

--- a/onnxruntime/contrib_ops/rocm/bert/multihead_attention.h
+++ b/onnxruntime/contrib_ops/rocm/bert/multihead_attention.h
@@ -25,6 +25,11 @@ class MultiHeadAttention final : public RocmKernel {
   float mask_filter_value_;
   float scale_;
   bool past_present_share_buffer_{false};
+
+  // type-erased GemmSoftmaxGemmPermuteTunableOp<HipT>, the reason for this is:
+  //   1. We don't want to include the cuh file where GemmSoftmaxGemmPermuteTunableOp<HipT> is defined.
+  //   2. We don't want to construct the object repeatly (which is expansive) during Compute.
+  std::shared_ptr<void> tunable_op_;
 };
 
 template <typename T>

--- a/onnxruntime/python/tools/kernel_explorer/kernels/rocm/gemm_softmax_gemm_permute.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/rocm/gemm_softmax_gemm_permute.cu
@@ -276,8 +276,11 @@ class GemmSoftmaxGemmPermuteTunable : public IGemmSoftmaxGemmPermuteKernelExplor
   }
 
   void Run() override {
-    ORT_THROW_IF_ERROR(GemmSoftmaxGemmPermuteTunableOp<T>{}(&this->params_));
+    ORT_THROW_IF_ERROR(op_(&this->params_));
   }
+
+  // NOTE: this op is expensive to construct
+  GemmSoftmaxGemmPermuteTunableOp<T> op_{};
 };
 
 #define REGISTER_COMMON(name, type, ...)                                                          \


### PR DESCRIPTION
The `GemmSoftmaxGemmPermuteTunableOp<HipT>` is expensive to construct, avoid the ctor invocation will substantially improve the launch time and get better performance during the decoding. This get <7% e2e time reduction of whisper large.