### PR TITLE
Fix UT issue for SequenceMap function-op in OpenVINO EP

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -75,11 +75,15 @@ std::vector<std::unique_ptr<ComputeCapability>> GetCapability::Execute() {
     }
 
     const auto& nodes = graph_viewer_.GetNodesInTopologicalOrder();
+    
+    // Handle cases where lone, reoccuring Ops in smaller models cannot be supported in OpenVINO
+    // If only a node of the same lone,unsupported type is present, then do not proceed with the subgraph
+    const auto& node = graph_viewer_.GetNode(nodes[0]);
+    if (data_ops_->IsOpSupportedOnlyInModel(node->OpType()))
+      return result;
+
     // Nodes that work well in models but not as a single node
     if (nodes.size() == 1) {
-      const auto& node = graph_viewer_.GetNode(nodes[0]);
-      if (data_ops_->IsOpSupportedOnlyInModel(node->OpType()))
-        return result;
       // If reshape is not an intermediate node, shape needs to be an initializer
       if (data_ops_->SpecialConditionForClusterSizeOne(ng_required_initializers, node)) {
         return result;

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -30,6 +30,7 @@ namespace openvino_ep {
 
 // Ops which are supported only in models(as intermediate nodes) and not in unit tests
 std::set<std::string> ops_supported_only_in_model = {
+    "Add",
     "Cast",
     "Concat",
     "ConstantOfShape",


### PR DESCRIPTION
Recent changes in https://github.com/microsoft/onnxruntime/pull/16330 exposed an issue in the handling of an edge-case in the OpenVINO-EP due to which the CI runs failed before. This PR fixes the failure.


