### PR TITLE
Use verbose logging in Android emulator in React Native CI

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -189,7 +189,7 @@ stages:
         python3 tools/python/run_android_emulator.py \
           --android-sdk-root $(ANDROID_SDK_ROOT) \
           --create-avd --system-image "system-images;android-30;default;x86_64" \
-          --start --emulator-extra-args="-partition-size 4096" \
+          --start --emulator-extra-args="-partition-size 4096 -verbose" \
           --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
       displayName: Start Android Emulator
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Set emulator logging to verbose to see if it helps with intermittent React Native CI failures when emulator crashes at startup


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


