### PR TITLE
Replace Split to SplitView if Axis is 0

### DIFF
--- a/orttraining/orttraining/core/graph/training_op_defs.cc
+++ b/orttraining/orttraining/core/graph/training_op_defs.cc
@@ -4610,6 +4610,18 @@ Return true if all elements are true and false otherwise.
           "T_INDEX",
           {"tensor(int32)", "tensor(int64)"},
           "Constrain indices to integer types");
+
+  ONNX_CONTRIB_OPERATOR_SCHEMA(SplitView)
+      .SetDoc("SplitView. The output tensors are views of the input.")
+      .SetDomain(kMSDomain)
+      .SinceVersion(1)
+      .Attr("num_outputs", "Number of outputs to split parts of the tensor into. ", AttributeProto::INT, false)
+      .AllowUncheckedAttributes()
+      .Input(0, "input", "Input tensor.", "T")
+      .Input(1, "split", "Optional length of each output. Values should be >= 0.", "tensor(int64)", OpSchema::Optional)
+      .Output(0, "outputs", "Output tensors viewed according the split input.", "T", OpSchema::Variadic)
+      .TypeConstraint("T", {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
+                      "Constrain input and output types to float tensors.");
 }
 
 }  // namespace training

--- a/orttraining/orttraining/core/optimizer/split_replacement.cc
+++ b/orttraining/orttraining/core/optimizer/split_replacement.cc
@@ -25,7 +25,13 @@ bool SplitReplacement::SatisfyCondition(const Graph& graph, const Node& node, co
   if ((nullptr != attr_proto) && attr_proto->has_i()) {
     axis = attr_proto->i();
   }
+
   if (axis != 0) {
+    return false;
+  }
+
+  // SplitView need to set Alias from input 0 to all outputs, currently we only support at most 16 outputs.
+  if (node.OutputDefs().size() > 16) {
     return false;
   }
 

--- a/orttraining/orttraining/core/optimizer/split_replacement.cc
+++ b/orttraining/orttraining/core/optimizer/split_replacement.cc
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "orttraining/core/optimizer/split_replacement.h"
+
+#include "core/graph/graph_utils.h"
+
+namespace onnxruntime {
+
+Status SplitReplacement::Apply(Graph& graph, Node& split_node, RewriteRuleEffect& rule_effect,
+                               const logging::Logger&) const {
+  Node& split_view_node =
+      graph.AddNode(graph.GenerateNodeName("SplitView"), "SplitView", "Split view.", split_node.MutableInputDefs(),
+                    split_node.MutableOutputDefs(), &split_node.GetAttributes(), kMSDomain);
+  // Assign provider to this new node. Provider should be same as the provider for old node.
+  split_view_node.SetExecutionProviderType(split_node.GetExecutionProviderType());
+  graph_utils::FinalizeNodeFusion(graph, split_view_node, split_node);
+  rule_effect = RewriteRuleEffect::kRemovedCurrentNode;
+  return Status::OK();
+}
+
+bool SplitReplacement::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger&) const {
+  int64_t axis = 0;
+  const auto* attr_proto = graph_utils::GetNodeAttribute(node, "axis");
+  if ((nullptr != attr_proto) && attr_proto->has_i()) {
+    axis = attr_proto->i();
+  }
+  if (axis != 0) {
+    return false;
+  }
+
+  for (const NodeArg* output : node.OutputDefs()) {
+    if (graph.IsOutput(output)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace onnxruntime

--- a/orttraining/orttraining/core/optimizer/split_replacement.h
+++ b/orttraining/orttraining/core/optimizer/split_replacement.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/rewrite_rule.h"
+
+namespace onnxruntime {
+
+/**
+@Class SplitReplacement
+
+Rewrite rule that replaces Split with SplitView if the following conditions are satisfied:
+- Split on axis 0
+- Split has no any graph output
+*/
+class SplitReplacement : public RewriteRule {
+ public:
+  SplitReplacement() noexcept : RewriteRule("SplitReplacement") {}
+  std::vector<std::string> TargetOpTypes() const noexcept override { return {"Split"}; }
+
+ private:
+  bool SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger& logger) const override;
+  Status Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/orttraining/orttraining/test/training_ops/cpu/tensor/split_view_op_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/tensor/split_view_op_test.cc
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+template <class T>
+using ShapeAndData = std::pair<const std::vector<int64_t>, const std::vector<T>>;
+
+template <typename T>
+void TestSplitViewOp(const ShapeAndData<T>& input, const int64_t num_outputs, const std::vector<int64_t> split_sizes,
+                     const std::vector<ShapeAndData<T>>& outputs) {
+  OpTester test("SplitView", 1, onnxruntime::kMSDomain);
+  if (num_outputs != -1) {
+    test.AddAttribute<int64_t>("num_outputs", num_outputs);
+  }
+  test.AddInput<T>("input", input.first, input.second);
+  if (!split_sizes.empty()) {
+    test.AddInput<int64_t>("split", {static_cast<int64_t>(split_sizes.size())}, split_sizes, true);
+  }
+
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    std::string name = "output" + std::to_string(i);
+    test.AddOutput<T>(name.c_str(), outputs[i].first, outputs[i].second);
+  }
+
+  test.Run();
+}
+
+TEST(SplitViewOpTest, NumOutputsEqualSplitFloat) {
+  ShapeAndData<float> input = {{4, 2}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f}};
+  std::vector<ShapeAndData<float>> outputs;
+  ShapeAndData<float> output0 = {{2, 2}, {1.f, 2.f, 3.f, 4.f}};
+  ShapeAndData<float> output1 = {{2, 2}, {5.f, 6.f, 7.f, 8.f}};
+  outputs.emplace_back(output0);
+  outputs.emplace_back(output1);
+  TestSplitViewOp<float>(input, 2, {}, outputs);
+}
+
+TEST(SplitViewOpTest, NumOutputsNonEqualSplitFloat16) {
+  ShapeAndData<MLFloat16> input = {{5, 2},
+                                   {MLFloat16(1.f), MLFloat16(2.f), MLFloat16(3.f), MLFloat16(4.f), MLFloat16(5.f),
+                                    MLFloat16(6.f), MLFloat16(7.f), MLFloat16(8.f), MLFloat16(9.f), MLFloat16(10.f)}};
+  std::vector<ShapeAndData<MLFloat16>> outputs;
+  ShapeAndData<MLFloat16> output0 = {{2, 2}, {MLFloat16(1.f), MLFloat16(2.f), MLFloat16(3.f), MLFloat16(4.f)}};
+  ShapeAndData<MLFloat16> output1 = {{2, 2}, {MLFloat16(5.f), MLFloat16(6.f), MLFloat16(7.f), MLFloat16(8.f)}};
+  ShapeAndData<MLFloat16> output2 = {{1, 2}, {MLFloat16(9.f), MLFloat16(10.f)}};
+  outputs.emplace_back(output0);
+  outputs.emplace_back(output1);
+  outputs.emplace_back(output2);
+  TestSplitViewOp<MLFloat16>(input, 3, {}, outputs);
+}
+
+TEST(SplitViewOpTest, SplitInputFloat) {
+  ShapeAndData<float> input = {{6, 2}, {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f}};
+  std::vector<ShapeAndData<float>> outputs;
+  ShapeAndData<float> output0 = {{1, 2}, {1.f, 2.f}};
+  ShapeAndData<float> output1 = {{2, 2}, {3.f, 4.f, 5.f, 6.f}};
+  ShapeAndData<float> output2 = {{3, 2}, {7.f, 8.f, 9.f, 10.f, 11.f, 12.f}};
+  outputs.emplace_back(output0);
+  outputs.emplace_back(output1);
+  outputs.emplace_back(output2);
+  TestSplitViewOp<float>(input, -1, {1, 2, 3}, outputs);
+}
+
+TEST(SplitViewOpTest, SplitInputFloat16) {
+  ShapeAndData<MLFloat16> input = {{5, 2},
+                                   {MLFloat16(1.f), MLFloat16(2.f), MLFloat16(3.f), MLFloat16(4.f), MLFloat16(5.f),
+                                    MLFloat16(6.f), MLFloat16(7.f), MLFloat16(8.f), MLFloat16(9.f), MLFloat16(10.f)}};
+  std::vector<ShapeAndData<MLFloat16>> outputs;
+  ShapeAndData<MLFloat16> output0 = {{2, 2}, {MLFloat16(1.f), MLFloat16(2.f), MLFloat16(3.f), MLFloat16(4.f)}};
+  ShapeAndData<MLFloat16> output1 = {
+      {3, 2}, {MLFloat16(5.f), MLFloat16(6.f), MLFloat16(7.f), MLFloat16(8.f), MLFloat16(9.f), MLFloat16(10.f)}};
+  outputs.emplace_back(output0);
+  outputs.emplace_back(output1);
+  TestSplitViewOp<MLFloat16>(input, -1, {2, 3}, outputs);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cpu/cpu_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cpu/cpu_training_kernels.cc
@@ -99,6 +99,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, LSTMTraining);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, LSTMGrad);
 
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, SplitView);
+
 // the kernels within the following ifdef are not included in a build with
 // --enable_training_ops but without --enable_training
 #ifdef ENABLE_TRAINING
@@ -226,6 +228,8 @@ Status RegisterCpuTrainingKernels(KernelRegistry& kernel_registry) {
           kCpuExecutionProvider, kMSDomain, 1, float, LSTMTraining)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(
           kCpuExecutionProvider, kMSDomain, 1, float, LSTMGrad)>,
+
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, SplitView)>,
 
 // the kernels within the following ifdef are not included in a build with
 // --enable_training_ops but without --enable_training

