### PR TITLE
Fix SkipLayerNorm for 2D input

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
@@ -112,7 +112,7 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
         hidden_size,
         row_count,
         skip_broadcasted,
-        skip_size);        
+        skip_size);
   }
 
   CUDA_RETURN_IF_ERROR(cudaGetLastError());

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
@@ -137,8 +137,7 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
     return Status::OK();
   }
 
-  int sequence_length = static_cast<int>(input_dims[1]);
-  int64_t element_count = input_dims[0] * sequence_length * hidden_size;
+  int64_t element_count = input->Shape().Size();
   size_t element_size = sizeof(T);
   typedef typename ToCudaType<T>::MappedType CudaT;
   return LaunchSkipLayerNormKernel<CudaT, Simplified>(

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
@@ -178,7 +178,7 @@ void LaunchSkipLayerNormKernel(
     cudaStream_t stream, T* output, T* skip_input_bias_add_output, const T* input, const T* skip, const T* gamma,
     const T* beta, const T* bias, float epsilon, int ld, int row_count, bool skip_broadcasted, int skip_size) {
   if (row_count == 0) {
-    return Status::OK();
+    return;
   }
 
   bool hasBias = (bias == nullptr) ? false : true;

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
@@ -9,7 +9,7 @@ namespace contrib {
 namespace cuda {
 
 template <typename T, bool Simplified>
-Status LaunchSkipLayerNormKernel(
+void LaunchSkipLayerNormKernel(
     cudaStream_t stream,
     T* output,                      // normalized output tensor
     T* skip_input_bias_add_output,  // sum of the input and skip (and bias if it exists) tensors output
@@ -20,8 +20,7 @@ Status LaunchSkipLayerNormKernel(
     const T* bias,                  // Layer normalization beta tensor
     float epsilon,                  // Layer normalization epsilon
     int hidden_size,                // hidden size, it is the leading dimension (ld)
-    int element_count,              // number of elements in input tensor
-    size_t element_size);
+    int row_count);                 // number of rows. That is total number of elements divided by hidden size.
 
 }  // namespace cuda
 }  // namespace contrib


### PR DESCRIPTION
### Description

Fix an obvious bug:
(1) In packing mode, the input for SLN has two dimensions (introduced by #15283): [token_count, hidden_size]. Current code of `element_count = input_dims[0] * sequence_length * hidden_size` will use element_size = token_count * hidden_size * hidden_size, and causes invalid memory write in cuda kernel and ORT crash

and two minor issues:
(2) potential integer overflow in `static_cast<int>(element_count)`
(3) some dead code after `return LaunchSkipLayerNormKernel` that will never have chance to run.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


