### PR TITLE
Fix a typo cuda 11.4 -> cuda 12.1.1

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------
 # Dockerfile to run ONNXRuntime with CUDA, CUDNN integration
 
-# nVidia cuda 11.4 Base Image
+# nVidia cuda 12.1.1 Base Image
 FROM nvcr.io/nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
 ENV	    DEBIAN_FRONTEND=noninteractive
 MAINTAINER Changming Sun "chasun@microsoft.com"


### PR DESCRIPTION
### Description

Fix a typo `cuda 11.4` -> `cuda 12.1.1`

### Motivation and Context

The motivation for this pull request was to ensure accuracy and clarity in our project's documentation. It's crucial that all parts of the project, including written materials, are correct and precise to foster an environment that encourages seamless user experience and helps other contributors to follow along without any confusion.

As for context, it's important to note that our project relies on CUDA for parallel computing. Correct specification of the version is a critical detail for users who are setting up their environments to work with or contribute to this project. Incorrect CUDA version could lead to misconfigurations, build errors, and other potential problems.

The specific typo being corrected (cuda 11.4 -> cuda 12.1.1) is not simply a trivial detail. It signifies a change in CUDA version, which potentially involves different features, bug fixes, and compatibility issues. As such, maintaining an accurate record of this information is vital for the functionality and continued growth of our project.




