### PR TITLE
[js/common] a few fixes/revises to onnxruntime-common

### DIFF
--- a/js/.vscode/launch.json
+++ b/js/.vscode/launch.json
@@ -5,9 +5,43 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "[common] Launch Unit Tests",
+      "args": [
+        "-u",
+        "bdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/common/test/**/*.js"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "cwd": "${workspaceFolder}/common",
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node",
+      "sourceMaps": true,
+      "preLaunchTask": "tsc: build - common/test/tsconfig.json"
+    },
+    {
+      "name": "[web] Launch Test Runner",
+      "program": "${workspaceFolder}/web/script/test-runner-cli.js",
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node",
+      "cwd": "${workspaceFolder}/web",
+      "args": [
+        "suite1"
+      ]
+    },
+    {
+      "name": "[web] Attach to Chrome",
       "type": "chrome",
       "request": "attach",
-      "name": "Attach to Chrome",
       "port": 9333,
       "webRoot": "${workspaceFolder}",
       "sourceMapPathOverrides": {
@@ -18,7 +52,7 @@
       "smartStep": true
     },
     {
-      "name": "Remote Browser via Webkit Adaptor",
+      "name": "[web] Remote Browser via Webkit Adaptor",
       "type": "chrome",
       "request": "attach",
       "port": 9000,

--- a/js/common/.gitignore
+++ b/js/common/.gitignore
@@ -3,5 +3,6 @@ dist/
 docs/
 
 /test/**/*.js
+/test/**/*.js.map
 
 tsconfig.tsbuildinfo

--- a/js/common/.npmignore
+++ b/js/common/.npmignore
@@ -6,4 +6,6 @@ typedoc.json
 tsconfig.json
 **/*.tsbuildinfo
 
+/test/
+
 *.tgz

--- a/js/common/package.json
+++ b/js/common/package.json
@@ -14,7 +14,7 @@
     "build:bundles": "webpack",
     "build": "node ./build.js",
     "prepare": "npm run build",
-    "pretest": "tsc -p test",
+    "pretest": "tsc --build ./test",
     "test": "mocha ./test/**/*.js --timeout 30000"
   },
   "devDependencies": {

--- a/js/common/package.json
+++ b/js/common/package.json
@@ -13,8 +13,9 @@
     "build:esm": "tsc",
     "build:bundles": "webpack",
     "build": "node ./build.js",
-    "prepare": "npm run build && tsc -p test",
-    "test": "mocha ./test/**/*.js"
+    "prepare": "npm run build",
+    "pretest": "tsc -p test",
+    "test": "mocha ./test/**/*.js --timeout 30000"
   },
   "devDependencies": {
     "typedoc": "^0.23.22"

--- a/js/common/test/tsconfig.json
+++ b/js/common/test/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.tools.json",
   "exclude": ["type-tests/**/*.ts"],
   "compilerOptions": {
-    "module": "ES2022"
+    "module": "ES2022",
+    "sourceMap": true
   }
 }

--- a/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-web-ci.yml
@@ -95,6 +95,10 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)/js/common'
     displayName: 'npm ci /js/common/'
   - script: |
+     npm test
+    workingDirectory: '$(Build.SourcesDirectory)/js/common'
+    displayName: 'run onnxruntime-common tests'
+  - script: |
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)/js/web'
     displayName: 'npm ci /js/web/'

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -103,6 +103,10 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)\js\common'
     displayName: 'npm ci /js/common/'
   - script: |
+     npm test
+    workingDirectory: '$(Build.SourcesDirectory)\js\common'
+    displayName: 'run onnxruntime-common tests'
+  - script: |
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'npm ci /js/web/'


### PR DESCRIPTION
### Description
- enable unit test for js/common in CI
- add debug config in js/.vscode/launch.json
- enable source map for js/common/test for debugging purposes; add source map files to ignore list
- ignore js/common/test folder for npm packaging