### PR TITLE
Allow disable exceptions to work with ort-extensions

### DIFF
--- a/onnxruntime/test/testdata/custom_op_get_const_input_test_library/custom_op.cc
+++ b/onnxruntime/test/testdata/custom_op_get_const_input_test_library/custom_op.cc
@@ -5,7 +5,12 @@
 
 void simple_assert(const bool cond, const std::string& text) {
   if (!cond) {
+#ifndef ORT_NO_EXCEPTIONS
     throw std::runtime_error(text);
+#else
+    std::cerr << text << std::endl;
+    std::terminate();
+#endif
   }
 }
 

--- a/onnxruntime/test/testdata/custom_op_get_const_input_test_library/custom_op_lib.cc
+++ b/onnxruntime/test/testdata/custom_op_get_const_input_test_library/custom_op_lib.cc
@@ -25,17 +25,21 @@ OrtStatus* ORT_API_CALL RegisterCustomOps(OrtSessionOptions* options, const OrtA
 
   OrtStatus* result = nullptr;
 
+#ifndef ORT_NO_EXCEPTIONS
   try {
+#endif
     Ort::CustomOpDomain domain{c_OpDomain};
     domain.Add(&c_CustomOp);
 
     session_options.Add(domain);
     AddOrtCustomOpDomainToContainer(std::move(domain));
 
+#ifndef ORT_NO_EXCEPTIONS
   } catch (const std::exception& e) {
     Ort::Status status{e};
     result = status.release();
   }
+#endif
 
   return result;
 }


### PR DESCRIPTION
A recent pull request (#15013) added some code that prevents building ort with both `--disable_exceptions` and `--use_extensions` flag (because it introduced some exception handling logic).

This pull request attempts to address that.