### PR TITLE
[js/rn] Add test for validating "executionProvider" options

### DIFF
--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -76,26 +76,24 @@ public class OnnxruntimeModuleTest {
 
       // test loadModel()
       {
-        InputStream modelStream =
-            reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
+        try (InputStream modelStream =
+                 reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);) {
+          byte[] modelBuffer = getInputModelBuffer(modelStream);
 
-        byte[] modelBuffer = getInputModelBuffer(modelStream);
+          JavaOnlyMap options = new JavaOnlyMap();
+          try {
+            ReadableMap resultMap = ortModule.loadModel(modelBuffer, options);
+            sessionKey = resultMap.getString("key");
+            ReadableArray inputNames = resultMap.getArray("inputNames");
+            ReadableArray outputNames = resultMap.getArray("outputNames");
 
-        modelStream.close();
-
-        JavaOnlyMap options = new JavaOnlyMap();
-        try {
-          ReadableMap resultMap = ortModule.loadModel(modelBuffer, options);
-          sessionKey = resultMap.getString("key");
-          ReadableArray inputNames = resultMap.getArray("inputNames");
-          ReadableArray outputNames = resultMap.getArray("outputNames");
-
-          Assert.assertEquals(inputNames.size(), 1);
-          Assert.assertEquals(inputNames.getString(0), "input");
-          Assert.assertEquals(outputNames.size(), 1);
-          Assert.assertEquals(outputNames.getString(0), "output");
-        } catch (Exception e) {
-          Assert.fail(e.getMessage());
+            Assert.assertEquals(inputNames.size(), 1);
+            Assert.assertEquals(inputNames.getString(0), "input");
+            Assert.assertEquals(outputNames.size(), 1);
+            Assert.assertEquals(outputNames.getString(0), "output");
+          } catch (Exception e) {
+            Assert.fail(e.getMessage());
+          }
         }
       }
 
@@ -171,17 +169,14 @@ public class OnnxruntimeModuleTest {
       String sessionKey = "";
 
       // test loadModel() with nnapi ep options
-      {
-        InputStream modelStream =
-            reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
+
+      try (InputStream modelStream =
+               reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);) {
 
         byte[] modelBuffer = getInputModelBuffer(modelStream);
 
-        modelStream.close();
-
-        JavaOnlyMap options = new JavaOnlyMap();
-
         // register with nnapi ep options
+        JavaOnlyMap options = new JavaOnlyMap();
         JavaOnlyArray epArray = new JavaOnlyArray();
         epArray.pushString("nnapi");
         options.putArray("executionProviders", epArray);

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -81,6 +81,8 @@ public class OnnxruntimeModuleTest {
 
         byte[] modelBuffer = getInputModelBuffer(modelStream);
 
+        modelStream.close();
+
         JavaOnlyMap options = new JavaOnlyMap();
         try {
           ReadableMap resultMap = ortModule.loadModel(modelBuffer, options);
@@ -174,6 +176,8 @@ public class OnnxruntimeModuleTest {
             reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
 
         byte[] modelBuffer = getInputModelBuffer(modelStream);
+
+        modelStream.close();
 
         JavaOnlyMap options = new JavaOnlyMap();
 

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -34,6 +34,22 @@ public class OnnxruntimeModuleTest {
 
   private FakeBlobModule blobModule;
 
+  private static byte[] getInputModelBuffer(InputStream modelStream) throws Exception {
+    ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
+
+    int bufferSize = 1024;
+    byte[] buffer = new byte[bufferSize];
+
+    int len;
+    while ((len = modelStream.read(buffer)) != -1) {
+      byteBuffer.write(buffer, 0, len);
+    }
+
+    byte[] modelBuffer = byteBuffer.toByteArray();
+
+    return modelBuffer;
+  }
+
   @Before
   public void setUp() {
     blobModule = new FakeBlobModule(reactContext);
@@ -62,17 +78,8 @@ public class OnnxruntimeModuleTest {
       {
         InputStream modelStream =
             reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
-        ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-        int bufferSize = 1024;
-        byte[] buffer = new byte[bufferSize];
-
-        int len;
-        while ((len = modelStream.read(buffer)) != -1) {
-          byteBuffer.write(buffer, 0, len);
-        }
-
-        byte[] modelBuffer = byteBuffer.toByteArray();
+        byte[] modelBuffer = getInputModelBuffer(modelStream);
 
         JavaOnlyMap options = new JavaOnlyMap();
         try {
@@ -144,6 +151,51 @@ public class OnnxruntimeModuleTest {
       }
 
       // test dispose
+      ortModule.dispose(sessionKey);
+    } finally {
+      mockSession.finishMocking();
+    }
+  }
+
+  @Test
+  public void onnxruntime_module_nnapi() throws Exception {
+    MockitoSession mockSession = mockitoSession().mockStatic(Arguments.class).startMocking();
+    try {
+      when(Arguments.createMap()).thenAnswer(i -> new JavaOnlyMap());
+      when(Arguments.createArray()).thenAnswer(i -> new JavaOnlyArray());
+
+      OnnxruntimeModule ortModule = new OnnxruntimeModule(reactContext);
+      ortModule.blobModule = blobModule;
+      String sessionKey = "";
+
+      // test loadModel() with nnapi ep options
+      {
+        InputStream modelStream =
+            reactContext.getResources().openRawResource(ai.onnxruntime.reactnative.test.R.raw.test_types_float);
+
+        byte[] modelBuffer = getInputModelBuffer(modelStream);
+
+        JavaOnlyMap options = new JavaOnlyMap();
+
+        // register with nnapi ep options
+        JavaOnlyArray epArray = new JavaOnlyArray();
+        epArray.pushString("nnapi");
+        options.putArray("executionProviders", epArray);
+
+        try {
+          ReadableMap resultMap = ortModule.loadModel(modelBuffer, options);
+          sessionKey = resultMap.getString("key");
+          ReadableArray inputNames = resultMap.getArray("inputNames");
+          ReadableArray outputNames = resultMap.getArray("outputNames");
+
+          Assert.assertEquals(inputNames.size(), 1);
+          Assert.assertEquals(inputNames.getString(0), "input");
+          Assert.assertEquals(outputNames.size(), 1);
+          Assert.assertEquals(outputNames.getString(0), "output");
+        } catch (Exception e) {
+          Assert.fail(e.getMessage());
+        }
+      }
       ortModule.dispose(sessionKey);
     } finally {
       mockSession.finishMocking();

--- a/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
+++ b/js/react_native/android/src/androidTest/java/ai/onnxruntime/reactnative/OnnxruntimeModuleTest.java
@@ -158,7 +158,7 @@ public class OnnxruntimeModuleTest {
   }
 
   @Test
-  public void onnxruntime_module_nnapi() throws Exception {
+  public void onnxruntime_module_append_nnapi() throws Exception {
     MockitoSession mockSession = mockitoSession().mockStatic(Arguments.class).startMocking();
     try {
       when(Arguments.createMap()).thenAnswer(i -> new JavaOnlyMap());

--- a/js/react_native/ios/OnnxruntimeModuleTest/OnnxruntimeModuleTest.mm
+++ b/js/react_native/ios/OnnxruntimeModuleTest/OnnxruntimeModuleTest.mm
@@ -115,4 +115,36 @@ FakeRCTBlobManager *fakeBlobManager = nil;
   }
 }
 
+- (void)testOnnxruntimeModule_AppendCoreml {
+  NSBundle *bundle = [NSBundle bundleForClass:[OnnxruntimeModuleTest class]];
+  NSString *dataPath = [bundle pathForResource:@"test_types_float" ofType:@"ort"];
+  NSString *sessionKey = @"";
+
+  OnnxruntimeModule *onnxruntimeModule = [OnnxruntimeModule new];
+  [onnxruntimeModule setBlobManager:fakeBlobManager];
+
+  {
+    // test loadModel() with coreml options
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+
+    // register coreml ep options
+    NSMutableArray *epList = [NSMutableArray array];
+    [epList addObject:@"coreml"];
+    NSArray *immutableEpList = [NSArray arrayWithArray:epList];
+    [options setObject:immutableEpList forKey:@"executionProviders"];
+
+    NSDictionary *resultMap = [onnxruntimeModule loadModel:dataPath options:options];
+
+    sessionKey = resultMap[@"key"];
+    NSArray *inputNames = resultMap[@"inputNames"];
+    XCTAssertEqual([inputNames count], 1);
+    XCTAssertEqualObjects(inputNames[0], @"input");
+    NSArray *outputNames = resultMap[@"outputNames"];
+    XCTAssertEqual([outputNames count], 1);
+    XCTAssertEqualObjects(outputNames[0], @"output");
+  }
+
+  { [onnxruntimeModule dispose:sessionKey]; }
+}
+
 @end


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As title.

Validation at JS call level in E2E app is not included. Can cover together in a separate pr.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Test coverage.

