### PR TITLE
skip test_smooth_quant to unblock Python Package Pipeline

### DIFF
--- a/onnxruntime/test/python/quantization/test_quantize_static.py
+++ b/onnxruntime/test/python/quantization/test_quantize_static.py
@@ -99,8 +99,13 @@ class TestStaticQuantization(unittest.TestCase):
         check_model_correctness(self, self._model_fp32_path, quant_model_path, data_reader.get_next())
         data_reader.rewind()
 
-    @unittest.skipIf(not find_spec("neural_compressor"), "Skip since neural-compressor is not installed.")
+    @unittest.skip(
+        "Skip failed test in Python Packaging Test Pipeline."
+        "During importing neural_compressor, pycocotools throws ValueError: numpy.ndarray size changed"
+    )
     def test_smooth_quant(self):
+        if not find_spec("neural_compressor"):
+            self.skipTest("skip test_smooth_quant since neural_compressor is not installed")
         data_reader = input_feeds_neg_one_zero_one(10, {"input": [1, self._channel_size, 1, 3]})
         quant_config = StaticQuantConfig(data_reader, extra_options={"SmoothQuant": True})
         quant_model_path = str(Path(self._tmp_model_dir.name) / "quant.config.onnx")


### PR DESCRIPTION
### Description
Python Package Pipeline failed since there is exception raised in test_smooth_quant (from #16288):
```
File "/home/cloudtest/.local/lib/python3.8/site-packages/onnxruntime/quantization/quantize.py", line 384, in quantize_static
    importlib.import_module("neural_compressor.adaptor.ox_utils.smooth_quant")
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/__init__.py", line 24, in <module>
    from .contrib import *
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/contrib/__init__.py", line 19, in <module>
    from .strategy import *
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/contrib/strategy/__init__.py", line 26, in <module>
    __import__(basename(f)[:-3], globals(), locals(), level=1)
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/contrib/strategy/sigopt.py", line 22, in <module>
    from neural_compressor.strategy.strategy import strategy_registry, TuneStrategy
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/strategy/__init__.py", line 20, in <module>
    from .strategy import STRATEGIES
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/strategy/strategy.py", line 41, in <module>
    from ..algorithm import AlgorithmScheduler, ALGORITHMS
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/algorithm/__init__.py", line 20, in <module>
    from .algorithm import ALGORITHMS, Algorithm, AlgorithmScheduler, algorithm_registry
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/algorithm/algorithm.py", line 21, in <module>
    from neural_compressor.utils.create_obj_from_config import get_algorithm
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/utils/create_obj_from_config.py", line 20, in <module>
    from neural_compressor.metric import METRICS
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/metric/__init__.py", line 30, in <module>
    __import__(basename(f)[:-3], globals(), locals(), level=1)
  File "/home/cloudtest/.local/lib/python3.8/site-packages/neural_compressor/metric/coco_tools.py", line 54, in <module>
    from pycocotools import coco
  File "/usr/local/lib/python3.8/dist-packages/pycocotools/coco.py", line 52, in <module>
    from . import mask as maskUtils
  File "/usr/local/lib/python3.8/dist-packages/pycocotools/mask.py", line 3, in <module>
    import pycocotools._mask as _mask
  File "pycocotools/_mask.pyx", line 1, in init pycocotools._mask
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```
The cause is pycocotools package uses "oldest-supported-numpy", which might cause older version numpy in build pycocotools:
https://github.com/ppwwyyxx/cocoapi/blob/9e9164f979fe4265c6f387f10e234f8697a15922/PythonAPI/pyproject.toml#L4

Related issue: https://github.com/cocodataset/cocoapi/issues/248

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->



