### PR TITLE
Fix name for ROCMExecutinProvider in ROcm-ExecutionProvider docs

### DIFF
--- a/docs/execution-providers/ROCm-ExecutionProvider.md
+++ b/docs/execution-providers/ROCm-ExecutionProvider.md
@@ -63,7 +63,7 @@ import onnxruntime as ort
 model_path = '<path to model>'
 
 providers = [
-    'ROCmExecutionProvider',
+    'ROCMExecutionProvider',
     'CPUExecutionProvider',
 ]
 


### PR DESCRIPTION
Need to captialize the name of ROCm to ROCM

### Description
Invalid EP name which causes confusion for users who use ROCMExecutionProvider


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
Fixes naming user sees in tutorial 


