### PR TITLE
[VITISAI] node arg can be used more than once

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -91,28 +91,25 @@ Node& graph_add_node(Graph& graph, const std::string& name,
   for (auto& o : outputs) {
     auto consumers = graph.GetConsumerNodes(o->Name());
     for (auto& consumer : consumers) {
-      auto dst_arg_index = -1;
-      int arg_index = 0;
+      auto dst_arg_index = 0u;
       auto tmp_inputs = node_get_inputs(*consumer);
       for (auto ni : *tmp_inputs) {
         auto name1 = ni.node_arg->Name();
         if (name1 == o->Name()) {
-          dst_arg_index = arg_index;
-          break;
+          graph.AddEdge(ret.Index(), consumer->Index(), src_arg_index,
+                        dst_arg_index);
         }
-        arg_index = arg_index + 1;
+        dst_arg_index = dst_arg_index + 1;
       }
+      // dst_arg_index should not init again.
       for (auto implicit_node_arg : node_get_implicit_input_node_args(*consumer)) {
         auto name1 = implicit_node_arg->Name();
         if (name1 == o->Name()) {
-          dst_arg_index = arg_index;
-          break;
+          graph.AddEdge(ret.Index(), consumer->Index(), src_arg_index,
+                        dst_arg_index);
         }
-        arg_index = arg_index + 1;
+        dst_arg_index = dst_arg_index + 1;
       }
-      assert(dst_arg_index != -1);
-      graph.AddEdge(ret.Index(), consumer->Index(), src_arg_index,
-                    dst_arg_index);
     }
     src_arg_index = src_arg_index + 1;
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
a node arg can be matched multiple times.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Previous, we thought the node name must be unique and thus can be used as identifier. However, we recently found that a node's name can be empty thus failed to identify which node is which. So, we use node arg to differentiate the node. To do so, we need to match node arg more than once.

