### PR TITLE
Fix orttraining-ortmodule-distributed CI

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -11,3 +11,4 @@ pytorch-lightning
 deepspeed==0.9.0
 fairscale==0.4.6
 parameterized>=0.8.1
+pydantic<2.0.0


### PR DESCRIPTION
### Fix orttraining-ortmodule-distributed CI

https://pypi.org/project/pydantic/#history released version 2.0 1st July, Deepspeed has known issue on newer version of it (https://github.com/microsoft/DeepSpeed/issues/3280). So fix this by add similar check as DS did in https://github.com/microsoft/DeepSpeed/pull/3290



