### PR TITLE
Fix ORT_RETURN condition mistake

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_gpt.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_gpt.h
@@ -55,11 +55,11 @@ class BeamSearchGpt : public BeamSearchBase<T> {
     cuda_device_prop_ = cuda_device_prop;
     cuda_device_arch_ = cuda_device_arch;
     if (gpt_subgraph_.has_decoder_masked_attention_) {
-      ORT_RETURN_IF(cuda_device_arch_ >= 530,
-                    "Decoder masked self attention can only be used on "
-                    "GPU cards of compute capability 5.3 or higher. "
-                    "This card has compute capability ",
-                    cuda_device_arch_);
+      ORT_RETURN_IF_NOT(cuda_device_arch_ >= 530,
+                        "Decoder masked self attention can only be used on "
+                        "GPU cards of compute capability 5.3 or higher. "
+                        "This card has compute capability ",
+                        cuda_device_arch_);
     }
     return Status::OK();
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_t5.h
@@ -64,11 +64,11 @@ class BeamSearchT5 : public BeamSearchBase<T> {
     cuda_device_prop_ = cuda_device_prop;
     cuda_device_arch_ = cuda_device_arch;
     if (decoder_subgraph_.has_decoder_masked_attention_) {
-      ORT_RETURN_IF(cuda_device_arch_ >= 530,
-                    "Decoder masked multihead attention can only be used on "
-                    "GPU cards of compute capability 5.3 or higher. "
-                    "This card has compute capability ",
-                    cuda_device_arch_);
+      ORT_RETURN_IF_NOT(cuda_device_arch_ >= 530,
+                        "Decoder masked multihead attention can only be used on "
+                        "GPU cards of compute capability 5.3 or higher. "
+                        "This card has compute capability ",
+                        cuda_device_arch_);
     }
     return Status::OK();
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_impl_whisper.h
@@ -62,11 +62,11 @@ class BeamSearchWhisper : public BeamSearchBase<T> {
     cuda_device_prop_ = cuda_device_prop;
     cuda_device_arch_ = cuda_device_arch;
     if (decoder_subgraph_.has_decoder_masked_attention_) {
-      ORT_RETURN_IF(cuda_device_arch_ >= 530,
-                    "Decoder masked multihead attention can only be used on "
-                    "GPU cards of compute capability 5.3 or higher. "
-                    "This card has compute capability ",
-                    cuda_device_arch_);
+      ORT_RETURN_IF_NOT(cuda_device_arch_ >= 530,
+                        "Decoder masked multihead attention can only be used on "
+                        "GPU cards of compute capability 5.3 or higher. "
+                        "This card has compute capability ",
+                        cuda_device_arch_);
     }
     return Status::OK();
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/greedy_search_impl_gpt.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/greedy_search_impl_gpt.h
@@ -69,11 +69,11 @@ class GreedySearchGpt : public GreedySearchBase<T, ParametersT> {
     cuda_device_prop_ = cuda_device_prop;
     cuda_device_arch_ = cuda_device_arch;
     if (gpt_subgraph_.has_decoder_masked_attention_) {
-      ORT_RETURN_IF(cuda_device_arch_ >= 530,
-                    "Decoder masked self attention can only be used on "
-                    "GPU cards of compute capability 5.3 or higher. "
-                    "This card has compute capability ",
-                    cuda_device_arch_);
+      ORT_RETURN_IF_NOT(cuda_device_arch_ >= 530,
+                        "Decoder masked self attention can only be used on "
+                        "GPU cards of compute capability 5.3 or higher. "
+                        "This card has compute capability ",
+                        cuda_device_arch_);
     }
     return Status::OK();
   }


### PR DESCRIPTION
In #16339, the  `ORT_ENFORCE(cuda_device_arch_ >= 530` (throw) it changed to `ORT_RETURN_IF` (Status) but the condition is negated. This fixes the problem.