### PR TITLE
[QNN EP] Remove duplicate string define

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_min_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_min_op_builder.cc
@@ -74,7 +74,7 @@ Status ArgMaxMinOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   int32_t default_axis_value = 0;
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), qnn_def::axis, axis_qnn_scalar);
+  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_ARGMAX_PARAM_AXIS, axis_qnn_scalar);
   param_tensor_names.push_back(axis_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
@@ -87,7 +87,7 @@ Status ArgMaxMinOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   Qnn_Scalar_t keep_dims_scalar = QNN_SCALAR_INIT;
   keep_dims_scalar.dataType = QNN_DATATYPE_BOOL_8;
   keep_dims_scalar.bool8Value = static_cast<uint8_t>(onnx_keepdims == 0 ? 0 : 1);
-  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), qnn_def::keep_dims, keep_dims_scalar);
+  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), QNN_OP_ARGMAX_PARAM_KEEP_DIMS, keep_dims_scalar);
   param_tensor_names.push_back(keep_dims_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(keep_dims_param));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -174,7 +174,7 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
   }
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                    qnn_def::package_name,
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     qnn_op_type,  // Typically GetQnnOpType(), but can be overridden.
                                                     std::move(input_names),
                                                     std::move(output_names),
@@ -184,7 +184,7 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
   for (const auto& cast_node_info : cast_node_info_vec) {
     // Insert cast node.
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_info.node_name,
-                                                      qnn_def::package_name,
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       "Cast",
                                                       {cast_node_info.input_name},
                                                       {cast_node_info.output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -118,7 +118,7 @@ Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                     "Failed to add output tensor for QNN Cast node.");
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                    qnn_def::package_name,
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     GetQnnOpType(node_unit.OpType()),
                                                     std::move(input_names),
                                                     {output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -129,14 +129,14 @@ Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   Qnn_Scalar_t min_qnn_scalar = QNN_SCALAR_INIT;
   min_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
   min_qnn_scalar.floatValue = min_value_;
-  QnnParamWrapper min_value_param(node_unit.Index(), node_unit.Name(), qnn_def::min_value, min_qnn_scalar);
+  QnnParamWrapper min_value_param(node_unit.Index(), node_unit.Name(), QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE, min_qnn_scalar);
   param_tensor_names.push_back(min_value_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(min_value_param));
 
   Qnn_Scalar_t max_qnn_scalar = QNN_SCALAR_INIT;
   max_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
   max_qnn_scalar.floatValue = max_value_;
-  QnnParamWrapper max_value_param(node_unit.Index(), node_unit.Name(), qnn_def::max_value, max_qnn_scalar);
+  QnnParamWrapper max_value_param(node_unit.Index(), node_unit.Name(), QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE, max_qnn_scalar);
   param_tensor_names.push_back(max_value_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(max_value_param));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -525,7 +525,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
       dilations[1] = width_dilation;
     }
 
-    QnnParamWrapper dilation_paramwrapper(node_unit.Index(), node_unit.Name(), qnn_def::dilation,
+    QnnParamWrapper dilation_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_DILATION,
                                           {SafeInt<uint32_t>(dilations.size())}, std::vector<uint32_t>(dilations));
     param_tensor_names.push_back(dilation_paramwrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(dilation_paramwrapper));
@@ -542,7 +542,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
       strides[1] = width_stride;
     }
 
-    QnnParamWrapper stride_amount_paramwrapper(node_unit.Index(), node_unit.Name(), qnn_def::stride,
+    QnnParamWrapper stride_amount_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_STRIDE,
                                                {SafeInt<uint32_t>(strides.size())}, std::vector<uint32_t>(strides));
     param_tensor_names.push_back(stride_amount_paramwrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(stride_amount_paramwrapper));
@@ -562,7 +562,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
       output_padding[1] = width_out_pad;
     }
 
-    QnnParamWrapper output_padding_paramwrapper(node_unit.Index(), node_unit.Name(), qnn_def::output_padding,
+    QnnParamWrapper output_padding_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_CONV_2D_PARAM_OUTPUT_PADDING,
                                                 {static_cast<uint32_t>(output_padding.size())}, std::vector<uint32_t>(output_padding));
     param_tensor_names.push_back(output_padding_paramwrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(output_padding_paramwrapper));
@@ -630,7 +630,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     }
 
     ReArranagePads(pads);