--- a/orttraining/orttraining/training_ops/cpu/tensor/split_view.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split_view.cc
@@ -21,6 +21,7 @@ Status SplitView::Compute(OpKernelContext* context) const {
   InlinedVector<TensorShape> output_shapes;
   InlinedVector<size_t> output_offsets;
   ORT_RETURN_IF_ERROR(PrepareForSplitView(input_tensor, num_outputs, p_split_tensor, output_shapes, output_offsets));
+  ORT_ENFORCE(output_shapes.size() <= KSplitViewMaxOutputCount, "Output count exceeds limit.");
   ORT_ENFORCE(static_cast<size_t>(context->OutputCount()) <= output_shapes.size(), "Output count mismatch.");
 
   const void* input_data = input_tensor.DataRaw();

--- a/orttraining/orttraining/training_ops/cpu/tensor/split_view.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split_view.cc
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "orttraining/training_ops/cpu/tensor/split_view.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+ONNX_OPERATOR_KERNEL_EX(SplitView, kMSDomain, 1, kCpuExecutionProvider,
+                        KernelDefBuilder()
+                            .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+                            .Alias(SplitViewAliasMapping()),  // all output tensors are sharing the same bffer as
+                                                              // input[0], execept that the byte_offset are different.
+                        SplitView);
+
+Status SplitView::Compute(OpKernelContext* context) const {
+  const Tensor& input_tensor = *context->Input<Tensor>(0);
+  const Tensor* p_split_tensor = context->Input<Tensor>(1);
+  size_t num_outputs =
+      num_outputs_ == -1 ? static_cast<size_t>(context->OutputCount()) : static_cast<size_t>(num_outputs_);
+  InlinedVector<TensorShape> output_shapes;
+  InlinedVector<size_t> output_offsets;
+  ORT_RETURN_IF_ERROR(PrepareForSplitView(input_tensor, num_outputs, p_split_tensor, output_shapes, output_offsets));
+  ORT_ENFORCE(static_cast<size_t>(context->OutputCount()) <= output_shapes.size(), "Output count mismatch.");
+
+  const void* input_data = input_tensor.DataRaw();
+  for (size_t i = 0; i < static_cast<size_t>(context->OutputCount()); ++i) {
+    // Outputs are allowed to be unused.
+    Tensor* output_tensor = context->Output(i, output_shapes[i]);
+    if (output_tensor != nullptr) {
+      void* output_data = output_tensor->MutableDataRaw();
+      if (input_data != output_data) {
+        // View output is not sharing the underlaying buffer of input, copy instead.
+        const void* source = static_cast<const char*>(input_data) + output_offsets[i];
+        memcpy(output_data, source, output_tensor->SizeInBytes());
+      } else {
+        output_tensor->SetByteOffset(output_offsets[i]);
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cpu/tensor/split_view.h
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split_view.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+constexpr size_t KSplitViewMaxOutputCount = 16;  // limit of output count.
+
+std::vector<std::pair<int, int>> SplitViewAliasMapping() {
+  std::vector<std::pair<int, int>> alias_pairs{};
+  for (size_t i = 0; i < KSplitViewMaxOutputCount; ++i) {
+    alias_pairs.emplace_back(std::make_pair(0, static_cast<int>(i)));
+  }
+  return alias_pairs;
+}
+
+Status PrepareForSplitView(const Tensor& input_tensor, int64_t num_outputs, const Tensor* p_split_tensor,
+                           InlinedVector<TensorShape>& output_shapes, InlinedVector<size_t>& output_offsets) {
+  std::vector<int64_t> split_sizes;
+  TensorShapeVector input_shape = input_tensor.Shape().AsShapeVector();
+  if (p_split_tensor) {
+    ORT_ENFORCE(p_split_tensor->Shape().NumDimensions() == 1, "An split tensor must be a vector tensor.");
+    auto num_dims = static_cast<size_t>(p_split_tensor->Shape()[0]);
+    split_sizes.resize(num_dims);
+    const int64_t* data = p_split_tensor->Data<int64_t>();
+    split_sizes.assign(data, data + num_dims);
+  } else {
+    const int64_t split_dim_size = input_shape[0];
+    int32_t size = narrow<int32_t>(std::ceil(float(split_dim_size) / num_outputs));
+    int32_t remainder = split_dim_size % size;
+    split_sizes = std::vector<int64_t>(num_outputs, size);
+    if (remainder) {
+      split_sizes.back() = remainder;
+    }
+  }
+
+  size_t bytes_per_elem = input_tensor.DataType()->Size();
+  size_t byte_offset = 0;
+  for (size_t i = 0; i < split_sizes.size(); ++i) {
+    input_shape[0] = split_sizes[i];
+    output_shapes.emplace_back(TensorShape(input_shape));
+    output_offsets.emplace_back(byte_offset);
+    byte_offset += output_shapes[i].Size() * bytes_per_elem;
+  }
+
+  if (byte_offset != input_tensor.SizeInBytes()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "The input view shapes doesn't adds up to match input buffer size.");
+  }
+
+  return Status::OK();
+}
+
+class SplitView final : public OpKernel {
+ public:
+  SplitView(const OpKernelInfo& info) : OpKernel(info) {
+    num_outputs_ = info.GetAttrOrDefault<int64_t>("num_outputs", -1);
+  }
+
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  int64_t num_outputs_ = -1;
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -198,6 +198,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, Inpl
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, FakeQuant);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, FakeQuantGrad);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, PadAndUnflatten);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, SplitView);
 
 // the kernels within the following ifdef are not included in a build with
 // --enable_training_ops but without --enable_training
