### PR TITLE
Add WAITPKG checks, add support for TPAUSE in ThreadPool spin

### DIFF
--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -18,8 +18,10 @@
 
 namespace onnxruntime {
 
+#if defined(_M_AMD64) || defined(__x86_64__)
 const bool tpause = CPUIDInfo::GetCPUIDInfo().HasTPAUSE();
 const std::uint64_t spin_delay_cycles = 2000;
+#endif
 
 namespace concurrency {
 

--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -11,6 +11,10 @@
 #include <xmmintrin.h>
 #endif
 
+#if defined(_M_AMD64) || defined(__x86_64__)
+#include <cstdint>
+#endif
+
 namespace onnxruntime {
 
 namespace concurrency {
@@ -20,6 +24,13 @@ namespace concurrency {
 inline void SpinPause() {
 #if defined(_M_AMD64) || defined(__x86_64__)
   _mm_pause();
+#endif
+}
+
+inline void SpinTPAUSE() {
+#if defined(_M_AMD64) || defined(__x86_64__)
+   const std::uint64_t spin_delay_cycles = 2000;
+  _tpause(0x0, __rdtsc() + spin_delay_cycles);
 #endif
 }
 

--- a/include/onnxruntime/core/common/spin_pause.h
+++ b/include/onnxruntime/core/common/spin_pause.h
@@ -13,27 +13,29 @@
 
 #if defined(_M_AMD64) || defined(__x86_64__)
 #include <cstdint>
+#include "core/common/cpuid_info.h"
 #endif
 
 namespace onnxruntime {
 
+const bool tpause = CPUIDInfo::GetCPUIDInfo().HasTPAUSE();
+const std::uint64_t spin_delay_cycles = 2000;
+
 namespace concurrency {
 
 // Intrinsic to use in spin-loops
-
 inline void SpinPause() {
 #if defined(_M_AMD64) || defined(__x86_64__)
-  _mm_pause();
-#endif
-}
-
-inline void SpinTPAUSE() {
-#if defined(_M_AMD64) || defined(__x86_64__)
-   const std::uint64_t spin_delay_cycles = 2000;
+if(tpause) {
   _tpause(0x0, __rdtsc() + spin_delay_cycles);
+}
+else{
+  _mm_pause();
+}
 #endif
 }
 
 }  // namespace concurrency
 
 }  // namespace onnxruntime
+

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -54,6 +54,10 @@
 #include "core/platform/ort_spin_lock.h"
 #include "core/platform/Barrier.h"
 
+#if defined(CPUINFO_SUPPORTED) && !defined(__APPLE__) && !defined(__ANDROID__) && !defined(__wasm__) && !defined(_AIX)
+#include <cpuinfo.h>
+#endif
+
 // ORT thread pool overview
 // ------------------------
 //
@@ -1535,6 +1539,7 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
     constexpr int log2_spin = 20;
     const int spin_count = allow_spinning_ ? (1ull << log2_spin) : 0;
     const int steal_count = spin_count / 100;
+    const bool tpause = CPUIDInfo::GetCPUIDInfo().HasTPAUSE();
 
     SetDenormalAsZero(set_denormal_as_zero_);
     profiler_.LogThreadId(thread_id);
@@ -1554,8 +1559,14 @@ class ThreadPoolTempl : public onnxruntime::concurrency::ExtendedThreadPoolInter
           if (spin_loop_status_.load(std::memory_order_relaxed) == SpinLoopStatus::kIdle) {
             break;
           }
-          onnxruntime::concurrency::SpinPause();
-        }
+		  
+          if (tpause) {
+            onnxruntime::concurrency::SpinTPAUSE();
+          }
+          else {
+            onnxruntime::concurrency::SpinPause();
+          }
+        } 
 
         // Attempt to block
         if (!t) {

--- a/onnxruntime/core/common/cpuid_info.h
+++ b/onnxruntime/core/common/cpuid_info.h
@@ -25,6 +25,7 @@ class CPUIDInfo {
   bool HasSSE3() const { return has_sse3_; }
   bool HasSSE4_1() const { return has_sse4_1_; }
   bool IsHybrid() const { return is_hybrid_; }
+  bool HasTPAUSE() const { return has_tpause_; }
 
   // ARM
   bool HasArmNeonDot() const { return has_arm_neon_dot_; }
@@ -104,6 +105,7 @@ class CPUIDInfo {
   bool has_sse3_{false};
   bool has_sse4_1_{false};
   bool is_hybrid_{false};
+  bool has_tpause_{false};
 
   std::vector<uint32_t> core_uarchs_;  // micro-arch of each core
 


### PR DESCRIPTION
### Description
Adding necessary runtime checks for WAITPKG:
onnxruntime/core/common/cpuid_info.cc
onnxruntime/core/common/cpuid_info.h

Added a spin function with TPAUSE, use it in WorkerLoop if HW has WAITPKG support. Defining the control bit as 0, since this will provide better power savings, but also improve performance of other SMT thread on the same core. See https://www.felixcloutier.com/x86/tpause.
include/onnxruntime/core/common/spin_pause.h
include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h

### Motivation and Context
Change enables TPAUSE support on Alder Lake and newer Intel microarchitectures in the context of Eigen-based threadpool implementation. This allows the CPU to enter light-weight C-state while in a spin, saving power and in this case, improving performance by 3-4%.
See section 'Active Spins in Applications' in
https://cdrdv2-public.intel.com/685865/211112_Hybrid_WP_2_Developing_v1.2.pdf

### Result
Tested with onnxruntime_perf_test.exe on a dynamically quantized model (which I can not share - however these changes are not model specific), running 
`onnxruntime_perf_test.exe -I -m times -r 10000 -o 2 model.onnx`

As to optimal TPAUSE cycle count, testing shows that ~2000 cycles provides the best results. First 2 graphs were generated from onnxruntime_perf_test.exe output, power data collected using Intel Power Gadget on ADL i9-12700H.
![image](https://github.com/microsoft/onnxruntime/assets/11665940/062f41e5-ab2a-4214-af57-7b2f7454a6e7)
![image](https://github.com/microsoft/onnxruntime/assets/11665940/39184e4a-e081-439f-a2ce-263a41688dfa)
![image](https://github.com/microsoft/onnxruntime/assets/11665940/777eed66-2403-4b5e-882f-217bc27dcb24)