-    QnnParamWrapper pad_amount_paramwrapper(node_unit.Index(), node_unit.Name(), qnn_def::pad_amount,
+    QnnParamWrapper pad_amount_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_PAD_AMOUNT,
                                             {2, 2}, std::move(pads));
     param_tensor_names.push_back(pad_amount_paramwrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_paramwrapper));
@@ -648,7 +648,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     Qnn_Scalar_t group_qnn_scalar = QNN_SCALAR_INIT;
     group_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
     group_qnn_scalar.uint32Value = group;
-    QnnParamWrapper group_paramwrapper(node_unit.Index(), node_unit.Name(), qnn_def::group, group_qnn_scalar);
+    QnnParamWrapper group_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_GROUP, group_qnn_scalar);
     param_tensor_names.push_back(group_paramwrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(group_paramwrapper));
   } else {
@@ -681,7 +681,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                                           std::vector<uint32_t>(output_shape_2d));
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                      qnn_def::package_name,
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       output_node_type,
                                                       std::move(input_names),
                                                       {conv_output_name},
@@ -705,7 +705,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                                           std::move(output_shape));
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                      qnn_def::package_name,
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       output_node_type,
                                                       std::move(input_names),
                                                       {output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -103,7 +103,7 @@ Status GatherOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                    std::move(cast_output_shape));
       ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_output)), "Failed to add tensor.");
       ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(indices_input_name,
-                                                        qnn_def::package_name,
+                                                        QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                         "Cast",
                                                         {input_name},
                                                         {indices_input_name},
@@ -129,7 +129,7 @@ Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
   int32_t axis_value = 0;
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), qnn_def::axis, axis_qnn_scalar);
+  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_GATHER_PARAM_AXIS, axis_qnn_scalar);
   param_tensor_names.push_back(axis_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
@@ -184,7 +184,7 @@ Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
   ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(gather_output_wrapper)), "Failed to add tensor.");
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                    qnn_def::package_name,
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     GetQnnOpType(node_unit.OpType()),
                                                     std::move(input_names),
                                                     {gather_output_name},
