### PR TITLE
Amx flag removal

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -3,28 +3,6 @@
 
 set(MLAS_SRC_DIR ${ONNXRUNTIME_ROOT}/core/mlas/lib)
 
-
-set(MLAS_AMX_SUPPORTED FALSE)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
-  # match assembler version, AMX instructions are supported from 2.38
-  if (CMAKE_ASM_COMPILER_ID STREQUAL "GNU")
-    execute_process(
-        COMMAND as --version
-        OUTPUT_VARIABLE _as_version
-    )
-    # 2.38 or later
-    if (_as_version MATCHES "GNU.[Aa]ssembler.*(2\\.38|2\\.39|2\\.[4-9][0-9]|[3-9]\\.[0-9][0-9])")
-        set(MLAS_AMX_SUPPORTED TRUE)
-    endif()
-  endif()
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(MLAS_AMX_SUPPORTED TRUE)
-endif()
-
-
 #
 # All hardware agnostic source files here
 # hardware specific files would cause trouble in
@@ -56,12 +34,6 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/qlgavgpool.cpp
   ${MLAS_SRC_DIR}/qdwconv_kernelsize.cpp
 )
-
-if(MLAS_AMX_SUPPORTED)
-  target_compile_definitions(onnxruntime_mlas PRIVATE MLAS_AMX_SUPPORTED)
-else()
-  message(WARNING "AMX instructions NOT supported due to lack of compiler tool chain!")
-endif()
 
 set(ONNXRUNTIME_MLAS_LIBS onnxruntime_mlas)
 
@@ -550,15 +522,16 @@ else()
           ${mlas_platform_srcs_avx512core}
         )
 
