### PR TITLE
make optimized_model_path be in temp folder instead of source model folder for transformer optimization

### DIFF
--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -195,6 +195,7 @@ def optimize_model(
     num_heads: int = 0,
     hidden_size: int = 0,
     optimization_options: Optional[FusionOptions] = None,
+    optimized_model_path: Optional[str] = None,
     opt_level: Optional[int] = None,
     use_gpu: bool = False,
     only_onnxruntime: bool = False,
@@ -230,6 +231,7 @@ def optimize_model(
             0 allows detect the parameter from graph automatically.
         optimization_options (FusionOptions, optional): optimization options that turn on/off some fusions.
             Defaults to None.
+        optimized_model_path (str, optional): output optimized model path. Defaults to None.
         opt_level (int, optional): onnxruntime graph optimization level (0, 1, 2 or 99) or None. Defaults to None.
             When the value is None, default value (1 for bert and gpt2, 0 for other model types) will be used.
             When the level > 0, onnxruntime will be used to optimize model first.
@@ -268,6 +270,7 @@ def optimize_model(
         temp_model_path = optimize_by_onnxruntime(
             input,
             use_gpu=use_gpu,
+            optimized_model_path=optimized_model_path,
             opt_level=opt_level,
             disabled_optimizers=disabled_optimizers,
             verbose=verbose,
@@ -278,6 +281,7 @@ def optimize_model(
         temp_model_path = optimize_by_onnxruntime(
             input,
             use_gpu=False,
+            optimized_model_path=optimized_model_path,
             opt_level=1,
             disabled_optimizers=disabled_optimizers,
             verbose=verbose,

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -299,11 +299,6 @@ def optimize_model(
     else:
         optimizer = optimize_by_fusion(model, model_type, num_heads, hidden_size, optimization_options)
 
-    # Remove the temporary model.
-    if temp_model_path:
-        os.remove(temp_model_path)
-        logger.debug(f"Remove temporary model: {temp_model_path}")
-
     # remove the temporary directory
     temp_dir.cleanup()
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -254,7 +254,7 @@ def optimize_model(
     disabled_optimizers = ["ConstantSharing"]
     temp_model_path = None
     temp_dir = tempfile.TemporaryDirectory()
-    optimized_model_name = "{}_o{}_{}.onnx".format(input[:-5], opt_level, "gpu" if use_gpu else "cpu")
+    optimized_model_name = "model_o{}_{}.onnx".format(opt_level, "gpu" if use_gpu else "cpu")
     optimized_model_path = os.path.join(temp_dir.name, optimized_model_name)
     if opt_level > 1:
         # Disable some optimizers that might cause failure in symbolic shape inference or attention fusion.


### PR DESCRIPTION
### Description
The optimize_model will generate a temporary model in current model folder. Most of time, it is fine. 

However, the scenario will break when the function run against input model mount from AzureML. In that case, the mounted folder is read-only. We have to copy the model to another temp folder to call optimize_model to workaround this issue. Otherwise, the optimize_model will fail when creating the optimized model in the read-only folder. However, the model copy is painful, especially when model is huge.

This PR just expose the optimized_model_path at optimize_model level so that the caller could decide where to save the temp model. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


