### PR TITLE
[QNN EP] Fix error handling for Softmax/ReduceOps

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -191,6 +191,13 @@ Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN EP: ReduceProd operator not supported by HTP backend.");
   }
 
+  if (is_quantized_model) {
+    std::vector<uint32_t> input_shape;
+    ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].node_arg, input_shape),
+                      "QNN EP: Cannot get input shape for");
+    ORT_RETURN_IF(input_shape.size() > 4, "QNN EP: HTP backend does not support Reduce ops with rank > 4.");
+  }
+
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, is_quantized_model, true);
 }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -50,7 +50,7 @@ class SimpleOpBuilder : public BaseOpBuilder {
 Status SimpleOpBuilder::ExplictOpCheck(const QnnModelWrapper& qnn_model_wrapper, const NodeUnit& node_unit) const {
   // QNN Softmax only supports an axis value equal to input_rank - 1 (i.e., same as -1).
   if (node_unit.OpType() == "Softmax") {
-    int32_t axis = node_unit.SinceVersion() < 13 ? 1 : - 1;  // Default axis changed from 1 to -1 in opset 13.
+    int32_t axis = node_unit.SinceVersion() < 13 ? 1 : -1;  // Default axis changed from 1 to -1 in opset 13.
     Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
     ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
     std::vector<uint32_t> input_shape;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -48,19 +48,16 @@ class SimpleOpBuilder : public BaseOpBuilder {
 };
 
 Status SimpleOpBuilder::ExplictOpCheck(const QnnModelWrapper& qnn_model_wrapper, const NodeUnit& node_unit) const {
-  if (node_unit.OpType() == "Softmax" && node_unit.SinceVersion() < 13) {
-    int32_t default_axis = -1;
+  // QNN Softmax only supports an axis value equal to input_rank - 1 (i.e., same as -1).
+  if (node_unit.OpType() == "Softmax") {
+    int32_t axis = node_unit.SinceVersion() < 13 ? 1 : - 1;  // Default axis changed from 1 to -1 in opset 13.
     Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
+    ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
     std::vector<uint32_t> input_shape;
     ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].node_arg, input_shape),
-                      "Cannot get shape");
-    // For Softmax opset < 13, it's still supported if axis=rank-1
-    if (default_axis == static_cast<int32_t>(input_shape.size() - 1)) {
-      return Status::OK();
-    }
-
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN Softmax only supports opset >= 13 or axis=input_rank-1.");
+                      "QNN EP: Cannot get shape for Softmax input");
+    ORT_RETURN_IF(axis != static_cast<int32_t>(input_shape.size() - 1),
+                  "QNN Softmax only supports an `axis` attribute equal to input_rank-1 (or -1)");
   }
 
   return Status::OK();

--- a/onnxruntime/test/providers/qnn/average_pool_test.cc
+++ b/onnxruntime/test/providers/qnn/average_pool_test.cc
@@ -111,7 +111,7 @@ static void RunAveragePoolOpTest(const std::vector<int64_t>& shape,
                                  const std::vector<int64_t>& pads,
                                  int64_t count_include_pad,
                                  const std::string& auto_pad,
-                                 ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
                                  int opset = 18) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -125,8 +125,7 @@ static void RunAveragePoolOpTest(const std::vector<int64_t>& shape,
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 // Runs a QDQ AveragePool model on the QNN HTP backend. Checks the graph node assignment, and that inference
@@ -138,7 +137,7 @@ static void RunQDQAveragePoolOpTest(const std::vector<int64_t>& shape,
                                     const std::vector<int64_t>& pads,
                                     int64_t count_include_pad,
                                     const std::string& auto_pad,
-                                    ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                    ExpectedEPNodeAssignment expected_ep_assignment,
                                     int opset = 18, float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -154,7 +153,6 @@ static void RunQDQAveragePoolOpTest(const std::vector<int64_t>& shape,
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -170,7 +168,7 @@ TEST_F(QnnCPUBackendTests, TestAveragePool_Global) {
                        {0, 0, 0, 0},  // pads
                        0,             // count_include_pad
                        "NOTSET",
-                       ExpectedEPNodeAssignment::All, "TestAveragePool_Global");
+                       ExpectedEPNodeAssignment::All);
 }
 
 // AveragePool that counts padding.
@@ -181,7 +179,7 @@ TEST_F(QnnCPUBackendTests, TestAveragePool_CountIncludePad) {
                        {0, 0, 0, 0},  // pads
                        1,             // count_include_pad
                        "NOTSET",
-                       ExpectedEPNodeAssignment::All, "TestAveragePool_CountIncludePad");
+                       ExpectedEPNodeAssignment::All);
 }
 
 // AveragePool that use auto_pad 'SAME_UPPER'.
@@ -192,7 +190,7 @@ TEST_F(QnnCPUBackendTests, TestAveragePool_AutopadSameUpper) {
                        {},            // pads
                        1,             // count_include_pad
                        "SAME_UPPER",
-                       ExpectedEPNodeAssignment::All, "TestAveragePool_CountIncludePad");
+                       ExpectedEPNodeAssignment::All);
 }
 
 // AveragePool that use auto_pad 'SAME_LOWER'.
@@ -203,7 +201,7 @@ TEST_F(QnnCPUBackendTests, TestAveragePool_AutopadSameLower) {
                        {},            // pads
                        1,             // count_include_pad
                        "SAME_LOWER",
-                       ExpectedEPNodeAssignment::All, "TestAveragePool_CountIncludePad");
+                       ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -219,7 +217,7 @@ TEST_F(QnnHTPBackendTests, TestAveragePool_Global_HTP_u8) {
                                    {0, 0, 0, 0},  // pads
                                    0,             // count_include_pad
                                    "NOTSET",
-                                   ExpectedEPNodeAssignment::All, "TestAveragePool_Global_HTP_u8");
+                                   ExpectedEPNodeAssignment::All);
 }
 
 // QDQ AveragePool that counts padding.
@@ -230,7 +228,7 @@ TEST_F(QnnHTPBackendTests, TestAveragePool_CountIncludePad_HTP_u8) {
                                    {0, 0, 0, 0},  // pads
                                    1,             // count_include_pad
                                    "NOTSET",
-                                   ExpectedEPNodeAssignment::All, "TestAveragePool_CountIncludePad_HTP_u8",
+                                   ExpectedEPNodeAssignment::All,
                                    18, 0.00381f);
 }
 
@@ -242,7 +240,7 @@ TEST_F(QnnHTPBackendTests, TestAveragePool_AutopadSameUpper_HTP_u8) {
                                    {},            // pads
                                    0,             // count_include_pad
                                    "SAME_UPPER",
-                                   ExpectedEPNodeAssignment::All, "TestAveragePool_AutopadSameUpper_HTP_u8",
+                                   ExpectedEPNodeAssignment::All,
                                    18, 0.00381f);
 }
 
@@ -254,7 +252,7 @@ TEST_F(QnnHTPBackendTests, TestAveragePool_AutopadSameLower_HTP_u8) {
                                    {},            // pads
                                    0,             // count_include_pad
                                    "SAME_LOWER",
-                                   ExpectedEPNodeAssignment::All, "TestAveragePool_AutopadSameLower_HTP_u8",
+                                   ExpectedEPNodeAssignment::All,
                                    18, 0.00381f);
 }
 

--- a/onnxruntime/test/providers/qnn/batch_norm_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/batch_norm_htp_test.cc
@@ -70,11 +70,10 @@ GetQDQTestCaseFn BuildQDQBatchNormTestCase(const std::vector<int64_t>& input_sha
  * outputs for QNN and CPU match.
  *
  * \param input_shape The input's shape.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  * \param num_modes_in_graph The number of expected nodes in the graph.
  */
-static void RunBatchNormQDQTest(const std::vector<int64_t>& input_shape, const char* test_description,
+static void RunBatchNormQDQTest(const std::vector<int64_t>& input_shape,
                                 ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_graph) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -88,26 +87,25 @@ static void RunBatchNormQDQTest(const std::vector<int64_t>& input_shape, const c
                   provider_options,
                   11,
                   expected_ep_assignment,
-                  num_nodes_in_graph,
-                  test_description);
+                  num_nodes_in_graph);
 }
 
 // Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQBatchNorm1D) {
