### PR TITLE
Add GroupedGemm op

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.cc
@@ -13,7 +13,6 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
       GroupedGemm,                                                \
@@ -25,14 +24,12 @@ namespace rocm {
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       GroupedGemm<T>);
 
-
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
 
 using namespace ONNX_NAMESPACE;
 
-
-template<typename T>
+template <typename T>
 Status GroupedGemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   typedef typename ToHipType<T>::MappedType HipT;
 
@@ -41,7 +38,7 @@ Status GroupedGemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor* B = ctx->Input<Tensor>(2);
   const Tensor* C = ctx->Input<Tensor>(3);
 
-  GroupedGemmHelper helper(A->Shape(), trans_A_, B->Shape(), trans_B_, C != nullptr ? C->Shape(): TensorShape({}), msizes->Shape());
+  GroupedGemmHelper helper(A->Shape(), trans_A_, B->Shape(), trans_B_, C != nullptr ? C->Shape() : TensorShape({}), msizes->Shape());
 
   if (!helper.State().IsOK()) {
     return helper.State();

--- a/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Modifications: Remove GetDeviceProp in LaunchFastGeluKernel.
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/rocm/rocm_common.h"
+#include "contrib_ops/rocm/bert/grouped_gemm.h"
+#include "contrib_ops/rocm/bert/grouped_gemm_tunable.cuh"
+#include "core/providers/rocm/tunable/gemm.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      GroupedGemm,                                                \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
+      GroupedGemm<T>);
+
+
+REGISTER_KERNEL_TYPED(float)
+REGISTER_KERNEL_TYPED(MLFloat16)
+
+using namespace ONNX_NAMESPACE;
+
+
+template<typename T>
+Status GroupedGemm::ComputeInternal(OpKernelContext* ctx) const {
+  typedef typename ToHipType<T>::MappedType HipT;
+
+  const Tensor* A = ctx->Input<Tensor>(0);
+  const Tensor* msizes = ctx->Input<Tensor>(1);
+  const Tensor* B = ctx->Input<Tensor>(2);
+  const Tensor* C = ctx->Input<Tensor>(3);
+
+  GroupedGemmHelper helper(A->Shape(), trans_A_, B->Shape(), trans_B_, C != nullptr ? C->Shape(): TensorShape({}));
+
+  if (!helper.State().IsOK()) {
+    return helper.State();
+  }
+
+  ptrdiff_t M = helper.M();
+  ptrdiff_t N = helper.N();
+  ptrdiff_t K = helper.K();
+  ptrdiff_t num_matrix = helper.num_matrix();
+
+  // allocate output memory
+  auto* Y = ctx->Output(0, {M, N});
+  HipT* out_data = reinterpret_cast<HipT*>(Y->MutableData<T>());
+
+  // broadcast bias if it is present
+  if (beta_ != 0. && C != nullptr) {
+    auto bias_shape = C->Shape();
+    const auto* bias_data = reinterpret_cast<HipT*>(C->Data<t>());
+
+    if (bias_shape[0] == M) {
+      // has same shape of output, directly copy bias into output buffer
+      HIP_RETURN_IF_ERROR(hipMemcpyAsync(out_data, bias_data, M * N * sizeof(T), hipMemcpyDeviceToDevice, Stream(ctx)));
+    } else {
+      // TODO: for bias shape is (m, N), need to broadcast each N into msizes.
+      // here need to implement a kernel to do this.
+    }
+  }
+
+  // call grouped_gemm kernel to compute grouped_gemm
+  return tunable::blas::column_major::GroupedGemm(
+      GetTunningContext(), Stream(ctx),
+      GetRocblasHandle(ctx),
+      trans_B_ ? BlasOp::Trans : BlasOp::NonTrans,
+      trans_A_ ? BlasOp::Trans : BlasOp::NonTrans,
+      N, M, K, num_matrix,
+      alpha_,
+      reinterpret_cast<HipT*>(B->Data<T>()), (trans_B_ ? K : N),
+      msizes->Data<std::int64_t>(),
+      reinterpret_cast<HipT*>(A->Data<T>()), (trans_A_ ? M : K),
+      C != nullptr ? beta_ : 0.0f,
+      out_data, N);
+}
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
+++ b/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
@@ -78,7 +78,7 @@ class GroupedGemmHelper {
 
     // valid shape is (M, N) or (m, N) where m is number of elements in msizes
     return (bias_shape[0] == M_ && bias_shape[1] == N_) ||
-	    (bias_shape[0] == msizes_shape[0] && bias_shape[1] == N_);
+           (bias_shape[0] == msizes_shape[0] && bias_shape[1] == N_);
   }
 
   GroupedGemmHelper() = default;
