### PR TITLE
Fix transformers optimizations for GPT-NeoX

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_base.py
+++ b/onnxruntime/python/tools/transformers/fusion_base.py
@@ -16,6 +16,7 @@ class Fusion:
     """
     Base class for Graph Fusion
     """
+
     def __init__(
         self,
         model: OnnxModel,

--- a/onnxruntime/python/tools/transformers/fusion_base.py
+++ b/onnxruntime/python/tools/transformers/fusion_base.py
@@ -4,20 +4,24 @@
 # --------------------------------------------------------------------------
 from collections import defaultdict
 from logging import getLogger
-from typing import List, Union
+from typing import Dict, List, Optional, Union
 
+from onnx import NodeProto
 from onnx_model import OnnxModel
 
 logger = getLogger(__name__)
 
 
 class Fusion:
+    """
+    Base class for Graph Fusion
+    """
     def __init__(
         self,
         model: OnnxModel,
         fused_op_type: str,
         search_op_types: Union[str, List[str]],
-        description: str = None,
+        description: str = "",
     ):
         self.search_op_types: List[str] = [search_op_types] if isinstance(search_op_types, str) else search_op_types
         self.fused_op_type: str = fused_op_type
@@ -27,14 +31,30 @@ class Fusion:
         self.nodes_to_add: List = []
         self.prune_graph: bool = False
         self.node_name_to_graph_name: dict = {}
-        self.this_graph_name: str = None
+        self.this_graph_name: Optional[str] = None
         # It is optional that subclass updates fused_count since we will also check nodes_to_add to get counter.
         self.fused_count: defaultdict = defaultdict(int)
 
-    def increase_counter(self, fused_op_name):
+    def increase_counter(self, fused_op_name: str):
+        """
+        Increase counter of a fused operator.
+        """
         self.fused_count[fused_op_name] += 1
 
+    def fuse(
+        self,
+        node: NodeProto,
+        input_name_to_nodes: Dict[str, List[NodeProto]],
+        output_name_to_node: Dict[str, NodeProto],
+    ):
+        """Interface for fusion that starts from a node"""
+        raise NotImplementedError
+
     def apply(self):
+        """
+        Apply graph fusion on the whole model graph.
+        It searched nodes of given operators, and start fusion on each of those nodes.
+        """
         logger.debug(f"start {self.description} fusion...")
         input_name_to_nodes = self.model.input_name_to_nodes()
         output_name_to_node = self.model.output_name_to_node()
@@ -44,7 +64,7 @@ class Fusion:
             for node in self.model.get_nodes_by_op_type(search_op_type):
                 graph = self.model.get_graph_by_node(node)
                 if graph is None:
-                    raise Exception("Can not find node in any graphs")
+                    raise Exception("Can not find node in any graph")
                 self.this_graph_name = graph.name
                 self.fuse(node, input_name_to_nodes, output_name_to_node)
 

--- a/onnxruntime/python/tools/transformers/fusion_layernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_layernorm.py
@@ -80,7 +80,7 @@ class FusionLayerNormalization(Fusion):
         second_add_node = parent_nodes[1]
         i, add_weight = self.model.get_constant_input(second_add_node)
         if add_weight is None or add_weight <= 0 or add_weight > 1.0e-4:
-            logger.warning(f"epsilon value is not expeced: {add_weight}")
+            logger.debug(f"skip SkipLayerNormalization fusion since epsilon value is not expeced: {add_weight}")
             return
 
         pow_node = parent_nodes[3]

--- a/onnxruntime/python/tools/transformers/fusion_layernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_layernorm.py
@@ -80,7 +80,7 @@ class FusionLayerNormalization(Fusion):
         second_add_node = parent_nodes[1]
         i, add_weight = self.model.get_constant_input(second_add_node)
         if add_weight is None or add_weight <= 0 or add_weight > 1.0e-4:
-            logger.debug(f"skip SkipLayerNormalization fusion since epsilon value is not expeced: {add_weight}")
+            logger.debug(f"skip SkipLayerNormalization fusion since epsilon value is not expected: {add_weight}")
             return
 
         pow_node = parent_nodes[3]

--- a/onnxruntime/python/tools/transformers/fusion_reshape.py
+++ b/onnxruntime/python/tools/transformers/fusion_reshape.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 import numpy as np
 from fusion_base import Fusion
-from onnx import TensorProto, helper, numpy_helper
+from onnx import TensorProto, helper
 from onnx_model import OnnxModel
 
 logger = getLogger(__name__)

--- a/onnxruntime/python/tools/transformers/fusion_reshape.py
+++ b/onnxruntime/python/tools/transformers/fusion_reshape.py
@@ -83,7 +83,7 @@ class FusionReshape(Fusion):
         path2 = []
         path3 = []
         shape_nodes = [shape_0, shape_1]
-        if len(concat_node.input) == 3 and self.model.get_initializer(concat_node.input[2]) is None:
+        if len(concat_node.input) == 3 and self.model.get_constant_value(concat_node.input[2]) is None:
             path2 = self.model.match_parent_path(
                 concat_node,
                 ["Unsqueeze", "Mul", "Gather", "Shape"],
@@ -149,11 +149,10 @@ class FusionReshape(Fusion):
             shape_nodes.extend([path2[-1]])
             shape.append(-1)
         elif len(concat_node.input) > 3:
-            concat_3 = self.model.get_initializer(concat_node.input[3])
-            if concat_3 is None:
+            concat_value = self.model.get_constant_value(concat_node.input[3])
+            if concat_value is None:
                 return
 
-            concat_value = numpy_helper.to_array(concat_3)
             if isinstance(concat_value, np.ndarray):
                 shape.extend(concat_value.tolist())
             else:

--- a/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
+++ b/onnxruntime/python/tools/transformers/fusion_skiplayernorm.py
@@ -49,6 +49,10 @@ class FusionSkipLayerNormalization(Fusion):
         if len(self.model.get_parents(add)) != 2:
             return
 
+        # To avoid an Add node have two children of LayerNormalization, we shall only fuse one SkipLayerNormalization
+        if add in self.nodes_to_remove:
+            return
+
         # Root Mean Square Layer Normalization
         simplified = node.op_type == "SimplifiedLayerNormalization"
 

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -1187,16 +1187,7 @@ class OnnxModel:
 
     def use_float16(self):
         """Check whether the model uses float16"""
-        for t in self.model.graph.input:
-            if t.type.tensor_type.elem_type == TensorProto.FLOAT16:
-                return True
-
-        for t in self.model.graph.output:
-            if t.type.tensor_type.elem_type == TensorProto.FLOAT16:
-                return True
-
-        # create a queue for BFS
-        queue = []
+        queue = []  # queue for BFS
         queue.append(self.model.graph)
         while queue:
             next_level = []

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -1213,7 +1213,8 @@ class OnnxModel:
                                 return True
 
                     for attr in node.attribute:
-                        sub_graphs.append(attr.g)
+                        if attr.type == AttributeProto.GRAPH:
+                            sub_graphs.append(attr.g)
 
                         for g in attr.graphs:
                             sub_graphs.append(g)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -49,7 +49,7 @@ MODEL_TYPES = {
     "clip": (ClipOnnxModel, "pytorch", 1),  # Clip in Stable Diffusion
     "gpt2": (Gpt2OnnxModel, "pytorch", 1),
     "gpt2_tf": (Gpt2OnnxModel, "tf2onnx", 0),  # might add a class for GPT2OnnxModel for TF later.
-    "gpt_neox": (BertOnnxModel, "pytorch", 1),  # GPT-NeoX
+    "gpt_neox": (BertOnnxModel, "pytorch", 0),  # GPT-NeoX
     "swin": (BertOnnxModel, "pytorch", 1),
     "tnlr": (TnlrOnnxModel, "pytorch", 1),
     "t5": (T5OnnxModel, "pytorch", 2),

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -91,10 +91,10 @@ def optimize_by_onnxruntime(
         return onnx_model_path
 
     model = OnnxModel(load_model(onnx_model_path, format=None, load_external_data=True))
-    if model.use_float16() and opt_level and not use_gpu:
+    if model.use_float16() and not use_gpu:
         logger.warning(
-            "This model uses float16 in the graph, use_gpu=False and opt_level > 0 might cause extra Cast nodes. "
-            "It is because most operators does not have float16 implementation in CPU, so Cast nodes are added to compute them in float32. "
+            "This model uses float16 in the graph, use_gpu=False might cause extra Cast nodes. "
+            "Most operators have no float16 implementation in CPU, so Cast nodes are added to compute them in float32. "
             "If the model is intended to use in GPU, please set use_gpu=True. Otherwise, inspect Cast nodes in the optimized model."
         )
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -96,7 +96,7 @@ def optimize_by_onnxruntime(
             "This model uses float16 in the graph, use_gpu=False might cause extra Cast nodes. "
             "Most operators have no float16 implementation in CPU, so Cast nodes are added to compute them in float32. "
             "If the model is intended to use in GPU, please set use_gpu=True. "
-            "Otherwise, consider export onnx model in float32 and optional int8 quantization for better performance. "
+            "Otherwise, consider exporting onnx in float32 and optional int8 quantization for better performance. "
         )
 
     sess_options = onnxruntime.SessionOptions()

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -90,12 +90,13 @@ def optimize_by_onnxruntime(
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
-    model = OnnxModel(load_model(onnx_model_path, format=None, load_external_data=True))
+    model = OnnxModel(load_model(onnx_model_path, format=None, load_external_data=False))
     if model.use_float16() and not use_gpu:
         logger.warning(
             "This model uses float16 in the graph, use_gpu=False might cause extra Cast nodes. "
             "Most operators have no float16 implementation in CPU, so Cast nodes are added to compute them in float32. "
-            "If the model is intended to use in GPU, please set use_gpu=True. Otherwise, inspect Cast nodes in the optimized model."
+            "If the model is intended to use in GPU, please set use_gpu=True. "
+            "Otherwise, consider export onnx model in float32 and optional int8 quantization for better performance. "
         )
 
     sess_options = onnxruntime.SessionOptions()

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -49,13 +49,13 @@ MODEL_TYPES = {
     "clip": (ClipOnnxModel, "pytorch", 1),  # Clip in Stable Diffusion
     "gpt2": (Gpt2OnnxModel, "pytorch", 1),
     "gpt2_tf": (Gpt2OnnxModel, "tf2onnx", 0),  # might add a class for GPT2OnnxModel for TF later.
+    "gpt_neox": (BertOnnxModel, "pytorch", 1),  # GPT-NeoX
     "swin": (BertOnnxModel, "pytorch", 1),
     "tnlr": (TnlrOnnxModel, "pytorch", 1),
     "t5": (T5OnnxModel, "pytorch", 2),
     "unet": (UnetOnnxModel, "pytorch", 1),  # UNet in Stable Diffusion
     "vae": (VaeOnnxModel, "pytorch", 1),  # UAE in Stable Diffusion
     "vit": (BertOnnxModel, "pytorch", 1),
-    "gpt_neox": (BertOnnxModel, "pytorch", 1),  # GPT-NeoX
 }
 
 

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -26,6 +26,7 @@ from typing import Dict, Optional
 import coloredlogs
 from fusion_options import FusionOptions
 from onnx import ModelProto, load_model
+from onnx_model import OnnxModel
 from onnx_model_bart import BartOnnxModel
 from onnx_model_bert import BertOnnxModel
 from onnx_model_bert_keras import BertOnnxModelKeras
@@ -45,20 +46,16 @@ MODEL_TYPES = {
     "bert": (BertOnnxModel, "pytorch", 1),
     "bert_tf": (BertOnnxModelTF, "tf2onnx", 0),
     "bert_keras": (BertOnnxModelKeras, "keras2onnx", 0),
+    "clip": (ClipOnnxModel, "pytorch", 1),  # Clip in Stable Diffusion
     "gpt2": (Gpt2OnnxModel, "pytorch", 1),
-    "gpt2_tf": (
-        Gpt2OnnxModel,
-        "tf2onnx",
-        0,
-    ),  # might add a class for GPT2OnnxModel for TF later.
+    "gpt2_tf": (Gpt2OnnxModel, "tf2onnx", 0),  # might add a class for GPT2OnnxModel for TF later.
+    "swin": (BertOnnxModel, "pytorch", 1),
     "tnlr": (TnlrOnnxModel, "pytorch", 1),
     "t5": (T5OnnxModel, "pytorch", 2),
-    # Stable Diffusion models
-    "unet": (UnetOnnxModel, "pytorch", 1),
-    "vae": (VaeOnnxModel, "pytorch", 1),
-    "clip": (ClipOnnxModel, "pytorch", 1),
+    "unet": (UnetOnnxModel, "pytorch", 1),  # UNet in Stable Diffusion
+    "vae": (VaeOnnxModel, "pytorch", 1),  # UAE in Stable Diffusion
     "vit": (BertOnnxModel, "pytorch", 1),
-    "swin": (BertOnnxModel, "pytorch", 1),
+    "gpt_neox": (BertOnnxModel, "pytorch", 1),  # GPT-NeoX
 }
 
 
@@ -93,6 +90,14 @@ def optimize_by_onnxruntime(
         logger.error("There is no gpu for onnxruntime to do optimization.")
         return onnx_model_path
 
+    model = OnnxModel(load_model(onnx_model_path, format=None, load_external_data=True))
+    if model.use_float16() and opt_level and not use_gpu:
+        logger.warning(
+            "This model uses float16 in the graph, use_gpu=False and opt_level > 0 might cause extra Cast nodes. "
+            "It is because most operators does not have float16 implementation in CPU, so Cast nodes are added to compute them in float32. "
+            "If the model is intended to use in GPU, please set use_gpu=True. Otherwise, inspect Cast nodes in the optimized model."
+        )
+
     sess_options = onnxruntime.SessionOptions()
     if opt_level == 1:
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC
@@ -120,15 +125,13 @@ def optimize_by_onnxruntime(
     else:
         gpu_ep = []
 
-        if torch_version.cuda:
-            gpu_ep.append("CUDAExecutionProvider")
-        elif torch_version.hip:
+        if torch_version.hip:
             gpu_ep.append("MIGraphXExecutionProvider")
             gpu_ep.append("ROCMExecutionProvider")
+        else:
+            gpu_ep.append("CUDAExecutionProvider")
+
         onnxruntime.InferenceSession(onnx_model_path, sess_options, providers=gpu_ep, **kwargs)
-        assert not set(onnxruntime.get_available_providers()).isdisjoint(
-            ["CUDAExecutionProvider", "ROCMExecutionProvider", "MIGraphXExecutionProvider"]
-        )
 
     assert os.path.exists(optimized_model_path) and os.path.isfile(optimized_model_path)
     logger.debug("Save optimized model by onnxruntime to %s", optimized_model_path)
@@ -279,10 +282,12 @@ def optimize_model(
         )
     elif opt_level == 1:
         # basic optimizations (like constant folding and cast elimination) are not specified to execution provider.
-        # CPU provider is used here so that there is no extra node for GPU memory copy.
+        # Note that use_gpu=False might cause extra Cast nodes for float16 model since most operators does not support float16 in CPU.
+        # Sometime, use_gpu=True might cause extra memory copy nodes when some operators are supported only in CPU.
+        # We might need remove GPU memory copy nodes as preprocess of optimize_by_fusion if they cause no matching in fusion.
         temp_model_path = optimize_by_onnxruntime(
             input,
-            use_gpu=False,
+            use_gpu=use_gpu,
             opt_level=1,
             disabled_optimizers=disabled_optimizers,
             verbose=verbose,


### PR DESCRIPTION
### Description
Fix some issues found in GPT-NeoX graph fusion:
(1) GPT-NeoX uses float16 weights. The step of using onnxruntime with opt_level==1 uses CPU provider. Since most operators does not have fp16 in CPU EP, so extra Cast nodes are added to up cast to fp32.
(2) Add is shared by two LayerNormalization  children, and SkipLayerNormalization might cause invalid graph.
(3) Reshape fusion might miss since some part only check initializer but not Constant.

This PR adds a check whether model uses FP16, and output a warning when use_gpu is not True.

Note that we will add attention fusion with rotary embedding later in another pull request.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


