### PR TITLE
Replace call to deprecated torch.norm

### DIFF
--- a/orttraining/orttraining/python/training/optim/_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_modifier.py
@@ -137,7 +137,10 @@ def clip_grad_norm_fp32(
 
         else:
             for grad in grads_for_norm:
-                grad_norm = torch.norm(grad, norm_type)
+                if norm_type in {'fro', 'nuc'}:
+                    grad_norm = torch.linalg.matrix_norm(grad, norm_type)
+                else:
+                    grad_norm = torch.linalg.norm(grad, norm_type)
                 total_norm += grad_norm**norm_type
 
         if horizontal_model_parallel_grad_norm_aggregation:

--- a/orttraining/orttraining/python/training/optim/_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_modifier.py
@@ -137,7 +137,7 @@ def clip_grad_norm_fp32(
 
         else:
             for grad in grads_for_norm:
-                if norm_type in {'fro', 'nuc'}:
+                if norm_type in {"fro", "nuc"}:
                     grad_norm = torch.linalg.matrix_norm(grad, norm_type)
                 else:
                     grad_norm = torch.linalg.norm(grad, norm_type)

--- a/orttraining/orttraining/python/training/optim/_modifier.py
+++ b/orttraining/orttraining/python/training/optim/_modifier.py
@@ -137,6 +137,9 @@ def clip_grad_norm_fp32(
 
         else:
             for grad in grads_for_norm:
+                # torch.norm is deprecated and moved to torch.linalg.norm
+                # with a different signature
+                # see https://pytorch.org/docs/stable/generated/torch.norm.html
                 if norm_type in {"fro", "nuc"}:
                     grad_norm = torch.linalg.matrix_norm(grad, norm_type)
                 else:


### PR DESCRIPTION
### Description
torch.norm is deprecated as mentioned in issue #16751. This PR replaces the call to torch.norm by the options suggested by torch documentation.



