### PR TITLE
Fix Resize op input check

### DIFF
--- a/js/web/lib/onnxjs/graph.ts
+++ b/js/web/lib/onnxjs/graph.ts
@@ -332,8 +332,9 @@ class GraphImpl implements Graph, Graph.Transformer {
       for (const input of nodeProto.input) {
         const dataIndex = dataIndices.get(input);
         if (typeof dataIndex === 'undefined') {
-          // handle exception when opset > 9 and roi not given
-          if (input === '' && nodeProto.input.length === 3 && nodeProto.opType === 'Resize') {
+          // handle exception when opset > 9 and roi / scales not given
+          if (input === '' && (nodeProto.input.length === 3 || nodeProto.input.length === 4) &&
+              nodeProto.opType === 'Resize') {
             continue;
           }
           throw new Error(`unrecognized input '${input}' for node: ${nodeProto.name}`);


### PR DESCRIPTION
### Description
onnxjs contains a `Resize` op input check which is outdated since opset 9. Currently `Resize` supports up to 4 inputs. This PR looses the input check.



### Motivation and Context

Fixes #15636 