@@ -439,6 +440,7 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(
         kCudaExecutionProvider, kMSDomain, 1, float, FakeQuantGrad)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, PadAndUnflatten)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, SplitView)>,
 // the kernels within the following ifdef are not included in a build with
 // --enable_training_ops but without --enable_training
 #ifdef ENABLE_TRAINING

--- a/orttraining/orttraining/training_ops/cuda/tensor/split_view.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/split_view.cc
@@ -26,6 +26,7 @@ Status SplitView::ComputeInternal(OpKernelContext* context) const {
   InlinedVector<TensorShape> output_shapes;
   InlinedVector<size_t> output_offsets;
   ORT_RETURN_IF_ERROR(PrepareForSplitView(input_tensor, num_outputs, p_split_tensor, output_shapes, output_offsets));
+  ORT_ENFORCE(output_shapes.size() <= KSplitViewMaxOutputCount, "Output count exceeds limit.");
   ORT_ENFORCE(static_cast<size_t>(context->OutputCount()) <= output_shapes.size(), "Output count mismatch.");
 
   const void* input_data = input_tensor.DataRaw();

--- a/orttraining/orttraining/training_ops/cuda/tensor/split_view.cc
+++ b/orttraining/orttraining/training_ops/cuda/tensor/split_view.cc
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "orttraining/training_ops/cuda/tensor/split_view.h"
+
+#include "orttraining/training_ops/cpu/tensor/split_view.h"
+
+using namespace onnxruntime::contrib;
+
+namespace onnxruntime {
+namespace cuda {
+
+ONNX_OPERATOR_KERNEL_EX(SplitView, kMSDomain, 1, kCudaExecutionProvider,
+                        (*KernelDefBuilder::Create())
+                            .InputMemoryType(OrtMemTypeCPUInput, 1)
+                            .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+                            .Alias(SplitViewAliasMapping()),  // all output tensors are sharing the same bffer as
+                                                              // input[0], execept that the byte_offset are different.
+                        SplitView);
+
+Status SplitView::ComputeInternal(OpKernelContext* context) const {
+  const Tensor& input_tensor = *context->Input<Tensor>(0);
+  const Tensor* p_split_tensor = context->Input<Tensor>(1);
+  size_t num_outputs =
+      num_outputs_ == -1 ? static_cast<size_t>(context->OutputCount()) : static_cast<size_t>(num_outputs_);
+  InlinedVector<TensorShape> output_shapes;
+  InlinedVector<size_t> output_offsets;
+  ORT_RETURN_IF_ERROR(PrepareForSplitView(input_tensor, num_outputs, p_split_tensor, output_shapes, output_offsets));
+  ORT_ENFORCE(static_cast<size_t>(context->OutputCount()) <= output_shapes.size(), "Output count mismatch.");
+
+  const void* input_data = input_tensor.DataRaw();
+  for (size_t i = 0; i < static_cast<size_t>(context->OutputCount()); ++i) {
+    // Outputs are allowed to be unused.
+    Tensor* output_tensor = context->Output(i, output_shapes[i]);
+    if (output_tensor != nullptr) {
+      void* output_data = output_tensor->MutableDataRaw();
+      if (input_data != output_data) {
+        // View output is not sharing the underlaying buffer of input, copy instead.
+        const void* source = static_cast<const char*>(input_data) + output_offsets[i];
+        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output_data, source, output_tensor->SizeInBytes(),
+                                             cudaMemcpyDeviceToDevice, Stream(context)));
+      } else {
+        output_tensor->SetByteOffset(output_offsets[i]);
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/cuda/tensor/split_view.h
+++ b/orttraining/orttraining/training_ops/cuda/tensor/split_view.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cuda/cuda_kernel.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+class SplitView final : public CudaKernel {
+ public:
+  SplitView(const OpKernelInfo& info) : CudaKernel(info) {
+    num_outputs_ = info.GetAttrOrDefault<int64_t>("num_outputs", -1);
+  }
+
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  int64_t num_outputs_ = -1;
+};
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/rocm/rocm_training_kernels.cc
@@ -183,6 +183,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float_BFloat16, ReduceAllL2);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16_BFloat16, ReduceAllL2);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, PadAndUnflatten);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, SplitView);
 
 #if defined(ORT_USE_NCCL) || defined(USE_MPI)
 // P2P communication operators.
@@ -380,6 +381,7 @@ Status RegisterRocmTrainingKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float_BFloat16, ReduceAllL2)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16_BFloat16, ReduceAllL2)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, PadAndUnflatten)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, SplitView)>,
 
 // P2P communication operators.
 #if defined(ORT_USE_NCCL) || defined(USE_MPI)


### PR DESCRIPTION
The PR adds a new contrib Op name SplitView, which is a replacement of Split when axis=0. The new Op will share data buffer from input, but set the offset in the tensor for different outputs. With this change, we don't need actual compute in such case.

The PR also move TransposeOptimizer from Level 1's end to Level 2's end. It's better we apply this optimizer after all transpose related optimizers such as MatMulTransposeFusion. For example, for some Bert-like models, there are Transpose Ops before and after a Split, and the Transpose Ops after Split are normally followed by MatMul, which can be fused together. But if we apply the TransposeOptimizer first, the Transpose will be pushed down, and changed the perm of these Transpose nodes, causing not able to fuse them with MatMul. At the end, it actually didn't reduce the Transpose count in total.

