### PR TITLE
Fix builds

### DIFF
--- a/onnxruntime/contrib_ops/cpu/tensor/shrunken_gather.cc
+++ b/onnxruntime/contrib_ops/cpu/tensor/shrunken_gather.cc
@@ -37,7 +37,7 @@ void ShrunkenGatherCommon::CheckInput(const Tensor* input_tensor, const Tensor* 
   auto axis = HandleNegativeAxis(axis_in, narrow<int64_t>(input_rank));
 
   const int64_t N = indices_shape.Size();
-  const int64_t indices_max = input_shape[axis];
+  const int64_t indices_max = input_shape[gsl::narrow_cast<size_t>(axis)];
   ORT_ENFORCE(indices_max >= N, "ShrunkenGather indices elem count should <= input dim on axis: ", axis,
               ", got indices elem count:", N, " input dim: ", indices_max);
 }

--- a/onnxruntime/core/optimizer/initializer.h
+++ b/onnxruntime/core/optimizer/initializer.h
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "core/common/common.h"
+#include "core/common/narrow.h"
 #include "core/common/path.h"
 #include "core/framework/allocator.h"
 #include "core/optimizer/graph_transformer.h"
@@ -70,7 +71,7 @@ class Initializer final {
     return data_.Shape().GetDims();
   }
 
