### PR TITLE
[java] Fills out the javadoc so there are no more documentation warnings

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxJavaType.java
@@ -8,19 +8,29 @@ import ai.onnxruntime.TensorInfo.OnnxTensorType;
 
 /** An enum representing ONNX Runtime supported Java primitive types (and String). */
 public enum OnnxJavaType {
+  /** A 32-bit floating point value. */
   FLOAT(1, float.class, 4),
+  /** A 64-bit floating point value. */
   DOUBLE(2, double.class, 8),
+  /** An 8-bit signed integer value. */
   INT8(3, byte.class, 1),
+  /** A 16-bit signed integer value. */
   INT16(4, short.class, 2),
+  /** A 32-bit signed integer value. */
   INT32(5, int.class, 4),
+  /** A 64-bit signed integer value. */
   INT64(6, long.class, 8),
+  /** A boolean value stored in a single byte. */
   BOOL(7, boolean.class, 1),
+  /** A UTF-8 string. */
   STRING(8, String.class, 4),
+  /** A 8-bit unsigned integer value. */
   UINT8(9, byte.class, 1),
   /** A IEEE 16-bit floating point value. */
   FLOAT16(10, short.class, 2),
   /** A non-IEEE 16-bit floating point value, with 8 exponent bits and 7 mantissa bits. */
   BFLOAT16(11, short.class, 2),
+  /** An unknown type used as an error condition or a sentinel. */
   UNKNOWN(0, Object.class, 0);
 
   private static final OnnxJavaType[] values;
@@ -33,8 +43,11 @@ public enum OnnxJavaType {
     }
   }
 
+  /** The native value of the enum. */
   public final int value;
+  /** The Java side type used as the carrier. */
   public final Class<?> clazz;
