### PR TITLE
[objc] Update docs and fix static analysis build

### DIFF
--- a/objectivec/docs/jazzy_config.yaml
+++ b/objectivec/docs/jazzy_config.yaml
@@ -4,7 +4,9 @@ author_url: https://www.onnxruntime.ai
 github_url: https://github.com/microsoft/onnxruntime
 
 objc: true
-umbrella_header: ../include/onnxruntime.h
+# Specify the training header as umbrella_header so that every public header is included.
+# The training header is a superset of the inference-only header.
+umbrella_header: ../include/onnxruntime_training.h
 framework_root: ..
 
 readme: ./main_page.md

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -13,12 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  * their gradients, optimizer parameters, and user properties. The `ORTTrainingSession` leverages the
  * `ORTCheckpoint` by accessing and updating the contained training state.
  *
- * Available since v1.16.0.
- *
- * @note Note that the training session created with a checkpoint state uses this state to store the entire training
- * state (including model parameters, its gradients, the optimizer states and the properties). The ORTTraingSession
- * does not hold a copy of the checkpoint state. Therefore, it is required that the checkpoint state outlive the
- * lifetime of the training session.
+ * Available since 1.16.
  */
 @interface ORTCheckpoint : NSObject
 

--- a/objectivec/include/ort_checkpoint.h
+++ b/objectivec/include/ort_checkpoint.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
  * `ORTCheckpoint` by accessing and updating the contained training state.
  *
  * Available since 1.16.
+ *
+ * @note This class is only available when the training APIs are enabled.
  */
 @interface ORTCheckpoint : NSObject
 

--- a/objectivec/include/ort_training_session.h
+++ b/objectivec/include/ort_training_session.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
  * can be used to generate above training artifacts.
  *
  * Available since 1.16.
+ *
+ * @note This class is only available when the training APIs are enabled.
  */
 @interface ORTTrainingSession : NSObject
 

--- a/objectivec/include/ort_training_session.h
+++ b/objectivec/include/ort_training_session.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  * [onnxruntime-training python utility](https://github.com/microsoft/onnxruntime/blob/main/orttraining/orttraining/python/training/onnxblock/README.md)
  * can be used to generate above training artifacts.
  *
- * Available since v1.16.0.
+ * Available since 1.16.
  */
 @interface ORTTrainingSession : NSObject
 
@@ -45,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Optional error information set if an error occurs.
  * @return The instance, or nil if an error occurs.
  *
+ * @note Note that the training session created with a checkpoint state uses this state to store the entire training
+ * state (including model parameters, its gradients, the optimizer states and the properties). The training session
+ * keeps a strong (owning) pointer to the checkpoint state.
  */
 - (nullable instancetype)initWithEnv:(ORTEnv*)env
                       sessionOptions:(ORTSessionOptions*)sessionOptions

--- a/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-objc-static-analysis-ci-pipeline.yml
@@ -23,6 +23,7 @@ jobs:
         --cmake_generator "Unix Makefiles" \
         --config Debug \
         --build_shared_lib --use_coreml --build_objc \
+        --enable_training_apis \
         --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON \
         --update --skip_submodule_sync \
         --build --parallel --target onnx_proto


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Update some documentation comments.
- Use onnxruntime_training.h as the umbrella header so training API docs are included in generated docs.
- Fix static analysis build.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Update docs, fix build.