### PR TITLE
[js/webgpu] Make sure only storage buffers are reused

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -92,6 +92,7 @@ export class WebGpuBackend {
 
   supportTimestampQuery = false;
   profilingQuerySet: GPUQuerySet;
+  profilingQueryData: GpuData;
   profilingTimeBase?: bigint;
 
   env: Env;

--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -81,6 +81,7 @@ class GpuDataManagerImpl implements GpuDataManager {
   // pending buffers for computing
   private buffersPending: GPUBuffer[];
 
+  // The reusable storage buffers for computing.
   private freeBuffers: Map<number, GPUBuffer[]>;
 
   constructor(private backend: WebGpuBackend) {
@@ -155,13 +156,19 @@ class GpuDataManagerImpl implements GpuDataManager {
     const bufferSize = calcNormalizedBufferSize(size);
 
     let gpuBuffer;
-    let buffers = this.freeBuffers.get(bufferSize);
-    if (!buffers) {
-      buffers = [];
-      this.freeBuffers.set(bufferSize, buffers);
-    }
-    if (buffers.length > 0) {
-      gpuBuffer = buffers.pop() as GPUBuffer;
+    // Currently, only storage buffers are reused.
+    if ((usage & GPUBufferUsage.STORAGE) === GPUBufferUsage.STORAGE) {
+      let buffers = this.freeBuffers.get(bufferSize);
+      if (!buffers) {
+        buffers = [];
+        this.freeBuffers.set(bufferSize, buffers);
+      }
+      if (buffers.length > 0) {
+        gpuBuffer = buffers.pop() as GPUBuffer;
+      } else {
+        // create gpu buffer
+        gpuBuffer = this.backend.device.createBuffer({size: bufferSize, usage});
+      }
     } else {
       // create gpu buffer
       gpuBuffer = this.backend.device.createBuffer({size: bufferSize, usage});
@@ -241,8 +248,12 @@ class GpuDataManagerImpl implements GpuDataManager {
     }
     this.buffersForUploadingPending = [];
     for (const buffer of this.buffersPending) {
-      // Put the pending buffer to freeBuffers list instead of really destroying it for buffer reusing.
-      this.freeBuffers.get(buffer.size)!.push(buffer);
+      if ((buffer.usage & GPUBufferUsage.STORAGE) === GPUBufferUsage.STORAGE) {
+        // Put the pending buffer to freeBuffers list instead of really destroying it for buffer reusing.
+        this.freeBuffers.get(buffer.size)!.push(buffer);
+      } else {
+        buffer.destroy();
+      }
     }
     this.buffersPending = [];
   }

--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -157,6 +157,7 @@ class GpuDataManagerImpl implements GpuDataManager {
 
     let gpuBuffer;
     // Currently, only storage buffers are reused.
+    // eslint-disable-next-line no-bitwise
     if ((usage & GPUBufferUsage.STORAGE) === GPUBufferUsage.STORAGE) {
       let buffers = this.freeBuffers.get(bufferSize);
       if (!buffers) {
@@ -248,6 +249,7 @@ class GpuDataManagerImpl implements GpuDataManager {
     }
     this.buffersForUploadingPending = [];
     for (const buffer of this.buffersPending) {
+      // eslint-disable-next-line no-bitwise
       if ((buffer.usage & GPUBufferUsage.STORAGE) === GPUBufferUsage.STORAGE) {
         // Put the pending buffer to freeBuffers list instead of really destroying it for buffer reusing.
         this.freeBuffers.get(buffer.size)!.push(buffer);

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -61,14 +61,19 @@ export class ProgramManager {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (computePassEncoder as any).writeTimestamp(this.backend.profilingQuerySet, 1);
-      // eslint-disable-next-line no-bitwise
-      const queryData = this.backend.gpuDataManager.create(16, GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE);
+      if (this.backend.profilingQueryData == null) {
+        // eslint-disable-next-line no-bitwise
+        this.backend.profilingQueryData =
+            this.backend.gpuDataManager.create(16, GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE);
+      }
       // eslint-disable-next-line no-bitwise
       const syncData = this.backend.gpuDataManager.create(16, GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST);
 
       this.backend.endComputePass();
-      this.backend.getCommandEncoder().resolveQuerySet(this.backend.profilingQuerySet, 0, 2, queryData.buffer, 0);
-      this.backend.getCommandEncoder().copyBufferToBuffer(queryData.buffer, 0, syncData.buffer, 0, 16);
+      this.backend.getCommandEncoder().resolveQuerySet(
+          this.backend.profilingQuerySet, 0, 2, this.backend.profilingQueryData.buffer, 0);
+      this.backend.getCommandEncoder().copyBufferToBuffer(
+          this.backend.profilingQueryData.buffer, 0, syncData.buffer, 0, 16);
       this.backend.flush();
 
       const kernelId = this.backend.currentKernelId!;
@@ -92,7 +97,6 @@ export class ProgramManager {
           throw new RangeError('incorrect timestamp range');
         }
 
-        this.backend.gpuDataManager.release(queryData.id);
         this.backend.gpuDataManager.release(syncData.id);
 
         // eslint-disable-next-line no-console

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -62,8 +62,8 @@ export class ProgramManager {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (computePassEncoder as any).writeTimestamp(this.backend.profilingQuerySet, 1);
       if (this.backend.profilingQueryData == null) {
-        // eslint-disable-next-line no-bitwise
         this.backend.profilingQueryData =
+            // eslint-disable-next-line no-bitwise
             this.backend.gpuDataManager.create(16, GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE);
       }
       // eslint-disable-next-line no-bitwise


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR makes sure that only storage buffers are reused. Previously, the query buffer might also get from the freeBuffers list if there is a matching size in it. But they are different usage, which results errors.