+  /** The number of bytes used by a single value of this type. */
   public final int size;
 
   OnnxJavaType(int value, Class<?> clazz, int size) {

--- a/java/src/main/java/ai/onnxruntime/OnnxMap.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -12,8 +12,8 @@ import java.util.Map;
 /**
  * A container for a map returned by {@link OrtSession#run(Map)}.
  *
- * <p>Supported types are those mentioned in "onnxruntime_c_api.h", keys: String and Long, values:
- * String, Long, Float, Double.
+ * <p>Supported types are those mentioned in {@code onnxruntime_c_api.h}, keys: String and Long,
+ * values: String, Long, Float, Double.
  */
 public class OnnxMap implements OnnxValue {
 
@@ -27,11 +27,17 @@ public class OnnxMap implements OnnxValue {
 
   /** An enum representing the Java type of the values stored in an {@link OnnxMap}. */
   public enum OnnxMapValueType {
+    /** An invalid Map value type. */
     INVALID(0),
+    /** A String value. */
     STRING(1),
+    /** A 64-bit signed integer value. */
     LONG(2),
+    /** A 32-bit floating point value. */
     FLOAT(3),
+    /** A 64-bit floating point value. */
     DOUBLE(4);
+    /** The native enum value. */
     final int value;
 
     OnnxMapValueType(int value) {
@@ -89,8 +95,10 @@ public class OnnxMap implements OnnxValue {
     }
   }
 
+  /** The native pointer. */
   final long nativeHandle;
 
+  /** The pointer to the allocator used by this {@code OnnxMap}. */
   final long allocatorHandle;
 
   private final MapInfo info;

--- a/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxRuntime.java
@@ -434,7 +434,7 @@ final class OnnxRuntime {
    *
    * <p>Throws IllegalArgumentException if a provider isn't recognised (note this exception should
    * only happen during development of ONNX Runtime, if it happens at any other point, file an issue
-   * on Github).
+   * on <a href="https://github.com/microsoft/onnxruntime">GitHub</a>).
    *
    * @param ortApiHandle The API Handle.
    * @return The enum set.

--- a/java/src/main/java/ai/onnxruntime/OnnxSequence.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -33,6 +33,7 @@ public class OnnxSequence implements OnnxValue {
     }
   }
 
+  /** The native pointer. */
   final long nativeHandle;
 
   private final long allocatorHandle;

--- a/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxSparseTensor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -109,6 +109,16 @@ public final class OnnxSparseTensor extends OnnxTensorLike {
     return createSparseTensor(env, env.defaultAllocator, tensor);
   }
 
+  /**
+   * Creates a Sparse Tensor in ORT from the Java side representation.
+   *
+   * @param env The OrtEnvironment.
+   * @param allocator The memory allocator.
+   * @param tensor The Java side representation.
+   * @param <T> The buffer type.
+   * @return The sparse tensor in ORT.
+   * @throws OrtException If the tensor could not be created or was invalid.
+   */
   static <T extends Buffer> OnnxSparseTensor createSparseTensor(
       OrtEnvironment env, OrtAllocator allocator, SparseTensor<T> tensor) throws OrtException {
     if (!allocator.isClosed()) {
@@ -600,6 +610,8 @@ public final class OnnxSparseTensor extends OnnxTensorLike {
    *
    * <p>Will be sealed to {@link COOTensor}, {@link CSRCTensor} and {@link BlockSparseTensor} one
    * day.
+   *
+   * @param <T> The type of the indices buffer.
    */
   public abstract static class SparseTensor<T extends Buffer> {
     private final long[] indicesShape;
@@ -608,7 +620,9 @@ public final class OnnxSparseTensor extends OnnxTensorLike {
     private final OnnxJavaType type;
     private final long numNonZero;
 
+    /** The buffer holding the indices. */
     final T indices;
+    /** The buffer holding the values. */
     final Buffer values;
 
     SparseTensor(

--- a/java/src/main/java/ai/onnxruntime/OnnxTensorLike.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxTensorLike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -19,10 +19,13 @@ public abstract class OnnxTensorLike implements OnnxValue {
     }
   }
 
+  /** The native pointer. */
   protected final long nativeHandle;
 
+  /** The pointer to the native memory allocator. */
   protected final long allocatorHandle;
 
+  /** The size and shape information for this tensor. */
   protected final TensorInfo info;
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OnnxValue.java
+++ b/java/src/main/java/ai/onnxruntime/OnnxValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -15,12 +15,19 @@ public interface OnnxValue extends AutoCloseable {
 
   /** The type of the {@link OnnxValue}, mirroring the id in the C API. */
   public enum OnnxValueType {
+    /** An unknown OrtValue type. */
     ONNX_TYPE_UNKNOWN(0),
+    /** A tensor. */
     ONNX_TYPE_TENSOR(1),
+    /** A sequence of tensors or maps. */
     ONNX_TYPE_SEQUENCE(2),
+    /** A map. */
     ONNX_TYPE_MAP(3),
+    /** An opaque type not accessible from Java. */
     ONNX_TYPE_OPAQUE(4),
+    /** A sparse tensor. */
     ONNX_TYPE_SPARSETENSOR(5),
+    /** An optional input value. */
     ONNX_TYPE_OPTIONAL(6);
 
     /** The id number of this type in the C API. */

--- a/java/src/main/java/ai/onnxruntime/OrtAllocator.java
+++ b/java/src/main/java/ai/onnxruntime/OrtAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -17,6 +17,7 @@ class OrtAllocator implements AutoCloseable {
     }
   }
 
+  /** The native pointer. */
   final long handle;
 
   private final boolean isDefault;
@@ -53,7 +54,7 @@ class OrtAllocator implements AutoCloseable {
   }
 
   /**
-   * Closes the allocator, must be done after all it's child objects have been closed.
+   * Closes the allocator, must be done after all its child objects have been closed.
    *
    * <p>The default allocator is not closeable, and this operation is a no-op on that allocator.
    *

--- a/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
+++ b/java/src/main/java/ai/onnxruntime/OrtEnvironment.java
@@ -12,8 +12,9 @@ import java.util.Objects;
 import java.util.logging.Logger;
 
 /**
- * The host object for the onnx-runtime system. Can create {@link OrtSession}s which encapsulate
- * specific models.
+ * The host object for the ONNX Runtime system. Can create {@link OrtSession}s which encapsulate
+ * specific models. This object should be instantiated before any other ONNX Runtime classes are
+ * created.
  *
  * <p>There can be at most one OrtEnvironment object created in a JVM lifetime. This class
  * implements {@link AutoCloseable} as before for backwards compatibility with 1.10 and earlier, but
@@ -24,6 +25,7 @@ public final class OrtEnvironment implements AutoCloseable {
 
   private static final Logger logger = Logger.getLogger(OrtEnvironment.class.getName());
 
+  /** The default name for ORT environments constructed from Java. */
   public static final String DEFAULT_NAME = "ort-java";
 
   static {
@@ -357,7 +359,7 @@ public final class OrtEnvironment implements AutoCloseable {
   /**
    * Turns on or off the telemetry.
    *
-   * @param sendTelemetry If true then send telemetry on onnxruntime usage.
+   * @param sendTelemetry If true then send telemetry on ONNX Runtime usage.
    * @throws OrtException If the call failed.
    */
   public void setTelemetry(boolean sendTelemetry) throws OrtException {

--- a/java/src/main/java/ai/onnxruntime/OrtException.java
+++ b/java/src/main/java/ai/onnxruntime/OrtException.java
@@ -72,7 +72,7 @@ public class OrtException extends Exception {
     ORT_ENGINE_ERROR(5),
     /** The operation threw a runtime exception. */
     ORT_RUNTIME_EXCEPTION(6),
-    /** The requested protobuf was invalid. */
+    /** The provided protobuf was invalid. */
     ORT_INVALID_PROTOBUF(7),
     /** The model was loaded. */
     ORT_MODEL_LOADED(8),

--- a/java/src/main/java/ai/onnxruntime/OrtException.java
+++ b/java/src/main/java/ai/onnxruntime/OrtException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -8,6 +8,7 @@ package ai.onnxruntime;
 public class OrtException extends Exception {
   private static final long serialVersionUID = 1L;
 
+  /** The OrtErrorCode for this exception. */
   private final OrtErrorCode errorCode;
 
   /**
@@ -51,22 +52,35 @@ public class OrtException extends Exception {
   }
 
   /**
-   * Maps the OrtErrorCode struct in "onnxruntime_c_api.h" with an additional entry for Java side
-   * errors.
+   * Maps the {@code OrtErrorCode} struct in {@code onnxruntime_c_api.h} with an additional entry
+   * for Java side errors.
    */
   public enum OrtErrorCode {
+    /** An unknown error occurred in the Java API. */
     ORT_JAVA_UNKNOWN(-1),
+    /** The operation completed without error. */
     ORT_OK(0),
+    /** The operation failed. */
     ORT_FAIL(1),
+    /** The operation received an invalid argument. */
     ORT_INVALID_ARGUMENT(2),
+    /** The operation could not load the required file. */
     ORT_NO_SUCHFILE(3),
+    /** The operation could not use the model. */
     ORT_NO_MODEL(4),
+    /** There is an internal error in the ORT engine. */
     ORT_ENGINE_ERROR(5),
+    /** The operation threw a runtime exception. */
     ORT_RUNTIME_EXCEPTION(6),
+    /** The requested protobuf was invalid. */
     ORT_INVALID_PROTOBUF(7),
+    /** The model was loaded. */
     ORT_MODEL_LOADED(8),
+    /** The requested operation has not been implemented. */
     ORT_NOT_IMPLEMENTED(9),
+    /** The ONNX graph is invalid. */
     ORT_INVALID_GRAPH(10),
+    /** The ORT execution provider failed. */
     ORT_EP_FAIL(11);
 
     private final int value;

--- a/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
+++ b/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -8,10 +8,15 @@ import java.util.logging.Logger;
 
 /** The logging level for messages from the environment and session. */
 public enum OrtLoggingLevel {
+  /** Print all log messages. */
   ORT_LOGGING_LEVEL_VERBOSE(0),
+  /** Print info and higher level log messages. */
   ORT_LOGGING_LEVEL_INFO(1),
+  /** Print warning and higher level log messages. */
   ORT_LOGGING_LEVEL_WARNING(2),
+  /** Print error log messages. */
   ORT_LOGGING_LEVEL_ERROR(3),
+  /** Print only fatal log messages. */
   ORT_LOGGING_LEVEL_FATAL(4);
   private final int value;
 

--- a/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
+++ b/java/src/main/java/ai/onnxruntime/OrtLoggingLevel.java
@@ -6,7 +6,7 @@ package ai.onnxruntime;
 
 import java.util.logging.Logger;
 
-/** The logging level for messages from the environment and session. */
+/** The logging severity level. */
 public enum OrtLoggingLevel {
   /** Print all log messages. */
   ORT_LOGGING_LEVEL_VERBOSE(0),

--- a/java/src/main/java/ai/onnxruntime/OrtProvider.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -9,21 +9,37 @@ import java.util.Map;
 
 /** The execution providers available through the Java API. */
 public enum OrtProvider {
+  /** The CPU execution provider. */
   CPU("CPUExecutionProvider"),
+  /** CUDA execution provider for Nvidia GPUs. */
   CUDA("CUDAExecutionProvider"),
+  /** The Intel Deep Neural Network Library execution provider. */
   DNNL("DnnlExecutionProvider"),
+  /** The OpenVINO execution provider. */
   OPEN_VINO("OpenVINOExecutionProvider"),
+  /** The AMD/Xilinx VitisAI execution provider. */
   VITIS_AI("VitisAIExecutionProvider"),
+  /** The TensorRT execution provider for Nvidia GPUs. */
   TENSOR_RT("TensorrtExecutionProvider"),
+  /** The Android NNAPI execution provider. */
   NNAPI("NnapiExecutionProvider"),
+  /** The RockChip NPU execution provider. */
   RK_NPU("RknpuExecutionProvider"),
+  /** The Windows DirectML execution provider. */
   DIRECT_ML("DmlExecutionProvider"),
+  /** The AMD MIGraphX execution provider. */
   MI_GRAPH_X("MIGraphXExecutionProvider"),
+  /** The ARM Compute Library execution provider. */
   ACL("ACLExecutionProvider"),
+  /** The ARM NN execution provider. */
   ARM_NN("ArmNNExecutionProvider"),
+  /** The AMD ROCm execution provider. */
   ROCM("ROCMExecutionProvider"),
+  /** The Apple CoreML execution provider. */
   CORE_ML("CoreMLExecutionProvider"),
+  /** The XNNPACK execution provider. */
   XNNPACK("XnnpackExecutionProvider"),
+  /** The Azure remote endpoint execution provider. */
   AZURE("AzureExecutionProvider");
 
   private static final Map<String, OrtProvider> valueMap = new HashMap<>(values().length);

--- a/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtProviderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime;
@@ -18,6 +18,7 @@ public abstract class OrtProviderOptions implements AutoCloseable {
     }
   }
 
+  /** The native pointer. */
   protected final long nativeHandle;
 
   /**

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -474,9 +474,19 @@ public class OrtSession implements AutoCloseable {
      * in the C API.
      */
     public enum OptLevel {
+      /** Apply no optimizations to the ONNX graph. */
       NO_OPT(0),
+      /**
+       * Apply basic optimizations such as constant folding, redundant computation elimination and
+       * node fusions to the ONNX graph.
+       */
       BASIC_OPT(1),
+      /**
+       * Applies all the basic optimizations plus more complex node fusion operations to the ONNX
+       * graph.
+       */
       EXTENDED_OPT(2),
+      /** Applies all available optimizations to the ONNX graph. */
       ALL_OPT(99);
 
       private final int id;
@@ -499,7 +509,9 @@ public class OrtSession implements AutoCloseable {
      * The execution mode to use. Needs to be kept in sync with the ExecutionMode enum in the C API.
      */
     public enum ExecutionMode {
+      /** Executes all nodes sequentially. */
       SEQUENTIAL(0),
+      /** Executes some nodes in parallel. */
       PARALLEL(1);
       private final int id;
 

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -472,6 +472,10 @@ public class OrtSession implements AutoCloseable {
     /**
      * The optimisation level to use. Needs to be kept in sync with the GraphOptimizationLevel enum
      * in the C API.
+     *
+     * <p>See <a
+     * href="https://onnxruntime.ai/docs/performance/model-optimizations/graph-optimizations.html">Graph
+     * Optimizations</a> for more details.
      */
     public enum OptLevel {
       /** Apply no optimizations to the ONNX graph. */
@@ -509,7 +513,12 @@ public class OrtSession implements AutoCloseable {
      * The execution mode to use. Needs to be kept in sync with the ExecutionMode enum in the C API.
      */
     public enum ExecutionMode {
-      /** Executes all nodes sequentially. */
+      /**
+       * Executes all nodes sequentially.
+       *
+       * <p>This is the default, and usually provides the most speedup as intra-op parallelism
+       * provides the most benefit.
+       */
       SEQUENTIAL(0),
       /** Executes some nodes in parallel. */
       PARALLEL(1);

--- a/java/src/main/java/ai/onnxruntime/OrtUtil.java
+++ b/java/src/main/java/ai/onnxruntime/OrtUtil.java
@@ -125,8 +125,6 @@ public final class OrtUtil {
   /**
    * Creates a new primitive boolean array of up to 8 dimensions, using the supplied shape.
    *
-   * <p>
-   *
    * @param shape The shape of array to create.
    * @return A boolean array.
    */
@@ -137,8 +135,6 @@ public final class OrtUtil {
 
   /**
    * Creates a new primitive byte array of up to 8 dimensions, using the supplied shape.
-   *
-   * <p>
    *
    * @param shape The shape of array to create.
    * @return A byte array.
@@ -151,8 +147,6 @@ public final class OrtUtil {
   /**
    * Creates a new primitive short array of up to 8 dimensions, using the supplied shape.
    *
-   * <p>
-   *
    * @param shape The shape of array to create.
    * @return A short array.
    */
@@ -163,8 +157,6 @@ public final class OrtUtil {
 
   /**
    * Creates a new primitive int array of up to 8 dimensions, using the supplied shape.
-   *
-   * <p>
    *
    * @param shape The shape of array to create.
    * @return A int array.
@@ -177,8 +169,6 @@ public final class OrtUtil {
   /**
    * Creates a new primitive long array of up to 8 dimensions, using the supplied shape.
    *
-   * <p>
-   *
    * @param shape The shape of array to create.
    * @return A long array.
    */
@@ -189,8 +179,6 @@ public final class OrtUtil {
 
   /**
    * Creates a new primitive float array of up to 8 dimensions, using the supplied shape.
-   *
-   * <p>
    *
    * @param shape The shape of array to create.
    * @return A float array.
@@ -203,8 +191,6 @@ public final class OrtUtil {
   /**
    * Creates a new primitive double array of up to 8 dimensions, using the supplied shape.
    *
-   * <p>
-   *
    * @param shape The shape of array to create.
    * @return A double array.
    */
@@ -215,8 +201,6 @@ public final class OrtUtil {
 
   /**
    * Creates a new String array of up to 8 dimensions, using the supplied shape.
-   *
-   * <p>
    *
    * @param shape The shape of array to create.
    * @return A double array.

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -50,7 +50,12 @@ public class TensorInfo implements ValueInfo {
     /** A 128-bit complex number, stored as 2 64-bit values. Not accessible from Java. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128(
         15), // complex with float64 real and imaginary components
-    /** A non-IEEE 16-bit floating point value. */
+    /**
+     * A non-IEEE 16-bit floating point value with 8 exponent bits and 7 mantissa bits.
+     *
+     * <p>See <a href="https://en.wikipedia.org/wiki/Bfloat16_floating-point_format">Bfloat16 on
+     * Wikipedia</a> for more details.
+     */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16(
         16), // Non-IEEE floating-point format based on IEEE754 single-precision
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN(

--- a/java/src/main/java/ai/onnxruntime/TensorInfo.java
+++ b/java/src/main/java/ai/onnxruntime/TensorInfo.java
@@ -16,24 +16,41 @@ public class TensorInfo implements ValueInfo {
 
   /** The native element types supported by the ONNX runtime. */
   public enum OnnxTensorType {
+    /** An undefined element type. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED(0),
+    /** An 8-bit unsigned integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8(1), // maps to c type uint8_t
+    /** An 8-bit signed integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8(2), // maps to c type int8_t
+    /** A 16-bit unsigned integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16(3), // maps to c type uint16_t
+    /** A 16-bit signed integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16(4), // maps to c type int16_t
+    /** A 32-bit unsigned integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32(5), // maps to c type uint32_t
+    /** A 32-bit signed integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32(6), // maps to c type int32_t
+    /** A 64-bit unsigned integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64(7), // maps to c type uint64_t
+    /** A 64-bit signed integer. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64(8), // maps to c type int64_t
+    /** An IEEE 16-bit floating point number. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16(9), // stored as a uint16_t
+    /** An IEEE 32-bit floating point number. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT(10), // maps to c type float
+    /** An IEEE 64-bit floating point number. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE(11), // maps to c type double
+    /** A UTF-8 string. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING(12), // maps to c++ type std::string
+    /** A boolean value stored in a byte. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL(13),
+    /** A 64-bit complex number, stored as 2 32-bit values. Not accessible from Java. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64(
         14), // complex with float32 real and imaginary components
+    /** A 128-bit complex number, stored as 2 64-bit values. Not accessible from Java. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128(
         15), // complex with float64 real and imaginary components
+    /** A non-IEEE 16-bit floating point value. */
     ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16(
         16), // Non-IEEE floating-point format based on IEEE754 single-precision
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN(
@@ -43,7 +60,7 @@ public class TensorInfo implements ValueInfo {
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2(
         19), // Non-IEEE floating-point format based on IEEE754 single-precision
     ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ(
-        20); // Non-IEEE floating-point format based on IEEE754 single-precisio
+        20); // Non-IEEE floating-point format based on IEEE754 single-precision
 
     /** The int id on the native side. */
     public final int value;
@@ -111,6 +128,7 @@ public class TensorInfo implements ValueInfo {
     }
   }
 
+  /** The shape of the tensor. */
   final long[] shape;
 
   /** The Java type of this tensor. */

--- a/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
@@ -1,15 +1,19 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime.providers;
 
 /** Flags for the CoreML provider. */
 public enum CoreMLFlags implements OrtFlags {
+  /** Use only the CPU, disables the GPU and Apple Neural Engine. */
   CPU_ONLY(1), // COREML_FLAG_USE_CPU_ONLY(0x001)
+  /** Enables CoreML on subgraphs. */
   ENABLE_ON_SUBGRAPH(2), // COREML_FLAG_ENABLE_ON_SUBGRAPH(0x002)
+  /** Only enables the Apple Neural Engine. */
   ONLY_ENABLE_DEVICE_WITH_ANE(4); // COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE(0x004),
 
+  /** The native value of the enum. */
   public final int value;
 
   CoreMLFlags(int value) {

--- a/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
@@ -6,8 +6,9 @@ package ai.onnxruntime.providers;
 
 /** Flags for the CoreML provider. */
 public enum CoreMLFlags implements OrtFlags {
-  /** Use only the CPU, disables the GPU and Apple Neural Engine. 
-      Only recommended for developer usage as it significantly impacts performance.
+  /**
+   * Use only the CPU, disables the GPU and Apple Neural Engine. Only recommended for developer
+   * usage as it significantly impacts performance.
    */
   CPU_ONLY(1), // COREML_FLAG_USE_CPU_ONLY(0x001)
   /** Enables CoreML on subgraphs. */

--- a/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/CoreMLFlags.java
@@ -6,11 +6,13 @@ package ai.onnxruntime.providers;
 
 /** Flags for the CoreML provider. */
 public enum CoreMLFlags implements OrtFlags {
-  /** Use only the CPU, disables the GPU and Apple Neural Engine. */
+  /** Use only the CPU, disables the GPU and Apple Neural Engine. 
+      Only recommended for developer usage as it significantly impacts performance.
+   */
   CPU_ONLY(1), // COREML_FLAG_USE_CPU_ONLY(0x001)
   /** Enables CoreML on subgraphs. */
   ENABLE_ON_SUBGRAPH(2), // COREML_FLAG_ENABLE_ON_SUBGRAPH(0x002)
-  /** Only enables the Apple Neural Engine. */
+  /** Only enable usage of CoreML if the device has an Apple Neural Engine. */
   ONLY_ENABLE_DEVICE_WITH_ANE(4); // COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE(0x004),
 
   /** The native value of the enum. */

--- a/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
@@ -1,16 +1,21 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime.providers;
 
 /** Flags for the NNAPI provider. */
 public enum NNAPIFlags implements OrtFlags {
+  /** Enables fp16 support. */
   USE_FP16(1), // NNAPI_FLAG_USE_FP16(0x001)
+  /** Uses channels first format. */
   USE_NCHW(2), // NNAPI_FLAG_USE_NCHW(0x002)
+  /** Disables CPU ops. */
   CPU_DISABLED(4), // NNAPI_FLAG_CPU_DISABLED(0x004)
+  /** Only runs on CPU. */
   CPU_ONLY(8); // NNAPI_FLAG_CPU_ONLY(0x008)
 
+  /** The native value of the enum. */
   public final int value;
 
   NNAPIFlags(int value) {

--- a/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
@@ -8,17 +8,20 @@ package ai.onnxruntime.providers;
 public enum NNAPIFlags implements OrtFlags {
   /** Enables fp16 support. */
   USE_FP16(1), // NNAPI_FLAG_USE_FP16(0x001)
-  /** Uses channels first format. 
-      Only recommended for developer usage to validate code changes to the execution provider implementation.
-  */
+  /**
+   * Uses channels first format. Only recommended for developer usage to validate code changes to
+   * the execution provider implementation.
+   */
   USE_NCHW(2), // NNAPI_FLAG_USE_NCHW(0x002)
-  /** Disables NNAPI from using CPU. 
-      If an operator could be assigned to NNAPI, but NNAPI only has a CPU implementation of that operator 
-      on the current device, model load will fail. */
+  /**
+   * Disables NNAPI from using CPU. If an operator could be assigned to NNAPI, but NNAPI only has a
+   * CPU implementation of that operator on the current device, model load will fail.
+   */
   CPU_DISABLED(4), // NNAPI_FLAG_CPU_DISABLED(0x004)
-  /** NNAPI will only use CPU. 
-      Only recommended for developer usage as it significantly impacts performance.
-  */
+  /**
+   * NNAPI will only use CPU. Only recommended for developer usage as it significantly impacts
+   * performance.
+   */
   CPU_ONLY(8); // NNAPI_FLAG_CPU_ONLY(0x008)
 
   /** The native value of the enum. */

--- a/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
+++ b/java/src/main/java/ai/onnxruntime/providers/NNAPIFlags.java
@@ -8,11 +8,17 @@ package ai.onnxruntime.providers;
 public enum NNAPIFlags implements OrtFlags {
   /** Enables fp16 support. */
   USE_FP16(1), // NNAPI_FLAG_USE_FP16(0x001)
-  /** Uses channels first format. */
+  /** Uses channels first format. 
+      Only recommended for developer usage to validate code changes to the execution provider implementation.
+  */
   USE_NCHW(2), // NNAPI_FLAG_USE_NCHW(0x002)
-  /** Disables CPU ops. */
+  /** Disables NNAPI from using CPU. 
+      If an operator could be assigned to NNAPI, but NNAPI only has a CPU implementation of that operator 
+      on the current device, model load will fail. */
   CPU_DISABLED(4), // NNAPI_FLAG_CPU_DISABLED(0x004)
-  /** Only runs on CPU. */
+  /** NNAPI will only use CPU. 
+      Only recommended for developer usage as it significantly impacts performance.
+  */
   CPU_ONLY(8); // NNAPI_FLAG_CPU_ONLY(0x008)
 
   /** The native value of the enum. */

--- a/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
+++ b/java/src/main/java/ai/onnxruntime/providers/StringConfigProviderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Licensed under the MIT License.
  */
 package ai.onnxruntime.providers;
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
  * Abstract base class for provider options which are configured solely by key value string pairs.
  */
 abstract class StringConfigProviderOptions extends OrtProviderOptions {
+  /** A Java side copy of the options. */
   protected final Map<String, String> options;
 
   protected StringConfigProviderOptions(long nativeHandle) {
@@ -38,7 +39,7 @@ abstract class StringConfigProviderOptions extends OrtProviderOptions {
   }
 
   /**
-   * Parses the output of {@link #getOptionsString()} and adds those options to this options
+   * Parses the output of {@code getOptionsString()} and adds those options to this options
    * instance.
    *
    * @param serializedForm The serialized form to parse.


### PR DESCRIPTION
### Description
Adds javadoc for all protected and public members, methods and classes.

### Motivation and Context
The javadoc warnings were annoying me when running the builds. Also, those types should have been documented.