### PR TITLE
[WebNN EP] Support InstanceNormalization and GroupNormalization.

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -129,6 +129,8 @@ static const InlinedHashMap<std::string, std::string> op_map = {
     {"GlobalAveragePool", "averagePool2d"},
     {"GlobalMaxPool", "maxPool2d"},
     {"AveragePool", "averagePool2d"},
+    {"GroupNormalization", "meanVarianceNormalization"},
+    {"InstanceNormalization", "meanVarianceNormalization"},
     {"LayerNormalization", "meanVarianceNormalization"},
     {"MaxPool", "maxPool2d"},
     {"ReduceMax", "reduceMax"},

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -177,21 +177,6 @@ bool NormalizationOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initi
     return false;
   }
 
-  const auto& scale_name = input_defs[1]->Name();
-  if (!Contains(initializers, scale_name)) {
-    LOGS(logger, VERBOSE) << "The scale must be a constant initializer.";
-    return false;
-  }
-
-  if (input_defs.size() == 3) {
-    // Inputs contain optional bias
-    const auto& bias_name = input_defs[2]->Name();
-    if (!Contains(initializers, bias_name)) {
-      LOGS(logger, VERBOSE) << "The bias must be a constant initializer.";
-      return false;
-    }
-  }
-
   const auto& output_defs = node.OutputDefs();
   if (output_defs.size() != 1) {
     LOGS(logger, VERBOSE) << node.OpType() << " output count must be one.";

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -131,7 +131,7 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
     options.set("axes", emscripten::val::array(axes));
     output = model_builder.GetBuilder().call<emscripten::val>("meanVarianceNormalization", input, options);
   } else if (op_type == "GroupNormalization") {
-    ORT_RETURN_IF_NOT(helper.HasAttr("num_groups"), "group must be provided.");
+    ORT_RETURN_IF_NOT(helper.HasAttr("num_groups"), "GroupNormalization num_group must be provided.");
     int32_t group_count = helper.Get("num_groups", -1);
     std::vector<int32_t> orig_shape, new_shape;
     std::transform(input_shape.cbegin(), input_shape.cend(),

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
@@ -90,7 +90,9 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateLogicalOpBuilder("Equal", op_registrations);
   }
 
-  {  // LayerNormalization
+  {  // Normalization
+    CreateNormalizationOpBuilder("GroupNormalization", op_registrations);
+    CreateNormalizationOpBuilder("InstanceNormalization", op_registrations);
     CreateNormalizationOpBuilder("LayerNormalization", op_registrations);
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add support for Op InstanceNormalization and GroupNormalization by  MeanVarianceNormalization.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable more models like Olive'ified SD unet to run on WebNN EP.

