### PR TITLE
[DML] Model corrupter during layernorm fusion and DmlNonZeroOperator crashes

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -294,7 +294,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<ConvActivationFusion>(cpu_cuda_rocm_acl_armnn_eps));
 
       transformers.emplace_back(std::make_unique<GeluFusion>(cpu_cuda_dml_rocm_eps));
-      transformers.emplace_back(std::make_unique<LayerNormFusion>(cpu_cuda_rocm_eps));
+      transformers.emplace_back(std::make_unique<LayerNormFusion>(cpu_cuda_dml_rocm_eps));
       transformers.emplace_back(std::make_unique<SimplifiedLayerNormFusion>(cpu_cuda_rocm_eps));
       transformers.emplace_back(std::make_unique<AttentionFusion>(cpu_cuda_dml_rocm_eps));
       transformers.emplace_back(std::make_unique<EmbedLayerNormFusion>(cpu_cuda_dml_rocm_eps));

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -294,7 +294,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<ConvActivationFusion>(cpu_cuda_rocm_acl_armnn_eps));
 
       transformers.emplace_back(std::make_unique<GeluFusion>(cpu_cuda_dml_rocm_eps));
-      transformers.emplace_back(std::make_unique<LayerNormFusion>(cpu_cuda_dml_rocm_eps));
+      transformers.emplace_back(std::make_unique<LayerNormFusion>(cpu_cuda_rocm_eps));
       transformers.emplace_back(std::make_unique<SimplifiedLayerNormFusion>(cpu_cuda_rocm_eps));
       transformers.emplace_back(std::make_unique<AttentionFusion>(cpu_cuda_dml_rocm_eps));
       transformers.emplace_back(std::make_unique<EmbedLayerNormFusion>(cpu_cuda_dml_rocm_eps));

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
@@ -124,7 +124,8 @@ public:
         {
             // TODO: Remove this hack when DML supports native int64 for NonZero
             // We use the int64/uint32 stride hack here, so zero out the data before writing to it
-            ComPtr<IDMLCompiledOperator> zeroOperator = InitializeZeroInt64Tensor(m_rank * nonzeroElementCount * sizeof(int64_t));
+            uint64_t tensorSizeInBytes = uint64_t(m_rank) * uint64_t(nonzeroElementCount) * sizeof(int64_t);
+            ComPtr<IDMLCompiledOperator> zeroOperator = InitializeZeroInt64Tensor(tensorSizeInBytes);
 
             // TODO: Remove this hack when DML supports native int64 for NonZero
             ExecuteZeroInt64Tensor(zeroOperator.Get(), outputTensor.GetInterface().Get());

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
@@ -65,10 +65,6 @@ public:
             nonzeroCoordinatesDesc.OutputCountTensor = &intermediateDescs[0];
             nonzeroCoordinatesDesc.OutputCoordinatesTensor = &intermediateDescs[1];
 
-            // TODO: Remove this hack when DML supports native int64 for NonZero
-            // We use the int64/uint32 stride hack here, so zero out the data before writing to it
-            m_zeroOperator = InitializeZeroInt64Tensor(m_intermediateTensorDescs[1].GetBufferSizeInBytes());
-
             DML_OPERATOR_DESC opDesc = { DML_OPERATOR_NONZERO_COORDINATES, &nonzeroCoordinatesDesc };
             SetDmlOperatorDesc(opDesc, kernelCreationContext);
         }
@@ -127,7 +123,11 @@ public:
         if (!m_emptyInput && nonzeroElementCount > 0)
         {
             // TODO: Remove this hack when DML supports native int64 for NonZero
-            ExecuteZeroInt64Tensor(m_zeroOperator.Get(), outputTensor.GetInterface().Get());
+            // We use the int64/uint32 stride hack here, so zero out the data before writing to it
+            ComPtr<IDMLCompiledOperator> zeroOperator = InitializeZeroInt64Tensor(m_rank * nonzeroElementCount * sizeof(int64_t));
+
+            // TODO: Remove this hack when DML supports native int64 for NonZero
+            ExecuteZeroInt64Tensor(zeroOperator.Get(), outputTensor.GetInterface().Get());
 
             ComPtr<IDMLCompiledOperator> sliceOperator = InitializeSlice(m_intermediateTensorDescs[1], nonzeroElementCount);
 
@@ -182,7 +182,6 @@ private:
     std::vector<TensorDesc> m_intermediateTensorDescs;
     onnxruntime::TensorShape m_outputCountShape;
     onnxruntime::TensorShape m_outputCoordinatesShape;
-    ComPtr<IDMLCompiledOperator> m_zeroOperator;
     bool m_emptyInput = false;
     uint32_t m_rank = 0;
 };


### PR DESCRIPTION
[DML] Model corrupter during layernorm fusion and DmlNonZeroOperator crashes

Two issues fixed in this PR:
1) Changes to layernom fusion regressed DirectML. This has been disabled for DML to unblock models.
2) DmlNonZero needs to create an operator call that needs to know the number of non-zero elements (size in bytes). Therefore this needs to be allocated during compute, but is being allocated during initialization. This causes the output tensor size to mismatch with the operator's expectations.