### PR TITLE
Fix Mac M1 build

### DIFF
--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -455,7 +455,7 @@ Return Value:
     asm("mrs %[reg], ID_AA64ISAR0_EL1\n" : [reg] "=r"(isar0_el1) : :);
     HasDotProductInstructions = ((isar0_el1 >> 44) & 0xfu) == 0x1u;
 #else
-    HasDotProductInstructions = false;
+    HasDotProductInstructions = MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeonDot();
 #endif
 
     if (HasDotProductInstructions) {

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -449,10 +449,13 @@ Return Value:
 
 #if defined(_WIN32)
     HasDotProductInstructions = (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) != 0);
-#else
+#elif !defined(__APPLE__)  // The next few lines result in an EXC_BAD_INSTRUCTION runtime error on a M1 Mac so we
+                           // disable it there.
     uint64_t isar0_el1;
     asm("mrs %[reg], ID_AA64ISAR0_EL1\n" : [reg] "=r"(isar0_el1) : :);
     HasDotProductInstructions = ((isar0_el1 >> 44) & 0xfu) == 0x1u;
+#else
+    HasDotProductInstructions = false;
 #endif
 
     if (HasDotProductInstructions) {

--- a/onnxruntime/test/framework/math_test.cc
+++ b/onnxruntime/test/framework/math_test.cc
@@ -202,4 +202,22 @@ TEST(MathTest, GemvTrans) {
   }
 }
 
+TEST(MathTest, HalfFloatConversion) {
+  constexpr float original_values[] = {-4.0f, -2.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 2.0f, 4.0f};
+  for (const auto original_value : original_values) {
+    const auto half_value = math::floatToHalf(original_value);
+    const auto round_trip_value = math::halfToFloat(half_value);
+    EXPECT_EQ(round_trip_value, original_value);
+  }
+}
+
+TEST(MathTest, HalfDoubleConversion) {
+  constexpr double original_values[] = {-4.0f, -2.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 2.0f, 4.0f};
+  for (const auto original_value : original_values) {
+    const auto half_value = math::doubleToHalf(original_value);
+    const auto round_trip_value = static_cast<double>(math::halfToFloat(half_value));
+    EXPECT_EQ(round_trip_value, original_value);
+  }
+}
+
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

1. Add ifndef `__APPLE__` to skip lines which cause EXC_BAD_INSTRUCTION error.

2. Fix floatToHalf/doubleToHalf conversion issue and add tests.
Eigen was updated and the type of `__half_raw.x` changed to `__fp16`. See [this commit]( https://gitlab.com/libeigen/eigen/-/commit/e265f7ed8e59c26e15f2c35162c6b8da1c5d594f). From [here](https://clang.llvm.org/docs/LanguageExtensions.html#half-precision-floating-point), "Operators that expect arithmetic operands immediately promote `__fp16` operands to `float`." Apparently, the `__fp16` result was promoted to `float` before assignment to `uint16_t`. Copying the bytes over with something like `std::bit_cast` does what we want here.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix Mac M1 build issues.

Fix #16496.
Fix #16230.