### PR TITLE
[MIGraphX EP] Fix CopyTensorAsync and add guards for stream sync CopyTensors

### DIFF
--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
@@ -24,23 +24,14 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const
       // Copy only if the two addresses are different.
       if (dst_data != src_data) {
         HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToDevice));
-#ifndef MIGRAPHX_STREAM_SYNC
-        HIP_CALL_THROW(hipStreamSynchronize(nullptr));
-#endif
       }
     } else {
       // copy from other CPU memory to GPU, this is blocking
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
-#ifndef MIGRAPHX_STREAM_SYNC
-      HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
-#endif
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
     // copying from GPU to CPU memory, this is blocking
     HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
-#ifndef MIGRAPHX_STREAM_SYNC
-    HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
-#endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);

--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
@@ -24,23 +24,23 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const
       // Copy only if the two addresses are different.
       if (dst_data != src_data) {
         HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToDevice));
-        #ifndef MIGRAPHX_STREAM_SYNC
+#ifndef MIGRAPHX_STREAM_SYNC
         HIP_CALL_THROW(hipStreamSynchronize(nullptr));
-        #endif
+#endif
       }
     } else {
       // copy from other CPU memory to GPU, this is blocking
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
-      #ifndef MIGRAPHX_STREAM_SYNC
+#ifndef MIGRAPHX_STREAM_SYNC
       HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
-      #endif
+#endif
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
     // copying from GPU to CPU memory, this is blocking
     HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
-    #ifndef MIGRAPHX_STREAM_SYNC
+#ifndef MIGRAPHX_STREAM_SYNC
     HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
-    #endif
+#endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);
@@ -69,7 +69,7 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
-    #ifndef MIGRAPHX_STREAM_SYNC
+#ifndef MIGRAPHX_STREAM_SYNC
     if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::HIP_PINNED) {
       // copying from GPU to pinned memory, this is non-blocking
       HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
@@ -77,9 +77,9 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
       // copying from GPU to CPU memory, this is blocking
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
     }
-    #else
+#else
     HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
-    #endif
+#endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);

--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.cc
@@ -24,17 +24,23 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const
       // Copy only if the two addresses are different.
       if (dst_data != src_data) {
         HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToDevice));
+        #ifndef MIGRAPHX_STREAM_SYNC
         HIP_CALL_THROW(hipStreamSynchronize(nullptr));
+        #endif
       }
     } else {
       // copy from other CPU memory to GPU, this is blocking
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
+      #ifndef MIGRAPHX_STREAM_SYNC
       HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
+      #endif
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
     // copying from GPU to CPU memory, this is blocking
     HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
+    #ifndef MIGRAPHX_STREAM_SYNC
     HIP_CALL_THROW(hipStreamSynchronize(nullptr));  // TODO: still need stream sync? since already blocking
+    #endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);
@@ -63,6 +69,7 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyHostToDevice));
     }
   } else if (src_device.Type() == OrtDevice::GPU) {
+    #ifndef MIGRAPHX_STREAM_SYNC
     if (dst_device.Type() == OrtDevice::CPU && dst_device.MemType() == OrtDevice::MemType::HIP_PINNED) {
       // copying from GPU to pinned memory, this is non-blocking
       HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
@@ -70,6 +77,9 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
       // copying from GPU to CPU memory, this is blocking
       HIP_CALL_THROW(hipMemcpy(dst_data, src_data, bytes, hipMemcpyDeviceToHost));
     }
+    #else
+    HIP_CALL_THROW(hipMemcpyAsync(dst_data, src_data, bytes, hipMemcpyDeviceToHost, static_cast<hipStream_t>(stream.GetHandle())));
+    #endif
   } else {
     // copying between cpu memory
     memcpy(dst_data, src_data, bytes);


### PR DESCRIPTION
Add compile guards to gate functionality based on MIGRAPHX_STREAM_SYNC for adding the following

- remove excess hipStreamSyncronize to nullstream on CopyTensor calls
- Add proper call for stream synchronized CopyTensorAsync for DeviceToHost case

Without this change subsequent CopyTensorAsync() calls will fail for cards that don't use pinned memory thus causing hipMemcpy() calls to occur before certain kernel operations occur.

### Description
<!-- Describe your changes. -->

Remove excess syncronization when stream sync is enabled but also block the DeviceTohost  CopyTensorAsync() to the desired GPU stream. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Without this change we fail to properly wait for a kernel to compute and synchronize correctly if memory isn't specifically pinned for the task.  This was observed when doing another run with test_parity_gelu and test_parity_layernorm tests.


![image](https://github.com/microsoft/onnxruntime/assets/107195283/4915c18a-fb2d-40c9-a50e-a7c6613c324b)


becomes

![image](https://github.com/microsoft/onnxruntime/assets/107195283/f661acf4-e2af-4c9a-b26a-30fca339cf1d)