-        if(MLAS_AMX_SUPPORTED)
+	if(NOT APPLE)
           set(mlas_platform_srcs
             ${mlas_platform_srcs}
+	    ${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmxCommon.S
             ${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp
             ${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmx.S
-          )
-          set_source_files_properties(${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp PROPERTIES COMPILE_FLAGS "-mamx-tile -mamx-int8 -mavx2 -mavx512bw -mavx512dq -mavx512vl")
-          set_source_files_properties(${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmx.S PROPERTIES COMPILE_FLAGS "-mamx-tile -mamx-int8 -mavx2 -mavx512bw -mavx512dq -mavx512vl")
-        endif()
+            )
+          set_source_files_properties(${MLAS_SRC_DIR}/qgemm_kernel_amx.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512bw -mavx512dq -mavx512vl -mavx512f")
+          set_source_files_properties(${MLAS_SRC_DIR}/x86_64/QgemmU8S8KernelAmx.S PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512bw -mavx512dq -mavx512vl -mavx512f")
+	endif()
 
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)
           onnxruntime_add_static_library(onnxruntime_mlas_x86_64 ${mlas_platform_srcs})

--- a/onnxruntime/core/mlas/lib/amx_common.h
+++ b/onnxruntime/core/mlas/lib/amx_common.h
@@ -1,0 +1,80 @@
+/*++
+
+Copyright (c) Microsoft Corporation.  All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    amx_common.h
+
+Abstract:
+
+    Intrinsic and inline functions for amx processing.
+
+--*/
+
+#pragma once
+
+#include "mlasi.h"
+
+#ifdef WIN32
+#define tile_dpbssd(dst, src1, src2) _tile_dpbssd(dst, src1, src2)
+
+#define tile_dpbsud(dst, src1, src2) _tile_dpbsud(dst, src1, src2)
+
+#define tile_dpbusd(dst, src1, src2) _tile_dpbusd(dst, src1, src2)
+
+#define tile_dpbuud(dst, src1, src2) _tile_dpbuud(dst, src1, src2)
+
+#define tile_loadd(dst, base, stride) _tile_loadd(dst, base, stride)
+
+#define tile_stream_loadd(dst, base, stride) _tile_stream_loadd(dst, base, stride)
+
+#define tile_stored(dst, base, stride) _tile_stored(dst, base, stride)
+
+#define tile_loadconfig(config)						\
+ _tile_loadconfig(config)
+
+#define tile_storeconfig(config) _tile_storeconfig(config)
+
+#else
+
+#define tile_dpbusd_internal(dst,src1,src2)  \
+__asm__ volatile (".set Payload1, 0x01\n\t"    \
+	".set Payload1, Payload1 + (("#src2" & 15) ^ 15) << 3\n\t"  \
+	".set ModRMByte, 0xC0\n\t" 		\
+	".set ModRMByte, ModRMByte + ("#dst" << 3)\n\t"     \
+	".set ModRMByte, ModRMByte + ("#src1")\n\t"     \
+	".byte 0xC4, 0xE2, Payload1, 0x5E, ModRMByte\n\t")
+
+#define tile_dpbusd(dst,src1,src2)					\
+tile_dpbusd_internal(dst,src1,src2)
+
+#define tile_loadd_internal1(dst,base,stride)				\
+  __asm__ volatile (".set ModRMByte, 0x04\n\t" 		\
+	".set ModRMByte, ModRMByte + ("#dst" << 3)\n\t"     \
+	".byte 0xC4, 0xE2, 0x7B, 0x4B, ModRMByte, 0x18\n\t" \
+   :: "a" ((const void*) (base)), "b" ((long) (stride)))
+
+#define tile_loadd(dst,base,stride)					\
+  tile_loadd_internal1(dst, base, stride)
+
+
+#define tile_stored_internal1(dst,base,stride)				\
+  __asm__ volatile (".set ModRMByte, 0x04\n\t" 		\
+	".set ModRMByte, ModRMByte + ("#dst" << 3)\n\t"     \
+	".byte 0xC4, 0xE2, 0x7A, 0x4B, ModRMByte, 0x18\n\t" \
+   :: "a" ((const void*) (base)), "b" ((long) (stride)))
+
+#define tile_stored(dst,base,stride)					\
+tile_stored_internal1(dst, base, stride)
+
+
+#define tile_loadconfig(config)						\
+__asm__ volatile (".byte 0xC4, 0xE2, 0x78, 0x49, 0x00" :: "a" (((const void *)config)))  \
+
+#define tile_storeconfig(config)					\
+__asm__ volatile (".byte 0xC4, 0xE2, 0x79, 0x49, 0x00" :: "a" (((const void *)config)))  \
+
+#endif

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -824,9 +824,7 @@ extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchSse;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchSse41;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchAvx2;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8U8DispatchAvx2;
-#ifdef MLAS_AMX_SUPPORTED
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8S8DispatchAmx;
-#endif
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchNeon;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmX8S8DispatchNeon;
 extern const MLAS_GEMM_QUANT_DISPATCH MlasGemmU8X8DispatchUdot;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -408,7 +408,7 @@ Return Value:
                     }
                 }
 
-#ifdef MLAS_AMX_SUPPORTED
+#ifndef __APPLE__
                 //
                 // Check if the processor supports AMX-TILE and AMX-INT8
                 // features.
@@ -419,7 +419,7 @@ Return Value:
                         this->GemmU8S8Dispatch = &MlasGemmU8S8DispatchAmx;
                     }
                 }
-#endif // MLAS_AMX_SUPPORTED
+#endif // __APPLE__
 
 #endif // ORT_MINIMAL_BUILD
 

--- a/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAmxCommon.S
+++ b/onnxruntime/core/mlas/lib/x86_64/QgemmU8S8KernelAmxCommon.S
@@ -1,0 +1,234 @@
+/*++
+
+Copyright (c) 2023 Intel Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    AssembleAmx.h
+
+Abstract:
+
+    This module contains macros to build AMX instructions for toolchains that
+    do not natively support this newer instruction set extension.
+
+--*/
+
+//
+// Map friendly register names to the encoded register index.
+//
+
+	.equ    .LTmmIndex_tmm0, 0
+        .equ    .LTmmIndex_tmm1, 1
+        .equ    .LTmmIndex_tmm2, 2
+        .equ    .LTmmIndex_tmm3, 3
+        .equ    .LTmmIndex_tmm4, 4
+        .equ    .LTmmIndex_tmm5, 5
+        .equ    .LTmmIndex_tmm6, 6
+        .equ    .LTmmIndex_tmm7, 7
+
+/*++
+
+Macro Description:
+
+    This macro builds a AMX instruction of the form:
+
+        instr tmm1,tmm2,tmm3
+
+Arguments:
+
+    prefix - Specifies the opcode for the AMX instruction.
+
+    DestReg - Specifies the destination AMX tile.
+
+    Src1Reg - Specifies the first source AMX tile.
+
+    Src2Reg - Specifies the second source AMX tile.
+
+--*/
+
+        .macro DPTmmTmmTmm prefix, DestReg, Src1Reg, Src2Reg
+
+        .set    Payload0, 0x02              # "0F 38" prefix
+        .set    Payload0, Payload0 + ((((.LTmmIndex_\DestReg\() >> 3) & 1) ^ 1) << 7)
+        .set    Payload0, Payload0 + (1 << 6)
+        .set    Payload0, Payload0 + ((((.LTmmIndex_\Src2Reg\() >> 3) & 1) ^ 1) << 5)
+
+        .set    Payload1, \prefix\()
+        .set    Payload1, Payload1 + (((.LTmmIndex_\Src2Reg\() & 15) ^ 15) << 3)
+
+        .set    ModRMByte, 0xC0             # register form
+        .set    ModRMByte, ModRMByte + ((.LTmmIndex_\DestReg\() & 7) << 3)
+        .set    ModRMByte, ModRMByte + (.LTmmIndex_\Src1Reg\() & 7)
+
+        .byte   0xC4, Payload0, Payload1, 0x5E, ModRMByte
+
+        .endm
+
+
+        .macro TdpbssdTmmTmmTmm DestReg, Src1Reg, Src2Reg
+
+        DPTmmTmmTmm 0x03, \DestReg\(), \Src1Reg\(), \Src2Reg\()
+
+        .endm
+
+
+        .macro TdpbsudTmmTmmTmm DestReg, Src1Reg, Src2Reg
+
+        DPTmmTmmTmm 0x02, \DestReg\(), \Src1Reg\(), \Src2Reg\()
+
+        .endm
+
+
+        .macro TdpbusdTmmTmmTmm DestReg, Src1Reg, Src2Reg
+
+        DPTmmTmmTmm 0x01, \DestReg\(), \Src1Reg\(), \Src2Reg\()
+
+        .endm
+
+
+        .macro TdpbuudTmmTmmTmm DestReg, Src1Reg, Src2Reg
+
+        DPTmmTmmTmm 0x00, \DestReg\(), \Src1Reg\(), \Src2Reg\()
+
+        .endm
+
+/*++
+
+Macro Description:
+
+    This macro builds a AMX tile release instruction.
+
+Arguments:
+
+
+
+--*/
+
+//        .macro TileReleaseMacro
+
+//        .byte 0xC4, 0xE2, 0x78, 0x49, 0xC0
+
+//        .endm
+
+
+/*++
+
+Macro Description:
+
+    This macro builds an AMX tile zero instruction of the form:
+
+        instr tmm1
+
+Arguments:
+
+    SrcReg - Specifies the source AMX tile.
+
+--*/
+
+        .macro TileZeroMacro SrcReg
+
+        .set 	ModRMByte, 0xC0     # register form
+        .set    ModRMByte, ModRMByte + ((.LTmmIndex_\SrcReg\() & 7) << 3)
+        .byte   0xC4, 0xE2, 0x7B, 0x49, ModRMByte
+
+        .endm
+
+/*++
+
+Macro Description:
+
+    This macro builds an AMX memory instruction of the form:
+
+        instr tmm, base, stride
+
+Arguments:
+
+    instr - Specifies the opcode for the AMX instruction.
+
+    SrcReg - Specifies the target AMX tile.
+
+    BaseReg - Specifies the base address of memory location.
+
+    Stride - Specifies the stride for the memory instruction
+
+--*/
+
+        .macro TileLoadMacro instr, SrcReg, BaseReg, Stride
+
+        .set    Payload0, 0x02              # "0F 38" prefix
+        .set    Payload0, Payload0 + ((((.LTmmIndex_\SrcReg\() >> 3) & 1) ^ 1) << 7)
+        .set    Payload0, Payload0 + ((((3 >> 3) & 1) ^ 1) << 6)
+        .set    Payload0, Payload0 + ((((0 >> 3) & 1) ^ 1) << 5)
+
+        .set 	ModRMByte, 0x00     # memory form
+        .set 	ModRMByte, ModRMByte + (1 << 2)   # SibBye required
+        .set 	ModRMByte, ModRMByte + ((.LTmmIndex_\SrcReg\() & 7) << 3)
+
+        .set 	SibByte, 0x00  # scale factor 1(SS)
+        .set 	SibByte, SibByte + ((3 & 7) << 3)
+        .set 	SibByte, SibByte + (0 & 7)
+
+        .byte   0xC4, Payload0, \instr\(), 0x4B, ModRMByte, SibByte
+
+        .endm
+
+
+        .macro TileloaddTmmMem DstReg, BaseReg, Stride
+        TileLoadMacro 0x7B, \DstReg\(), \BaseReg\(), \Stride\()
+        .endm
+
+        .macro TileloaddT1TmmMem DstReg, BaseReg, Stride
+        TileLoadMacro 0x79, \DstReg\(), \BaseReg\(), \Stride\()
+        .endm
+
+
+        .macro TileStoredMemTmm SrcReg, BaseReg, Stride
+        TileLoadMacro 0x7A, \SrcReg\(), \BaseReg\(), \Stride\()
+        .endm
+
+
+/*++
+
+Macro Description:
+
+    This macro builds an AMX tile configuration instruction of the form:
+
+        instr base
+
+Arguments:
+
+    instr - Specifies the opcode for the AMX instruction.
+
+    BaseReg - Specifies the memory address of the tile configuration.
+
+--*/
+
+        .macro tilecfgMacro instr, BaseReg
+	.set    Payload0, 0x02              # "0F 38" prefix
+	.set    Payload0, Payload0 + (1 << 7)
+	.set    Payload0, Payload0 + (1 << 6)
+	.set    Payload0, Payload0 + ((((0 >> 3) & 1) ^ 1) << 5)
+
+	.set 	ModRMByte, 0x00     # memory form & no reg
+	.set 	ModRMByte, ModRMByte + (0 & 7)
+
+	.byte 0xC4, Payload0, \instr\(), 0x49, ModRMByte
+
+        .endm
+
+
+        .macro ldtilecfgMacro BaseReg
+
+        tilecfgMacro 0x78, \BaseReg\()
+
+        .endm
+
+
+        .macro sttilecfgMacro BaseReg
+        
+	tilecfgMacro 0x79, \BaseReg\()
+
+        .endm
+	


### PR DESCRIPTION
### Description
1. Replacing AMX intrinsics with machine code macros in QGEMM kernel.
2. Removing AMX build flags for GCC in cmake file.
3. Fixing the link time optimization issue introduced with asm .include of an assembly file.

I have moved the AMX instruction macro definitions from QgemmU8S8KernelAmxCommon.S to the amx_common.h to fix the LTO issue. Note that I am also pushing the macros defined in QgemmU8S8KernelAmxCommon.S for future reference. 

### Motivation and Context
The additional AMX flag in cmake adds an extra layer of dependency on
GCC version to use the feature.These changes should allow the usage of
the AMX feature with just the CPU ID check.