@@ -89,7 +89,7 @@ class GroupedGemmHelper {
   Status status_;
 };
 
-template<typename T>
+template <typename T>
 class GroupedGemm final : public RocmKernel {
  public:
   GroupedGemm(const OpKernelInfo& info) : RocmKernel(info) {
@@ -101,10 +101,11 @@ class GroupedGemm final : public RocmKernel {
     trans_B_ = (temp != 0);
 
     ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
-    ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK()); 
+    ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK());
   }
 
   Status ComputeInternal(OpKernelContext* ctx) const override;
+
  private:
   float alpha_;
   float beta_;

--- a/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
+++ b/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/providers/rocm/rocm_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+using namespace onnxruntime::rocm;
+
+class GroupedGemmHelper {
+ public:
+  GroupedGemmHelper(const TensorShape& left, bool trans_left, const TensorShape& right, bool trans_right, const TensorShape& bias_shape, const TensorShape& msizes_shape) {
+    // dimension check
+    ORT_ENFORCE(left.NumDimensions() == 2);
+    ORT_ENFORCE(right.NumDimensions() == 2);
+    ORT_ENFORCE(msizes_shape.NumDimensions() == 2);
+
+    for (size_t i = 0; i != left.NumDimensions(); ++i) {
+      ORT_ENFORCE(left[i] >= 0);
+      ORT_ENFORCE(left[i] <= std::numeric_limits<ptrdiff_t>::max());
+    }
+
+    for (size_t i = 0; i != right.NumDimensions(); ++i) {
+      ORT_ENFORCE(right[i] >= 0);
+      ORT_ENFORCE(right[i] <= std::numeric_limits<ptrdiff_t>::max());
+    }
+
+    if (trans_left) {
+      M_ = static_cast<ptrdiff_t>(left[1]);
+      K_ = static_cast<ptrdiff_t>(left[0]);
+    } else {
+      M_ = static_cast<ptrdiff_t>(left[0]);
+      K_ = static_cast<ptrdiff_t>(left[1];)
+    }
+
+    int k_dim;
+    if (trans_right) {
+      N_ = static_cast<ptrdiff_t>(right[0]);
+      k_dim = 1;
+    } else {
+      N_ = static_cast<ptrdiff_t>(right[1]);
+      k_dim = 0;
+    }
+
+    num_matrix_ = msizes_shape[0];
+
+    if (right[k_dim] != K_)
+      status_ = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                "GEMM: Dimension mismatch, W: ",
+                                right.ToString(),
+                                " K: " + std::to_string(K_),
+                                " N:" + std::to_string(N_));
+    // check bias shape
+    if (!IsValidBroadcast(bias_shape, msizes_shape)) {
+      status_ = common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "GroupedGemm: Invalid bias shape for broadcast");
+    }
+
+    // it is possible the input is empty tensor, for example the output of roipool in fast rcnn.
+    ORT_ENFORCE(M_ >= 0 && K_ > 0 && N_ >= 0);
+  }
+
+  ptrdiff_t M() const { return M_; }
+  ptrdiff_t N() const { return N_; }
+  ptrdiff_t K() const { return K_; }
+  ptrdiff_t num_matrix const { return num_matrix_; }
+  Status State() const { return status_; }
+
+ private:
+  static bool IsValidBroadcast(const TensorShape& bias_shape, const TensorShape& msizes_shape) {
+    if (bias_shape.NumDimensions() != 2) {
+      return false;
+    }
+
+    // valid shape is (M, N) or (m, N) where m is number of elements in msizes
+    return (bias_shape[0] == M_ && bias_shape[1] == N_) ||
+	    (bias_shape[0] == msizes_shape[0] && bias_shape[1] == N);
+  }
+
+  GroupedGemmHelper() = default;
+  ptrdiff_t M_;
+  ptrdiff_t K_;
+  ptrdiff_t N_;
+  ptrdiff_t num_matrix_;
+  Status status_;
+};
+
+template<typename T>
+class GroupedGemm final : public RocmKernel {
+ public:
+  GroupedGemm(const OpKernelInfo& op_kernel_info) {
+    int64_t temp;
+    ORT_ENFORCE(info.GetAttr<int64_t>("transA", &temp).IsOK());
+    trans_A_ = (temp != 0);
+
+    ORT_ENFORCE(info.GetAttr<int64_t>("transB", &temp).IsOK());
+    trans_B_ = (temp != 0);
+
+    ORT_ENFORCE(info.GetAttr<float>("alpha", &alpha_).IsOK());
+    ORT_ENFORCE(info.GetAttr<float>("beta", &beta_).IsOK()); 
+  }
+
+  Status ComputeInternal(OpKernelContext* ctx) const override;
+ private:
+  float alpha_;
+  float beta_;
+  bool trans_A_;
+  bool trans_B_;
+};
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
+++ b/onnxruntime/contrib_ops/rocm/bert/grouped_gemm.h
@@ -35,7 +35,7 @@ class GroupedGemmHelper {
       K_ = static_cast<ptrdiff_t>(left[0]);
     } else {
       M_ = static_cast<ptrdiff_t>(left[0]);
-      K_ = static_cast<ptrdiff_t>(left[1];)
+      K_ = static_cast<ptrdiff_t>(left[1]);
     }
 
     int k_dim;
