### PR TITLE
Add On-Device Training Mac & iOS package installation options

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@ Console.WriteLine(outputs[0].AsTensor<float>()[0]);</code>
 											<div class="col-md-3 r-heading">
 												<h3 id="ot_selectOS">Platform</h3>
 												<p id="ot_decriptionOS" class="sr-only">
-													Platform list contains three items
+													Platform list contains five items
 												</p>
 											</div>
 											<div class="col-md-9 r-content pr-0 pl-md-4" role="listbox"
@@ -641,8 +641,16 @@ Console.WriteLine(outputs[0].AsTensor<float>()[0]);</code>
 														<span>Windows</span>
 													</div>
 													<div class="col r-option" role="option" tabindex="0"
+														aria-selected="true" id="ot_mac">
+														<span>Mac</span>
+													</div>
+													<div class="col r-option" role="option" tabindex="0"
 														aria-selected="true" id="ot_android">
 														<span>Android</span>
+													</div>
+													<div class="col r-option" role="option" tabindex="0"
+														aria-selected="true" id="ot_ios">
+														<span>iOS</span>
 													</div>
 												</div>
 											</div>
@@ -652,7 +660,7 @@ Console.WriteLine(outputs[0].AsTensor<float>()[0]);</code>
 											<div class="col-md-3 r-heading">
 												<h3 id="ot_selectLanguage">API</h3>
 												<p id="ot_decriptionLanguage" class="sr-only">
-													API list contains five items
+													API list contains six items
 												</p>
 											</div>
 											<div class="col-md-9 r-content pr-0 pl-md-4" role="listbox"
@@ -678,6 +686,10 @@ Console.WriteLine(outputs[0].AsTensor<float>()[0]);</code>
 													<div class="col r-option" role="option" tabindex="0"
 														aria-selected="true" id="ot_java">
 														<span>Java</span>
+													</div>
+													<div class="col r-option" role="option" tabindex="0"
+														aria-selected="true" id="ot_objc">
+														<span>Obj-C</span>
 													</div>
 												</div>
 											</div>

--- a/js/script.js
+++ b/js/script.js
@@ -636,13 +636,13 @@ var ot_validCombos = {
     "pip install onnxruntime-training<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
 
     "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU":
-        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+        "Add 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
     "ot_ios,ot_on_device,ot_c,ot_X64,ot_CPU":
-        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+        "Add 'onnxruntime-training-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
     "ot_ios,ot_on_device,ot_cplusplus,ot_X64,ot_CPU":
-        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+        "Add 'onnxruntime-training-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
 };
 

--- a/js/script.js
+++ b/js/script.js
@@ -641,7 +641,7 @@ var ot_validCombos = {
     "ot_ios,ot_on_device,ot_c,ot_X64,ot_CPU":
         "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
-    "ot_ios,ot_on_device,ot_plusplus,ot_X64,ot_CPU":
+    "ot_ios,ot_on_device,ot_cplusplus,ot_X64,ot_CPU":
         "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
 };

--- a/js/script.js
+++ b/js/script.js
@@ -638,6 +638,12 @@ var ot_validCombos = {
     "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU":
         "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
     
+    "ot_ios,ot_on_device,ot_c,ot_X64,ot_CPU":
+        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+    
+    "ot_ios,ot_on_device,ot_plusplus,ot_X64,ot_CPU":
+        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+    
 };
 
 function ot_commandMessage(key) {

--- a/js/script.js
+++ b/js/script.js
@@ -576,7 +576,7 @@ var ot_validCombos = {
     "pip install onnxruntime-training -f https://downloads.onnxruntime.ai/onnxruntime_stable_<b>&lt;rocm_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*<a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
     
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CPU":
-    "pip install onnxruntime-training -f https://downloads.onnxruntime.ai/onnxruntime_stable_<b>&lt;cu_version*</b>&gt;.html<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
+    "pip install onnxruntime-training<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
@@ -631,6 +631,13 @@ var ot_validCombos = {
     
     "ot_android,ot_on_device,ot_java,ot_X64,ot_CPU":
     "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-training-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-training-android</a> using Maven/Gradle and refer to the instructions <a href='https://onnxruntime.ai/docs/install/#install-for-on-device-training' target='_blank'>here.</a>",
+
+    "ot_mac,ot_on_device,ot_python,ot_X64,ot_CPU":
+    "pip install onnxruntime-training<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
+
+    "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU":
+        "Add 'onnxruntime-training-c' or 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
+    
 };
 
 function ot_commandMessage(key) {


### PR DESCRIPTION
### Description
Added the option to install Mac & iOS packages for on-device training under the training installation options.

### Motivation and Context
Mac & iOS on-device training packages will be available soon.

live preview available [here](https://carzh.github.io/onnxruntime/)