### PR TITLE
[ROCm] add gfx1100 and gfx1101 to CMAKE_HIP_ARCHITECTURES

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -274,7 +274,7 @@ if (onnxruntime_USE_ROCM)
   endif()
 
   if (NOT CMAKE_HIP_ARCHITECTURES)
-    set(CMAKE_HIP_ARCHITECTURES "gfx906;gfx908;gfx90a;gfx1030")
+    set(CMAKE_HIP_ARCHITECTURES "gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101")
   endif()
 
   file(GLOB rocm_cmake_components ${onnxruntime_ROCM_HOME}/lib/cmake/*)


### PR DESCRIPTION
### Description
Support additional AMD GPU architectures.

### Motivation and Context
AMD announced expanding support for additional GPUs.

https://community.amd.com/t5/rocm/new-rocm-5-6-release-brings-enhancements-and-optimizations-for/ba-p/614745

This PR is how we will deliver that expanded support to onnxruntime.

