### PR TITLE
[js/rn] always use 'typescript' from /js/ folder

### DIFF
--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -17,7 +17,6 @@
     "ONNX Runtime"
   ],
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.0",
     "@types/react": "^18.0.9",
     "@types/react-native": "^0.67.7",
@@ -26,8 +25,7 @@
     "prettier": "^2.6.2",
     "react": "^18.1.0",
     "react-native": "^0.69.7",
-    "react-native-builder-bob": "^0.18.2",
-    "typescript": "^4.9.4"
+    "react-native-builder-bob": "^0.18.2"
   },
   "peerDependencies": {
     "react": "*",
@@ -70,7 +68,8 @@
       [
         "typescript",
         {
-          "project": "tsconfig.build.json"
+          "project": "tsconfig.build.json",
+          "tsc": "../node_modules/.bin/tsc"
         }
       ]
     ],

--- a/js/react_native/yarn.lock
+++ b/js/react_native/yarn.lock
@@ -1833,13 +1833,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/fs-extra@^9.0.13":
-  version "9.0.13"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
-  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -6414,11 +6407,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typescript@^4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
-  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
### Description
always use 'typescript' from /js/ folder. This allows all NPM packages to use the same typescript version.

- remove 'typescript' from /js/react_native/package.json. use the one from /js/package.json
- remove unused '@types/fs-extra'