### PR TITLE
Update build.bat Prevent spaces in path

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -3,4 +3,4 @@
 
 @echo off
 rem Requires a python 3.6 or higher install to be available in your PATH
-python %~dp0\tools\ci_build\build.py --build_dir %~dp0\build\Windows %*
+python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows %*"

--- a/build.bat
+++ b/build.bat
@@ -3,4 +3,4 @@
 
 @echo off
 rem Requires a python 3.6 or higher install to be available in your PATH
-python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows %*"
+python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" %*


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Simply add double quotes to prevent there is spaces in the path


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
As if there are spaces in path the bat cannot run, error would occurs. So with a simple double quotes can fix these problems
- If it fixes an open issue, please link to the issue here. -->


