### PR TITLE
[VITISAI] nested subgraph is unsupported for now

### DIFF
--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -92,6 +92,10 @@ std::shared_ptr<KernelRegistry> VitisAIExecutionProvider::GetKernelRegistry() co
 std::vector<std::unique_ptr<ComputeCapability>>
 VitisAIExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
                                         const IKernelLookup& /*kernel_lookup*/) const {
+  if (graph.IsSubgraph()) {
+    // VITIS AI EP not support sungraph. Assigned to CPU.
+    return {};
+  }
   auto opt_str = info_.get_json_config_str();  // String
   execution_providers_ =
       std::make_unique<my_ep_t>(compile_onnx_model(graph, *GetLogger(), opt_str));


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
return empty ComputeCapability when a graph contains nested subgraph.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
For now, our architecture does not support nested subgraph. So, we return empty ComputeCapability for this case.

