### PR TITLE
Refactor schema extraction and output unflattening

### DIFF
--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -393,6 +393,9 @@ if (onnxruntime_ENABLE_TRAINING)
   file(GLOB onnxruntime_python_ort_triton_kernel_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/ort_triton/kernel/*.py"
   )
+  file(GLOB onnxruntime_python_utils_srcs CONFIGURE_DEPENDS
+    "${ORTTRAINING_SOURCE_DIR}/python/training/utils/*.py"
+  )
   file(GLOB onnxruntime_python_utils_data_srcs CONFIGURE_DEPENDS
     "${ORTTRAINING_SOURCE_DIR}/python/training/utils/data/*"
   )
@@ -733,6 +736,7 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ort_triton
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ort_triton/kernel
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/hooks/
     COMMAND ${CMAKE_COMMAND} -E copy
@@ -789,6 +793,9 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_ort_triton_kernel_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ort_triton/kernel/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${onnxruntime_python_utils_srcs}
+        $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/
     COMMAND ${CMAKE_COMMAND} -E copy
         ${onnxruntime_python_utils_data_srcs}
         $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -736,7 +736,7 @@ if (onnxruntime_ENABLE_TRAINING)
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ortmodule/torch_cpp_extensions/cuda/fused_ops
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ort_triton
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/ort_triton/kernel
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/data/
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${build_output_target}>/onnxruntime/training/utils/hooks/
     COMMAND ${CMAKE_COMMAND} -E copy

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -271,7 +271,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         # e.g., some sympy functions in symbolic_shape_infer will change Python's random state.
         random_states = _utils.get_random_states()
 
-        schema = _io._extract_schema({"args": copy.copy(inputs), "kwargs": copy.copy(kwargs)})
+        schema = _io._extract_schema({"args": copy.copy(inputs), "kwargs": copy.copy(kwargs)}, self._device)
         if (
             self._onnx_models.exported_model
             and schema == self._input_info.schema
@@ -279,7 +279,6 @@ class GraphExecutionManager(GraphExecutionInterface):
         ):
             # All required models have already been exported previously
             return False
-
         self._set_device_from_module(inputs, kwargs)
         self._onnx_models.exported_model = self._get_exported_model(schema, *inputs, **kwargs)
         if self._debug_options.save_onnx_models.save:
@@ -319,7 +318,9 @@ class GraphExecutionManager(GraphExecutionInterface):
             output_names,
             output_dynamic_axes,
             self._module_output_schema,
-        ) = _io.parse_outputs_for_onnx_export_and_extract_schema(self._original_module, inputs, kwargs, self._logger)
+        ) = _io.parse_outputs_for_onnx_export_and_extract_schema(
+            self._original_module, inputs, kwargs, self._logger, self._device
+        )
         self._input_info.dynamic_axes.update(output_dynamic_axes)
 
         # FlattenedModule needs _InputInfo to expand user input from *args to *args + **kwargs

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -18,7 +18,7 @@ from torch.utils.cpp_extension import ROCM_HOME
 import onnxruntime
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
-from onnxruntime.training.utils.torch_io_helper import ORTModelInputOutputSchemaType, get_schema_for_flatten_data
+from onnxruntime.training.utils import ORTModelInputOutputSchemaType, get_schema_for_flatten_data
 
 from . import _are_deterministic_algorithms_enabled, _io, _logger, _onnx_models, _utils
 from ._custom_autograd_function_exporter import _post_process_after_export

--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -18,7 +18,7 @@ from torch.utils.cpp_extension import ROCM_HOME
 import onnxruntime
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
-from onnxruntime.training.utils import ORTModelInputOutputSchemaType, get_schema_for_flatten_data
+from onnxruntime.training.utils import ORTModelInputOutputSchemaType
 
 from . import _are_deterministic_algorithms_enabled, _io, _logger, _onnx_models, _utils
 from ._custom_autograd_function_exporter import _post_process_after_export
@@ -271,9 +271,7 @@ class GraphExecutionManager(GraphExecutionInterface):
         # e.g., some sympy functions in symbolic_shape_infer will change Python's random state.
         random_states = _utils.get_random_states()
 
-        schema = get_schema_for_flatten_data(
-            {"args": copy.copy(inputs), "kwargs": copy.copy(kwargs)}, constant_as_tensor=True
-        )
+        schema = _io._extract_schema({"args": copy.copy(inputs), "kwargs": copy.copy(kwargs)})
         if (
             self._onnx_models.exported_model
             and schema == self._input_info.schema

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -10,12 +10,12 @@ import onnx
 import torch
 
 from onnxruntime.capi import _pybind_state as C
-from onnxruntime.training.utils import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import InferenceAgent
 from ._fallback import ORTModuleFallbackException, _FallbackManager, _FallbackPolicy
 from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo
+from ._io import unflatten_user_output
 from ._logger import ORTModuleInitPhase, SuppressLogs, TrackTime
 from ._utils import save_tuning_results, set_tuning_results
 from .options import DebugOptions, _SkipCheck
@@ -186,7 +186,7 @@ class InferenceManager(GraphExecutionManager):
                     self._execution_agent._inference_session, False, self._runtime_options.tuning_results_path
                 )
 
-            return unflatten_from_data_and_schema(user_outputs, self._module_output_schema)
+            return unflatten_user_output(self._module_output_schema, user_outputs)
         except ORTModuleFallbackException as e:
             # Exceptions subject to fallback are handled here
             self._fallback_manager.handle_exception(exception=e, log_level=self._debug_options.logging.log_level)

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -10,7 +10,7 @@ import onnx
 import torch
 
 from onnxruntime.capi import _pybind_state as C
-from onnxruntime.training.utils.torch_io_helper import unflatten_from_data_and_schema
+from onnxruntime.training.utils import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import InferenceAgent

--- a/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_inference_manager.py
@@ -10,6 +10,7 @@ import onnx
 import torch
 
 from onnxruntime.capi import _pybind_state as C
+from onnxruntime.training.utils.torch_io_helper import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import InferenceAgent
@@ -185,7 +186,7 @@ class InferenceManager(GraphExecutionManager):
                     self._execution_agent._inference_session, False, self._runtime_options.tuning_results_path
                 )
 
-            return _io.unflatten_user_output(self._module_output_schema, user_outputs)
+            return unflatten_from_data_and_schema(user_outputs, self._module_output_schema)
         except ORTModuleFallbackException as e:
             # Exceptions subject to fallback are handled here
             self._fallback_manager.handle_exception(exception=e, log_level=self._debug_options.logging.log_level)

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -17,8 +17,8 @@ from onnxruntime.training.utils import (
     ORTModelInputOutputSchemaType,
     ORTModelInputOutputType,
     PrimitiveType,
-    flatten_data_with_schema,
-    unflatten_from_data_and_schema,
+    extract_data_and_schema,
+    unflatten_data_using_schema,
 )
 
 from ._fallback import ORTModuleIOError, ORTModuleONNXModelException, wrap_exception
@@ -284,7 +284,7 @@ def deepcopy_model_input(
 
 def unflatten_user_output(output_schema: Optional[ORTModelInputOutputSchemaType], outputs: List[torch.Tensor]):
     try:
-        return unflatten_from_data_and_schema(outputs, output_schema)
+        return unflatten_data_using_schema(outputs, output_schema)
     except TypeError as e:
         raise wrap_exception(
             ORTModuleIOError,
@@ -294,7 +294,7 @@ def unflatten_user_output(output_schema: Optional[ORTModelInputOutputSchemaType]
 
 def _extract_schema(data: ORTModelInputOutputType, device) -> ORTModelInputOutputSchemaType:
     try:
-        schema, _ = flatten_data_with_schema(data, constant_as_tensor=True, device=device)
+        _, schema = extract_data_and_schema(data, constant_as_tensor=True, device=device)
         return schema
     except TypeError as e:
         raise wrap_exception(ORTModuleIOError, TypeError(f"ORTModule fails to extract schema from data: {e}")) from None

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -17,7 +17,7 @@ from onnxruntime.training.utils.torch_io_helper import (
     ORTModelInputOutputSchemaType,
     ORTModelInputOutputType,
     PrimitiveType,
-    flatten_data_with_schema,
+    get_schema_for_flatten_data,
 )
 
 from ._fallback import ORTModuleIOError, ORTModuleONNXModelException, wrap_exception
@@ -536,7 +536,7 @@ def parse_outputs_for_onnx_export_and_extract_schema(
         # Parse the output and extract the output_names and output_dynamic_axes to be used for onnx export
         output_names, output_dynamic_axes = _parse_outputs_and_extract_names_and_dynamic_axes(sample_outputs)
 
-    output_schema = flatten_data_with_schema(sample_outputs, constant_as_tensor=True)
+    output_schema = get_schema_for_flatten_data(sample_outputs, constant_as_tensor=True)
     if is_deepcopy:
         del model_copy
         gc.collect()

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -8,82 +8,20 @@ import gc
 import inspect
 from collections import OrderedDict, abc
 from logging import Logger
-from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import onnx
 import torch
 
+from onnxruntime.training.utils.torch_io_helper import (
+    ORTModelInputOutputSchemaType,
+    ORTModelInputOutputType,
+    PrimitiveType,
+    flatten_data_with_schema,
+)
+
 from ._fallback import ORTModuleIOError, ORTModuleONNXModelException, wrap_exception
 from ._runtime_inspector import RuntimeInspector
-from ._utils import warn_of_constant_inputs
-
-_ModelInputOutputType = Union[
-    None,
-    str,
-    int,
-    bool,
-    float,
-    torch.Tensor,
-    Sequence["_ModelInputOutputType"],
-    Mapping[str, "_ModelInputOutputType"],
-]
-
-
-class _TensorStub:
-    """Tensor stub class used to represent model's input or output"""
-
-    __slots__ = ["name", "dtype", "shape", "shape_dims"]
-
-    def __init__(
-        self, name: Optional[str] = None, dtype: Optional[str] = None, shape=None, shape_dims: Optional[int] = None
-    ):
-        self.name: Optional[str] = name
-        self.dtype: Optional[str] = dtype
-        self.shape = shape
-        self.shape_dims: Optional[int] = shape_dims  # r.g. rank.
-
-    def __repr__(self) -> str:
-        result = "_TensorStub("
-        if self.name is not None:
-            result += f"name={self.name}"
-        if self.dtype is not None:
-            if result[-1] != "(":
-                result += ", "
-            result += f"dtype={self.dtype}"
-        if self.shape is not None:
-            if result[-1] != "(":
-                result += ", "
-            result += f"shape={self.shape}"
-        if self.shape_dims is not None:
-            if result[-1] != "(":
-                result += ", "
-            result += f"shape_dims={self.shape_dims}"
-        result += ")"
-        return result
-
-    def __eq__(self, other):
-        if not other:
-            return False
-        elif not isinstance(other, _TensorStub):
-            raise NotImplementedError("_TensorStub must only be compared to another _TensorStub instance!")
-        elif self.name != other.name:
-            return False
-        elif self.dtype != other.dtype:
-            return False
-        elif self.shape != other.shape:
-            return False
-        elif self.shape_dims != other.shape_dims:
-            return False
-        return True
-
-
-_ModelInputOutputSchemaType = Union[
-    None,
-    str,
-    _TensorStub,
-    Sequence["_ModelInputOutputSchemaType"],
-    Mapping[str, "_ModelInputOutputSchemaType"],
-]
 
 
 class _OutputIdentityOp(torch.autograd.Function):
@@ -137,29 +75,10 @@ class _OutputIdentityOp(torch.autograd.Function):
         return g.op("Identity", self)
 
 
-class _PrimitiveType:
-    _primitive_types = {int, bool, float}  # noqa: RUF012
-
-    @staticmethod
-    def is_primitive_type(value):
-        return type(value) in _PrimitiveType._primitive_types
-
-    @staticmethod
-    def get_tensor(value, device) -> torch.Tensor:
-        return torch.tensor(value, device=device)
-
-    @staticmethod
-    def get_primitive_dtype(value):
-        # If `value` is a boolean, save the value of the boolean in dtype.
-        # This way, if the value changes from one forward call to the next, the schema will mismatch,
-        # and the model will be re-exported.
-        return f"{type(value)!s}_{value}" if isinstance(value, bool) else str(type(value))
-
-
 def flatten_kwargs(kwargs, device):
     def _flatten_kwargs(value, name):
-        if _PrimitiveType.is_primitive_type(value):
-            flattened_kwargs[name] = _PrimitiveType.get_tensor(value, device)
+        if PrimitiveType.is_primitive_type(value):
+            flattened_kwargs[name] = PrimitiveType.get_tensor(value, device)
         elif isinstance(value, torch.Tensor):
             flattened_kwargs[name] = value
         elif isinstance(value, abc.Sequence):
@@ -188,14 +107,14 @@ class _InputInfo:
         shape: List[List[int]],
         require_grad_names: Optional[List[str]] = None,
         dynamic_axes: Optional[Dict[str, Dict[int, str]]] = None,
-        schema: Optional[_ModelInputOutputSchemaType] = None,
+        schema: Optional[ORTModelInputOutputSchemaType] = None,
         num_positionals=0,
     ):
         self.names: List[str] = names
         self.shape: List[List[int]] = shape
         self.require_grad_names: List[str] = require_grad_names if require_grad_names else []
         self.dynamic_axes: Dict[str, Dict[int, str]] = dynamic_axes if dynamic_axes else {}
-        self.schema: _ModelInputOutputSchemaType = schema if schema else []
+        self.schema: ORTModelInputOutputSchemaType = schema if schema else []
         self.num_positionals = num_positionals
         self.kwargs = None
 
@@ -209,11 +128,14 @@ class _InputInfo:
             \t#Positionals (total):             {self.num_positionals}"""
 
     def flatten(
-        self, args: Sequence[_ModelInputOutputType], kwargs: Mapping[str, _ModelInputOutputType], device: torch.device
-    ) -> Sequence[_ModelInputOutputType]:
+        self,
+        args: Sequence[ORTModelInputOutputType],
+        kwargs: Mapping[str, ORTModelInputOutputType],
+        device: torch.device,
+    ) -> Sequence[ORTModelInputOutputType]:
         """Flatten args and kwargs in a single tuple of tensors with strict ordering"""
 
-        ret = [_PrimitiveType.get_tensor(arg, device) if _PrimitiveType.is_primitive_type(arg) else arg for arg in args]
+        ret = [PrimitiveType.get_tensor(arg, device) if PrimitiveType.is_primitive_type(arg) else arg for arg in args]
         flattened_kwargs = flatten_kwargs(kwargs, device)
         ret += [flattened_kwargs[name] for name in self.names if name in flattened_kwargs]
         self.kwargs = kwargs
@@ -226,8 +148,8 @@ class _InputInfo:
         return ret
 
     def unflatten(
-        self, flat_args: Sequence[_ModelInputOutputType]
-    ) -> Tuple[Sequence[_ModelInputOutputType], Mapping[str, _ModelInputOutputType]]:
+        self, flat_args: Sequence[ORTModelInputOutputType]
+    ) -> Tuple[Sequence[ORTModelInputOutputType], Mapping[str, ORTModelInputOutputType]]:
         """Unflatten tuple of tensors into args and kwargs"""
 
         args = tuple(flat_args[: self.num_positionals])
@@ -241,8 +163,8 @@ def _combine_input_buffers_initializers(
     onnx_input_names: List[str],
     input_info: Optional[_InputInfo],
     named_buffer: Iterator[Tuple[str, torch.Tensor]],
-    inputs: Sequence[_ModelInputOutputType],
-    kwargs: Mapping[str, _ModelInputOutputType],
+    inputs: Sequence[ORTModelInputOutputType],
+    kwargs: Mapping[str, ORTModelInputOutputType],
     device: torch.device,
     rt_inspector: RuntimeInspector,
 ):
@@ -315,8 +237,8 @@ def _combine_input_buffers_initializers(
                 pass
 
         if inp is not None:
-            if _PrimitiveType.is_primitive_type(inp):
-                inp = _PrimitiveType.get_tensor(inp, device)
+            if PrimitiveType.is_primitive_type(inp):
+                inp = PrimitiveType.get_tensor(inp, device)
 
             found, embedding_density, label_density = rt_inspector.inspect_input(name, inp)
             if found:
@@ -338,7 +260,7 @@ def _combine_input_buffers_initializers(
 
 def deepcopy_model_input(
     *args, **kwargs
-) -> Tuple[Sequence[_ModelInputOutputType], Mapping[str, _ModelInputOutputType]]:
+) -> Tuple[Sequence[ORTModelInputOutputType], Mapping[str, ORTModelInputOutputType]]:
     def extract_tensor(value):
         if isinstance(value, torch.Tensor):
             if value.requires_grad:
@@ -348,139 +270,15 @@ def deepcopy_model_input(
         else:
             return value
 
-    sample_args_copy: Sequence[_ModelInputOutputType] = [extract_tensor(value) for value in args]
+    sample_args_copy: Sequence[ORTModelInputOutputType] = [extract_tensor(value) for value in args]
     sample_args_copy = copy.deepcopy(tuple(sample_args_copy))
 
-    sample_kwargs_copy: Mapping[str, _ModelInputOutputType] = {}
+    sample_kwargs_copy: Mapping[str, ORTModelInputOutputType] = {}
     for name, value in kwargs.items():
         sample_kwargs_copy[name] = extract_tensor(value)
     sample_kwargs_copy = copy.deepcopy(sample_kwargs_copy)
 
     return sample_args_copy, sample_kwargs_copy
-
-
-def unflatten_user_output(output_schema: Optional[_ModelInputOutputSchemaType], outputs):
-    """Follows the schema to generate an output that is expected by the user"""
-
-    def _replace_stub_with_tensor_value(user_output, outputs, output_idx):
-        # Recursively traverse across user_output and replace all _TensorStub
-        # with torch.Tensor values from outputs following output_idx
-
-        if user_output is None:
-            return None
-        elif isinstance(user_output, _TensorStub):
-            out = outputs[output_idx[0]]
-            output_idx[0] += 1
-            return out
-
-        if isinstance(user_output, abc.Sequence):
-            sequence_type = type(user_output)
-            if hasattr(sequence_type, "_make"):  # namedtuple
-                sequence_type = type(user_output)
-                user_output = sequence_type._make(
-                    _replace_stub_with_tensor_value(uo, outputs, output_idx) for uo in user_output
-                )
-            else:
-                user_output = sequence_type(
-                    _replace_stub_with_tensor_value(uo, outputs, output_idx) for uo in user_output
-                )
-        elif isinstance(user_output, abc.Mapping):
-            new_user_output = copy.copy(user_output)
-            for key in sorted(user_output):
-                new_user_output[key] = _replace_stub_with_tensor_value(new_user_output[key], outputs, output_idx)
-            user_output = new_user_output
-        else:
-            raise wrap_exception(
-                ORTModuleIOError,
-                TypeError(f"ORTModule does not support the following model output type {type(user_output)}."),
-            )
-
-        return user_output
-
-    # It is expected that the outputs are ordered in the way defined in the exported onnx model
-    # which is the order in which the output schema was saved.
-    output_idx = [0]
-    user_output = _replace_stub_with_tensor_value(output_schema, outputs, output_idx)
-    return user_output
-
-
-def _extract_schema(data: _ModelInputOutputType, logger: Logger) -> _ModelInputOutputSchemaType:
-    """Extract the data schema by replacing every torch.Tensor value with _TensorStub.
-
-    Depth first traversal to iterate over the data:
-    > Replace every tensor with a stub
-    > Replace None/str typed data with itself
-    > Recreate tensor from data for other primitive types, and replace them with a stub.
-
-    Examples:
-        Example 1, list:
-            data = [torch.tensor(1), torch.tensor(2)]
-            schema = [_TensorStub(shape=()), _TensorStub(shape=())]
-
-        Example 2, dict:
-            data = {"a": torch.tensor(1), "b": torch.tensor(2)}
-            schema = {"a": _TensorStub(shape=()), "b": _TensorStub(shape=())}
-
-        Example 3, dict of list:
-            data = {"a": [torch.tensor(1), torch.tensor(2)], "b": [torch.tensor(3), torch.tensor(4)]}
-            schema = {"a": [_TensorStub(shape=()), _TensorStub(shape=())],
-                        "b": [_TensorStub(shape=()), _TensorStub(shape=())]}
-
-        Example 4, nested dict:
-            data = {"a": {"b": torch.tensor(1), "c": torch.tensor(2)},
-                    "d": {"e": torch.tensor(3), "f": torch.tensor(4)}}
-            schema = {"a": {"b": _TensorStub(shape=()), "c": _TensorStub(shape=())},
-                        "d": {"e": _TensorStub(shape=()), "f": _TensorStub(shape=())}}
-
-        Example 5, dict of mixed list and dict:
-            data = {"a": [torch.tensor(1), torch.tensor(2)], "b": {"c": torch.tensor(3), "d": torch.tensor(4)}}
-            schema = {"a": [_TensorStub(shape=()), _TensorStub(shape=())],
-                        "b": {"c": _TensorStub(shape=()), "d": _TensorStub(shape=())}}
-
-    Args:
-        data: The data to extract the schema from, which can be in any kind of nested structure,
-            including Sequence and Mapping.
-
-
-    Returns:
-        The schema of the data, which has the same structure as the data.
-
-    """
-
-    if data is None:
-        return data
-    elif isinstance(data, str):
-        warn_of_constant_inputs(data, logger)
-        return data
-    elif _PrimitiveType.is_primitive_type(data):
-        if isinstance(data, bool):
-            warn_of_constant_inputs(data, logger)
-        return _TensorStub(dtype=_PrimitiveType.get_primitive_dtype(data), shape_dims=0)
-    # Depth first traversal to iterate over the data to replace every tensor with a stub
-    elif isinstance(data, torch.Tensor):
-        return _TensorStub(dtype=str(data.dtype), shape_dims=len(data.size()))
-
-    # Instead of replacing the tensor with a stub in the original user input, build the stubbed_schema
-    # from scratch from the user input.
-    stubbed_schema: Optional[_ModelInputOutputSchemaType] = None
-    if isinstance(data, abc.Sequence):
-        sequence_type = type(data)
-        stubbed_schema = [_extract_schema(val, logger) for val in data]
-        try:
-            # namedtuple can be created by passing the list sequence to method _make
-            stubbed_schema = sequence_type._make(stubbed_schema)
-        except AttributeError:
-            # If attribute error encountered, create the sequence directly
-            stubbed_schema = sequence_type(stubbed_schema)
-    elif isinstance(data, abc.Mapping):
-        dict_type = type(data)
-        stubbed_schema = {key: _extract_schema(data[key], logger) for key in data}
-        stubbed_schema = dict_type(**stubbed_schema)
-    else:
-        raise wrap_exception(
-            ORTModuleIOError, TypeError(f"ORTModule does not support the following model data type {type(data)}")
-        )
-    return stubbed_schema
 
 
 def _parse_outputs_and_extract_names_and_dynamic_axes(module_output) -> Tuple[List[str], Dict[str, Dict[int, str]]]:
@@ -568,9 +366,9 @@ class _FlattenedModule(torch.nn.Module):
 def parse_inputs_for_onnx_export(
     all_input_parameters: List[inspect.Parameter],
     onnx_graph: Optional[onnx.ModelProto],
-    schema: _ModelInputOutputSchemaType,
-    args: Sequence[_ModelInputOutputType],
-    kwargs: Mapping[str, _ModelInputOutputType],
+    schema: ORTModelInputOutputSchemaType,
+    args: Sequence[ORTModelInputOutputType],
+    kwargs: Mapping[str, ORTModelInputOutputType],
 ) -> _InputInfo:
     """Parses through the model inputs and returns _InputInfo.
 
@@ -655,7 +453,7 @@ def parse_inputs_for_onnx_export(
     var_positional_idx = 0
 
     # Be noted, all_input_parameters is a list of inspect.Parameters parsed from the original module's forward method.
-    # While the execution manger's forward function will map all given model inputs to *args and **kwargs, so it is
+    # While the execution manager's forward function will map all given model inputs to *args and **kwargs, so it is
     # possible the input parameter list cannot represent the real model inputs given here (e.g., *args, **kwargs).
     # But it is still fine to use all_input_parameters to make sure all model inputs are covered.
     #
@@ -712,7 +510,7 @@ def parse_inputs_for_onnx_export(
 
 
 def parse_outputs_for_onnx_export_and_extract_schema(
-    module, args: Sequence[_ModelInputOutputType], kwargs: Mapping[str, _ModelInputOutputType], logger: Logger
+    module, args: Sequence[ORTModelInputOutputType], kwargs: Mapping[str, ORTModelInputOutputType], logger: Logger
 ):
     # Perform a forward call to grab outputs
     output_names = None
@@ -738,7 +536,7 @@ def parse_outputs_for_onnx_export_and_extract_schema(
         # Parse the output and extract the output_names and output_dynamic_axes to be used for onnx export
         output_names, output_dynamic_axes = _parse_outputs_and_extract_names_and_dynamic_axes(sample_outputs)
 
-    output_schema = _extract_schema(sample_outputs, logger)
+    output_schema = flatten_data_with_schema(sample_outputs, constant_as_tensor=True)
     if is_deepcopy:
         del model_copy
         gc.collect()

--- a/orttraining/orttraining/python/training/ortmodule/_io.py
+++ b/orttraining/orttraining/python/training/ortmodule/_io.py
@@ -13,7 +13,7 @@ from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 import onnx
 import torch
 
-from onnxruntime.training.utils.torch_io_helper import (
+from onnxruntime.training.utils import (
     ORTModelInputOutputSchemaType,
     ORTModelInputOutputType,
     PrimitiveType,

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -11,6 +11,7 @@ import torch
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import get_ort_device_type
+from onnxruntime.training.utils.torch_io_helper import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import TrainingAgent
@@ -322,9 +323,9 @@ class TrainingManager(GraphExecutionManager):
                 self._runtime_inspector,
             )
 
-            outputs = _io.unflatten_user_output(
-                self._module_output_schema,
+            outputs = unflatten_from_data_and_schema(
                 self._forward_class.apply(*prepared_input_list),
+                self._module_output_schema,
             )
 
             if (

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -11,14 +11,13 @@ import torch
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import get_ort_device_type
-from onnxruntime.training.utils import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import TrainingAgent
 from ._fallback import ORTModuleFallbackException, _FallbackManager, _FallbackPolicy
 from ._gradient_accumulation_manager import GradientAccumulationManager
 from ._graph_execution_manager import GraphExecutionManager, _RunStateInfo
-from ._io import _FlattenedModule, _InputInfo
+from ._io import _FlattenedModule, _InputInfo, unflatten_user_output
 from ._logger import ORTModuleInitPhase, SuppressLogs, TrackTime
 from ._runtime_inspector import Phase
 from ._utils import save_tuning_results, set_tuning_results
@@ -323,9 +322,9 @@ class TrainingManager(GraphExecutionManager):
                 self._runtime_inspector,
             )
 
-            outputs = unflatten_from_data_and_schema(
-                self._forward_class.apply(*prepared_input_list),
+            outputs = unflatten_user_output(
                 self._module_output_schema,
+                self._forward_class.apply(*prepared_input_list),
             )
 
             if (

--- a/orttraining/orttraining/python/training/ortmodule/_training_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_training_manager.py
@@ -11,7 +11,7 @@ import torch
 
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_inference_collection import get_ort_device_type
-from onnxruntime.training.utils.torch_io_helper import unflatten_from_data_and_schema
+from onnxruntime.training.utils import unflatten_from_data_and_schema
 
 from . import _are_deterministic_algorithms_enabled, _io, _use_deterministic_algorithms, _utils
 from ._execution_agent import TrainingAgent

--- a/orttraining/orttraining/python/training/ortmodule/_utils.py
+++ b/orttraining/orttraining/python/training/ortmodule/_utils.py
@@ -345,13 +345,6 @@ def switch_backend_to_pytorch(ortmodule, pytorch_module):
     ortmodule.forward = pytorch_module.forward
 
 
-def warn_of_constant_inputs(data, logger: logging.Logger):
-    logger.info(
-        f"Received input of type {type(data)} which may be treated as a constant by ORT by default."
-        " Please consider moving constant arguments to the model constructor."
-    )
-
-
 def patch_torch_module_ort_forward_method(torch_module_ort):
     def _forward(self, *inputs, **kwargs):
         """Forward pass starts here and continues at `_ORTModuleFunction.forward`

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -7,7 +7,6 @@ from onnxruntime.training.utils.torch_io_helper import (
     ORTModelInputOutputType,
     PrimitiveType,
     flatten_data_with_schema,
-    get_schema_for_flatten_data,
     unflatten_from_data_and_schema,
 )
 
@@ -15,7 +14,6 @@ __all__ = [
     "PrimitiveType",
     "ORTModelInputOutputType",
     "ORTModelInputOutputSchemaType",
-    "get_schema_for_flatten_data",
     "flatten_data_with_schema",
     "unflatten_from_data_and_schema",
 ]

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -6,14 +6,14 @@ from onnxruntime.training.utils.torch_io_helper import (
     ORTModelInputOutputSchemaType,
     ORTModelInputOutputType,
     PrimitiveType,
-    flatten_data_with_schema,
-    unflatten_from_data_and_schema,
+    extract_data_and_schema,
+    unflatten_data_using_schema,
 )
 
 __all__ = [
     "PrimitiveType",
     "ORTModelInputOutputType",
     "ORTModelInputOutputSchemaType",
-    "flatten_data_with_schema",
-    "unflatten_from_data_and_schema",
+    "extract_data_and_schema",
+    "unflatten_data_using_schema",
 ]

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -2,12 +2,22 @@
 # Licensed under the MIT License.
 # __init__.py
 
-from .torch_io_helper import (
-    PrimitiveType,
-    ORTModelInputOutputType,
-    _TensorStub,
+from onnxruntime.training.utils.torch_io_helper import (
     ORTModelInputOutputSchemaType,
-    get_schema_for_flatten_data,
+    ORTModelInputOutputType,
+    PrimitiveType,
+    _TensorStub,
     flatten_data_with_schema,
+    get_schema_for_flatten_data,
     unflatten_from_data_and_schema,
-)  # noqa: F401
+)
+
+__all__ = [
+    "PrimitiveType",
+    "ORTModelInputOutputType",
+    "_TensorStub",
+    "ORTModelInputOutputSchemaType",
+    "get_schema_for_flatten_data",
+    "flatten_data_with_schema",
+    "unflatten_from_data_and_schema",
+]

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -6,7 +6,6 @@ from onnxruntime.training.utils.torch_io_helper import (
     ORTModelInputOutputSchemaType,
     ORTModelInputOutputType,
     PrimitiveType,
-    _TensorStub,
     flatten_data_with_schema,
     get_schema_for_flatten_data,
     unflatten_from_data_and_schema,
@@ -15,7 +14,6 @@ from onnxruntime.training.utils.torch_io_helper import (
 __all__ = [
     "PrimitiveType",
     "ORTModelInputOutputType",
-    "_TensorStub",
     "ORTModelInputOutputSchemaType",
     "get_schema_for_flatten_data",
     "flatten_data_with_schema",

--- a/orttraining/orttraining/python/training/utils/__init__.py
+++ b/orttraining/orttraining/python/training/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# __init__.py
+
+from .torch_io_helper import (
+    PrimitiveType,
+    ORTModelInputOutputType,
+    _TensorStub,
+    ORTModelInputOutputSchemaType,
+    get_schema_for_flatten_data,
+    flatten_data_with_schema,
+    unflatten_from_data_and_schema,
+)  # noqa: F401

--- a/orttraining/orttraining/python/training/utils/io.py
+++ b/orttraining/orttraining/python/training/utils/io.py
@@ -1,0 +1,257 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import copy
+from collections import abc
+from logging import Logger
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
+
+import torch
+import warnings
+
+
+def warn_of_constant_inputs(data):
+    warnings.warn(
+        f"Received input of type {type(data)} which may be treated as a constant by ORT by default."
+        " Please consider moving constant arguments to the model constructor."
+    )
+
+
+class _PrimitiveType:
+    _primitive_types = {int, bool, float}  # noqa: RUF012
+
+    @staticmethod
+    def is_primitive_type(value):
+        return type(value) in _PrimitiveType._primitive_types
+
+    @staticmethod
+    def get_tensor(value, device) -> torch.Tensor:
+        return torch.tensor(value, device=device)
+
+    @staticmethod
+    def get_primitive_dtype(value):
+        # If `value` is a boolean, save the value of the boolean in dtype.
+        # This way, if the value changes from one forward call to the next, the schema will mismatch,
+        # and the model will be re-exported.
+        return f"{type(value)!s}_{value}" if isinstance(value, bool) else str(type(value))
+
+
+ORTModelInputOutputType = Union[
+    None,
+    str,
+    int,
+    bool,
+    float,
+    torch.Tensor,
+    Sequence["ORTModelInputOutputType"],
+    Mapping[str, "ORTModelInputOutputType"],
+]
+
+
+class _TensorStub:
+    """Tensor stub class used to represent model's input or output"""
+
+    __slots__ = ["tensor_idx", "name", "dtype", "shape", "shape_dims"]
+
+    def __init__(
+        self,
+        tensor_idx: int,
+        name: Optional[str] = None,
+        dtype: Optional[str] = None,
+        shape=None,
+        shape_dims: Optional[int] = None,
+    ):
+        self.tensor_idx = tensor_idx
+        self.name: Optional[str] = name
+        self.dtype: Optional[str] = dtype
+        self.shape = shape
+        self.shape_dims: Optional[int] = shape_dims  # r.g. rank.
+
+    def __repr__(self) -> str:
+        result = "_TensorStub("
+
+        l = []
+        if self.tensor_idx is not None:
+            l.append(f"tensor_idx={self.tensor_idx}")
+        if self.name is not None:
+            l.append(f"name={self.name}")
+        if self.dtype is not None:
+            l.append(f"dtype={self.dtype}")
+        if self.shape is not None:
+            l.append(f"shape={self.shape}")
+        if self.shape_dims is not None:
+            l.append(f"shape_dims={self.shape_dims}")
+
+        result += ",".join(l) + ")"
+        return result
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __eq__(self, other):
+        if not other:
+            return False
+        elif not isinstance(other, _TensorStub):
+            raise NotImplementedError("_TensorStub must only be compared to another _TensorStub instance!")
+        elif self.tensor_idx != other.tensor_idx:
+            return False
+        elif self.name != other.name:
+            return False
+        elif self.dtype != other.dtype:
+            return False
+        elif self.shape != other.shape:
+            return False
+        elif self.shape_dims != other.shape_dims:
+            return False
+        return True
+
+
+ORTModelInputOutputSchemaType = Union[
+    None,
+    str,
+    _TensorStub,
+    Sequence["ORTModelInputOutputSchemaType"],
+    Mapping[str, "ORTModelInputOutputSchemaType"],
+]
+
+
+def flatten_data_with_schema(
+    data, constant_as_tensor=False, device: Optional[torch.device] = None
+) -> Tuple[ORTModelInputOutputSchemaType, List[torch.Tensor]]:
+    """Extract the data schema by replacing every torch.Tensor value with _TensorStub.
+
+    Depth first traversal to iterate over the data:
+    > Replace every tensor with a stub
+    > Replace None/str typed data with itself
+    > Recreate tensor from data for other primitive types, and replace them with a stub.
+
+    Examples:
+        Example 1, list:
+            data = [torch.tensor(1), torch.tensor(2)]
+            schema = [_TensorStub(shape=()), _TensorStub(shape=())]
+
+        Example 2, dict:
+            data = {"a": torch.tensor(1), "b": torch.tensor(2)}
+            schema = {"a": _TensorStub(shape=()), "b": _TensorStub(shape=())}
+
+        Example 3, dict of list:
+            data = {"a": [torch.tensor(1), torch.tensor(2)], "b": [torch.tensor(3), torch.tensor(4)]}
+            schema = {"a": [_TensorStub(shape=()), _TensorStub(shape=())],
+                        "b": [_TensorStub(shape=()), _TensorStub(shape=())]}
+
+        Example 4, nested dict:
+            data = {"a": {"b": torch.tensor(1), "c": torch.tensor(2)},
+                    "d": {"e": torch.tensor(3), "f": torch.tensor(4)}}
+            schema = {"a": {"b": _TensorStub(shape=()), "c": _TensorStub(shape=())},
+                        "d": {"e": _TensorStub(shape=()), "f": _TensorStub(shape=())}}
+
+        Example 5, dict of mixed list and dict:
+            data = {"a": [torch.tensor(1), torch.tensor(2)], "b": {"c": torch.tensor(3), "d": torch.tensor(4)}}
+            schema = {"a": [_TensorStub(shape=()), _TensorStub(shape=())],
+                        "b": {"c": _TensorStub(shape=()), "d": _TensorStub(shape=())}}
+
+    Args:
+        data: The data to extract the schema from, which can be in any kind of nested structure,
+            including Sequence and Mapping.
+
+
+    Returns:
+        The schema of the data, which has the same structure as the data.
+
+    """
+
+    flatten_tensor_data = []
+    tensor_idx = [-1]
+
+    def _flatten_from_data(data, prefix_name=""):
+        if data is None:
+            return data
+        elif isinstance(data, str):
+            warn_of_constant_inputs(data)
+            return data
+        elif _PrimitiveType.is_primitive_type(data):
+            warn_of_constant_inputs(data)
+            if constant_as_tensor:
+                tensor_idx[0] += 1
+                flatten_tensor_data.append(_PrimitiveType.get_tensor(data, device))
+                return _TensorStub(
+                    tensor_idx[0], dtype=_PrimitiveType.get_primitive_dtype(data), shape_dims=0, name=prefix_name
+                )
+            return data
+        # Depth first traversal to iterate over the data to replace every tensor with a stub
+        elif isinstance(data, torch.Tensor):
+            tensor_idx[0] += 1
+            flatten_tensor_data.append(data)
+            return _TensorStub(
+                tensor_idx[0],
+                dtype=str(data.dtype),
+                shape_dims=len(data.size()),
+                name=prefix_name,
+            )
+
+        # Instead of replacing the tensor with a stub in the original user input, build the stubbed_schema
+        # from scratch from the user input.
+        stubbed_schema: Optional[ORTModelInputOutputSchemaType] = None
+        if isinstance(data, abc.Sequence):
+            sequence_type = type(data)
+            stubbed_schema = []
+            for i, val in enumerate(data):
+                stubbed_schema.append(_flatten_from_data(val, f"{prefix_name}_{i}" if prefix_name else f"{i}"))
+
+            try:
+                # namedtuple can be created by passing the list sequence to method _make
+                stubbed_schema = sequence_type._make(stubbed_schema)
+            except AttributeError:
+                # If attribute error is encountered, create the sequence directly
+                stubbed_schema = sequence_type(stubbed_schema)
+        elif isinstance(data, abc.Mapping):
+            dict_type = type(data)
+            stubbed_schema = {}
+            for key, val in sorted(data.items()):
+                stubbed_schema[key] = _flatten_from_data(val, f"{prefix_name}_{key}" if prefix_name else f"{key}")
+            stubbed_schema = dict_type(**stubbed_schema)
+        else:
+            raise RuntimeError(f"Unsupported data type: {type(data)}")
+        return stubbed_schema
+
+    schemas = _flatten_from_data(data)
+    return schemas, flatten_tensor_data
+
+
+def unflatten_from_data_and_schema(data: List[torch.Tensor], schema: ORTModelInputOutputSchemaType):
+    """Follows the schema to generate an output that is expected by the user"""
+
+    def _replace_stub_with_tensor_value(data_schema: ORTModelInputOutputSchemaType, data: List[torch.Tensor]):
+        # Recursively traverse across user_output and replace all _TensorStub
+        # with torch.Tensor values from outputs following output_idx
+
+        if data_schema is None:
+            return None
+        elif isinstance(data_schema, str):
+            return data_schema
+        elif _PrimitiveType.is_primitive_type(data_schema):
+            return data_schema
+        elif isinstance(data_schema, _TensorStub):
+            return data[data_schema.tensor_idx]
+        elif isinstance(data_schema, abc.Sequence):
+            sequence_type = type(data_schema)
+            if hasattr(sequence_type, "_make"):  # namedtuple
+                sequence_type = type(data_schema)
+                data_schema = sequence_type._make(_replace_stub_with_tensor_value(uo, data) for uo in data_schema)
+            else:
+                data_schema = sequence_type(_replace_stub_with_tensor_value(uo, data) for uo in data_schema)
+            return data_schema
+        elif isinstance(data_schema, abc.Mapping):
+            new_user_output = copy.copy(data_schema)
+            for key, schema_val in sorted(data_schema.items()):
+                new_user_output[key] = _replace_stub_with_tensor_value(schema_val, data)
+            data_schema = new_user_output
+
+            return data_schema
+
+        raise RuntimeError(f"ORTModule does not support the following model output type {type(data_schema)}.")
+
+    user_output = _replace_stub_with_tensor_value(schema, data)
+    return user_output

--- a/orttraining/orttraining/python/training/utils/torch_io_helper.py
+++ b/orttraining/orttraining/python/training/utils/torch_io_helper.py
@@ -255,7 +255,7 @@ def unflatten_from_data_and_schema(data: List[torch.Tensor], schema: ORTModelInp
 
             return data_schema
 
-        raise RuntimeError(f"ORTModule does not support the following model output type {type(data_schema)}.")
+        raise RuntimeError(f"ORT does not support the following model output type {type(data_schema)}.")
 
     user_output = _replace_stub_with_tensor_value(schema, data)
     return user_output

--- a/orttraining/orttraining/python/training/utils/torch_io_helper.py
+++ b/orttraining/orttraining/python/training/utils/torch_io_helper.py
@@ -122,10 +122,11 @@ def _warn_of_constant_inputs(data):
     )
 
 
-def flatten_data_with_schema(
+def extract_data_and_schema(
     data: ORTModelInputOutputType, constant_as_tensor=False, device: Optional[torch.device] = None
-) -> Tuple[ORTModelInputOutputSchemaType, List[torch.Tensor]]:
-    """Extract the data schema by replacing every torch.Tensor value with _TensorStub.
+) -> Tuple[List[torch.Tensor], ORTModelInputOutputSchemaType]:
+    """Extract the data schema by replacing every torch.Tensor value with _TensorStub, and return all tensors in
+    a list.
 
     Depth first traversal to iterate over the data:
     > Replace every tensor with a stub
@@ -168,8 +169,9 @@ def flatten_data_with_schema(
 
     Returns:
         Tuple:
-            The first value: schema of the data, which has the same structure as the data.
-            The second value: a list of tensors extracted from the data.
+            The first value: a list of tensors extracted from the data.
+            The second value: schema of the data, which has the same structure as the data.
+
 
     """
 
@@ -225,10 +227,10 @@ def flatten_data_with_schema(
             raise TypeError(f"Unsupported flatten data type: {type(data)}")
 
     schemas = _flatten_from_data(data)
-    return schemas, flatten_tensor_data
+    return flatten_tensor_data, schemas
 
 
-def unflatten_from_data_and_schema(
+def unflatten_data_using_schema(
     data: List[torch.Tensor], schema: ORTModelInputOutputSchemaType
 ) -> ORTModelInputOutputType:
     """Follows the schema to generate an output that is expected by the user.

--- a/orttraining/orttraining/python/training/utils/torch_io_helper.py
+++ b/orttraining/orttraining/python/training/utils/torch_io_helper.py
@@ -238,6 +238,9 @@ def unflatten_from_data_and_schema(data: List[torch.Tensor], schema: ORTModelInp
         elif PrimitiveType.is_primitive_type(data_schema):
             return data_schema
         elif isinstance(data_schema, _TensorStub):
+            assert isinstance(
+                data[data_schema.tensor_idx], torch.Tensor
+            ), f"Expecting torch.Tensor, got {type(data[data_schema.tensor_idx])}"
             return data[data_schema.tensor_idx]
         elif isinstance(data_schema, abc.Sequence):
             sequence_type = type(data_schema)

--- a/orttraining/orttraining/python/training/utils/torch_io_helper.py
+++ b/orttraining/orttraining/python/training/utils/torch_io_helper.py
@@ -11,13 +11,6 @@ from typing import List, Mapping, Optional, Sequence, Tuple, Union
 import torch
 
 
-def warn_of_constant_inputs(data):
-    warnings.warn(
-        f"Received input of type {type(data)} which may be treated as a constant by ORT by default."
-        " Please consider moving constant arguments to the model constructor."
-    )
-
-
 class PrimitiveType:
     _primitive_types = {int, bool, float}  # noqa: RUF012
 
@@ -47,6 +40,13 @@ ORTModelInputOutputType = Union[
     Sequence["ORTModelInputOutputType"],
     Mapping[str, "ORTModelInputOutputType"],
 ]
+
+
+def _warn_of_constant_inputs(data):
+    warnings.warn(
+        f"Received input of type {type(data)} which may be treated as a constant by ORT by default."
+        " Please consider moving constant arguments to the model constructor."
+    )
 
 
 class _TensorStub:
@@ -173,10 +173,10 @@ def flatten_data_with_schema(
         if data is None:
             return data
         elif isinstance(data, str):
-            warn_of_constant_inputs(data)
+            _warn_of_constant_inputs(data)
             return data
         elif PrimitiveType.is_primitive_type(data):
-            warn_of_constant_inputs(data)
+            _warn_of_constant_inputs(data)
             if constant_as_tensor:
                 tensor_idx[0] += 1
                 flatten_tensor_data.append(PrimitiveType.get_tensor(data, device))

--- a/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
+++ b/orttraining/orttraining/test/python/orttraining_ortmodule_tests.py
@@ -151,6 +151,14 @@ def run_hooks_tests(cwd, log):
     run_subprocess(command, cwd=cwd, log=log).check_returncode()
 
 
+def run_utils_tests(cwd, log):
+    log.debug("Running: Utils tests")
+
+    command = [sys.executable, "-m", "pytest", "-sv", "orttraining_test_utilities.py"]
+
+    run_subprocess(command, cwd=cwd, log=log).check_returncode()
+
+
 def run_pytorch_export_contrib_ops_tests(cwd, log):
     log.debug("Running: PyTorch Export Contrib Ops Tests")
 
@@ -204,6 +212,8 @@ def main():
     run_data_sampler_tests(cwd, log)
 
     run_hooks_tests(cwd, log)
+
+    run_utils_tests(cwd, log)
 
     run_experimental_gradient_graph_tests(cwd, log)
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2610,7 +2610,7 @@ def test_exception_raised_for_custom_class_return_value_module(device):
         # ORT backend
         with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
             ort_model(x, y, z)
-        assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
+        assert "ORTModule does not support the following model output type" in str(runtime_error.value)
 
     del os.environ["ORTMODULE_SKIPCHECK_POLICY"]
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4217,12 +4217,8 @@ def test_ortmodule_string_inputs_are_ignored():
 
     target_str = "Received input of type <class 'str'> which may be treated as a constant by ORT by default."
     found_target_str = False
-    with warnings.catch_warnings(record=True) as w:
-        for i in range(len(w)):
-            msg = str(w[i].message)
-            if target_str in msg:
-                found_target_str = True
-                break
+    with warnings.catch_warnings(record=True) as ws:
+        found_target_str = any(target_str in str(w.message) for w in ws)
 
     assert found_target_str
     _test_helpers.assert_values_are_close(out, x + 1)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4210,18 +4210,12 @@ def test_hf_save_pretrained():
 
 def test_ortmodule_string_inputs_are_ignored():
     pt_model = MyStrNet()
-    ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(log_level=LogLevel.INFO))
-    x = torch.randn(1, 2)
-
-    out = ort_model(x, "hello")
-
     target_str = "Received input of type <class 'str'> which may be treated as a constant by ORT by default."
-    found_target_str = False
-    with warnings.catch_warnings(record=True) as ws:
-        found_target_str = any(target_str in str(w.message) for w in ws)
-
-    assert found_target_str
-    _test_helpers.assert_values_are_close(out, x + 1)
+    with pytest.warns(UserWarning, match=target_str):
+        ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(log_level=LogLevel.INFO))
+        x = torch.randn(1, 2)
+        out = ort_model(x, "hello")
+        _test_helpers.assert_values_are_close(out, x + 1)
 
 
 def test_ortmodule_list_input():

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4208,7 +4208,7 @@ def test_hf_save_pretrained():
             assert p1.data.ne(p2.data).sum() == 0
 
 
-def test_ortmodule_string_inputs_are_ignored(caplog):
+def test_ortmodule_string_inputs_are_ignored():
     pt_model = MyStrNet()
     ort_model = ORTModule(copy.deepcopy(pt_model), DebugOptions(log_level=LogLevel.INFO))
     x = torch.randn(1, 2)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -4217,9 +4217,12 @@ def test_ortmodule_string_inputs_are_ignored(caplog):
 
     target_str = "Received input of type <class 'str'> which may be treated as a constant by ORT by default."
     found_target_str = False
-    for record in caplog.records:
-        if target_str in record.message:
-            found_target_str = True
+    with warnings.catch_warnings(record=True) as w:
+        for i in range(len(w)):
+            msg = str(w[i].message)
+            if target_str in msg:
+                found_target_str = True
+                break
 
     assert found_target_str
     _test_helpers.assert_values_are_close(out, x + 1)

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_api.py
@@ -2610,7 +2610,7 @@ def test_exception_raised_for_custom_class_return_value_module(device):
         # ORT backend
         with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
             ort_model(x, y, z)
-        assert "ORTModule does not support the following model output type" in str(runtime_error.value)
+        assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
 
     del os.environ["ORTMODULE_SKIPCHECK_POLICY"]
 

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
@@ -250,11 +250,11 @@ def test_ortmodule_fallback_output(is_training, fallback_enabled, matching_polic
             else:
                 with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
                     ort_model(x, y, z)
-                assert "ORTModule does not support the following model output type" in str(runtime_error.value)
+                assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
         else:
             with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
                 ort_model(x, y, z)
-            assert "ORTModule does not support the following model output type" in str(runtime_error.value)
+            assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
 
 
 @pytest.mark.parametrize(

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_fallback.py
@@ -78,11 +78,11 @@ def test_ortmodule_fallback_forward(is_training, fallback_enabled, matching_poli
             else:
                 with pytest.raises(_fallback.ORTModuleFallbackException) as type_error:
                     ort_model(inputs)
-                assert "ORTModule does not support the following model data type" in str(type_error.value)
+                assert "ORTModule fails to extract schema from data" in str(type_error.value)
         else:
             with pytest.raises(_fallback.ORTModuleFallbackException) as type_error:
                 ort_model(inputs)
-            assert "ORTModule does not support the following model data type" in str(type_error.value)
+            assert "ORTModule fails to extract schema from data" in str(type_error.value)
 
 
 @pytest.mark.parametrize(
@@ -250,11 +250,11 @@ def test_ortmodule_fallback_output(is_training, fallback_enabled, matching_polic
             else:
                 with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
                     ort_model(x, y, z)
-                assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
+                assert "ORTModule does not support the following model output type" in str(runtime_error.value)
         else:
             with pytest.raises(_fallback.ORTModuleIOError) as runtime_error:
                 ort_model(x, y, z)
-            assert "ORTModule fails to unflatten user output" in str(runtime_error.value)
+            assert "ORTModule does not support the following model output type" in str(runtime_error.value)
 
 
 @pytest.mark.parametrize(
@@ -302,16 +302,18 @@ def test_ortmodule_fallback_input(is_training, fallback_enabled, matching_policy
                 with pytest.raises(_fallback.ORTModuleIOError) as ex_info:
                     _ = ort_model(torch.randn(1, 2), CustomClass(1))
                 assert (
-                    "ORTModule does not support the following model data"
-                    " type <class 'orttraining_test_ortmodule_fallback."
+                    "ORTModule fails to extract schema from data: "
+                    "Unsupported flatten data type: "
+                    "<class 'orttraining_test_ortmodule_fallback."
                     "test_ortmodule_fallback_input.<locals>.CustomClass'>" in str(ex_info.value)
                 )
         else:
             with pytest.raises(_fallback.ORTModuleIOError) as ex_info:
                 _ = ort_model(torch.randn(1, 2), CustomClass(1))
             assert (
-                "ORTModule does not support the following model data"
-                " type <class 'orttraining_test_ortmodule_fallback."
+                "ORTModule fails to extract schema from data: "
+                "Unsupported flatten data type: "
+                "<class 'orttraining_test_ortmodule_fallback."
                 "test_ortmodule_fallback_input.<locals>.CustomClass'>" in str(ex_info.value)
             )
 

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 from collections import abc
 
 import pytest
@@ -11,10 +14,10 @@ from onnxruntime.training.utils.io import _TensorStub, flatten_data_with_schema,
     # list
     [
         [
-            [True, False, 1, 2.0, "abc", None],
-            [],
-            [True, False, 1, 2.0, "abc", None],
-            # for constant_as_tensor=True test
+            [True, False, 1, 2.0, "abc", None],  # input
+            [],  # flatten tensor list
+            [True, False, 1, 2.0, "abc", None],  # extracted schema
+            # flatten tensor lis when constant_as_tensor=True
             [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
         ],
         [
@@ -175,9 +178,7 @@ from onnxruntime.training.utils.io import _TensorStub, flatten_data_with_schema,
 )
 @pytest.mark.parametrize(
     "flag",
-    [
-        0,
-    ],
+    [0, 1, 2],
 )  # 0: flatten, 1: unflatten, 2: flatten and unflatten
 def test_data_flatten_and_unflatten(input_output_map, flag: int):
     raw_data = input_output_map[0]

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -6,8 +6,8 @@ from collections import abc
 import pytest
 import torch
 
-from onnxruntime.training.utils.torch_io_helper import _TensorStub
 from onnxruntime.training.utils import flatten_data_with_schema, unflatten_from_data_and_schema
+from onnxruntime.training.utils.torch_io_helper import _TensorStub
 
 
 @pytest.mark.parametrize(

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -1,8 +1,9 @@
+from collections import abc
+
 import pytest
 import torch
 
-from collections import abc
-from onnxruntime.training.utils.io import flatten_data_with_schema, unflatten_from_data_and_schema, _TensorStub
+from onnxruntime.training.utils.io import _TensorStub, flatten_data_with_schema, unflatten_from_data_and_schema
 
 
 @pytest.mark.parametrize(

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -19,42 +19,42 @@ from onnxruntime.training.utils.torch_io_helper import _TensorStub
             [],  # expected output: flatten tensor list
             True,  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            torch.tensor(True),
+            [torch.tensor(True)],
         ],
         [
             False,  # test input
             [],  # expected output: flatten tensor list
             False,  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            torch.tensor(False),
+            [torch.tensor(False)],
         ],
         [
             1,  # test input
             [],  # expected output: flatten tensor list
             1,  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            torch.tensor(1),
+            [torch.tensor(1)],
         ],
         [
             2.0,  # test input
             [],  # expected output: flatten tensor list
             2.0,  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            torch.tensor(2.0),
+            [torch.tensor(2.0)],
         ],
         [
             "abc",  # test input
             [],  # expected output: flatten tensor list
             "abc",  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            "abc",
+            [],
         ],
         [
             None,  # test input
             [],  # expected output: flatten tensor list
             None,  # expected output: extracted schema
             # expected output: flatten tensor list when constant_as_tensor=True
-            None,
+            [],
         ],
         [
             torch.tensor([1, 2, 3]),  # test input
@@ -264,10 +264,7 @@ def test_data_flatten_and_unflatten(input_output_map, flag: int):
 
         flatten_data_constant_as_tensor = input_output_map[3]
         schema, out = flatten_data_with_schema(raw_data, constant_as_tensor=True, device=torch.device("cpu"))
-        if isinstance(raw_data, (torch.Tensor, bool, int, float)):
-            d = torch.tensor(raw_data, device=out[0].device) if not isinstance(raw_data, torch.Tensor) else raw_data
-            assert torch.allclose(d, out[0])
-        elif isinstance(
+        if isinstance(
             raw_data,
             (
                 type(None),

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -6,7 +6,8 @@ from collections import abc
 import pytest
 import torch
 
-from onnxruntime.training.utils.io import _TensorStub, flatten_data_with_schema, unflatten_from_data_and_schema
+from onnxruntime.training.utils.torch_io_helper import _TensorStub
+from onnxruntime.training.utils import flatten_data_with_schema, unflatten_from_data_and_schema
 
 
 @pytest.mark.parametrize(

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -6,7 +6,7 @@ from collections import abc
 import pytest
 import torch
 
-from onnxruntime.training.utils import flatten_data_with_schema, unflatten_from_data_and_schema
+from onnxruntime.training.utils import extract_data_and_schema, unflatten_data_using_schema
 from onnxruntime.training.utils.torch_io_helper import _TensorStub
 
 
@@ -255,7 +255,7 @@ def test_data_flatten_and_unflatten(input_output_map, flag: int):
                 assert real == expected
 
     if flag == 0:
-        schema, out = flatten_data_with_schema(raw_data)
+        out, schema = extract_data_and_schema(raw_data)
         assert all([torch.allclose(o, d) if isinstance(o, torch.Tensor) else o == d for o, d in zip(out, flatten_data)])
         if not isinstance(raw_data, torch.Tensor):
             assert type(schema) == type(raw_data)
@@ -263,7 +263,7 @@ def test_data_flatten_and_unflatten(input_output_map, flag: int):
         assert str(schema) == str(flatten_schema)
 
         flatten_data_constant_as_tensor = input_output_map[3]
-        schema, out = flatten_data_with_schema(raw_data, constant_as_tensor=True, device=torch.device("cpu"))
+        out, schema = extract_data_and_schema(raw_data, constant_as_tensor=True, device=torch.device("cpu"))
         if isinstance(
             raw_data,
             (
@@ -281,10 +281,10 @@ def test_data_flatten_and_unflatten(input_output_map, flag: int):
             )
 
     elif flag == 1:
-        restored_data = unflatten_from_data_and_schema(flatten_data, flatten_schema)
+        restored_data = unflatten_data_using_schema(flatten_data, flatten_schema)
         _recursive_compare(restored_data, raw_data)
     elif flag == 2:
-        schema, out = flatten_data_with_schema(raw_data)
-        restored_data = unflatten_from_data_and_schema(out, schema)
+        out, schema = extract_data_and_schema(raw_data)
+        restored_data = unflatten_data_using_schema(out, schema)
 
         _recursive_compare(restored_data, raw_data)

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -1,0 +1,226 @@
+import pytest
+import torch
+
+from collections import abc
+from onnxruntime.training.utils.io import flatten_data_with_schema, unflatten_from_data_and_schema, _TensorStub
+
+
+@pytest.mark.parametrize(
+    "input_output_map",
+    # list
+    [
+        [
+            [True, False, 1, 2.0, "abc", None],
+            [],
+            [True, False, 1, 2.0, "abc", None],
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
+        ],
+        [
+            [True, False, 1, 2.0, "abc", None, torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])],
+            [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])],
+            [
+                True,
+                False,
+                1,
+                2.0,
+                "abc",
+                None,
+                _TensorStub(tensor_idx=0, name="6", dtype=torch.int64, shape_dims=1),
+                _TensorStub(tensor_idx=1, name="7", dtype=torch.int64, shape_dims=1),
+            ],
+            # for constant_as_tensor=True test
+            [
+                torch.tensor(True),
+                torch.tensor(False),
+                torch.tensor(1),
+                torch.tensor(2.0),
+                torch.tensor([1, 2, 3]),
+                torch.tensor([4, 5, 6]),
+            ],
+        ],
+        # dict
+        [
+            {"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None},
+            [],
+            {"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None},
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
+        ],
+        [
+            {"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None, "g": torch.tensor([1, 2, 3])},
+            [torch.tensor([1, 2, 3])],
+            {
+                "a": True,
+                "b": False,
+                "c": 1,
+                "d": 2.0,
+                "e": "abc",
+                "f": None,
+                "g": _TensorStub(tensor_idx=0, name="g", dtype=torch.int64, shape_dims=1),
+            },
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0), torch.tensor([1, 2, 3])],
+        ],
+        # list of list
+        [
+            [[True, False, 1, 2.0, "abc", None]],
+            [],
+            [[True, False, 1, 2.0, "abc", None]],
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
+        ],
+        [
+            [[True, False, 1, 2.0, "abc", None, torch.tensor([1, 2, 3])]],
+            [torch.tensor([1, 2, 3])],
+            [
+                [
+                    True,
+                    False,
+                    1,
+                    2.0,
+                    "abc",
+                    None,
+                    _TensorStub(tensor_idx=0, name="0_6", dtype=torch.int64, shape_dims=1),
+                ]
+            ],
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0), torch.tensor([1, 2, 3])],
+        ],
+        # list of dict
+        [
+            [{"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None}],
+            [],
+            [{"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None}],
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
+        ],
+        [
+            [{"a": True, "b": False, "c": 1, "d": 2.0, "e": "abc", "f": None, "g": torch.tensor([1, 2, 3])}],
+            [torch.tensor([1, 2, 3])],
+            [
+                {
+                    "a": True,
+                    "b": False,
+                    "c": 1,
+                    "d": 2.0,
+                    "e": "abc",
+                    "f": None,
+                    "g": _TensorStub(tensor_idx=0, name="0_g", dtype=torch.int64, shape_dims=1),
+                }
+            ],
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0), torch.tensor([1, 2, 3])],
+        ],
+        # dict of list
+        [
+            {"a": [True, False, 1, 2.0, "abc", None]},
+            [],
+            {"a": [True, False, 1, 2.0, "abc", None]},
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
+        ],
+        [
+            {"a": [True, False, 1, 2.0, "abc", None, torch.tensor([1, 2, 3])]},
+            [torch.tensor([1, 2, 3])],
+            {
+                "a": [
+                    True,
+                    False,
+                    1,
+                    2.0,
+                    "abc",
+                    None,
+                    _TensorStub(tensor_idx=0, name="a_6", dtype=torch.int64, shape_dims=1),
+                ]
+            },
+            # for constant_as_tensor=True test
+            [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0), torch.tensor([1, 2, 3])],
+        ],
+        # dict of dict
+        [
+            {"a": {"b": torch.tensor([1, 2, 3]), "c": torch.tensor([4, 5, 6])}},
+            [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])],
+            {
+                "a": {
+                    "b": _TensorStub(tensor_idx=0, name="a_b", dtype=torch.int64, shape_dims=1),
+                    "c": _TensorStub(tensor_idx=1, name="a_c", dtype=torch.int64, shape_dims=1),
+                }
+            },
+            # for constant_as_tensor=True test
+            [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])],
+        ],
+        # list of mixed types
+        [
+            [[torch.tensor([[1.3]]), {"a": True}], {"b": torch.tensor([1, 2, 3]), "c": [torch.tensor([4, 5]), 2.0]}],
+            [torch.tensor([[1.3]]), torch.tensor([1, 2, 3]), torch.tensor([4, 5])],
+            [
+                [_TensorStub(tensor_idx=0, name="0_0", dtype=torch.float32, shape_dims=2), {"a": True}],
+                {
+                    "b": _TensorStub(tensor_idx=1, name="1_b", dtype=torch.int64, shape_dims=1),
+                    "c": [_TensorStub(tensor_idx=2, name="1_c_0", dtype=torch.int64, shape_dims=1), 2.0],
+                },
+            ],
+            # for constant_as_tensor=True test
+            [
+                torch.tensor([[1.3]]),
+                torch.tensor(True),
+                torch.tensor([1, 2, 3]),
+                torch.tensor([4, 5]),
+                torch.tensor(2.0),
+            ],
+        ],
+    ],
+)
+@pytest.mark.parametrize(
+    "flag",
+    [
+        0,
+    ],
+)  # 0: flatten, 1: unflatten, 2: flatten and unflatten
+def test_data_flatten_and_unflatten(input_output_map, flag: int):
+    raw_data = input_output_map[0]
+    flatten_data = input_output_map[1]
+    flatten_schema = input_output_map[2]
+
+    def _recursive_compare(real, expected):
+        assert type(real) == type(expected)
+        if isinstance(real, str):
+            assert real == expected
+        elif isinstance(real, abc.Sequence):
+            assert len(real) == len(expected)
+            for i in range(len(real)):
+                _recursive_compare(real[i], expected[i])
+        elif isinstance(real, abc.Mapping):
+            assert len(real.keys()) == len(expected.keys())
+            for real_key, real_value in real.items():
+                _recursive_compare(real_value, expected[real_key])
+        else:
+            if isinstance(real, torch.Tensor):
+                assert torch.allclose(real, expected)
+            else:
+                assert real == expected
+
+    if flag == 0:
+        schema, out = flatten_data_with_schema(raw_data)
+        assert all([torch.allclose(o, d) if isinstance(o, torch.Tensor) else o == d for o, d in zip(out, flatten_data)])
+        assert type(schema) == type(raw_data)
+        assert str(schema) == str(flatten_schema)
+
+        flatten_data_constant_as_tensor = input_output_map[3]
+        schema, out = flatten_data_with_schema(raw_data, constant_as_tensor=True, device=torch.device("cpu"))
+        assert all(
+            [
+                torch.allclose(o, d) if isinstance(o, torch.Tensor) else o == d
+                for o, d in zip(out, flatten_data_constant_as_tensor)
+            ]
+        )
+
+    elif flag == 1:
+        restored_data = unflatten_from_data_and_schema(flatten_data, flatten_schema)
+        _recursive_compare(restored_data, raw_data)
+    elif flag == 2:
+        schema, out = flatten_data_with_schema(raw_data)
+        restored_data = unflatten_from_data_and_schema(out, schema)
+
+        _recursive_compare(restored_data, raw_data)

--- a/orttraining/orttraining/test/python/orttraining_test_utilities.py
+++ b/orttraining/orttraining/test/python/orttraining_test_utilities.py
@@ -15,10 +15,10 @@ from onnxruntime.training.utils.torch_io_helper import _TensorStub
     # list
     [
         [
-            [True, False, 1, 2.0, "abc", None],  # input
-            [],  # flatten tensor list
-            [True, False, 1, 2.0, "abc", None],  # extracted schema
-            # flatten tensor lis when constant_as_tensor=True
+            [True, False, 1, 2.0, "abc", None],  # test input
+            [],  # expected output: flatten tensor list
+            [True, False, 1, 2.0, "abc", None],  # expected output: extracted schema
+            # expected output: flatten tensor list when constant_as_tensor=True
             [torch.tensor(True), torch.tensor(False), torch.tensor(1), torch.tensor(2.0)],
         ],
         [

--- a/setup.py
+++ b/setup.py
@@ -531,6 +531,7 @@ if enable_training or enable_training_apis:
                 "onnxruntime.training.ortmodule.torch_cpp_extensions.cuda.fused_ops",
                 "onnxruntime.training.ort_triton",
                 "onnxruntime.training.ort_triton.kernel",
+                "onnxruntime.training.utils",
                 "onnxruntime.training.utils.data",
                 "onnxruntime.training.utils.hooks",
             ]


### PR DESCRIPTION
### Motivation and Context

When we handle PyTorch models' inputs in different places (ORTModule or others), it's common for us to flatten a structured data into a 1-D tensor list (required by lib for example torch.onnx.export, torch.autograd.Function.forward or ORT inference session), then do subsequent work, then unflatten back to original hierarchy as returned values. 

DeepStage3 hooks support work also need such a lib to do similar things, so I was proposing to extract this pair of APIs in training/utils/, which can be more used more generally. Also a comprehensive set of test data are used for testing unflatten/flatten in unit tests. 

Let me know if you have any other suggestions. 


### Refactor schema extraction and output unflattening

Move `_extract_schema` and `unflatten_user_output`  in `orttraining/orttraining/python/training/ortmodule/_io.py` . to `extract_data_and_schema` and `unflatten_data_using_schema` in `orttraining/orttraining/python/training/utils/torch_io_helper.py` as shared libs, which can be used later by other features (deepspeed stage 3 hook rewrite). 

While there are still a few duplicated logic handling flatten with different task by recursively loop the data struct, will change them step by step in case of heavy review efforts. 