@@ -200,7 +200,7 @@ Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_output)), "Failed to add tensor.");
     const static std::string qnn_node_type = "Reshape";
     ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(output_name,
-                                                      qnn_def::package_name,
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       qnn_node_type,
                                                       {gather_output_name},
                                                       {output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instance_norm_op_builder.cc
@@ -105,7 +105,7 @@ Status InstanceNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   epsilon_param.floatValue = epsilon;
   QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
                                         node_unit.Name(),
-                                        qnn_def::epsilon,
+                                        QNN_OP_INSTANCE_NORM_PARAM_EPSILON,
                                         epsilon_param);
   param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -159,7 +159,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   std::vector<std::string> param_tensor_names;
   QnnParamWrapper filter_size_param(node_unit.Index(),
                                     node_unit.Name(),
-                                    qnn_def::filter_size,
+                                    QNN_OP_POOL_MAX_2D_PARAM_FILTER_SIZE,
                                     std::move(filter_size_dim),
                                     std::move(filter_size));
   param_tensor_names.push_back(filter_size_param.GetParamTensorName());
@@ -167,7 +167,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
 
   QnnParamWrapper pad_amount_param(node_unit.Index(),
                                    node_unit.Name(),
-                                   qnn_def::pad_amount,
+                                   QNN_OP_POOL_MAX_2D_PARAM_PAD_AMOUNT,
                                    std::move(pad_amount_dim),
                                    std::move(pad_amount));
   param_tensor_names.push_back(pad_amount_param.GetParamTensorName());
@@ -175,7 +175,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
 
   QnnParamWrapper stride_param(node_unit.Index(),
                                node_unit.Name(),
-                               qnn_def::stride,
+                               QNN_OP_POOL_MAX_2D_PARAM_STRIDE,
                                std::move(stride_dim),
                                std::move(stride));
   param_tensor_names.push_back(stride_param.GetParamTensorName());
@@ -186,7 +186,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     rounding_mode_param.int32Value = ceil_mode;
     QnnParamWrapper rounding_mode_param_wrapper(node_unit.Index(),
                                                 node_unit.Name(),
-                                                qnn_def::rounding_mode,
+                                                QNN_OP_POOL_MAX_2D_PARAM_ROUNDING_MODE,
                                                 rounding_mode_param);
     param_tensor_names.push_back(rounding_mode_param_wrapper.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(rounding_mode_param_wrapper));
@@ -197,7 +197,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     scalar_param.bool8Value = 1;
     QnnParamWrapper count_pad_for_edges_param(node_unit.Index(),
                                               node_unit.Name(),
-                                              qnn_def::count_pad_for_edges,
+                                              QNN_OP_POOL_AVG_2D_PARAM_COUNT_PAD_FOR_EDGES,
                                               scalar_param);
     param_tensor_names.push_back(count_pad_for_edges_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(count_pad_for_edges_param));
@@ -207,7 +207,7 @@ Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
     scalar_param.bool8Value = static_cast<uint8_t>(node_helper.Get("count_include_pad", static_cast<int64_t>(0)) != 0);
     QnnParamWrapper count_pad_for_edges_param(node_unit.Index(),
                                               node_unit.Name(),
-                                              qnn_def::count_pad_for_edges,
+                                              QNN_OP_POOL_AVG_2D_PARAM_COUNT_PAD_FOR_EDGES,
                                               scalar_param);
     param_tensor_names.push_back(count_pad_for_edges_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(count_pad_for_edges_param));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -110,7 +110,7 @@ Status ReduceOpBuilder::GetAxesSet(QnnModelWrapper& qnn_model_wrapper, const Nod
 
   // Extract the axes values from either the attribute or initializer input (depending on opset).
   if (opset < opset_axes_as_input) {  // Axes is in ONNX node attribute.
-    reduce_axes = node_helper.Get(qnn_def::axes, reduce_axes);
+    reduce_axes = node_helper.Get(QNN_OP_REDUCE_MAX_PARAM_AXES, reduce_axes);
   } else if (inputs.size() > 1) {  // Axes is in ONNX input[1] initializer.
     const auto& axes_input = inputs[1];
 
@@ -241,7 +241,7 @@ Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
   std::transform(axes_set.begin(), axes_set.end(), axes_data.begin(),
                  [](AxesOnnxIntType item) { return SafeInt<AxesQnnIntType>(item); });
 
-  QnnParamWrapper axes_param(node_unit.Index(), node_unit.Name(), qnn_def::axes,
+  QnnParamWrapper axes_param(node_unit.Index(), node_unit.Name(), QNN_OP_REDUCE_MAX_PARAM_AXES,
                              std::move(axes_shape), std::move(axes_data));
   param_tensor_names.push_back(axes_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axes_param));
@@ -253,7 +253,7 @@ Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
   Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
   scalar_param.dataType = QNN_DATATYPE_BOOL_8;
   scalar_param.bool8Value = static_cast<uint8_t>(onnx_keepdims == 0 ? 0 : 1);
-  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), qnn_def::keep_dims, scalar_param);
+  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, scalar_param);
   param_tensor_names.push_back(keep_dims_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(keep_dims_param));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -357,9 +357,9 @@ Status ResizeOpBuilder::ProcessOpAttrsAndOutputs(QnnModelWrapper& qnn_model_wrap
     qnn_half_pixel.bool8Value = static_cast<uint8_t>(1);
   }
   QnnParamWrapper qnn_align_corners_param(node_unit.Index(), node_unit.Name(),
-                                          qnn_def::align_corners, qnn_align_corners);
+                                          QNN_OP_RESIZE_BILINEAR_PARAM_ALIGN_CORNERS, qnn_align_corners);
   QnnParamWrapper qnn_half_pixel_param(node_unit.Index(), node_unit.Name(),
-                                       qnn_def::half_pixel_centers, qnn_half_pixel);
+                                       QNN_OP_RESIZE_BILINEAR_PARAM_HALF_PIXEL_CENTERS, qnn_half_pixel);
 
   std::vector<std::string> param_tensor_names;
   param_tensor_names.push_back(qnn_align_corners_param.GetParamTensorName());
@@ -398,7 +398,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
     qnn_align_corners.dataType = QNN_DATATYPE_BOOL_8;
     qnn_align_corners.bool8Value = static_cast<uint8_t>(0);
     QnnParamWrapper qnn_align_corners_param(node_unit.Index(), node_unit.Name(),
-                                            qnn_def::align_corners, qnn_align_corners);
+                                            QNN_OP_RESIZE_BILINEAR_PARAM_ALIGN_CORNERS, qnn_align_corners);
     param_tensor_names.push_back(qnn_align_corners_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_align_corners_param));
 
