### PR TITLE
Remove assertion that breaks google/flan-t5-small

### DIFF
--- a/onnxruntime/python/tools/transformers/onnx_model_bert.py
+++ b/onnxruntime/python/tools/transformers/onnx_model_bert.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.  All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-
+import pdb
 from logging import getLogger
 from typing import List, Optional
 
@@ -48,7 +48,8 @@ class BertOnnxModel(OnnxModel):
             num_heads (int, optional): number of attention heads. Defaults to 0 (detect the parameter automatically).
             hidden_size (int, optional): hidden dimension. Defaults to 0 (detect the parameter automatically).
         """
-        assert (num_heads == 0 and hidden_size == 0) or (num_heads > 0 and hidden_size % num_heads == 0)
+        #pdb.set_trace()
+        #assert (num_heads == 0 and hidden_size == 0) or (num_heads > 0 and hidden_size % num_heads == 0)
 
         super().__init__(model)
         self.num_heads = num_heads


### PR DESCRIPTION
### Description
google/flan-t5-small is a T5 model that is mostly supported by OnnxRuntime's `convert_generation.py` export script. There's only one failed assertion statement that stops execution - the check that the hidden size is divisible by the number of attention heads. 

google/flan-t5-base and google/flan-t5-large don't hit any issues with this statement, but google/flan-t5-small has a `hidden_size` of 512 and uses 6 attention heads (512 % 6 = 2) [[link to huggingface config values](https://huggingface.co/google/flan-t5-small/blob/f6b63ff0230b8e19027b922964cab639c1c6da9c/config.json#L18)]

When commenting this check out, the flan-t5-small exports successfully with parity.


To recreate the assertion error:



` python -m convert_generation.py -m google/flan-t5-small --num_beams=5 --output beamsearch.onnx --model_type t5 --early_stopping`