### PR TITLE
Update some more Mac agents to MacOS 13, add '-gpu swiftshader_indirect' to Android emulator args.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -192,9 +192,7 @@ stages:
   jobs:
   - job: Test_CPU_EP
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     workspace:
       clean: all
     condition: succeeded()
@@ -263,9 +261,7 @@ stages:
 
   - job: Test_NNAPI_EP
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     timeoutInMinutes: 90
     workspace:
       clean: all
@@ -358,9 +354,7 @@ stages:
   jobs:
   - job: NNAPI_EP_MASTER
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     timeoutInMinutes: 180
     workspace:
       clean: all

--- a/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/android-java-api-aar-test.yml
@@ -20,9 +20,7 @@ jobs:
   workspace:
     clean: all
   pool:
-    # We need macOS-12 to run the Android emulator for now.
-    # https://github.com/actions/runner-images/issues/7671
-    vmImage: 'macOS-12'
+    vmImage: 'macOS-13'
   variables:
   - name: runCodesignValidationInjection
     value: false

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -50,9 +50,7 @@ stages:
   jobs:
   - job: ReactNative_CI
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     variables:
       runCodesignValidationInjection: false
       TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]

--- a/tools/python/util/android/android.py
+++ b/tools/python/util/android/android.py
@@ -111,6 +111,8 @@ def start_emulator(
             "-no-audio",
             "-no-boot-anim",
             "-no-window",
+            "-gpu",
+            "swiftshader_indirect",
         ]
         if extra_args is not None:
             emulator_args += extra_args


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update some more Mac hosted agents to use the MacOS 13 image.

Pass `-gpu swiftshader_indirect` emulator args as a workaround to get Android emulator running on the MacOS 13 hosted agents.

See https://github.com/actions/runner-images/issues/7671

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Update hosted build agent images.