### PR TITLE
More element types in AllGather and AllToAll

### DIFF
--- a/onnxruntime/contrib_ops/cuda/collective/nccl_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/collective/nccl_kernels.cc
@@ -14,6 +14,9 @@ namespace cuda {
 static ncclDataType_t GetNcclDataType(onnxruntime::MLDataType type) {
   if (type == DataTypeImpl::GetType<uint8_t>()) {
     return ncclUint8;
+  } else if (type == DataTypeImpl::GetType<bool>()) {
+    // CUDA bool is 8-bit large.
+    return ncclUint8;
   } else if (type == DataTypeImpl::GetType<int8_t>()) {
     return ncclInt8;
   } else if (type == DataTypeImpl::GetType<int32_t>()) {
@@ -226,7 +229,7 @@ ONNX_OPERATOR_KERNEL_EX(
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .AllocateInputsContiguously()
-        .TypeConstraint("T", DataTypeImpl::AllIEEEFloatTensorTypes()),
+        .TypeConstraint("T", DataTypeImpl::AllTensorTypes()),
     AllGather);
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -237,7 +240,7 @@ ONNX_OPERATOR_KERNEL_EX(
     (*KernelDefBuilder::Create())
         .VariadicAlias(0, 0)  // outputs and inputs are mapped one to one
         .AllocateInputsContiguously()
-        .TypeConstraint("T", DataTypeImpl::AllIEEEFloatTensorTypes()),
+        .TypeConstraint("T", DataTypeImpl::AllTensorTypes()),
     AllToAll);
 
 }  // namespace cuda

--- a/onnxruntime/core/graph/contrib_ops/collective_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/collective_defs.cc
@@ -42,8 +42,8 @@ void RegisterCollectiveOps() {
       .Output(0, "output", "gathered tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain to float, float16 and double tensors.")
+          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int64)", "tensor(bool)"},
+          "Constrain to bool, float, float16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         auto group_size = getAttribute(ctx, "group_size", 1);
         auto axis = getAttribute(ctx, "axis", 0);
@@ -74,8 +74,8 @@ void RegisterCollectiveOps() {
       .Output(0, "output", "collected tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain to float, float16 and double tensors.")
+          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int64)", "tensor(bool)"},
+          "Constrain to bool, float, float16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateShapeAndTypeFromFirstInput(ctx);
       });

--- a/onnxruntime/test/python/onnxruntime_test_collective.py
+++ b/onnxruntime/test/python/onnxruntime_test_collective.py
@@ -11,6 +11,20 @@ import onnxruntime as ort
 
 
 class ORTBertPretrainTest(unittest.TestCase):
+    @staticmethod
+    def _create_model_with_opsets(
+        graph_def,
+    ):
+        opset_imports = [
+            helper.make_operatorsetid("", 18),
+            helper.make_operatorsetid(".com.microsoft", 1),
+        ]
+        return helper.make_model(
+            graph_def,
+            producer_name="ORTBertPretrainTest in onnxruntime_test_collective.py",
+            opset_imports=opset_imports,
+        )
+
     def _create_allreduce_ut_model(self, shape):
         X = helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)  # noqa: N806
         Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)  # noqa: N806
@@ -21,7 +35,7 @@ class ORTBertPretrainTest(unittest.TestCase):
             [X],
             [Y],
         )
-        return helper.make_model(graph_def, producer_name="ort-distributed-inference-unittest")
+        return ORTBertPretrainTest._create_model_with_opsets(graph_def)
 
     def _get_rank_size(self):
         comm = MPI.COMM_WORLD
@@ -39,7 +53,7 @@ class ORTBertPretrainTest(unittest.TestCase):
             [X],
             [Y],
         )
-        return helper.make_model(graph_def, producer_name="ort-distributed-inference-unittest")
+        return ORTBertPretrainTest._create_model_with_opsets(graph_def)
 
     def _create_alltoall_ut_model(self, shape):
         X = helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)  # noqa: N806
@@ -52,7 +66,7 @@ class ORTBertPretrainTest(unittest.TestCase):
             [X],
             [Y],
         )
-        return helper.make_model(graph_def, producer_name="ort-distributed-inference-unittest")
+        return ORTBertPretrainTest._create_model_with_opsets(graph_def)
 
     def test_all_reduce(self):
         model = self._create_allreduce_ut_model((128, 128))


### PR DESCRIPTION
Two things done in this PR.
- [2nd commit] More tensor element types are supported because in distributed computation, we need to re-shard tensors in many different types.
- [1st commit] We now specify opset version in test models. Without this change, those models will have opset=20 with latest ONNX and results test errors.
- [3rd commit] Tests are modified to test `AllGather` and `AllToAll` for boolean tensors. Several graph patterns are tried for tests. We found that `int64_tensor -> Cast -> bool_tensor -> AllToAll -> bool_tensor -> Cast -> int64_tensor` always generate random results. My guess is that `AllToAll` needs to synchronize all GPUs before calling `ncclSend` and `ncclRecv` since `AllGather` doesn't hit this problem. For reproducing the error, search for `TODO` in this PR. Note that this PR doesn't fix it.