@@ -407,7 +407,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
     qnn_half_pixel.dataType = QNN_DATATYPE_BOOL_8;
     qnn_half_pixel.bool8Value = static_cast<uint8_t>(0);
     QnnParamWrapper qnn_half_pixel_param(node_unit.Index(), node_unit.Name(),
-                                         qnn_def::half_pixel_centers, qnn_half_pixel);
+                                         QNN_OP_RESIZE_BILINEAR_PARAM_HALF_PIXEL_CENTERS, qnn_half_pixel);
     param_tensor_names.push_back(qnn_half_pixel_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_half_pixel_param));
   } else {
@@ -417,7 +417,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
     ORT_RETURN_IF_ERROR(GetQnnModeFromString(supported_coord_transf_modes, transformation_mode,
                                              "coordinate_transformation_mode", qnn_transformation_mode.uint32Value));
 
-    QnnParamWrapper qnn_transformation_mode_param(node_unit.Index(), node_unit.Name(), qnn_def::transformation_mode,
+    QnnParamWrapper qnn_transformation_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_TRANSFORMATION_MODE,
                                                   qnn_transformation_mode);
     param_tensor_names.push_back(qnn_transformation_mode_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_transformation_mode_param));
@@ -427,7 +427,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
     qnn_exclude_outside.dataType = QNN_DATATYPE_BOOL_8;
     qnn_exclude_outside.bool8Value = static_cast<uint8_t>(GetOnnxAttr(node_helper, onnx_exclude_outside_attr) != 0);
 
-    QnnParamWrapper qnn_exclude_outside_param(node_unit.Index(), node_unit.Name(), qnn_def::exclude_outside,
+    QnnParamWrapper qnn_exclude_outside_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_EXCLUDE_OUTSIDE,
                                               qnn_exclude_outside);
     param_tensor_names.push_back(qnn_exclude_outside_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_exclude_outside_param));
@@ -437,7 +437,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
     qnn_interp_mode.dataType = QNN_DATATYPE_UINT_32;
     ORT_RETURN_IF_ERROR(GetQnnModeFromString(supported_modes, interp_mode, "mode", qnn_interp_mode.uint32Value));
 
-    QnnParamWrapper qnn_interp_mode_param(node_unit.Index(), node_unit.Name(), qnn_def::interpolation_mode,
+    QnnParamWrapper qnn_interp_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_INTERPOLATION_MODE,
                                           qnn_interp_mode);
     param_tensor_names.push_back(qnn_interp_mode_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_interp_mode_param));
