### PR TITLE
Avoid cmake repeatly printing DISABLE_FLOAT8_TYPES=ON

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -800,17 +800,14 @@ function(onnxruntime_set_compile_flags target_name)
     endif()
 
     if (onnxruntime_DISABLE_SPARSE_TENSORS)
-      message(STATUS "DISABLE_SPARSE_TENSORS=ON")
       target_compile_definitions(${target_name} PRIVATE DISABLE_SPARSE_TENSORS)
     endif()
 
     if (onnxruntime_DISABLE_OPTIONAL_TYPE)
-      message(STATUS "DISABLE_OPTIONAL_TYPE=ON")
       target_compile_definitions(${target_name} PRIVATE DISABLE_OPTIONAL_TYPE)
     endif()
 
     if (onnxruntime_DISABLE_FLOAT8_TYPES)
-      message(STATUS "DISABLE_FLOAT8_TYPES=ON")
       target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT8_TYPES)
     endif()
 


### PR DESCRIPTION
Avoid the log message `DISABLE_FLOAT8_TYPES=ON` during building

```
-- Python Build is enabled
-- Kernel Explorer Build is enabled
-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
CMake Warning at onnxruntime_mlas.cmake:63 (message):
  AMX instructions NOT supported due to lack of compiler tool chain!
Call Stack (most recent call first):
  CMakeLists.txt:1645 (include)


-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
-- DISABLE_FLOAT8_TYPES=ON
...
```
And so on.