### PR TITLE
[QNN EP] Increase tolerance for ReduceProd test on x64 Windows

### DIFF
--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -168,13 +168,24 @@ TEST_F(QnnCPUBackendTests, ReduceSumOpset11_Float) {
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnCPUBackendTests, ReduceProdOpset18) {
   RunReduceOpCpuTest<float>("ReduceProd",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                            TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
+                            std::vector<int64_t>{0, 1},
+                            true,  // keepdims
+                            18,
+                            ExpectedEPNodeAssignment::All);
+}
+
+// TODO: Investigate slight inaccuracy. x64 Windows requires a slightly larger error tolerance greater than 1.5e-f.
+// LOG: ... the value pair (208.881729, 208.881744) at index #0 don't match, which is 1.52588e-05 from 208.882
+TEST_F(QnnCPUBackendTests, ReduceProdOpset18_SlightlyInaccurate_WindowsX64) {
+  RunReduceOpCpuTest<float>("ReduceProd",
+                            TestInputDef<float>({2, 2}, false, {3.21289f, -5.9981f, -1.72799f, 6.27263f}),
                             std::vector<int64_t>{0, 1},
                             true,  // keepdims
                             18,
                             ExpectedEPNodeAssignment::All,
 #if defined(_WIN32) && !defined(__aarch64__)
-                            2e-5f);  // x64 Windows requires a tolerance > 1.5e-5f
+                            2e-5f);  // x64 Windows requires larger tolerance.
 #else
                             1e-5f);
 #endif
@@ -187,16 +198,11 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset18) {
 // - Uses opset 13, which has "axes" as an attribute.
 TEST_F(QnnCPUBackendTests, ReduceProdOpset13) {
   RunReduceOpCpuTest<float>("ReduceProd",
-                            TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                            TestInputDef<float>({2, 2}, false, {-10.0f, -8.2f, 0.0f, 10.0f}),
                             std::vector<int64_t>{0, 1},
                             true,  // keepdims
                             13,
-                            ExpectedEPNodeAssignment::All,
-#if defined(_WIN32) && !defined(__aarch64__)
-                            2e-5f);  // x64 Windows requires a tolerance > 1.5e-5f
-#else
-                            1e-5f);
-#endif
+                            ExpectedEPNodeAssignment::All);
 }
 
 //

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -175,20 +175,16 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset18) {
                             ExpectedEPNodeAssignment::All);
 }
 
-// TODO: Investigate slight inaccuracy. x64 Windows requires a slightly larger error tolerance greater than 1.5e-f.
+// TODO: Investigate slight inaccuracy. x64 Windows/Linux require a slightly larger error tolerance greater than 1.5e-5f.
 // LOG: ... the value pair (208.881729, 208.881744) at index #0 don't match, which is 1.52588e-05 from 208.882
-TEST_F(QnnCPUBackendTests, ReduceProdOpset18_SlightlyInaccurate_WindowsX64) {
+TEST_F(QnnCPUBackendTests, ReduceProdOpset18_SlightlyInaccurate_WindowsLinuxX64) {
   RunReduceOpCpuTest<float>("ReduceProd",
                             TestInputDef<float>({2, 2}, false, {3.21289f, -5.9981f, -1.72799f, 6.27263f}),
                             std::vector<int64_t>{0, 1},
                             true,  // keepdims
                             18,
                             ExpectedEPNodeAssignment::All,
-#if defined(_WIN32) && !defined(__aarch64__)
-                            2e-5f);  // x64 Windows requires larger tolerance.
-#else
-                            1e-5f);
-#endif
+                            2e-5f);  // x64 Linux & Windows require larger tolerance.
 }
 
 // Test creates a graph with a ReduceProd node, and checks that all

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -76,7 +76,8 @@ static void RunReduceOpCpuTest(const std::string& op_type,
                                const std::vector<int64_t>& axes,
                                bool keepdims,
                                int opset,
-                               ExpectedEPNodeAssignment expected_ep_assignment) {
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               float fp32_abs_err = 1e-5f) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnCpu.dll";
@@ -92,7 +93,8 @@ static void RunReduceOpCpuTest(const std::string& op_type,
                                                   false),  // noop_with_empty_axes
                   provider_options,
                   opset,
-                  expected_ep_assignment);
+                  expected_ep_assignment,
+                  fp32_abs_err);
 }
 
 //
@@ -170,7 +172,12 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset18) {
                             std::vector<int64_t>{0, 1},
                             true,  // keepdims
                             18,
-                            ExpectedEPNodeAssignment::All);
+                            ExpectedEPNodeAssignment::All,
+#if defined(_WIN32) && !defined(__aarch64__)
+                            2e-5f);  // x64 Windows requires a tolerance > 1.5e-5f
+#else
+                            1e-5f);
+#endif
 }
 
 // Test creates a graph with a ReduceProd node, and checks that all
@@ -184,7 +191,12 @@ TEST_F(QnnCPUBackendTests, ReduceProdOpset13) {
                             std::vector<int64_t>{0, 1},
                             true,  // keepdims
                             13,
-                            ExpectedEPNodeAssignment::All);
+                            ExpectedEPNodeAssignment::All,
+#if defined(_WIN32) && !defined(__aarch64__)
+                            2e-5f);  // x64 Windows requires a tolerance > 1.5e-5f
+#else
+                            1e-5f);
+#endif
 }
 
 //


### PR DESCRIPTION
### Description
Slightly increases the allowable error tolerance for ReduceProd tests on x64 Windows/Linux with the QNN CPU backend.


### Motivation and Context
A recent [PR](https://github.com/microsoft/onnxruntime/pull/16916) updated the input range for ReduceProd tests, which uncovered an inaccuracy for ReduceProd on x64 Windows/Linux with the QNN CPU backend. This PR updates the allowable error tolerance and adds a TODO for investigation.

This is needed to ensure the QNN_Nuget_Windows pipeline runs successfully.