### PR TITLE
[aarch64] Add Sbgemm kernel to accelerate fp32 tensor matmul with bfloat16

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -34,6 +34,7 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/platform.cpp
   ${MLAS_SRC_DIR}/threading.cpp
   ${MLAS_SRC_DIR}/sgemm.cpp
+  ${MLAS_SRC_DIR}/sbgemm.cpp
   ${MLAS_SRC_DIR}/halfgemm.cpp
   ${MLAS_SRC_DIR}/qgemm.cpp
   ${MLAS_SRC_DIR}/qdwconv.cpp
@@ -338,6 +339,7 @@ else()
           ${MLAS_SRC_DIR}/aarch64/QgemmU8X8KernelUdot.S
           ${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSdot.S
           ${MLAS_SRC_DIR}/aarch64/SgemmKernelNeon.S
+          ${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SgemvKernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelNeon.S
           ${MLAS_SRC_DIR}/aarch64/SymQgemmS8KernelSdot.S
@@ -359,6 +361,10 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/activate_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/dwconv.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/pooling_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+          set_source_files_properties(${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 ")
+          set_source_files_properties(${MLAS_SRC_DIR}/sbgemm.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 ")
+
+          set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -march=armv8.2-a+bf16")
         endif()
 
         if(ONNXRUNTIME_MLAS_MULTI_ARCH)
@@ -584,7 +590,7 @@ set_target_properties(onnxruntime_mlas PROPERTIES FOLDER "ONNXRuntime")
 if (WIN32)
   target_compile_options(onnxruntime_mlas PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/wd6385>" "$<$<COMPILE_LANGUAGE:CXX>:/wd4127>")
   if (onnxruntime_ENABLE_STATIC_ANALYSIS)
-    target_compile_options(onnxruntime_mlas PRIVATE  "$<$<COMPILE_LANGUAGE:CXX>:/analyze:stacksize" 131072>)
+    target_compile_options(onnxruntime_mlas PRIVATE  "$<$<COMPILE_LANGUAGE:CXX>:/analyze:stacksize 131072">)
   endif()
 endif()
 

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -239,6 +239,33 @@ MlasGemmBatch(
     );
 
 /**
+ * @brief  Batched bfloat16 half precision matrix/matrix multiply operation (SBGEMM)
+ *
+ * @param TransA     Supplies the transpose operation for matrix A.
+ * @param TransB     Supplies the transpose operation for matrix B.
+ * @param M          Supplies the number of rows of matrix A and matrix C.
+ * @param N          Supplies the number of columns of matrix B and matrix C.
+ * @param K          Supplies the number of columns of matrix A and the number
+                     of rows of matrix B.
+ * @param Data       A array of matrices data parameters
+ * @param BatchSize  Supplies number of multiplications in this batch
+ * @param ThreadPool Supplies the thread pool object to use, else nullptr if the
+                     base library threading support should be used.
+ */
+void
+MLASCALL
+MlasSBGemmBatch(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB,
+    size_t M,
+    size_t N,
+    size_t K,
+    const MLAS_SGEMM_DATA_PARAMS* Data,
+    size_t BatchSize,
+    MLAS_THREADPOOL* ThreadPool
+    );
+
+/**
  * @brief  Single precision matrix/matrix multiply operation (SGEMM)
  *
  * @param TransA  Supplies the transpose operation for matrix A.
@@ -711,6 +738,24 @@ MlasGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
+    void* PackedB
+    );
+
+size_t
+MLASCALL
+MlasSBGemmPackBSize(
+    size_t N,
+    size_t K
+    );
+
+void
+MLASCALL
+MlasSBGemmPackB(
+    CBLAS_TRANSPOSE TransB,
+    size_t N,
+    size_t K,
+    const float* B,
+    size_t ldb,
     void* PackedB
     );
 

--- a/onnxruntime/core/mlas/lib/aarch64/SbgemmKernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SbgemmKernelNeon.S
@@ -1,0 +1,924 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    SbgemmKernelNeon.s
+
+Abstract:
+
+    This module implements the kernels for the bfloat16 half precision matrix/matrix
+    multiply operation (SBGEMM).
+
+--*/
+
+#include "asmmacro.h"
+
+        .text
+
+//
+// Stack frame layout for the sbgemm kernel. d8-d15, x19-x30 need save
+//
+        .equ  .LMlasSbgemmKernel_backup_x19_x20,    0
+        .equ  .LMlasSbgemmKernel_backup_x21_x22,    16
+        .equ  .LMlasSbgemmKernel_backup_x23_x24,    32
+        .equ  .LMlasSbgemmKernel_backup_x25_x26,    48
+        .equ  .LMlasSbgemmKernel_backup_x27_x28,    64
+        .equ  .LMlasSbgemmKernel_backup_d8_d9,      80
+        .equ  .LMlasSbgemmKernel_backup_d10_d11,    96
+        .equ  .LMlasSbgemmKernel_backup_d12_d13,    112
+        .equ  .LMlasSbgemmKernel_backup_d14_d15,    128
+        .equ  .LMlasSbgemmKernel_SavedRegisters,    144
+        .equ  .LMlasSbgemmKernel_SavedRegisters_Neg, -144
+
+
+//
+// ClearRowAccumulators
+//
+// Generates the code to clear the accumulators for a single row of the output
+// block.
+//
+
+        .macro  ClearRowAccumulators Columns, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg
+
+        movi    v\Vec1Reg\().16b,#0
+.if \Columns\() > 2
+        movi    v\Vec2Reg\().16b,#0
+.endif
+.if \Columns\() > 4
+        movi    v\Vec3Reg\().16b,#0
+.endif
+.if \Columns\() > 6
+        movi    v\Vec4Reg\().16b,#0
+.endif
+
+        .endm
+
+//
+// ClearBlockAccumulators
+//
+// Generates the code to clear the accumulators for a single row of the output
+// block.
+//
+
+        .macro  ClearBlockAccumulators Columns, Rows
+
+        ClearRowAccumulators \Columns\(),16,17,18,19
+.if \Rows\() > 2
+        ClearRowAccumulators \Columns\(),20,21,22,23
+.endif
+.if \Rows\() > 4
+        ClearRowAccumulators \Columns\(),24,25,26,27
+.endif
+.if \Rows\() > 6
+        ClearRowAccumulators \Columns\(),28,29,30,31
+.endif
+
+        .endm
+
+// LoadMatrixAElementsBy8
+//
+// Generates the code to load 4 or 8 elements from matrix A.
+//
+        .macro  LoadMatrixAElementsBy8 Rows
+
+        ldr     q8,[x0],#16
+        bfcvtn  v8.4h, v8.4s
+.if \Rows\() > 1
+        ldr     q1,[x10],#16
+        bfcvtn2 v8.8h, v1.4s
+.endif
+
+.if \Rows\() > 2
+        ldr     q9,[x11],#16
+        bfcvtn  v9.4h, v9.4s
+.endif
+.if \Rows\() > 3
+        ldr     q1,[x12],#16
+        bfcvtn2 v9.8h, v1.4s
+.endif
+
+.if \Rows\() > 4
+        ldr     q10,[x20],#16
+        bfcvtn  v10.4h, v10.4s
+.endif
+.if \Rows\() > 5
+        ldr     q1,[x21],#16
+        bfcvtn2 v10.8h, v1.4s
+.endif
+
+.if \Rows\() > 6
+        ldr     q11,[x22],#16
+        bfcvtn  v11.4h, v11.4s
+.endif
+.if \Rows\() > 7
+        ldr     q1,[x23],#16
+        bfcvtn2 v11.8h, v1.4s
+.endif
+
+        .endm
+
+
+//
+// MultiplyAccumulateRow
+//
+// Generates the code to multiply and accumulate a single row of the output
+// block.
+//
+
+        .macro  MultiplyAccumulateRow Columns, MatrixAReg, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg
+
+        bfmmla    v\Vec1Reg\().4s, \MatrixAReg\().8h, v4.8h
+.if \Columns\() > 2
+        bfmmla    v\Vec2Reg\().4s, \MatrixAReg\().8h, v5.8h
+.endif
+.if \Columns\() > 4
+	bfmmla    v\Vec3Reg\().4s, \MatrixAReg\().8h, v6.8h
+.endif
+.if \Columns\() > 6
+        bfmmla    v\Vec4Reg\().4s, \MatrixAReg\().8h, v7.8h
+.endif
+
+        .endm
+
+//
+// MultiplyAccumulateBlock
+//
+// Generates the code to multiply and accumulate into the output block.
+//
+
+        .macro  MultiplyAccumulateBlock Columns, Rows
+
+        MultiplyAccumulateRow \Columns\(),v8,16,17,18,19
+.if \Rows\() > 2
+        MultiplyAccumulateRow \Columns\(),v9,20,21,22,23
+.endif
+.if \Rows\() > 4
+        MultiplyAccumulateRow \Columns\(),v10,24,25,26,27
+.endif
+.if \Rows\() > 6
+        MultiplyAccumulateRow \Columns\(),v11,28,29,30,31
+.endif
+
+        .endm
+
+//
+// ComputeBlockLoop
+//
+// Generates the code to loop over K entries of the input matrices to produce
+// the output block.
+//
+
+        .macro  ComputeBlockLoop Mode, Columns, Rows
+
+        ClearBlockAccumulators \Columns\(),\Rows\()
+
+        add     x10,x0,x6,lsl #2            // compute matrix A plus 1 row
+.if \Rows\() > 2
+        add     x11,x10,x6,lsl #2           // compute matrix A plus 2 rows
+        add     x12,x11,x6,lsl #2           // compute matrix A plus 3 rows
+.endif
+.if \Rows\() > 4
+        add     x20,x12,x6,lsl #2           // compute matrix A plus 4 rows
+        add     x21,x20,x6,lsl #2           // compute matrix A plus 5 rows
+.endif
+.if \Rows\() > 6
+        add     x22,x21,x6,lsl #2           // compute matrix A plus 6 rows
+        add     x23,x22,x6,lsl #2           // compute matrix A plus 7 rows
+.endif
+        sub    x9,x3,#4                   //  block count to process
+        tbnz    x9,#7,.L\Mode\().ProcessRemaining\Columns\().x\Rows\().Blocks
+
+.L\Mode\().Compute\Columns\().x\Rows\().BlockBy4Loop:
+
+        LoadMatrixAElementsBy8 \Rows\()
+        ldr     q4, [x1],#16
+.if \Columns\() > 2
+	ldr     q5,[x1],#16
+.endif
+.if \Columns\() > 4
+        ldr     q6,[x1],#16
+.endif
+.if \Columns\() > 6
+        ldr     q7,[x1],#16
+.endif
+        MultiplyAccumulateBlock \Columns\(),\Rows\()
+
+        sub     x9,x9,#4
+        tbz     x9,#7,.L\Mode\().Compute\Columns\().x\Rows\().BlockBy4Loop
+.L\Mode\().ProcessRemaining\Columns\().x\Rows\().Blocks:
+        add     x9,x9,#4                    // correct for over-subtract above
+        cbz     x9,.L\Mode\().Output\Columns\().x\Rows\().Block
+
+.L\Mode\().Compute\Columns\().x\Rows\().BlockBy4PaddedLoop:
+        LoadMatrixAElementsBy8 \Rows\()
+        ldr     q4, [x1],#16
+.if \Columns\() > 2
+        ldr     q5,[x1],#16
+.endif
+.if \Columns\() > 4
+        ldr     q6,[x1],#16
+.endif
+.if \Columns\() > 6
+        ldr     q7,[x1],#16
+.endif
+        MultiplyAccumulateBlock \Columns\(),\Rows\()
+
+.L\Mode\().Output\Columns\().x\Rows\().Block:
+
+        .endm
+
+//
+// MultiplyAlphaRow
+//
+// Generates the code to multiply a single row of the output block by the alpha
+// value.
+//
+
+        .macro  MultiplyAlphaRow Columns, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg
+
+        fmul    v\Vec1Reg\().4s,v\Vec1Reg\().4s,v0.s[0]
+.if \Columns\() > 2
+        fmul    v\Vec2Reg\().4s,v\Vec2Reg\().4s,v0.s[0]
+.endif
+.if \Columns\() > 4
+        fmul    v\Vec3Reg\().4s,v\Vec3Reg\().4s,v0.s[0]
+.endif
+.if \Columns\() > 6
+        fmul    v\Vec4Reg\().4s,v\Vec4Reg\().4s,v0.s[0]
+.endif
+
+        .endm
+
+//
+// MultiplyAlphaBlock
+//
+// Generates the code to multiply the output block by the alpha value.
+//
+
+        .macro  MultiplyAlphaBlock Columns, Rows
+
+        MultiplyAlphaRow \Columns\(),16,17,18,19
+.if \Rows\() > 2
+        MultiplyAlphaRow \Columns\(),20,21,22,23
+.endif
+.if \Rows\() > 4
+        MultiplyAlphaRow \Columns\(),24,25,26,27
+.endif
+.if \Rows\() > 6
+        MultiplyAlphaRow \Columns\(),28,29,30,31
+.endif
+
+        .endm
+
+//
+// OutputRow2Element
+// OutputRow4Element
+// OutputRow6Element
+// OutputRow8Element
+// OutputRow10Element
+// OutputRow12Element
+// OutputRow14Element
+// OutputRow16Element
+//
+// Generates the code to store elements to the output block.
+//
+
+        .macro  OutputRow2Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#4
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#4
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+        mov v8.4S[2], v9.4S[0]
+        fmla    v8.4s,v\Vec1Reg\().4s,v0.s[0]
+
+        mov     w27, v8.4S[0]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        mov     w27, v8.4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+
+.else
+        mov     w27, v\Vec1Reg\().4S[0]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        mov     w27, v\Vec1Reg\().4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+
+.endif
+
+        .endm
+
+
+        .macro  OutputRow4Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#8
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#8
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+
+        mov v8.2D[1], v9.2D[0]
+
+        fmla    v8.4s,v\Vec1Reg\().4s,v0.s[0]
+
+        mov     x27, v8.2D[0]
+        mov     x28, v8.2D[1]
+
+        str      x27, [\AddrReg1\()],#8
+.if \last_row\() == 0
+        str      x28, [\AddrReg2\()],#8
+.endif
+
+.else
+        mov     x27, v\Vec1Reg\().2D[0]
+        mov     x28, v\Vec1Reg\().2D[1]
+
+        str      x27, [\AddrReg1\()],#8
+.if \last_row\() == 0
+        str      x28, [\AddrReg2\()],#8
+.endif
+
+.endif
+
+        .endm
+
+
+        .macro  OutputRow6Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#12
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#12
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+
+        mov     x27, v8.2D[0]
+        str   x27, [\AddrReg1\()],#8
+        mov     w27, v8.4S[2]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        mov     x27, v9.2D[0]
+        str   x27, [\AddrReg2\()],#8
+        mov     w27, v9.4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        mov     x27, v4.2D[0]
+        str   x27, [\AddrReg1\()],#8
+        mov     w27, v4.4S[2]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        mov     x27, v5.2D[0]
+        str   x27, [\AddrReg2\()],#8
+        mov     w27, v5.4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+
+.endif
+
+        .endm
+
+
+        .macro  OutputRow8Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#16
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+
+        str     q8,[\AddrReg1\()],#16
+.if \last_row\() != 0
+        str     q9,[\AddrReg2\()],#16
+.endif
+
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        str     q4,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        str     q5,[\AddrReg2\()],#16
+.endif
+
+.endif
+
+        .endm
+
+
+        .macro  OutputRow10Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#16
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+
+        str     q8,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        str     q9,[\AddrReg2\()],#16
+.endif
+
+        ldr     q8,[\AddrReg1\()],#4
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#4
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+
+        mov v8.4S[2],v9.4S[0]
+
+        fmla    v8.4s,v\Vec3Reg\().4s,v0.s[0]
+
+        mov     w27, v8.4S[0]
+        mov     w28, v8.4S[2]
+
+        str      w27, [\AddrReg1\()],#4
+.if \last_row\() == 0
+        str      w28, [\AddrReg2\()],#4
+.endif
+
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        str     q4,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        str     q5,[\AddrReg2\()],#16
+.endif
+        mov     w27, v\Vec3Reg\().4S[0]
+        mov     w28, v\Vec3Reg\().4S[2]
+
+        str      w27, [\AddrReg1\()],#4
+.if \last_row\() == 0
+        str      w28, [\AddrReg2\()],#4
+.endif
+.endif
+
+.endm
+
+
+        .macro  OutputRow12Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#16
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+
+        str     q8,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        str     q9,[\AddrReg2\()],#16
+.endif
+
+        mov v8.2D[1], v9.2D[0]
+
+        fmla    v8.4s,v\Vec3Reg\().4s,v0.s[0]
+
+        mov     x27, v8.2D[0]
+        mov     x28, v8.2D[1]
+
+        str      x27, [\AddrReg1\()],#8
+.if \last_row\() == 0
+        str      x28, [\AddrReg2\()],#8
+.endif
+
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        str     q4,[\AddrReg1\()],#16
+.if \last_row\() == 0
+        str     q5,[\AddrReg2\()],#16
+.endif
+        mov     x27, v\Vec3Reg\().2D[0]
+        mov     x28, v\Vec3Reg\().2D[1]
+
+        str	 x27, [\AddrReg1\()],#8
+.if \last_row\() == 0
+        str      x28, [\AddrReg2\()],#8
+.endif
+.endif
+
+        .endm
+
+       .macro  OutputRow14Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldr     q8,[\AddrReg1\()],#16
+        ldr     q10,[\AddrReg1\()],#12
+.if \last_row\() == 0
+        ldr     q9,[\AddrReg2\()],#16
+        ldr     q11,[\AddrReg1\()],#12
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+
+        mov v11.2D[0],x27
+        mov v11.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        uzp1    v6.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+        uzp2    v7.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+        fmla    v10.4s,v6.4s,v0.s[0]
+        fmla    v11.4s,v7.4s,v0.s[0]
+
+        str     q8,[\AddrReg1\()],#16
+
+        mov     x27, v10.2D[0]
+        str   x27, [\AddrReg1\()],#8
+        mov     w27, v10.4S[2]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        str     q9,[\AddrReg2\()],#32
+        mov     x27, v11.2D[0]
+        str   x27, [\AddrReg2\()],#8
+        mov     w27, v11.4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp1    v6.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+        uzp2    v7.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+
+        str     q4,[\AddrReg1\()],#16
+        mov     x27, v6.2D[0]
+        str   x27, [\AddrReg1\()],#8
+        mov     w27, v6.4S[2]
+        str   w27, [\AddrReg1\()],#4
+
+.if \last_row\() == 0
+        str     q5,[\AddrReg2\()],#16
+        mov     x27, v7.2D[0]
+        str   x27, [\AddrReg2\()],#8
+        mov     w27, v7.4S[2]
+        str   w27, [\AddrReg2\()],#4
+.endif
+.endif
+
+        .endm
+
+
+        .macro  OutputRow16Element Mode, AddrReg1, AddrReg2, Vec1Reg, Vec2Reg, Vec3Reg, Vec4Reg, last_row
+
+.ifeqs "\Mode\()","Add"
+        ldp     q8,q10,[\AddrReg1\()],#32
+.if \last_row\() != 1
+        ldp     q9,q11,[\AddrReg2\()],#32
+.else
+        mov x27,#0
+        mov v9.2D[0],x27
+        mov v9.2D[1],x27
+
+        mov v11.2D[0],x27
+        mov v11.2D[1],x27
+.endif
+        uzp1    v4.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d,v\Vec1Reg\().2d,v\Vec2Reg\().2d
+
+        uzp1    v6.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+        uzp2    v7.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+
+        fmla    v8.4s,v4.4s,v0.s[0]
+        fmla    v9.4s,v5.4s,v0.s[0]
+        fmla    v10.4s,v6.4s,v0.s[0]
+        fmla    v11.4s,v7.4s,v0.s[0]
+
+        stp     q8,q10,[\AddrReg1\()],#32
+.if \last_row\() == 0
+        stp     q9,q11,[\AddrReg2\()],#32
+.endif
+.else
+        uzp1    v4.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp2    v5.2d, v\Vec1Reg\().2d,v\Vec2Reg\().2d
+        uzp1    v6.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+        uzp2    v7.2d, v\Vec3Reg\().2d,v\Vec4Reg\().2d
+
+        stp 	q4,q6,[\AddrReg1\()],#32
+.if \last_row\() == 0
+        stp	q5,q7,[\AddrReg2\()],#32
+.endif
+.endif
+
+        .endm
+
+//
+// OutputBlock
+//
+// Generates the code to store the output block.
+//
+
+        .macro  OutputBlock Mode, Columns, Rows
+
+        OutputRow\Columns\()Element \Mode\(),x2,x13,16,17,18,19,(\Rows\() == 1)
+
+.if \Rows\() > 2
+        OutputRow\Columns\()Element \Mode\(),x14,x15,20,21,22,23,(\Rows\() == 3)
+.endif
+
+.if \Rows\() > 4
+        OutputRow\Columns\()Element \Mode\(),x16,x17,24,25,26,27,(\Rows\() == 5)
+.endif
+
+.if \Rows\() > 6
+        OutputRow\Columns\()Element \Mode\(),x18,x19,28,29,30,31,(\Rows\() == 7)
+.endif
+
+        .endm
+//
+// ProcessRows
+//
+// Generates the code to process a compute and store the output block for a
+// fixed number of rows.
+//
+
+        .macro  ProcessRows Mode, Rows
+        mov     x4,#\Rows\()                   // return number of rows handled
+        cmp     x5,#6
+        ble     .L\Mode\().ProcessNextColumnLoop6x\Rows\()
+
+.L\Mode\().ProcessNextColumnLoop8x\Rows\():
+        ComputeBlockLoop \Mode\(),8,\Rows\()
+.ifeqs "\Mode\()","Zero"
+        MultiplyAlphaBlock 8,\Rows\()
+.endif
+
+        sub     x5,x5,#8
+        cmp   x5,#0
+        blt   .L\Mode\().Output14ElementsOnlyFor\Rows\()
+        OutputBlock \Mode\(),16,\Rows\()
+        mov     x0,x8               // reload matrix A
+        cmp     x5,#6
+        bgt     .L\Mode\().ProcessNextColumnLoop8x\Rows\()
+        cbz     x5,.L\Mode\().ExitKernel
+
+
+.L\Mode\().ProcessNextColumnLoop6x\Rows\():
+
+        cmp    x5,#4
+        ble .L\Mode\().ProcessNextColumnLoop4x\Rows\()
+        ComputeBlockLoop \Mode\(),6,\Rows\()
+.ifeqs "\Mode\()","Zero"
+        MultiplyAlphaBlock 6,\Rows\()
+.endif
+        sub 	x5,x5,#6
+                cmp   x5,#0
+        blt   .L\Mode\().Output10ElementsOnlyFor\Rows\()
+        OutputBlock \Mode\(),12,\Rows\()
+
+        mov     x0,x8               // reload matrix A
+        cmp     x5,#4
+        bgt     .L\Mode\().ProcessNextColumnLoop6x\Rows\()
+        b     .L\Mode\().ExitKernel
+
+.L\Mode\().ProcessNextColumnLoop4x\Rows\():
+        cmp     x5,#2
+        ble .L\Mode\().ProcessNextColumnLoop2x\Rows\()
+        ComputeBlockLoop \Mode\(),4,\Rows\()
+.ifeqs "\Mode\()","Zero"
+        MultiplyAlphaBlock 4,\Rows\()
+.endif
+        sub     x5,x5,#4
+        cmp   x5,#0
+        blt   .L\Mode\().Output6ElementsOnlyFor\Rows\()
+
+        OutputBlock \Mode\(),8,\Rows\()
+
+        mov     x0,x8               // reload matrix A
+        cmp     x5,#2
+        bgt     .L\Mode\().ProcessNextColumnLoop4x\Rows\()
+        b     .L\Mode\().ExitKernel
+
+.L\Mode\().ProcessNextColumnLoop2x\Rows\():
+        ComputeBlockLoop \Mode\(),2,\Rows\()
+.ifeqs "\Mode\()","Zero"
+        MultiplyAlphaBlock 2,\Rows\()
+.endif
+        sub     x5,x5,#2
+        cmp   x5,#0
+        blt   .L\Mode\().Output2ElementsOnlyFor\Rows\()
+
+        OutputBlock \Mode\(),4,\Rows\()
+
+        mov     x0,x8               // reload matrix A
+        cmp     x5,#2
+        b     .L\Mode\().ExitKernel
+
+.L\Mode\().Output14ElementsOnlyFor\Rows\():
+	OutputBlock \Mode\(),14,\Rows\()
+        b     .L\Mode\().ExitKernel
+
+
+.L\Mode\().Output10ElementsOnlyFor\Rows\():
+        OutputBlock \Mode\(),10,\Rows\()
+        b     .L\Mode\().ExitKernel
+
+
+.L\Mode\().Output6ElementsOnlyFor\Rows\():
+        OutputBlock \Mode\(),6,\Rows\()
+        b     .L\Mode\().ExitKernel
+
+
+.L\Mode\().Output2ElementsOnlyFor\Rows\():
+        OutputBlock \Mode\(),2,\Rows\()
+        b     .L\Mode\().ExitKernel
+
+        .endm
+
+
+/*++
+
+Routine Description:
+
+    This routine is an inner kernel to compute matrix multiplication for a
+    set of rows.
+
+Arguments:
+
+    A (x0) - Supplies the address of matrix A.
+
+    B (x1) - Supplies the address of matrix B. The matrix data has been packed
+        using MlasSgemmCopyPackB or MlasSgemmTransposePackB.
+
+    C (x2) - Supplies the address of matrix C.
+
+    CountK (x3) - Supplies the number of columns from matrix A and the number
+        of rows from matrix B to iterate over.
+
+    CountM (x4) - Supplies the maximum number of rows that can be processed for
+        matrix A and matrix C. The actual number of rows handled for this
+        invocation depends on the kernel implementation.
+
+    CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    lda (x6) - Supplies the first dimension of matrix A.
+
+    ldc (x7) - Supplies the first dimension of matrix C.
+
+    Alpha (s0) - Supplies the scalar multiplier (see SGEMM definition).
+
+Return Value:
+
+    Returns the number of rows handled.
+
+--*/
+
+        .macro  SbgemmKernelNeonFunction Mode
+
+        FUNCTION_ENTRY MlasSbgemmKernel\Mode\()
+
+        stp     x19, x20, [sp, #.LMlasSbgemmKernel_SavedRegisters_Neg]!
+        stp     x21, x22, [sp, #.LMlasSbgemmKernel_backup_x21_x22]
+        stp     x23, x24, [sp, #.LMlasSbgemmKernel_backup_x23_x24]
+        stp     x25, x26, [sp, #.LMlasSbgemmKernel_backup_x25_x26]
+        stp     x27, x28, [sp, #.LMlasSbgemmKernel_backup_x27_x28]
+        stp     d8, d9, [sp, #.LMlasSbgemmKernel_backup_d8_d9]
+        stp     d10, d11, [sp, #.LMlasSbgemmKernel_backup_d10_d11]
+        stp     d12, d13, [sp, #.LMlasSbgemmKernel_backup_d12_d13]
+        stp     d14, d15, [sp, #.LMlasSbgemmKernel_backup_d14_d15]
+
+        add     x13,x2,x7,lsl #2            // compute matrix C plus 1 row
+        add     x14,x13,x7,lsl #2           // compute matrix C plus 2 rows
+        add     x15,x14,x7,lsl #2           // compute matrix C plus 3 rows
+        add     x16,x15,x7,lsl #2           // compute matrix C plus 4 rows
+        add     x17,x16,x7,lsl #2           // compute matrix C plus 5 rows
+        add     x18,x17,x7,lsl #2           // compute matrix C plus 6 rows
+        add     x19,x18,x7,lsl #2           // compute matrix C plus 7 rows
+
+        mov     x8,x0                       // save matrix A
+
+//
+// Process 8 rows of the matrices.
+//
+        cmp     x4,#8
+        blt     .L\Mode\().ProcessCountMLessThan8
+        ProcessRows \Mode\(),8
+
+//
+// Restore non-volatile registers and return.
+//
+
+.L\Mode\().ExitKernel:
+        mov     x0,x4
+
+        ldp     d14, d15, [sp, #.LMlasSbgemmKernel_backup_d14_d15]
+        ldp     d12, d13, [sp, #.LMlasSbgemmKernel_backup_d12_d13]
+        ldp     d10, d11, [sp, #.LMlasSbgemmKernel_backup_d10_d11]
+        ldp     d8, d9, [sp, #.LMlasSbgemmKernel_backup_d8_d9]
+        ldp     x27, x28, [sp, #.LMlasSbgemmKernel_backup_x27_x28]
+        ldp     x25, x26, [sp, #.LMlasSbgemmKernel_backup_x25_x26]
+        ldp     x23, x24, [sp, #.LMlasSbgemmKernel_backup_x23_x24]
+        ldp     x21, x22, [sp, #.LMlasSbgemmKernel_backup_x21_x22]
+        ldp     x19, x20, [sp], #.LMlasSbgemmKernel_SavedRegisters
+
+        ret
+
+//
+// Process 4 rows of the matrix.
+//
+
+.L\Mode\().ProcessCountMLessThan8:
+        cmp     x4,#4
+        blt     .L\Mode\().ProcessCountMLessThan4
+        ProcessRows \Mode\(),4
+        b       .L\Mode\().ExitKernel
+
+//
+// Process 2 row of the matrix.
+//
+
+.L\Mode\().ProcessCountMLessThan4:
+        cmp     x4,#2
+        blt     .L\Mode\().ProcessCountMLessThan2
+
+        ProcessRows \Mode\(),2
+        b       .L\Mode\().ExitKernel
+
+
+//
+// Process the last row of the matrix.
+//
+
+.L\Mode\().ProcessCountMLessThan2:
+        ProcessRows \Mode\(),1
+        b       .L\Mode\().ExitKernel
+
+
+        .endm
+
+        SbgemmKernelNeonFunction Zero
+        SbgemmKernelNeonFunction Add
+
+        .end

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -340,6 +340,20 @@ size_t
 
 typedef
 size_t
+(MLASCALL MLAS_SBGEMM_FLOAT_KERNEL)(
+    const float* A,
+    const bfloat16_t* B,
+    float* C,
+    size_t CountK,
+    size_t CountM,
+    size_t CountN,
+    size_t lda,
+    size_t ldc,
+    float alpha
+    );
+
+typedef
+size_t
 (MLASCALL MLAS_GEMM_FLOAT_KERNEL)(
     const float* A,
     const float* B,
@@ -666,6 +680,8 @@ extern "C" {
 #else
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelZero;
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelAdd;
+    MLAS_SBGEMM_FLOAT_KERNEL MlasSbgemmKernelZero;
+    MLAS_SBGEMM_FLOAT_KERNEL MlasSbgemmKernelAdd;
     MLAS_GEMM_DOUBLE_KERNEL MlasDgemmKernelZero;
     MLAS_GEMM_DOUBLE_KERNEL MlasDgemmKernelAdd;
 #endif
@@ -790,6 +806,7 @@ extern "C" {
 //
 
 #define MLAS_SGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
+#define MLAS_SBGEMM_THREAD_COMPLEXITY               (size_t(64) * size_t(1024))
 #define MLAS_DGEMM_THREAD_COMPLEXITY                (size_t(64) * size_t(1024))
 #define MLAS_QGEMM_THREAD_COMPLEXITY                65536
 
@@ -1179,6 +1196,7 @@ MlasConvDepthwiseFloat_CHW(
 #if defined(MLAS_NEON_INTRINSICS)
 typedef float32x4_t MLAS_FLOAT32X4;
 typedef int32x4_t MLAS_INT32X4;
+typedef bfloat16x8_t MLAS_BFLOAT16X8;
 #elif defined(MLAS_SSE2_INTRINSICS)
 typedef __m128 MLAS_FLOAT32X4;
 typedef __m128i MLAS_INT32X4;

--- a/onnxruntime/core/mlas/lib/sbgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sbgemm.cpp
@@ -1,0 +1,1147 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sbgemm.cpp
+
+Abstract:
+
+    This module implements the bfloat16 half precision matrix/matrix multiply
+    operation (SBGEMM).
+
+--*/
+
+#include "mlasi.h"
+//
+// Define the number of rows from matrix A to transpose to a local buffer.
+//
+// N.B. aarch64 sbgemm kernel processes 8 rows in one loop
+//
+
+#define MLAS_SGEMM_TRANSA_ROWS              8
+
+//
+// Define the parameters to execute segments of a SBGEMM operation on worker
+// threads.
+//
+
+void
+MlasSbgemmMultiplyBeta(
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    float beta
+    )
+/*++
+
+Routine Description:
+
+    This routine multiplies all elements of the output matrix by the beta
+    scalar value.
+
+Arguments:
+
+    C - Supplies the address of matrix C.
+
+    CountM - Supplies the number of rows from matrix C.
+
+    CountN - Supplies the number of columns from matrix C.
+
+    ldc - Supplies the first dimension of matrix C.
+
+    beta - Supplies the scalar beta multiplier (see SGEMM definition).
+
+Return Value:
+
+    None.
+
+--*/
+{
+
+    MLAS_FLOAT32X4 BetaBroadcast = MlasBroadcastFloat32x4(beta);
+
+    while (CountM-- > 0) {
+
+        float* c = C;
+        size_t n = CountN;
+
+        while (n >= 4) {
+            MlasStoreFloat32x4(c, MlasMultiplyFloat32x4(MlasLoadFloat32x4(c), BetaBroadcast));
+            c += 4;
+            n -= 4;
+        }
+
+        while (n > 0) {
+            *c = *c * beta;
+            c += 1;
+            n -= 1;
+        }
+
+        C += ldc;
+    }
+}
+
+void
+MlasSbgemmTransposeA(
+    float* D,
+    const float* A,
+    size_t lda,
+    size_t CountY,
+    size_t CountX
+    )
+/*++
+
+Routine Description:
+
+    This routine transposes elements from the source matrix to the destination
+    buffer.
+
+Arguments:
+
+    D - Supplies the address of the destination buffer.
+
+    A - Supplies the address of the source matrix.
+
+    lda - Supplies the number of elements per row of the source matrix.
+
+    CountY - Supplies the number of columns of the source matrix to transpose.
+
+    CountX - Supplies the number of rows of the source matrix to transpose.
+
+Return Value:
+
+    None.
+
+--*/
+{
+
+    size_t ldd = CountX;
+
+    //
+    // Transpose elements from matrix A into the destination buffer 4 columns
+    // at a time.
+    //
+
+    while (CountX >= 4) {
+
+        float* d = D;
+        const float* a = A;
+        size_t y = CountY;
+
+        do {
+
+            float t0 = a[0];
+            float t1 = a[lda];
+            float t2 = a[lda * 2];
+            float t3 = a[lda * 3];
+
+            d[0] = t0;
+            d[1] = t1;
+            d[2] = t2;
+            d[3] = t3;
+
+            d += ldd;
+            a += 1;
+            y--;
+
+        } while (y > 0);
+
+        D += 4;
+        A += lda * 4;
+        CountX -= 4;
+    }
+
+    //
+    // Transpose elements from matrix A into the destination buffer for the
+    // remaining columns.
+    //
+
+    if (CountX >= 2) {
+
+        float* d = D;
+        const float* a = A;
+        size_t y = CountY;
+
+        do {
+
+            float t0 = a[0];
+            float t1 = a[lda];
+
+            d[0] = t0;
+            d[1] = t1;
+
+            d += ldd;
+            a += 1;
+            y--;
+
+        } while (y > 0);
+
+        D += 2;
+        A += lda * 2;
+        CountX -= 2;
+    }
+
+    if (CountX >= 1) {
+
+        float* d = D;
+        const float* a = A;
+        size_t y = CountY;
+
+        do {
+
+            d[0] = a[0];
+
+            d += ldd;
+            a += 1;
+            y--;
+
+        } while (y > 0);
+    }
+}
+
+void
+MlasSbgemmCopyPackB(
+    bfloat16_t* D,
+    const float* B,
+    size_t ldb,
+    size_t CountX,
+    size_t CountY
+    )
+/*++
+
+Routine Description:
+
+    This routine copies elements from the source matrix to the destination
+    packed buffer.
+
+    4x2 elements from the source matrix are unrolled to be physically
+    contiguous for better locality inside the SBGEMM kernels. The remaining
+    rows and columns are padded to 4 and 2 alignment.
+
+Arguments:
+
+    D - Supplies the address of the destination packed buffer.
+
+    B - Supplies the address of the source matrix.
+
+    ldb - Supplies the number of elements per row of the source matrix.
+
+    CountX - Supplies the number of columns of the source matrix to copy.
+
+    CountY - Supplies the number of rows of the source matrix to copy.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    //
+    // Copy data from matrix B into the destination buffer 4x2 blocks at a
+    // time.
+    //
+    //
+    while (CountX >= 8) {
+        const float* b = B;
+        int y = CountY;
+
+        while (y > 0) {
+            MLAS_FLOAT32X4 t0_l = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t0_h = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t1_l = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t1_h = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t2_l = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t2_h = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t3_l = MlasZeroFloat32x4();
+            MLAS_FLOAT32X4 t3_h = MlasZeroFloat32x4();
+
+            if (y >= 4) {
+                t0_l = MlasLoadFloat32x4(&b[ldb * 0]);
+                t0_h = MlasLoadFloat32x4(&b[ldb * 0 + 4]);
+                t1_l = MlasLoadFloat32x4(&b[ldb * 1]);
+                t1_h = MlasLoadFloat32x4(&b[ldb * 1 + 4]);
+                t2_l = MlasLoadFloat32x4(&b[ldb * 2]);
+                t2_h = MlasLoadFloat32x4(&b[ldb * 2 + 4]);
+                t3_l = MlasLoadFloat32x4(&b[ldb * 3]);
+                t3_h = MlasLoadFloat32x4(&b[ldb * 3 + 4]);
+            } else {
+                switch (y) {
+                    case 3:
+                        t0_l = MlasLoadFloat32x4(&b[ldb * 0]);
+                        t0_h = MlasLoadFloat32x4(&b[ldb * 0 + 4]);
+                        t1_l = MlasLoadFloat32x4(&b[ldb * 1]);
+                        t1_h = MlasLoadFloat32x4(&b[ldb * 1 + 4]);
+                        t2_l = MlasLoadFloat32x4(&b[ldb * 2]);
+                        t2_h = MlasLoadFloat32x4(&b[ldb * 2 + 4]);
+                    break;
+                    case 2:
+                        t0_l = MlasLoadFloat32x4(&b[ldb * 0]);
+                        t0_h = MlasLoadFloat32x4(&b[ldb * 0 + 4]);
+                        t1_l = MlasLoadFloat32x4(&b[ldb * 1]);
+                        t1_h = MlasLoadFloat32x4(&b[ldb * 1 + 4]);
+                    break;
+                    case 1:
+                        t0_l = MlasLoadFloat32x4(&b[ldb * 0]);
+                        t0_h = MlasLoadFloat32x4(&b[ldb * 0 + 4]);
+                    break;
+                }
+            }
+
+            float32x4x2_t z0_l = vzipq_f32(t0_l, t2_l);
+            float32x4x2_t z1_l = vzipq_f32(t1_l, t3_l);
+            float32x4x2_t o0_l = vzipq_f32(z0_l.val[0], z1_l.val[0]);
+            float32x4x2_t o1_l = vzipq_f32(z0_l.val[1], z1_l.val[1]);
+            t0_l = o0_l.val[0];
+            t1_l = o0_l.val[1];
+            t2_l = o1_l.val[0];
+            t3_l = o1_l.val[1];
+
+            bfloat16x8_t t0t1_l_4h = vcvtq_low_bf16_f32(t0_l);
+            bfloat16x8_t t0t1_l_8h = vcvtq_high_bf16_f32(t0t1_l_4h, t1_l);
+
+            bfloat16x8_t t2t3_l_4h = vcvtq_low_bf16_f32(t2_l);
+            bfloat16x8_t t2t3_l_8h = vcvtq_high_bf16_f32(t2t3_l_4h, t3_l);
+
+            vst1q_bf16(&D[0], t0t1_l_8h);
+            vst1q_bf16(&D[8], t2t3_l_8h);
+
+            float32x4x2_t z0_h = vzipq_f32(t0_h, t2_h);
+            float32x4x2_t z1_h = vzipq_f32(t1_h, t3_h);
+            float32x4x2_t o0_h = vzipq_f32(z0_h.val[0], z1_h.val[0]);
+            float32x4x2_t o1_h = vzipq_f32(z0_h.val[1], z1_h.val[1]);
+            t0_h = o0_h.val[0];
+            t1_h = o0_h.val[1];
+            t2_h = o1_h.val[0];
+            t3_h = o1_h.val[1];
+
+            bfloat16x8_t t0t1_h_4h = vcvtq_low_bf16_f32(t0_h);
+            bfloat16x8_t t0t1_h_8h = vcvtq_high_bf16_f32(t0t1_h_4h, t1_h);
+
+            bfloat16x8_t t2t3_h_4h = vcvtq_low_bf16_f32(t2_h);
+            bfloat16x8_t t2t3_h_8h = vcvtq_high_bf16_f32(t2t3_h_4h, t3_h);
+
+            vst1q_bf16(&D[16], t0t1_h_8h);
+            vst1q_bf16(&D[24], t2t3_h_8h);
+
+            D += 32;
+            b += ldb*4;
+            y -= 4;
+        };
+        B += 8;
+        CountX -= 8;
+    }
+
+    //
+    // Special case the handling of the remaining columns less than 8 elements
+    // wide.
+    //
+    if (CountX > 0) {
+        int y = CountY;
+        while (y > 0) {
+            const float* b = B;
+	    size_t b_inc = 0;
+
+            if ((CountX & 4) != 0) {
+                MLAS_FLOAT32X4 t0 = MlasZeroFloat32x4();
+                MLAS_FLOAT32X4 t1 = MlasZeroFloat32x4();
+                MLAS_FLOAT32X4 t2 = MlasZeroFloat32x4();
+                MLAS_FLOAT32X4 t3 = MlasZeroFloat32x4();
+                if ( y >= 4) {
+                    t0 = MlasLoadFloat32x4(&b[ldb * 0]);
+                    t1 = MlasLoadFloat32x4(&b[ldb * 1]);
+                    t2 = MlasLoadFloat32x4(&b[ldb * 2]);
+                    t3 = MlasLoadFloat32x4(&b[ldb * 3]);
+                } else {
+                    switch(y) {
+                        case 3:
+                            t0 = MlasLoadFloat32x4(&b[ldb * 0]);
+                            t1 = MlasLoadFloat32x4(&b[ldb * 1]);
+                            t2 = MlasLoadFloat32x4(&b[ldb * 2]);
+                        break;
+                        case 2:
+                            t0 = MlasLoadFloat32x4(&b[ldb * 0]);
+                            t1 = MlasLoadFloat32x4(&b[ldb * 1]);
+                        break;
+                        case 1:
+                            t0 = MlasLoadFloat32x4(&b[ldb * 0]);
+                        break;
+                    }
+                }
+
+                float32x4x2_t z0 = vzipq_f32(t0, t2);
+                float32x4x2_t z1 = vzipq_f32(t1, t3);
+                float32x4x2_t o0 = vzipq_f32(z0.val[0], z1.val[0]);
+                float32x4x2_t o1 = vzipq_f32(z0.val[1], z1.val[1]);
+
+                t0 = o0.val[0];
+                t1 = o0.val[1];
+                t2 = o1.val[0];
+                t3 = o1.val[1];
+
+                bfloat16x8_t t0t1_4h = vcvtq_low_bf16_f32(t0);
+                bfloat16x8_t t0t1_8h = vcvtq_high_bf16_f32(t0t1_4h, t1);
+
+                bfloat16x8_t t2t3_4h = vcvtq_low_bf16_f32(t2);
+                bfloat16x8_t t2t3_8h = vcvtq_high_bf16_f32(t2t3_4h, t3);
+
+                vst1q_bf16(&D[0], t0t1_8h);
+                vst1q_bf16(&D[8], t2t3_8h);
+
+                D += 16;
+                b += 4;
+                b_inc += 4;
+	    }
+	    if ((CountX & 2) != 0) {
+                float32x2_t t0 = {0x0, 0x0};
+                float32x2_t t1 = {0x0, 0x0};
+                float32x2_t t2 = {0x0, 0x0};
+                float32x2_t t3 = {0x0, 0x0};
+
+                if (y >= 4) {
+                    t0 = vld1_f32(&b[ldb * 0]);
+                    t1 = vld1_f32(&b[ldb * 1]);
+                    t2 = vld1_f32(&b[ldb * 2]);
+                    t3 = vld1_f32(&b[ldb * 3]);
+                } else {
+                    switch(y) {
+                        case 3:
+                            t0 = vld1_f32(&b[ldb * 0]);
+                            t1 = vld1_f32(&b[ldb * 1]);
+                            t2 = vld1_f32(&b[ldb * 2]);
+                        break;
+                        case 2:
+                            t0 = vld1_f32(&b[ldb * 0]);
+                            t1 = vld1_f32(&b[ldb * 1]);
+                        break;
+                        case 1:
+                            t0 = vld1_f32(&b[ldb * 0]);
+                        break;
+                    }
+                }
+
+                float32x2x2_t z0 = vzip_f32(t0, t2);
+                float32x2x2_t z1 = vzip_f32(t1, t3);
+                float32x2x2_t o0 = vzip_f32(z0.val[0], z1.val[0]);
+                float32x2x2_t o1 = vzip_f32(z0.val[1], z1.val[1]);
+
+                float32x4_t tt0 = vcombine_f32(o0.val[0], o0.val[1]);
+                float32x4_t tt1 = vcombine_f32(o1.val[0], o1.val[1]);
+
+                bfloat16x8_t t_4h = vcvtq_low_bf16_f32(tt0);
+                bfloat16x8_t t_8h = vcvtq_high_bf16_f32(t_4h, tt1);
+
+                vst1q_bf16(&D[0], t_8h);
+
+                D += 8;
+                b += 2;
+		b_inc += 2;
+            }
+            if ((CountX & 1) != 0) {
+                float  a = 0.0f;
+                float  b = 0.0f;
+                float  c = 0.0f;
+                float  d = 0.0f;
+
+                if (y >=4 ) {
+                    a = *(float*)(&B[ldb * 0 + b_inc]);
+                    b = *(float*)(&B[ldb * 1 + b_inc]);
+                    c = *(float*)(&B[ldb * 2 + b_inc]);
+                    d = *(float*)(&B[ldb * 3 + b_inc]);
+                 } else {
+                    switch(y) {
+                        case 3:
+                            a = *(float*)(&B[ldb * 0 + b_inc]);
+                            b = *(float*)(&B[ldb * 1 + b_inc]);
+                            c = *(float*)(&B[ldb * 2 + b_inc]);
+                        break;
+                        case 2:
+                            a = *(float*)(&B[ldb * 0 + b_inc]);
+                            b = *(float*)(&B[ldb * 1 + b_inc]);
+                        break;
+                        case 1:
+                            a = *(float*)(&B[ldb * 0 + b_inc]);
+                        break;
+                    }
+                }
+                float32x2_t t0 = {a, 0x0};
+                float32x2_t t1 = {b, 0x0};
+                float32x2_t t2 = {c, 0x0};
+                float32x2_t t3 = {d, 0x0};
+
+                float32x2x2_t z0 = vzip_f32(t0, t2);
+                float32x2x2_t z1 = vzip_f32(t1, t3);
+                float32x2x2_t o0 = vzip_f32(z0.val[0], z1.val[0]);
+                float32x2x2_t o1 = vzip_f32(z0.val[1], z1.val[1]);
+
+                float32x4_t tt0 = vcombine_f32(o0.val[0], o0.val[1]);
+                float32x4_t tt1 = vcombine_f32(o1.val[0], o1.val[1]);
+
+                bfloat16x8_t t_4h = vcvtq_low_bf16_f32(tt0);
+                bfloat16x8_t t_8h = vcvtq_high_bf16_f32(t_4h, tt1);
+
+                vst1q_bf16(&D[0], t_8h);
+
+                D += 8;
+                b += 1;
+		b_inc += 1;
+            }
+            B += 4*ldb;
+            y -= 4;
+            }
+       }
+}
+
+MLAS_FORCEINLINE
+float*
+MlasSbgemmKernelLoop(
+    const float* A,
+    const bfloat16_t* B,
+    float* C,
+    size_t CountK,
+    size_t CountM,
+    size_t CountN,
+    size_t lda,
+    size_t ldc,
+    float alpha,
+    bool ZeroMode
+    )
+/*++
+
+Routine Description:
+
+    This routine steps through the rows of the input and output matrices calling
+    the kernel until all rows have been processed.
+
+Arguments:
+
+    A - Supplies the address of matrix A.
+
+    B - Supplies the address of matrix B. The matrix data has been packed using
+        MlasSgemmCopyPackB or MlasSgemmTransposePackB.
+
+    C - Supplies the address of matrix C.
+
+    CountK - Supplies the number of columns from matrix A and the number of rows
+        from matrix B to iterate over.
+
+    CountM - Supplies the number of rows from matrix A and matrix C to iterate
+        over.
+
+    CountN - Supplies the number of columns from matrix B and matrix C to
+        iterate over.
+
+    lda - Supplies the first dimension of matrix A.
+
+    ldc - Supplies the first dimension of matrix C.
+
+    alpha - Supplies the scalar alpha multiplier (see SGEMM definition).
+
+    ZeroMode - Supplies true if the output matrix must be zero initialized,
+        else false if the output matrix is accumulated into.
+
+Return Value:
+
+    Returns the next address of matrix C.
+
+--*/
+{
+    while (CountM > 0) {
+        size_t RowsHandled;
+        if (ZeroMode) {
+            RowsHandled = MlasSbgemmKernelZero(A, B, C, CountK, CountM, CountN, lda, ldc, alpha);
+        } else {
+            RowsHandled = MlasSbgemmKernelAdd(A, B, C, CountK, CountM, CountN, lda, ldc, alpha);
+        }
+        C += ldc * RowsHandled;
+        A += lda * RowsHandled;
+        CountM -= RowsHandled;
+    }
+
+return C;
+}
+
+void
+MlasSbgemmOperation(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB,
+    size_t M,
+    size_t N,
+    size_t K,
+    float alpha,
+    const float* A,
+    size_t lda,
+    const float* B,
+    size_t ldb,
+    float beta,
+    float* C,
+    size_t ldc
+    )
+/*++
+
+Routine Description:
+
+    This routine implements the bfloat16 half precision matrix/matrix multiply
+    operation (SBGEMM).
+
+Arguments:
+
+    TransA - Supplies the transpose operation for matrix A.
+
+    TransB - Supplies the transpose operation for matrix B.
+
+    M - Supplies the number of rows of matrix A and matrix C.
+
+    N - Supplies the number of columns of matrix B and matrix C.
+
+    K - Supplies the number of columns of matrix A and the number of rows of
+        matrix B.
+
+    alpha - Supplies the scalar alpha multiplier (see SGEMM definition).
+
+    A - Supplies the address of matrix A.
+
+    lda - Supplies the first dimension of matrix A.
+
+    B - Supplies the address of matrix B.
+
+    ldb - Supplies the first dimension of matrix B.
+
+    beta - Supplies the scalar beta multiplier (see SGEMM definition).
+
+    C - Supplies the address of matrix C.
+
+    ldc - Supplies the first dimension of matrix C.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    float PanelA[MLAS_SGEMM_TRANSA_ROWS * MLAS_SGEMM_STRIDEK];
+    MLAS_DECLSPEC_ALIGN(bfloat16_t PanelB[MLAS_SGEMM_STRIDEN * MLAS_SGEMM_STRIDEK], 16 * sizeof(bfloat16_t));
+
+    //
+    // Compute the strides to step through slices of the input matrices.
+    //
+    // Expand the N stride if K is small or expand the K stride if N is small
+    // for better utilization of the B panel. Avoid changing the K stride if
+    // the A panel needs to be used for transposing.
+    //
+
+    size_t StrideN = MLAS_SGEMM_STRIDEN;
+    size_t StrideK = MLAS_SGEMM_STRIDEK;
+
+    if (N >= K) {
+        while (StrideK / 2 >= K) {
+            StrideN *= 2;
+            StrideK /= 2;
+        }
+    } else if (TransA == CblasNoTrans) {
+        while (StrideN > 16 && StrideN / 2 >= N) {
+            StrideK *= 2;
+            StrideN /= 2;
+        }
+    }
+
+    //
+    // Step through each slice of matrix B along the N dimension.
+    //
+
+    size_t CountN;
+
+    for (size_t n = 0; n < N; n += CountN) {
+
+        CountN = std::min(N - n, StrideN);
+
+        //
+        // Multiply the output matrix by beta as needed.
+        //
+
+        if (beta != 0.0f && beta != 1.0f) {
+            MlasSbgemmMultiplyBeta(C + n, M, CountN, ldc, beta);
+        }
+
+        //
+        // Step through each slice of matrix B along the K dimension.
+        //
+
+        size_t CountK;
+        bool ZeroMode = (beta == 0.0f);
+
+        for (size_t k = 0; k < K; k += CountK) {
+
+            CountK = std::min(K - k, StrideK);
+
+            //
+            // Copy or transpose a panel of matrix B to a local packed buffer.
+            //
+
+            if (TransB == CblasNoTrans) {
+                MlasSbgemmCopyPackB(PanelB, B + n + k * ldb, ldb, CountN, CountK);
+            }
+
+            //
+            // Step through each slice of matrix A along the M dimension.
+            //
+
+            float* c = C + n;
+
+            if (TransA == CblasNoTrans) {
+                MlasSbgemmKernelLoop(A + k, PanelB, c, CountK, M, CountN, lda, ldc, alpha, ZeroMode);
+            } else {
+
+                const float* a = A + k * lda;
+                size_t RowsRemaining = M;
+
+                while (RowsRemaining > 0) {
+
+                    //
+                    // Transpose elements from matrix A into a local buffer.
+                    //
+
+                    size_t RowsTransposed = std::min(RowsRemaining, size_t(MLAS_SGEMM_TRANSA_ROWS));
+
+                    MlasSbgemmTransposeA(PanelA, a, lda, RowsTransposed, CountK);
+
+                    RowsRemaining -= RowsTransposed;
+                    a += RowsTransposed;
+
+                    //
+                    // Step through the rows of the local buffer.
+                    //
+                    c = MlasSbgemmKernelLoop(PanelA, PanelB, c, CountK, RowsTransposed, CountN, CountK, ldc, alpha, ZeroMode);
+                }
+            }
+
+            ZeroMode = false;
+        }
+    }
+}
+
+
+void
+MlasSbgemmPackedOperation(
+    CBLAS_TRANSPOSE TransA,
+    size_t M,
+    size_t RangeStartN,
+    size_t RangeCountN,
+    size_t K,
+    float alpha,
+    const float* A,
+    size_t lda,
+    const void* PackedB,
+    size_t AlignedN,
+    float beta,
+    float* C,
+    size_t ldc
+    )
+/*++
+
+Routine Description:
+
+    This routine implements the bfloat16 half precision matrix/matrix multiply
+    operation (SBGEMM).
+
+Arguments:
+
+    TransA - Supplies the transpose operation for matrix A.
+
+    M - Supplies the number of rows of matrix A and matrix C.
+
+    RangeStartN - Supplies the starting column from packed matrix B.
+
+    RangeCountN - Supplies the number of columns of matrix B and matrix C.
+
+    K - Supplies the number of columns of matrix A and the number of rows of
+        matrix B.
+
+    alpha - Supplies the scalar alpha multiplier (see SGEMM definition).
+
+    A - Supplies the address of matrix A.
+
+    lda - Supplies the first dimension of matrix A.
+
+    PackedB - Supplies the address of packed matrix B.
+
+    AlignedN - Supplies the total number of aligned columns for packed matrix B.
+
+    ldb - Supplies the first dimension of matrix B.
+
+    beta - Supplies the scalar beta multiplier (see SGEMM definition).
+
+    C - Supplies the address of matrix C.
+
+    ldc - Supplies the first dimension of matrix C.
+
+Return Value:
+
+    None.
+
+--*/
+
+{
+    float PanelA[MLAS_SGEMM_TRANSA_ROWS * MLAS_SGEMM_PACKED_STRIDEK];
+
+    //
+    // Step through each slice of matrix B along the N dimension.
+    //
+
+    size_t CountN;
+
+    for (size_t n = 0; n < RangeCountN; n += CountN) {
+
+        const size_t SliceStartN = RangeStartN + n;
+
+        CountN = std::min(RangeCountN - n, size_t(MLAS_SGEMM_PACKED_STRIDEN));
+
+        //
+        // Multiply the output matrix by beta as needed.
+        //
+
+        if (beta != 0.0f && beta != 1.0f) {
+            MlasSbgemmMultiplyBeta(C + n, M, CountN, ldc, beta);
+        }
+
+        //
+        // Step through each slice of matrix B along the K dimension.
+        //
+
+        size_t CountK;
+        bool ZeroMode = (beta == 0.0f);
+
+        for (size_t k = 0; k < K; k += CountK) {
+
+            CountK = std::min(K - k, size_t(MLAS_SGEMM_PACKED_STRIDEK));
+
+            //
+            // Step through each slice of matrix A along the M dimension.
+            //
+
+            const bfloat16_t* pb = (const bfloat16_t*)PackedB + AlignedN * k + CountK * SliceStartN;
+            float* c = C + n;
+
+            if (TransA == CblasNoTrans) {
+
+                MlasSbgemmKernelLoop(A + k, pb, c, CountK, M, CountN, lda, ldc, alpha, ZeroMode);
+            } else {
+
+                const float* a = A + k * lda;
+                size_t RowsRemaining = M;
+
+                while (RowsRemaining > 0) {
+
+                    //
+                    // Transpose elements from matrix A into a local buffer.
+                    //
+
+                    size_t RowsTransposed = std::min(RowsRemaining, size_t(MLAS_SGEMM_TRANSA_ROWS));
+
+                    MlasSbgemmTransposeA(PanelA, a, lda, RowsTransposed, CountK);
+
+                    RowsRemaining -= RowsTransposed;
+                    a += RowsTransposed;
+
+                    //
+                    // Step through the rows of the local buffer.
+                    //
+                    c = MlasSbgemmKernelLoop(PanelA, pb, c, CountK, RowsTransposed, CountN, CountK, ldc, alpha, ZeroMode);
+                }
+            }
+
+            ZeroMode = false;
+        }
+    }
+}
+
+
+void
+MlasSbgemmThreaded(
+    const ptrdiff_t ThreadCountM,
+    const ptrdiff_t ThreadCountN,
+    const CBLAS_TRANSPOSE TransA,
+    const CBLAS_TRANSPOSE TransB,
+    const size_t M,
+    const size_t N,
+    const size_t K,
+
+    const MLAS_SGEMM_DATA_PARAMS* DataParams,
+    ptrdiff_t ThreadId
+    )
+/*++
+
+Routine Description:
+
+    This routine is invoked from a worker thread to execute a segment of a
+    SBGEMM operation.
+
+Arguments:
+
+    ThreadCountM - Supplies the total thread partition on the M dimension.
+
+    ThreadCountN - Supplies the total thread partition on the N dimension.
+
+    TransA - Supplies the transpose operation on A matrix
+
+    TransB - Supplies the transpose operation on B matrix
+
+    M, N, K - Supplies the shape of the multiplication
+
+    DataParams - Supplies the data position and layout of the matrices
+
+    ThreadId - Supplies the current index of the threaded operation.
+
+Return Value:
+
+    None.
+
+--*/
+{
+    const ptrdiff_t ThreadIdM = ThreadId / ThreadCountN;
+    const ptrdiff_t ThreadIdN = ThreadId % ThreadCountN;
+
+    //
+    // Partition the operation along the M dimension.
+    //
+
+    size_t RangeStartM;
+    size_t RangeCountM;
+
+    MlasPartitionWork(ThreadIdM, ThreadCountM, M, &RangeStartM, &RangeCountM);
+
+    //
+    // Partition the operation along the N dimension.
+    //
+
+    size_t RangeStartN;
+    size_t RangeCountN;
+
+    const size_t BlockedN = (N + MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1) /
+        MLAS_SGEMM_STRIDEN_THREAD_ALIGN;
+
+    MlasPartitionWork(ThreadIdN, ThreadCountN, BlockedN, &RangeStartN,
+        &RangeCountN);
+
+    RangeStartN *= MLAS_SGEMM_STRIDEN_THREAD_ALIGN;
+    RangeCountN *= MLAS_SGEMM_STRIDEN_THREAD_ALIGN;
+
+    RangeCountN = std::min(N - RangeStartN, RangeCountN);
+
+    //
+    // Dispatch the partitioned operation.
+    //
+    const size_t lda = DataParams->lda;
+    const size_t ldc = DataParams->ldc;
+    const float* A = DataParams->A + RangeStartM * ((TransA == CblasNoTrans) ? lda : 1);
+    float* C = DataParams->C + RangeStartM * ldc + RangeStartN;
+
+
+    if (DataParams->BIsPacked) {
+
+	    MlasSbgemmPackedOperation(TransA, RangeCountM, RangeStartN, RangeCountN,
+            K, DataParams->alpha, A, lda, DataParams->B,
+            BlockedN * MLAS_SGEMM_STRIDEN_THREAD_ALIGN, DataParams->beta, C, ldc);
+
+    } else {
+
+        const size_t ldb = DataParams->ldb;
+
+        const float* B = (const float*)DataParams->B + RangeStartN * ((TransB == CblasNoTrans) ? 1 : ldb);
+
+        MlasSbgemmOperation(TransA, TransB, RangeCountM, RangeCountN, K,
+            DataParams->alpha, A, lda, B, ldb, DataParams->beta, C, ldc);
+    }
+
+}
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+// Chance of arithmetic overflow could be reduced
+#pragma warning(disable : 26451)
+#endif
+void
+MLASCALL
+MlasSBGemmBatch(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB,
+    size_t M,
+    size_t N,
+    size_t K,
+    const MLAS_SGEMM_DATA_PARAMS* Data,
+    size_t BatchSize,
+    MLAS_THREADPOOL* ThreadPool
+    )
+{
+    //
+    // Compute the number of target threads given the complexity of the SGEMM
+    // operation. Small requests should run using the single threaded path.
+    //
+
+    const double Complexity = double(M) * double(N) * double(K);
+
+    ptrdiff_t TargetThreadCount;
+
+
+    if (Complexity < double(MLAS_SBGEMM_THREAD_COMPLEXITY * GetMlasPlatform().MaximumThreadCount)) {
+        TargetThreadCount = ptrdiff_t(Complexity / double(MLAS_SGEMM_THREAD_COMPLEXITY)) + 1;
+    } else {
+        TargetThreadCount = GetMlasPlatform().MaximumThreadCount;
+    }
+
+    ptrdiff_t MaximumThreadCount = MlasGetMaximumThreadCount(ThreadPool);
+
+    if (TargetThreadCount >= MaximumThreadCount) {
+        TargetThreadCount = MaximumThreadCount;
+    }
+
+    //
+    // Segment the operation across multiple threads.
+    //
+    // N.B. Currently, the operation is segmented as a 1D partition, which
+    // works okay for operations involving skinny matrices.
+    //
+
+    ptrdiff_t ThreadsPerGemm = (TargetThreadCount + BatchSize - 1) / BatchSize;
+    ptrdiff_t ThreadCountM;
+    ptrdiff_t ThreadCountN;
+
+    if (N > M) {
+
+        const size_t BlockedN = (N + MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1) /
+            MLAS_SGEMM_STRIDEN_THREAD_ALIGN;
+
+        if (size_t(ThreadsPerGemm) > BlockedN) {
+            ThreadsPerGemm = ptrdiff_t(BlockedN);
+        }
+
+        ThreadCountM = 1;
+        ThreadCountN = ThreadsPerGemm;
+
+    } else {
+
+        if (size_t(ThreadsPerGemm) > M) {
+            ThreadsPerGemm = ptrdiff_t(M);
+        }
+
+        ThreadCountM = ThreadsPerGemm;
+        ThreadCountN = 1;
+    }
+
+    MlasTrySimpleParallel(ThreadPool,
+        ThreadsPerGemm * static_cast<ptrdiff_t>(BatchSize),
+        [=](ptrdiff_t tid)
+    {
+        ptrdiff_t GemmIdx = tid / ThreadsPerGemm;
+        ptrdiff_t ThreadIdx = tid % ThreadsPerGemm;
+        MlasSbgemmThreaded(ThreadCountM, ThreadCountN,
+            TransA, TransB, M, N, K, &(Data[GemmIdx]), ThreadIdx);
+    });
+}
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
+
+size_t
+MLASCALL
+MlasSBGemmPackBSize(
+    size_t N,
+    size_t K
+    )
+/*++
+
+Routine Description:
+
+    This routine computes the length in bytes for the packed matrix B buffer.
+
+Arguments:
+
+    N - Supplies the number of columns of matrix B.
+
+    K - Supplies the number of rows of matrix B.
+
+Return Value:
+
+    Returns the size in bytes for the packed matrix B buffer.
+
+--*/
+{
+    //
+    // Compute the number of bytes required to hold the packed buffer.
+    //
+
+    const size_t AlignedN =
+        (N + MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1) & ~(MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1);
+
+    const size_t BytesRequired = AlignedN * K * sizeof(bfloat16_t);
+    const size_t BufferAlignment = MlasGetPreferredBufferAlignment();
+    const size_t AlignedBytesRequired = (BytesRequired + BufferAlignment - 1) &
+        ~(BufferAlignment - 1);
+
+    return AlignedBytesRequired;
+}
+
+void
+MLASCALL
+MlasSBGemmPackB(
+    CBLAS_TRANSPOSE TransB,
+    size_t N,
+    size_t K,
+    const float* B,
+    size_t ldb,
+    void* PackedB
+    )
+/*++
+
+Routine Description:
+
+    This routine packs the contents of matrix B to the destination buffer. The
+    destination buffer should be sized based on MlasSBGemmPackBSize(). For best
+    performance, the destination buffer should be aligned to the value returned
+    from MlasGetPreferredBufferAlignment().
+
+Arguments:
+
+    TransB - Supplies the transpose operation for matrix B.
+
+    N - Supplies the number of columns of matrix B.
+
+    K - Supplies the number of rows of matrix B.
+
+    B - Supplies the address of matrix B.
+
+    ldb - Supplies the first dimension of matrix B.
+
+    PackedB - Supplies the address of packed matrix B.
+
+Return Value:
+
+    None.
+
+--*/
+{
+
+    const size_t AlignedN =
+        (N + MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1) & ~(MLAS_SGEMM_STRIDEN_THREAD_ALIGN - 1);
+
+    //
+    // Step through each slice of matrix B along the K dimension.
+    //
+
+    size_t CountK;
+
+    for (size_t k = 0; k < K; k += CountK) {
+
+        CountK = std::min(K - k, size_t(MLAS_SGEMM_PACKED_STRIDEK));
+
+        if (TransB == CblasNoTrans) {
+                MlasSbgemmCopyPackB((bfloat16_t*)PackedB, B + k * ldb, ldb, N, CountK);
+        }
+
+        PackedB = (bfloat16_t*)PackedB + AlignedN * CountK;
+    }
+}

--- a/onnxruntime/test/providers/base_tester.h
+++ b/onnxruntime/test/providers/base_tester.h
@@ -652,7 +652,8 @@ class BaseTester {
                     const std::unordered_map<std::string, OrtValue>& feeds,
                     const std::vector<std::string>& output_names,
                     const std::string& provider_type,
-                    bool allow_released_onnx_opset_only = true);
+                    bool allow_released_onnx_opset_only = true,
+                    bool use_cosine_similarity = false);
 
   template <typename T>
   void AddData(std::vector<Data>& data, const char* name, const DimsVariant& dims_var, const T* values,
@@ -903,7 +904,8 @@ class BaseTester {
                           bool try_assign_ep_for_nodes,
                           bool allow_released_onnx_opset_only,
                           size_t* number_of_pre_packed_weights_counter,
-                          size_t* number_of_shared_pre_packed_weights_counter);
+                          size_t* number_of_shared_pre_packed_weights_counter,
+                          bool use_cosine_similarity);
 
   const std::string test_name_;
   const std::string domain_;

--- a/onnxruntime/test/providers/checkers.h
+++ b/onnxruntime/test/providers/checkers.h
@@ -27,7 +27,8 @@ struct ValidateOutputParams {
 /// <param name="params">Optional parameters to adjust how the check is performed.</param>
 /// <param name="provider_type">Execution provider type if relevant.</param>
 void CheckOrtValuesAreEqual(std::string_view name, const OrtValue& expected, const OrtValue& actual,
-                            const ValidateOutputParams& params = {}, const std::string& provider_type = "");
+                            const ValidateOutputParams& params = {}, const std::string& provider_type = "",
+                            bool use_cosine_similarity=false);
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR adds SbgemmKernel for aarch64. This includes Sbegmm kernel to implement matrix multiplication with bfloat16 SIMD instructions (bfmmla) and  MatMul <float> operator changes to invoke the Sbgemm kernel. To enable Sbgemm kernel, set the below environment variable
ORT_USE_FASTMATH_MODE=1


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This is to improve MatMul performance on aarch64 platform.
I have run the below benchmarking script (bert , roberta and gpt2 model inference) on AWS Graviton3 based c7g.4xl instance and observed 2x -3x performance improvement compared to sgemm (fp32) kernel performance.

```
cd onnxruntime/python/tools/transformers
python3 benchmark.py
```

And the unit test precision results are matching to sgemm kernel results.
`./build.sh --config RelWithDebInfo --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync
`