### PR TITLE
Fix DML regression from allocator refactor and enable unrounded weight allocation in ORT API

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/inc/DmlExecutionProvider.h
@@ -32,7 +32,6 @@ namespace Dml
 
     ID3D12Resource* GetD3D12ResourceFromAllocation(onnxruntime::IAllocator* allocator, void* ptr);
     void FlushContext(onnxruntime::IExecutionProvider* provider);
-    void SetDefaultRoundingMode(onnxruntime::IExecutionProvider* provider, AllocatorRoundingMode roundingMode);
     void ReleaseCompletedReferences(onnxruntime::IExecutionProvider* provider);
 
     onnxruntime::common::Status CopyTensor(

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
@@ -82,6 +82,11 @@ namespace Dml
 
     void* BucketizedBufferAllocator::Alloc(size_t size)
     {
+        return Alloc(size, m_defaultRoundingMode);
+    }
+
+    void* BucketizedBufferAllocator::Alloc(size_t size, AllocatorRoundingMode roundingMode)
+    {
         // For some reason lotus likes requesting 0 bytes of memory
         size = std::max<size_t>(1, size);
 
@@ -90,7 +95,7 @@ namespace Dml
         uint64_t bucketSize = 0;
 
         // Use a pooled resource if the size (post rounding, if requested) matches a bucket size
-        if (m_defaultRoundingMode == AllocatorRoundingMode::Enabled || size == GetBucketSizeFromIndex(GetBucketIndexFromSize(size)))
+        if (roundingMode == AllocatorRoundingMode::Enabled || size == GetBucketSizeFromIndex(GetBucketIndexFromSize(size)))
         {
             Bucket* bucket = nullptr;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
@@ -47,6 +47,7 @@ namespace Dml
         void SetDefaultRoundingMode(AllocatorRoundingMode roundingMode);
 
     public: // onnxruntime::IAllocator
+        void* Alloc(size_t size, AllocatorRoundingMode roundingMode);
         void* Alloc(size_t size) final;
         void Free(void* p) final;
 
@@ -82,7 +83,12 @@ namespace Dml
         std::vector<Bucket> m_pool;
         size_t m_currentAllocationId = 0;
         uint64_t m_currentResourceId = 0;
-        AllocatorRoundingMode m_defaultRoundingMode = AllocatorRoundingMode::Enabled;
+        
+        // Unless specifically requested, allocation sizes are not rounded to enable pooling 
+        // until SetDefaultRoundingMode is called.  This should be done at completion of session 
+        // initialization.
+        AllocatorRoundingMode m_defaultRoundingMode = AllocatorRoundingMode::Disabled;
+
         std::shared_ptr<ExecutionContext> m_context;
         std::unique_ptr<DmlSubAllocator> m_subAllocator;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -126,8 +126,6 @@ namespace Dml
         STDMETHOD_(D3D12_COMMAND_LIST_TYPE, GetCommandListTypeForQueue)() const override;
         STDMETHOD_(void, Flush)() const override;
 
-        void SetDefaultRoundingMode(AllocatorRoundingMode roundingMode);
-
         // Waits for flushed work, discards unflushed work, and discards associated references to
         // prevent circular references.  Must be the last call on the object before destruction.
         void Close() override;
@@ -198,7 +196,6 @@ namespace Dml
         bool m_closed = false;
         mutable std::chrono::time_point<std::chrono::steady_clock> m_lastUploadFlushTime;
         static constexpr std::chrono::milliseconds m_batchFlushInterval = std::chrono::milliseconds(10);
-        AllocatorRoundingMode m_defaultRoundingMode = AllocatorRoundingMode::Enabled;
     };
 
     class DataTransfer : public onnxruntime::IDataTransfer
@@ -285,11 +282,6 @@ namespace Dml
         void Flush()
         {
             return m_impl->Flush();
-        }
-
-        void SetDefaultRoundingMode(AllocatorRoundingMode roundingMode)
-        {
-            return m_impl->SetDefaultRoundingMode(roundingMode);
         }
 
         void ReleaseCompletedReferences()

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -32,25 +32,18 @@ struct DMLProviderFactory : IExecutionProviderFactory {
   ~DMLProviderFactory() override {}
 
   std::unique_ptr<IExecutionProvider> CreateProvider() override;
-  void SetDefaultRoundingMode(AllocatorRoundingMode rounding_mode);
 
   void SetMetacommandsEnabled(bool metacommands_enabled);
 
  private:
   ComPtr<IDMLDevice> dml_device_{};
   ComPtr<ID3D12CommandQueue> cmd_queue_{};
-  AllocatorRoundingMode rounding_mode_ = AllocatorRoundingMode::Enabled;
   bool metacommands_enabled_ = true;
 };
 
 std::unique_ptr<IExecutionProvider> DMLProviderFactory::CreateProvider() {
   auto provider = Dml::CreateExecutionProvider(dml_device_.Get(), cmd_queue_.Get(), metacommands_enabled_);
-  Dml::SetDefaultRoundingMode(provider.get(), rounding_mode_);
   return provider;
-}
-
-void DMLProviderFactory::SetDefaultRoundingMode(AllocatorRoundingMode rounding_mode) {
-  rounding_mode_ = rounding_mode;
 }
 
 void DMLProviderFactory::SetMetacommandsEnabled(bool metacommands_enabled) {
@@ -78,11 +71,6 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_DML(ID
   auto luid = d3d12_device->GetAdapterLuid();
   env.GetTelemetryProvider().LogExecutionProviderEvent(&luid);
   return std::make_shared<onnxruntime::DMLProviderFactory>(dml_device, cmd_queue);
-}
-
-void DmlConfigureProviderFactoryDefaultRoundingMode(IExecutionProviderFactory* factory, AllocatorRoundingMode rounding_mode) {
-  auto dml_provider_factory = static_cast<DMLProviderFactory*>(factory);
-  dml_provider_factory->SetDefaultRoundingMode(rounding_mode);
 }
 
 void DmlConfigureProviderFactoryMetacommandsEnabled(IExecutionProviderFactory* factory, bool metacommandsEnabled) {

--- a/winml/adapter/winml_adapter_apis.h
+++ b/winml/adapter/winml_adapter_apis.h
@@ -122,9 +122,6 @@ ORT_API_STATUS(
 );
 
 // Dml methods (TODO need to figure out how these need to move to session somehow...)
-ORT_API_STATUS(
-  DmlExecutionProviderSetDefaultRoundingMode, _In_ OrtExecutionProvider* dml_provider, _In_ bool is_enabled
-);
 ORT_API_STATUS(DmlExecutionProviderFlushContext, _In_ OrtExecutionProvider* dml_provider);
 ORT_API_STATUS(DmlExecutionProviderReleaseCompletedReferences, _In_ OrtExecutionProvider* dml_provider);
 

--- a/winml/adapter/winml_adapter_c_api.cpp
+++ b/winml/adapter/winml_adapter_c_api.cpp
@@ -62,7 +62,6 @@ static constexpr WinmlAdapterApi winml_adapter_api_1 = {
   &winmla::SessionGetNamedDimensionsOverrides,
 
     // Dml methods (TODO need to figure out how these need to move to session somehow...)
-  &winmla::DmlExecutionProviderSetDefaultRoundingMode,
   &winmla::DmlExecutionProviderFlushContext,
   &winmla::DmlExecutionProviderReleaseCompletedReferences,
   &winmla::DmlCopyTensor,

--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -413,16 +413,6 @@ struct WinmlAdapterApi {
   )NO_EXCEPTION;
 
   /**
-    * DmlExecutionProviderSetDefaultRoundingMode
-	  * This api is used to configure the DML EP to turn on/off rounding.
-    *
- 	  * WinML uses this to disable rounding during session initialization and then enables it again post initialization.
-    */
-  OrtStatus*(ORT_API_CALL* DmlExecutionProviderSetDefaultRoundingMode)(
-    _In_ OrtExecutionProvider* dml_provider, _In_ bool is_enabled
-  )NO_EXCEPTION;
-
-  /**
     * DmlExecutionProviderFlushContext
 	 * This api is used to flush the DML EP.
     *

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -68,9 +68,6 @@ Microsoft::WRL::ComPtr<IDMLDevice> CreateDmlDevice(ID3D12Device* d3d12Device) {
 }
 
 namespace onnxruntime {
-void DmlConfigureProviderFactoryDefaultRoundingMode(
-  onnxruntime::IExecutionProviderFactory* factory, AllocatorRoundingMode rounding_mode
-);
 void DmlConfigureProviderFactoryMetacommandsEnabled(IExecutionProviderFactory* factory, bool metacommandsEnabled);
 }// namespace onnxruntime
 
@@ -90,29 +87,9 @@ ORT_API_STATUS_IMPL(
     return status;
   }
   auto factory = options->provider_factories.back().get();
-
-  // OnnxRuntime uses the default rounding mode when calling the session's allocator.
-  // During initialization, OnnxRuntime allocates weights, which are permanent across session
-  // lifetime and can be large, so shouldn't be rounded.
-  // So we create the provider with rounding disabled, and expect the caller to enable it after.
-  onnxruntime::DmlConfigureProviderFactoryDefaultRoundingMode(factory, AllocatorRoundingMode::Disabled);
-
+  
   onnxruntime::DmlConfigureProviderFactoryMetacommandsEnabled(factory, metacommands_enabled);
 #endif  // USE_DML
-  return nullptr;
-  API_IMPL_END
-}
-
-ORT_API_STATUS_IMPL(
-  winmla::DmlExecutionProviderSetDefaultRoundingMode, _In_ OrtExecutionProvider* dml_provider, _In_ bool is_enabled
-) {
-  API_IMPL_BEGIN
-#ifdef USE_DML
-  auto dml_provider_internal = reinterpret_cast<::onnxruntime::IExecutionProvider*>(dml_provider);
-  Dml::SetDefaultRoundingMode(
-    dml_provider_internal, is_enabled ? AllocatorRoundingMode::Enabled : AllocatorRoundingMode::Disabled
-  );
-#endif
   return nullptr;
   API_IMPL_END
 }

--- a/winml/adapter/winml_adapter_dml.cpp
+++ b/winml/adapter/winml_adapter_dml.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+ // Licensed under the MIT License.
 
 #pragma once
 #include "adapter/pch.h"
@@ -87,7 +87,7 @@ ORT_API_STATUS_IMPL(
     return status;
   }
   auto factory = options->provider_factories.back().get();
-  
+
   onnxruntime::DmlConfigureProviderFactoryMetacommandsEnabled(factory, metacommands_enabled);
 #endif  // USE_DML
   return nullptr;

--- a/winml/lib/Api.Ort/OnnxruntimeDmlSessionBuilder.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeDmlSessionBuilder.cpp
@@ -104,10 +104,6 @@ HRESULT OnnxruntimeDmlSessionBuilder::Initialize(OrtSession* session) {
     winml_adapter_api->SessionGetExecutionProvider(session, 0, &ort_provider), engine_factory_->UseOrtApi()
   );
 
-  RETURN_HR_IF_NOT_OK_MSG(
-    winml_adapter_api->DmlExecutionProviderSetDefaultRoundingMode(ort_provider, true), engine_factory_->UseOrtApi()
-  );
-
   // Flush the D3D12 work from the DML execution provider
   RETURN_HR_IF_NOT_OK_MSG(
     winml_adapter_api->DmlExecutionProviderFlushContext(ort_provider), engine_factory_->UseOrtApi()

--- a/winml/test/adapter/AdapterDmlEpTest.cpp
+++ b/winml/test/adapter/AdapterDmlEpTest.cpp
@@ -93,14 +93,6 @@ UniqueOrtSession CreateCpuSession() {
   return CreateUniqueOrtSession(FileHelpers::GetModulePath() + L"fns-candy.onnx", session_options);
 }
 
-void DmlExecutionProviderSetDefaultRoundingMode() {
-  GPUTEST;
-  auto session = CreateDmlSession();
-  OrtExecutionProvider* ort_provider;
-  THROW_IF_NOT_OK_MSG(winml_adapter_api->SessionGetExecutionProvider(session.get(), 0, &ort_provider), ort_api);
-  THROW_IF_NOT_OK_MSG(winml_adapter_api->DmlExecutionProviderSetDefaultRoundingMode(ort_provider, false), ort_api);
-}
-
 void DmlExecutionProviderFlushContext() {
   GPUTEST;
   auto session = CreateDmlSession();
@@ -364,7 +356,6 @@ const AdapterDmlEpTestApi& getapi() {
   static constexpr AdapterDmlEpTestApi api = {
     AdapterDmlEpTestSetup,
     AdapterDmlEpTestTeardown,
-    DmlExecutionProviderSetDefaultRoundingMode,
     DmlExecutionProviderFlushContext,
     DmlExecutionProviderReleaseCompletedReferences,
     DmlCreateAndFreeGPUAllocationFromD3DResource,

--- a/winml/test/adapter/AdapterDmlEpTest.h
+++ b/winml/test/adapter/AdapterDmlEpTest.h
@@ -5,7 +5,6 @@
 struct AdapterDmlEpTestApi {
   SetupTest AdapterDmlEpTestSetup;
   TeardownClass AdapterDmlEpTestTeardown;
-  VoidTest DmlExecutionProviderSetDefaultRoundingMode;
   VoidTest DmlExecutionProviderFlushContext;
   VoidTest DmlExecutionProviderReleaseCompletedReferences;
   VoidTest DmlCreateGPUAllocationFromD3DResource;
@@ -23,7 +22,6 @@ WINML_TEST_CLASS_BEGIN(AdapterDmlEpTest)
 WINML_TEST_CLASS_SETUP_METHOD(AdapterDmlEpTestSetup)
 WINML_TEST_CLASS_TEARDOWN_METHOD(AdapterDmlEpTestTeardown)
 WINML_TEST_CLASS_BEGIN_TESTS
-WINML_TEST(AdapterDmlEpTest, DmlExecutionProviderSetDefaultRoundingMode)
 WINML_TEST(AdapterDmlEpTest, DmlExecutionProviderFlushContext)
 WINML_TEST(AdapterDmlEpTest, DmlExecutionProviderReleaseCompletedReferences)
 WINML_TEST(AdapterDmlEpTest, DmlCreateGPUAllocationFromD3DResource)


### PR DESCRIPTION
This addresses a DML performance regression from the following PR resulting in allocations not being rounded and pooled in the DML execution provider.

https://github.com/microsoft/onnxruntime/pull/15833

This also fixes a pre-existing limitation that allocations during session initialization (primarily large weights and persistent resources) only bypassed rounding and pooling while using the Winml API.  The allocator now also respects a caller's rounding mode parameter when provided.