### PR TITLE
Update upload_pod_archive_and_update_podspec.sh to take path pattern

### DIFF
--- a/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
+++ b/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
@@ -2,10 +2,15 @@
 
 # Note: This script is intended to be called from the iOS CocoaPods package release pipeline or a similar context.
 
-set -e
 set -x
 
-USAGE_TEXT="Usage: ${0} <pod archive path pattern (quote to prevent shell expansion)> <podspec path>"
+IFS='' read -d '' -r USAGE_TEXT <<USAGE
+Usage: ${0} <pod archive path glob pattern> <podspec path>
+  Example pod archive path glob pattern: "./pod-archive-*.zip"
+  Quote the pattern to avoid shell expansion.
+USAGE
+
+set -e
 
 abspath() {
   local INPUT_PATH=${1:?"Expected path as the first argument."}

--- a/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
+++ b/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
@@ -16,7 +16,8 @@ POD_ARCHIVE_PATH_PATTERN=${1:?${USAGE_TEXT}}
 PODSPEC_PATH=$(abspath "${2:?${USAGE_TEXT}}")
 
 # expand pod archive path pattern to exactly one path
-POD_ARCHIVE_PATHS=( $( compgen -G "${POD_ARCHIVE_PATH_PATTERN}" ) )
+POD_ARCHIVE_PATHS=()
+while IFS='' read -r line; do POD_ARCHIVE_PATHS+=("$line"); done < <( compgen -G "${POD_ARCHIVE_PATH_PATTERN}" )
 if [[ "${#POD_ARCHIVE_PATHS[@]}" -ne "1" ]]; then
   echo "Did not find exactly one pod archive file."
   exit 1

--- a/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
+++ b/tools/ci_build/github/apple/upload_pod_archive_and_update_podspec.sh
@@ -5,16 +5,24 @@
 set -e
 set -x
 
-USAGE_TEXT="Usage: ${0} <path to pod archive> <path to podspec>"
+USAGE_TEXT="Usage: ${0} <pod archive path pattern (quote to prevent shell expansion)> <podspec path>"
 
 abspath() {
   local INPUT_PATH=${1:?"Expected path as the first argument."}
   echo "$(cd "$(dirname "${INPUT_PATH}")" && pwd)/$(basename "${INPUT_PATH}")"
 }
 
-POD_ARCHIVE_PATH=$(abspath "${1:?${USAGE_TEXT}}")
+POD_ARCHIVE_PATH_PATTERN=${1:?${USAGE_TEXT}}
 PODSPEC_PATH=$(abspath "${2:?${USAGE_TEXT}}")
 
+# expand pod archive path pattern to exactly one path
+POD_ARCHIVE_PATHS=( $( compgen -G "${POD_ARCHIVE_PATH_PATTERN}" ) )
+if [[ "${#POD_ARCHIVE_PATHS[@]}" -ne "1" ]]; then
+  echo "Did not find exactly one pod archive file."
+  exit 1
+fi
+
+POD_ARCHIVE_PATH=$(abspath "${POD_ARCHIVE_PATHS[0]}")
 POD_ARCHIVE_BASENAME=$(basename "${POD_ARCHIVE_PATH}")
 
 STORAGE_ACCOUNT_NAME="onnxruntimepackages"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update upload_pod_archive_and_update_podspec.sh to take a pod archive path pattern. The actual pod archive path has a version suffix which changes.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Reduce the amount of code in the release pipeline definition. By moving some code here, it doesn't need to be duplicated in each pod's release script.