### PR TITLE
fix .back() for dim_block_size

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -340,7 +340,7 @@ Status ScatterData(
   // and so on
   std::vector<int64_t> dim_block_size(num_dims);
 
-  dim_block_size.back() = 1;
+  dim_block_size[num_dims-1] = 1;
   if (num_dims > 1) {
     // We start at num_dims - 2 because we already pre-populated
     // the last element above


### PR DESCRIPTION
### Description
Using the `.back()` method to access the last element of `dim_block_size` object results in the following error during compilation.

#### Compilation flags
```
./build.sh --config Release --build_wheel --build --cmake_extra_defines CMAKE_PREFIX_PATH=/opt/rocm/lib/cmake ONNXRUNTIME_VERSION=$ONNXRUNTIME_VERSION onnxruntime_BUILD_UNIT_TESTS=off --use_rocm --rocm_home=/opt/rocm
```
#### Error
```
onnxruntime/core/providers/cpu/tensor/scatter.cc: In function ‘onnxruntime::common::Status onnxruntime::ScatterData(const FuncT&, const Tensor*, const std::vector<long int>&, const Tensor*, int64_t, Tensor*) [with Tdata = bool; FuncT = Func_Assignment<bool>]’:
/home/d3v/lab/roop-git/onnxruntime/onnxruntime/core/providers/cpu/tensor/scatter.cc:343:25: error: array subscript -1 is outside array bounds of ‘long int [1152921504606846975]’ [-Werror=array-bounds=]
  343 |   dim_block_size.back() = 1;
```

This change replaces the `.back()` method with a simple index based item retrieval i.e. `dim_block_size[num_dims-1] = 1`

This issue is also mentioned [here](https://github.com/microsoft/onnxruntime/issues/14981#issuecomment-1497253686).


