### PR TITLE
[CANN EP] Fix Float16 support for CANN EP

### DIFF
--- a/onnxruntime/core/providers/cann/cann_common.cc
+++ b/onnxruntime/core/providers/cann/cann_common.cc
@@ -8,9 +8,9 @@ namespace onnxruntime {
 namespace cann {
 
 template <>
-const MLFloat16 Constants<MLFloat16>::Zero = MLFloat16(static_cast<uint16_t>(0));
+const MLFloat16 Constants<MLFloat16>::Zero = MLFloat16::FromBits(static_cast<uint16_t>(0));
 template <>
-const MLFloat16 Constants<MLFloat16>::One = MLFloat16(static_cast<uint16_t>(0x3C00));
+const MLFloat16 Constants<MLFloat16>::One = MLFloat16::FromBits(static_cast<uint16_t>(0x3C00));
 
 template <>
 const float Constants<float>::Zero = 0;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Replace the constructor function `MLFloat16()` with the public member function `FromBits()` in the file `onnxruntime/core/providers/cann/cann_common.cc`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
PR [#16506](https://github.com/microsoft/onnxruntime/pull/16506) changed the public constructor function `MLFloat16(uint16_t x)` to private, and added a public function `MLFloat16::FromBits(uint16_t x)` in the file `include/onnxruntime/core/framework/float16.h`, which broke the CANN CI.

This PR aligns the CANN behavior with the modified class `MLFloat16`.


