### PR TITLE
update onnxruntime_perftest's README.md as vitisai is supported on v1.15.1

### DIFF
--- a/onnxruntime/test/perftest/README.md
+++ b/onnxruntime/test/perftest/README.md
@@ -14,7 +14,7 @@ Options:
 	
 	-c: [parallel runs]: Specifies the (max) number of runs to invoke simultaneously. Default:1.
 	
-	-e: [cpu|cuda|mkldnn|tensorrt|openvino|acl]: Specifies the execution provider 'cpu','cuda','dnnn','tensorrt', 'openvino', or 'acl'. Default is 'cpu'.
+	-e: [cpu|cuda|mkldnn|tensorrt|openvino|acl|vitisai]: Specifies the execution provider 'cpu','cuda','dnnn','tensorrt', 'openvino', 'acl' and 'vitisai'. Default is 'cpu'.
         
 	-m: [test_mode]: Specifies the test mode. Value coulde be 'duration' or 'times'. Provide 'duration' to run the test for a fix duration, and 'times' to repeated for a certain times. Default:'duration'.
         


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Updating README.md to add vitisai for onnxruntime_perftest


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
The perftest tool does support vitisai whereas the README.md does not list it. This creates some confusions internally about if vitisai is supported. See https://github.com/microsoft/onnxruntime/pull/15673 for context.


