### PR TITLE
Fix warning about uninitialized member

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_float16.h
+++ b/include/onnxruntime/core/session/onnxruntime_float16.h
@@ -246,7 +246,7 @@ union float32_bits {
 
 template <class Derived>
 inline constexpr uint16_t Float16Impl<Derived>::ToUint16Impl(float v) noexcept {
-  detail::float32_bits f;
+  detail::float32_bits f{};
   f.f = v;
 
   constexpr detail::float32_bits f32infty = {255 << 23};
@@ -296,7 +296,7 @@ template <class Derived>
 inline float Float16Impl<Derived>::ToFloatImpl() const noexcept {
   constexpr detail::float32_bits magic = {113 << 23};
   constexpr unsigned int shifted_exp = 0x7c00 << 13;  // exponent mask after shift
-  detail::float32_bits o;
+  detail::float32_bits o{};
 
   o.u = (val & 0x7fff) << 13;            // exponent/mantissa bits
   unsigned int exp = shifted_exp & o.u;  // just the exponent


### PR DESCRIPTION
#16506 Cause almost every translation units on linux complaint

```
[1175/1235] Building CXX object CMakeFiles/onnxruntime_test_all.dir/home/guangyunhan/onnxruntime/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc.o
In file included from /home/guangyunhan/onnxruntime/include/onnxruntime/core/framework/float16.h:18,
                 from /home/guangyunhan/onnxruntime/include/onnxruntime/core/framework/data_types.h:17,
                 from /home/guangyunhan/onnxruntime/include/onnxruntime/core/framework/tensor.h:17,
                 from /home/guangyunhan/onnxruntime/onnxruntime/test/common/tensor_op_test_utils.h:16,
                 from /home/guangyunhan/onnxruntime/onnxruntime/test/providers/compare_provider_test_utils.h:7,
                 from /home/guangyunhan/onnxruntime/orttraining/orttraining/test/training_ops/cuda/softmax_test.cc:4:
/home/guangyunhan/onnxruntime/include/onnxruntime/core/session/onnxruntime_float16.h: In instantiation of ‘static constexpr uint16_t onnxruntime_float16::Float16Impl<Derived>::ToUint16Impl(float) [with Derived = onnxruntime::MLFloat16; uint16_t = short unsigned int]’:
/home/guangyunhan/onnxruntime/include/onnxruntime/core/framework/float16.h:42:66:   required from here
/home/guangyunhan/onnxruntime/include/onnxruntime/core/session/onnxruntime_float16.h:241:7: note: ‘union onnxruntime_float16::detail::float32_bits’ has no user-provided default constructor
  241 | union float32_bits {
      |       ^~~~~~~~~~~~
/home/guangyunhan/onnxruntime/include/onnxruntime/core/session/onnxruntime_float16.h:242:16: note: and the implicitly-defined constructor does not initialize ‘unsigned int onnxruntime_float16::detail::float32_bits::u’
  242 |   unsigned int u;
      |                ^
```

This PR shut the compiler up.