-  RunBatchNormQDQTest({1, 2, 3}, "TestQDQBatchNorm1D", ExpectedEPNodeAssignment::All, 1);
+  RunBatchNormQDQTest({1, 2, 3}, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.
 // Use an input of rank 4.
 TEST_F(QnnHTPBackendTests, TestQDQBatchNorm2D) {
-  RunBatchNormQDQTest({2, 3, 4, 5}, "TestQDQBatchNorm2D", ExpectedEPNodeAssignment::All, 1);
+  RunBatchNormQDQTest({2, 3, 4, 5}, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.
 // Use an input of rank 5. QNN BatchNormalization doesn't support 5D on HTP
 TEST_F(QnnHTPBackendTests, TestQDQBatchNorm3D) {
-  RunBatchNormQDQTest({1, 2, 3, 4, 5}, "TestQDQBatchNorm3D", ExpectedEPNodeAssignment::None, 8);
+  RunBatchNormQDQTest({1, 2, 3, 4, 5}, ExpectedEPNodeAssignment::None, 8);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -43,13 +43,12 @@ static GetTestModelFn BuildCastTestCase(const std::vector<int64_t>& shape,
  *
  * \param shape The shape of the input and output. Input data is randomly generated with this shape.
  * \param dst_type The destination type as an instance of the DataType enum in TensorProto.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  * \param use_htp True to run on HTP backend. Otherwise, runs on CPU.
  */
 template <typename InputType>
 static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::TensorProto_DataType dst_type,
-                          ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                          ExpectedEPNodeAssignment expected_ep_assignment,
                           bool use_htp) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -63,8 +62,7 @@ static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::Ten
                   provider_options,
                   13,  // opset
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 //
@@ -74,19 +72,19 @@ static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::Ten
 // Cast int32_t to float on CPU
 TEST_F(QnnCPUBackendTests, TestCastInt32ToFloat) {
   RunCastOpTest<int32_t>({2, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT, ExpectedEPNodeAssignment::All,
-                         "TestCastInt32ToFloat", false);
+                         false);
 }
 
 // Cast uint8_t to float on CPU
 TEST_F(QnnCPUBackendTests, TestCastUInt8ToFloat) {
   RunCastOpTest<uint8_t>({2, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT, ExpectedEPNodeAssignment::All,
-                         "TestCastUInt8ToFloat", false);
+                         false);
 }
 
 // Cast float to int32_t on CPU
 TEST_F(QnnCPUBackendTests, TestCastFloatToInt32) {
   RunCastOpTest<float>({2, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32, ExpectedEPNodeAssignment::All,
-                       "TestCastInt32ToFloat", false);
+                       false);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -97,19 +95,19 @@ TEST_F(QnnCPUBackendTests, TestCastFloatToInt32) {
 // Cast int32_t to float on HTP
 TEST_F(QnnHTPBackendTests, TestCastInt32ToFloatHTP) {
   RunCastOpTest<int32_t>({3, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT, ExpectedEPNodeAssignment::All,
-                         "TestCastInt32ToFloatHTP", true);
+                         true);
 }
 
 // Cast uint8_t to float on HTP
 TEST_F(QnnHTPBackendTests, TestCastUInt8ToFloatHTP) {
   RunCastOpTest<uint8_t>({3, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT, ExpectedEPNodeAssignment::All,
-                         "TestCastUInt8ToFloatHTP", true);
+                         true);
 }
 
 // Cast float to int32_t on HTP
 TEST_F(QnnHTPBackendTests, TestCastFloatToInt32HTP) {
   RunCastOpTest<float>({3, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32, ExpectedEPNodeAssignment::All,
-                       "TestCastFloatToInt32HTP", true);
+                       true);
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -76,8 +76,7 @@ TEST_F(QnnHTPBackendTests, Test_QDQConvWithDynamicWeightsFromMul) {
                   provider_options,
                   13,
                   ExpectedEPNodeAssignment::All,
-                  expected_nodes_in_partition,
-                  "Test_ConvWithDynamicWeightsFromMul");
+                  expected_nodes_in_partition);
 }
 
 // Creates a graph with a single float32 Conv operator. Used for testing CPU backend.
@@ -125,7 +124,7 @@ static void RunCPUConvOpTest(const std::string& conv_op_type, const TestInputDef
                              const std::vector<int64_t>& pads,
                              const std::vector<int64_t>& dilations,
                              const std::string& auto_pad,
-                             ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                             ExpectedEPNodeAssignment expected_ep_assignment,
                              int opset = 13,
                              float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
@@ -142,7 +141,6 @@ static void RunCPUConvOpTest(const std::string& conv_op_type, const TestInputDef
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -240,7 +238,7 @@ static void RunHTPConvOpTest(const std::string& conv_op_type, const TestInputDef
                              const std::vector<int64_t>& pads,
                              const std::vector<int64_t>& dilations,
                              const std::string& auto_pad,
-                             ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                             ExpectedEPNodeAssignment expected_ep_assignment,
                              int opset = 13,
                              float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
@@ -258,7 +256,6 @@ static void RunHTPConvOpTest(const std::string& conv_op_type, const TestInputDef
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -274,8 +271,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestCPUConvf32_dynamic_bias) {
                    {0, 0, 0, 0},                                           // default pads
                    {1, 1},                                                 // default dilations
                    "NOTSET",                                               // No auto-padding
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_bias_input");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
@@ -289,8 +285,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvf32_bias_initializer) {
                    {0, 0, 0, 0},                                           // default pads
                    {1, 1},                                                 // default dilations
                    "NOTSET",                                               // No auto-padding
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_bias_initializer");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Tests Conv's auto_pad value "SAME_UPPER" (compares to CPU EP).
@@ -303,8 +298,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvf32_AutoPadUpper) {
                    {},                                                     // pads
                    {1, 1},                                                 // dilations
                    "SAME_UPPER",                                           // auto_pad
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_AutoPadUpper");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Tests ConvTranspose's auto_pad value "SAME_UPPER" (compares to CPU EP).
@@ -317,8 +311,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvTransposef32_AutoPadUpper) {
                    {},                                                     // pads
                    {1, 1},                                                 // dilations
                    "SAME_UPPER",                                           // auto_pad
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvTransposef32_AutoPadUpper");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Tests Conv's auto_pad value "SAME_LOWER" (compares to CPU EP).
@@ -331,8 +324,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvf32_AutoPadLower) {
                    {},                                                     // pads
                    {1, 1},                                                 // dilations
                    "SAME_LOWER",                                           // auto_pad
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_AutoPadLower");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Tests ConvTranspose's auto_pad value "SAME_LOWER" (compares to CPU EP).
@@ -345,8 +337,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvTransposef32_AutoPadLower) {
                    {},                                                     // pads
                    {1, 1},                                                 // dilations
                    "SAME_LOWER",                                           // auto_pad
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvTransposef32_AutoPadLower");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // large input,output, pads
@@ -360,7 +351,6 @@ TEST_F(QnnCPUBackendTests, TestCPUConvf32_large_input1_pad_bias_initializer) {
                    {1, 1},
                    "NOTSET",
                    ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_large_input1_pad_bias_initializer",
                    13,
                    1e-4f);
 }
@@ -383,7 +373,6 @@ TEST_F(QnnCPUBackendTests, TestCPUConvf32_large_input2_nopad_bias_initializer) {
                    {1, 1},
                    "NOTSET",
                    ExpectedEPNodeAssignment::All,
-                   "TestCPUConvf32_large_input2_nopad_bias_initializer",
                    13,  // opset
                    fp32_abs_err);
 }
@@ -398,8 +387,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConv1Df32_StaticWeights_DefaultBias) {
                    {0, 0},                                                                                   // Pads
                    {1},                                                                                      // Dilations
                    "NOTSET",
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConv1Df32_StaticWeights_DefaultBias");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Test 1D Conv with dynamic weights (implemented in QNN EP as 2D convolution with height of 1).
@@ -412,8 +400,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConv1Df32_DynamicWeights_DefaultBias) {
                    {0, 0},                                                                                   // Pads
                    {1},                                                                                      // Dilations
                    "NOTSET",
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConv1Df32_DynamicWeights_DefaultBias");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Test 1D ConvTranspose with static weights (implemented in QNN EP as 2D convolution with height of 1).
@@ -426,8 +413,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvTranspose1Df32_StaticWeights_DefaultBias) 
                    {0, 0},                                                                                   // Pads
                    {1},                                                                                      // Dilations
                    "NOTSET",
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvTranspose1Df32_StaticWeights_DefaultBias");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // Test 1D ConvTranspose with dynamic weights (implemented in QNN EP as 2D convolution with height of 1).
@@ -440,8 +426,7 @@ TEST_F(QnnCPUBackendTests, TestCPUConvTranspose1Df32_DynamicWeights_DefaultBias)
                    {0, 0},                                                                                   // Pads
                    {1},                                                                                      // Dilations
                    "NOTSET",
-                   ExpectedEPNodeAssignment::All,
-                   "TestCPUConvTranspose1Df32_DynamicWeights_DefaultBias");
+                   ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -457,8 +442,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConvU8S32_bias_dynamic_input) {
                             {0, 0, 0, 0},                                            // Pads
                             {1, 1},                                                  // Dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8S32_bias_dynamic_input");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Test that dynamic weights with default bias works for Conv. This was previously not working
@@ -472,8 +456,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConvU8S32_DynamicWeight_NoBias) {
                             {0, 0, 0, 0},                                             // Pads
                             {1, 1},                                                   // Dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8S32_DynamicWeight_NoBias");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Test that dynamic weights with default bias works for ConvTranspose. This was previously not working
@@ -487,8 +470,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConvTransposeU8S32_DynamicWeight_NoBias) {
                             {0, 0, 0, 0},                                              // Pads
                             {1, 1},                                                    // Dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvTransposeU8S32_DynamicWeight_NoBias");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
@@ -502,8 +484,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConvU8U8S32_bias_initializer) {
                             {0, 0, 0, 0},                                            // Pads
                             {1, 1},                                                  // Dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8S32_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Tests 1D Conv with bias as an initializer.
@@ -516,8 +497,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConv1DU8S32_bias_initializer) {
                             {0, 0},                                                                           // pads
                             {1},                                                                              // dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConv1DU8S32_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Tests 1D ConvTranspose with bias as an initializer.
@@ -530,8 +510,7 @@ TEST_F(QnnHTPBackendTests, TestQDQConvTranspose1DU8S32_bias_initializer) {
                             {0, 0},                                                                           // pads
                             {1},                                                                              // dilations
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvTranspose1DU8S32_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // Tests auto_pad value "SAME_UPPER" on HTP backend (compares to CPU EP).
@@ -545,7 +524,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConvU8S32_AutoPadUpper) {
                             {1, 1},                                               // dilations
                             "SAME_UPPER",                                         // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConvU8S32_AutoPadUpper",
                             13,
                             1e-4f);
 }
@@ -561,7 +539,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConv1DU8U8S32_AutoPadUpper) {
                             {1},                                                                              // dilations
                             "SAME_UPPER",                                                                     // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConv1DU8U8S32_AutoPadUpper",
                             13,
                             1e-4f);
 }
@@ -577,7 +554,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConvTranspose1DU8U8S32_AutoPadUpper) {
                             {1},                                                                              // dilations
                             "SAME_UPPER",                                                                     // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConvTranspose1DU8U8S32_AutoPadUpper",
                             13,
                             1e-4f);
 }
@@ -593,7 +569,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConvU8U8S32_AutoPadLower) {
                             {1, 1},                                               // dilations
                             "SAME_LOWER",                                         // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConvU8U8S32_AutoPadLower",
                             13,
                             1e-4f);
 }
@@ -609,7 +584,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConvTransposeU8U8S32_AutoPadLower) {
                             {1, 1},                                               // dilations
                             "SAME_LOWER",                                         // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConvU8U8S32_AutoPadLower",
                             13,
                             1e-4f);
 }
@@ -625,7 +599,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConv1DU8U8S32_AutoPadLower) {
                             {1},                                                                              // dilations
                             "SAME_LOWER",                                                                     // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConv1DU8U8S32_AutoPadLower",
                             13,
                             1e-4f);
 }
@@ -641,7 +614,6 @@ TEST_F(QnnHTPBackendTests, TestQDQConvTranspose1DU8U8S32_AutoPadLower) {
                             {1},                                                                              // dilations
                             "SAME_LOWER",                                                                     // auto_pad
                             ExpectedEPNodeAssignment::All,
-                            "TestConvTranspose1DU8U8S32_AutoPadLower",
                             13,
                             1e-4f);
 }
