### PR TITLE
updated Python version used in Mac CI pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -46,9 +46,9 @@ jobs:
 
   - task: UsePythonVersion@0
     # Use python 3.8 to avoid build some of the required packages
-    displayName: Use Python 3.8
+    displayName: Use Python 3.11
     inputs:
-      versionSpec: 3.8
+      versionSpec: 3.11
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'


### PR DESCRIPTION
### Description
updates Mac CI pipelines to use Python 3.11



### Motivation and Context
attempts to fix failing mac pipelines


