### PR TITLE
Hardcode xcodebuild destination iOS simulator OS to 16.4.

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1680,7 +1680,8 @@ def run_ios_tests(args, source_dir, config, cwd):
                 "-scheme",
                 xc_test_scheme,
                 "-destination",
-                f"platform=iOS Simulator,OS=latest,name={simulator_device_name}",
+                # hardcode iOS 16.4 for now. latest macOS-13 image defaults to iOS 17 (beta) which doesn't work.
+                f"platform=iOS Simulator,OS=16.4,name={simulator_device_name}",
             ],
             cwd=cwd,
         )

--- a/tools/ci_build/github/apple/test_ios_packages.py
+++ b/tools/ci_build/github/apple/test_ios_packages.py
@@ -129,7 +129,8 @@ def _test_ios_packages(args):
                     "-scheme",
                     "ios_package_test",
                     "-destination",
-                    f"platform=iOS Simulator,OS=latest,name={simulator_device_name}",
+                    # hardcode iOS 16.4 for now. latest macOS-13 image defaults to iOS 17 (beta) which doesn't work.
+                    f"platform=iOS Simulator,OS=16.4,name={simulator_device_name}",
                 ],
                 shell=False,
                 check=True,

--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -15,7 +15,7 @@ name: "$(Date:yyyyMMdd)$(Rev:rrr)"  # build number format
 stages:
 - stage: IosPackaging_SetCommonVariables
   dependsOn: []
-  
+
   variables:
     skipComponentGovernanceDetection: true
 
@@ -112,6 +112,7 @@ stages:
         set -e -x
         cp "$(Pipeline.Workspace)/ios_packaging_artifacts_full/pod-archive-onnxruntime-c-$(ortPodVersion).zip" swift/
         export ORT_IOS_POD_LOCAL_PATH="swift/pod-archive-onnxruntime-c-$(ortPodVersion).zip"
-        xcodebuild test -scheme onnxruntime -destination 'platform=iOS Simulator,name=iPhone 14'
+        # hardcode iOS 16.4 for now. latest macOS-13 image defaults to iOS 17 (beta).
+        xcodebuild test -scheme onnxruntime -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
         rm swift/pod-archive-onnxruntime-c-$(ortPodVersion).zip
       displayName: "Test Package.swift usage"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Hardcode xcodebuild destination iOS simulator OS to 16.4.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix iOS CI build.