### PR TITLE
Add lsb-release package to android custom build

### DIFF
--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   python3-pip \
   python3-setuptools \
   python3-wheel \
-  unzip
+  unzip lsb-release
 
 # cmake
 RUN CMAKE_VERSION=3.26.3 && \


### PR DESCRIPTION
### Description
Add lsb-release package to android custom build


### Motivation and Context
To fix a build issue:

/workspace/onnxruntime/tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/install_protobuf.sh: line 27: lsb_release: command not found



