### PR TITLE
Add option for max intermediate outputs for MinMaxCalibrater

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -239,16 +239,17 @@ class MinMaxCalibrater(CalibraterBase):
         self.intermediate_outputs = []
 
     def collect_data(self, data_reader: CalibrationDataReader):
+        print(self.max_intermediate_outputs)
         while True:
             inputs = data_reader.get_next()
             if not inputs:
                 break
             self.intermediate_outputs.append(self.infer_session.run(None, inputs))
-            if len(self.intermediate_outputs) == self.max_intermediate_outputs:
+            if self.max_intermediate_outputs is not None and len(self.intermediate_outputs) == self.max_intermediate_outputs:
                 self.compute_range()
                 self.clear_collected_data()
 
-        if self.max_intermediate_outputs is not None and len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
+        if self.max_intermediate_outputs is None and len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
             raise ValueError("No data is collected.")
 
         self.compute_range()

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -858,7 +858,9 @@ def create_calibrator(
         symmetric = False if "symmetric" not in extra_options else extra_options["symmetric"]
         moving_average = False if "moving_average" not in extra_options else extra_options["moving_average"]
         averaging_constant = 0.01 if "averaging_constant" not in extra_options else extra_options["averaging_constant"]
-        max_intermediate_outputs = None if "max_intermediate_outputs" not in extra_options else extra_options["max_intermediate_outputs"]
+        max_intermediate_outputs = (
+            None if "max_intermediate_outputs" not in extra_options else extra_options["max_intermediate_outputs"]
+        )
         calibrator = MinMaxCalibrater(
             model,
             op_types_to_calibrate,

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -239,7 +239,6 @@ class MinMaxCalibrater(CalibraterBase):
         self.intermediate_outputs = []
 
     def collect_data(self, data_reader: CalibrationDataReader):
-        print(self.max_intermediate_outputs)
         while True:
             inputs = data_reader.get_next()
             if not inputs:

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -244,11 +244,18 @@ class MinMaxCalibrater(CalibraterBase):
             if not inputs:
                 break
             self.intermediate_outputs.append(self.infer_session.run(None, inputs))
-            if self.max_intermediate_outputs is not None and len(self.intermediate_outputs) == self.max_intermediate_outputs:
+            if (
+                self.max_intermediate_outputs is not None
+                and len(self.intermediate_outputs) == self.max_intermediate_outputs
+            ):
                 self.compute_range()
                 self.clear_collected_data()
 
-        if self.max_intermediate_outputs is None and len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
+        if (
+            self.max_intermediate_outputs is None
+            and len(self.intermediate_outputs) == 0
+            and self.calibrate_tensors_range is None
+        ):
             raise ValueError("No data is collected.")
 
         self.compute_range()

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -251,11 +251,7 @@ class MinMaxCalibrater(CalibraterBase):
                 self.compute_range()
                 self.clear_collected_data()
 
-        if (
-            self.max_intermediate_outputs is None
-            and len(self.intermediate_outputs) == 0
-            and self.calibrate_tensors_range is None
-        ):
+        if len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
             raise ValueError("No data is collected.")
 
         self.compute_range()

--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -248,7 +248,7 @@ class MinMaxCalibrater(CalibraterBase):
                 self.compute_range()
                 self.clear_collected_data()
 
-        if len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
+        if self.max_intermediate_outputs is not None and len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
             raise ValueError("No data is collected.")
 
         self.compute_range()

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -376,7 +376,7 @@ def quantize_static(
         ("CalibTensorRangeSymmetric", "symmetric"),
         ("CalibMovingAverage", "moving_average"),
         ("CalibMovingAverageConstant", "averaging_constant"),
-        ("CalibMaxIntermediateOutputs", "max_intermediate_outputs")
+        ("CalibMaxIntermediateOutputs", "max_intermediate_outputs"),
     ]
     calib_extra_options = {
         key: extra_options.get(name) for (name, key) in calib_extra_options_keys if name in extra_options

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -335,7 +335,7 @@ def quantize_static(
                     Default is 0.01. Constant smoothing factor to use when computing the moving average of the
                     minimum and maximum values. Effective only when the calibration method selected is MinMax and
                     when CalibMovingAverage is set to True.
-                CalibMaxIntermediateOutputs = Optoinal[int] :
+                CalibMaxIntermediateOutputs = Optional[int] :
                     Default is None. If set to an integer, during calculation of the min-max range of the tensors
                     it will load at max value number of outputs before computing and merging the range. This will
                     produce the same result as all computing with None, but is more memory efficient.

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -335,6 +335,10 @@ def quantize_static(
                     Default is 0.01. Constant smoothing factor to use when computing the moving average of the
                     minimum and maximum values. Effective only when the calibration method selected is MinMax and
                     when CalibMovingAverage is set to True.
+                CalibMaxIntermediateOutputs = Optoinal[int] :
+                    Default is None. If set to an integer, during calculation of the min-max range of the tensors
+                    it will load at max value number of outputs before computing and merging the range. This will
+                    produce the same result as all computing with None, but is more memory efficient.
                 SmoothQuant = True/False :
                     Default is False. If enabled, SmoothQuant algorithm will be applied before quantization to do
                     fake input channel quantization.
@@ -372,6 +376,7 @@ def quantize_static(
         ("CalibTensorRangeSymmetric", "symmetric"),
         ("CalibMovingAverage", "moving_average"),
         ("CalibMovingAverageConstant", "averaging_constant"),
+        ("CalibMaxIntermediateOutputs", "max_intermediate_outputs")
     ]
     calib_extra_options = {
         key: extra_options.get(name) for (name, key) in calib_extra_options_keys if name in extra_options


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds the option to set max_intermediate_outputs for quantization with the MinMaxCalibrater via. extra_options following the structure of existing flags.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When running quantization with the MinMaxCalibrater with larger datasets, one quickly runs out of memory since it tries to load the full dataset. Since merging and clearing of the intermediate_outputs is already implemented within the Calibrater this simply adds an optional flag to make use of these functions during quantization. 