-  int64_t size() const { return data_.Shape().Size(); }
+  size_t size() const { return narrow<size_t>(data_.Shape().Size()); }
 
 #if !defined(ORT_EXTENDED_MINIMAL_BUILD)
   Initializer& add(float value);

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -99,7 +99,7 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph) {
   Initializer w_temp(*weight_tensor_proto, graph.ModelPath());
   {
     int8_t* p = w_temp.data<int8_t>();
-    for (int i = 0; i < w_temp.size(); i++) {
+    for (size_t i = 0; i < w_temp.size(); i++) {
       if (*p < -64 || *p > 64) {
         should_convert = true;
       }
@@ -111,7 +111,7 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph) {
   Initializer r_temp(*r_tensor_proto, graph.ModelPath());
   {
     int8_t* p = r_temp.data<int8_t>();
-    for (int i = 0; i < r_temp.size(); i++) {
+    for (size_t i = 0; i < r_temp.size(); i++) {
       if (*p < -64 || *p > 64) {
         should_convert = true;
       }

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
@@ -50,7 +50,7 @@ inline bool Int8TensorProto2Uint8(
   Initializer temp(*src, graph.ModelPath());
   int8_t* p = temp.data<int8_t>();
   bool should_convert = false;
-  for (int i = 0; i < temp.size(); i++) {
+  for (size_t i = 0; i < temp.size(); i++) {
     if (*p < -64 || *p > 64) {
       should_convert = true;
     }

--- a/onnxruntime/core/optimizer/utils.cc
+++ b/onnxruntime/core/optimizer/utils.cc
@@ -180,7 +180,7 @@ bool AppendTensorFromInitializer(const Graph& graph, const NodeArg& input_arg, I
   } else if (data_type == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
     const int32_t* val = init_const.data<int32_t>();
     data.reserve(data.size() + gsl::narrow<size_t>(init_const.size()));
-    for (int64_t i = 0; i < init_const.size(); i++) {
+    for (size_t i = 0; i < init_const.size(); i++) {
       data.push_back(static_cast<int64_t>(val[i]));
     }
   } else {

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -351,7 +351,8 @@ class PosixEnv : public Env {
       sleep_time.tv_nsec = 0;
 
       if (micros >= OneMillion) {
-        sleep_time.tv_sec = std::min<int64_t>(micros / OneMillion, std::numeric_limits<time_t>::max());
+        sleep_time.tv_sec = static_cast<time_t>(std::min<int64_t>(micros / OneMillion,
+                                                                  std::numeric_limits<time_t>::max()));
         micros -= static_cast<int64_t>(sleep_time.tv_sec) * OneMillion;
       }
       if (micros < OneMillion) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/batchnorm_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/batchnorm_op_builder.cc
@@ -85,7 +85,7 @@ Status BatchNormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_bu
   auto mean_data = unpacked_mean_tensor.DataAsSpan<float>();
   auto var_data = unpacked_var_tensor.DataAsSpan<float>();
 
-  for (int64_t i = 0; i < size; i++) {
+  for (uint32_t i = 0; i < size; i++) {
     a.push_back(scale_data[i] / sqrt(var_data[i] + eps));
     b.push_back((scale_data[i] * -mean_data[i]) / sqrt(var_data[i] + eps) +
                 bias_data[i]);

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/pad_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/pad_op_builder.cc
@@ -161,7 +161,7 @@ bool PadOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, c
     const ONNX_NAMESPACE::TensorProto& pads_initializer = *pads_initializer_it->second;
     Initializer unpacked_tensor(pads_initializer);
     auto tensor_data = unpacked_tensor.DataAsSpan<int64_t>();
-    for (int64_t i = 0; i < unpacked_tensor.size(); i++) {
+    for (size_t i = 0; i < unpacked_tensor.size(); i++) {
       if (tensor_data[i] < 0) {
         LOGS_DEFAULT(VERBOSE) << "Negative pad value is not supported: pads["
                               << i << "] = " << tensor_data[i];

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder_helpers.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/op_builder_helpers.cc
@@ -736,7 +736,7 @@ Status GetConvMatMulOpQuantizationScaleAndZeroPoint(
   // We need to copy the 1d scales array for per-channel quantization
   Initializer unpacked_tensor(scale_tensor);
   auto scales = unpacked_tensor.DataAsSpan<float>();
-  const size_t scales_size = scale_tensor.dims().empty() ? 1 : scale_tensor.dims()[0];
+  const size_t scales_size = scale_tensor.dims().empty() ? 1 : narrow<size_t>(scale_tensor.dims()[0]);
   std::vector<float> scales_vec(scales.begin(), scales.begin() + scales_size);
   w_scales = onnxruntime::make_optional(std::move(scales_vec));
 
@@ -1182,7 +1182,7 @@ bool IsQuantizationZeroPointSupported(const InitializedTensorSet& initializers,
     Initializer unpacked_tensor(zero_tensor, model_path);
     // Verify all onnx weight zero point(s) are 0(s)
     auto zero_points = unpacked_tensor.DataAsSpan<int8_t>();
-    for (int64_t i = 0; i < unpacked_tensor.size(); i++) {
+    for (size_t i = 0; i < unpacked_tensor.size(); i++) {
       if (zero_points[i] != 0) {
         LOGS_DEFAULT(VERBOSE) << "u8s8 Qlinear[Conv/MatMul]  only support 0 as zero point, "
                               << "zero_points[" << i << "] has value: " << zero_points[i];

--- a/onnxruntime/core/providers/xnnpack/detail/utils.cc
+++ b/onnxruntime/core/providers/xnnpack/detail/utils.cc
@@ -356,7 +356,7 @@ TensorQuantType GetTensorQuantType(const NodeUnit& node_unit, int32_t io_index,
         if (zero_tensor != nullptr) {
           Initializer zp_val(*zero_tensor, node_unit.ModelPath());
           auto zero_points = zp_val.DataAsSpan<int8_t>();
-          for (int64_t i = 0; i < zp_val.size(); i++) {
+          for (size_t i = 0; i < zp_val.size(); i++) {
             if (zero_points[i] != 0) {
               LOGS_DEFAULT(VERBOSE) << "only support 0 as zero point for per-channel quantization, "
                                     << "zero_points[" << i << "] has value: " << zero_points[i];

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -902,7 +902,7 @@ TEST_F(GraphTransformationTests, ConstantFoldingAShapeNodeDeepInTheGraph) {
   // removes all its ancestors and the Identity node consuming this Shape's
   // output is subsequently constant folded to leave the graph with no
   // nodes.
-  ASSERT_TRUE(op_to_count.size() == 0);
+  ASSERT_TRUE(op_to_count.size() == 0U);
 }
 
 // Check transformations in the case of a subgraph with constant inputs.
@@ -2621,7 +2621,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionTest) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 4);
+      EXPECT_EQ(initializer->size(), 4U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2657,7 +2657,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionOneConstTest) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2692,7 +2692,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionInternalNodeIsOutput) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2728,7 +2728,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionInternalReuseTest) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 5);
+      EXPECT_EQ(initializer->size(), 5U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2787,7 +2787,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerSubgrap
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 1);
@@ -2820,7 +2820,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionMultipleValuesInInitializerApplies
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 1);
@@ -2890,7 +2890,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphMultipleOutputs) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2924,7 +2924,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraph) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -2958,7 +2958,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionWithSlice1) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -3028,7 +3028,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithDiv) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -3064,7 +3064,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionConcatSubgraphWithMul) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 3);
+      EXPECT_EQ(initializer->size(), 3U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -3098,7 +3098,7 @@ TEST_F(GraphTransformationTests, ReshapeFusionDistilBertTest) {
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_INT64);
-      EXPECT_EQ(initializer->size(), 4);
+      EXPECT_EQ(initializer->size(), 4U);
 
       const int64_t* val = initializer->data<int64_t>();
       EXPECT_EQ(val[0], 0);
@@ -3238,7 +3238,7 @@ static void ValidateAttention(Graph& graph) {
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
-      EXPECT_EQ(initializer->size(), 192);
+      EXPECT_EQ(initializer->size(), 192U);
 
       // Validate two rows (2x24 items) for sanity check.
       std::vector<double> expected_value = {
@@ -3302,7 +3302,7 @@ static void ValidateAttention(Graph& graph) {
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
       auto initializer2 = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
-      EXPECT_EQ(initializer2->size(), 24);
+      EXPECT_EQ(initializer2->size(), 24U);
 
       std::vector<double> expected_value2 = {
           -0.23681640625,
@@ -5534,7 +5534,7 @@ TEST_F(GraphTransformationTests, ConstantSharing_ShareFloatOrHalfTypedInitialize
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         int32_t data_type = tensor_proto->data_type();
         onnxruntime::Initializer float_const{*tensor_proto, graph.ModelPath()};
-        TEST_RETURN_IF_NOT(float_const.size() == 1);
+        TEST_RETURN_IF_NOT(float_const.size() == 1U);
         float float_const_value;
         if (data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
           float_const_value = math::halfToFloat(float_const.data<MLFloat16>()->val);
@@ -5657,7 +5657,7 @@ TEST_F(GraphTransformationTests, ConstantSharing_Share2DFloatOrHalfTypedInitiali
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         int32_t data_type = tensor_proto->data_type();
         onnxruntime::Initializer float_const{*tensor_proto, graph.ModelPath()};
-        TEST_RETURN_IF_NOT(float_const.size() == 8);
+        TEST_RETURN_IF_NOT(float_const.size() == 8U);
         for (int i = 0; i < 8; ++i) {
           float float_const_value;
           if (data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
@@ -5764,12 +5764,12 @@ TEST_F(GraphTransformationTests, ConstantSharing_ShareFloatAndHalfTypedInitializ
       int32_t data_type = tensor_proto->data_type();
       onnxruntime::Initializer float_const{*tensor_proto, graph.ModelPath()};
       if (entry.first.compare(mul_initializer->Name()) == 0) {
-        TEST_RETURN_IF_NOT(float_const.size() == 1);
+        TEST_RETURN_IF_NOT(float_const.size() == 1U);
         TEST_RETURN_IF_NOT(data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
         float float_const_value = *(float_const.data<float>());
         TEST_RETURN_IF_NOT(float_const_value == 1.0f);
       } else if (entry.first.compare(add_initializer->Name()) == 0) {
-        TEST_RETURN_IF_NOT(float_const.size() == 1);
+        TEST_RETURN_IF_NOT(float_const.size() == 1U);
         TEST_RETURN_IF_NOT(data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
         float float_const_value = math::halfToFloat(float_const.data<MLFloat16>()->val);
         TEST_RETURN_IF_NOT(float_const_value == 1.0f);
@@ -5892,7 +5892,7 @@ TEST_F(GraphTransformationTests, ConstantSharing_Share2DFloatAndHalfTypedInitial
       const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
       int32_t data_type = tensor_proto->data_type();
       onnxruntime::Initializer float_const{*tensor_proto, graph.ModelPath()};
-      TEST_RETURN_IF_NOT(float_const.size() == 8);
+      TEST_RETURN_IF_NOT(float_const.size() == 8U);
       if (entry.first.compare(mul_initializer->Name()) == 0) {
         TEST_RETURN_IF_NOT(data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
         for (int i = 0; i < 8; ++i) {
@@ -6030,13 +6030,13 @@ TEST_F(GraphTransformationTests, ConstantSharing_ShareIntMaxOrFloatInfinityIniti
       if (entry.first.compare(mul_initializer->Name()) == 0) {
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         onnxruntime::Initializer int64_const{*tensor_proto, graph.ModelPath()};
-        TEST_RETURN_IF_NOT(int64_const.size() == 1);
+        TEST_RETURN_IF_NOT(int64_const.size() == 1U);
         int64_t int64_const_value = *(int64_const.data<int64_t>());
         TEST_RETURN_IF_NOT(int64_const_value == std::numeric_limits<int64_t>::max());
       } else if (entry.first.compare(sub_initializer->Name()) == 0) {
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         onnxruntime::Initializer float_const{*tensor_proto, graph.ModelPath()};
-        TEST_RETURN_IF_NOT(float_const.size() == 1);
+        TEST_RETURN_IF_NOT(float_const.size() == 1U);
         float float_const_value = *(float_const.data<float>());
         TEST_RETURN_IF_NOT(float_const_value == std::numeric_limits<float>::infinity());
       }
@@ -6129,13 +6129,13 @@ TEST_F(GraphTransformationTests, ConstantSharing_ShouldNotShareForGraphOutput) {
       if (entry.first.compare("y_scale") == 0) {
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         onnxruntime::Initializer int64_const{*tensor_proto, graph.ModelPath()};
-        ASSERT_TRUE(int64_const.size() == 1);
+        ASSERT_TRUE(int64_const.size() == 1U);
         float float_const_value = *(int64_const.data<float>());
         ASSERT_TRUE(float_const_value == 1);
       } else {
         const ONNX_NAMESPACE::TensorProto* tensor_proto = entry.second;
         onnxruntime::Initializer uint8_const{*tensor_proto, graph.ModelPath()};
-        ASSERT_TRUE(uint8_const.size() == 1);
+        ASSERT_TRUE(uint8_const.size() == 1U);
         uint8_t uint8_const_value = *(uint8_const.data<uint8_t>());
         ASSERT_TRUE(uint8_const_value == static_cast<uint8_t>(1));
       }

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -766,7 +766,7 @@ static void EmbedLayerNormFusionFormat5(const std::basic_string<ORTCHAR_T>& file
       EXPECT_EQ(tensor_proto->data_type(), ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
       auto initializer = std::make_unique<Initializer>(*tensor_proto, graph.ModelPath());
-      EXPECT_EQ(initializer->size(), 12);
+      EXPECT_EQ(initializer->size(), 12U);
 
       std::vector<double> expected_value = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 8.0, 7.0, 6.0};
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -1927,7 +1927,7 @@ TEST(CApiTest, create_tensor) {
   auto shape_info = tensor.GetTensorTypeAndShapeInfo();
 
   const auto len = shape_info.GetElementCount();
-  ASSERT_EQ(len, expected_len);
+  ASSERT_EQ(len, static_cast<size_t>(expected_len));
   std::vector<int64_t> shape_array(len);
 
   size_t data_len = tensor.GetStringTensorDataLength();
@@ -1951,7 +1951,7 @@ TEST(CApiTest, fill_string_tensor) {
   auto shape_info = tensor.GetTensorTypeAndShapeInfo();
 
   const auto len = shape_info.GetElementCount();
-  ASSERT_EQ(len, expected_len);
+  ASSERT_EQ(len, static_cast<size_t>(expected_len));
 }
 
 TEST(CApiTest, fill_string_tensor_directly) {
@@ -1968,8 +1968,8 @@ TEST(CApiTest, fill_string_tensor_directly) {
   }
 
   auto shape_info = tensor.GetTensorTypeAndShapeInfo();
-  int64_t len = shape_info.GetElementCount();
-  ASSERT_EQ(len, expected_len);
+  const auto len = shape_info.GetElementCount();
+  ASSERT_EQ(len, static_cast<size_t>(expected_len));
 
   for (size_t i = 0; i < expected_len; i++) {
     auto element = tensor.GetStringTensorElement(i);

--- a/onnxruntime/test/shared_lib/test_model_loading.cc
+++ b/onnxruntime/test/shared_lib/test_model_loading.cc
@@ -3,6 +3,7 @@
 
 #include "core/session/onnxruntime_cxx_api.h"
 #include "onnxruntime_session_options_config_keys.h"
+#include "core/common/narrow.h"
 #include "test/util/include/asserts.h"
 #include <fstream>
 #include "test_fixture.h"
@@ -24,7 +25,7 @@ TEST(CApiTest, model_from_array) {
     std::ifstream file(model_path, std::ios::binary | std::ios::ate);
     if (!file)
       ORT_THROW("Error reading model");
-    buffer.resize(file.tellg());
+    buffer.resize(narrow<size_t>(file.tellg()));
     file.seekg(0, std::ios::beg);
     if (!file.read(buffer.data(), buffer.size()))
       ORT_THROW("Error reading model");

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -351,7 +351,7 @@ TEST(CApiTest, SparseTensorUsingAPI) {
 
     {
       const auto* values = coo_st.GetSparseTensorValues<int32_t>();
-      auto val_span = gsl::make_span(values, values_shape[0]);
+      auto val_span = gsl::make_span(values, gsl::narrow_cast<size_t>(values_shape[0]));
       ASSERT_TRUE(std::equal(expected_values.cbegin(), expected_values.cend(), val_span.begin(), val_span.end()));
     }
 
@@ -537,7 +537,7 @@ TEST(CApiTest, SparseTensorFillSparseTensorFormatAPI) {
 
     {
       const auto* values = coo_st.GetSparseTensorValues<int32_t>();
-      auto val_span = gsl::make_span(values, values_shape[0]);
+      auto val_span = gsl::make_span(values, gsl::narrow_cast<size_t>(values_shape[0]));
       ASSERT_TRUE(std::equal(expected_values.cbegin(), expected_values.cend(), val_span.begin(), val_span.end()));
     }
 
@@ -811,7 +811,7 @@ TEST(CApiTest, SparseTensorFillSparseFormatStringsAPI) {
       /// XXX: Do something about this API.
       /// Need to add N + 1 terminating offset, or skip the first zero offset
       /// altogether and add the N + 1
-      csr_st.GetStringTensorContent(buffer.get(), data_len, offsets.get(), values_len);
+      csr_st.GetStringTensorContent(buffer.get(), data_len, offsets.get(), gsl::narrow_cast<size_t>(values_len));
       for (size_t i = 0, limit = expected_values.size(); i < limit; ++i) {
         const auto& ex = expected_values[i];
         const char* p = &buffer[offsets[i]];

--- a/orttraining/orttraining/core/optimizer/megatron_transformer.cc
+++ b/orttraining/orttraining/core/optimizer/megatron_transformer.cc
@@ -960,7 +960,7 @@ Status MegatronTransformer::TransformBARTAttention(Graph& graph, bool& modified,
     return skip_status;
   }
   // map between reshape node and dim of reshape that must be modified
-  std::unordered_map<Node*, int64_t> reshape_node_ptrs;
+  std::unordered_map<Node*, size_t> reshape_node_ptrs;
   reshape_node_ptrs[sub_graph_node_ptrs[sub_graph_node_ptrs.size() - 16]] = 1;
   reshape_node_ptrs[sub_graph_node_ptrs[sub_graph_node_ptrs.size() - 12]] = 1;
   reshape_node_ptrs[sub_graph_node_ptrs[sub_graph_node_ptrs.size() - 10]] = 0;
@@ -1054,7 +1054,7 @@ Status MegatronTransformer::TransformBARTAttention(Graph& graph, bool& modified,
   bool is_reshape_valid = true;
   for (auto x : reshape_node_ptrs) {
     Node* node_ptr = x.first;
-    int64_t idx = x.second;
+    auto idx = x.second;
     auto shape_arg = node_ptr->MutableInputDefs()[1];
     const ONNX_NAMESPACE::TensorProto* tensor;
     if (!graph.GetInitializedTensor(shape_arg->Name(), tensor)) {

--- a/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/activation/activations_grad.cc
@@ -148,7 +148,8 @@ Status BiasGeluGrad_dX<T, GeluComputationMode>::Compute(OpKernelContext* context
   auto* dX = context->Output(0, input_shape);
   ORT_ENFORCE(dX);
 
-  const auto input_size = input_shape.Size(), bias_size = bias_shape.Size();
+  const auto input_size = narrow<Eigen::Index>(input_shape.Size()),
+             bias_size = narrow<Eigen::Index>(bias_shape.Size());
 
   // X + B, broadcasting
   AllocatorPtr allocator;
@@ -163,7 +164,7 @@ Status BiasGeluGrad_dX<T, GeluComputationMode>::Compute(OpKernelContext* context
   X_plus_B_array = X_array.colwise() + B_vector;
 
   // dX
-  const auto biased_X_span = gsl::make_span<const T>(X_plus_B_buffer.get(), X->Shape().Size());
+  const auto biased_X_span = gsl::make_span<const T>(X_plus_B_buffer.get(), narrow<size_t>(X->Shape().Size()));
   ORT_RETURN_IF_ERROR((ComputeGeluGradDX<T>(
       dY->template DataAsSpan<T>(), biased_X_span, dX->template MutableDataAsSpan<T>(),
       GeluComputationMode{})));

--- a/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
+++ b/orttraining/orttraining/training_ops/cpu/loss/cross_entropy.cc
@@ -69,7 +69,7 @@ Status SoftmaxCrossEntropy<T>::Compute(OpKernelContext* context) const {
   int64_t D = logit_shape[logit_shape.NumDimensions() - 1];
   const int n = gsl::narrow_cast<int>(N);
   const int d = gsl::narrow_cast<int>(D);
-  const uint64_t nd = N * D;
+  const ptrdiff_t nd = narrow<ptrdiff_t>(N * D);
 
   Tensor* loss = context->Output(0, TensorShape({}));
   Tensor* log_prob = context->Output(1, logit_shape);
@@ -85,8 +85,7 @@ Status SoftmaxCrossEntropy<T>::Compute(OpKernelContext* context) const {
   // where shifted_logit = logit - max_logit
   // along classes
 
-  ORT_ENFORCE(nd <= static_cast<uint64_t>(std::numeric_limits<Eigen::Index>::max()));
-  ComputeShareSoftmaxCrossEntropyCPU(n, d, static_cast<Eigen::Index>(nd),
+  ComputeShareSoftmaxCrossEntropyCPU(n, d, nd,
                                      logit_data,
                                      shifted_logit.data(),
                                      log_prob_data);
@@ -182,7 +181,7 @@ Status SparseSoftmaxCrossEntropy<T>::Compute(OpKernelContext* context) const {
   int64_t D = logit_shape[logit_shape.NumDimensions() - 1];
   const int n = gsl::narrow_cast<int>(N);
   const int d = gsl::narrow_cast<int>(D);
-  const uint64_t nd = N * D;
+  const ptrdiff_t nd = narrow<ptrdiff_t>(N * D);
 
   Tensor* loss = context->Output(0, TensorShape({}));
   Tensor* log_prob = context->Output(1, logit_shape);
@@ -195,8 +194,7 @@ Status SparseSoftmaxCrossEntropy<T>::Compute(OpKernelContext* context) const {
   // computation begins here
   std::vector<float> shifted_logit(nd);
 
-  ORT_ENFORCE(nd <= static_cast<uint64_t>(std::numeric_limits<Eigen::Index>::max()));
-  ComputeShareSoftmaxCrossEntropyCPU(n, d, static_cast<Eigen::Index>(nd), logit_data,
+  ComputeShareSoftmaxCrossEntropyCPU(n, d, nd, logit_data,
                                      shifted_logit.data(),
                                      log_prob_data);
 

--- a/orttraining/orttraining/training_ops/cpu/nn/batch_norm_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/batch_norm_grad.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "orttraining/training_ops/cpu/nn/batch_norm_grad.h"
+#include "core/common/narrow.h"
 #include "core/util/math_cpuonly.h"
 #include "core/framework/op_kernel_context_internal.h"
 #include "core/providers/cpu/nn/batch_norm_helper.h"
@@ -34,11 +35,11 @@ Status BatchNormalizationGrad<T>::Compute(OpKernelContext* ctx) const {
   auto* dBias_data = ctx->Output(2, channel_shape)->template MutableData<T>();
 
   const auto& dims_vec = X_shape.GetDims();
-  const size_t N = dims_vec[0];
-  const size_t C = dims_vec[1];  // assume NCHW as per the spec
+  const size_t N = narrow<size_t>(dims_vec[0]);
+  const size_t C = narrow<size_t>(dims_vec[1]);  // assume NCHW as per the spec
 
   // calculate sample_size (per individual channel)
-  size_t sample_size = X_shape.SizeFromDimension(2);
+  size_t sample_size = narrow<size_t>(X_shape.SizeFromDimension(2));
   size_t scale_tensor_size = C;
 
   ConstEigenVectorArrayMap<T> scale_arr(scale_data, scale_tensor_size);

--- a/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/conv_grad.cc
@@ -16,6 +16,7 @@
 /* Modifications Copyright (c) Microsoft. */
 
 #include "orttraining/training_ops/cpu/nn/conv_grad.h"
+#include "core/common/narrow.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
 
@@ -72,23 +73,24 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
   AllocatorPtr alloc;
   ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
 
-  BufferUniquePtr col_buffer(alloc->Alloc(sizeof(T) * col_buffer_size), BufferDeleter(alloc));
+  BufferUniquePtr col_buffer(alloc->Alloc(narrow<size_t>(sizeof(T) * col_buffer_size)), BufferDeleter(alloc));
   T* col_buffer_data = static_cast<T*>(col_buffer.get());
 
   const T* Xdata = X->template Data<T>();
   const T* Wdata = W->template Data<T>();
   const T* dYdata = dY->template Data<T>();
 
-  BufferUniquePtr bias_multiplier(alloc->Alloc(sizeof(T) * output_image_size), BufferDeleter(alloc));
+  BufferUniquePtr bias_multiplier(alloc->Alloc(narrow<size_t>(sizeof(T) * output_image_size)), BufferDeleter(alloc));
   T* bias_multiplier_data = nullptr;
   Tensor* dB = context->Output(2, {M});
   T* dBdata = nullptr;
   if (dB) {
     dBdata = dB->template MutableData<T>();
-    math::Set<T, CPUMathUtil>(dB->Shape().Size(), static_cast<T>(0), dBdata, &CPUMathUtil::Instance());
+    math::Set<T, CPUMathUtil>(narrow<ptrdiff_t>(dB->Shape().Size()),
+                              static_cast<T>(0), dBdata, &CPUMathUtil::Instance());
 
     bias_multiplier_data = static_cast<T*>(bias_multiplier.get());
-    math::Set<T, CPUMathUtil>(output_image_size,
+    math::Set<T, CPUMathUtil>(narrow<ptrdiff_t>(output_image_size),
                               static_cast<T>(1),
                               bias_multiplier_data,
                               &CPUMathUtil::Instance());
@@ -98,7 +100,7 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
   if (dW) {
     dWdata = dW->template MutableData<T>();
     // Pre-setting the gradients to zero.
-    math::Set<T, CPUMathUtil>(dW->Shape().Size(), 0, dWdata, &CPUMathUtil::Instance());
+    math::Set<T, CPUMathUtil>(narrow<ptrdiff_t>(dW->Shape().Size()), 0, dWdata, &CPUMathUtil::Instance());
   }
 
   bool skip_im2col = (kernel_size == 1) && conv_attrs_.HasStridesOneAndNoPadding();
@@ -159,9 +161,9 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
         math::Gemm<T>(
             CblasNoTrans,
             CblasTrans,
-            M / conv_attrs_.group,
-            kernel_dim,
-            output_image_size,
+            narrow<ptrdiff_t>(M / conv_attrs_.group),
+            narrow<ptrdiff_t>(kernel_dim),
+            narrow<ptrdiff_t>(output_image_size),
             1,
             dYdata + group_id * Y_offset,
             skip_im2col ? Xdata + group_id * X_offset : col_buffer_data,
@@ -197,9 +199,9 @@ Status ConvGrad<T>::Compute(OpKernelContext* context) const {
         math::Gemm<T>(
             CblasTrans,
             CblasNoTrans,
-            kernel_dim,
-            output_image_size,
-            M / conv_attrs_.group,
+            narrow<ptrdiff_t>(kernel_dim),
+            narrow<ptrdiff_t>(output_image_size),
+            narrow<ptrdiff_t>(M / conv_attrs_.group),
             1,
             Wdata + group_id * W_offset,
             dYdata,

--- a/orttraining/orttraining/training_ops/cpu/nn/dropout_7.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/dropout_7.cc
@@ -35,7 +35,7 @@ Status Dropout_7::Compute(OpKernelContext* context) const {
     void* target = Y.MutableDataRaw(X_type);
     if (target != source) {
       // If source and target pointers are not equal, we need to copy the data.
-      memcpy(target, source, shape.Size() * X_type->Size());
+      memcpy(target, source, X.SizeInBytes());
     }
   } else {
     float scale = 1.0f / keep_prob_;

--- a/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
+++ b/orttraining/orttraining/training_ops/cpu/nn/layer_norm.cc
@@ -49,10 +49,10 @@ Status LayerNormGrad<T, simplified>::Compute(OpKernelContext* op_kernel_context)
   const Tensor* X = op_kernel_context->Input<Tensor>(input_index++);
   const auto& X_shape = X->Shape();
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
-  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
-  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(axis));
-  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(axis));
+  ORT_ENFORCE(X_shape.SizeToDimension(gsl::narrow_cast<size_t>(axis)) <= std::numeric_limits<Eigen::Index>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis)) <= std::numeric_limits<Eigen::Index>::max());
+  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(gsl::narrow_cast<size_t>(axis)));
+  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis)));
   ORT_ENFORCE(M != 1);
 
   const Tensor* scale = op_kernel_context->Input<Tensor>(input_index++);
@@ -139,10 +139,10 @@ Status InvertibleLayerNormGrad<T>::Compute(OpKernelContext* op_kernel_context) c
   const auto& Y_shape = Y_grad->Shape();
   const auto& X_shape = Y_shape;
   const auto axis = HandleNegativeAxis(axis_, X_shape.NumDimensions());
-  ORT_ENFORCE(X_shape.SizeToDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
-  ORT_ENFORCE(X_shape.SizeFromDimension(axis) <= std::numeric_limits<Eigen::Index>::max());
-  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(axis));
-  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(axis));
+  ORT_ENFORCE(X_shape.SizeToDimension(gsl::narrow_cast<size_t>(axis)) <= std::numeric_limits<Eigen::Index>::max());
+  ORT_ENFORCE(X_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis)) <= std::numeric_limits<Eigen::Index>::max());
+  const auto N = static_cast<Eigen::Index>(X_shape.SizeToDimension(gsl::narrow_cast<size_t>(axis)));
+  const auto M = static_cast<Eigen::Index>(X_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis)));
   ORT_ENFORCE(M != 1);
   const auto& scale_shape = scale->Shape();
 

--- a/orttraining/orttraining/training_ops/cpu/optimizer/gradient_control.cc
+++ b/orttraining/orttraining/training_ops/cpu/optimizer/gradient_control.cc
@@ -64,7 +64,7 @@ Status ZeroGradient<T>::Compute(OpKernelContext* context) const {
   const Tensor& old_gradient = *context->Input<Tensor>(0);
   Tensor& zero_gradient = *context->Output(0, old_gradient.Shape());
 
-  std::memset(zero_gradient.template MutableData<T>(), 0, zero_gradient.Shape().Size() * sizeof(T));
+  std::memset(zero_gradient.template MutableData<T>(), 0, zero_gradient.SizeInBytes());
   return Status::OK();
 }
 

--- a/orttraining/orttraining/training_ops/cpu/quantization/fake_quant.cc
+++ b/orttraining/orttraining/training_ops/cpu/quantization/fake_quant.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "orttraining/training_ops/cpu/quantization/fake_quant.h"
+#include "core/common/narrow.h"
 #include "core/providers/common.h"
 #include "core/providers/cpu/math/element_wise_ops.h"
 
@@ -17,7 +18,7 @@ void FakeQuantPerTensor(OpKernelContext* ctx, const int64_t num_elements, const 
   const auto zero_point_int = static_cast<int64_t>(quant_zero_point);
   auto* tp = ctx->GetOperatorThreadPool();
   concurrency::ThreadPool::TryParallelFor(
-      tp, num_elements, /* 1 Read, 2 Writes, 4 Computes */ TensorOpCost{1.0, 2.0, 4.0},
+      tp, narrow<ptrdiff_t>(num_elements), /* 1 Read, 2 Writes, 4 Computes */ TensorOpCost{1.0, 2.0, 4.0},
       [quant_scale, zero_point_int, quant_min, quant_max, &input_data, &fake_quantized_data, &quantization_mask_data](
           std::ptrdiff_t begin, std::ptrdiff_t end) {
         for (std::ptrdiff_t index = begin; index != end; ++index) {

--- a/orttraining/orttraining/training_ops/cpu/tensor/concat.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/concat.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "orttraining/training_ops/cpu/tensor/concat.h"
+#include "core/common/narrow.h"
 #include "core/providers/common.h"
 #include "core/framework/TensorSeq.h"
 
@@ -44,7 +45,7 @@ Status ConcatTraining::Compute(OpKernelContext* ctx) const {
   if (per_input_length_tensor) {
     int64_t* per_input_length = per_input_length_tensor->template MutableData<int64_t>();
     for (int i = 0; i < input_count; ++i) {
-      per_input_length[i] = input_tensors[i]->Shape()[p.axis];
+      per_input_length[i] = input_tensors[i]->Shape()[narrow<size_t>(p.axis)];
     }
   }
   // Compute values to be placed in the output tensor

--- a/orttraining/orttraining/training_ops/cpu/tensor/gather_elements_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/gather_elements_grad.cc
@@ -34,7 +34,7 @@ ONNX_OPERATOR_KERNEL_EX(
 Status GatherElementsGrad::Compute(OpKernelContext* context) const {
   const auto* dY = context->Input<Tensor>(0);
   const Tensor* shape = context->Input<Tensor>(1);
-  const TensorShape data_shape(shape->template Data<int64_t>(), shape->Shape().Size());
+  const TensorShape data_shape(shape->template DataAsSpan<int64_t>());
 
   const int axis = static_cast<int>(HandleNegativeAxis(axis_, data_shape.NumDimensions()));
 

--- a/orttraining/orttraining/training_ops/cpu/tensor/gather_nd_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/gather_nd_grad.cc
@@ -24,12 +24,12 @@ ONNX_OPERATOR_KERNEL_EX(GatherNDGrad, kMSDomain, 1, kCpuExecutionProvider,
 template <typename InputT>
 struct GatherNDGradComputeImpl {
   void operator()(GatherNDBase::Prepare& p, const Tensor* update_tensor) const {
-    const int64_t grad_size = update_tensor->Shape().Size();
-    const int64_t slice_size = p.element_count_per_slice;
+    const size_t grad_size = narrow<size_t>(update_tensor->Shape().Size());
+    const size_t slice_size = narrow<size_t>(p.element_count_per_slice);
     const InputT* input_base_casted = reinterpret_cast<const InputT*>(p.input_base);
     InputT* output_base_casted = reinterpret_cast<InputT*>(p.output_base);
 
-    for (int64_t i = 0; i < grad_size; i++) {
+    for (size_t i = 0; i < grad_size; i++) {
       uint64_t slice_offset = p.slice_offsets[i / slice_size];
       size_t j = i % slice_size;
       output_base_casted[slice_offset + j] += input_base_casted[i];

--- a/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/slice_grad.cc
@@ -24,7 +24,7 @@ ONNX_OPERATOR_KERNEL_EX(
 Status SliceGrad::Compute(OpKernelContext* context) const {
   const Tensor& grad = *context->Input<Tensor>(0);
   const Tensor& shape = *context->Input<Tensor>(1);
-  const TensorShape data_shape(shape.template Data<int64_t>(), shape.Shape().Size());
+  const TensorShape data_shape(shape.template DataAsSpan<int64_t>());
   Tensor& output = *context->Output(0, data_shape);
   memset(output.MutableDataRaw(), 0, output.SizeInBytes());
   // Initialize the starts & ends to the actual tensor shape

--- a/orttraining/orttraining/training_ops/cpu/tensor/split.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split.cc
@@ -26,15 +26,16 @@ Status PrepareForTrainingCompute(const TensorShape& input_shape, int num_outputs
                                  std::vector<int64_t>& split_sizes) {
   auto input_dims = input_shape.GetDims();
   const auto num_dimensions = gsl::narrow_cast<int64_t>(input_shape.NumDimensions());
-  int64_t axis_value = axis;
-  axis = HandleNegativeAxis(axis_value, num_dimensions);  // handle negative and enforce axis is valid
-  const int64_t split_dim_size = input_dims[axis];
+  const int64_t original_axis_value = axis;
+  axis = HandleNegativeAxis(original_axis_value, num_dimensions);  // handle negative and enforce axis is valid
+  const size_t axis_value = gsl::narrow_cast<size_t>(axis);
+  const int64_t split_dim_size = input_dims[axis_value];
 
-  before_dims = narrow<int>(input_shape.SizeToDimension(axis));
-  after_dims_including_split_axis = narrow<int>(input_shape.SizeFromDimension(axis));
-  after_dims_excluding_split = (axis + 1 == num_dimensions)
+  before_dims = narrow<int>(input_shape.SizeToDimension(axis_value));
+  after_dims_including_split_axis = narrow<int>(input_shape.SizeFromDimension(axis_value));
+  after_dims_excluding_split = (axis_value + 1 == num_dimensions)
                                    ? 1  // we multiply by this value so must be 1 not 0
-                                   : narrow<int>(input_shape.SizeFromDimension(axis + 1));
+                                   : narrow<int>(input_shape.SizeFromDimension(axis_value + 1));
 
   std::vector<int64_t> split_sizes_values(split_sizes);
   split_sizes.clear();
@@ -44,7 +45,7 @@ Status PrepareForTrainingCompute(const TensorShape& input_shape, int num_outputs
     // equal split based on number of outputs
     if (split_dim_size % static_cast<size_t>(num_outputs) != 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Input cannot be split evenly on selected axis. Input shape=", input_shape,
-                             " Axis=", axis_value, " NumOutputs=", num_outputs);
+                             " Axis=", original_axis_value, " NumOutputs=", num_outputs);
     }
 
     // populate split_sizes with the same size for each output
@@ -52,7 +53,7 @@ Status PrepareForTrainingCompute(const TensorShape& input_shape, int num_outputs
   } else {
     if (split_sizes_values.size() != static_cast<size_t>(num_outputs) || split_size_sum != split_dim_size) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                             "Cannot split using values in 'split' input. Axis=", axis_value,
+                             "Cannot split using values in 'split' input. Axis=", original_axis_value,
                              " Input shape=", input_shape,
                              " NumOutputs=", num_outputs,
                              " Num entries in 'split' (must equal number of outputs) was ", split_sizes_values.size(),
@@ -127,7 +128,7 @@ Status SplitTraining::ComputeImpl(OpKernelContext& context, const Tensor& input)
   for (int i = 0; i < num_outputs; ++i) {
     // update size of dimension for axis we're splitting on
     auto split_size = narrow<int>(split_sizes[i]);
-    output_dimensions[axis] = split_size;
+    output_dimensions[gsl::narrow_cast<size_t>(axis)] = split_size;
 
     Tensor* output = context.Output(i, TensorShape{output_dimensions});
     T* output_data = output->template MutableData<T>();

--- a/orttraining/orttraining/training_ops/cpu/tensor/split.cc
+++ b/orttraining/orttraining/training_ops/cpu/tensor/split.cc
@@ -28,14 +28,13 @@ Status PrepareForTrainingCompute(const TensorShape& input_shape, int num_outputs
   const auto num_dimensions = gsl::narrow_cast<int64_t>(input_shape.NumDimensions());
   const int64_t original_axis_value = axis;
   axis = HandleNegativeAxis(original_axis_value, num_dimensions);  // handle negative and enforce axis is valid
-  const size_t axis_value = gsl::narrow_cast<size_t>(axis);
-  const int64_t split_dim_size = input_dims[axis_value];
+  const int64_t split_dim_size = input_dims[gsl::narrow_cast<size_t>(axis)];
 
-  before_dims = narrow<int>(input_shape.SizeToDimension(axis_value));
-  after_dims_including_split_axis = narrow<int>(input_shape.SizeFromDimension(axis_value));
-  after_dims_excluding_split = (axis_value + 1 == num_dimensions)
+  before_dims = narrow<int>(input_shape.SizeToDimension(gsl::narrow_cast<size_t>(axis)));
+  after_dims_including_split_axis = narrow<int>(input_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis)));
+  after_dims_excluding_split = (axis + 1 == num_dimensions)
                                    ? 1  // we multiply by this value so must be 1 not 0
-                                   : narrow<int>(input_shape.SizeFromDimension(axis_value + 1));
+                                   : narrow<int>(input_shape.SizeFromDimension(gsl::narrow_cast<size_t>(axis) + 1));
 
   std::vector<int64_t> split_sizes_values(split_sizes);
   split_sizes.clear();

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -46,9 +46,12 @@ class UsageError(BaseError):
 
 
 def _check_python_version():
-    if (sys.version_info.major, sys.version_info.minor) < (3, 7):
+    # TODO Upgrade this, Python 3.6 is no longer supported. However, some packaging pipelines are still using it.
+    required_minor_version = 6
+    if (sys.version_info.major, sys.version_info.minor) < (3, required_minor_version):
         raise UsageError(
-            f"Invalid Python version. At least Python 3.7 is required. Actual Python version: {sys.version}"
+            f"Invalid Python version. At least Python 3.{required_minor_version} is required. "
+            f"Actual Python version: {sys.version}"
         )
 
 

--- a/tools/ci_build/github/pai/pai_huggingface_bert_large_test.sh
+++ b/tools/ci_build/github/pai/pai_huggingface_bert_large_test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 rocm_version=$1
-mi200_gpus=$(rocm-smi --showproductname | grep -c "MI250")
+mi200_gpus=$(rocm-smi --showproductname | grep -c "MI250" | xargs)
 
 echo "mi200_gpus: $mi200_gpus"
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Fix some more `shorten-64-to-32` warnings
- Move minimum build.py Python version back to 3.6

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix builds.
