### PR TITLE
build break: apply formatter fix (2)

### DIFF
--- a/js/.vscode/launch.json
+++ b/js/.vscode/launch.json
@@ -6,21 +6,12 @@
   "configurations": [
     {
       "name": "[common] Launch Unit Tests",
-      "args": [
-        "-u",
-        "bdd",
-        "--timeout",
-        "999999",
-        "--colors",
-        "${workspaceFolder}/common/test/**/*.js"
-      ],
+      "args": ["-u", "bdd", "--timeout", "999999", "--colors", "${workspaceFolder}/common/test/**/*.js"],
       "internalConsoleOptions": "openOnSessionStart",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceFolder}/common",
       "request": "launch",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "type": "node",
       "sourceMaps": true,
       "preLaunchTask": "tsc: build - common/test/tsconfig.json"
@@ -29,14 +20,10 @@
       "name": "[web] Launch Test Runner",
       "program": "${workspaceFolder}/web/script/test-runner-cli.js",
       "request": "launch",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "type": "node",
       "cwd": "${workspaceFolder}/web",
-      "args": [
-        "suite1"
-      ]
+      "args": ["suite1"]
     },
     {
       "name": "[web] Attach to Chrome",


### PR DESCRIPTION
### Description
explaining why we need this PR and #16947 :

we have a formatter update (#16888) but some PR already did CI checks before it gets merged. When we merge the PRs they fail the build pipeline.

solutions (for future):
- if we have formatter updates, need to make sure existing PRs merge latest main branch to perform latest check
- a formatter update is not common and is not doing frequently at all. so need extra careful doing this