@@ -450,7 +450,7 @@ Status ResizeOpBuilder::ProcessQDQOpAttrsAndOutputs(QnnModelWrapper& qnn_model_w
       ORT_RETURN_IF_ERROR(GetQnnModeFromString(supported_nearest_modes, nearest_mode, "nearest_mode",
                                                qnn_nearest_mode.uint32Value));
 
-      QnnParamWrapper qnn_nearest_mode_param(node_unit.Index(), node_unit.Name(), qnn_def::nearest_mode,
+      QnnParamWrapper qnn_nearest_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_NEAREST_MODE,
                                              qnn_nearest_mode);
       param_tensor_names.push_back(qnn_nearest_mode_param.GetParamTensorName());
       qnn_model_wrapper.AddParamWrapper(std::move(qnn_nearest_mode_param));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -77,7 +77,7 @@ Status SimpleOpBuilder::ProcessPermAttribute(QnnModelWrapper& qnn_model_wrapper,
   }
 
   NodeAttrHelper node_helper(node_unit);
-  transpose_perm = node_helper.Get(qnn_def::perm, transpose_perm);
+  transpose_perm = node_helper.Get("perm", transpose_perm);
   auto perm_size = static_cast<uint32_t>(transpose_perm.size());
   std::vector<uint32_t> perm_shape{perm_size};
   std::vector<uint32_t> perm_data;
@@ -85,7 +85,7 @@ Status SimpleOpBuilder::ProcessPermAttribute(QnnModelWrapper& qnn_model_wrapper,
   std::transform(transpose_perm.begin(), transpose_perm.end(), perm_data.begin(),
                  [](int64_t item) { return SafeInt<uint32_t>(item); });
 
-  QnnParamWrapper transpose_param(node_unit.Index(), node_unit.Name(), qnn_def::perm,
+  QnnParamWrapper transpose_param(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_PARAM_PERM,
                                   std::move(perm_shape), std::move(perm_data));
   param_tensor_names.push_back(transpose_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(transpose_param));
@@ -102,7 +102,7 @@ Status SimpleOpBuilder::ProcessAlphaAttribute(QnnModelWrapper& qnn_model_wrapper
   alpha_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
   alpha_qnn_scalar.floatValue = alpha;
 
-  QnnParamWrapper alpha_param(node_unit.Index(), node_unit.Name(), qnn_def::alpha, alpha_qnn_scalar);
+  QnnParamWrapper alpha_param(node_unit.Index(), node_unit.Name(), QNN_OP_ELU_PARAM_ALPHA, alpha_qnn_scalar);
   param_tensor_names.push_back(alpha_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(alpha_param));
 
@@ -182,7 +182,7 @@ Status SimpleOpBuilder::HandleSingleTransposeNode(QnnModelWrapper& qnn_model_wra
   }
 
   ORT_RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(GetNodeName(node_unit),
-                                                    qnn_def::package_name,
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     GetQnnOpType(node_unit.OpType()),
                                                     std::move(input_names),
                                                     {output_name},
@@ -217,7 +217,7 @@ Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
     int32_t default_axis = ("Softmax" == op_type) ? -1 : 0;
     Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
     ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), qnn_def::axis, axis_qnn_scalar);
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
   }
@@ -226,11 +226,11 @@ Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
     Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
     scalar_param.dataType = QNN_DATATYPE_BOOL_8;
     scalar_param.bool8Value = 0;
-    QnnParamWrapper transpose_in0_param(node_unit.Index(), node_unit.Name(), qnn_def::transpose_in0, scalar_param);
+    QnnParamWrapper transpose_in0_param(node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, scalar_param);
     param_tensor_names.push_back(transpose_in0_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(transpose_in0_param));
 
-    QnnParamWrapper transpose_in1_param(node_unit.Index(), node_unit.Name(), qnn_def::transpose_in1, scalar_param);
+    QnnParamWrapper transpose_in1_param(node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, scalar_param);
     param_tensor_names.push_back(transpose_in1_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(transpose_in1_param));
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
@@ -206,7 +206,7 @@ Status SliceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wr
   }
   QnnParamWrapper ranges_paramwrapper(node_unit.Index(),
                                       node_unit.Name(),
-                                      qnn_def::ranges,
+                                      QNN_OP_STRIDED_SLICE_PARAM_RANGES,
                                       std::move(ranges_dims),
                                       std::move(ranges_data),
                                       true);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
@@ -60,7 +60,7 @@ Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wr
   int32_t axis_value = 0;
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   ORT_RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), qnn_def::axis, axis_qnn_scalar);
+  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SPLIT_PARAM_AXIS, axis_qnn_scalar);
   param_tensor_names.push_back(axis_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
@@ -112,7 +112,7 @@ Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wr
 
   uint32_t split_size = static_cast<uint32_t>(split_index.size());
   std::vector<uint32_t> split_dim{split_size};
-  QnnParamWrapper split_param(node_unit.Index(), node_unit.Name(), qnn_def::split_index, std::move(split_dim),
+  QnnParamWrapper split_param(node_unit.Index(), node_unit.Name(), QNN_OP_SPLIT_PARAM_SPLIT_INDEX, std::move(split_dim),
                               std::move(split_index));
   param_tensor_names.push_back(split_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(split_param));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/tile_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/tile_op_builder.cc
@@ -77,7 +77,7 @@ Status TileOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
 
   uint32_t multiples_size = static_cast<uint32_t>(multiples.size());
   std::vector<uint32_t> multiples_dim{multiples_size};
-  QnnParamWrapper multiples_param(node_unit.Index(), node_unit.Name(), qnn_def::multiples, std::move(multiples_dim),
+  QnnParamWrapper multiples_param(node_unit.Index(), node_unit.Name(), QNN_OP_TILE_PARAM_MULTIPLES, std::move(multiples_dim),
                                   std::move(multiples));
   param_tensor_names.push_back(multiples_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(multiples_param));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk.cc
@@ -108,7 +108,7 @@ Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   Qnn_Scalar_t qnn_scalar_k = QNN_SCALAR_INIT;
   qnn_scalar_k.dataType = QNN_DATATYPE_UINT_32;
   qnn_scalar_k.uint32Value = k;
-  QnnParamWrapper k_param(node_unit.Index(), node_unit.Name(), qnn_def::topk, qnn_scalar_k);
+  QnnParamWrapper k_param(node_unit.Index(), node_unit.Name(), QNN_OP_TOP_K_PARAM_K, qnn_scalar_k);
   std::string k_param_name = k_param.GetParamTensorName();
   qnn_model_wrapper.AddParamWrapper(std::move(k_param));
   std::vector<std::string> param_tensor_names{k_param_name};

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -437,38 +437,5 @@ typedef struct GraphConfigInfo {
   const QnnGraph_Config_t** graphConfigs;
 } GraphConfigInfo_t;
 
-namespace qnn_def {
-const std::string package_name = "qti.aisw";
-// TODO: remove these parameter name, re-use from QnnOpDef.h
-const std::string dilation = "dilation";
-const std::string pad_amount = "pad_amount";
-const std::string stride = "stride";
-const std::string group = "group";
-const std::string filter_size = "filter_size";
-const std::string count_pad_for_edges = "count_pad_for_edges";
-const std::string perm = "perm";
-const std::string axis = "axis";
-const std::string axes = "axes";
-const std::string keep_dims = "keep_dims";
-const std::string transpose_in0 = "transpose_in0";
-const std::string transpose_in1 = "transpose_in1";
-const std::string min_value = "min_value";
-const std::string max_value = "max_value";
-const std::string ranges = "ranges";
-const std::string output_padding = "output_padding";
-const std::string split_index = "split_index";
-const std::string align_corners = "align_corners";
-const std::string half_pixel_centers = "half_pixel_centers";
-const std::string exclude_outside = "exclude_outside";
-const std::string transformation_mode = "transformation_mode";
-const std::string interpolation_mode = "interpolation_mode";
-const std::string nearest_mode = "nearest_mode";
-const std::string rounding_mode = "rounding_mode";
-const std::string topk = "k";
-const std::string multiples = "multiples";
-const std::string epsilon = "epsilon";
-const std::string alpha = "alpha";
-}  // namespace qnn_def
-
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -413,7 +413,7 @@ Status QnnModelWrapper::AddReshapeNode(const std::string& input_name,
                     "QNN EP: Failed to add output tensor for inserted Reshape.");
 
   ORT_RETURN_IF_NOT(CreateQnnNode(output_name,
-                                  qnn_def::package_name,
+                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
                                   QNN_OP_RESHAPE,
                                   {input_name},
                                   {output_name},
@@ -450,7 +450,7 @@ Status QnnModelWrapper::AddTransposeNode(NodeIndex node_index,
   std::vector<uint32_t> perm_dim{perm_size};
   std::vector<uint32_t> transpose_perm_copy = transpose_perm;
   const std::string& node_name = output_name;
-  QnnParamWrapper transpose_param(node_index, node_name, qnn_def::perm, std::move(perm_dim), std::move(transpose_perm_copy));
+  QnnParamWrapper transpose_param(node_index, node_name, QNN_OP_TRANSPOSE_PARAM_PERM, std::move(perm_dim), std::move(transpose_perm_copy));
   std::string param_tensor_name(transpose_param.GetParamTensorName());
   ORT_RETURN_IF_NOT(AddParamWrapper(std::move(transpose_param)), "Failed to add tensor.");
   Qnn_TensorType_t tensor_type = (false == is_for_output) ? QNN_TENSOR_TYPE_NATIVE : QNN_TENSOR_TYPE_APP_READ;
@@ -464,7 +464,7 @@ Status QnnModelWrapper::AddTransposeNode(NodeIndex node_index,
   const static std::string qnn_node_type = "Transpose";
 
   CreateQnnNode(output_name,
-                qnn_def::package_name,
+                QNN_OP_PACKAGE_NAME_QTI_AISW,
                 qnn_node_type,
                 {input_name},
                 {output_name},


### PR DESCRIPTION
[QNN EP] Remove duplicate string define

### Description
Remove duplicate string define for QNN op parameters, use them directly from QNN header file.

