### PR TITLE
Enable CodeQL for Android build as per 1CS requirement.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -155,10 +155,6 @@ stages:
         env | grep ANDROID
       displayName: View Android ENVs
 
-    # CodeQL3000Init and CodeQL3000Finalize are only required if manually running CodeQL on a branch.
-    # - task: CodeQL3000Init@0
-    #   displayName: "Init CodeQL"
-
     - script: |
         python3 tools/ci_build/build.py \
           --android \
@@ -175,9 +171,6 @@ stages:
           --build_java \
           --skip_tests
       displayName: NNAPI EP, Build
-
-    # - task: CodeQL3000Finalize@0
-    #   displayName: "Finalize CodeQL"
 
     - task: CopyFiles@2
       displayName: Copy apks

--- a/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-x86_64-crosscompile-ci-pipeline.yml
@@ -17,7 +17,11 @@ parameters:
   default: 0
 
 stages:
-- stage: BUILD_STAGE
+# Separate stage for building CPU vs NNAPI as we only want CodeQL to run on one of them so we don't get duplicate
+# issues for code that is built in both. We pick NNAPI as that includes the NNAPI EP code.
+- stage: BUILD_CPU_STAGE
+  variables:
+    Codeql.Enabled: false
   jobs:
   - job: Build_CPU_EP
     pool: onnxruntime-Linux-CPU-For-Android-CI
@@ -104,9 +108,20 @@ stages:
 
     - template: templates/clean-agent-build-directory-step.yml
 
+- stage: BUILD_NNAPI_STAGE
+  variables:
+    Codeql.ProjectConfigPath: .github/workflows
+    Codeql.Enabled: true
+    Codeql.Language: cpp
+    ${{ if variables['Codeql.Enabled'] }}:
+      JobsTimeout: 120
+    ${{ else }}:
+      JobsTimeout: 60
+
+  jobs:
   - job: Build_NNAPI_EP
     pool: onnxruntime-Linux-CPU-For-Android-CI
-    timeoutInMinutes: 60
+    timeoutInMinutes: ${{ variables.JobsTimeout }}
     workspace:
       clean: all
     condition: notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')
@@ -140,6 +155,10 @@ stages:
         env | grep ANDROID
       displayName: View Android ENVs
 
+    # CodeQL3000Init and CodeQL3000Finalize are only required if manually running CodeQL on a branch.
+    # - task: CodeQL3000Init@0
+    #   displayName: "Init CodeQL"
+
     - script: |
         python3 tools/ci_build/build.py \
           --android \
@@ -156,6 +175,9 @@ stages:
           --build_java \
           --skip_tests
       displayName: NNAPI EP, Build
+
+    # - task: CodeQL3000Finalize@0
+    #   displayName: "Finalize CodeQL"
 
     - task: CopyFiles@2
       displayName: Copy apks
@@ -188,7 +210,7 @@ stages:
     - template: templates/clean-agent-build-directory-step.yml
 
 - stage: TEST_STAGE
-  dependsOn: BUILD_STAGE
+  dependsOn: [BUILD_CPU_STAGE, BUILD_NNAPI_STAGE]
   jobs:
   - job: Test_CPU_EP
     pool:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Split stages for CPU and CPU+NNAPI builds as CodeQL is enabled at the stage level. 
We run it for CPU+NNAPI as that covers all the Android code. 
We don't want to run it for both as duplicate issues would be created for a problem in code included in both builds.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


