### PR TITLE
Allow ORT actively fallback CUDAExecutionProvider to ROCMExecutionProvider

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -66,6 +66,7 @@ def check_and_normalize_provider_args(
         if (
             os.environ.get("ORT_FALLBACK_CUDA_EP_TO_ROCM_EP", "0") == "1"
             and "CUDAExecutionProvider" not in available_provider_names
+            and "ROCMExecutionProvider" in available_provider_names
         ):
             if name == "CUDAExecutionProvider":
                 name = "ROCMExecutionProvider"

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -63,11 +63,22 @@ def check_and_normalize_provider_args(
     provider_name_to_options = collections.OrderedDict()
 
     def set_provider_options(name, options):
+        if (
+            os.environ.get("ORT_FALLBACK_CUDA_EP_TO_ROCM_EP", "0") == "1"
+            and "CUDAExecutionProvider" not in available_provider_names
+        ):
+            if name == "CUDAExecutionProvider":
+                name = "ROCMExecutionProvider"
+
         if name not in available_provider_names:
             warnings.warn(
                 "Specified provider '{}' is not in available provider names."
                 "Available providers: '{}'".format(name, ", ".join(available_provider_names))
             )
+            if name == "CUDAExecutionProvider" and "ROCMExecutionProvider" in available_provider_names:
+                warnings.warn(
+                    "Set environment variable ORT_FALLBACK_CUDA_EP_TO_ROCM_EP=1 to enable CUDA to ROCm fallback."
+                )
 
         if name in provider_name_to_options:
             warnings.warn(f"Duplicate provider '{name}' encountered, ignoring.")


### PR DESCRIPTION
In the wild, for example, pytorch and huggingface (pytorch pipelines) use `cuda` for amd gpu. Their user can basically painless switch from cuda devices to rocm devices. That is, in pytorch world they fallback cuda to rocm.

When switched to hf ort backend, it will populate a string `CUDAExecutionProvider` automatically to pin down the provider. Then ORT will not play well in this case because the framework will fallback cuda to cpu.

The disparity creates a lot of headache during benchmarking the ROCm EP when reusing scripts for cuda.

This PR address it by allow cuda to fallback to rocm.