### PR TITLE
[Better Engineering] Fix N802 lint errors in tests

### DIFF
--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
+from __future__ import annotations
 
 import argparse
 import os
@@ -29,8 +30,9 @@ integer_dict = {
 }
 
 
-def generate_feeds(sess, symbolic_dims={}):  # noqa: B006
+def generate_feeds(sess, symbolic_dims: dict | None = None):
     feeds = {}
+    symbolic_dims = symbolic_dims or {}
     for input_meta in sess.get_inputs():
         # replace any symbolic dimensions
         shape = []
@@ -67,10 +69,11 @@ def run_model(
     num_iters=1,
     debug=None,
     profile=None,
-    symbolic_dims={},  # noqa: B006
+    symbolic_dims=None,
     feeds=None,
     override_initializers=True,
 ):
+    symbolic_dims = symbolic_dims or {}
     if debug:
         print(f"Pausing execution ready for debugger to attach to pid: {os.getpid()}")
         print("Press key to continue.")

--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer.py
@@ -138,7 +138,7 @@ def create_ort_trainer(
     return model, model_desc, device
 
 
-def runBertTrainingTest(  # noqa: N802
+def run_bert_training_test(
     gradient_accumulation_steps,
     use_mixed_precision,
     allreduce_post_accumulation,
@@ -516,10 +516,10 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="test accuracy mismatch",
         )
 
-    def testMNISTTrainingAndTestingOpset12(self):  # noqa: N802
+    def test_mnist_training_and_testing_opset12(self):
         TestOrtTrainer.run_mnist_training_and_testing(onnx_opset_ver=12)
 
-    def testMNISTResumeTrainingAndTesting(self):  # noqa: N802
+    def test_mnist_resume_training_and_testing(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -588,7 +588,7 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="test accuracy mismatch",
         )
 
-    def testMNISTStateDict(self):  # noqa: N802
+    def test_mnist_state_dict(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -617,7 +617,7 @@ class TestOrtTrainer(unittest.TestCase):
             "bias_buffer",
         }
 
-    def testMNISTSaveAsONNX(self):  # noqa: N802
+    def test_mnist_save_as_onnx(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
         onnx_file_name = "mnist.onnx"
@@ -643,7 +643,7 @@ class TestOrtTrainer(unittest.TestCase):
         trainer.save_as_onnx(onnx_file_name)
         assert os.path.exists(onnx_file_name)
 
-    def testMNISTDevice(self):  # noqa: N802
+    def test_mnist_device(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -662,7 +662,7 @@ class TestOrtTrainer(unittest.TestCase):
 
             loss, _ = trainer.train_step(data, target, torch.tensor([learningRate]))
 
-    def testMNISTInitializerNames(self):  # noqa: N802
+    def test_mnist_initializer_names(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -683,7 +683,7 @@ class TestOrtTrainer(unittest.TestCase):
             n for n, t in model.named_parameters()
         }
 
-    def testMNISTInitializerNamesWithInternalLoss(self):  # noqa: N802
+    def test_mnist_initializer_names_with_internal_loss(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -711,7 +711,7 @@ class TestOrtTrainer(unittest.TestCase):
 
         assert {n.name for n in trainer.onnx_model_.graph.initializer} == {n for n, t in model.named_parameters()}
 
-    def testMNISTFrozenWeight(self):  # noqa: N802
+    def test_mnist_frozen_weight(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -738,7 +738,7 @@ class TestOrtTrainer(unittest.TestCase):
         fc2_trainstep_2 = trainer.state_dict()["fc2.weight"]
         assert np.array_equal(fc1_trainstep_1, fc1_trainstep_2) and not np.array_equal(fc2_trainstep_1, fc2_trainstep_2)
 
-    def testMNISTTorchBuffer(self):  # noqa: N802
+    def test_mnist_torch_buffer(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -767,7 +767,7 @@ class TestOrtTrainer(unittest.TestCase):
             bias_buffer_trainstep_1, bias_buffer_trainstep_2
         )
 
-    def testMNISTFrozenWeightCheckpoint(self):  # noqa: N802
+    def test_mnist_frozen_weight_checkpoint(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -806,7 +806,7 @@ class TestOrtTrainer(unittest.TestCase):
         loaded_state_dict = trainer.state_dict()
         assert state_dict.keys() == loaded_state_dict.keys()
 
-    def testMNISTTrainingCheckpoint(self):  # noqa: N802
+    def test_mnist_training_checkpoint(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 
@@ -860,7 +860,7 @@ class TestOrtTrainer(unittest.TestCase):
         for key in state_dict:
             assert np.array_equal(state_dict[key], loaded_state_dict[key])
 
-    def testBertTrainingBasic(self):  # noqa: N802
+    def test_bert_training_basic(self):
         expected_losses = [
             11.027887,
             11.108191,
@@ -872,7 +872,7 @@ class TestOrtTrainer(unittest.TestCase):
             10.920979,
         ]
         expected_eval_loss = [10.958977]
-        actual_losses, actual_eval_loss = runBertTrainingTest(
+        actual_losses, actual_eval_loss = run_bert_training_test(
             gradient_accumulation_steps=1,
             use_mixed_precision=False,
             allreduce_post_accumulation=False,
@@ -894,7 +894,7 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="evaluation loss mismatch",
         )
 
-    def testBertTrainingGradientAccumulation(self):  # noqa: N802
+    def test_bert_training_gradient_accumulation(self):
         expected_losses = [
             11.027887,
             11.108191,
@@ -907,7 +907,7 @@ class TestOrtTrainer(unittest.TestCase):
         ]
         expected_eval_loss = [10.958998]
 
-        actual_losses, actual_eval_loss = runBertTrainingTest(
+        actual_losses, actual_eval_loss = run_bert_training_test(
             gradient_accumulation_steps=4,
             use_mixed_precision=False,
             allreduce_post_accumulation=False,
@@ -929,7 +929,7 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="evaluation loss mismatch",
         )
 
-    def testBertCheckpointingBasic(self):  # noqa: N802
+    def test_bert_checkpointing_basic(self):
         model, _, _ = create_ort_trainer(
             gradient_accumulation_steps=1,
             use_mixed_precision=False,
@@ -963,7 +963,7 @@ class TestOrtTrainer(unittest.TestCase):
         for k, v in loaded_sd.items():
             assert torch.all(torch.eq(v, sd[k]))
 
-    def testWrapModelLossFnStateDict(self):  # noqa: N802
+    def test_wrap_model_loss_fn_state_dict(self):
         torch.manual_seed(1)
         device = torch.device("cuda")
 

--- a/onnxruntime/test/python/onnxruntime_test_ort_trainer_with_mixed_precision.py
+++ b/onnxruntime/test/python/onnxruntime_test_ort_trainer_with_mixed_precision.py
@@ -4,11 +4,11 @@
 import unittest
 
 from numpy.testing import assert_allclose, assert_array_equal
-from onnxruntime_test_ort_trainer import runBertTrainingTest
+from onnxruntime_test_ort_trainer import run_bert_training_test
 
 
 class TestOrtTrainer(unittest.TestCase):
-    def testBertTrainingMixedPrecision(self):  # noqa: N802
+    def test_bert_training_mixed_precision(self):
         expected_losses = [
             11.034248352050781,
             11.125300407409668,
@@ -21,7 +21,7 @@ class TestOrtTrainer(unittest.TestCase):
         ]
         expected_all_finites = [True, True, True, True, True, True, True, True]
         expected_eval_loss = [10.959012985229492]
-        actual_losses, actual_all_finites, actual_eval_loss = runBertTrainingTest(
+        actual_losses, actual_all_finites, actual_eval_loss = run_bert_training_test(
             gradient_accumulation_steps=1,
             use_mixed_precision=True,
             allreduce_post_accumulation=False,
@@ -38,7 +38,7 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="evaluation loss mismatch",
         )
 
-    def testBertTrainingMixedPrecisionInternalLossScale(self):  # noqa: N802
+    def test_bert_training_mixed_precision_internal_loss_scale(self):
         expected_losses = [
             11.034248352050781,
             11.125300407409668,
@@ -50,7 +50,7 @@ class TestOrtTrainer(unittest.TestCase):
             10.971782684326172,
         ]
         expected_eval_loss = [10.959012985229492]
-        actual_losses, actual_eval_loss = runBertTrainingTest(
+        actual_losses, actual_eval_loss = run_bert_training_test(
             gradient_accumulation_steps=1,
             use_mixed_precision=True,
             allreduce_post_accumulation=False,
@@ -67,7 +67,7 @@ class TestOrtTrainer(unittest.TestCase):
             err_msg="evaluation loss mismatch",
         )
 
-    def testBertTrainingGradientAccumulationMixedPrecision(self):  # noqa: N802
+    def test_bert_training_gradient_accumulation_mixed_precision(self):
         expected_losses = [
             11.034248352050781,
             11.125300407409668,
@@ -80,7 +80,7 @@ class TestOrtTrainer(unittest.TestCase):
         ]
         expected_all_finites = [True, True]
         expected_eval_loss = [10.95903205871582]
-        actual_losses, actual_all_finites, actual_eval_loss = runBertTrainingTest(
+        actual_losses, actual_all_finites, actual_eval_loss = run_bert_training_test(
             gradient_accumulation_steps=4,
             use_mixed_precision=True,
             allreduce_post_accumulation=False,

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-# pylint: disable=C0116,W0212,R1720,C0114
+from __future__ import annotations
 
 import copy
+import ctypes
 import gc
 import os
 import pathlib
@@ -59,21 +60,21 @@ class TestInferenceSession(unittest.TestCase):
             predict = session_object.run(None, {input_name: input_value})[0]
             queue.put(max(predict.flatten().tolist()))
 
-    def testTvmImported(self):  # noqa: N802
+    def test_tvm_imported(self):
         if "TvmExecutionProvider" not in onnxrt.get_available_providers():
             return
         import tvm
 
         self.assertTrue(tvm is not None)
 
-    def testGetVersionString(self):  # noqa: N802
+    def test_get_version_string(self):
         self.assertIsNot(onnxrt.get_version_string(), None)
 
-    def testGetBuildInfo(self):  # noqa: N802
+    def test_get_build_info(self):
         self.assertIsNot(onnxrt.get_build_info(), None)
         self.assertIn("Build Info", onnxrt.get_build_info())
 
-    def testModelSerialization(self):  # noqa: N802
+    def test_model_serialization(self):
         try:
             so = onnxrt.SessionOptions()
             so.log_severity_level = 1
@@ -94,7 +95,7 @@ class TestInferenceSession(unittest.TestCase):
             else:
                 raise onnxruntime_error
 
-    def testModelSerializationWithExternalInitializers(self):  # noqa: N802
+    def test_model_serialization_with_external_initializers(self):
         try:
             so = onnxrt.SessionOptions()
             so.log_severity_level = 1
@@ -121,7 +122,7 @@ class TestInferenceSession(unittest.TestCase):
             else:
                 raise onnxruntime_error
 
-    def testModelSerializationWithExternalInitializersToDirectory(self):  # noqa: N802
+    def test_model_serialization_with_external_initializers_to_directory(self):
         try:
             so = onnxrt.SessionOptions()
             so.log_severity_level = 1
@@ -145,7 +146,7 @@ class TestInferenceSession(unittest.TestCase):
             else:
                 raise onnxruntime_error
 
-    def testGetProviders(self):  # noqa: N802
+    def test_get_providers(self):
         self.assertTrue("CPUExecutionProvider" in onnxrt.get_available_providers())
         # get_all_providers() returns the default EP order from highest to lowest.
         # CPUExecutionProvider should always be last.
@@ -153,18 +154,18 @@ class TestInferenceSession(unittest.TestCase):
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         self.assertTrue("CPUExecutionProvider" in sess.get_providers())
 
-    def testEnablingAndDisablingTelemetry(self):  # noqa: N802
+    def test_enabling_and_disabling_telemetry(self):
         onnxrt.disable_telemetry_events()
 
         # no-op on non-Windows builds
         # may be no-op on certain Windows builds based on build configuration
         onnxrt.enable_telemetry_events()
 
-    def testDeserializationFromPathObject(self):  # noqa: N802
+    def test_deserialization_from_path_object(self):
         # path object is allowed
         onnxrt.InferenceSession(pathlib.Path(get_name("mul_1.onnx")), providers=available_providers)
 
-    def testSetProviders(self):  # noqa: N802
+    def test_set_providers(self):
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
             sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CUDAExecutionProvider"])
             # confirm that CUDA Provider is in list of registered providers.
@@ -174,7 +175,7 @@ class TestInferenceSession(unittest.TestCase):
             # confirm only CPU Provider is registered now.
             self.assertEqual(["CPUExecutionProvider"], sess.get_providers())
 
-    def testSetProvidersWithOptions(self):  # noqa: N802
+    def test_set_providers_with_options(self):
         if "TensorrtExecutionProvider" in onnxrt.get_available_providers():
             sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["TensorrtExecutionProvider"])
             self.assertIn("TensorrtExecutionProvider", sess.get_providers())
@@ -238,12 +239,9 @@ class TestInferenceSession(unittest.TestCase):
             """
 
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
-            import ctypes
-            import sys  # noqa: F401
+            cuda_success = 0
 
-            CUDA_SUCCESS = 0  # noqa: N806
-
-            def runBaseTest1():  # noqa: N802
+            def run_base_test1():
                 sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CUDAExecutionProvider"])
                 self.assertTrue("CUDAExecutionProvider" in sess.get_providers())
 
@@ -262,7 +260,7 @@ class TestInferenceSession(unittest.TestCase):
                     sess.get_providers(),
                 )
 
-            def runBaseTest2():  # noqa: N802
+            def run_base_test2():
                 sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CUDAExecutionProvider"])
                 self.assertIn("CUDAExecutionProvider", sess.get_providers())
 
@@ -343,27 +341,21 @@ class TestInferenceSession(unittest.TestCase):
                 with self.assertRaises(RuntimeError):
                     sess.set_providers(["CUDAExecutionProvider"], [option])
 
-            def getCudaDeviceCount():  # noqa: N802
-                import ctypes
-
+            def get_cuda_device_count():
                 num_device = ctypes.c_int()
                 result = ctypes.c_int()
                 error_str = ctypes.c_char_p()
 
                 result = cuda.cuInit(0)
                 result = cuda.cuDeviceGetCount(ctypes.byref(num_device))
-                if result != CUDA_SUCCESS:
+                if result != cuda_success:
                     cuda.cuGetErrorString(result, ctypes.byref(error_str))
                     print("cuDeviceGetCount failed with error code %d: %s" % (result, error_str.value.decode()))
                     return -1
 
                 return num_device.value
 
-            def setDeviceIdTest(i):  # noqa: N802
-                import ctypes
-
-                import onnxruntime as onnxrt
-
+            def set_device_id_test(i):
                 device = ctypes.c_int()
                 result = ctypes.c_int()
                 error_str = ctypes.c_char_p()
@@ -376,21 +368,21 @@ class TestInferenceSession(unittest.TestCase):
                     sess.get_providers(),
                 )
                 result = cuda.cuCtxGetDevice(ctypes.byref(device))
-                if result != CUDA_SUCCESS:
+                if result != cuda_success:
                     cuda.cuGetErrorString(result, ctypes.byref(error_str))
-                    print("cuCtxGetDevice failed with error code %d: %s" % (result, error_str.value.decode()))
+                    print(f"cuCtxGetDevice failed with error code {result}: {error_str.value.decode()}")
 
-                self.assertEqual(result, CUDA_SUCCESS)
+                self.assertEqual(result, cuda_success)
                 self.assertEqual(i, device.value)
 
-            def runAdvancedTest():  # noqa: N802
-                num_device = getCudaDeviceCount()
+            def run_advanced_test():
+                num_device = get_cuda_device_count()
                 if num_device < 0:
                     return
 
                 # Configure session to be ready to run on all available cuda devices
                 for i in range(num_device):
-                    setDeviceIdTest(i)
+                    set_device_id_test(i)
 
                 sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CPUExecutionProvider"])
 
@@ -410,22 +402,21 @@ class TestInferenceSession(unittest.TestCase):
             for libname in libnames:
                 try:
                     cuda = ctypes.CDLL(libname)
-                    runBaseTest1()
-                    runBaseTest2()
-                    runAdvancedTest()
+                    run_base_test1()
+                    run_base_test2()
+                    run_advanced_test()
 
                 except OSError:
                     continue
                 else:
                     break
             else:
-                runBaseTest1()
-                runBaseTest2()
-                # raise OSError("could not load any of: " + ' '.join(libnames))
+                run_base_test1()
+                run_base_test2()
 
         if "ROCMExecutionProvider" in onnxrt.get_available_providers():
 
-            def runRocmOptionsTest():  # noqa: N802
+            def run_rocm_options_test():
                 sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["ROCMExecutionProvider"])
                 self.assertIn("ROCMExecutionProvider", sess.get_providers())
                 options = sess.get_provider_options()
@@ -450,22 +441,22 @@ class TestInferenceSession(unittest.TestCase):
 
                 test_get_and_set_option_with_values("tunable_op_max_tuning_duration_ms", ["-1", "1"])
 
-            runRocmOptionsTest()
+            run_rocm_options_test()
 
-    def testInvalidSetProviders(self):  # noqa: N802
+    def test_invalid_set_providers(self):
         with self.assertRaises(RuntimeError) as context:
             sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CPUExecutionProvider"])
             sess.set_providers(["InvalidProvider"])
         self.assertTrue("Unknown Provider Type: InvalidProvider" in str(context.exception))
 
-    def testSessionProviders(self):  # noqa: N802
+    def test_session_providers(self):
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
             # create session from scratch, but constrain it to only use the CPU.
             sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=["CPUExecutionProvider"])
             self.assertEqual(["CPUExecutionProvider"], sess.get_providers())
 
-    def testGetAndSetTuningResults(self):  # noqa: N802
-        def getTuningResultsForEp(sess, ep):  # without the outer list  # noqa: N802
+    def test_get_and_set_tuning_results(self):
+        def get_tuning_results_for_ep(sess, ep):  # without the outer list
             tuning_results = sess.get_tuning_results()
             self.assertGreaterEqual(len(tuning_results), 1)
             tuning_results_for_this_ep = [t for t in tuning_results if t.get("ep") == ep]
@@ -476,23 +467,23 @@ class TestInferenceSession(unittest.TestCase):
         probe_params_sig = "probe_but_not_an_params_signature"
         probe_value = 10000000
 
-        def copyTuningResultsWithProbe(tr):  # noqa: N802
+        def copy_tuning_results_with_probe(tr):
             tr = copy.deepcopy(tr)
             tr["results"][probe_op_sig] = {probe_params_sig: probe_value}
             return tr
 
-        def assertTuningResultsLoaded(sess, ep):  # noqa: N802
-            tr = getTuningResultsForEp(sess, ep)
+        def assert_tuning_results_loaded(sess, ep):
+            tr = get_tuning_results_for_ep(sess, ep)
             self.assertIn(probe_op_sig, tr["results"])
             self.assertEqual(tr["results"][probe_op_sig], {probe_params_sig: probe_value})
 
-        def assertTuningResultsNotLoaded(sess, ep):  # noqa: N802
-            tr = getTuningResultsForEp(sess, ep)
+        def assert_tuning_results_not_loaded(sess, ep):
+            tr = get_tuning_results_for_ep(sess, ep)
             self.assertNotIn(probe_op_sig, tr["results"])
 
-        def doTestGetAndSetTuningResults(ep):  # noqa: N802
+        def do_test_get_and_set_tuning_results(ep):
             sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=[ep])
-            tuning_results = getTuningResultsForEp(sess, ep)
+            tuning_results = get_tuning_results_for_ep(sess, ep)
 
             self.assertIn("ep", tuning_results)
             self.assertIn("results", tuning_results)
@@ -501,53 +492,53 @@ class TestInferenceSession(unittest.TestCase):
             self.assertNotIn("NOT_A_VALIDATOR_KEY", tuning_results["validators"])
 
             # invalid EP will be rejected
-            invalid_unknown_ep = copyTuningResultsWithProbe(tuning_results)
+            invalid_unknown_ep = copy_tuning_results_with_probe(tuning_results)
             invalid_unknown_ep["ep"] = "UnknownEP"
             sess.set_tuning_results([invalid_unknown_ep])
             with self.assertRaises(RuntimeError) as context:
                 sess.set_tuning_results([invalid_unknown_ep], error_on_invalid=True)
             self.assertIn("Cannot find execution provider UnknownEP", str(context.exception))
-            assertTuningResultsNotLoaded(sess, ep)
+            assert_tuning_results_not_loaded(sess, ep)
 
             # missing validator key will be rejected
-            mismatched_validator_key_missing = copyTuningResultsWithProbe(tuning_results)
+            mismatched_validator_key_missing = copy_tuning_results_with_probe(tuning_results)
             mismatched_validator_key_missing["validators"].pop("ORT_VERSION")
             sess.set_tuning_results([mismatched_validator_key_missing])
             with self.assertRaises(RuntimeError) as context:
                 sess.set_tuning_results([mismatched_validator_key_missing], error_on_invalid=True)
             self.assertIn("ORT_VERSION", str(context.exception))
             self.assertIn("is not provided for validation", str(context.exception))
-            assertTuningResultsNotLoaded(sess, ep)
+            assert_tuning_results_not_loaded(sess, ep)
 
-            mismatched_validator_key_extra = copyTuningResultsWithProbe(tuning_results)
+            mismatched_validator_key_extra = copy_tuning_results_with_probe(tuning_results)
             mismatched_validator_key_extra["validators"]["NOT_A_VALIDATOR_KEY"] = "NOT_USED"
             sess.set_tuning_results([mismatched_validator_key_extra])
             with self.assertRaises(RuntimeError) as context:
                 sess.set_tuning_results([mismatched_validator_key_extra], error_on_invalid=True)
             self.assertIn("NOT_A_VALIDATOR_KEY", str(context.exception))
             self.assertIn("is unable to consume it", str(context.exception))
-            assertTuningResultsNotLoaded(sess, ep)
+            assert_tuning_results_not_loaded(sess, ep)
 
-            validation_failure = copyTuningResultsWithProbe(tuning_results)
+            validation_failure = copy_tuning_results_with_probe(tuning_results)
             validation_failure["validators"]["ORT_VERSION"] = "This is not a proper ORT_VERSION value!"
             sess.set_tuning_results([validation_failure])
             with self.assertRaises(RuntimeError) as context:
                 sess.set_tuning_results([validation_failure], error_on_invalid=True)
             self.assertIn("Failed to load TuningResults", str(context.exception))
             self.assertIn("version mismatch", str(context.exception))
-            assertTuningResultsNotLoaded(sess, ep)
+            assert_tuning_results_not_loaded(sess, ep)
 
-            loadable = copyTuningResultsWithProbe(tuning_results)
+            loadable = copy_tuning_results_with_probe(tuning_results)
             sess.set_tuning_results([loadable], error_on_invalid=True)
-            assertTuningResultsLoaded(sess, ep)
+            assert_tuning_results_loaded(sess, ep)
 
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
-            doTestGetAndSetTuningResults("CUDAExecutionProvider")
+            do_test_get_and_set_tuning_results("CUDAExecutionProvider")
 
         if "ROCMExecutionProvider" in onnxrt.get_available_providers():
-            doTestGetAndSetTuningResults("ROCMExecutionProvider")
+            do_test_get_and_set_tuning_results("ROCMExecutionProvider")
 
-    def testRunModel(self):  # noqa: N802
+    def test_run_model(self):
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=available_providers)
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
@@ -562,7 +553,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testRunModelFromBytes(self):  # noqa: N802
+    def test_run_model_from_bytes(self):
         with open(get_name("mul_1.onnx"), "rb") as f:
             content = f.read()
         sess = onnxrt.InferenceSession(content, providers=onnxrt.get_available_providers())
@@ -579,7 +570,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testRunModel2(self):  # noqa: N802
+    def test_run_model2(self):
         sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
@@ -594,7 +585,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[5.0], [11.0], [17.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testRunModel2Contiguous(self):  # noqa: N802
+    def test_run_model2_contiguous(self):
         sess = onnxrt.InferenceSession(get_name("matmul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[2.0, 1.0], [4.0, 3.0], [6.0, 5.0]], dtype=np.float32)[:, [1, 0]]
         input_name = sess.get_inputs()[0].name
@@ -612,7 +603,7 @@ class TestInferenceSession(unittest.TestCase):
         rescontiguous = sess.run([output_name], {input_name: xcontiguous})
         np.testing.assert_allclose(output_expected, rescontiguous[0], rtol=1e-05, atol=1e-08)
 
-    def testRunModelMultipleThreads(self):  # noqa: N802
+    def test_run_model_multiple_threads(self):
         # Skip this test for a "pure" DML onnxruntime python wheel.
         # We keep this test enabled for instances where both DML and CUDA EPs are available
         # (Windows GPU CI pipeline has this config) - this test will pass because CUDA has higher precedence
@@ -669,7 +660,7 @@ class TestInferenceSession(unittest.TestCase):
             while q.qsize() > 0:
                 self.assertEqual(result, q.get())
 
-    def testListAsInput(self):  # noqa: N802
+    def test_list_as_input(self):
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
@@ -677,18 +668,18 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testStringListAsInput(self):  # noqa: N802
+    def test_string_list_as_input(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         x = np.array(["this", "is", "identity", "test"], dtype=str).reshape((2, 2))
         x_name = sess.get_inputs()[0].name
         res = sess.run([], {x_name: x.tolist()})
         np.testing.assert_equal(x, res[0])
 
-    def testRunDevice(self):  # noqa: N802
+    def test_run_device(self):
         device = onnxrt.get_device()
         self.assertTrue("CPU" in device or "GPU" in device)
 
-    def testRunModelSymbolicInput(self):  # noqa: N802
+    def test_run_model_symbolic_input(self):
         sess = onnxrt.InferenceSession(get_name("matmul_2.onnx"), providers=available_providers_without_tvm)
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         input_name = sess.get_inputs()[0].name
@@ -705,7 +696,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[5.0], [11.0], [17.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testBooleanInputs(self):  # noqa: N802
+    def test_boolean_inputs(self):
         sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), providers=available_providers)
         a = np.array([[True, True], [False, False]], dtype=bool)
         b = np.array([[True, False], [True, False]], dtype=bool)
@@ -737,7 +728,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {a_name: a, b_name: b})
         np.testing.assert_equal(output_expected, res[0])
 
-    def testStringInput1(self):  # noqa: N802
+    def test_string_input1(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         x = np.array(["this", "is", "identity", "test"], dtype=str).reshape((2, 2))
 
@@ -758,7 +749,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         np.testing.assert_equal(x, res[0])
 
-    def testStringInput2(self):  # noqa: N802
+    def test_string_input2(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         x = np.array(["Olá", "你好", "여보세요", "hello"], dtype=str).reshape((2, 2))
 
@@ -779,7 +770,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         np.testing.assert_equal(x, res[0])
 
-    def testInputBytes(self):  # noqa: N802
+    def test_input_bytes(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         x = np.array([b"this", b"is", b"identity", b"test"]).reshape((2, 2))
 
@@ -800,7 +791,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         np.testing.assert_equal(x, res[0].astype("|S8"))
 
-    def testInputObject(self):  # noqa: N802
+    def test_input_object(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         x = np.array(["this", "is", "identity", "test"], object).reshape((2, 2))
 
@@ -821,7 +812,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         np.testing.assert_equal(x, res[0])
 
-    def testInputVoid(self):  # noqa: N802
+    def test_input_void(self):
         sess = onnxrt.InferenceSession(get_name("identity_string.onnx"), providers=available_providers_without_tvm)
         # numpy 1.20+ doesn't automatically pad the bytes based entries in the array when dtype is np.void,
         # so we use inputs where that is the case
@@ -846,7 +837,7 @@ class TestInferenceSession(unittest.TestCase):
         expr = np.array([["must", "have"], ["same", "size"]], dtype=object)
         np.testing.assert_equal(expr, res[0])
 
-    def testRaiseWrongNumInputs(self):  # noqa: N802
+    def test_raise_wrong_num_inputs(self):
         with self.assertRaises(ValueError) as context:
             sess = onnxrt.InferenceSession(get_name("logicaland.onnx"), providers=onnxrt.get_available_providers())
             a = np.array([[True, True], [False, False]], dtype=bool)
@@ -855,7 +846,7 @@ class TestInferenceSession(unittest.TestCase):
             "Required inputs (['input1:0']) are missing from input feed (['input:0'])", str(context.exception)
         )
 
-    def testModelMeta(self):  # noqa: N802
+    def test_model_meta(self):
         model_path = "../models/opset8/test_squeezenet/model.onnx"
         if not os.path.exists(model_path):
             return
@@ -867,7 +858,7 @@ class TestInferenceSession(unittest.TestCase):
         self.assertEqual("", modelmeta.description)
         self.assertEqual("", modelmeta.graph_description)
 
-    def testProfilerWithSessionOptions(self):  # noqa: N802
+    def test_profiler_with_session_options(self):
         so = onnxrt.SessionOptions()
         so.enable_profiling = True
         sess = onnxrt.InferenceSession(
@@ -888,8 +879,8 @@ class TestInferenceSession(unittest.TestCase):
                     self.assertTrue(tag in lines[i])
             self.assertTrue("]" in lines[-1])
 
-    def testProfilerGetStartTimeNs(self):  # noqa: N802
-        def getSingleSessionProfilingStartTime():  # noqa: N802
+    def test_profiler_get_start_time_ns(self):
+        def get_single_session_profiling_start_time():
             so = onnxrt.SessionOptions()
             so.enable_profiling = True
             sess = onnxrt.InferenceSession(
@@ -900,16 +891,16 @@ class TestInferenceSession(unittest.TestCase):
             return sess.get_profiling_start_time_ns()
 
         # Get 1st profiling's start time
-        start_time_1 = getSingleSessionProfilingStartTime()
+        start_time_1 = get_single_session_profiling_start_time()
         # Get 2nd profiling's start time
-        start_time_2 = getSingleSessionProfilingStartTime()
+        start_time_2 = get_single_session_profiling_start_time()
         # Get 3rd profiling's start time
-        start_time_3 = getSingleSessionProfilingStartTime()
+        start_time_3 = get_single_session_profiling_start_time()
 
         # Chronological profiling's start time
         self.assertTrue(start_time_1 <= start_time_2 <= start_time_3)
 
-    def testGraphOptimizationLevel(self):  # noqa: N802
+    def test_graph_optimization_level(self):
         opt = onnxrt.SessionOptions()
         # default should be all optimizations optimization
         self.assertEqual(opt.graph_optimization_level, onnxrt.GraphOptimizationLevel.ORT_ENABLE_ALL)
@@ -924,7 +915,7 @@ class TestInferenceSession(unittest.TestCase):
 
         sess.run([], {"input1:0": a, "input:0": b})
 
-    def testSequenceLength(self):  # noqa: N802
+    def test_sequence_length(self):
         sess = onnxrt.InferenceSession(get_name("sequence_length.onnx"), providers=available_providers_without_tvm)
         x = [
             np.array([1.0, 0.0, 3.0, 44.0, 23.0, 11.0], dtype=np.float32).reshape((2, 3)),
@@ -945,7 +936,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         self.assertEqual(output_expected, res[0])
 
-    def testSequenceConstruct(self):  # noqa: N802
+    def test_sequence_construct(self):
         sess = onnxrt.InferenceSession(
             get_name("sequence_construct.onnx"),
             providers=available_providers_without_tvm,
@@ -977,7 +968,7 @@ class TestInferenceSession(unittest.TestCase):
 
         np.testing.assert_array_equal(output_expected, res[0])
 
-    def testSequenceInsert(self):  # noqa: N802
+    def test_sequence_insert(self):
         opt = onnxrt.SessionOptions()
         opt.execution_mode = onnxrt.ExecutionMode.ORT_SEQUENTIAL
         sess = onnxrt.InferenceSession(
@@ -1007,13 +998,13 @@ class TestInferenceSession(unittest.TestCase):
         )
         np.testing.assert_array_equal(output_expected, res[0])
 
-    def testOrtExecutionMode(self):  # noqa: N802
+    def test_ort_execution_mode(self):
         opt = onnxrt.SessionOptions()
         self.assertEqual(opt.execution_mode, onnxrt.ExecutionMode.ORT_SEQUENTIAL)
         opt.execution_mode = onnxrt.ExecutionMode.ORT_PARALLEL
         self.assertEqual(opt.execution_mode, onnxrt.ExecutionMode.ORT_PARALLEL)
 
-    def testLoadingSessionOptionsFromModel(self):  # noqa: N802
+    def test_loading_session_options_from_model(self):
         try:
             os.environ["ORT_LOAD_CONFIG_FROM_MODEL"] = str(1)
             sess = onnxrt.InferenceSession(
@@ -1044,7 +1035,7 @@ class TestInferenceSession(unittest.TestCase):
             # Make sure the usage of the feature is disabled after this test
             os.environ["ORT_LOAD_CONFIG_FROM_MODEL"] = str(0)
 
-    def testSessionOptionsAddFreeDimensionOverrideByDenotation(self):  # noqa: N802
+    def test_session_options_add_free_dimension_override_by_denotation(self):
         so = onnxrt.SessionOptions()
         so.add_free_dimension_override_by_denotation("DATA_BATCH", 3)
         so.add_free_dimension_override_by_denotation("DATA_CHANNEL", 5)
@@ -1059,7 +1050,7 @@ class TestInferenceSession(unittest.TestCase):
         # Free dims with denotations - "DATA_BATCH" and "DATA_CHANNEL" have values assigned to them.
         self.assertEqual(input_shape, [3, 5, 5])
 
-    def testSessionOptionsAddFreeDimensionOverrideByName(self):  # noqa: N802
+    def test_session_options_add_free_dimension_override_by_name(self):
         so = onnxrt.SessionOptions()
         so.add_free_dimension_override_by_name("Dim1", 4)
         so.add_free_dimension_override_by_name("Dim2", 6)
@@ -1074,14 +1065,14 @@ class TestInferenceSession(unittest.TestCase):
         # "Dim1" and "Dim2" have values assigned to them.
         self.assertEqual(input_shape, [4, 6, 5])
 
-    def testSessionOptionsAddConfigEntry(self):  # noqa: N802
+    def test_session_options_add_config_entry(self):
         so = onnxrt.SessionOptions()
         key = "CONFIG_KEY"
         val = "CONFIG_VAL"
         so.add_session_config_entry(key, val)
         self.assertEqual(so.get_session_config_entry(key), val)
 
-    def testInvalidSessionOptionsConfigEntry(self):  # noqa: N802
+    def test_invalid_session_options_config_entry(self):
         so = onnxrt.SessionOptions()
         invalide_key = "INVALID_KEY"
         with self.assertRaises(RuntimeError) as context:
@@ -1090,7 +1081,7 @@ class TestInferenceSession(unittest.TestCase):
             "SessionOptions does not have configuration with key: " + invalide_key in str(context.exception)
         )
 
-    def testSessionOptionsAddInitializer(self):  # noqa: N802
+    def test_session_options_add_initializer(self):
         # Create an initializer and add it to a SessionOptions instance
         so = onnxrt.SessionOptions()
         # This initializer is different from the actual initializer in the model for "W"
@@ -1116,7 +1107,7 @@ class TestInferenceSession(unittest.TestCase):
             )
         )
 
-    def testSessionOptionsAddExternalInitializers(self):  # noqa: N802
+    def test_session_options_add_external_initializers(self):
         # Create an external initializer data in OrtValue
         # This initializer will replace the initializer with external data reference in the graph
         ortvalue_initializer = onnxrt.OrtValue.ortvalue_from_numpy(np.array([0, 0, 1, 1]).astype(np.int64))
@@ -1129,7 +1120,7 @@ class TestInferenceSession(unittest.TestCase):
             providers=["CPUExecutionProvider"],
         )
 
-    def testRegisterCustomOpsLibrary(self):  # noqa: N802
+    def test_register_custom_ops_library(self):
         if sys.platform.startswith("win"):
             shared_library = "custom_op_library.dll"
             if not os.path.exists(shared_library):
@@ -1183,7 +1174,7 @@ class TestInferenceSession(unittest.TestCase):
             custom_op_model, sess_options=so3, providers=available_providers_without_tvm_and_tensorrt
         )
 
-    def testOrtValue(self):  # noqa: N802
+    def test_ort_value(self):
         numpy_arr_input = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         numpy_arr_output = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
 
@@ -1221,7 +1212,7 @@ class TestInferenceSession(unittest.TestCase):
             # The constructed OrtValue should still be valid after being used in a session
             self.assertTrue(np.array_equal(ortvalue2.numpy(), numpy_arr_input))
 
-    def testOrtValue_ghIssue9799(self):  # noqa: N802
+    def test_ort_value_gh_issue9799(self):
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
             session = onnxrt.InferenceSession(
                 get_name("identity_9799.onnx"),
@@ -1235,7 +1226,7 @@ class TestInferenceSession(unittest.TestCase):
                 outs = session.run(output_names=["output"], input_feed=upstreams_onnxrt)[0]
                 self.assertTrue(np.allclose(inps, outs))
 
-    def testSparseTensorCooFormat(self):  # noqa: N802
+    def test_sparse_tensor_coo_format(self):
         cpu_device = onnxrt.OrtDevice.make("cpu", 0)
         shape = [9, 9]
         values = np.array([1.0, 2.0, 3.0], dtype=np.float32)
@@ -1302,7 +1293,7 @@ class TestInferenceSession(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 sparse_tensor.to_cuda(cuda_device)
 
-    def testSparseTensorCsrFormat(self):  # noqa: N802
+    def test_sparse_tensor_csr_format(self):
         cpu_device = onnxrt.OrtDevice.make("cpu", 0)
         shape = [9, 9]
         values = np.array([1.0, 2.0, 3.0], dtype=np.float32)
@@ -1343,7 +1334,7 @@ class TestInferenceSession(unittest.TestCase):
             self.assertEqual(cuda_sparse_tensor.dense_shape(), shape)
             self.assertEqual(cuda_sparse_tensor.data_type(), "sparse_tensor(float)")
 
-    def testRunModelWithCudaCopyStream(self):  # noqa: N802
+    def test_run_model_with_cuda_copy_stream(self):
         available_providers = onnxrt.get_available_providers()
 
         if "CUDAExecutionProvider" not in available_providers:
@@ -1365,7 +1356,7 @@ class TestInferenceSession(unittest.TestCase):
             for _iteration in range(100000):
                 session.run(output_names=["output"], input_feed={"shape": shape})
 
-    def testSharedAllocatorUsingCreateAndRegisterAllocator(self):  # noqa: N802
+    def test_shared_allocator_using_create_and_register_allocator(self):
         # Create and register an arena based allocator
 
         # To create an OrtArenaCfg using non-default parameters, use one of below templates:
@@ -1417,7 +1408,7 @@ class TestInferenceSession(unittest.TestCase):
                 providers=onnxrt.get_available_providers(),
             )
 
-    def testMemoryArenaShrinkage(self):  # noqa: N802
+    def test_memory_arena_shrinkage(self):
         if platform.architecture()[0] == "32bit" or "ppc" in platform.machine() or "powerpc" in platform.machine():
             # on x86 or ppc builds, the CPU allocator does not use an arena
             print("Skipping testMemoryArenaShrinkage in 32bit or powerpc platform.")
@@ -1450,7 +1441,7 @@ class TestInferenceSession(unittest.TestCase):
                 )
                 sess2.run([], {input_name: x}, ro2)
 
-    def testCheckAndNormalizeProviderArgs(self):  # noqa: N802
+    def test_check_and_normalize_provider_args(self):
         from onnxruntime.capi.onnxruntime_inference_collection import check_and_normalize_provider_args
 
         valid_providers = ["a", "b", "c"]
@@ -1502,7 +1493,7 @@ class TestInferenceSession(unittest.TestCase):
         # provider options unsupported mixed specification
         check_failure([("a", {1: 2})], [{3: 4}])
 
-    def testRegisterCustomEPsLibrary(self):  # noqa: N802
+    def test_register_custom_e_ps_library(self):
         from onnxruntime.capi import _pybind_state as C
 
         available_eps = C.get_available_providers()
@@ -1542,7 +1533,7 @@ class TestInferenceSession(unittest.TestCase):
         )
         print("Create session with customize execution provider successfully!")
 
-    def testCreateAllocator(self):  # noqa: N802
+    def test_create_allocator(self):
         def verify_allocator(allocator, expected_config):
             for key, val in expected_config.items():
                 if key == "max_mem":

--- a/onnxruntime/test/python/onnxruntime_test_python_azure.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_azure.py
@@ -8,7 +8,7 @@ import onnxruntime as ort
 
 class TestAmlEndpoint(unittest.TestCase):
     # test an endpoint of adding floats
-    def testAddf(self):  # noqa: N802
+    def test_addf(self):
         sess_opt = ort.SessionOptions()
         sess_opt.add_session_config_entry("azure.endpoint_type", "triton")
         sess_opt.add_session_config_entry("azure.uri", "https://endpoint-2930.westus2.inference.ml.azure.com")
@@ -32,7 +32,7 @@ class TestAmlEndpoint(unittest.TestCase):
         np.testing.assert_allclose(z, expected_z, rtol=1e-05, atol=1e-08)
 
     # test an endpoint of adding doubles
-    def testAddf8(self):  # noqa: N802
+    def test_addf8(self):
         sess_opt = ort.SessionOptions()
         sess_opt.add_session_config_entry("azure.endpoint_type", "triton")
         sess_opt.add_session_config_entry("azure.uri", "https://endpoint-1364.westus2.inference.ml.azure.com")
@@ -56,7 +56,7 @@ class TestAmlEndpoint(unittest.TestCase):
         np.testing.assert_allclose(z, expected_z, rtol=1e-05, atol=1e-08)
 
     # test an endpoint of adding int
-    def testAddi4(self):  # noqa: N802
+    def test_addi4(self):
         sess_opt = ort.SessionOptions()
         sess_opt.add_session_config_entry("azure.endpoint_type", "triton")
         sess_opt.add_session_config_entry("azure.uri", "https://endpoint-9879.westus2.inference.ml.azure.com")
@@ -80,7 +80,7 @@ class TestAmlEndpoint(unittest.TestCase):
         np.testing.assert_allclose(z, expected_z, rtol=1e-05, atol=1e-08)
 
     # test an endpoint of "And"
-    def testAnd(self):  # noqa: N802
+    def test_and(self):
         sess_opt = ort.SessionOptions()
         sess_opt.add_session_config_entry("azure.endpoint_type", "triton")
         sess_opt.add_session_config_entry("azure.uri", "https://endpoint-6811.westus2.inference.ml.azure.com")

--- a/onnxruntime/test/python/onnxruntime_test_python_backend.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_backend.py
@@ -13,7 +13,7 @@ import onnxruntime.backend as backend
 
 
 class TestBackend(unittest.TestCase):
-    def testRunModel(self):  # noqa: N802
+    def test_run_model(self):
         name = get_name("mul_1.onnx")
         rep = backend.prepare(name)
         x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
@@ -21,7 +21,7 @@ class TestBackend(unittest.TestCase):
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testAllocationPlanWorksWithOnlyExecutePathToFetchesOption(self):  # noqa: N802
+    def test_allocation_plan_works_with_only_execute_path_to_fetches_option(self):
         """
                (inp0)  (inp1)
                   |  \\/  |

--- a/onnxruntime/test/python/onnxruntime_test_python_backend_mlops.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_backend_mlops.py
@@ -32,7 +32,7 @@ def check_list_of_map_to_float(testcase, expected_rows, actual_rows):
 
 
 class TestBackend(unittest.TestCase):
-    def testRunModelNonTensor(self):  # noqa: N802
+    def test_run_model_non_tensor(self):
         name = get_name("pipeline_vectorize.onnx")
         rep = backend.prepare(name)
         x = {0: 25.0, 1: 5.13, 2: 0.0, 3: 0.453, 4: 5.966}
@@ -40,7 +40,7 @@ class TestBackend(unittest.TestCase):
         output_expected = np.array([[49.752754]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testRunModelProto(self):  # noqa: N802
+    def test_run_model_proto(self):
         name = datasets.get_example("logreg_iris.onnx")
         model = load(name)
 
@@ -65,7 +65,7 @@ class TestBackend(unittest.TestCase):
 
         check_list_of_map_to_float(self, output_expected, res[1])
 
-    def testRunModelProtoApi(self):  # noqa: N802
+    def test_run_model_proto_api(self):
         name = datasets.get_example("logreg_iris.onnx")
         model = load(name)
 

--- a/onnxruntime/test/python/onnxruntime_test_python_cudagraph.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_cudagraph.py
@@ -124,7 +124,7 @@ class TestInferenceSessionWithCudaGraph(unittest.TestCase):
             atol=1e-05,
         )
 
-    def testArenaWithCudaGraph(self):  # noqa: N802
+    def test_arena_with_cuda_graph(self):
         if "CUDAExecutionProvider" in onnxrt.get_available_providers():
             # To test cuda graph catpure, we set Arena extend strategy to be SameAsRequested so as to detect any
             # potential memory allocation after the first run.

--- a/onnxruntime/test/python/onnxruntime_test_python_keras.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_keras.py
@@ -43,7 +43,7 @@ def custom_activation(scope, operator, container):
 
 
 class TestInferenceSessionKeras(unittest.TestCase):
-    def testRunModelConv(self):  # noqa: N802
+    def test_run_model_conv(self):
         # keras model
         N, C, H, W = 2, 3, 5, 5  # noqa: N806
         x = np.random.rand(N, H, W, C).astype(np.float32, copy=False)

--- a/onnxruntime/test/python/onnxruntime_test_python_mlops.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_mlops.py
@@ -13,7 +13,7 @@ import onnxruntime as onnxrt
 
 
 class TestInferenceSession(unittest.TestCase):
-    def testZipMapStringFloat(self):  # noqa: N802
+    def test_zip_map_string_float(self):
         sess = onnxrt.InferenceSession(
             get_name("zipmap_stringfloat.onnx"),
             providers=onnxrt.get_available_providers(),
@@ -37,7 +37,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         self.assertEqual(output_expected, res[0])
 
-    def testZipMapInt64Float(self):  # noqa: N802
+    def test_zip_map_int64_float(self):
         sess = onnxrt.InferenceSession(
             get_name("zipmap_int64float.onnx"),
             providers=onnxrt.get_available_providers(),
@@ -58,7 +58,7 @@ class TestInferenceSession(unittest.TestCase):
         res = sess.run([output_name], {x_name: x})
         self.assertEqual(output_expected, res[0])
 
-    def testDictVectorizer(self):  # noqa: N802
+    def test_dict_vectorizer(self):
         sess = onnxrt.InferenceSession(
             get_name("pipeline_vectorize.onnx"),
             providers=onnxrt.get_available_providers(),
@@ -108,7 +108,7 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[49.752754]], dtype=np.float32)
         np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
-    def testLabelEncoder(self):  # noqa: N802
+    def test_label_encoder(self):
         sess = onnxrt.InferenceSession(get_name("LabelEncoder.onnx"), providers=onnxrt.get_available_providers())
         input_name = sess.get_inputs()[0].name
         self.assertEqual(input_name, "input")

--- a/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_sparse_matmul.py
@@ -14,7 +14,7 @@ from onnxruntime.capi.onnxruntime_pybind11_state import OrtValueVector, RunOptio
 
 
 class TestSparseToDenseMatmul(unittest.TestCase):
-    def testRunSparseOutputOrtValueVector(self):  # noqa: N802
+    def test_run_sparse_output_ort_value_vector(self):
         """
         Try running models using the new run_with_ort_values
         sparse_initializer_as_output.onnx - requires no inputs, but only one output
@@ -28,7 +28,7 @@ class TestSparseToDenseMatmul(unittest.TestCase):
         res = sess._sess.run_with_ort_values({}, ["values"], RunOptions())
         self.assertIsInstance(res, OrtValueVector)
 
-    def testRunSparseOutputOnly(self):  # noqa: N802
+    def test_run_sparse_output_only(self):
         """
         Try running models using the new run_with_ort_values
         sparse_initializer_as_output.onnx - requires no inputs, but only one output
@@ -52,7 +52,7 @@ class TestSparseToDenseMatmul(unittest.TestCase):
         self.assertTrue(np.array_equal(values, sparse_output.values()))
         self.assertTrue(np.array_equal(indices, sparse_output.as_coo_view().indices()))
 
-    def testRunContribSparseMatMul(self):  # noqa: N802
+    def test_run_contrib_sparse_mat_mul(self):
         """
         Mutliple sparse COO tensor to dense
         """

--- a/onnxruntime/test/python/onnxruntime_test_training_unit_tests.py
+++ b/onnxruntime/test/python/onnxruntime_test_training_unit_tests.py
@@ -12,18 +12,17 @@ from onnxruntime_test_training_unittest_utils import process_dropout
 import onnxruntime
 from onnxruntime.capi.ort_trainer import IODescription, ModelDescription, ORTTrainer
 
-torch.manual_seed(1)
-onnxruntime.set_seed(1)
-
 
 class TestTrainingDropout(unittest.TestCase):
-    def testTrainingAndEvalDropout(self):  # noqa: N802
-        # Temporarily disable this test.
-        # The graph below will trigger ORT
-        # to sort backward graph before forward graph which gives incorrect result.
-        # TODO Re-enable when that is fixed.
-        return
+    def setUp(self):
+        torch.manual_seed(1)
+        onnxruntime.set_seed(1)
 
+    @unittest.skip(
+        "Temporarily disable this test. The graph below will trigger ORT to "
+        "sort backward graph before forward graph which gives incorrect result."
+    )
+    def test_training_and_eval_dropout(self):
         class TwoDropoutNet(nn.Module):
             def __init__(self, drop_prb_1, drop_prb_2, dim_size):
                 super().__init__()

--- a/onnxruntime/test/python/quantization/op_test_utils.py
+++ b/onnxruntime/test/python/quantization/op_test_utils.py
@@ -23,7 +23,7 @@ class TestDataFeeds(CalibrationDataReader):
         self.iter_next = iter(self.data_feeds)
 
 
-def InputFeedsNegOneZeroOne(n, name2shape):  # noqa: N802
+def input_feeds_neg_one_zero_one(n, name2shape):
     """
     randomize n feed according to shape, its values are from -1, 0, and 1
     """

--- a/onnxruntime/test/python/quantization/test_op_concat.py
+++ b/onnxruntime/test/python/quantization/test_op_concat.py
@@ -9,10 +9,10 @@ import unittest
 import numpy as np
 from onnx import TensorProto, helper, numpy_helper, save
 from op_test_utils import (
-    InputFeedsNegOneZeroOne,
     check_model_correctness,
     check_op_type_count,
     check_qtype_by_node_type,
+    input_feeds_neg_one_zero_one,
 )
 
 from onnxruntime.quantization import QuantFormat, QuantType, quantize_static
@@ -91,7 +91,7 @@ class TestConcatModel(unittest.TestCase):
         np.random.seed(1)
         model_fp32_path = "concat_fp32.onnx"
         self.construct_model(model_fp32_path)
-        data_reader = InputFeedsNegOneZeroOne(1, {"input": [1, 3, 15, 15]})
+        data_reader = input_feeds_neg_one_zero_one(1, {"input": [1, 3, 15, 15]})
 
         activation_proto_qtype = TensorProto.UINT8 if activation_type == QuantType.QUInt8 else TensorProto.INT8
         activation_type_str = "u8" if (activation_type == QuantType.QUInt8) else "s8"

--- a/onnxruntime/test/python/quantization/test_op_split.py
+++ b/onnxruntime/test/python/quantization/test_op_split.py
@@ -10,10 +10,10 @@ import numpy as np
 import onnx
 from onnx import TensorProto, helper, save
 from op_test_utils import (
-    InputFeedsNegOneZeroOne,
     check_model_correctness,
     check_op_type_count,
     check_qtype_by_node_type,
+    input_feeds_neg_one_zero_one,
 )
 
 from onnxruntime.quantization import QuantFormat, QuantType, quantize_static
@@ -78,7 +78,7 @@ class TestONNXModel(unittest.TestCase):
         np.random.seed(1)
         model_fp32_path = "split_fp32.onnx"
         self.construct_model(model_fp32_path)
-        data_reader = InputFeedsNegOneZeroOne(1, {"input": [6, 3]})
+        data_reader = input_feeds_neg_one_zero_one(1, {"input": [6, 3]})
 
         activation_proto_qtype = TensorProto.UINT8 if activation_type == QuantType.QUInt8 else TensorProto.INT8
         activation_type_str = "u8" if (activation_type == QuantType.QUInt8) else "s8"

--- a/onnxruntime/test/python/quantization/test_op_where.py
+++ b/onnxruntime/test/python/quantization/test_op_where.py
@@ -147,7 +147,7 @@ class TestWhereModel(unittest.TestCase):
         self.quantize_where_test(QuantType.QUInt8, QuantType.QUInt8, extra_options={"ForceQuantizeNoInputCheck": True})
         print(__name__)
 
-    def test_quantize_where_u8u8_no_ForceQuantizeNoInputCheck(self):  # noqa: N802
+    def test_quantize_where_u8u8_no_force_quantize_no_input_check(self):
         self.quantize_where_test(QuantType.QUInt8, QuantType.QUInt8, extra_options={"ForceQuantizeNoInputCheck": False})
         print(__name__)
 

--- a/onnxruntime/test/python/quantization/test_quantize_static.py
+++ b/onnxruntime/test/python/quantization/test_quantize_static.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import numpy as np
 import onnx
 from onnx import TensorProto, helper
-from op_test_utils import InputFeedsNegOneZeroOne, check_model_correctness, generate_random_initializer
+from op_test_utils import check_model_correctness, generate_random_initializer, input_feeds_neg_one_zero_one
 
 from onnxruntime.quantization import QuantType, StaticQuantConfig, quantize, quantize_static
 
@@ -72,7 +72,7 @@ class TestStaticQuantization(unittest.TestCase):
         cls._tmp_model_dir.cleanup()
 
     def test_save_as_external(self):
-        data_reader = InputFeedsNegOneZeroOne(10, {"input": [1, self._channel_size, 1, 3]})
+        data_reader = input_feeds_neg_one_zero_one(10, {"input": [1, self._channel_size, 1, 3]})
         for use_external_data_format in [True, False]:
             quant_model_path = str(Path(self._tmp_model_dir.name) / f"quant.{use_external_data_format}.onnx")
             quantize_static(
@@ -89,7 +89,7 @@ class TestStaticQuantization(unittest.TestCase):
             data_reader.rewind()
 
     def test_static_quant_config(self):
-        data_reader = InputFeedsNegOneZeroOne(10, {"input": [1, self._channel_size, 1, 3]})
+        data_reader = input_feeds_neg_one_zero_one(10, {"input": [1, self._channel_size, 1, 3]})
         quant_config = StaticQuantConfig(data_reader)
         quant_model_path = str(Path(self._tmp_model_dir.name) / "quant.config.onnx")
         quantize(self._model_fp32_path, quant_model_path, quant_config)

--- a/onnxruntime/test/python/transformers/test_gemmfastgelu_fusion.py
+++ b/onnxruntime/test/python/transformers/test_gemmfastgelu_fusion.py
@@ -43,7 +43,7 @@ def float_tensor(name: str, shape: List[int], random=False):
     return helper.make_tensor(name, TensorProto.FLOAT, shape, weights)
 
 
-def create_MatMul_FastGelu_withoutBias(batch_size, m, n, k):  # noqa: N802
+def create_mat_mul_fast_gelu_without_bias(batch_size, m, n, k):
     # MatMul + FastGelu
     nodes = [
         helper.make_node("MatMul", ["input", "matmul_weight"], ["fastgelu_input"], "matmul"),
@@ -77,7 +77,7 @@ def create_MatMul_FastGelu_withoutBias(batch_size, m, n, k):  # noqa: N802
     return helper.make_model(graph)
 
 
-def create_MatMul_FastGelu_withBias(batch_size, m, n, k):  # noqa: N802
+def create_mat_mul_fast_gelu_with_bias(batch_size, m, n, k):
     # MatMul + FastGelu
     nodes = [
         helper.make_node("MatMul", ["input", "matmul_weight"], ["fastgelu_input"], "matmul"),
@@ -122,7 +122,7 @@ class TestFusion(unittest.TestCase):
         self.assertEqual(str(optimized_model.model.graph), str(expected_model.model.graph))
 
     def test_gemmfastgelu_fusion_withoutbias(self):
-        model = create_MatMul_FastGelu_withoutBias(32, 128, 64, 1024)
+        model = create_mat_mul_fast_gelu_without_bias(32, 128, 64, 1024)
         dir = "."
         model_path = os.path.join(dir, "gemmfastgelu_nobias.onnx")
         onnx.save(model, model_path)
@@ -135,7 +135,7 @@ class TestFusion(unittest.TestCase):
         self.verify_fusion(optimized_model, "gemmfastgelu_nobias_opt.onnx")
 
     def test_gemmfastgelu_fusion_withbias(self):
-        model = create_MatMul_FastGelu_withBias(32, 128, 64, 1024)
+        model = create_mat_mul_fast_gelu_with_bias(32, 128, 64, 1024)
         dir = "."
         model_path = os.path.join(dir, "gemmfastgelu_withbias.onnx")
         onnx.save(model, model_path)

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -311,7 +311,7 @@ class TestModelOptimization(unittest.TestCase):
 
 @unittest.skipUnless(is_tf_available(), "skip TestBertOptimizationTF since tensorflow is not available")
 class TestTensorflowModelOptimization(unittest.TestCase):
-    def Setup(self):  # noqa: N802
+    def setUp(self):
         try:
             import tf2onnx  # noqa: F401
         except ImportError:

--- a/onnxruntime/test/python/transformers/test_parity_decoder_attention.py
+++ b/onnxruntime/test/python/transformers/test_parity_decoder_attention.py
@@ -239,7 +239,7 @@ class AttentionForONNX(nn.Module):
 
         return attn_output, new_key_cache, new_value_cache
 
-    def ORT_forward(  # noqa: N802
+    def ort_forward(
         self,
         query,
         key: Tensor,
@@ -458,7 +458,7 @@ def parity_check(
         use_past,
         has_key_padding_mask,
     )
-    attn_output_ort, new_key_cache_ort, new_value_cache_ort = attn.ORT_forward(
+    attn_output_ort, new_key_cache_ort, new_value_cache_ort = attn.ort_forward(
         query,
         key,
         key_padding_mask,
@@ -468,7 +468,7 @@ def parity_check(
         use_past,
         has_key_padding_mask,
     )
-    attn_output_ort_1, _, _ = attn.ORT_forward(
+    attn_output_ort_1, _, _ = attn.ort_forward(
         query,
         key,
         key_padding_mask,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16789
* __->__ #16788

This change fixes the N802 lint errors by renaming the test case to use snake case.