### PR TITLE
Fix orttraining_test_dort.py

### DIFF
--- a/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
+++ b/orttraining/orttraining/python/training/torchdynamo/ort_backend.py
@@ -461,7 +461,7 @@ class OrtBackend:
         ep: str = "CPUExecutionProvider",
         preallocate_output: bool = False,
         session_options=None,
-        onnx_exporter_options: Optional["torch.onnx._internal.exporter.ExportOptions"] = None,
+        onnx_exporter_options: Optional["torch.onnx.ExportOptions"] = None,
     ):
         # onnx_exporter_options contains information shared between exporter and DORT.
         # For example, they should use the same decomposition table when
@@ -469,7 +469,7 @@ class OrtBackend:
         #  2. call exporter's API to convert `torch.fx.GraphModule` to ONNX model
         #     (see onnxfunction_dispatcher passed to FxOnnxInterpreter.run below).
         if onnx_exporter_options is None:
-            onnx_exporter_options = torch.onnx._internal.exporter.ExportOptions()
+            onnx_exporter_options = torch.onnx.ExportOptions()
         # Convert user-facing option to internal option used by ONNX exporter
         # to access required information.
         # Some useful fields:
@@ -592,7 +592,7 @@ class OrtBackend:
             )
             # Convert the exported result to ONNX ModelProto.
             onnx_proto = exported.to_model_proto(
-                opset_version=self.resolved_onnx_exporter_options.opset_version
+                opset_version=self.resolved_onnx_exporter_options.onnx_registry.opset_version
             ).SerializeToString()
 
             # Initialize a ORT session to execute this ONNX model.

--- a/orttraining/orttraining/test/python/orttraining_test_dort_custom_ops.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort_custom_ops.py
@@ -163,9 +163,8 @@ class TestTorchDynamoOrtCustomOp(unittest.TestCase):
         onnx_registry = torch.onnx.OnnxRegistry()
         onnx_registry.register_op(
             function=custom_exporter_for_aten_add_Tensor,
-            namespace="aten",
-            op_name="mul",
-            overload="Tensor",
+            namespace="foo",
+            op_name="bar",
         )
 
         # Create executor of ONNX model.

--- a/orttraining/orttraining/test/python/orttraining_test_dort_custom_ops.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort_custom_ops.py
@@ -162,7 +162,7 @@ class TestTorchDynamoOrtCustomOp(unittest.TestCase):
         # custom_exporter_for_foo_bar_default.
         onnx_registry = torch.onnx.OnnxRegistry()
         onnx_registry.register_op(
-            function=custom_exporter_for_aten_add_Tensor,
+            function=custom_exporter_for_foo_bar_default,
             namespace="foo",
             op_name="bar",
         )


### PR DESCRIPTION
Converter has moved `opset_version` out from `torch.onnx.ExportOptions`, and put it into `torch.onnx.OnnxRegistry`.
This PR fixes the usage in DORT.
