### PR TITLE
[CUDA][ROCm] Allow allocating ScratchBuffer from TuningContext

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention.cc
@@ -228,7 +228,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   data.cumulated_sequence_length_q_cache = nullptr;
   data.cumulated_sequence_length_kv_cache = nullptr;
 
-  return QkvToContext<CudaT>(device_prop, cublas, Stream(context), parameters, data);
+  return QkvToContext<CudaT>(device_prop, cublas, context->GetComputeStream(), parameters, data);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_impl.h
@@ -84,13 +84,13 @@ template <typename T>
 Status QkvToContext(
     const cudaDeviceProp& device_prop,
     cublasHandle_t& cublas,
-    cudaStream_t stream,
+    Stream* stream,
     contrib::AttentionParameters& parameters,
     AttentionData<T>& data);
 
 Status LaunchDecoderAttentionKernel(
     const cudaDeviceProp& prop,       // Device Properties
-    cudaStream_t stream,              // Cuda stream
+    Stream* stream,                   // ORT Stream
     cublasHandle_t& cublas,           // Cublas handle
     const size_t element_size,        // Element size of input tensor
     const int batch_size,             // Batch size (B)

--- a/onnxruntime/contrib_ops/cuda/bert/attention_softmax.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_softmax.cu
@@ -797,7 +797,7 @@ Status ComputeSoftmaxWithMask1D(cudaStream_t stream,
 }
 
 template <typename T>
-Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
+Status ComputeSoftmaxWithRawMask(Stream* ort_stream,
                                  const int all_sequence_length,
                                  const int sequence_length,
                                  const int batch_size,
@@ -815,6 +815,7 @@ Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
                                  const bool use_persistent_softmax,
                                  T* persistent_softmax_workspace,
                                  const float mask_filter_value) {
+  auto stream = static_cast<cudaStream_t>(ort_stream->GetHandle());
   const dim3 grid(sequence_length * num_heads, batch_size, 1);
 
   T* out = use_persistent_softmax ? persistent_softmax_workspace : output;
@@ -873,7 +874,7 @@ Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
 
   if (use_persistent_softmax) {
     return onnxruntime::cuda::dispatch_warpwise_softmax_forward<T, T, float, false>(
-        stream,
+        ort_stream,
         output,
         persistent_softmax_workspace,
         all_sequence_length,
@@ -941,7 +942,7 @@ template Status ComputeSoftmaxWithMask1D<half>(cudaStream_t stream,
                                                half* output,
                                                const bool causal);
 
-template Status ComputeSoftmaxWithRawMask<float>(cudaStream_t stream,
+template Status ComputeSoftmaxWithRawMask<float>(Stream* ort_stream,
                                                  const int all_sequence_length,
                                                  const int sequence_length,
                                                  const int batch_size,
@@ -960,7 +961,7 @@ template Status ComputeSoftmaxWithRawMask<float>(cudaStream_t stream,
                                                  float* persistent_softmax_workspace,
                                                  const float mask_filter_value);
 
-template Status ComputeSoftmaxWithRawMask<half>(cudaStream_t stream,
+template Status ComputeSoftmaxWithRawMask<half>(Stream* ort_stream,
                                                 const int all_sequence_length,
                                                 const int sequence_length,
                                                 const int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_softmax.h
@@ -38,7 +38,7 @@ Status ComputeSoftmaxWithMask1D(cudaStream_t stream,
                                 const bool causal);
 
 template <typename T>
-Status ComputeSoftmaxWithRawMask(cudaStream_t stream,
+Status ComputeSoftmaxWithRawMask(Stream* ort_stream,
                                  const int all_sequence_length,
                                  const int sequence_length,
                                  const int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/decoder_attention.cc
@@ -369,7 +369,7 @@ Status DecoderAttention<T>::ComputeInternal(OpKernelContext* context) const {
 #ifdef USE_ROCM
       GetTuningContext(),
 #endif
-      stream,
+      context->GetComputeStream(),
       cublas,
       element_size,
       batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/multihead_attention.cc
@@ -251,7 +251,7 @@ Status MultiHeadAttention<T>::ComputeInternal(OpKernelContext* context) const {
   cublasHandle_t cublas = GetCublasHandle(context);
 
   return QkvToContext<CudaT>(
-      device_prop, cublas, Stream(context), parameters, data);
+      device_prop, cublas, context->GetComputeStream(), parameters, data);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/attention_quantization.cc
@@ -215,7 +215,7 @@ Status QAttention<T, int8_t>::ComputeInternal(OpKernelContext* context) const {
   data.cumulated_sequence_length_q_cache = nullptr;
   data.cumulated_sequence_length_kv_cache = nullptr;
 
-  return QkvToContext<CudaT>(GetDeviceProp(), cublas, Stream(context), parameters, data);
+  return QkvToContext<CudaT>(GetDeviceProp(), cublas, context->GetComputeStream(), parameters, data);
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -417,7 +417,7 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   const CudaT* X_data = is_reuse_logits_buffer ? logits_data : reinterpret_cast<const CudaT*>(next_token_logits.data());
 
   ORT_RETURN_IF_ERROR((dispatch_blockwise_softmax_forward<CudaT, float, float, true>(
-      cuda_stream, Y_data, X_data, vocab_size,
+      ort_stream, Y_data, X_data, vocab_size,
       is_reuse_logits_buffer ? padded_vocab_size : vocab_size,
       vocab_size,
       batch_size * num_beams)));
@@ -865,7 +865,7 @@ Status GreedySearchProcessLogits(
 
   if (do_sampling) {
     ORT_RETURN_IF_ERROR(SamplingCudaHelper::Sample(allocator,
-                                                   cuda_stream,
+                                                   stream,
                                                    next_token_scores,
                                                    sampling_state,
                                                    greedy_state,

--- a/onnxruntime/contrib_ops/cuda/transformers/sampling_cuda_helper.h
+++ b/onnxruntime/contrib_ops/cuda/transformers/sampling_cuda_helper.h
@@ -20,7 +20,7 @@ namespace SamplingCudaHelper {
 
 template <typename T>
 Status Sample(AllocatorPtr& allocator,
-              cudaStream_t cuda_stream,
+              Stream* stream,
               gsl::span<T>& next_token_scores,
               transformers::ISamplingState<T>* sampling_state,
               transformers::IGreedySearchState<T>* greedy_state,
@@ -29,6 +29,8 @@ Status Sample(AllocatorPtr& allocator,
               const transformers::IConsoleDumper* dumper) {
   ORT_UNUSED_PARAMETER(dumper);
   typedef typename ToCudaType<T>::MappedType CudaT;
+
+  auto cuda_stream = static_cast<cudaStream_t>(stream->GetHandle());
 
   gsl::span<int>& d_index_in = sampling_state->d_index_in;
   gsl::span<int>& d_offset = sampling_state->d_offset;
@@ -91,7 +93,7 @@ Status Sample(AllocatorPtr& allocator,
 #endif
 
   gsl::span<float>& d_sorted_softmaxed_score = sampling_state->d_sorted_softmaxed_score;
-  ORT_RETURN_IF_ERROR((dispatch_blockwise_softmax_forward<CudaT, float, float, false>(cuda_stream,
+  ORT_RETURN_IF_ERROR((dispatch_blockwise_softmax_forward<CudaT, float, float, false>(stream,
                                                                                       d_sorted_softmaxed_score.data(),
                                                                                       reinterpret_cast<CudaT*>(d_sorted_score.data()),
                                                                                       parameters->vocab_size,
@@ -125,7 +127,7 @@ Status Sample(AllocatorPtr& allocator,
 #endif
 
   gsl::span<float>& d_softmaxed_score = sampling_state->d_softmaxed_score;
-  ORT_RETURN_IF_ERROR((dispatch_blockwise_softmax_forward<CudaT, float, float, false>(cuda_stream,
+  ORT_RETURN_IF_ERROR((dispatch_blockwise_softmax_forward<CudaT, float, float, false>(stream,
                                                                                       d_softmaxed_score.data(),
                                                                                       reinterpret_cast<CudaT*>(next_token_scores.data()),
                                                                                       parameters->vocab_size,

--- a/onnxruntime/contrib_ops/rocm/bert/attention.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/attention.cu
@@ -112,7 +112,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   {
     auto& params = gemm_permute_params;
     params.tuning_ctx = GetTuningContext();
-    params.stream = stream;
+    params.stream = context->GetComputeStream();
     params.handle = rocblas;
     params.attention = &attn;
     params.device_prop = &device_prop;
@@ -178,7 +178,7 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   {
     auto& params = gemm_softmax_gemm_permute_params;
     params.tuning_ctx = GetTuningContext();
-    params.stream = Stream(context);
+    params.stream = context->GetComputeStream();
     params.handle = rocblas;
     params.attention = &attn;
     params.device_prop = &device_prop;

--- a/onnxruntime/contrib_ops/rocm/bert/attention_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/attention_impl.cu
@@ -180,7 +180,7 @@ template <typename T>
 Status DecoderQkvToContext(
     const hipDeviceProp_t& prop,
     RocmTuningContext* tuning_ctx,
-    hipStream_t stream,
+    Stream* ort_stream,
     rocblas_handle& rocblas,
     const size_t element_size,
     const int batch_size,
@@ -211,6 +211,7 @@ Status DecoderQkvToContext(
   const int v_buffer_offset = (sequence_length + kv_sequence_length) * BHN;
 
   T* temp_qkv_buffer = workspace_buffer;
+  auto stream = static_cast<hipStream_t>(ort_stream->GetHandle());
 
   const T* q = qkv_buffer;
   // transpose q and copy them to qkv_buffer
@@ -282,7 +283,7 @@ Status DecoderQkvToContext(
   const int strideB = sequence_length * head_size;
   if (use_past && static_kv) {
     ORT_RETURN_IF_ERROR(blas::column_major::StridedBatchedGemm(
-        tuning_ctx, stream, rocblas,
+        tuning_ctx, ort_stream, rocblas,
         blas::BlasOp::Trans, blas::BlasOp::NonTrans,
         kv_sequence_length, sequence_length, head_size,
         /*alpha=*/rsqrt_head_size,
@@ -293,7 +294,7 @@ Status DecoderQkvToContext(
         BN));
   } else {
     ORT_RETURN_IF_ERROR(blas::column_major::StridedBatchedGemm(
-        tuning_ctx, stream, rocblas,
+        tuning_ctx, ort_stream, rocblas,
         blas::BlasOp::Trans, blas::BlasOp::NonTrans,
         kv_sequence_length, sequence_length, head_size,
         /*alpha=*/rsqrt_head_size,
@@ -307,7 +308,7 @@ Status DecoderQkvToContext(
   if (has_key_padding_mask) {
     int3 strides = Get2DMaskStrides(kv_sequence_length);
     ORT_RETURN_IF_ERROR(ComputeSoftmaxWithRawMask<T>(
-        stream, kv_sequence_length, sequence_length, batch_size, num_heads,
+        ort_stream, kv_sequence_length, sequence_length, batch_size, num_heads,
         strides, nullptr, key_padding_mask, nullptr, scratch1, scratch2,
         false, 1.0f, false, nullptr, mask_filter_value));
   } else {
@@ -318,7 +319,7 @@ Status DecoderQkvToContext(
   // compute P*V (as V*P), and store in scratch3: BxNxSxH
   if (use_past && static_kv) {
     ORT_RETURN_IF_ERROR(blas::column_major::StridedBatchedGemm(
-        tuning_ctx, stream, rocblas,
+        tuning_ctx, ort_stream, rocblas,
         blas::BlasOp::NonTrans, blas::BlasOp::NonTrans,
         head_size, sequence_length, kv_sequence_length,
         /*alpha=*/1.0f,
@@ -329,7 +330,7 @@ Status DecoderQkvToContext(
         BN));
   } else {
     ORT_RETURN_IF_ERROR(blas::column_major::StridedBatchedGemm(
-        tuning_ctx, stream, rocblas,
+        tuning_ctx, ort_stream, rocblas,
         blas::BlasOp::NonTrans, blas::BlasOp::NonTrans,
         head_size, sequence_length, kv_sequence_length,
         /*alpha=*/1.0f,
@@ -348,7 +349,7 @@ Status DecoderQkvToContext(
 Status LaunchDecoderAttentionKernel(
     const hipDeviceProp_t& prop,
     RocmTuningContext* tuning_ctx,
-    hipStream_t stream,
+    Stream* stream,
     rocblas_handle& rocblas,
     const size_t element_size,
     const int batch_size,

--- a/onnxruntime/contrib_ops/rocm/bert/attention_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/attention_impl.h
@@ -31,7 +31,7 @@ size_t GetAttentionWorkspaceSize(
 Status LaunchDecoderAttentionKernel(
     const hipDeviceProp_t& prop,      // Device Properties
     RocmTuningContext* tuning_ctx,    // context for tuning
-    hipStream_t stream,               // Hip stream
+    Stream* stream,                   // ORT Stream
     rocblas_handle& rocblas,          // Rocblas handle
     const size_t element_size,        // Element size of input tensor
     const int batch_size,             // Batch size (B)

--- a/onnxruntime/contrib_ops/rocm/bert/batched_gemm_permute_pipelines.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/batched_gemm_permute_pipelines.cuh
@@ -107,7 +107,7 @@ struct GemmPermuteGenericPipeline {
     auto* attn = params->attention;
     // input should be BxSx3xNxH => gemm_buffer: 3xBxNxSxH
     return LaunchTransQkv(
-        params->Stream(), 3, attn->sequence_length, attn->batch_size, attn->head_size, attn->num_heads,
+        params->StreamHandle(), 3, attn->sequence_length, attn->batch_size, attn->head_size, attn->num_heads,
         params->device_prop->maxThreadsPerBlock, false, params->workspace_buffer, params->out_buffer);
   }
 

--- a/onnxruntime/contrib_ops/rocm/bert/batched_gemm_softmax_gemm_permute_pipelines.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/batched_gemm_softmax_gemm_permute_pipelines.cuh
@@ -498,7 +498,7 @@ struct GemmSoftmaxGemmPermuteGenericPipeline {
     auto [gemm1_out, softmax_out, gemm2_out] = GetWorkspacePlan(params);
     const int* mask_start = (mask_1d_size > attn->batch_size) ? mask_1d + attn->batch_size : nullptr;
     return ComputeSoftmaxWithMask1D<T>(
-        params->Stream(), attn->total_sequence_length, attn->sequence_length, attn->batch_size, attn->num_heads,
+        params->StreamHandle(), attn->total_sequence_length, attn->sequence_length, attn->batch_size, attn->num_heads,
         mask_1d, mask_start, params->bias_buffer, gemm1_out, softmax_out, attn->is_unidirectional);
   }
 
@@ -507,7 +507,7 @@ struct GemmSoftmaxGemmPermuteGenericPipeline {
     auto attn = params->attention;
     auto [gemm1_out, softmax_out, gemm2_out] = GetWorkspacePlan(params);
     return ComputeSoftmax<T>(
-        params->Stream(), attn->total_sequence_length, attn->sequence_length, attn->batch_size, attn->num_heads,
+        params->StreamHandle(), attn->total_sequence_length, attn->sequence_length, attn->batch_size, attn->num_heads,
         params->bias_buffer, gemm1_out, softmax_out, attn->is_unidirectional);
   }
 
@@ -540,7 +540,7 @@ struct GemmSoftmaxGemmPermuteGenericPipeline {
     auto attn = params->attention;
     auto [gemm1_out, softmax_out, gemm2_out] = GetWorkspacePlan(params);
     return LaunchTransCtx(
-        params->Stream(),
+        params->StreamHandle(),
         attn->sequence_length, attn->batch_size, attn->head_size, attn->num_heads,
         params->device_prop->maxThreadsPerBlock, false, gemm2_out, params->out_buffer);
   }
@@ -721,7 +721,7 @@ class GemmSoftmaxGemmPermuteTunableOp : public tunable::TunableOp<GemmSoftmaxGem
       return v == 1 ? 0 : mask_filter_value;
     };
 
-    ConvertToFilledMaskValue<kVecSize><<<num_blocks, kThreadPerBlock, 0, params->Stream()>>>(
+    ConvertToFilledMaskValue<kVecSize><<<num_blocks, kThreadPerBlock, 0, params->StreamHandle()>>>(
         reinterpret_cast<T*>(params->workspace_buffer), {lengths.y * lengths.z, lengths.z, 1},  // out desc
         buffer, lengths, strides,                                                               // mask desc
         cvt);
@@ -843,7 +843,7 @@ auto GetCKGemmSoftmaxGemmPermuteTypeStringAndOps() {
       if constexpr (USE_MASK) {
         ORT_RETURN_IF_ERROR(GemmSoftmaxGemmPermuteTunableOp<T>::LaunchConvertToFilledMaskValue(params));
       }
-      invoker->Run(arg.get(), StreamConfig{params->Stream()});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(op)));

--- a/onnxruntime/contrib_ops/rocm/bert/elementwise.h
+++ b/onnxruntime/contrib_ops/rocm/bert/elementwise.h
@@ -11,7 +11,7 @@ namespace contrib {
 namespace rocm {
 
 template <typename Fn, typename T>
-Status LaunchElementwiseKernel(RocmTuningContext* tuning_ctx, hipStream_t stream,
+Status LaunchElementwiseKernel(RocmTuningContext* tuning_ctx, Stream* stream,
                                const T* input, int input_length,
                                const T* bias, int bias_length,
                                T* output);
@@ -21,7 +21,7 @@ namespace internal {
 
 template <typename T>
 struct ElementwiseParams : OpParams {
-  ElementwiseParams(RocmTuningContext* tuning_ctx, hipStream_t stream,
+  ElementwiseParams(RocmTuningContext* tuning_ctx, onnxruntime::Stream* stream,
                     const T* input, const T* bias, T* output, int input_length, int bias_length)
       : OpParams(tuning_ctx, stream),
         input(input),

--- a/onnxruntime/contrib_ops/rocm/bert/fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/fast_gelu.cc
@@ -48,7 +48,7 @@ Status FastGelu<T>::ComputeInternal(OpKernelContext* context) const {
   const HipT* input_buffer = reinterpret_cast<const HipT*>(input->Data<T>());
   const HipT* bias_buffer = (nullptr != bias) ? reinterpret_cast<const HipT*>(bias->Data<T>()) : nullptr;
   return LaunchElementwiseKernel<functor::FastGeLU, HipT>(
-      GetTuningContext(), Stream(context),
+      GetTuningContext(), context->GetComputeStream(),
       input_buffer, static_cast<int>(input_length),
       bias_buffer, static_cast<int>(bias_length),
       reinterpret_cast<HipT*>(output->MutableData<T>()));

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu.cc
@@ -58,8 +58,7 @@ Status GemmFastGelu<T>::ComputeInternal(OpKernelContext* ctx) const {
   using onnxruntime::rocm::tunable::blas::BlasOp;
 
   return blas::row_major::GemmFastGelu(
-      GetTuningContext(),
-      Stream(ctx), GetRocblasHandle(ctx),
+      GetTuningContext(), ctx->GetComputeStream(), GetRocblasHandle(ctx),
       transa ? BlasOp::Trans : BlasOp::NonTrans,
       transb ? BlasOp::Trans : BlasOp::NonTrans,
       helper.M(), helper.N(), helper.K(),

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_ck.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_ck.cuh
@@ -68,7 +68,7 @@ auto GetCKGemmAddFastGeluTypeStringAndOps() {
                                            nop, nop, addfastgelu);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemmfastgelu_op)));
@@ -109,7 +109,7 @@ auto GetCKGemmFastGeluTypeStringAndOps() {
                                            nop, nop, fastgelu);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemmfastgelu_op)));

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_impl.h
@@ -14,7 +14,7 @@ namespace blas {
 
 #define GEMMFASTGELU(T, ScalarT)                                                 \
   common::Status GemmFastGelu(                                                   \
-      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle,  \
+      RocmTuningContext* tuning_ctx, Stream* stream, rocblas_handle handle,      \
       BlasOp opa, BlasOp opb,                                                    \
       std::int64_t m, std::int64_t n, std::int64_t k,                            \
       ScalarT alpha, const T* a, std::int64_t lda, const T* b, std::int64_t ldb, \

--- a/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_tunable.cuh
+++ b/onnxruntime/contrib_ops/rocm/bert/gemm_fast_gelu_tunable.cuh
@@ -45,7 +45,7 @@ Status GemmFastGeluUnfused(const GemmFastGeluParams<T>* params) {
   // Note: If any change cause directly usage of GemmFastGeluUnfused, add PreTuning() and PostTuning() in FastGeluTunableOp
   // to protect original input value.
   return onnxruntime::contrib::rocm::LaunchElementwiseKernel<functor::FastGeLU, T>(
-      params->tuning_ctx, params->stream,
+      params->tuning_ctx, params->Stream(),
       params->c, static_cast<int>(fast_gelu_input_length),
       params->bias, static_cast<int>(bias_length),
       params->c);

--- a/onnxruntime/contrib_ops/rocm/bert/multihead_attention.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/multihead_attention.cu
@@ -241,7 +241,7 @@ Status MultiHeadAttention<T>::ComputeInternal(OpKernelContext* context) const {
 
   GemmSoftmaxGemmPermuteParams<HipT> params;
   params.tuning_ctx = GetTuningContext();
-  params.stream = stream;
+  params.stream = context->GetComputeStream();
   params.handle = GetRocblasHandle(context);
   params.attention = &attn;
   params.device_prop = &device_prop;

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm.cc
@@ -104,7 +104,7 @@ Status SkipLayerNorm<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   return LaunchSkipLayerNormKernel<HipT, float, HipT>(
       GetTuningContext(),
-      Stream(ctx),
+      ctx->GetComputeStream(),
       reinterpret_cast<HipT*>(output->MutableData<T>()),
       skip_input_bias_add_output != nullptr ? reinterpret_cast<HipT*>(skip_input_bias_add_output->MutableData<T>()) : nullptr,
       reinterpret_cast<const HipT*>(input->Data<T>()),

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.cu
@@ -41,7 +41,7 @@ namespace rocm {
 
 template <typename T, typename U, typename V>
 Status LaunchSkipLayerNormKernel(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, V* output, T* skip_input_bias_add_output, const T* input,
+    RocmTuningContext* tuning_ctx, Stream* stream, V* output, T* skip_input_bias_add_output, const T* input,
     const T* skip, const V* gamma, const V* beta, const T* bias, float epsilon, int ld, int element_count) {
   // this must be true because element_count is the total size of the tensor
   assert(element_count % ld == 0);
@@ -58,13 +58,13 @@ Status LaunchSkipLayerNormKernel(
 }
 
 template Status LaunchSkipLayerNormKernel<float, float, float>(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, float* output, float* skip_input_bias_add_output, const float* input,
+    RocmTuningContext* tuning_ctx, Stream* stream, float* output, float* skip_input_bias_add_output, const float* input,
     const float* skip, const float* gamma, const float* beta,
     const float* bias, float epsilon, int ld,
     int element_count);
 
 template Status LaunchSkipLayerNormKernel<half, float, half>(
-    RocmTuningContext* tuning_ctx, hipStream_t stream, half* output, half* skip_input_bias_add_output, const half* input,
+    RocmTuningContext* tuning_ctx, Stream* stream, half* output, half* skip_input_bias_add_output, const half* input,
     const half* skip, const half* gamma, const half* beta,
     const half* bias, float epsilon, int ld,
     int element_count);

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_impl.h
@@ -13,7 +13,7 @@ namespace rocm {
 template <typename T, typename U, typename V>
 Status LaunchSkipLayerNormKernel(
     RocmTuningContext* tuning,
-    hipStream_t stream,
+    Stream* stream,
     V* output,                      // output tensor
     T* skip_input_bias_add_output,  // optional output tensor
     const T* input,                 // input tensor

--- a/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
+++ b/onnxruntime/contrib_ops/rocm/bert/skip_layer_norm_tunable_op.h
@@ -20,7 +20,7 @@ namespace rocm {
 
 template <typename T, typename V>
 struct SkipLayerNormParams : OpParams {
-  SkipLayerNormParams(RocmTuningContext* tuning_ctx, hipStream_t stream, V* output, T* skip_input_bias_add_output, const T* input,
+  SkipLayerNormParams(RocmTuningContext* tuning_ctx, onnxruntime::Stream* stream, V* output, T* skip_input_bias_add_output, const T* input,
                       const T* skip, const V* gamma, const V* beta,
                       const T* bias, float epsilon, int ld, int element_count)
       : OpParams(tuning_ctx, stream), output(output), skip_input_bias_add_output(skip_input_bias_add_output), input(input), skip(skip), gamma(gamma), beta(beta), bias(bias), epsilon(epsilon), ld(ld), element_count(element_count) {}
@@ -51,7 +51,7 @@ Status SkipLayerNormSmallOp(const SkipLayerNormParams<T, V>* params) {
          params->ld <= ThreadsPerBlock * VecSize && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)));
   SkipLayerNormKernelSmall<T, U, V, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
                                                                 dim3(ThreadsPerBlock),
-                                                                0, params->stream>>>(
+                                                                0, params->StreamHandle()>>>(
       params->ld, params->input, params->skip,
       params->beta, params->gamma, params->bias, static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output,
       (params->bias == nullptr) ? false : true, (params->skip_input_bias_add_output == nullptr) ? false : true);
@@ -66,7 +66,7 @@ Status SkipLayerNormRegularOp(const SkipLayerNormParams<T, V>* params) {
           (params->ld < GPU_WARP_SIZE && params->ld > (ThreadsPerBlock - GPU_WARP_SIZE) * VecSize)))));
   SkipLayerNormKernelVec<T, U, V, ThreadsPerBlock, VecSize><<<dim3(CeilDiv(params->element_count, params->ld)),
                                                               dim3(ThreadsPerBlock),
-                                                              0, params->stream>>>(
+                                                              0, params->StreamHandle()>>>(
       params->ld, params->input, params->skip,
       params->beta, params->gamma, params->bias, static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output,
       (params->bias == nullptr) ? false : true, (params->skip_input_bias_add_output == nullptr) ? false : true);
@@ -80,13 +80,13 @@ Status SkipLayerNormStaticSelection(const SkipLayerNormParams<T, V>* params) {
   const int grid_size = params->element_count / params->ld;
   const int block_size = 256;
 
-#define LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(ELEMENTS, TPB, ILP)                               \
-  if (params->ld <= ELEMENTS) {                                                              \
-    SkipLayerNormKernelSmall<T, U, V, TPB, ILP><<<grid_size, TPB, 0, params->stream>>>(      \
-        params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,  \
-        static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output, \
-        hasBias, hasSkipInputBiasAdditionOutput);                                            \
-    break;                                                                                   \
+#define LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(ELEMENTS, TPB, ILP)                                  \
+  if (params->ld <= ELEMENTS) {                                                                 \
+    SkipLayerNormKernelSmall<T, U, V, TPB, ILP><<<grid_size, TPB, 0, params->StreamHandle()>>>( \
+        params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,     \
+        static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output,    \
+        hasBias, hasSkipInputBiasAdditionOutput);                                               \
+    break;                                                                                      \
   }
   if (0 == (params->ld % 4)) {
     do {
@@ -97,7 +97,7 @@ Status SkipLayerNormStaticSelection(const SkipLayerNormParams<T, V>* params) {
       LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(768, 192, 4)
       LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(1024, 256, 4)
 
-      SkipLayerNormKernel<T, U, V, block_size><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernel<T, U, V, block_size><<<grid_size, block_size, 0, params->StreamHandle()>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
           static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output);
     } while (0);
@@ -108,7 +108,7 @@ Status SkipLayerNormStaticSelection(const SkipLayerNormParams<T, V>* params) {
       LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(128, 128, 1)
       LAUNCH_SKIPLAYERNORM_SMALL_FORWARD(384, 384, 1)
 
-      SkipLayerNormKernel<T, U, V, block_size><<<grid_size, block_size, 0, params->stream>>>(
+      SkipLayerNormKernel<T, U, V, block_size><<<grid_size, block_size, 0, params->StreamHandle()>>>(
           params->ld, params->input, params->skip, params->beta, params->gamma, params->bias,
           static_cast<U>(params->epsilon), params->output, params->skip_input_bias_add_output);
     } while (0);

--- a/onnxruntime/contrib_ops/rocm/diffusion/group_norm.cc
+++ b/onnxruntime/contrib_ops/rocm/diffusion/group_norm.cc
@@ -21,7 +21,7 @@ namespace {
 template <typename T>
 struct DispatchGroupNorm {
   Status operator()(RocmTuningContext* tuning_ctx,
-                    hipStream_t stream,
+                    Stream* stream,
                     Tensor* output,
                     const Tensor* input,
                     const Tensor* gamma,
@@ -130,7 +130,7 @@ Status GroupNorm::ComputeInternal(OpKernelContext* context) const {
   auto workspace = GetScratchBuffer<void>(GetGroupNormWorkspaceSizeInBytes(), context->GetComputeStream());
 
   utils::MLTypeCallDispatcher<GROUP_NORM_TYPES> dispatcher(input->GetElementType());
-  return dispatcher.InvokeRet<Status, DispatchGroupNorm>(GetTuningContext(), Stream(context),
+  return dispatcher.InvokeRet<Status, DispatchGroupNorm>(GetTuningContext(), context->GetComputeStream(),
                                                          output, input, gamma, beta, workspace.get(),
                                                          epsilon_,
                                                          batch_size,

--- a/onnxruntime/contrib_ops/rocm/diffusion/group_norm_ck.cuh
+++ b/onnxruntime/contrib_ops/rocm/diffusion/group_norm_ck.cuh
@@ -80,7 +80,7 @@ auto GetCKGroupNormNHWCTypeStringAndOps() {
                                            activation);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_group_norm_op)));

--- a/onnxruntime/contrib_ops/rocm/diffusion/group_norm_common.h
+++ b/onnxruntime/contrib_ops/rocm/diffusion/group_norm_common.h
@@ -35,7 +35,7 @@ int32_t findMaxDivisor(int32_t n, int32_t maxAllowedDivisor) {
 
 template <typename T>
 struct GroupNormNHWCParams : OpParams {
-  GroupNormNHWCParams(RocmTuningContext* tuning_ctx, hipStream_t stream, T* dst, float* redBuffer, const T* src, const float* gamma,
+  GroupNormNHWCParams(RocmTuningContext* tuning_ctx, onnxruntime::Stream* stream, T* dst, float* redBuffer, const T* src, const float* gamma,
                       const float* beta, int32_t n, int32_t h, int32_t w, int32_t c, int32_t groups, float epsilon, bool withSwish)
       : OpParams(tuning_ctx, stream), dst(dst), src(src), gamma(gamma), beta(beta), redBuffer(redBuffer), epsilon(epsilon), n(n), h(h), w(w), c(c), groups(groups), withSwish(withSwish) {
     int32_t maxBlocksPerHW = 1024;

--- a/onnxruntime/contrib_ops/rocm/diffusion/group_norm_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/diffusion/group_norm_impl.cu
@@ -15,7 +15,7 @@ namespace rocm {
 template <typename T>
 Status LaunchGroupNormKernel(
     RocmTuningContext* tuning_ctx,
-    hipStream_t stream,
+    Stream* stream,
     T* output,
     const T* input,
     const float* gamma,
@@ -49,12 +49,12 @@ Status LaunchGroupNormKernel(
   return GroupNormNHWCStaticSelection(&params);
 }
 
-template Status LaunchGroupNormKernel<half>(RocmTuningContext* tuning_ctx, hipStream_t stream, half* output,
+template Status LaunchGroupNormKernel<half>(RocmTuningContext* tuning_ctx, Stream* stream, half* output,
                                             const half* input, const float* gamma, const float* beta, void* workspace,
                                             float epsilon, int batch_size, int num_channels,
                                             int height, int width, int num_groups, bool swish);
 
-template Status LaunchGroupNormKernel<float>(RocmTuningContext* tuning_ctx, hipStream_t stream, float* output,
+template Status LaunchGroupNormKernel<float>(RocmTuningContext* tuning_ctx, Stream* stream, float* output,
                                              const float* input, const float* gamma, const float* beta, void* workspace,
                                              float epsilon, int batch_size, int num_channels,
                                              int height, int width, int num_groups, bool swish);

--- a/onnxruntime/contrib_ops/rocm/diffusion/group_norm_impl.h
+++ b/onnxruntime/contrib_ops/rocm/diffusion/group_norm_impl.h
@@ -27,7 +27,7 @@ constexpr size_t GetGroupNormWorkspaceSizeInBytes() {
 template <typename T>
 Status LaunchGroupNormKernel(
     RocmTuningContext* tuning_ctx,
-    hipStream_t stream,
+    Stream* stream,
     T* output,                 // normalized output tensor
     const T* input,            // input tensor
     const float* gamma,        // gamma (also known as weight or scale)

--- a/onnxruntime/core/framework/tuning_context.h
+++ b/onnxruntime/core/framework/tuning_context.h
@@ -7,6 +7,7 @@
 
 #include "core/common/common.h"
 #include "core/platform/ort_mutex.h"
+#include "core/framework/allocator.h"
 #include "core/framework/tuning_results.h"
 
 namespace onnxruntime {
@@ -48,8 +49,11 @@ class ITuningContext {
   virtual TuningResults GetTuningResults() const;
   virtual Status LoadTuningResults(const TuningResults& tr);
 
+  void RegisterAllocatorsView(const AllocatorMap* allocators) { allocators_ = allocators; }
+
  protected:
   IExecutionProvider* ep_;
+  const AllocatorMap* allocators_;
 };
 
 class TuningResultsManager {

--- a/onnxruntime/core/providers/cuda/math/softmax.cc
+++ b/onnxruntime/core/providers/cuda/math/softmax.cc
@@ -13,7 +13,7 @@ namespace cuda {
 
 template <typename T, typename TOut, bool is_log_softmax>
 Status SoftMaxComputeHelper(
-    cudaStream_t stream,
+    Stream* stream,
     const T* X,
     const TensorShape& input_shape,
     TOut* Y,
@@ -40,9 +40,9 @@ Status SoftMaxComputeHelper(
 }
 
 #define SPECIALIZED_SOFTMAX_HELPER_IMPL(T, TOut)                                                         \
-  template Status SoftMaxComputeHelper<T, TOut, false>(cudaStream_t stream, const T* input,              \
+  template Status SoftMaxComputeHelper<T, TOut, false>(Stream * stream, const T* input,                  \
                                                        const TensorShape& shape, TOut* Y, int64_t axis); \
-  template Status SoftMaxComputeHelper<T, TOut, true>(cudaStream_t stream, const T* input,               \
+  template Status SoftMaxComputeHelper<T, TOut, true>(Stream * stream, const T* input,                   \
                                                       const TensorShape& shape, TOut* Y, int64_t axis);
 
 SPECIALIZED_SOFTMAX_HELPER_IMPL(MLFloat16, float)
@@ -178,11 +178,11 @@ Status Softmax<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   Status status;
   if (log_softmax_) {
-    status = SoftMaxComputeHelper<T, T, true>(Stream(ctx), X_data, *compute_input_shape, Y_data,
+    status = SoftMaxComputeHelper<T, T, true>(ctx->GetComputeStream(), X_data, *compute_input_shape, Y_data,
                                               is_transpose_required ? static_cast<int64_t>(rank) - 1
                                                                     : static_cast<int64_t>(axis));
   } else {
-    status = SoftMaxComputeHelper<T, T, false>(Stream(ctx), X_data, *compute_input_shape, Y_data,
+    status = SoftMaxComputeHelper<T, T, false>(ctx->GetComputeStream(), X_data, *compute_input_shape, Y_data,
                                                is_transpose_required ? static_cast<int64_t>(rank) - 1
                                                                      : static_cast<int64_t>(axis));
   }

--- a/onnxruntime/core/providers/cuda/math/softmax.h
+++ b/onnxruntime/core/providers/cuda/math/softmax.h
@@ -11,18 +11,18 @@ namespace cuda {
 
 template <typename T, typename TOut, bool is_log_softmax>
 Status SoftMaxComputeHelper(
-    cudaStream_t stream,
+    Stream* stream,
     const T* input,
     const TensorShape& shape,
     TOut* Y,
     int64_t axis);
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
-Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, const input_t* src,
+Status dispatch_warpwise_softmax_forward(Stream* stream, output_t* dst, const input_t* src,
                                          int softmax_elements, int softmax_elements_stride, int batch_count);
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
-Status dispatch_blockwise_softmax_forward(cudaStream_t stream, output_t* output, const input_t* input,
+Status dispatch_blockwise_softmax_forward(Stream* stream, output_t* output, const input_t* input,
                                           int softmax_elements, int input_stride, int output_stride, int batch_count);
 
 template <typename T>

--- a/onnxruntime/core/providers/cuda/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/softmax_impl.cu
@@ -29,8 +29,9 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
-Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, const input_t* src, int softmax_elements,
+Status dispatch_warpwise_softmax_forward(Stream* ort_stream, output_t* dst, const input_t* src, int softmax_elements,
                                          int softmax_elements_stride, int batch_count) {
+  auto stream = static_cast<cudaStream_t>(ort_stream->GetHandle());
   if (softmax_elements == 0) {
     return Status::OK();
   } else {
@@ -96,13 +97,13 @@ Status dispatch_warpwise_softmax_forward(cudaStream_t stream, output_t* dst, con
 }
 
 #define SPECIALIZED_WRAPWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                                               \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(cudaStream_t stream,         \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, false>(Stream* ort_stream,          \
                                                                                      output_t * dst,              \
                                                                                      const input_t* src,          \
                                                                                      int softmax_elements,        \
                                                                                      int softmax_elements_stride, \
                                                                                      int batch_count);            \
-  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(cudaStream_t stream,          \
+  template Status dispatch_warpwise_softmax_forward<input_t, output_t, acc_t, true>(Stream* ort_stream,           \
                                                                                     output_t * dst,               \
                                                                                     const input_t* src,           \
                                                                                     int softmax_elements,         \
@@ -116,8 +117,9 @@ SPECIALIZED_WRAPWISE_SOFTMAX_IMPL(double, double, double)
 SPECIALIZED_WRAPWISE_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 template <typename input_t, typename output_t, typename acc_t, bool is_log_softmax>
-Status dispatch_blockwise_softmax_forward(cudaStream_t stream, output_t* output, const input_t* input, int softmax_elements,
+Status dispatch_blockwise_softmax_forward(Stream* ort_stream, output_t* output, const input_t* input, int softmax_elements,
                                           int input_stride, int output_stride, int batch_count) {
+  auto stream = static_cast<cudaStream_t>(ort_stream->GetHandle());
   dim3 grid(batch_count);
   constexpr int ILP = sizeof(float4) / sizeof(input_t);
   dim3 block = SoftMax_getBlockSize(ILP, softmax_elements);
@@ -135,10 +137,10 @@ Status dispatch_blockwise_softmax_forward(cudaStream_t stream, output_t* output,
 
 #define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(input_t, output_t, acc_t)                    \
   template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, false>(  \
-      cudaStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
+      Stream* ort_stream, output_t * output, const input_t* src, int softmax_elements,  \
       int input_stride, int output_stride, int batch_count);                            \
   template Status dispatch_blockwise_softmax_forward<input_t, output_t, acc_t, true>(   \
-      cudaStream_t stream, output_t * output, const input_t* src, int softmax_elements, \
+      Stream* ort_stream, output_t * output, const input_t* src, int softmax_elements,  \
       int input_stride, int output_stride, int batch_count);
 
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(float, float, float)

--- a/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.cc
+++ b/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.cc
@@ -110,19 +110,17 @@ const TuningResultsValidator& CudaTuningContext::GetTuningResultsValidator() con
 }
 
 IAllocatorUniquePtr<void> CudaTuningContext::GetScratchBuffer(
-    size_t num_bytes, cudaStream_t stream, OrtMemType mem_type) const {
+    size_t num_bytes, Stream* stream, OrtMemType mem_type) const {
   if (num_bytes == 0) {
     return nullptr;
   }
 
-  OrtDevice dev = ep_->GetOrtDeviceByMemType(mem_type);
-  auto it = allocators_->find(dev);
+  auto it = allocators_->find(ep_->GetOrtDeviceByMemType(mem_type));
   if (it == allocators_->end()) {
     return nullptr;
   }
 
-  Stream ort_stream{stream, dev};
-  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, &ort_stream, WaitCudaNotificationOnDevice);
+  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, stream, WaitCudaNotificationOnDevice);
 }
 
 }  // namespace tunable

--- a/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.h
+++ b/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.h
@@ -49,6 +49,9 @@ class CudaTuningContext : public ITuningContext {
 
   const TuningResultsValidator& GetTuningResultsValidator() const override;
 
+  IAllocatorUniquePtr<void> GetScratchBuffer(
+      size_t bytes, cudaStream_t stream, OrtMemType mem_type = OrtMemTypeDefault) const;
+
  private:
   TunableOpInfo* info_;  // non-owning handle
   TuningResultsManager manager_;

--- a/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.h
+++ b/onnxruntime/core/providers/cuda/tunable/cuda_tuning_context.h
@@ -50,7 +50,7 @@ class CudaTuningContext : public ITuningContext {
   const TuningResultsValidator& GetTuningResultsValidator() const override;
 
   IAllocatorUniquePtr<void> GetScratchBuffer(
-      size_t bytes, cudaStream_t stream, OrtMemType mem_type = OrtMemTypeDefault) const;
+      size_t bytes, Stream* stream, OrtMemType mem_type = OrtMemTypeDefault) const;
 
  private:
   TunableOpInfo* info_;  // non-owning handle

--- a/onnxruntime/core/providers/cuda/tunable/math/gemm.cc
+++ b/onnxruntime/core/providers/cuda/tunable/math/gemm.cc
@@ -12,7 +12,7 @@ namespace tunable {
 template <typename T>
 GemmParams<T>::GemmParams(int m, int n, int k, bool trans_a, bool trans_b, float alpha, float beta,
                           const Gemm<T>* gemm_kernel, OpKernelContext* ctx)
-    : OpParams(gemm_kernel->GetTuningContext(), gemm_kernel->Stream(ctx)),
+    : OpParams(gemm_kernel->GetTuningContext(), ctx->GetComputeStream()),
       trans_a_(trans_a),
       trans_b_(trans_b),
       alpha_(alpha),

--- a/onnxruntime/core/providers/cuda/tunable/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/tunable/math/matmul.cc
@@ -12,7 +12,7 @@ namespace tunable {
 template <typename T>
 MatMulParams<T>::MatMulParams(float alpha, bool trans_a, bool trans_b, bool trans_batch_a, bool trans_batch_b,
                               MatMulComputeHelper& helper, const MatMul<T>* matmul_kernel, OpKernelContext* ctx)
-    : OpParams(matmul_kernel->GetTuningContext(), matmul_kernel->Stream(ctx)),
+    : OpParams(matmul_kernel->GetTuningContext(), ctx->GetComputeStream()),
       alpha_(alpha),
       trans_a_(trans_a),
       trans_b_(trans_b),

--- a/onnxruntime/core/providers/rocm/math/einsum_utils/einsum_auxiliary_ops.cc
+++ b/onnxruntime/core/providers/rocm/math/einsum_utils/einsum_auxiliary_ops.cc
@@ -53,7 +53,7 @@ Status MatMul(const T* input_1_data, const T* input_2_data, T* output_data,
   return blas::column_major::StridedBatchedGemm(
       static_cast<rocm::tunable::RocmTuningContext*>(
           static_cast<EinsumRocmAssets*>(einsum_rocm_assets)->rocm_ep_->GetTuningContext()),
-      static_cast<hipStream_t>(static_cast<EinsumRocmAssets*>(einsum_rocm_assets)->ort_stream_->GetHandle()),
+      static_cast<EinsumRocmAssets*>(einsum_rocm_assets)->ort_stream_,
       static_cast<EinsumRocmAssets*>(einsum_rocm_assets)->rocblas_handle_,
       blas::BlasOp::NonTrans, blas::BlasOp::NonTrans,
       N, M, K,

--- a/onnxruntime/core/providers/rocm/math/gemm.cc
+++ b/onnxruntime/core/providers/rocm/math/gemm.cc
@@ -96,7 +96,7 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
     } else if (b_shape.NumDimensions() == 1 || b_shape[0] == 1) {
       // B is (N,) or (1, N), broadcast using Y(N,M) = 1 * B(N,1) x ones(1,M) + 0 * Y
       ORT_RETURN_IF_ERROR(tunable::blas::column_major::Gemm(
-          GetTuningContext(), Stream(ctx), GetRocblasHandle(ctx),
+          GetTuningContext(), ctx->GetComputeStream(), GetRocblasHandle(ctx),
           tunable::blas::BlasOp::NonTrans,
           tunable::blas::BlasOp::NonTrans,
           N, M, 1,
@@ -108,7 +108,7 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
     } else if (b_shape.NumDimensions() == 2 && b_shape[1] == 1) {
       // B is (M, 1), broadcast using Y(N,M) = 1 * ones(N,1) x B(1,M) + 0 * Y
       ORT_RETURN_IF_ERROR(tunable::blas::column_major::Gemm(
-          GetTuningContext(), Stream(ctx), GetRocblasHandle(ctx),
+          GetTuningContext(), ctx->GetComputeStream(), GetRocblasHandle(ctx),
           tunable::blas::BlasOp::NonTrans,
           tunable::blas::BlasOp::NonTrans,
           N, M, 1,
@@ -124,7 +124,7 @@ Status Gemm<T>::ComputeInternal(OpKernelContext* ctx) const {
   }
 
   return tunable::blas::column_major::Gemm(
-      GetTuningContext(), Stream(ctx),
+      GetTuningContext(), ctx->GetComputeStream(),
       GetRocblasHandle(ctx),
       trans_B_ ? BlasOp::Trans : BlasOp::NonTrans,
       trans_A_ ? BlasOp::Trans : BlasOp::NonTrans,

--- a/onnxruntime/core/providers/rocm/math/matmul_impl.cc
+++ b/onnxruntime/core/providers/rocm/math/matmul_impl.cc
@@ -78,12 +78,11 @@ Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
   const int ldc = helper.Ldc();
   int64_t stride_A, stride_B, stride_C, batch_count;
 
-  auto hip_stream = static_cast<hipStream_t>(stream->GetHandle());
   auto rocblas_handle = op->GetRocblasHandle(static_cast<RocmStream*>(stream));
 
   if (helper.OutputOffsets().size() == 1) {
     return tunable::blas::column_major::Gemm(
-        op->GetTuningContext(), hip_stream, rocblas_handle,
+        op->GetTuningContext(), stream, rocblas_handle,
         transB, transA,
         helper.N(), helper.M(), helper.K(),
         alpha,
@@ -95,7 +94,7 @@ Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
                                       transa, transb, trans_batch_a, trans_batch_b,
                                       stride_A, stride_B, stride_C, batch_count)) {
     return tunable::blas::column_major::StridedBatchedGemm(
-        op->GetTuningContext(), hip_stream, rocblas_handle,
+        op->GetTuningContext(), stream, rocblas_handle,
         transB, transA,
         helper.N(), helper.M(), helper.K(),
         alpha,
@@ -127,7 +126,7 @@ Status MatMulImpl(const RocmKernel* op, MatMulComputeHelper& helper,
   // note that onnxruntime OrtValue is row major, while rocblas is column major,
   // so swap left/right operands
   return tunable::blas::column_major::BatchedGemm(
-      op->GetTuningContext(), hip_stream, rocblas_handle,
+      op->GetTuningContext(), stream, rocblas_handle,
       transB, transA,
       helper.N(), helper.M(), helper.K(),
       alpha,

--- a/onnxruntime/core/providers/rocm/math/softmax.h
+++ b/onnxruntime/core/providers/rocm/math/softmax.h
@@ -13,7 +13,7 @@ using tunable::RocmTuningContext;
 
 template <typename T, typename TOut, bool IsLogSoftmax>
 Status SoftMaxComputeHelper(
-    hipStream_t stream,
+    Stream* stream,
     const T* input,
     const TensorShape& shape,
     TOut* Y,
@@ -21,12 +21,12 @@ Status SoftMaxComputeHelper(
     RocmTuningContext* tuning_ctx = nullptr);
 
 template <typename InputT, typename OutputT, typename AccT, bool IsLogSoftmax>
-Status dispatch_warpwise_softmax_forward(hipStream_t stream, OutputT* dst, const InputT* src, int softmax_elements,
+Status dispatch_warpwise_softmax_forward(Stream* stream, OutputT* dst, const InputT* src, int softmax_elements,
                                          int softmax_elements_stride, int batch_count,
                                          RocmTuningContext* tuning_ctx = nullptr);
 
 template <typename InputT, typename OutputT, typename AccT, bool IsLogSoftmax>
-Status dispatch_blockwise_softmax_forward(hipStream_t stream, OutputT* output, const InputT* input, int softmax_elements,
+Status dispatch_blockwise_softmax_forward(Stream* stream, OutputT* output, const InputT* input, int softmax_elements,
                                           int input_stride, int output_stride, int batch_count,
                                           RocmTuningContext* tuning_ctx = nullptr);
 

--- a/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
+++ b/onnxruntime/core/providers/rocm/math/softmax_ck.cuh
@@ -62,7 +62,7 @@ auto GetCKSoftmaxTypeStringAndOps() {
                                            params->input, params->output, nop, nop);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_softmax_op)));

--- a/onnxruntime/core/providers/rocm/math/softmax_common.h
+++ b/onnxruntime/core/providers/rocm/math/softmax_common.h
@@ -12,7 +12,7 @@ namespace rocm {
 
 template <typename InputT, typename OutputT>
 struct SoftmaxParams : tunable::OpParams {
-  SoftmaxParams(tunable::RocmTuningContext* tuning_ctx, hipStream_t stream, OutputT* output, const InputT* input,
+  SoftmaxParams(tunable::RocmTuningContext* tuning_ctx, onnxruntime::Stream* stream, OutputT* output, const InputT* input,
                 int softmax_elements, int input_stride, int output_stride, int batch_count, bool is_log_softmax)
       : OpParams(tuning_ctx, stream), output(output), input(input), softmax_elements(softmax_elements), input_stride(input_stride), output_stride(output_stride), batch_count(batch_count), is_log_softmax(is_log_softmax) {}
 

--- a/onnxruntime/core/providers/rocm/math/softmax_impl.cu
+++ b/onnxruntime/core/providers/rocm/math/softmax_impl.cu
@@ -31,7 +31,7 @@ namespace onnxruntime {
 namespace rocm {
 
 template <typename InputT, typename OutputT, typename AccT, bool IsLogSoftmax>
-Status dispatch_warpwise_softmax_forward(hipStream_t stream, OutputT* dst, const InputT* src, int softmax_elements,
+Status dispatch_warpwise_softmax_forward(Stream* stream, OutputT* dst, const InputT* src, int softmax_elements,
                                          int softmax_elements_stride, int batch_count, RocmTuningContext* tuning_ctx) {
   SoftmaxParams<InputT, OutputT> params(tuning_ctx, stream, dst, src, softmax_elements, softmax_elements_stride,
                                         softmax_elements_stride, batch_count, IsLogSoftmax);
@@ -44,10 +44,10 @@ Status dispatch_warpwise_softmax_forward(hipStream_t stream, OutputT* dst, const
 
 #define SPECIALIZED_SOFTMAX_IMPL(InputT, OutputT, AccT)                             \
   template Status dispatch_warpwise_softmax_forward<InputT, OutputT, AccT, false>(  \
-      hipStream_t stream, OutputT * dst, const InputT* src, int softmax_elements,   \
+      Stream* stream, OutputT * dst, const InputT* src, int softmax_elements,       \
       int softmax_elements_stride, int batch_count, RocmTuningContext* tuning_ctx); \
   template Status dispatch_warpwise_softmax_forward<InputT, OutputT, AccT, true>(   \
-      hipStream_t stream, OutputT * dst, const InputT* src, int softmax_elements,   \
+      Stream* stream, OutputT * dst, const InputT* src, int softmax_elements,       \
       int softmax_elements_stride, int batch_count, RocmTuningContext* tuning_ctx);
 
 SPECIALIZED_SOFTMAX_IMPL(float, float, float)
@@ -57,7 +57,7 @@ SPECIALIZED_SOFTMAX_IMPL(double, double, double)
 SPECIALIZED_SOFTMAX_IMPL(BFloat16, BFloat16, float)
 
 template <typename InputT, typename OutputT, typename AccT, bool IsLogSoftmax>
-Status dispatch_blockwise_softmax_forward(hipStream_t stream, OutputT* output,
+Status dispatch_blockwise_softmax_forward(Stream* stream, OutputT* output,
                                           const InputT* input, int softmax_elements,
                                           int input_stride, int output_stride,
                                           int batch_count, RocmTuningContext* tuning_ctx) {
@@ -72,10 +72,10 @@ Status dispatch_blockwise_softmax_forward(hipStream_t stream, OutputT* output,
 
 #define SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(InputT, OutputT, AccT)                           \
   template Status dispatch_blockwise_softmax_forward<InputT, OutputT, AccT, false>(         \
-      hipStream_t stream, OutputT * output, const InputT* input, int softmax_elements,      \
+      Stream* stream, OutputT * output, const InputT* input, int softmax_elements,          \
       int input_stride, int output_stride, int batch_count, RocmTuningContext* tuning_ctx); \
   template Status dispatch_blockwise_softmax_forward<InputT, OutputT, AccT, true>(          \
-      hipStream_t stream, OutputT * output, const InputT* input, int softmax_elements,      \
+      Stream* stream, OutputT * output, const InputT* input, int softmax_elements,          \
       int input_stride, int output_stride, int batch_count, RocmTuningContext* tuning_ctx);
 
 SPECIALIZED_BLOCKWISE_SOFTMAX_IMPL(float, float, float)

--- a/onnxruntime/core/providers/rocm/tunable/gemm.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm.h
@@ -14,32 +14,32 @@ namespace blas {
 
 #define GEMM(T, ScalarT)                                                         \
   common::Status Gemm(                                                           \
-      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle,  \
+      RocmTuningContext* tuning_ctx, Stream* stream, rocblas_handle handle,      \
       BlasOp opa, BlasOp opb,                                                    \
       std::int64_t m, std::int64_t n, std::int64_t k,                            \
       ScalarT alpha, const T* a, std::int64_t lda, const T* b, std::int64_t ldb, \
       ScalarT beta, T* c, std::int64_t ldc)
 
-#define BATCHED_GEMM(T, ScalarT)                                                \
-  common::Status BatchedGemm(                                                   \
-      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle, \
-      BlasOp opa, BlasOp opb,                                                   \
-      std::int64_t m, std::int64_t n, std::int64_t k,                           \
-      ScalarT alpha,                                                            \
-      const T** as, std::int64_t lda,                                           \
-      const T** bs, std::int64_t ldb,                                           \
-      ScalarT beta,                                                             \
+#define BATCHED_GEMM(T, ScalarT)                                            \
+  common::Status BatchedGemm(                                               \
+      RocmTuningContext* tuning_ctx, Stream* stream, rocblas_handle handle, \
+      BlasOp opa, BlasOp opb,                                               \
+      std::int64_t m, std::int64_t n, std::int64_t k,                       \
+      ScalarT alpha,                                                        \
+      const T** as, std::int64_t lda,                                       \
+      const T** bs, std::int64_t ldb,                                       \
+      ScalarT beta,                                                         \
       T** cs, std::int64_t ldc, std::int64_t batch)
 
-#define STRIDED_BATCHED_GEMM(T, ScalarT)                                        \
-  common::Status StridedBatchedGemm(                                            \
-      RocmTuningContext* tuning_ctx, hipStream_t stream, rocblas_handle handle, \
-      BlasOp opa, BlasOp opb,                                                   \
-      std::int64_t m, std::int64_t n, std::int64_t k,                           \
-      ScalarT alpha,                                                            \
-      const T* a, std::int64_t lda, std::int64_t stride_a,                      \
-      const T* b, std::int64_t ldb, std::int64_t stride_b,                      \
-      ScalarT beta,                                                             \
+#define STRIDED_BATCHED_GEMM(T, ScalarT)                                    \
+  common::Status StridedBatchedGemm(                                        \
+      RocmTuningContext* tuning_ctx, Stream* stream, rocblas_handle handle, \
+      BlasOp opa, BlasOp opb,                                               \
+      std::int64_t m, std::int64_t n, std::int64_t k,                       \
+      ScalarT alpha,                                                        \
+      const T* a, std::int64_t lda, std::int64_t stride_a,                  \
+      const T* b, std::int64_t ldb, std::int64_t stride_b,                  \
+      ScalarT beta,                                                         \
       T* c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch)
 
 namespace row_major {

--- a/onnxruntime/core/providers/rocm/tunable/gemm_ck.cuh
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_ck.cuh
@@ -72,7 +72,7 @@ auto GetCKGemmTypeStringAndOps() {
                                            nop, nop, nop);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemm_op)));
@@ -111,7 +111,7 @@ auto GetCKStridedBatchedGemmTypeStringAndOps() {
                                            nop, nop, nop);
       TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(!impl->IsSupportedArgument(arg.get()),
                                                 impl->GetTypeString(), " does not support ", params->Signature());
-      invoker->Run(arg.get(), StreamConfig{params->stream});
+      invoker->Run(arg.get(), StreamConfig{params->StreamHandle()});
       return Status::OK();
     };
     ret.emplace_back(std::make_pair(std::move(type_string), std::move(ck_gemm_op)));

--- a/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_rocblas.h
@@ -313,7 +313,7 @@ auto GetRocBlasStridedBatchedGemmTypeStringAndOps() {
 
 template <typename T>
 Status RocBlasGemmOp(const GemmParams<T>* params) {
-  RocblasHandleStreamGuard guard(params->handle, params->stream);
+  RocblasHandleStreamGuard guard(params->handle, params->StreamHandle());
   // NOTE: rocblas assumes the storage is column-majored, swapping A and B makes it have the same interface
   // as those with row-majored convention. That is, if you treat the storage as row-majored but view the matrices as
   // transposed, then by using the property Transpose(A*B) = Tranpose(B)*Transpose(A), the correctness is obvious.
@@ -331,7 +331,7 @@ Status RocBlasGemmOp(const GemmParams<T>* params) {
 
 template <typename T>
 Status RocBlasBatchedGemmOp(const BatchedGemmParams<T>* params) {
-  RocblasHandleStreamGuard guard(params->handle, params->stream);
+  RocblasHandleStreamGuard guard(params->handle, params->StreamHandle());
   return ROCBLAS_CALL(rocblasGemmBatchedHelper(
       params->handle,
       params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,
@@ -347,7 +347,7 @@ Status RocBlasBatchedGemmOp(const BatchedGemmParams<T>* params) {
 
 template <typename T>
 Status RocBlasStridedBatchedGemmOp(const StridedBatchedGemmParams<T>* params) {
-  RocblasHandleStreamGuard guard(params->handle, params->stream);
+  RocblasHandleStreamGuard guard(params->handle, params->StreamHandle());
   return ROCBLAS_CALL(rocblasGemmStridedBatchedHelper(
       params->handle,
       params->opb == BlasOp::N ? rocblas_operation_none : rocblas_operation_transpose,

--- a/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.cc
+++ b/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.cc
@@ -136,19 +136,17 @@ const TuningResultsValidator& RocmTuningContext::GetTuningResultsValidator() con
 }
 
 IAllocatorUniquePtr<void> RocmTuningContext::GetScratchBuffer(
-    size_t num_bytes, hipStream_t stream, OrtMemType mem_type) const {
+    size_t num_bytes, Stream* stream, OrtMemType mem_type) const {
   if (num_bytes == 0) {
     return nullptr;
   }
 
-  OrtDevice dev = ep_->GetOrtDeviceByMemType(mem_type);
-  auto it = allocators_->find(dev);
+  auto it = allocators_->find(ep_->GetOrtDeviceByMemType(mem_type));
   if (it == allocators_->end()) {
     return nullptr;
   }
 
-  Stream ort_stream{stream, dev};
-  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, &ort_stream, WaitRocmNotificationOnDevice);
+  return IAllocator::MakeUniquePtr<void>(it->second, num_bytes, false, stream, WaitRocmNotificationOnDevice);
 }
 
 }  // namespace tunable

--- a/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.h
+++ b/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.h
@@ -50,7 +50,7 @@ class RocmTuningContext : public ITuningContext {
   const TuningResultsValidator& GetTuningResultsValidator() const override;
 
   IAllocatorUniquePtr<void> GetScratchBuffer(
-      size_t bytes, hipStream_t stream, OrtMemType mem_type = OrtMemTypeDefault) const;
+      size_t bytes, Stream* stream, OrtMemType mem_type = OrtMemTypeDefault) const;
 
  private:
   TunableOpInfo* info_;  // non-owning handle

--- a/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.h
+++ b/onnxruntime/core/providers/rocm/tunable/rocm_tuning_context.h
@@ -49,6 +49,9 @@ class RocmTuningContext : public ITuningContext {
 
   const TuningResultsValidator& GetTuningResultsValidator() const override;
 
+  IAllocatorUniquePtr<void> GetScratchBuffer(
+      size_t bytes, hipStream_t stream, OrtMemType mem_type = OrtMemTypeDefault) const;
+
  private:
   TunableOpInfo* info_;  // non-owning handle
   TuningResultsManager manager_;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1475,6 +1475,13 @@ common::Status InferenceSession::Initialize() {
       session_state_->UpdateAllocatorsWithEnvAllocators(environment_.GetRegisteredSharedAllocators());
     }
 
+    for (auto& ep : execution_providers_) {
+      auto tuning_ctx = ep->GetTuningContext();
+      if (nullptr != tuning_ctx) {
+        tuning_ctx->RegisterAllocatorsView(&session_state_->GetAllocators());
+      }
+    }
+
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
     // Don't want to pollute SessionState constructor since memory profile is enabled optionally.
     session_state_->SetMemoryProfiler(&memory_profiler_);

--- a/onnxruntime/python/tools/kernel_explorer/kernel_explorer_interface.h
+++ b/onnxruntime/python/tools/kernel_explorer/kernel_explorer_interface.h
@@ -50,7 +50,7 @@ class IKernelExplorer {
     for (int i = 0; i < 5; i++) {
       Run();
     }
-    Timer timer{Stream()};
+    Timer timer{static_cast<Timer::TimerBase::NativeStreamT>(Stream()->GetHandle())};
     timer.Start();
     for (int i = 0; i < repeats_; i++) {
       Run();
@@ -74,6 +74,7 @@ class IKernelExplorer {
       if (nullptr != tuning_ctx) {
         tuning_ctx->RegisterAllocatorsView(&this->allocators_);
       }
+      stream_ = std::make_unique<onnxruntime::Stream>(nullptr, this->ep_->GetOrtDeviceByMemType(OrtMemTypeDefault));
     });
     return ep_.get();
   }
@@ -82,13 +83,14 @@ class IKernelExplorer {
     return static_cast<TuningContextT*>(GetEp()->GetTuningContext());
   }
 
-  StreamT Stream() { return stream_; }
+  onnxruntime::Stream* Stream() { return stream_.get(); }
 
  private:
   std::once_flag ep_create_once_;
   std::unique_ptr<ExecutionProvider> ep_{};
   std::map<OrtDevice, AllocatorPtr> allocators_;
-  StreamT stream_{0};
+  OrtDevice dev_;
+  std::unique_ptr<onnxruntime::Stream> stream_;
   int repeats_{100};
 };
 

--- a/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cu
+++ b/onnxruntime/python/tools/kernel_explorer/kernels/vector_add.cu
@@ -52,7 +52,7 @@ struct VectorAddParams :
 template <typename T, int TPB, int Vec>
 Status VectorAddOp(const VectorAddParams<T>* params) {
   return LaunchVectorAdd<T, TPB, Vec>(
-      params->stream,
+      params->StreamHandle(),
       params->x,
       params->y,
       params->z,

--- a/onnxruntime/test/framework/tunable_op_test.cc
+++ b/onnxruntime/test/framework/tunable_op_test.cc
@@ -117,7 +117,7 @@ class TestTimer : public ITimer<StreamT> {
   TimePoint end_;
 };
 
-using OpParams = OpParams<TestTuningContext, StreamT>;
+using OpParams = OpParams<TestTuningContext, void*>;
 
 template <typename ParamsT>
 using Op = Op<ParamsT>;
@@ -129,7 +129,7 @@ using TunableOp = TunableOp<ParamsT, TestTimer>;
 
 struct VecAddParams : OpParams {
   VecAddParams(const int* a_buf, const int* b_buf, int* c_buf, int num_elem, int beta)
-      : OpParams(nullptr, StreamT{}),
+      : OpParams(nullptr, nullptr),
         a(a_buf),
         b(b_buf),
         c(c_buf),

--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
@@ -110,7 +110,7 @@ Status SoftmaxCrossEntropyLoss<T, TLabel, TOut>::ComputeInternal(OpKernelContext
   }
 
   // Calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, TOut, true>(Stream(ctx), logit_data, logit_reshape, log_prob_data, 1);
+  auto status = SoftMaxComputeHelper<T, TOut, true>(ctx->GetComputeStream(), logit_data, logit_reshape, log_prob_data, 1);
   ORT_RETURN_IF_ERROR(status);
 
   const T* weight_data = nullptr;

--- a/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cc
@@ -49,7 +49,7 @@ Status SoftmaxCrossEntropy<T>::ComputeInternal(OpKernelContext* ctx) const {
   T* log_prob_data = log_prob->template MutableData<T>();
 
   // calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, T, true>(Stream(ctx),
+  auto status = SoftMaxComputeHelper<T, T, true>(ctx->GetComputeStream(),
                                                  logit_data,
                                                  logit_reshape,
                                                  log_prob_data,
@@ -151,7 +151,7 @@ Status SparseSoftmaxCrossEntropy<T, Tin>::ComputeInternal(OpKernelContext* ctx) 
   T* log_prob_data = log_prob->template MutableData<T>();
 
   // calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, T, true>(Stream(ctx),
+  auto status = SoftMaxComputeHelper<T, T, true>(ctx->GetComputeStream(),
                                                  logit_data,
                                                  logit_reshape,
                                                  log_prob_data,


### PR DESCRIPTION
By switching to ort native stream, we can allocate scratch buffer directly from tuning context.