@@ -656,8 +628,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8U8S32_large_input1_padding_bias
                             {1, 1, 1, 1},
                             {1, 1},
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8U8S32_large_input1_padding_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8S32_large_input2_bias_initializer) {
@@ -669,8 +640,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8S32_large_input2_bias_initializ
                             {0, 0, 0, 0},
                             {1, 1},
                             "NOTSET",
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8S32_large_input2_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -683,8 +653,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestQDQConvU8U8S32_LargeInput_Dilations_Pads
                             {3, 3, 3, 3},                                              // pads
                             {1, 1},                                                    // dilations
                             "NOTSET",                                                  // auto_pad
-                            ExpectedEPNodeAssignment::All,
-                            "TestQDQConvU8U8S32_large_input2_bias_initializer");
+                            ExpectedEPNodeAssignment::All);
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/gather_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/gather_op_htp_test.cc
@@ -20,12 +20,11 @@ namespace test {
  * outputs for QNN and CPU match.
  *
  * \param opset The opset version.
- * \param test_description Description of the test for error reporting.
  * \param scalar_indices whether the incidices input is scalar or not.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None)
  */
 template <typename QuantType, typename IndicesType>
-static void RunGatherOpQDQTest(int opset, const char* test_description, bool scalar_indices = false,
+static void RunGatherOpQDQTest(int opset, bool scalar_indices = false,
                                ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -42,8 +41,7 @@ static void RunGatherOpQDQTest(int opset, const char* test_description, bool sca
                     provider_options,
                     opset,
                     expected_ep_assignment,
-                    expected_nodes_in_partition,
-                    test_description);
+                    expected_nodes_in_partition);
   } else {
     RunQnnModelTest(BuildQDQGatherOpTestCase<QuantType, IndicesType>({2, 3, 4},                    // input shape
                                                                      std::vector<IndicesType>{1},  // indices
@@ -52,8 +50,7 @@ static void RunGatherOpQDQTest(int opset, const char* test_description, bool sca
                     provider_options,
                     opset,
                     expected_ep_assignment,
-                    expected_nodes_in_partition,
-                    test_description);
+                    expected_nodes_in_partition);
   }
 }
 
