### PR TITLE
[js/webgpu] Check profilingMode in each run

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -33,8 +33,8 @@ export class ProgramManager {
   run(buildArtifact: Artifact, inputs: GpuData[], outputs: GpuData[], dispatchGroup: [number, number, number]): void {
     const device = this.backend.device;
     const computePassEncoder = this.backend.getComputePassEncoder();
-
-    if (this.backend.profilingEnabled) {
+    const profilingEnabled = this.backend.supportTimestampQuery && this.backend.env.webgpu.profilingMode === 'default';
+    if (profilingEnabled) {
       // profiling write start timestamp
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -56,7 +56,7 @@ export class ProgramManager {
 
     this.backend.pendingDispatchNumber++;
 
-    if (this.backend.profilingEnabled) {
+    if (profilingEnabled) {
       // profiling write end timestamp
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR moves checking profilingMode to each run instead of the initialization stage. In this way, users can start/stop profiling at any time. Otherwise, profiling only take effects at the very beginning and can't be stopped.
