### PR TITLE
[C#] Allow users to quickly populate native string buffers with utf8 bytes

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -261,6 +261,23 @@ namespace Microsoft.ML.OnnxRuntime
             }
         }
 
+        /// <summary>
+        /// This API resizes String Tensor element to the requested amount of bytes (UTF-8)
+        /// and returns a span to the resized buffer. This API is useful when you have UTF-8 data
+        /// that you want to quickly stick into the OrtValue native memory.
+        /// </summary>
+        /// <param name="bytesCount">requested buffer size in bytes</param>
+        /// <param name="index">flat index of the element in the string tensor</param>
+        /// <returns></returns>
+        public Span<byte> GetMutableStringElementAsSpan(int bytesCount, int index)
+        {
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetResizedStringTensorElementBuffer(Handle,
+                                  (UIntPtr)index, (UIntPtr)bytesCount, out IntPtr buffer));
+            unsafe
+            {
+                return new Span<byte>(buffer.ToPointer(), bytesCount);
+            }
+        }
 
         /// <summary>
         /// Convenience method to obtain all string tensor elements as a string array.
@@ -953,7 +970,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             Debug.Assert(_handle != IntPtr.Zero);
             NativeMethods.OrtReleaseValue(_handle);
-           _handle = IntPtr.Zero;
+            _handle = IntPtr.Zero;
             _disposed = true;
         }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
@@ -589,10 +589,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 for (int i = 0; i < strings.Count; ++i)
                 {
-                    var srcSpan = strings[i].Span;
-                    var destSpan = ortValue.GetMutableStringElementAsSpan(srcSpan.Length, i);
-                    Assert.Equal(srcSpan.Length, destSpan.Length);
-                    srcSpan.CopyTo(destSpan);
+                    ortValue.FillStringTensorElement(strings[i].Span, i);
                 }
                 return ortValue;
             }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/TestDataLoader.cs
@@ -571,7 +571,11 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             string[] strArray = new string[strings.Count];
             for (int i = 0; i < strings.Count; ++i)
             {
-                strArray[i] = System.Text.Encoding.UTF8.GetString(strings[i].ToByteArray());
+#if NET6_0_OR_GREATER
+                strArray[i] = Encoding.UTF8.GetString(strings[i].Span);
+#else
+                strArray[i] = Encoding.UTF8.GetString(strings[i].ToByteArray());
+#endif
             }
 
             var dt = new DenseTensor<string>(strArray, dimensions);
@@ -585,8 +589,10 @@ namespace Microsoft.ML.OnnxRuntime.Tests
             {
                 for (int i = 0; i < strings.Count; ++i)
                 {
-                    var str = Encoding.UTF8.GetString(strings[i].ToByteArray());
-                    ortValue.FillStringTensorElement(str.AsSpan(), i);
+                    var srcSpan = strings[i].Span;
+                    var destSpan = ortValue.GetMutableStringElementAsSpan(srcSpan.Length, i);
+                    Assert.Equal(srcSpan.Length, destSpan.Length);
+                    srcSpan.CopyTo(destSpan);
                 }
                 return ortValue;
             }


### PR DESCRIPTION
### Description
Introduce an API that allows users to gain access to a string tensor element buffer of requested length in bytes
so then can quickly load any utf8 data.

### Motivation and Context
Useful for testing an otherwise.

