### PR TITLE
[ROCm] fix shell bug

### DIFF
--- a/tools/ci_build/github/pai/pai_huggingface_bert_large_test.sh
+++ b/tools/ci_build/github/pai/pai_huggingface_bert_large_test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 rocm_version=$1
-mi200_gpus=$(rocm-smi --showproductname | grep -c "MI250")
+mi200_gpus=$(rocm-smi --showproductname | grep -c "MI250" | xargs)
 
 echo "mi200_gpus: $mi200_gpus"
 


### PR DESCRIPTION
`set -ex` with `grep` will exit when grep doesn't meet any string.



