### PR TITLE
[js/webgpu] Don't release uploading buffers

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -71,15 +71,12 @@ class GpuDataManagerImpl implements GpuDataManager {
   // GPU Data ID => GPU Data ( read buffer )
   downloadCache: Map<GpuDataId, DownloadCacheValue>;
 
-  // pending buffers for uploading ( data is unmapped )
-  private buffersForUploadingPending: GPUBuffer[];
   // pending buffers for computing
   private buffersPending: GPUBuffer[];
 
   constructor(private backend: WebGpuBackend /* , private reuseBuffer: boolean */) {
     this.storageCache = new Map();
     this.downloadCache = new Map();
-    this.buffersForUploadingPending = [];
     this.buffersPending = [];
   }
 
@@ -115,8 +112,6 @@ class GpuDataManagerImpl implements GpuDataManager {
     commandEncoder.copyBufferToBuffer(gpuBufferForUploading, 0, gpuDataCache.gpuData.buffer, 0, size);
 
     LOG_DEBUG('verbose', () => `[WebGPU] GpuDataManager.upload(id=${id})`);
-
-    this.buffersForUploadingPending.push(gpuBufferForUploading);
   }
 
   memcpy(sourceId: GpuDataId, destinationId: GpuDataId): void {
@@ -222,12 +217,10 @@ class GpuDataManagerImpl implements GpuDataManager {
   }
 
   refreshPendingBuffers(): void {
-    for (const buffer of this.buffersForUploadingPending) {
-      buffer.destroy();
-    }
     for (const buffer of this.buffersPending) {
       buffer.destroy();
     }
+    this.buffersPending = [];
   }
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
uploading buffers are usually holding the weights data which should follow the session's life cycle. So session.release will trigger those uploading buffers' release. We shouldn't release them early.
### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
If the weight buffers are destroyed early, it may result incorrect result when using them.