@@ -62,7 +59,7 @@ static void RunGatherOpQDQTest(int opset, const char* test_description, bool sca
 //
 // - Uses uint8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQGatherOpU8) {
-  RunGatherOpQDQTest<uint8_t, int64_t>(11, "TestQDQGatherOpU8");
+  RunGatherOpQDQTest<uint8_t, int64_t>(11);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all
@@ -70,7 +67,7 @@ TEST_F(QnnHTPBackendTests, TestQDQGatherOpU8) {
 //
 // - Uses int8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQGatherOpI8) {
-  RunGatherOpQDQTest<int8_t, int32_t>(11, "TestQDQGatherOpI8");
+  RunGatherOpQDQTest<int8_t, int32_t>(11);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all
@@ -78,7 +75,7 @@ TEST_F(QnnHTPBackendTests, TestQDQGatherOpI8) {
 //
 // - Uses uint8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQGatherOpScalarIndicesU8) {
-  RunGatherOpQDQTest<uint8_t, int64_t>(11, "TestQDQGatherOpScalarIndicesU8", true);
+  RunGatherOpQDQTest<uint8_t, int64_t>(11, true);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all
@@ -86,7 +83,7 @@ TEST_F(QnnHTPBackendTests, TestQDQGatherOpScalarIndicesU8) {
 //
 // - Uses int8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQGatherOpScalarIndicesI8) {
-  RunGatherOpQDQTest<int8_t, int32_t>(11, "TestQDQGatherOpScalarIndicesI8", true);
+  RunGatherOpQDQTest<int8_t, int32_t>(11, true);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/instance_norm_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/instance_norm_htp_test.cc
@@ -21,11 +21,10 @@ namespace test {
  *
  * \param input_shape The input's shape.
  * \param epsilon The epsilon attribute.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  * \param num_modes_in_graph The number of expected nodes in the graph.
  */
-static void RunInstanceNormQDQTest(const std::vector<int64_t>& input_shape, float epsilon, const char* test_description,
+static void RunInstanceNormQDQTest(const std::vector<int64_t>& input_shape, float epsilon,
                                    ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_graph) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -39,26 +38,25 @@ static void RunInstanceNormQDQTest(const std::vector<int64_t>& input_shape, floa
                   provider_options,
                   18,
                   expected_ep_assignment,
-                  num_nodes_in_graph,
-                  test_description);
+                  num_nodes_in_graph);
 }
 
 // Check that QNN compiles DQ -> InstanceNormalization -> Q as a single unit.
 // Use an input of rank 4.
 TEST_F(QnnHTPBackendTests, TestQDQInstanceNormU8) {
-  RunInstanceNormQDQTest({1, 2, 3, 3}, 1e-05f, "TestQDQInstanceNormU8", ExpectedEPNodeAssignment::All, 1);
+  RunInstanceNormQDQTest({1, 2, 3, 3}, 1e-05f, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN compiles DQ -> InstanceNormalization -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQInstanceNormU8Rank3) {
-  RunInstanceNormQDQTest({1, 2, 3}, 1e-05f, "TestQDQInstanceNormU8Rank3", ExpectedEPNodeAssignment::All, 1);
+  RunInstanceNormQDQTest({1, 2, 3}, 1e-05f, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN InstanceNorm operator does not handle inputs with rank > 4.
 TEST_F(QnnHTPBackendTests, TestQDQInstanceNormU8Rank5) {
   // No nodes should be assigned to QNN EP, and graph should have 5 (non-fused) nodes.
-  RunInstanceNormQDQTest({1, 2, 3, 3, 3}, 1e-05f, "TestQDQInstanceNormU8Rank5", ExpectedEPNodeAssignment::None, 5);
+  RunInstanceNormQDQTest({1, 2, 3, 3, 3}, 1e-05f, ExpectedEPNodeAssignment::None, 5);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/leakyrelu_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/leakyrelu_op_htp_test.cc
@@ -21,11 +21,10 @@ namespace test {
  *
  * \param op_type The LeakyRelu op type (e.g., ReduceSum).
  * \param opset The opset version.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None)
  */
 template <typename QuantType>
-static void RunLeakyReluOpQDQTest(int opset, const char* test_description,
+static void RunLeakyReluOpQDQTest(int opset,
                                   ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -39,8 +38,7 @@ static void RunLeakyReluOpQDQTest(int opset, const char* test_description,
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all
@@ -48,7 +46,7 @@ static void RunLeakyReluOpQDQTest(int opset, const char* test_description,
 //
 // - Uses uint8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQLeakyReluOpSet15) {
-  RunLeakyReluOpQDQTest<uint8_t>(15, "TestQDQLeakyReluOpSet15");
+  RunLeakyReluOpQDQTest<uint8_t>(15);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all
@@ -56,7 +54,7 @@ TEST_F(QnnHTPBackendTests, TestQDQLeakyReluOpSet15) {
 //
 // - Uses uint8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQLeakyReluOpSet16) {
-  RunLeakyReluOpQDQTest<uint8_t>(16, "TestQDQLeakyReluOpSet16");
+  RunLeakyReluOpQDQTest<uint8_t>(16);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
+++ b/onnxruntime/test/providers/qnn/logical_comp_ops_test.cc
@@ -64,7 +64,7 @@ static GetTestModelFn BuildQDQLogicalOpTestCase(const std::string& op_type, cons
 // Runs a model with a logical operator on the QNN CPU backend. Checks the graph node assignment, and that inference
 // outputs for QNN EP and CPU EP match.
 static void RunCPULogicalOpTest(const std::string& op_type, const std::vector<int64_t>& shape,
-                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
                                 int opset = 17) {
   ProviderOptions provider_options;
 
@@ -79,15 +79,14 @@ static void RunCPULogicalOpTest(const std::string& op_type, const std::vector<in
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 // Runs a model with a logical operator on the QNN HTP backend. Checks the graph node assignment, and that inference
 // outputs for QNN EP and CPU EP match.
 template <typename QuantType>
 static void RunQDQLogicalOpTest(const std::string& op_type, const std::vector<int64_t>& shape,
-                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
                                 int opset = 17) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -101,8 +100,7 @@ static void RunQDQLogicalOpTest(const std::string& op_type, const std::vector<in
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 //
@@ -110,23 +108,23 @@ static void RunQDQLogicalOpTest(const std::string& op_type, const std::vector<in
 //
 
 TEST_F(QnnCPUBackendTests, LogicalOpEqual4D) {
-  RunCPULogicalOpTest("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpEqual4D");
+  RunCPULogicalOpTest("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, LogicalOpGreater4D) {
-  RunCPULogicalOpTest("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
+  RunCPULogicalOpTest("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, LogicalOpGreaterOrEqual4D) {
-  RunCPULogicalOpTest("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
+  RunCPULogicalOpTest("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, LogicalOpLess4D) {
-  RunCPULogicalOpTest("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
+  RunCPULogicalOpTest("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, LogicalOpLessOrEqual4D) {
-  RunCPULogicalOpTest("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
+  RunCPULogicalOpTest("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -135,23 +133,23 @@ TEST_F(QnnCPUBackendTests, LogicalOpLessOrEqual4D) {
 //
 
 TEST_F(QnnHTPBackendTests, LogicalOpEqual4D) {
-  RunQDQLogicalOpTest<uint8_t>("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpEqual4D");
+  RunQDQLogicalOpTest<uint8_t>("Equal", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, LogicalOpGreater4D) {
-  RunQDQLogicalOpTest<uint8_t>("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreater4D");
+  RunQDQLogicalOpTest<uint8_t>("Greater", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, LogicalOpGreaterOrEqual4D) {
-  RunQDQLogicalOpTest<uint8_t>("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpGreaterOrEqual4D");
+  RunQDQLogicalOpTest<uint8_t>("GreaterOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, LogicalOpLess4D) {
-  RunQDQLogicalOpTest<uint8_t>("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLess4D");
+  RunQDQLogicalOpTest<uint8_t>("Less", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, LogicalOpLessOrEqual4D) {
-  RunQDQLogicalOpTest<uint8_t>("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All, "LogicalOpLessOrEqual4D");
+  RunQDQLogicalOpTest<uint8_t>("LessOrEqual", {1, 3, 16, 16}, ExpectedEPNodeAssignment::All);
 }
 
 // Test for bug 44777546.
@@ -193,8 +191,7 @@ TEST_F(QnnHTPBackendTests, EqualToCast4D) {
                   provider_options,
                   17,  // opset
                   ExpectedEPNodeAssignment::All,
-                  1,  // expected nodes in graph
-                  "EqualToCast4D");
+                  1);  // expected nodes in graph
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/lrn_op_test.cc
+++ b/onnxruntime/test/providers/qnn/lrn_op_test.cc
@@ -65,7 +65,7 @@ static GetTestModelFn BuildQDQLRNTestCase(const std::vector<int64_t>& shape, int
 // Runs an LRN model on the QNN CPU backend. Checks the graph node assignment, and that inference
 // outputs for QNN EP and CPU EP match.
 static void RunCPULRNOpTest(const std::vector<int64_t>& shape, int64_t size,
-                            ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                            ExpectedEPNodeAssignment expected_ep_assignment,
                             float alpha = 0.0001f, float beta = 0.75f, float bias = 1.0f, int opset = 13) {
   ProviderOptions provider_options;
   float fp32_abs_err = 1e-5f;  // default tolerance
@@ -83,7 +83,6 @@ static void RunCPULRNOpTest(const std::vector<int64_t>& shape, int64_t size,
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -91,7 +90,7 @@ static void RunCPULRNOpTest(const std::vector<int64_t>& shape, int64_t size,
 // outputs for QNN EP and CPU EP match.
 template <typename QuantType>
 static void RunQDQLRNOpTest(const std::vector<int64_t>& shape, int64_t size,
-                            ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                            ExpectedEPNodeAssignment expected_ep_assignment,
                             float alpha = 0.0001f, float beta = 0.75f, float bias = 1.0f,
                             int opset = 13, float fp32_abs_err = qdq_scale) {
   ProviderOptions provider_options;
@@ -107,7 +106,6 @@ static void RunQDQLRNOpTest(const std::vector<int64_t>& shape, int64_t size,
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err + 0.0001f);
 }
 
@@ -116,15 +114,15 @@ static void RunQDQLRNOpTest(const std::vector<int64_t>& shape, int64_t size,
 //
 
 TEST_F(QnnCPUBackendTests, TestCPULRNSize3) {
-  RunCPULRNOpTest({1, 128, 4, 5}, 3, ExpectedEPNodeAssignment::All, "TestCPULRNSize3");
+  RunCPULRNOpTest({1, 128, 4, 5}, 3, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestCPULRNSize5) {
-  RunCPULRNOpTest({1, 128, 4, 5}, 5, ExpectedEPNodeAssignment::All, "TestCPULRNSize5");
+  RunCPULRNOpTest({1, 128, 4, 5}, 5, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestCPULRN_size_larger_than_channel) {
-  RunCPULRNOpTest({1, 128, 4, 5}, 255, ExpectedEPNodeAssignment::All, "TestCPULRN_size_larger_than_channel");
+  RunCPULRNOpTest({1, 128, 4, 5}, 255, ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -133,15 +131,15 @@ TEST_F(QnnCPUBackendTests, TestCPULRN_size_larger_than_channel) {
 //
 
 TEST_F(QnnHTPBackendTests, TestHTPLRNSize3) {
-  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 3, ExpectedEPNodeAssignment::All, "TestHTPLRNSize3");
+  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 3, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, TestHTPLRNSize5) {
-  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 5, ExpectedEPNodeAssignment::All, "TestHTPLRNSize5");
+  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 5, ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, TestHTPLRN_size_larger_than_channel) {
-  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 255, ExpectedEPNodeAssignment::All, "TestHTPLRN_size_larger_than_channel");
+  RunQDQLRNOpTest<uint8_t>({1, 128, 4, 5}, 255, ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/matmul_test.cpp
+++ b/onnxruntime/test/providers/qnn/matmul_test.cpp
@@ -85,7 +85,7 @@ GetQDQTestCaseFn BuildMatMulOpQDQTestCase(const std::vector<int64_t>& input1_sha
 // outputs for QNN and CPU match.
 static void RunMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
                               const std::vector<int64_t>& input2_shape,
-                              ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                              ExpectedEPNodeAssignment expected_ep_assignment,
                               int opset = 13) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -99,8 +99,7 @@ static void RunMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 // Runs a QDQ AveragePool model on the QNN HTP backend. Checks the graph node assignment, and that inference
@@ -108,7 +107,7 @@ static void RunMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
 template <typename QuantType>
 static void RunQDQMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
                                  const std::vector<int64_t>& input2_shape,
-                                 ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
                                  int opset = 18, float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -123,7 +122,6 @@ static void RunQDQMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -134,14 +132,14 @@ static void RunQDQMatMulOpOpTest(const std::vector<int64_t>& input1_shape,
 TEST_F(QnnCPUBackendTests, TestMatMulOp) {
   RunMatMulOpOpTest({2, 2} /* input_shape1 */,
                     {2, 2} /* input_shape2 */,
-                    ExpectedEPNodeAssignment::All, "TestMatMulOp", 18);
+                    ExpectedEPNodeAssignment::All, 18);
 }
 
 // QNN broadcast issue
 TEST_F(QnnCPUBackendTests, DISABLED_TestMatMulOp2) {
   RunMatMulOpOpTest({28, 1, 64} /* input_shape1 */,
                     {64, 32} /* input_shape2 */,
-                    ExpectedEPNodeAssignment::All, "TestMatMulOp2", 18);
+                    ExpectedEPNodeAssignment::All, 18);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -152,7 +150,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestMatMulOp2) {
 TEST_F(QnnHTPBackendTests, TestMatMulOp_HTP_u8) {
   RunQDQMatMulOpOpTest<uint8_t>({2, 2} /* input_shape1 */,
                                 {2, 2} /* input_shape2 */,
-                                ExpectedEPNodeAssignment::All, "TestMatMulOp_HTP_u8",
+                                ExpectedEPNodeAssignment::All,
                                 18, 0.00381f);
 }
 
@@ -160,7 +158,7 @@ TEST_F(QnnHTPBackendTests, TestMatMulOp_HTP_u8) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestMatMulOp2_HTP_u8) {
   RunQDQMatMulOpOpTest<uint8_t>({28, 1, 64} /* input_shape1 */,
                                 {64, 32} /* input_shape2 */,
-                                ExpectedEPNodeAssignment::All, "TestMatMulOp2_HTP_u8",
+                                ExpectedEPNodeAssignment::All,
                                 18, 0.00381f);
 }
 
@@ -168,7 +166,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMatMulOp2_HTP_u8) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestMatMulOp3_HTP_u8) {
   RunQDQMatMulOpOpTest<uint8_t>({28, 1, 32} /* input_shape1 */,
                                 {32, 2} /* input_shape2 */,
-                                ExpectedEPNodeAssignment::All, "TestMatMulOp3_HTP_u8",
+                                ExpectedEPNodeAssignment::All,
                                 18, 0.00381f);
 }
 

--- a/onnxruntime/test/providers/qnn/max_pool_test.cpp
+++ b/onnxruntime/test/providers/qnn/max_pool_test.cpp
@@ -133,7 +133,7 @@ static void RunMaxPoolOpTest(const std::vector<int64_t>& shape,
                              int64_t ceil_mode,
                              int64_t storage_order,
                              const std::string& auto_pad,
-                             ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                             ExpectedEPNodeAssignment expected_ep_assignment,
                              int opset = 18) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -147,8 +147,7 @@ static void RunMaxPoolOpTest(const std::vector<int64_t>& shape,
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 // Runs a QDQ MaxPool model on the QNN HTP backend. Checks the graph node assignment, and that inference
@@ -162,7 +161,7 @@ static void RunQDQMaxPoolOpTest(const std::vector<int64_t>& shape,
                                 int64_t ceil_mode,
                                 int64_t storage_order,
                                 const std::string& auto_pad,
-                                ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
                                 int opset = 18, float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -177,7 +176,6 @@ static void RunQDQMaxPoolOpTest(const std::vector<int64_t>& shape,
                   opset,
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -195,7 +193,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Global) {
                    0,             // ceil_mode
                    0,             // storage_order
                    "NOTSET",      // auto_pad
-                   ExpectedEPNodeAssignment::All, "TestMaxPool_Global");
+                   ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input) {
@@ -207,7 +205,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input) {
                    0,                // ceil_mode
                    0,                // storage_order
                    "NOTSET",         // auto_pad
-                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input");
+                   ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
@@ -219,7 +217,7 @@ TEST_F(QnnCPUBackendTests, TestMaxPool_Large_Input2) {
                    0,                  // ceil_mode
                    0,                  // storage_order
                    "NOTSET",           // auto_pad
-                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -232,7 +230,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Ceil) {
                    1,             // ceil_mode
                    0,             // storage_order
                    "NOTSET",      // auto_pad
-                   ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil");
+                   ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -245,7 +243,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil) {
                    1,                  // ceil_mode
                    0,                  // storage_order
                    "NOTSET",           // auto_pad
-                   ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil");
+                   ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -262,7 +260,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Global_HTP_u8) {
                                0,             // ceil_mode
                                0,             // storage_order
                                "NOTSET",      // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_Global_HTP_u8");
+                               ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -275,7 +273,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input_HTP_u8) {
                                0,                // ceil_mode
                                0,                // storage_order
                                "NOTSET",         // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input_HTP_u8");
+                               ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -288,7 +286,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_HTP_u8) {
                                0,                  // ceil_mode
                                0,                  // storage_order
                                "NOTSET",           // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_HTP_u8");
+                               ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
@@ -300,7 +298,7 @@ TEST_F(QnnHTPBackendTests, TestMaxPool_Ceil_HTP_u8) {
                                1,             // ceil_mode
                                0,             // storage_order
                                "NOTSET",      // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_Ceil_HTP_u8");
+                               ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -313,7 +311,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_Large_Input2_Ceil_HTP_u8) {
                                1,                  // ceil_mode
                                0,                  // storage_order
                                "NOTSET",           // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_Large_Input2_Ceil_HTP_u8");
+                               ExpectedEPNodeAssignment::All);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -326,7 +324,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestMaxPool_LargeInput_1Pads) {
                                0,                  // ceil_mode
                                0,                  // storage_order
                                "NOTSET",           // auto_pad
-                               ExpectedEPNodeAssignment::All, "TestMaxPool_LargeInput_1Pads");
+                               ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -16,9 +16,9 @@ namespace test {
 
 void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOptions& provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_ep,
-                     const char* test_description, float fp32_abs_err, logging::Severity log_severity) {
-  std::function<void(const Graph&)> graph_verify = [num_nodes_in_ep, test_description](const Graph& graph) -> void {
-    ASSERT_EQ(graph.NumberOfNodes(), num_nodes_in_ep) << test_description;
+                     float fp32_abs_err, logging::Severity log_severity) {
+  std::function<void(const Graph&)> graph_verify = [num_nodes_in_ep](const Graph& graph) -> void {
+    ASSERT_EQ(graph.NumberOfNodes(), num_nodes_in_ep);
   };
 
   EPVerificationParams verification_params;
@@ -31,7 +31,7 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOption
   auto& logging_manager = DefaultLoggingManager();
   logging_manager.SetDefaultLoggerSeverity(log_severity);
 
-  onnxruntime::Model model(test_description, false, ModelMetaData(), PathString(),
+  onnxruntime::Model model("QNN_EP_TestModel", false, ModelMetaData(), PathString(),
                            IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
                            logging_manager.DefaultLogger());
   Graph& graph = model.MainGraph();
@@ -43,7 +43,7 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOption
   // Serialize the model to a string.
   std::string model_data;
   model.ToProto().SerializeToString(&model_data);
-  RunAndVerifyOutputsWithEP(model_data, "QnnEP.TestQDQModel",
+  RunAndVerifyOutputsWithEP(model_data, "QNN_EP_TestLogID",
                             QnnExecutionProviderWithOptions(provider_options),
                             helper.feeds_, verification_params);
 }

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -34,13 +34,15 @@ struct TestInputDef {
 
   TestInputDef() : is_initializer_(false) {}
 
-  // Create a random input.
+  // Creates a random input definition. Specify its shape, whether it's an initializer, and
+  // the min/max range.
   TestInputDef(std::vector<int64_t> shape, bool is_initializer, T rand_min, T rand_max)
       : shape_(std::move(shape)),
         data_info_(RandomData{rand_min, rand_max}),
         is_initializer_(is_initializer) {}
 
-  // Create an input with explicit data.
+  // Create an input definition with explicit data. Specify its shape, whether it's an initializer,
+  // and the raw data.
   TestInputDef(std::vector<int64_t> shape, bool is_initializer, std::vector<T> data)
       : shape_(std::move(shape)),
         data_info_(RawData{std::move(data)}),
@@ -126,14 +128,12 @@ inline NodeArg* MakeTestInput(ModelTestBuilder& builder, const TestInputDef<T>& 
  * \param opset_version The opset version.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  * \param num_modes_in_ep The expected number of nodes assigned to QNN EP's partition.
- * \param test_description Description of the test for error reporting.
  * \param fp32_abs_err The acceptable error between CPU EP and QNN EP.
  * \param log_severity The logger's minimum severity level.
  */
 void RunQnnModelTest(const GetTestModelFn& build_test_case, const ProviderOptions& provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment, int num_nodes_in_ep,
-                     const char* test_description, float fp32_abs_err = 1e-5f,
-                     logging::Severity log_severity = logging::Severity::kERROR);
+                     float fp32_abs_err = 1e-5f, logging::Severity log_severity = logging::Severity::kERROR);
 
 enum class BackendSupport {
   SUPPORT_UNKNOWN,

--- a/onnxruntime/test/providers/qnn/reduce_op_cpu_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_cpu_test.cc
@@ -66,12 +66,11 @@ static GetTestModelFn BuildReduceOpTestCase(const std::string& reduce_op_type,
  *
  * \param op_type The ReduceOp type (e.g., ReduceSum).
  * \param opset The opset version. Some opset versions have "axes" as an attribute or input.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None)
  * \param keepdims Common attribute for all reduce operations.
  */
 template <typename DataType>
-static void RunReduceOpCpuTest(const std::string& op_type, int opset, const char* test_description,
+static void RunReduceOpCpuTest(const std::string& op_type, int opset,
                                ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
                                bool keepdims = true) {
   ProviderOptions provider_options;
@@ -91,8 +90,7 @@ static void RunReduceOpCpuTest(const std::string& op_type, int opset, const char
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 //
@@ -105,7 +103,7 @@ static void RunReduceOpCpuTest(const std::string& op_type, int opset, const char
 // - The input and output data type is int32.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestInt32ReduceSumOpset13) {
-  RunReduceOpCpuTest<int32_t>("ReduceSum", 13, "TestInt32ReduceSumOpset13");
+  RunReduceOpCpuTest<int32_t>("ReduceSum", 13);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -114,7 +112,7 @@ TEST_F(QnnCPUBackendTests, TestInt32ReduceSumOpset13) {
 // - The input and output data type is int32.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestInt32ReduceSumOpset11) {
-  RunReduceOpCpuTest<int32_t>("ReduceSum", 11, "TestInt32ReduceSumOpset11");
+  RunReduceOpCpuTest<int32_t>("ReduceSum", 11);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -123,7 +121,7 @@ TEST_F(QnnCPUBackendTests, TestInt32ReduceSumOpset11) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestFloatReduceSumOpset13) {
-  RunReduceOpCpuTest<float>("ReduceSum", 13, "TestFloatReduceSumOpset13");
+  RunReduceOpCpuTest<float>("ReduceSum", 13);
 }
 
 // Test creates a graph with a ReduceSum node, and checks that all
@@ -132,7 +130,7 @@ TEST_F(QnnCPUBackendTests, TestFloatReduceSumOpset13) {
 // - The input and output data type is float.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestFloatReduceSumOpset11) {
-  RunReduceOpCpuTest<float>("ReduceSum", 11, "TestFloatReduceSumOpset11");
+  RunReduceOpCpuTest<float>("ReduceSum", 11);
 }
 
 //
@@ -145,7 +143,7 @@ TEST_F(QnnCPUBackendTests, TestFloatReduceSumOpset11) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestReduceProdOpset18) {
-  RunReduceOpCpuTest<float>("ReduceProd", 18, "TestReduceProdOpset18");
+  RunReduceOpCpuTest<float>("ReduceProd", 18);
 }
 
 // Test creates a graph with a ReduceProd node, and checks that all
@@ -154,7 +152,7 @@ TEST_F(QnnCPUBackendTests, TestReduceProdOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestReduceProdOpset13) {
-  RunReduceOpCpuTest<float>("ReduceProd", 13, "TestReduceProdOpset13");
+  RunReduceOpCpuTest<float>("ReduceProd", 13);
 }
 
 //
@@ -167,7 +165,7 @@ TEST_F(QnnCPUBackendTests, TestReduceProdOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestReduceMaxOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMax", 18, "TestReduceMaxOpset18");
+  RunReduceOpCpuTest<float>("ReduceMax", 18);
 }
 
 // Test creates a graph with a ReduceMax node, and checks that all
@@ -176,7 +174,7 @@ TEST_F(QnnCPUBackendTests, TestReduceMaxOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestReduceMaxOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMax", 13, "TestReduceMaxOpset13");
+  RunReduceOpCpuTest<float>("ReduceMax", 13);
 }
 
 //
@@ -189,7 +187,7 @@ TEST_F(QnnCPUBackendTests, TestReduceMaxOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestReduceMinOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMin", 18, "TestReduceMinOpset18");
+  RunReduceOpCpuTest<float>("ReduceMin", 18);
 }
 
 // Test creates a graph with a ReduceMin node, and checks that all
@@ -198,7 +196,7 @@ TEST_F(QnnCPUBackendTests, TestReduceMinOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestReduceMinOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMin", 13, "TestReduceMinOpset18");
+  RunReduceOpCpuTest<float>("ReduceMin", 13);
 }
 
 //
@@ -211,7 +209,7 @@ TEST_F(QnnCPUBackendTests, TestReduceMinOpset13) {
 // - The input and output data type is float.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, TestReduceMeanOpset18) {
-  RunReduceOpCpuTest<float>("ReduceMean", 18, "TestReduceMeanOpset18");
+  RunReduceOpCpuTest<float>("ReduceMean", 18);
 }
 
 // Test creates a graph with a ReduceMean node, and checks that all
@@ -220,7 +218,7 @@ TEST_F(QnnCPUBackendTests, TestReduceMeanOpset18) {
 // - The input and output data type is float.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, TestReduceMeanOpset13) {
-  RunReduceOpCpuTest<float>("ReduceMean", 13, "TestReduceMeanOpset13");
+  RunReduceOpCpuTest<float>("ReduceMean", 13);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/reduce_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_htp_test.cc
@@ -15,6 +15,65 @@ namespace onnxruntime {
 namespace test {
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
+// Creates the following graph if axes is an input (newer opsets):
+//                                _______________________
+//    input (f32) -> Q -> DQ ->  |                       | -> Q -> DQ -> output (f32)
+// axes (int32, initializer) ->  |       Reduce___       |
+//                               |_______________________|
+//
+// Creates the following graph if axes is an attribute (older opsets):
+//                                _______________________
+//    input (f32) -> Q -> DQ ->  |                       | -> Q -> DQ -> output (f32)
+//                               |       Reduce___       |
+//                               |_______________________|
+//
+template <typename QuantType>
+GetTestModelFn BuildQDQReduceOpTestCase(const std::string& reduce_op_type, const std::vector<int64_t>& input_shape,
+                                        bool axes_as_input, const std::vector<int64_t>& axes, bool keepdims,
+                                        bool noop_with_empty_axes) {
+  return [reduce_op_type, input_shape, axes_as_input, axes, keepdims,
+          noop_with_empty_axes](ModelTestBuilder& builder) {
+    using QuantTypeLimits = std::numeric_limits<QuantType>;
+    QuantType input_quant_min_value = QuantTypeLimits::min();
+    QuantType input_quant_max_value = QuantTypeLimits::max();
+
+    auto* input_data = builder.MakeInput<float>(input_shape, -100.0f, 100.0f);
+    auto* final_output = builder.MakeOutput();
+
+    // input_data -> Q/DQ ->
+    auto* input_qdq_output = AddQDQNodePair<QuantType>(builder, input_data, .04f,
+                                                       (input_quant_min_value + input_quant_max_value) / 2 + 1);
+
+    // -> ReduceOp (e.g., ReduceSum) ->
+    std::vector<NodeArg*> reduce_op_inputs;
+    reduce_op_inputs.push_back(input_qdq_output);
+
+    if (axes_as_input) {
+      reduce_op_inputs.push_back(builder.MakeInitializer({static_cast<int64_t>(axes.size())}, axes));
+    }
+
+    auto* reduce_sum_output = builder.MakeIntermediate();
+    Node& reduce_sum_node = builder.AddNode(reduce_op_type, reduce_op_inputs, {reduce_sum_output});
+    reduce_sum_node.AddAttribute("keepdims", static_cast<int64_t>(keepdims));
+
+    if (axes_as_input) {
+      reduce_sum_node.AddAttribute("noop_with_empty_axes", static_cast<int64_t>(noop_with_empty_axes));
+    } else {
+      reduce_sum_node.AddAttribute("axes", axes);
+    }
+
+    // -> Q/DQ -> final_output
+    auto* q_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<QuantType>(reduce_sum_output, .039f,
+                                             (QuantTypeLimits::min() + QuantTypeLimits::max()) / 2 + 1,
+                                             q_output);
+
+    builder.AddDequantizeLinearNode<QuantType>(q_output, .039f,
+                                               (QuantTypeLimits::min() + QuantTypeLimits::max()) / 2 + 1,
+                                               final_output);
+  };
+}
+
 /**
  * Runs a ReduceOp model on the QNN HTP backend. Checks the graph node assignment, and that inference
  * outputs for QNN and CPU match.
@@ -25,7 +84,8 @@ namespace test {
  * \param keepdims Common attribute for all reduce operations.
  */
 template <typename QuantType>
-static void RunReduceOpQDQTest(const std::string& op_type, int opset,
+static void RunReduceOpQDQTest(const std::string& op_type, int opset, const std::vector<int64_t>& input_shape,
+                               const std::vector<int64_t>& axes,
                                ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
                                bool keepdims = true) {
   ProviderOptions provider_options;
@@ -35,13 +95,16 @@ static void RunReduceOpQDQTest(const std::string& op_type, int opset,
   provider_options["backend_path"] = "libQnnHtp.so";
 #endif
 
-  constexpr int expected_nodes_in_partition = 1;
+  // If QNN EP can support all ops, then we expect a single fused node in the graph.
+  // Otherwise, we'll get a graph with 5 individual nodes handled by CPU EP.
+  const int expected_nodes_in_partition = expected_ep_assignment == ExpectedEPNodeAssignment::All ? 1 : 5;
+  constexpr bool noop_with_empty_axes = false;
   RunQnnModelTest(BuildQDQReduceOpTestCase<QuantType>(op_type,
-                                                      {2, 2},                                // Input shape
-                                                      ReduceOpHasAxesInput(op_type, opset),  // Axes is an input
-                                                      {0, 1},                                // Axes
-                                                      keepdims,                              // keepdims
-                                                      false),                                // noop_with_empty_axes
+                                                      input_shape,
+                                                      ReduceOpHasAxesInput(op_type, opset),  // New opset changed axes to input.
+                                                      axes,
+                                                      keepdims,
+                                                      noop_with_empty_axes),
                   provider_options,
                   opset,
                   expected_ep_assignment,
@@ -58,7 +121,7 @@ static void RunReduceOpQDQTest(const std::string& op_type, int opset,
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceSum", 13);
+  RunReduceOpQDQTest<uint8_t>("ReduceSum", 13, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceSum -> Q -> DQ graph, and checks that all
@@ -67,7 +130,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset13) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset11) {
-  RunReduceOpQDQTest<uint8_t>("ReduceSum", 11);
+  RunReduceOpQDQTest<uint8_t>("ReduceSum", 11, {1, 3, 4, 4}, {0, 1, 2, 3});
 }
 
 // Test creates a Q -> DQ -> ReduceSum -> Q -> DQ graph, and checks that all
@@ -76,7 +139,17 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset11) {
 // - Uses int8 as the quantization type.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13) {
-  RunReduceOpQDQTest<int8_t>("ReduceSum", 13);
+  RunReduceOpQDQTest<int8_t>("ReduceSum", 13, {2, 2}, {0, 1});
+}
+
+// Tests that keepdims = false generates expected results.
+TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13_NoKeepDims) {
+  RunReduceOpQDQTest<int8_t>("ReduceSum", 13, {2, 2}, {1}, ExpectedEPNodeAssignment::All, false);
+}
+
+// Test that we don't support rank 5 Reduce ops.
+TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13_Rank5Unsupported) {
+  RunReduceOpQDQTest<int8_t>("ReduceSum", 13, {1, 3, 4, 4, 2}, {0, 1, 2, 3, 4}, ExpectedEPNodeAssignment::None);
 }
 
 //
@@ -92,7 +165,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMax", 18);
+  RunReduceOpQDQTest<uint8_t>("ReduceMax", 18, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMax -> Q -> DQ graph, and checks that all
@@ -101,7 +174,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMax", 13);
+  RunReduceOpQDQTest<uint8_t>("ReduceMax", 13, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMax -> Q -> DQ graph, and checks that all
@@ -110,7 +183,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset13) {
 // - Uses int8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMax", 18);
+  RunReduceOpQDQTest<int8_t>("ReduceMax", 18, {2, 2}, {0, 1});
 }
 #endif  // !defined(__linux__)
 
@@ -126,7 +199,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxS8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMin", 18);
+  RunReduceOpQDQTest<uint8_t>("ReduceMin", 18, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMin -> Q -> DQ graph, and checks that all
@@ -135,7 +208,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMin", 13);
+  RunReduceOpQDQTest<uint8_t>("ReduceMin", 13, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMin -> Q -> DQ graph, and checks that all
@@ -143,7 +216,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset13) {
 //
 // Uses int8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMin", 18);
+  RunReduceOpQDQTest<int8_t>("ReduceMin", 18, {2, 2}, {0, 1});
 }
 #endif  // !defined(__linux__)
 
@@ -157,7 +230,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinS8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMean", 18);
+  RunReduceOpQDQTest<uint8_t>("ReduceMean", 18, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMean -> Q -> DQ graph, and checks that all
@@ -166,7 +239,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMean", 13);
+  RunReduceOpQDQTest<uint8_t>("ReduceMean", 13, {2, 2}, {0, 1});
 }
 
 // Test creates a Q -> DQ -> ReduceMean -> Q -> DQ graph, and checks that all
@@ -175,7 +248,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset13) {
 // - Uses int8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMean", 18);
+  RunReduceOpQDQTest<int8_t>("ReduceMean", 18, {2, 2}, {0, 1});
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/reduce_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_htp_test.cc
@@ -21,12 +21,11 @@ namespace test {
  *
  * \param op_type The ReduceOp type (e.g., ReduceSum).
  * \param opset The opset version. Some opset versions have "axes" as an attribute or input.
- * \param test_description Description of the test for error reporting.
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None)
  * \param keepdims Common attribute for all reduce operations.
  */
 template <typename QuantType>
-static void RunReduceOpQDQTest(const std::string& op_type, int opset, const char* test_description,
+static void RunReduceOpQDQTest(const std::string& op_type, int opset,
                                ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
                                bool keepdims = true) {
   ProviderOptions provider_options;
@@ -46,8 +45,7 @@ static void RunReduceOpQDQTest(const std::string& op_type, int opset, const char
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 //
@@ -60,7 +58,7 @@ static void RunReduceOpQDQTest(const std::string& op_type, int opset, const char
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceSum", 13, "TestQDQReduceSumU8Opset13");
+  RunReduceOpQDQTest<uint8_t>("ReduceSum", 13);
 }
 
 // Test creates a Q -> DQ -> ReduceSum -> Q -> DQ graph, and checks that all
@@ -69,7 +67,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset13) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 11, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset11) {
-  RunReduceOpQDQTest<uint8_t>("ReduceSum", 11, "TestQDQReduceSumU8Opset11");
+  RunReduceOpQDQTest<uint8_t>("ReduceSum", 11);
 }
 
 // Test creates a Q -> DQ -> ReduceSum -> Q -> DQ graph, and checks that all
@@ -78,7 +76,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumU8Opset11) {
 // - Uses int8 as the quantization type.
 // - Uses opset 13, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13) {
-  RunReduceOpQDQTest<int8_t>("ReduceSum", 13, "TestQDQReduceSumS8Opset13");
+  RunReduceOpQDQTest<int8_t>("ReduceSum", 13);
 }
 
 //
@@ -94,7 +92,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceSumS8Opset13) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMax", 18, "TestQDQReduceMaxU8Opset18");
+  RunReduceOpQDQTest<uint8_t>("ReduceMax", 18);
 }
 
 // Test creates a Q -> DQ -> ReduceMax -> Q -> DQ graph, and checks that all
@@ -103,7 +101,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMax", 13, "TestQDQReduceMaxU8Opset13");
+  RunReduceOpQDQTest<uint8_t>("ReduceMax", 13);
 }
 
 // Test creates a Q -> DQ -> ReduceMax -> Q -> DQ graph, and checks that all
@@ -112,7 +110,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxU8Opset13) {
 // - Uses int8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMaxS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMax", 18, "TestQDQReduceMaxS8Opset18");
+  RunReduceOpQDQTest<int8_t>("ReduceMax", 18);
 }
 #endif  // !defined(__linux__)
 
@@ -128,7 +126,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMaxS8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMin", 18, "TestQDQReduceMinU8Opset18");
+  RunReduceOpQDQTest<uint8_t>("ReduceMin", 18);
 }
 
 // Test creates a Q -> DQ -> ReduceMin -> Q -> DQ graph, and checks that all
@@ -137,7 +135,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMin", 13, "TestQDQReduceMinU8Opset13");
+  RunReduceOpQDQTest<uint8_t>("ReduceMin", 13);
 }
 
 // Test creates a Q -> DQ -> ReduceMin -> Q -> DQ graph, and checks that all
@@ -145,7 +143,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinU8Opset13) {
 //
 // Uses int8 as the quantization type.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMinS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMin", 18, "TestQDQReduceMinS8Opset18");
+  RunReduceOpQDQTest<int8_t>("ReduceMin", 18);
 }
 #endif  // !defined(__linux__)
 
@@ -159,7 +157,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMinS8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset18) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMean", 18, "TestQDQReduceMeanU8Opset18");
+  RunReduceOpQDQTest<uint8_t>("ReduceMean", 18);
 }
 
 // Test creates a Q -> DQ -> ReduceMean -> Q -> DQ graph, and checks that all
@@ -168,7 +166,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset18) {
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset13) {
-  RunReduceOpQDQTest<uint8_t>("ReduceMean", 13, "TestQDQReduceMeanU8Opset13");
+  RunReduceOpQDQTest<uint8_t>("ReduceMean", 13);
 }
 
 // Test creates a Q -> DQ -> ReduceMean -> Q -> DQ graph, and checks that all
@@ -177,7 +175,7 @@ TEST_F(QnnHTPBackendTests, TestQDQReduceMeanU8Opset13) {
 // - Uses int8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, TestQDQReduceMeanS8Opset18) {
-  RunReduceOpQDQTest<int8_t>("ReduceMean", 18, "TestQDQReduceMeanS8Opset18");
+  RunReduceOpQDQTest<int8_t>("ReduceMean", 18);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -80,13 +80,12 @@ static GetTestModelFn BuildResizeTestCaseWithScales(const std::vector<int64_t>& 
  * \param coordinate_transformation_mode The coordinate transformation mode (e.g., half_pixel, pytorch_half_pixel).
  * \param nearest_mode The rounding for "nearest" mode (e.g., round_prefer_floor, floor).
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
- * \param test_description Description of the test for error reporting.
  * \param opset The opset version to use.
  */
 static void RunCPUResizeOpTest(const std::vector<int64_t>& shape, const std::vector<int64_t>& sizes_data,
                                const std::string& mode, const std::string& coordinate_transformation_mode,
                                const std::string& nearest_mode,
-                               ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                               ExpectedEPNodeAssignment expected_ep_assignment,
                                int opset = 11) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -100,14 +99,13 @@ static void RunCPUResizeOpTest(const std::vector<int64_t>& shape, const std::vec
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 static void RunCPUResizeOpTestWithScales(const std::vector<int64_t>& shape, const std::vector<float>& scales_data,
                                          const std::string& mode, const std::string& coordinate_transformation_mode,
                                          const std::string& nearest_mode,
-                                         ExpectedEPNodeAssignment expected_ep_assignment, const char* test_description,
+                                         ExpectedEPNodeAssignment expected_ep_assignment,
                                          int opset = 11) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
@@ -121,16 +119,14 @@ static void RunCPUResizeOpTestWithScales(const std::vector<int64_t>& shape, cons
                   provider_options,
                   opset,
                   expected_ep_assignment,
-                  expected_nodes_in_partition,
-                  test_description);
+                  expected_nodes_in_partition);
 }
 
 template <typename QuantType>
 static void RunQDQResizeOpTest(const std::vector<int64_t>& shape, const std::vector<int64_t>& sizes_data,
                                const std::string& mode, const std::string& coordinate_transformation_mode,
                                const std::string& nearest_mode,
-                               ExpectedEPNodeAssignment expected_ep_assignment, float fp32_abs_err,
-                               const char* test_description) {
+                               ExpectedEPNodeAssignment expected_ep_assignment, float fp32_abs_err) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnHtp.dll";
@@ -145,7 +141,6 @@ static void RunQDQResizeOpTest(const std::vector<int64_t>& shape, const std::vec
                   18,  // opset
                   expected_ep_assignment,
                   expected_nodes_in_partition,
-                  test_description,
                   fp32_abs_err);
 }
 
@@ -165,56 +160,56 @@ static void RunQDQResizeOpTest(const std::vector<int64_t>& shape, const std::vec
 // coordinate_transformation_mode: "half_pixel"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeUpsampleNearestHalfPixel_rpf) {
   RunCPUResizeOpTest({1, 2, 7, 5}, {1, 2, 21, 10}, "nearest", "half_pixel", "round_prefer_floor",
-                     ExpectedEPNodeAssignment::All, "TestResizeUpsampleNearestHalfPixel_rpf");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Upsample that uses "round_prefer_ceil" as the "nearest_mode".
 // coordinate_transformation_mode: "half_pixel"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeUpsampleNearestHalfPixel_rpc) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 7, 5}, "nearest", "half_pixel", "round_prefer_ceil",
-                     ExpectedEPNodeAssignment::All, "TestResizeUpsampleNearestHalfPixel_rpc");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Downsample that uses "round_prefer_ceil" as the "nearest_mode".
 // coordinate_transformation_mode: "half_pixel"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeDownsampleNearestHalfPixel_rpc) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 1, 3}, "nearest", "half_pixel", "round_prefer_ceil",
-                     ExpectedEPNodeAssignment::All, "TestResizeDownsampleNearestHalfPixel_rpc");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Downsample that uses "round_prefer_floor" as the "nearest_mode".
 // coordinate_transformation_mode: "half_pixel"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeDownsampleNearestHalfPixel_rpf) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 1, 2}, "nearest", "half_pixel", "round_prefer_ceil",
-                     ExpectedEPNodeAssignment::All, "TestResizeDownsampleNearestHalfPixel_rpf");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Upsample that uses "round_prefer_floor" as the "nearest_mode".
 // coordinate_transformation_mode: "align_corners"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeUpsampleNearestAlignCorners_rpf) {
   RunCPUResizeOpTest({1, 2, 7, 5}, {1, 2, 21, 10}, "nearest", "align_corners", "round_prefer_floor",
-                     ExpectedEPNodeAssignment::All, "TestResizeUpsampleNearestAlignCorners_rpf");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Upsample that uses "round_prefer_ceil" as the "nearest_mode".
 // coordinate_transformation_mode: "align_corners"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeUpsampleNearestAlignCorners_rpc) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 7, 5}, "nearest", "align_corners", "round_prefer_ceil",
-                     ExpectedEPNodeAssignment::All, "TestResizeUpsampleNearestAlignCorners_rpc");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Downsample that uses "round_prefer_ceil" as the "nearest_mode".
 // coordinate_transformation_mode: "align_corners"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeDownsampleNearestAlignCorners_rpc) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 1, 3}, "nearest", "align_corners", "round_prefer_ceil",
-                     ExpectedEPNodeAssignment::All, "TestResizeDownsampleNearestAlignCorners_rpc");
+                     ExpectedEPNodeAssignment::All);
 }
 
 // Downsample that uses "round_prefer_floor" as the "nearest_mode".
 // coordinate_transformation_mode: "align_corners"
 TEST_F(QnnCPUBackendTests, DISABLED_TestResizeDownsampleNearestAlignCorners_rpf) {
   RunCPUResizeOpTest({1, 1, 2, 4}, {1, 1, 1, 2}, "nearest", "align_corners", "round_prefer_floor",
-                     ExpectedEPNodeAssignment::All, "TestResizeDownsampleNearestAlignCorners_rpf");
+                     ExpectedEPNodeAssignment::All);
 }
 
 //
@@ -223,22 +218,22 @@ TEST_F(QnnCPUBackendTests, DISABLED_TestResizeDownsampleNearestAlignCorners_rpf)
 
 TEST_F(QnnCPUBackendTests, TestResize2xLinearHalfPixel) {
   RunCPUResizeOpTest({1, 3, 4, 5}, {1, 3, 8, 10}, "linear", "half_pixel", "",
-                     ExpectedEPNodeAssignment::All, "TestResize2xLinearHalfPixel");
+                     ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestResize2xLinearHalfPixel_scales) {
   RunCPUResizeOpTestWithScales({1, 3, 4, 5}, {1.0f, 1.0f, 2.0f, 2.0f}, "linear", "half_pixel", "",
-                               ExpectedEPNodeAssignment::All, "TestResize2xLinearHalfPixel_scales");
+                               ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestResize2xLinearAlignCorners) {
   RunCPUResizeOpTest({1, 3, 4, 5}, {1, 3, 8, 10}, "linear", "align_corners", "",
-                     ExpectedEPNodeAssignment::All, "TestResize2xLinearAlignCorners");
+                     ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, TestResize2xLinearAlignCorners_scales) {
   RunCPUResizeOpTestWithScales({1, 3, 4, 5}, {1.0f, 1.0f, 2.0f, 2.0f}, "linear", "align_corners", "",
-                               ExpectedEPNodeAssignment::All, "TestResize2xLinearAlignCorners_scales");
+                               ExpectedEPNodeAssignment::All);
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
@@ -248,20 +243,17 @@ TEST_F(QnnCPUBackendTests, TestResize2xLinearAlignCorners_scales) {
 
 TEST_F(QnnHTPBackendTests, TestQDQU8Resize2xLinearPytorchHalfPixel) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 8, 8}, "linear", "pytorch_half_pixel", "",
-                              ExpectedEPNodeAssignment::All, 0.0031f,
-                              "TestQDQU8Resize2xLinearPytorchHalfPixel");
+                              ExpectedEPNodeAssignment::All, 0.0031f);
 }
 
 TEST_F(QnnHTPBackendTests, TestQDQU8Resize2xNearestHalfPixelRoundPreferFloor) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 8, 8}, "nearest", "half_pixel", "round_prefer_floor",
-                              ExpectedEPNodeAssignment::All, 1e-5f,
-                              "TestQDQU8Resize2xNearestHalfPixelRoundPreferFloor");
+                              ExpectedEPNodeAssignment::All, 1e-5f);
 }
 
 TEST_F(QnnHTPBackendTests, TestQDQU8Resize2xNearestAsymmetricFloor) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 8, 8}, "nearest", "asymmetric", "floor",
-                              ExpectedEPNodeAssignment::All, 1e-5f,
-                              "TestQDQU8Resize2xNearestAsymmetricFloor");
+                              ExpectedEPNodeAssignment::All, 1e-5f);
 }
 
 // TODO: Investigate with Qualcomm. The qnn-onnx-converter tool translates ONNX Resize [nearest, asymmetric, ceil] to
@@ -275,20 +267,17 @@ TEST_F(QnnHTPBackendTests, TestQDQU8Resize2xNearestAsymmetricFloor) {
 // where the value pair(0.15, 0.501) at index #1 don't match, which is 0.351 from 0.15
 TEST_F(QnnHTPBackendTests, DISABLED_TestQDQU8Resize2xNearestAsymmetricCeil) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 8, 8}, "nearest", "asymmetric", "ceil",
-                              ExpectedEPNodeAssignment::All, 1e-5f,
-                              "TestQDQU8Resize2xNearestAsymmetricFloor");
+                              ExpectedEPNodeAssignment::All, 1e-5f);
 }
 
 TEST_F(QnnHTPBackendTests, TestQDQU8Resize3xNearestAsymmetricFloor) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 12, 12}, "nearest", "asymmetric", "floor",
-                              ExpectedEPNodeAssignment::All, 1e-5f,
-                              "TestQDQU8Resize2xNearestAsymmetricFloor");
+                              ExpectedEPNodeAssignment::All, 1e-5f);
 }
 
 TEST_F(QnnHTPBackendTests, TestQDQU8ResizeHalfNearestAsymmetricFloor) {
   RunQDQResizeOpTest<uint8_t>({1, 3, 4, 4}, {1, 3, 2, 2}, "nearest", "asymmetric", "floor",
-                              ExpectedEPNodeAssignment::All, 1e-5f,
-                              "TestQDQU8Resize2xNearestAsymmetricFloor");
+                              ExpectedEPNodeAssignment::All, 1e-5f);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_htp_test.cc
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <variant>
 #include "core/graph/graph.h"
+#include "core/graph/node_attr_utils.h"
 
 #include "test/optimizer/qdq_test_utils.h"
 #include "test/providers/qnn/qnn_test_utils.h"
@@ -17,6 +18,8 @@ namespace onnxruntime {
 namespace test {
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
+using UInt8Limits = std::numeric_limits<uint8_t>;
+
 // Creates the graph:
 //                       _______________________
 //                      |                       |
@@ -25,26 +28,27 @@ namespace test {
 //
 // Currently used to test QNN EP.
 template <typename InputQType>
-GetQDQTestCaseFn BuildQDQSingleInputOpTestCase(const std::vector<int64_t>& input_shape,
+GetQDQTestCaseFn BuildQDQSingleInputOpTestCase(const TestInputDef<InputQType>& input_def,
                                                const std::string& op_type,
+                                               const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs = {},
                                                const std::string& domain = kOnnxDomain) {
-  return [input_shape, op_type, domain](ModelTestBuilder& builder) {
+  return [input_def, op_type, attrs, domain](ModelTestBuilder& builder) {
     const InputQType quant_zero_point = 0;
     const float quant_scale = 1.0f;
 
-    auto* input = builder.MakeInput<InputQType>(input_shape, std::numeric_limits<InputQType>::min(),
-                                                std::numeric_limits<InputQType>::max());
+    auto* input = MakeTestInput<InputQType>(builder, input_def);
     auto* dq_input = builder.MakeIntermediate();
     builder.AddDequantizeLinearNode<InputQType>(input, quant_scale, quant_zero_point, dq_input);
 
     auto* op_output = builder.MakeIntermediate();
-    builder.AddNode(op_type, {dq_input}, {op_output}, domain);
+    auto& op_node = builder.AddNode(op_type, {dq_input}, {op_output}, domain);
 
-    auto* q_output = builder.MakeIntermediate();
+    for (const auto& attr : attrs) {
+      op_node.AddAttributeProto(attr);
+    }
+
+    auto* q_output = builder.MakeOutput();
     builder.AddQuantizeLinearNode<InputQType>(op_output, quant_scale, quant_zero_point, q_output);
-
-    auto* final_output = builder.MakeOutput();
-    builder.AddDequantizeLinearNode<InputQType>(q_output, quant_scale, quant_zero_point, final_output);
   };
 }
 
@@ -77,7 +81,6 @@ static GetTestModelFn BuildQDQBinaryOpTestCase(const std::string& op_type, const
 template <typename InputType = float, typename InputQType = uint8_t>
 static void RunQDQBinaryOpTest(const std::string& op_type, const TestInputDef<InputType>& input0_def,
                                const TestInputDef<InputType>& input1_def,
-                               const char* test_description,
                                int opset_version,
                                ExpectedEPNodeAssignment expected_ep_assignment,
                                int num_nodes_in_graph) {
@@ -93,8 +96,7 @@ static void RunQDQBinaryOpTest(const std::string& op_type, const TestInputDef<In
                   provider_options,
                   opset_version,
                   expected_ep_assignment,
-                  num_nodes_in_graph,
-                  test_description);
+                  num_nodes_in_graph);
 }
 
 /**
@@ -106,8 +108,9 @@ static void RunQDQBinaryOpTest(const std::string& op_type, const TestInputDef<In
  * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
  * \param num_modes_in_graph The number of expected nodes in the graph.
  */
-static void RunQDQSingleInputOpTest(const std::vector<int64_t>& input_shape, const std::string& op_type,
-                                    const char* test_description,
+template <typename InputQType = uint8_t>
+static void RunQDQSingleInputOpTest(const TestInputDef<InputQType>& input_def, const std::string& op_type,
+                                    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                     int opset_version,
                                     ExpectedEPNodeAssignment expected_ep_assignment,
                                     int num_nodes_in_graph,
@@ -119,37 +122,76 @@ static void RunQDQSingleInputOpTest(const std::vector<int64_t>& input_shape, con
   provider_options["backend_path"] = "libQnnHtp.so";
 #endif
 
-  // Runs model with DQ-> InstanceNorm -> Q and compares the outputs of the CPU and QNN EPs.
-  RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>(input_shape, op_type, domain),
+  // Runs model with DQ-> Op -> Q and compares the outputs of the CPU and QNN EPs.
+  RunQnnModelTest(BuildQDQSingleInputOpTestCase<InputQType>(input_def, op_type, attrs, domain),
                   provider_options,
                   opset_version,
                   expected_ep_assignment,
-                  num_nodes_in_graph,
-                  test_description);
+                  num_nodes_in_graph);
 }
 
 // Check that QNN compiles DQ -> Gelu -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQGeluTest) {
-  RunQDQSingleInputOpTest({1, 2, 3}, "Gelu", "TestQDQGeluTest", 11, ExpectedEPNodeAssignment::All, 1, kMSDomain);
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Gelu", {}, 11, ExpectedEPNodeAssignment::All, 1, kMSDomain);
 }
 
 // Check that QNN compiles DQ -> Elu -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQEluTest) {
-  RunQDQSingleInputOpTest({1, 2, 3}, "Elu", "TestQDQGeluTest", 11, ExpectedEPNodeAssignment::All, 1);
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Elu", {}, 11, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN compiles DQ -> HardSwish -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQHardSwishTest) {
-  RunQDQSingleInputOpTest({1, 2, 3}, "HardSwish", "TestQDQGeluTest", 14, ExpectedEPNodeAssignment::All, 1);
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "HardSwish", {}, 14, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Check that QNN compiles DQ -> Atan -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, TestQDQAtanTest) {
-  RunQDQSingleInputOpTest({1, 2, 3}, "Atan", "TestQDQGeluTest", 11, ExpectedEPNodeAssignment::All, 1);
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Atan", {}, 11, ExpectedEPNodeAssignment::All, 1);
+}
+
+// Check that QNN compiles DQ -> Softmax -> Q as a single unit.
+// Test that the default axis (-1) for SoftMax opset 13 works.
+TEST_F(QnnHTPBackendTests, TestQDQSoftmax13_DefaultAxis) {
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Softmax",
+                          {},  // Uses default axis of -1 for opset 13
+                          13, ExpectedEPNodeAssignment::All, 1);
+}
+
+// Check that QNN compiles DQ -> Softmax -> Q as a single unit.
+// Test that an axis != -1 is not supported.
+TEST_F(QnnHTPBackendTests, TestQDQSoftmax13_UnsupportedAxis) {
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Softmax",
+                          {utils::MakeAttribute("axis", static_cast<int64_t>(1))},
+                          13, ExpectedEPNodeAssignment::None, 1);
+}
+
+// Check that QNN compiles DQ -> Softmax -> Q as a single unit.
+// Test that the default axis (1) for SoftMax opset < 13 does not work.
+TEST_F(QnnHTPBackendTests, TestQDQSoftmax11_DefaultAxisFails) {
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Softmax",
+                          {},  // Uses default axis of 1 for opset < 13.
+                          11, ExpectedEPNodeAssignment::None, 1);
+}
+
+// Check that QNN compiles DQ -> Softmax -> Q as a single unit.
+// Test that setting an axis value of -1 works for Softmax opset < 13.
+TEST_F(QnnHTPBackendTests, TestQDQSoftmax11_SetValidAxis) {
+  RunQDQSingleInputOpTest(TestInputDef<uint8_t>({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max()),
+                          "Softmax",
+                          {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                          11, ExpectedEPNodeAssignment::All, 1);
 }
 
 // Run QDQ model on HTP twice
@@ -166,31 +208,31 @@ TEST_F(QnnHTPBackendTests, ContextBinaryCacheTest) {
   const std::string context_binary_file = "./qnn_context_binary_test.bin";
   provider_options["qnn_context_cache_path"] = context_binary_file;
 
+  const TestInputDef<uint8_t> input_def({1, 2, 3}, false, UInt8Limits::min(), UInt8Limits::max());
+
   // Runs model with DQ-> Atan-> Q and compares the outputs of the CPU and QNN EPs.
   // 1st run will generate the Qnn context cache binary file
-  RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>({1, 2, 3}, "Atan", kOnnxDomain),
+  RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>(input_def, "Atan"),
                   provider_options,
                   11,
                   ExpectedEPNodeAssignment::All,
-                  1,
-                  "ContextBinaryCacheTest");
+                  1);
 
   // Make sure the Qnn context cache binary file is generated
   EXPECT_TRUE(std::filesystem::exists(context_binary_file.c_str()));
 
   // 2nd run will load and run from Qnn context cache binary file
-  RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>({1, 2, 3}, "Atan", kOnnxDomain),
+  RunQnnModelTest(BuildQDQSingleInputOpTestCase<uint8_t>(input_def, "Atan"),
                   provider_options,
                   11,
                   ExpectedEPNodeAssignment::All,
-                  1,
-                  "ContextBinaryCacheTest");
+                  1);
 }
 
 TEST_F(QnnHTPBackendTests, TestSub4D_SmallInputs) {
   RunQDQBinaryOpTest<float, uint8_t>("Sub", TestInputDef<float>({1, 3, 8, 8}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({1, 3, 8, 8}, false, -1.0f, 1.0f),
-                                     "TestSub4D_SmallInputs", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -198,7 +240,7 @@ TEST_F(QnnHTPBackendTests, TestSub4D_SmallInputs) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestSub4D_LargeInputs) {
   RunQDQBinaryOpTest<float, uint8_t>("Sub", TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
-                                     "TestSub4D_LargeInputs", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -206,13 +248,13 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestSub4D_LargeInputs) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestSub4D_Broadcast) {
   RunQDQBinaryOpTest<float, uint8_t>("Sub", TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({3, 1, 1}, true, {1.0f, 0.5f, -0.3f}),
-                                     "TestSub4D_Broadcast", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 TEST_F(QnnHTPBackendTests, TestDiv4D_SmallInputs) {
   RunQDQBinaryOpTest<float, uint8_t>("Div", TestInputDef<float>({1, 3, 8, 8}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({1, 3, 8, 8}, false, -1.0f, 1.0f),
-                                     "TestDiv4D_SmallInputs", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -220,7 +262,7 @@ TEST_F(QnnHTPBackendTests, TestDiv4D_SmallInputs) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestDiv4D_LargeInputs) {
   RunQDQBinaryOpTest<float, uint8_t>("Div", TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
-                                     "TestDiv4D_LargeInputs", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 // TODO: Certain large input sizes cause the QNN graph to fail to finalize with error 1002 (QNN_COMMON_ERROR_MEM_ALLOC).
@@ -229,7 +271,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_TestDiv4D_LargeInputs) {
 TEST_F(QnnHTPBackendTests, DISABLED_TestDiv4D_Broadcast) {
   RunQDQBinaryOpTest<float, uint8_t>("Div", TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
                                      TestInputDef<float>({3, 1, 1}, true, {1.0f, 0.5f, -0.3f}),
-                                     "TestDiv4D_Broadcast", 17, ExpectedEPNodeAssignment::All, 1);
+                                     17, ExpectedEPNodeAssignment::All, 1);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
- Fix check for Softmax with axis attributes not equal to -1. QNN EP only supports axis values equal to -1 (or rank - 1).
- Explicit error when Reduce* ops have an input with rank > 4 on HTP backend (unsupported).
- Correctly filter out partitions that only contain a single QuantizeLinear or DequantizeLinear node.
- Add tests for the above and clean up unnecessary usage of test description labels.



### Motivation and Context
Make it easier to debug why a model may not be supported.