### PR TITLE
[VITISAI] fix out of bound error on graph with loop

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/node.cc
+++ b/onnxruntime/core/providers/vitisai/imp/node.cc
@@ -21,7 +21,11 @@ vaip_core::DllSafe<std::vector<NodeInput>> node_get_inputs(const Node& node) {
   }
   for (auto iter = node.InputEdgesBegin(); iter != node.InputEdgesEnd();
        ++iter) {
-    ret[iter->GetDstArgIndex()].node = &iter->GetNode();
+    auto dst_idx = static_cast<size_t>(iter->GetDstArgIndex());
+    if (dst_idx < ret.size()) {
+      // ignore implicit nodes.
+      ret[dst_idx].node = &iter->GetNode();
+    }
   }
   return vaip_core::DllSafe(ret);
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Check the bound of the node_get_inputs for out of bound error.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Model with loop would encounter this error. Currrent we do not support custom op for loop. So, ideally it would throw an error and fall back to CPU evalution.


