### PR TITLE
[java] Adds support for fp16 and bf16 tensors

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
 
 import ai.onnxruntime.TensorInfo.OnnxTensorType;
 
-/** An enum representing onnxruntime supported Java primitive types (and String). */
+/** An enum representing ONNX Runtime supported Java primitive types (and String). */
 public enum OnnxJavaType {
   FLOAT(1, float.class, 4),
   DOUBLE(2, double.class, 8),

--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -17,6 +17,8 @@ public enum OnnxJavaType {
   BOOL(7, boolean.class, 1),
   STRING(8, String.class, 4),
   UINT8(9, byte.class, 1),
+  FLOAT16(10, short.class, 2),
+  BFLOAT16(11, short.class, 2),
   UNKNOWN(0, Object.class, 0);
 
   private static final OnnxJavaType[] values = new OnnxJavaType[10];
@@ -76,6 +78,9 @@ public enum OnnxJavaType {
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
         return OnnxJavaType.INT64;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+        return OnnxJavaType.FLOAT16;
+      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+        return OnnxJavaType.BFLOAT16;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
         return OnnxJavaType.FLOAT;
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
@@ -87,7 +92,6 @@ public enum OnnxJavaType {
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
       case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:
-      case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
       default:
         return OnnxJavaType.UNKNOWN;
     }

--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -21,7 +21,7 @@ public enum OnnxJavaType {
   BFLOAT16(11, short.class, 2),
   UNKNOWN(0, Object.class, 0);
 
-  private static final OnnxJavaType[] values = new OnnxJavaType[13];
+  private static final OnnxJavaType[] values = new OnnxJavaType[12];
 
   static {
     for (OnnxJavaType ot : OnnxJavaType.values()) {

--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -21,7 +21,7 @@ public enum OnnxJavaType {
   BFLOAT16(11, short.class, 2),
   UNKNOWN(0, Object.class, 0);
 
-  private static final OnnxJavaType[] values = new OnnxJavaType[10];
+  private static final OnnxJavaType[] values = new OnnxJavaType[13];
 
   static {
     for (OnnxJavaType ot : OnnxJavaType.values()) {

--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -17,14 +17,18 @@ public enum OnnxJavaType {
   BOOL(7, boolean.class, 1),
   STRING(8, String.class, 4),
   UINT8(9, byte.class, 1),
+  /** A IEEE 16-bit floating point value. */
   FLOAT16(10, short.class, 2),
+  /** A non-IEEE 16-bit floating point value, with 8 exponent bits and 7 mantissa bits. */
   BFLOAT16(11, short.class, 2),
   UNKNOWN(0, Object.class, 0);
 
-  private static final OnnxJavaType[] values = new OnnxJavaType[12];
+  private static final OnnxJavaType[] values;
 
   static {
-    for (OnnxJavaType ot : OnnxJavaType.values()) {
+    OnnxJavaType[] tmpValues = OnnxJavaType.values();
+    values = new OnnxJavaType[tmpValues.length];
+    for (OnnxJavaType ot : tmpValues) {
       values[ot.value] = ot;
     }
   }

--- a/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
@@ -312,22 +312,24 @@ public final class OnnxSparseTensor extends OnnxTensorLike {
     ByteBuffer buffer =
         getValuesBuffer(OnnxRuntime.ortApiHandle, nativeHandle).order(ByteOrder.nativeOrder());
     switch (info.type) {
-      case FLOAT: {
-        // regular fp32
-        FloatBuffer floatBuf = buffer.asFloatBuffer();
-        FloatBuffer output = FloatBuffer.allocate(floatBuf.capacity());
-        output.put(floatBuf);
-        output.rewind();
-        return output;
-      }
-      case FLOAT16: {
-        ShortBuffer shortBuffer = buffer.asShortBuffer();
-        return OnnxTensor.convertFp16BufferToFloatBuffer(shortBuffer);
-      }
-      case BFLOAT16: {
-        ShortBuffer shortBuffer = buffer.asShortBuffer();
-        return OnnxTensor.convertBf16BufferToFloatBuffer(shortBuffer);
-      }
+      case FLOAT:
+        {
+          FloatBuffer floatBuf = buffer.asFloatBuffer();
+          FloatBuffer output = FloatBuffer.allocate(floatBuf.capacity());
+          output.put(floatBuf);
+          output.rewind();
+          return output;
+        }
+      case FLOAT16:
+        {
+          ShortBuffer shortBuffer = buffer.asShortBuffer();
+          return OrtUtil.convertFp16BufferToFloatBuffer(shortBuffer);
+        }
+      case BFLOAT16:
+        {
+          ShortBuffer shortBuffer = buffer.asShortBuffer();
+          return OrtUtil.convertBf16BufferToFloatBuffer(shortBuffer);
+        }
       case DOUBLE:
         {
           DoubleBuffer doubleBuf = buffer.asDoubleBuffer();

--- a/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
-
-import static ai.onnxruntime.OnnxTensor.fp16ToFloat;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -314,27 +312,22 @@ public final class OnnxSparseTensor extends OnnxTensorLike {
     ByteBuffer buffer =
         getValuesBuffer(OnnxRuntime.ortApiHandle, nativeHandle).order(ByteOrder.nativeOrder());
     switch (info.type) {
-      case FLOAT:
-        if (info.onnxType == TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
-          ShortBuffer shortBuffer = buffer.asShortBuffer();
-          int bufferCap = shortBuffer.capacity();
-          FloatBuffer output = FloatBuffer.allocate(bufferCap);
-          for (int i = 0; i < bufferCap; i++) {
-            output.put(fp16ToFloat(shortBuffer.get(i)));
-          }
-          output.rewind();
-          return output;
-        } else if (info.onnxType
-            == TensorInfo.OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
-          throw new IllegalArgumentException("BFloat16 is not supported.");
-        } else {
-          // regular fp32
-          FloatBuffer floatBuf = buffer.asFloatBuffer();
-          FloatBuffer output = FloatBuffer.allocate(floatBuf.capacity());
-          output.put(floatBuf);
-          output.rewind();
-          return output;
-        }
+      case FLOAT: {
+        // regular fp32
+        FloatBuffer floatBuf = buffer.asFloatBuffer();
+        FloatBuffer output = FloatBuffer.allocate(floatBuf.capacity());
+        output.put(floatBuf);
+        output.rewind();
+        return output;
+      }
+      case FLOAT16: {
+        ShortBuffer shortBuffer = buffer.asShortBuffer();
+        return OnnxTensor.convertFp16BufferToFloatBuffer(shortBuffer);
+      }
+      case BFLOAT16: {
+        ShortBuffer shortBuffer = buffer.asShortBuffer();
+        return OnnxTensor.convertBf16BufferToFloatBuffer(shortBuffer);
+      }
       case DOUBLE:
         {
           DoubleBuffer doubleBuf = buffer.asDoubleBuffer();

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -110,6 +111,10 @@ public class OnnxTensor extends OnnxTensorLike {
           return getBool(OnnxRuntime.ortApiHandle, nativeHandle);
         case STRING:
           return getString(OnnxRuntime.ortApiHandle, nativeHandle);
+        case FLOAT16:
+          return fp16ToFloat(getShort(OnnxRuntime.ortApiHandle, nativeHandle, info.onnxType.value));
+        case BFLOAT16:
+          return bf16ToFloat(getShort(OnnxRuntime.ortApiHandle, nativeHandle, info.onnxType.value));
         case UNKNOWN:
         default:
           throw new OrtException("Extracting the value of an invalid Tensor.");
@@ -318,26 +323,93 @@ public class OnnxTensor extends OnnxTensorLike {
   private native void close(long apiHandle, long nativeHandle);
 
   /**
-   * Mirrors the conversion in the C code. It's not precise if there are subnormal values, nor does
-   * it preserve all the different kinds of NaNs (which aren't representable in Java anyway).
+   * Upcasts a fp16 value to a float. Mirrors the conversion in MLAS.
    *
    * @param input A uint16_t representing an IEEE half precision float.
    * @return A float.
    */
   static float fp16ToFloat(short input) {
-    int output =
-        ((input & 0x8000) << 16) | (((input & 0x7c00) + 0x1C000) << 13) | ((input & 0x03FF) << 13);
-    return Float.intBitsToFloat(output);
+    // Port of MLAS_Half2Float from onnxruntime/core/mlas/inc/mlas_float16.h
+    final int MAGIC = 113 << 23;
+    // exponent mask after shift
+    final int SHIFTED_EXP = 0x7c00 << 13;
+
+    // exponent/mantissa bits
+    int bits = (input & 0x7fff) << 13;
+    // just the exponent
+    final int exp = SHIFTED_EXP & bits;
+    // exponent adjust
+    bits += (127 - 15) << 23;
+
+    // handle exponent special cases
+    if (exp == SHIFTED_EXP) {
+      // Inf/NaN?
+      // extra exp adjust
+      bits += (128 - 16) << 23;
+    } else if (exp == 0) {
+      // Zero/Denormal?
+      // extra exp adjust
+      bits += (1 << 23);
+      // renormalize
+      float tmp = Float.intBitsToFloat(bits) - Float.intBitsToFloat(MAGIC);
+      bits = Float.floatToIntBits(tmp);
+    }
+
+    // sign bit
+    bits |= (input & 0x8000) << 16;
+
+    return Float.intBitsToFloat(bits);
   }
 
   /**
-   * Rounds a float value to fp16.
+   * Rounds a float value to fp16. Mirrors the conversion in MLAS.
    *
    * @param input A float value.
-   * @return The value rounded to an fp16 value.
+   * @return The value rounded to an IEEE half precision value.
    */
   static short floatToFp16(float input) {
-    return 0;
+    // Port of MLAS_Float2Half from onnxruntime/core/mlas/inc/mlas_float16.h
+    int bits = Float.floatToIntBits(input);
+    final int F32_INFINITY = Float.floatToIntBits(Float.POSITIVE_INFINITY);
+    final int F16_MAX = (127 + 16) << 23;
+    final int DENORM_MAGIC = ((127 - 15) + (23 - 10) + 1) << 23;
+    final int SIGN_MASK = 0x80000000;
+    final int ROUNDING_CONST = ((15 - 127) << 23) + 0xfff;
+
+    int sign = bits & SIGN_MASK;
+    // mask out sign bit
+    bits ^= sign;
+
+    short output;
+    if (bits >= F16_MAX) {
+      // Inf or NaN (all exponent bits set)
+      output = (bits > F32_INFINITY) ? (short) 0x7e00 : (short) 0x7c00;
+    } else {
+      if (bits < (113 << 23)) {
+        // Subnormal or zero
+        // use a magic value to align our 10 mantissa bits at the bottom of
+        // the float. as long as FP addition is round-to-nearest-even this
+        // just works.
+        float tmp = Float.intBitsToFloat(bits) + Float.intBitsToFloat(DENORM_MAGIC);
+
+        // and one integer subtract of the bias later, we have our final float!
+        output = (short) (Float.floatToIntBits(tmp) - DENORM_MAGIC);
+      } else {
+        int mant_odd = (bits >> 13) & 1;  // resulting mantissa is odd
+
+        // update exponent, rounding bias part 1
+        bits += ROUNDING_CONST;
+        // rounding bias part 2
+        bits += mant_odd;
+        // take the bits!
+        output = (short) (bits >> 13);
+      }
+    }
+
+    // Add the sign back in
+    output = (short) (output | ((short) (sign >> 16)));
+
+    return output;
   }
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -73,7 +72,7 @@ public class OnnxTensor extends OnnxTensorLike {
         case STRING:
           return getString(OnnxRuntime.ortApiHandle, nativeHandle);
         case FLOAT16:
-          return OrtUtil.mlasFp16ToFloat(
+          return OrtUtil.fp16ToFloat(
               getShort(OnnxRuntime.ortApiHandle, nativeHandle, info.onnxType.value));
         case BFLOAT16:
           return OrtUtil.bf16ToFloat(

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -148,11 +148,13 @@ public class OnnxTensor extends OnnxTensorLike {
       return output;
     } else if (info.type == OnnxJavaType.FLOAT16) {
       // if it's fp16 we need to copy it out by hand.
-      ShortBuffer buffer = getBuffer().asShortBuffer();
+      ByteBuffer buf = getBuffer();
+      ShortBuffer buffer = buf.asShortBuffer();
       return OrtUtil.convertFp16BufferToFloatBuffer(buffer);
     } else if (info.type == OnnxJavaType.BFLOAT16) {
       // if it's bf16 we need to copy it out by hand.
-      ShortBuffer buffer = getBuffer().asShortBuffer();
+      ByteBuffer buf = getBuffer();
+      ShortBuffer buffer = buf.asShortBuffer();
       return OrtUtil.convertBf16BufferToFloatBuffer(buffer);
     } else {
       return null;

--- a/java/src/main/java/ai/onnxruntime/OnnxTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensor.java
@@ -395,7 +395,7 @@ public class OnnxTensor extends OnnxTensorLike {
         // and one integer subtract of the bias later, we have our final float!
         output = (short) (Float.floatToIntBits(tmp) - DENORM_MAGIC);
       } else {
-        int mant_odd = (bits >> 13) & 1;  // resulting mantissa is odd
+        int mant_odd = (bits >> 13) & 1; // resulting mantissa is odd
 
         // update exponent, rounding bias part 1
         bits += ROUNDING_CONST;

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -607,12 +607,8 @@ public final class OrtUtil {
     int remaining = buf.remaining();
     ShortBuffer output =
         ByteBuffer.allocateDirect(remaining * 2).order(ByteOrder.nativeOrder()).asShortBuffer();
-    try {
-      for (int i = 0; i < remaining; i++) {
-        output.put(i, (short) fp32ToFp16.invokeExact(buf.get(i + pos)));
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+    for (int i = 0; i < remaining; i++) {
+      output.put(i, floatToFp16(buf.get(i + pos)));
     }
     return output;
   }
@@ -630,12 +626,8 @@ public final class OrtUtil {
     int remaining = buf.remaining();
     FloatBuffer output =
         ByteBuffer.allocateDirect(remaining * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
-    try {
-      for (int i = 0; i < remaining; i++) {
-        output.put(i, (float) fp16ToFp32.invokeExact(buf.get(i + pos)));
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+    for (int i = 0; i < remaining; i++) {
+      output.put(i, fp16ToFloat(buf.get(i + pos)));
     }
     return output;
   }
@@ -693,7 +685,7 @@ public final class OrtUtil {
       float ret = (float) fp16ToFp32.invokeExact(input);
       return ret;
     } catch (Throwable e) {
-      throw new RuntimeException(e);
+      throw new AssertionError("Should not reach here", e);
     }
   }
 
@@ -712,7 +704,7 @@ public final class OrtUtil {
       short ret = (short) fp32ToFp16.invokeExact(input);
       return ret;
     } catch (Throwable e) {
-      throw new RuntimeException(e);
+      throw new AssertionError("Should not reach here", e);
     }
   }
 
@@ -812,7 +804,7 @@ public final class OrtUtil {
    * @param input A uint16_t representing a bfloat16 value.
    * @return A float.
    */
-  static float bf16ToFloat(short input) {
+  public static float bf16ToFloat(short input) {
     int bits = input << 16;
     return Float.intBitsToFloat(bits);
   }
@@ -823,7 +815,7 @@ public final class OrtUtil {
    * @param input The float input.
    * @return A bfloat16 value which is closest to the float.
    */
-  static short floatToBf16(float input) {
+  public static short floatToBf16(float input) {
     return (short) (Float.floatToIntBits(input) >> 16);
   }
 

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -810,13 +810,19 @@ public final class OrtUtil {
   }
 
   /**
-   * Converts a float into bf16 by truncation. May not produce correct values for subnormal floats.
+   * Converts a float into bf16. May not produce correct values for subnormal floats.
+   *
+   * <p>Rounds to nearest even.
    *
    * @param input The float input.
    * @return A bfloat16 value which is closest to the float.
    */
   public static short floatToBf16(float input) {
-    return (short) (Float.floatToIntBits(input) >> 16);
+    int bits = Float.floatToIntBits(input);
+    int lsb = (bits >> 16) & 1;
+    int roundingBias = 0x7fff + lsb;
+    bits += roundingBias;
+    return (short) (bits >> 16);
   }
 
   static final class BufferTuple {

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -4,6 +4,9 @@
  */
 package ai.onnxruntime;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -15,9 +18,45 @@ import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Util code for interacting with Java arrays. */
 public final class OrtUtil {
+  private static final Logger logger = Logger.getLogger(OrtUtil.class.getName());
+
+  private static final MethodHandle fp16ToFp32;
+  private static final MethodHandle fp32ToFp16;
+
+  static {
+    MethodHandle tmp16 = null;
+    MethodHandle tmp32 = null;
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      // Attempt to lookup the Java 20 fp16 conversion methods which can use SIMD intrinsics.
+      tmp16 =
+          lookup.findStatic(
+              Float.class, "float16ToFloat", MethodType.methodType(float.class, short.class));
+      tmp32 =
+          lookup.findStatic(
+              Float.class, "floatToFloat16", MethodType.methodType(short.class, float.class));
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      // Must be on Java 19 or earlier, create handles for our methods.
+      try {
+        tmp16 =
+            lookup.findStatic(
+                OrtUtil.class, "mlasFp16ToFloat", MethodType.methodType(float.class, short.class));
+        tmp32 =
+            lookup.findStatic(
+                OrtUtil.class, "mlasFloatToFp16", MethodType.methodType(short.class, float.class));
+      } catch (IllegalAccessException | NoSuchMethodException ex) {
+        // Should not happen
+        logger.log(Level.SEVERE, "Failed to find fp16 conversion methods on OnnxTensor", e);
+      }
+    }
+    fp16ToFp32 = tmp16;
+    fp32ToFp16 = tmp32;
+  }
 
   /** Private constructor for static util class. */
   private OrtUtil() {}
@@ -553,6 +592,251 @@ public final class OrtUtil {
     }
 
     return new BufferTuple(tmp, bufferPos, bufferSize, data.remaining(), tmp != data);
+  }
+
+  /**
+   * Rounds a buffer of floats into a buffer containing fp16 values (stored as shorts in Java).
+   *
+   * <p>Respects the position and limit of the input buffer.
+   *
+   * @param buf The buffer of floats.
+   * @return A buffer of fp16 values stored as shorts.
+   */
+  public static ShortBuffer convertFloatBufferToFp16Buffer(FloatBuffer buf) {
+    int pos = buf.position();
+    int remaining = buf.remaining();
+    ShortBuffer output =
+        ByteBuffer.allocateDirect(remaining * 2).order(ByteOrder.nativeOrder()).asShortBuffer();
+    try {
+      for (int i = 0; i < remaining; i++) {
+        output.put(i, (short) fp32ToFp16.invokeExact(buf.get()));
+      }
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+    buf.position(pos);
+    return output;
+  }
+
+  /**
+   * Casts a buffer of fp16 values stored as shorts into a buffer of floats.
+   *
+   * <p>Respects the position and limit of the input buffer.
+   *
+   * @param buf The buffer of fp16 values stored as shorts.
+   * @return A buffer of float values.
+   */
+  public static FloatBuffer convertFp16BufferToFloatBuffer(ShortBuffer buf) {
+    int pos = buf.position();
+    int remaining = buf.remaining();
+    FloatBuffer output =
+        ByteBuffer.allocateDirect(remaining * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
+    try {
+      for (int i = 0; i < remaining; i++) {
+        output.put(i, (float) fp16ToFp32.invokeExact(buf.get(i)));
+      }
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+    buf.position(pos);
+    return output;
+  }
+
+  /**
+   * Rounds a buffer of floats into a buffer containing bf16 values (stored as shorts in Java).
+   *
+   * <p>Respects the position and limit of the input buffer.
+   *
+   * @param buf The buffer of floats.
+   * @return A buffer of bf16 values stored as shorts.
+   */
+  public static ShortBuffer convertFloatBufferToBf16Buffer(FloatBuffer buf) {
+    int pos = buf.position();
+    int remaining = buf.remaining();
+    ShortBuffer output =
+        ByteBuffer.allocateDirect(remaining * 2).order(ByteOrder.nativeOrder()).asShortBuffer();
+    try {
+      for (int i = 0; i < remaining; i++) {
+        output.put(i, floatToBf16(buf.get()));
+      }
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+    buf.position(pos);
+    return output;
+  }
+
+  /**
+   * Casts a buffer of bf16 values stored as shorts into a buffer of floats.
+   *
+   * <p>Respects the position and limit of the input buffer.
+   *
+   * @param buf The buffer of bf16 values stored as shorts.
+   * @return A buffer of float values.
+   */
+  public static FloatBuffer convertBf16BufferToFloatBuffer(ShortBuffer buf) {
+    int pos = buf.position();
+    int remaining = buf.remaining();
+    FloatBuffer output =
+        ByteBuffer.allocateDirect(remaining * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
+    try {
+      for (int i = 0; i < remaining; i++) {
+        output.put(i, bf16ToFloat(buf.get(i)));
+      }
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+    buf.position(pos);
+    return output;
+  }
+
+  /**
+   * Converts a fp16 value stored in a short into a float value.
+   *
+   * <p>Note on Java 20 or newer this uses {@code Float.float16ToFloat} which may use CPU specific
+   * instructions for the conversion, otherwise it uses the conversion operation from ORT's native
+   * implementation.
+   *
+   * @param input The fp16 value.
+   * @return The float value.
+   */
+  public static float fp16ToFloat(short input) {
+    try {
+      float ret = (float) fp16ToFp32.invokeExact(input);
+      return ret;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Converts a float value into a fp16 value stored in a short.
+   *
+   * <p>Note on Java 20 or newer this uses {@code Float.floatToFloat16} which may use CPU specific
+   * instructions for the conversion, otherwise it uses the conversion operation from ORT's native
+   * implementation.
+   *
+   * @param input The float value.
+   * @return The fp16 value.
+   */
+  public static short floatToFp16(float input) {
+    try {
+      short ret = (short) fp32ToFp16.invokeExact(input);
+      return ret;
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Upcasts a fp16 value to a float. Mirrors the conversion in MLAS.
+   *
+   * @param input A uint16_t representing an IEEE half precision float.
+   * @return A float.
+   */
+  static float mlasFp16ToFloat(short input) {
+    // Port of MLAS_Half2Float from onnxruntime/core/mlas/inc/mlas_float16.h
+    final int MAGIC = 113 << 23;
+    // exponent mask after shift
+    final int SHIFTED_EXP = 0x7c00 << 13;
+
+    // exponent/mantissa bits
+    int bits = (input & 0x7fff) << 13;
+    // just the exponent
+    final int exp = SHIFTED_EXP & bits;
+    // exponent adjust
+    bits += (127 - 15) << 23;
+
+    // handle exponent special cases
+    if (exp == SHIFTED_EXP) {
+      // Inf/NaN?
+      // extra exp adjust
+      bits += (128 - 16) << 23;
+    } else if (exp == 0) {
+      // Zero/Denormal?
+      // extra exp adjust
+      bits += (1 << 23);
+      // renormalize
+      float tmp = Float.intBitsToFloat(bits) - Float.intBitsToFloat(MAGIC);
+      bits = Float.floatToIntBits(tmp);
+    }
+
+    // sign bit
+    bits |= (input & 0x8000) << 16;
+
+    return Float.intBitsToFloat(bits);
+  }
+
+  /**
+   * Rounds a float value to fp16. Mirrors the conversion in MLAS.
+   *
+   * @param input A float value.
+   * @return The value rounded to an IEEE half precision value.
+   */
+  static short mlasFloatToFp16(float input) {
+    // Port of MLAS_Float2Half from onnxruntime/core/mlas/inc/mlas_float16.h
+    int bits = Float.floatToIntBits(input);
+    final int F32_INFINITY = Float.floatToIntBits(Float.POSITIVE_INFINITY);
+    final int F16_MAX = (127 + 16) << 23;
+    final int DENORM_MAGIC = ((127 - 15) + (23 - 10) + 1) << 23;
+    final int SIGN_MASK = 0x80000000;
+    final int ROUNDING_CONST = ((15 - 127) << 23) + 0xfff;
+
+    int sign = bits & SIGN_MASK;
+    // mask out sign bit
+    bits ^= sign;
+
+    short output;
+    if (bits >= F16_MAX) {
+      // Inf or NaN (all exponent bits set)
+      output = (bits > F32_INFINITY) ? (short) 0x7e00 : (short) 0x7c00;
+    } else {
+      if (bits < (113 << 23)) {
+        // Subnormal or zero
+        // use a magic value to align our 10 mantissa bits at the bottom of
+        // the float. as long as FP addition is round-to-nearest-even this
+        // just works.
+        float tmp = Float.intBitsToFloat(bits) + Float.intBitsToFloat(DENORM_MAGIC);
+
+        // and one integer subtract of the bias later, we have our final float!
+        output = (short) (Float.floatToIntBits(tmp) - DENORM_MAGIC);
+      } else {
+        int mant_odd = (bits >> 13) & 1; // resulting mantissa is odd
+
+        // update exponent, rounding bias part 1
+        bits += ROUNDING_CONST;
+        // rounding bias part 2
+        bits += mant_odd;
+        // take the bits!
+        output = (short) (bits >> 13);
+      }
+    }
+
+    // Add the sign back in
+    output = (short) (output | ((short) (sign >> 16)));
+
+    return output;
+  }
+
+  /**
+   * Converts a bf16 value stored in a short into a float value.
+   *
+   * @param input A uint16_t representing a bfloat16 value.
+   * @return A float.
+   */
+  static float bf16ToFloat(short input) {
+    int bits = input << 16;
+    return Float.intBitsToFloat(bits);
+  }
+
+  /**
+   * Converts a float into bf16 by truncation. May not produce correct values for subnormal floats.
+   *
+   * @param input The float input.
+   * @return A bfloat16 value which is closest to the float.
+   */
+  static short floatToBf16(float input) {
+    return (short) (Float.floatToIntBits(input) >> 16);
   }
 
   static final class BufferTuple {

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -532,6 +532,8 @@ public final class OrtUtil {
           tmp = buffer.put((ByteBuffer) data);
           break;
         case INT16:
+        case FLOAT16:
+        case BFLOAT16:
           tmp = buffer.asShortBuffer().put((ShortBuffer) data);
           break;
         case INT32:

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -609,12 +609,11 @@ public final class OrtUtil {
         ByteBuffer.allocateDirect(remaining * 2).order(ByteOrder.nativeOrder()).asShortBuffer();
     try {
       for (int i = 0; i < remaining; i++) {
-        output.put(i, (short) fp32ToFp16.invokeExact(buf.get()));
+        output.put(i, (short) fp32ToFp16.invokeExact(buf.get(i + pos)));
       }
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
-    buf.position(pos);
     return output;
   }
 
@@ -633,12 +632,11 @@ public final class OrtUtil {
         ByteBuffer.allocateDirect(remaining * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
     try {
       for (int i = 0; i < remaining; i++) {
-        output.put(i, (float) fp16ToFp32.invokeExact(buf.get(i)));
+        output.put(i, (float) fp16ToFp32.invokeExact(buf.get(i + pos)));
       }
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
-    buf.position(pos);
     return output;
   }
 
@@ -655,14 +653,9 @@ public final class OrtUtil {
     int remaining = buf.remaining();
     ShortBuffer output =
         ByteBuffer.allocateDirect(remaining * 2).order(ByteOrder.nativeOrder()).asShortBuffer();
-    try {
-      for (int i = 0; i < remaining; i++) {
-        output.put(i, floatToBf16(buf.get()));
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+    for (int i = 0; i < remaining; i++) {
+      output.put(i, floatToBf16(buf.get(i + pos)));
     }
-    buf.position(pos);
     return output;
   }
 
@@ -679,14 +672,9 @@ public final class OrtUtil {
     int remaining = buf.remaining();
     FloatBuffer output =
         ByteBuffer.allocateDirect(remaining * 4).order(ByteOrder.nativeOrder()).asFloatBuffer();
-    try {
-      for (int i = 0; i < remaining; i++) {
-        output.put(i, bf16ToFloat(buf.get(i)));
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+    for (int i = 0; i < remaining; i++) {
+      output.put(i, bf16ToFloat(buf.get(i + pos)));
     }
-    buf.position(pos);
     return output;
   }
 

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -333,15 +333,20 @@ public class TensorInfo implements ValueInfo {
 
     long bufferRemaining = buffer.remaining();
 
+    // Check if size matches
     if (elementCount != bufferRemaining) {
-      throw new OrtException(
-          "Shape "
-              + Arrays.toString(shape)
-              + ", requires "
-              + elementCount
-              + " elements but the buffer has "
-              + bufferRemaining
-              + " elements.");
+      // if not it could be a ByteBuffer passed in, so check how many bytes there are
+      long elemRemaining = bufferRemaining / type.size;
+      if (elementCount != elemRemaining) {
+        throw new OrtException(
+                "Shape "
+                        + Arrays.toString(shape)
+                        + ", requires "
+                        + elementCount
+                        + " elements but the buffer has "
+                        + bufferRemaining
+                        + " elements.");
+      }
     }
 
     return new TensorInfo(

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -92,6 +92,10 @@ public class TensorInfo implements ValueInfo {
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
         case STRING:
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING;
+        case FLOAT16:
+          return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+        case BFLOAT16:
+          return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
         case UNKNOWN:
         default:
           return OnnxTensorType.ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -35,12 +35,20 @@ public class TensorInfo implements ValueInfo {
     ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128(
         15), // complex with float64 real and imaginary components
     ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16(
-        16); // Non-IEEE floating-point format based on IEEE754 single-precision
+        16), // Non-IEEE floating-point format based on IEEE754 single-precision
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN(
+        17), // Non-IEEE floating-point format based on IEEE754 single-precision
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ(
+        18), // Non-IEEE floating-point format based on IEEE754 single-precision
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2(
+        19), // Non-IEEE floating-point format based on IEEE754 single-precision
+    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ(
+        20); // Non-IEEE floating-point format based on IEEE754 single-precisio
 
     /** The int id on the native side. */
     public final int value;
 
-    private static final OnnxTensorType[] values = new OnnxTensorType[17];
+    private static final OnnxTensorType[] values = new OnnxTensorType[21];
 
     static {
       for (OnnxTensorType ot : OnnxTensorType.values()) {

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -339,13 +339,13 @@ public class TensorInfo implements ValueInfo {
       long elemRemaining = bufferRemaining / type.size;
       if (elementCount != elemRemaining) {
         throw new OrtException(
-                "Shape "
-                        + Arrays.toString(shape)
-                        + ", requires "
-                        + elementCount
-                        + " elements but the buffer has "
-                        + bufferRemaining
-                        + " elements.");
+            "Shape "
+                + Arrays.toString(shape)
+                + ", requires "
+                + elementCount
+                + " elements but the buffer has "
+                + bufferRemaining
+                + " elements.");
       }
     }
 

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 #include <jni.h>
@@ -492,6 +492,7 @@ int64_t copyJavaToPrimitiveArray(JNIEnv* jniEnv, ONNXTensorElementDataType onnxT
             (*jniEnv)->GetLongArrayRegion(jniEnv, typedArr, 0, inputLength, (jlong * )outputTensor);
             return consumedSize;
         }
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: {
             throwOrtException(jniEnv, convertErrorCode(ORT_NOT_IMPLEMENTED), "16-bit float not supported.");
             return -1;
@@ -528,7 +529,6 @@ int64_t copyJavaToPrimitiveArray(JNIEnv* jniEnv, ONNXTensorElementDataType onnxT
         }
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:   // complex with float32 real and imaginary components
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:  // complex with float64 real and imaginary components
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:
         default: {
             throwOrtException(jniEnv, convertErrorCode(ORT_INVALID_ARGUMENT), "Invalid outputTensor element type.");

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -146,6 +146,14 @@ jint convertFromONNXDataFormat(ONNXTensorElementDataType type) {
             return 15;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
             return 16;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+            return 17;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+            return 18;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+            return 19;
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
+            return 20;
         default:
             return -1;
     }
@@ -190,6 +198,14 @@ ONNXTensorElementDataType convertToONNXDataFormat(jint type) {
             return ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128;  // complex with float64 real and imaginary components
         case 16:
             return ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;    // Non-IEEE floating-point format based on IEEE754 single-precision
+        case 17:
+          return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN;
+        case 18:
+          return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ;
+        case 19:
+          return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2;
+        case 20:
+          return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ;
         default:
             return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
     }

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -216,10 +216,15 @@ size_t onnxTypeSize(ONNXTensorElementDataType type) {
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:   // maps to c type uint8_t
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:    // maps to c type int8_t
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
             return 1;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:  // maps to c type uint16_t
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   // maps to c type int16_t
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
             return 2;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  // maps to c type uint32_t
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   // maps to c type int32_t
@@ -231,7 +236,6 @@ size_t onnxTypeSize(ONNXTensorElementDataType type) {
             return 8;
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING:  // maps to c++ type std::string
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED:
-        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:    // Non-IEEE floating-point format based on IEEE754 single-precision
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:   // complex with float32 real and imaginary components
         case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:  // complex with float64 real and imaginary components
         default:

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -44,6 +44,8 @@ OrtErrorCode getTensorTypeShape(JNIEnv * jniEnv, JavaTensorTypeShape * output, c
 
 jfloat convertHalfToFloat(uint16_t half);
 
+jfloat convertBF16ToFloat(uint16_t half);
+
 jobject convertToValueInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTypeInfo * info);
 
 jobject convertToTensorInfo(JNIEnv *jniEnv, const OrtApi * api, const OrtTensorTypeAndShapeInfo * info);

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -304,7 +304,10 @@ JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
-  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16)) {
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) ||
+      (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16)  ||
+      (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) ||
+      (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16)) {
     uint16_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {

--- a/java/src/main/native/ai_onnxruntime_OnnxTensor.c
+++ b/java/src/main/native/ai_onnxruntime_OnnxTensor.c
@@ -246,14 +246,7 @@ JNIEXPORT jfloat JNICALL Java_ai_onnxruntime_OnnxTensor_getFloat
   (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
   const OrtApi* api = (const OrtApi*) apiHandle;
   ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
-  if (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
-    uint16_t* arr = NULL;
-    OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
-    if (code == ORT_OK) {
-      jfloat floatVal = convertHalfToFloat(*arr);
-      return floatVal;
-    }
-  } else if (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+  if (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
     jfloat* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {
@@ -311,7 +304,7 @@ JNIEXPORT jshort JNICALL Java_ai_onnxruntime_OnnxTensor_getShort
     (void) jobj;  // Required JNI parameter not needed by functions which don't need to access their host object.
     const OrtApi* api = (const OrtApi*) apiHandle;
   ONNXTensorElementDataType onnxType = convertToONNXDataFormat(onnxTypeInt);
-  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16)) {
+  if ((onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) || (onnxType == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16)) {
     uint16_t* arr = NULL;
     OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetTensorMutableData((OrtValue*)handle, (void**)&arr));
     if (code == ORT_OK) {

--- a/java/src/test/java/ai/onnxruntime/ModelGenerators.java
+++ b/java/src/test/java/ai/onnxruntime/ModelGenerators.java
@@ -14,7 +14,6 @@ import java.nio.FloatBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import org.junit.jupiter.api.Test;
 
 /** Methods to generate test models. */
 public final class ModelGenerators {

--- a/java/src/test/java/ai/onnxruntime/ModelGenerators.java
+++ b/java/src/test/java/ai/onnxruntime/ModelGenerators.java
@@ -212,7 +212,11 @@ public final class ModelGenerators {
     matmul.addInput("input");
     matmul.addOutput("output");
     matmul.addAttribute(
-        OnnxMl.AttributeProto.newBuilder().setName("to").setI(outputDataType.getNumber()).build());
+        OnnxMl.AttributeProto.newBuilder()
+            .setName("to")
+            .setType(OnnxMl.AttributeProto.AttributeType.INT)
+            .setI(outputDataType.getNumber())
+            .build());
     graph.addNode(matmul);
 
     // Build model
@@ -224,28 +228,26 @@ public final class ModelGenerators {
     model.setDomain("ai.onnxruntime.test");
     model.addOpsetImport(OnnxMl.OperatorSetIdProto.newBuilder().setVersion(18).build());
     try (OutputStream os =
-        Files.newOutputStream(Paths.get("..","..","..","java","src", "test", "resources", "java-" + name + ".onnx"))) {
+        Files.newOutputStream(
+            Paths.get(
+                "..", "..", "..", "java", "src", "test", "resources", "java-" + name + ".onnx"))) {
       model.build().writeTo(os);
     }
   }
 
-  @Test
   public void generateFp16Fp32Cast() throws IOException {
     genCast("fp16-to-fp32", OnnxMl.TensorProto.DataType.FLOAT16, OnnxMl.TensorProto.DataType.FLOAT);
   }
 
-  @Test
   public void generateFp32Fp16Cast() throws IOException {
     genCast("fp32-to-fp16", OnnxMl.TensorProto.DataType.FLOAT, OnnxMl.TensorProto.DataType.FLOAT16);
   }
 
-  @Test
   public void generateBf16Fp32Cast() throws IOException {
     genCast(
         "bf16-to-fp32", OnnxMl.TensorProto.DataType.BFLOAT16, OnnxMl.TensorProto.DataType.FLOAT);
   }
 
-  @Test
   public void generateFp32Bf16Cast() throws IOException {
     genCast(
         "fp32-to-bf16", OnnxMl.TensorProto.DataType.FLOAT, OnnxMl.TensorProto.DataType.BFLOAT16);

--- a/java/src/test/java/ai/onnxruntime/ModelGenerators.java
+++ b/java/src/test/java/ai/onnxruntime/ModelGenerators.java
@@ -205,18 +205,18 @@ public final class ModelGenerators {
     graph.addOutput(output);
 
     // Add operations
-    OnnxMl.NodeProto.Builder matmul = OnnxMl.NodeProto.newBuilder();
-    matmul.setName("cast-0");
-    matmul.setOpType("Cast");
-    matmul.addInput("input");
-    matmul.addOutput("output");
-    matmul.addAttribute(
+    OnnxMl.NodeProto.Builder cast = OnnxMl.NodeProto.newBuilder();
+    cast.setName("cast-0");
+    cast.setOpType("Cast");
+    cast.addInput("input");
+    cast.addOutput("output");
+    cast.addAttribute(
         OnnxMl.AttributeProto.newBuilder()
             .setName("to")
             .setType(OnnxMl.AttributeProto.AttributeType.INT)
             .setI(outputDataType.getNumber())
             .build());
-    graph.addNode(matmul);
+    graph.addNode(cast);
 
     // Build model
     OnnxMl.ModelProto.Builder model = OnnxMl.ModelProto.newBuilder();

--- a/java/src/test/java/ai/onnxruntime/ModelGenerators.java
+++ b/java/src/test/java/ai/onnxruntime/ModelGenerators.java
@@ -14,6 +14,7 @@ import java.nio.FloatBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 
 /** Methods to generate test models. */
 public final class ModelGenerators {
@@ -180,5 +181,73 @@ public final class ModelGenerators {
         Files.newOutputStream(Paths.get("src", "test", "resources", "java-matmul.onnx"))) {
       model.build().writeTo(os);
     }
+  }
+
+  private static void genCast(
+      String name,
+      OnnxMl.TensorProto.DataType inputDataType,
+      OnnxMl.TensorProto.DataType outputDataType)
+      throws IOException {
+    OnnxMl.GraphProto.Builder graph = OnnxMl.GraphProto.newBuilder();
+    graph.setName("ort-test-" + name);
+
+    // Add placeholders
+    OnnxMl.ValueInfoProto.Builder input = OnnxMl.ValueInfoProto.newBuilder();
+    input.setName("input");
+    OnnxMl.TypeProto inputType =
+        buildTensorTypeNode(new long[] {-1, 5}, new String[] {"batch_size", null}, inputDataType);
+    input.setType(inputType);
+    graph.addInput(input);
+    OnnxMl.ValueInfoProto.Builder output = OnnxMl.ValueInfoProto.newBuilder();
+    output.setName("output");
+    OnnxMl.TypeProto outputType =
+        buildTensorTypeNode(new long[] {-1, 5}, new String[] {"batch_size", null}, outputDataType);
+    output.setType(outputType);
+    graph.addOutput(output);
+
+    // Add operations
+    OnnxMl.NodeProto.Builder matmul = OnnxMl.NodeProto.newBuilder();
+    matmul.setName("cast-0");
+    matmul.setOpType("Cast");
+    matmul.addInput("input");
+    matmul.addOutput("output");
+    matmul.addAttribute(
+        OnnxMl.AttributeProto.newBuilder().setName("to").setI(outputDataType.getNumber()).build());
+    graph.addNode(matmul);
+
+    // Build model
+    OnnxMl.ModelProto.Builder model = OnnxMl.ModelProto.newBuilder();
+    model.setGraph(graph);
+    model.setDocString("ORT " + name + " test");
+    model.setModelVersion(0);
+    model.setIrVersion(8);
+    model.setDomain("ai.onnxruntime.test");
+    model.addOpsetImport(OnnxMl.OperatorSetIdProto.newBuilder().setVersion(18).build());
+    try (OutputStream os =
+        Files.newOutputStream(Paths.get("..","..","..","java","src", "test", "resources", "java-" + name + ".onnx"))) {
+      model.build().writeTo(os);
+    }
+  }
+
+  @Test
+  public void generateFp16Fp32Cast() throws IOException {
+    genCast("fp16-to-fp32", OnnxMl.TensorProto.DataType.FLOAT16, OnnxMl.TensorProto.DataType.FLOAT);
+  }
+
+  @Test
+  public void generateFp32Fp16Cast() throws IOException {
+    genCast("fp32-to-fp16", OnnxMl.TensorProto.DataType.FLOAT, OnnxMl.TensorProto.DataType.FLOAT16);
+  }
+
+  @Test
+  public void generateBf16Fp32Cast() throws IOException {
+    genCast(
+        "bf16-to-fp32", OnnxMl.TensorProto.DataType.BFLOAT16, OnnxMl.TensorProto.DataType.FLOAT);
+  }
+
+  @Test
+  public void generateFp32Bf16Cast() throws IOException {
+    genCast(
+        "fp32-to-bf16", OnnxMl.TensorProto.DataType.FLOAT, OnnxMl.TensorProto.DataType.BFLOAT16);
   }
 }

--- a/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
@@ -170,7 +170,7 @@ public class OnnxTensorTest {
     shortBuf.rewind();
 
     try (OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-        OrtSession session = env.createSession(modelPath);
+        OrtSession session = env.createSession(modelPath, opts);
         OnnxTensor tensor =
             OnnxTensor.createTensor(env, buf, new long[] {10, 5}, OnnxJavaType.BFLOAT16);
         OrtSession.Result result = session.run(Collections.singletonMap("input", tensor))) {
@@ -203,7 +203,7 @@ public class OnnxTensorTest {
     shortBuf.rewind();
 
     try (OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-        OrtSession session = env.createSession(modelPath);
+        OrtSession session = env.createSession(modelPath, opts);
         OnnxTensor tensor =
             OnnxTensor.createTensor(env, buf, new long[] {10, 5}, OnnxJavaType.FLOAT16);
         OrtSession.Result result = session.run(Collections.singletonMap("input", tensor))) {
@@ -239,24 +239,24 @@ public class OnnxTensorTest {
     shortBuf.rewind();
 
     try (OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-        OrtSession session = env.createSession(modelPath);
+        OrtSession session = env.createSession(modelPath, opts);
         OnnxTensor tensor = OnnxTensor.createTensor(env, floatBuf, new long[] {10, 5});
         OrtSession.Result result = session.run(Collections.singletonMap("input", tensor))) {
       OnnxTensor output = (OnnxTensor) result.get(0);
 
       // Check outbound Java side cast to fp32 works
       FloatBuffer castOutput = output.getFloatBuffer();
-      float[] expectedFloatArr = new float[10*5];
+      float[] expectedFloatArr = new float[10 * 5];
       OrtUtil.convertFp16BufferToFloatBuffer(shortBuf).get(expectedFloatArr);
-      float[] actualFloatArr = new float[10*5];
+      float[] actualFloatArr = new float[10 * 5];
       castOutput.get(actualFloatArr);
       Assertions.assertArrayEquals(expectedFloatArr, actualFloatArr);
 
       // Check bits are correct
       ShortBuffer outputBuf = output.getShortBuffer();
-      short[] expectedShortArr = new short[10*5];
+      short[] expectedShortArr = new short[10 * 5];
       shortBuf.get(expectedShortArr);
-      short[] actualShortArr = new short[10*5];
+      short[] actualShortArr = new short[10 * 5];
       outputBuf.get(actualShortArr);
       Assertions.assertArrayEquals(expectedShortArr, actualShortArr);
     }
@@ -286,24 +286,24 @@ public class OnnxTensorTest {
     shortBuf.rewind();
 
     try (OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-        OrtSession session = env.createSession(modelPath);
+        OrtSession session = env.createSession(modelPath, opts);
         OnnxTensor tensor = OnnxTensor.createTensor(env, floatBuf, new long[] {10, 5});
         OrtSession.Result result = session.run(Collections.singletonMap("input", tensor))) {
       OnnxTensor output = (OnnxTensor) result.get(0);
 
       // Check outbound Java side cast to fp32 works
       FloatBuffer castOutput = output.getFloatBuffer();
-      float[] expectedFloatArr = new float[10*5];
+      float[] expectedFloatArr = new float[10 * 5];
       OrtUtil.convertBf16BufferToFloatBuffer(shortBuf).get(expectedFloatArr);
-      float[] actualFloatArr = new float[10*5];
+      float[] actualFloatArr = new float[10 * 5];
       castOutput.get(actualFloatArr);
       Assertions.assertArrayEquals(expectedFloatArr, actualFloatArr);
 
       // Check bits are correct
       ShortBuffer outputBuf = output.getShortBuffer();
-      short[] expectedShortArr = new short[10*5];
+      short[] expectedShortArr = new short[10 * 5];
       shortBuf.get(expectedShortArr);
-      short[] actualShortArr = new short[10*5];
+      short[] actualShortArr = new short[10 * 5];
       outputBuf.get(actualShortArr);
       Assertions.assertArrayEquals(expectedShortArr, actualShortArr);
     }

--- a/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
@@ -9,7 +9,7 @@ import java.nio.FloatBuffer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TensorCreationTest {
+public class OnnxTensorTest {
 
   @Test
   public void testScalarCreation() throws OrtException {
@@ -142,6 +142,34 @@ public class TensorCreationTest {
       Assertions.assertArrayEquals(shape, t.getInfo().getShape());
       float[][] output = (float[][]) t.getValue();
       Assertions.assertEquals(0, output.length);
+    }
+  }
+
+  @Test
+  public void testFp16RoundTrip() {
+    for (int i = 0; i < 0xffff; i++) {
+      // Round trip every value
+      short curVal = (short) (0xffff & i);
+      float upcast = OnnxTensor.fp16ToFloat(curVal);
+      short output = OnnxTensor.floatToFp16(upcast);
+      if (!Float.isNaN(upcast)) {
+        // We coerce NaNs to the same value.
+        Assertions.assertEquals(curVal, output, "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
+      }
+    }
+  }
+
+  @Test
+  public void testBf16RoundTrip() {
+    for (int i = 0; i < 0xffff; i++) {
+      // Round trip every value
+      short curVal = (short) (0xffff & i);
+      float upcast = OnnxTensor.bf16ToFloat(curVal);
+      short output = OnnxTensor.floatToBf16(upcast);
+      if (!Float.isNaN(upcast)) {
+        // We coerce NaNs to the same value.
+        Assertions.assertEquals(curVal, output, "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
+      }
     }
   }
 }

--- a/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
@@ -150,8 +150,8 @@ public class OnnxTensorTest {
     for (int i = 0; i < 0xffff; i++) {
       // Round trip every value
       short curVal = (short) (0xffff & i);
-      float upcast = OnnxTensor.fp16ToFloat(curVal);
-      short output = OnnxTensor.floatToFp16(upcast);
+      float upcast = OrtUtil.mlasFp16ToFloat(curVal);
+      short output = OrtUtil.mlasFloatToFp16(upcast);
       if (!Float.isNaN(upcast)) {
         // We coerce NaNs to the same value.
         Assertions.assertEquals(
@@ -167,8 +167,8 @@ public class OnnxTensorTest {
     for (int i = 0; i < 0xffff; i++) {
       // Round trip every value
       short curVal = (short) (0xffff & i);
-      float upcast = OnnxTensor.bf16ToFloat(curVal);
-      short output = OnnxTensor.floatToBf16(upcast);
+      float upcast = OrtUtil.bf16ToFloat(curVal);
+      short output = OrtUtil.floatToBf16(upcast);
       if (!Float.isNaN(upcast)) {
         // We coerce NaNs to the same value.
         Assertions.assertEquals(

--- a/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
+++ b/java/src/test/java/ai/onnxruntime/OnnxTensorTest.java
@@ -154,7 +154,10 @@ public class OnnxTensorTest {
       short output = OnnxTensor.floatToFp16(upcast);
       if (!Float.isNaN(upcast)) {
         // We coerce NaNs to the same value.
-        Assertions.assertEquals(curVal, output, "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
+        Assertions.assertEquals(
+            curVal,
+            output,
+            "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
       }
     }
   }
@@ -168,7 +171,10 @@ public class OnnxTensorTest {
       short output = OnnxTensor.floatToBf16(upcast);
       if (!Float.isNaN(upcast)) {
         // We coerce NaNs to the same value.
-        Assertions.assertEquals(curVal, output, "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
+        Assertions.assertEquals(
+            curVal,
+            output,
+            "Expected " + curVal + " received " + output + ", intermediate float was " + upcast);
       }
     }
   }

--- a/java/src/test/resources/java-bf16-to-fp32.onnx
+++ b/java/src/test/resources/java-bf16-to-fp32.onnx
@@ -1,0 +1,14 @@
+"ai.onnxruntime.test2ORT bf16-to-fp32 test:…
+%
+inputoutputcast-0"Cast*
+toort-test-bf16-to-fp32Z!
+input
+
+
+batch_size
+b"
+output
+
+
+batch_size
+B

--- a/java/src/test/resources/java-bf16-to-fp32.onnx
+++ b/java/src/test/resources/java-bf16-to-fp32.onnx
@@ -1,7 +1,7 @@
-"ai.onnxruntime.test2ORT bf16-to-fp32 test:…
-%
-inputoutputcast-0"Cast*
-toort-test-bf16-to-fp32Z!
+"ai.onnxruntime.test2ORT bf16-to-fp32 test:ˆ
+(
+inputoutputcast-0"Cast*	
+to ort-test-bf16-to-fp32Z!
 input
 
 

--- a/java/src/test/resources/java-fp16-to-fp32.onnx
+++ b/java/src/test/resources/java-fp16-to-fp32.onnx
@@ -1,7 +1,7 @@
-"ai.onnxruntime.test2ORT fp16-to-fp32 test:…
-%
-inputoutputcast-0"Cast*
-toort-test-fp16-to-fp32Z!
+"ai.onnxruntime.test2ORT fp16-to-fp32 test:ˆ
+(
+inputoutputcast-0"Cast*	
+to ort-test-fp16-to-fp32Z!
 input
 
 

--- a/java/src/test/resources/java-fp16-to-fp32.onnx
+++ b/java/src/test/resources/java-fp16-to-fp32.onnx
@@ -1,0 +1,15 @@
+"ai.onnxruntime.test2ORT fp16-to-fp32 test:…
+%
+inputoutputcast-0"Cast*
+toort-test-fp16-to-fp32Z!
+input
+
+
+
+batch_size
+b"
+output
+
+
+batch_size
+B

--- a/java/src/test/resources/java-fp32-to-bf16.onnx
+++ b/java/src/test/resources/java-fp32-to-bf16.onnx
@@ -1,7 +1,7 @@
-"ai.onnxruntime.test2ORT fp32-to-bf16 test:…
-%
-inputoutputcast-0"Cast*
-toort-test-fp32-to-bf16Z!
+"ai.onnxruntime.test2ORT fp32-to-bf16 test:ˆ
+(
+inputoutputcast-0"Cast*	
+to ort-test-fp32-to-bf16Z!
 input
 
 

--- a/java/src/test/resources/java-fp32-to-bf16.onnx
+++ b/java/src/test/resources/java-fp32-to-bf16.onnx
@@ -1,0 +1,14 @@
+"ai.onnxruntime.test2ORT fp32-to-bf16 test:…
+%
+inputoutputcast-0"Cast*
+toort-test-fp32-to-bf16Z!
+input
+
+
+batch_size
+b"
+output
+
+
+batch_size
+B

--- a/java/src/test/resources/java-fp32-to-fp16.onnx
+++ b/java/src/test/resources/java-fp32-to-fp16.onnx
@@ -1,0 +1,16 @@
+"ai.onnxruntime.test2ORT fp32-to-fp16 test:…
+%
+inputoutputcast-0"Cast*
+to
+ort-test-fp32-to-fp16Z!
+input
+
+
+batch_size
+b"
+output
+
+
+
+batch_size
+B

--- a/java/src/test/resources/java-fp32-to-fp16.onnx
+++ b/java/src/test/resources/java-fp32-to-fp16.onnx
@@ -1,8 +1,8 @@
-"ai.onnxruntime.test2ORT fp32-to-fp16 test:…
-%
-inputoutputcast-0"Cast*
+"ai.onnxruntime.test2ORT fp32-to-fp16 test:ˆ
+(
+inputoutputcast-0"Cast*	
 to
-ort-test-fp32-to-fp16Z!
+ ort-test-fp32-to-fp16Z!
 input
 
 


### PR DESCRIPTION
### Description
The Java API currently only supports fp16 output tensors which it automatically casts to floats on the way out. This PR adds support for creating fp16 and bf16 tensors (from `java.nio.Buffer` objects or as the output of models, creation from Java short arrays is not supported), along with efficient methods for casting `FloatBuffer` into `ShortBuffer` filled with fp16 or bf16 values and vice versa.

The fp16 conversions use a trick to pull in the efficient conversion methods added to Java 20, falling back to ports of the MLAS methods otherwise. The Java 20 methods can be special cased by the C2 JIT compiler to emit the single instruction on x86 and ARM which converts fp32<->fp16, or the vectorized versions thereof, so they should be quite a bit faster than the MLAS ported one.

### Motivation and Context
fp16 and bf16 are increasingly popular formats and we've had several requests for this functionality. Fixes #7003.

cc @yuslepukhin  @cassiebreviu