### PR TITLE
[WinML] Fix warnings in OnnxruntimeEngine and OnnxruntimeEngineBuilder

### DIFF
--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -564,6 +564,7 @@ OnnxruntimeEngineFactory* OnnxruntimeEngine::GetEngineFactory() {
 }
 
 HRESULT OnnxruntimeEngine::CreateTensorValueFromDefaultAllocator(const int64_t* shape, size_t count, winml::TensorKind kind, _Out_ IValue** out) {
+  *out = nullptr;
   auto ort_api = engine_factory_->UseOrtApi();
 
   OrtAllocator* ort_allocator;

--- a/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngineBuilder.cpp
@@ -20,6 +20,7 @@ HRESULT OnnxruntimeEngineBuilder::RuntimeClassInitialize(_In_ OnnxruntimeEngineF
 }
 
 STDMETHODIMP OnnxruntimeEngineBuilder::CreateEngine(_Outptr_ _winml::IEngine** out) {
+  *out = nullptr;
   auto ort_api = engine_factory_->UseOrtApi();
 
   Microsoft::WRL::ComPtr<IOrtSessionBuilder> onnxruntime_session_builder;


### PR DESCRIPTION
Fix [prefast:Warning]: C6101 (in '_winml::OnnxruntimeEngine::CreateTensorValueFromDefaultAllocator'
Fix [prefast:Warning]: C6101 (in '_winml::OnnxruntimeEngineBuilder::CreateEngine'