### PR TITLE
[ios] Enable `--use_extensions` with custom built iOS pod

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -226,6 +226,12 @@ if (onnxruntime_ENABLE_LANGUAGE_INTEROP_OPS)
   )
 endif()
 
+if (onnxruntime_USE_EXTENSIONS)
+  list(APPEND onnxruntime_INTERNAL_LIBRARIES
+    onnxruntime_extensions
+  )
+endif()
+
 # If you are linking a new library, please add it to the list onnxruntime_INTERNAL_LIBRARIES or onnxruntime_EXTERNAL_LIBRARIES,
 # Please do not add a library directly to the target_link_libraries command
 target_link_libraries(onnxruntime PRIVATE

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -229,6 +229,7 @@ endif()
 if (onnxruntime_USE_EXTENSIONS)
   list(APPEND onnxruntime_INTERNAL_LIBRARIES
     onnxruntime_extensions
+    ocos_operators
   )
 endif()
 

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -243,6 +243,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)registerCustomOpsUsingFunctionPointer:(ORTCAPIRegisterCustomOpsFnPtr)registerCustomOpsFn
                                         error:(NSError**)error;
 
+/**
+ * Registers ONNX Runtime Extensions custom ops that have been built in to ONNX Runtime.
+ *
+ * Available since 1.16.
+ *
+ * @note ONNX Runtime must have been built with the `--use_extensions` flag for the ONNX Runtime Extensions custom ops
+ * to be able to be registered with this method. When using a separate ONNX Runtime Extensions library, use
+ * `registerCustomOpsUsingFunctionPointer:error:` instead.
+ *
+ * @param error Optional error information set if an error occurs.
+ * @return Whether the ONNX Runtime Extensions custom ops were successfully registered.
+ */
+- (BOOL)enableOrtExtensionsCustomOpsWithError:(NSError**)error;
+
 @end
 
 /**

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -322,6 +322,14 @@ NS_ASSUME_NONNULL_BEGIN
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
 }
 
+- (BOOL)enableOrtExtensionsCustomOpsWithError:(NSError**)error {
+  try {
+    _sessionOptions->EnableOrtCustomOps();
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
 #pragma mark - Internal
 
 - (Ort::SessionOptions&)CXXAPIOrtSessionOptions {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Fix link errors by including the needed onnxruntime-extensions libraries in the static framework.
- Add Objective-C API to register custom ops from embedded onnxruntime-extensions.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Allow iOS pod custom build with `--use_extensions`.
Caveat: Not all onnxruntime-extensions build options are working yet. E.g., building with the onnxruntime-extensions OpenCV dependency does not work.