@@ -67,18 +67,18 @@ class GroupedGemmHelper {
   ptrdiff_t M() const { return M_; }
   ptrdiff_t N() const { return N_; }
   ptrdiff_t K() const { return K_; }
-  ptrdiff_t num_matrix const { return num_matrix_; }
+  ptrdiff_t num_matrix() const { return num_matrix_; }
   Status State() const { return status_; }
 
  private:
-  static bool IsValidBroadcast(const TensorShape& bias_shape, const TensorShape& msizes_shape) {
+  bool IsValidBroadcast(const TensorShape& bias_shape, const TensorShape& msizes_shape) {
     if (bias_shape.NumDimensions() != 2) {
       return false;
     }
 
     // valid shape is (M, N) or (m, N) where m is number of elements in msizes
     return (bias_shape[0] == M_ && bias_shape[1] == N_) ||
-	    (bias_shape[0] == msizes_shape[0] && bias_shape[1] == N);
+	    (bias_shape[0] == msizes_shape[0] && bias_shape[1] == N_);
   }
 
   GroupedGemmHelper() = default;
@@ -92,7 +92,7 @@ class GroupedGemmHelper {
 template<typename T>
 class GroupedGemm final : public RocmKernel {
  public:
-  GroupedGemm(const OpKernelInfo& op_kernel_info) {
+  GroupedGemm(const OpKernelInfo& info) : RocmKernel(info) {
     int64_t temp;
     ORT_ENFORCE(info.GetAttr<int64_t>("transA", &temp).IsOK());
     trans_A_ = (temp != 0);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2389,52 +2389,52 @@ ONNX_MS_OPERATOR_SET_SCHEMA(CropAndResize, 1,
 
 ONNX_MS_OPERATOR_SET_SCHEMA(GroupedGemm, 1,
                             OpSchema()
-			        .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
-			        .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
-				.Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
-				.Attr("beta", "Scalar multiplier for the input tensor C.", AttributeProto::FLOAT, 0.0f)
+                                .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
+                                .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
+                                .Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
+                                .Attr("beta", "Scalar multiplier for the input tensor C.", AttributeProto::FLOAT, 0.0f)
                                 .Input(
-		                   0,
-		                   "A",
-		                   "Input tensor A. It is a packed tensor at axis of M. The real size of M is described in Input msize."
-		                   "The shape of A should be (M, K) if transA is 0, "
-		                   "or (K, M) if transA is non-zero.",
-		                   "T",
-		                   OpSchema::Single,
-		                   true,
-		                   1,
-		                   OpSchema::Differentiable)
-                               .Input(
-                                  1,
-                                  "msizes",
-                                  "Specified size of M for each tensor in A.",
-                                  "tensor(int64)",
-                                  OpSchema::Single,
-                                  true,
-                                  1,
-                                  OpSchema::NonDifferentiable)
-		               .Input(
-		                   2,
-		                   "B",
-		                   "Input tensor B. "
-		                   "The shape of B should be (mK, N) if transB is 0, "
-		                   "or (N, mK) if transB is non-zero. mK means m*K where m is the number of tensors in A, and K is same as A's K dim.",
-		                   "T",
-		                   OpSchema::Single,
-		                   true,
-		                   1,
-		                   OpSchema::Differentiable)
-		               .Input(
-		                   3,
-		                   "C",
-		                   "Optional input tensor C. "
-		                   "If not specified, the computation is done as if C is a scalar 0. "
-		                   "The shape of C should be unidirectional broadcastable to (M, N).",
-		                   "T",
-		                   OpSchema::Optional,
-		                   true,
-		                   1,
-		                   OpSchema::Differentiable)
+                                    0,
+                                    "A",
+                                    "Input tensor A. It is a packed tensor at axis of M. The real size of M is described in Input msize."
+                                    "The shape of A should be (M, K) if transA is 0, "
+                                    "or (K, M) if transA is non-zero.",
+                                    "T",
+                                    OpSchema::Single,
+                                    true,
+                                    1,
+                                    OpSchema::Differentiable)
+                                .Input(
+                                    1,
+                                    "msizes",
+                                    "Specified size of M for each tensor in A.",
+                                    "tensor(int64)",
+                                    OpSchema::Single,
+                                    true,
+                                    1,
+                                    OpSchema::NonDifferentiable)
+                                .Input(
+                                    2,
+                                    "B",
+                                    "Input tensor B. "
+                                    "The shape of B should be (mK, N) if transB is 0, "
+                                    "or (N, mK) if transB is non-zero. mK means m*K where m is the number of tensors in A, and K is same as A's K dim.",
+                                    "T",
+                                    OpSchema::Single,
+                                    true,
+                                    1,
+                                    OpSchema::Differentiable)
+                                .Input(
+                                    3,
+                                    "C",
+                                    "Optional input tensor C. "
+                                    "If not specified, the computation is done as if C is a scalar 0. "
+                                    "The shape of C should be unidirectional broadcastable to (M, N).",
+                                    "T",
+                                    OpSchema::Optional,
+                                    true,
+                                    1,
+                                    OpSchema::Differentiable)
                                 .Output(
                                     0,
                                     "Y",
@@ -2462,7 +2462,6 @@ ONNX_MS_OPERATOR_SET_SCHEMA(GroupedGemm, 1,
                                   updateOutputShape(ctx, 0, {A_shape.dim(transA ? 1 : 0), B_shape.dim(transB ? 0 : 1)});
                                 })
                                 .SetDoc(R"DOC(used for grouped_gemm.)DOC"));
-
 
 void RegisterContribSchemas() {
   ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2456,6 +2456,9 @@ ONNX_MS_OPERATOR_SET_SCHEMA(GroupedGemm, 1,
                                   if (B_shape.dim_size() != 2) {
                                     fail_shape_inference("second input tensor does not have rank 2.");
                                   }
+
+                                  auto transA = ctx.getAttribute("transA")->i();
+                                  auto transB = ctx.getAttribute("transB")->i();
                                   updateOutputShape(ctx, 0, {A_shape.dim(transA ? 1 : 0), B_shape.dim(transB ? 0 : 1)});
                                 })
                                 .SetDoc(R"DOC(used for grouped_gemm.)DOC"));

--- a/onnxruntime/core/providers/rocm/tunable/gemm.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm.h
@@ -42,11 +42,11 @@ namespace blas {
       ScalarT beta,                                                             \
       T* c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch)
 
-#define GROUPED_GEMM(T, ScalarT)                                                         \
-  common::Status GroupedGemm(                                                           \
-      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle,  \
-      BlasOp opa, BlasOp opb,                                                    \
-      std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t num_matrix,   \
+#define GROUPED_GEMM(T, ScalarT)                                                                             \
+  common::Status GroupedGemm(                                                                                \
+      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle,                              \
+      BlasOp opa, BlasOp opb,                                                                                \
+      std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t num_matrix,                               \
       ScalarT alpha, const T* a, std::int64_t lda, const std::int64_t* msizes, const T* b, std::int64_t ldb, \
       ScalarT beta, T* c, std::int64_t ldc)
 

--- a/onnxruntime/core/providers/rocm/tunable/gemm.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm.h
@@ -42,6 +42,14 @@ namespace blas {
       ScalarT beta,                                                             \
       T* c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch)
 
+#define GROUPED_GEMM(T, ScalarT)                                                         \
+  common::Status GroupedGemm(                                                           \
+      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle,  \
+      BlasOp opa, BlasOp opb,                                                    \
+      std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t num_matrix,   \
+      ScalarT alpha, const T* a, std::int64_t lda, const std::int64_t* msizes, const T* b, std::int64_t ldb, \
+      ScalarT beta, T* c, std::int64_t ldc)
+
 namespace row_major {
 
 GEMM(double, double);
@@ -67,6 +75,9 @@ STRIDED_BATCHED_GEMM(BFloat16, BFloat16);
 STRIDED_BATCHED_GEMM(double, float);
 STRIDED_BATCHED_GEMM(half, float);
 STRIDED_BATCHED_GEMM(BFloat16, float);
+
+GROUPED_GEMM(float, float);
+GROUPED_GEMM(half, float);
 
 }  // namespace row_major
 
@@ -99,6 +110,9 @@ STRIDED_BATCHED_GEMM(BFloat16, BFloat16);
 STRIDED_BATCHED_GEMM(double, float);
 STRIDED_BATCHED_GEMM(half, float);
 STRIDED_BATCHED_GEMM(BFloat16, float);
+
+GROUPED_GEMM(float, float);
+GROUPED_GEMM(half, float);
 
 }  // namespace column_major
 

--- a/onnxruntime/core/providers/rocm/tunable/gemm_common.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_common.h
@@ -106,6 +106,30 @@ struct StridedBatchedGemmParams : tunable::OpParams {
   int64_t batch;
 };
 
+template <typename T>
+struct GroupedGemmParams : tunable::OpParams {
+  std::string Signature() const override {
+    return MakeString(BlasOpToString(opa), BlasOpToString(opb), "_", m, "_", n, "_", k, "_", num_matrix);
+  }
+
+  rocblas_handle handle;
+  BlasOp opa;
+  BlasOp opb;
+  int64_t m;
+  int64_t n;
+  int64_t k;
+  int64_t num_matrix;
+  T alpha;
+  const T* a;
+  int64_t lda;
+  const int64_t* msizes;
+  const T* b;
+  int64_t ldb;
+  T beta;
+  T* c;
+  int64_t ldc;
+};
+
 }  // namespace blas
 }  // namespace tunable
 }  // namespace rocm

--- a/onnxruntime/core/providers/rocm/tunable/grouped_gemm_triton.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/grouped_gemm_triton.cuh
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/providers/rocm/triton_kernel.h"
+
+namespace onnxruntime {
+namespace rocm {
+
+#ifdef USE_TRITON_KERNEL
+
+namespace {
+
+template <typename T>
+std::string GetGroupedGemmTritonGroupName() {
+  std::string ret = "grouped_gemm_";
+  ret += GetDataTypeName<T>();
+  return ret;
+}
+
+}  // end of namespace
+
+template <typename T, typename ALayout, typename BLayout>
+auto GetGroupedGemmTritonOps() {
+  std::vector<std::pair<std::string, tunable::Op<GroupedGemmParams<T>>>> ret;
+  auto group_name = GetGroupedGemmTritonGroupName<T>();
+  auto *kernel_list = GetOrtTritonKernelByGroup(group_name);
+  if (kernel_list == nullptr) {
+    return ret;
+  }
+
+  for (auto i : *kernel_list) {
+    // check params match
+    auto *metadata = GetOrtTritonKernelMetadata(i);
+    auto grid0 = -1;
+    const std::string grid0_name = "GRID_SIZE0";
+    if (metadata->constants.count(grid0_name) != 0) {
+      grid0 = metadata->constants.at(grid0_name);
+    }
+    auto grid1 = -1;
+    const std::string grid1_name = "GRID_SIZE1";
+    if (metadata->constants.count(grid1_name) != 0) {
+      grid1 = metadata->constants.at(grid1_name);
+    }
+    auto impl = [i, grid0, grid1](const GroupedGemmParams<T> *params) -> Status {
+      // construct args for launch kernel
+      struct {
+	int num_matrix;
+        const void* msizes;
+	float alpha;
+	const void* A;
+	int lda;
+	const void* B;
+	int ldb;
+	float beta;
+        void *out;
+	int ldc;
+      } args = {params->num_matrix, (const void*)params->msizes, param->alpha, (const void*)params->a, params->lda, (const void*)params->b, params->ldb, params->beta, (void*)params->c, params->ldc};
+
+      // grid dim is (batch_count, 1, 1)
+      return LaunchTritonKernel(params->stream, i, grid0, grid1, 1, &args, sizeof(args));
+    };
+    ret.emplace_back(std::make_pair(metadata->name, std::move(impl)));
+  }
+  return ret;
+}
+
+#endif  // USE_TRITON_KERNEL
+
+}  // namespace rocm
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description
Here add a GroupGemm operator.

As defined in contrib_defs.cc, this operator has some difference between original Gemm op, here is an image to show it.

![image](https://github.com/microsoft/onnxruntime/assets/109063327/637f49ca-bc6f-49fa-89fa-9650ae9289df)

The GroupedGemm op computes multiple matmul, for each matrix of `i`: `Y[i] = A[i] * B[i] + C[i]`. As shown in above image, each matrix with same color do a matmul.

`A` contains multi-matrix, each has same K dim, and the M dim may be different. M is described by `msizes` argument. So, I add an additional tensor argument `msizes`, it is a tensor with each element is the size of M dim for matrix `A`.

`B` is a large matrix that contains multi-matrix too, but each has same `N` and `K` dim.

`C` is optional, it has multiple matrix with each is broadcastable to `Y[i]`. It's shape is `(1,N) or `(M[i], N)`.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


