### PR TITLE
replace one pool with onnxruntime-Win2022-GPU-T4

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -486,7 +486,7 @@ stages:
   - job:
     workspace:
       clean: all
-    pool: 'onnxruntime-gpu-tensorrt8-winbuild-t4'
+    pool: 'onnxruntime-Win2022-GPU-T4'
 
     steps:
     - checkout: self                           # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime


### PR DESCRIPTION
### Description
replace one pool

### Motivation and Context
onnxruntime-gpu-tensorrt8-winbuild-t4 would be deprecated


