### PR TITLE
[ROCm] update header and binary search paths used by cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -312,7 +312,15 @@ if (onnxruntime_USE_ROCM)
   add_compile_options("$<$<COMPILE_LANGUAGE:HIP>:SHELL:-x hip>")
 
   if (NOT onnxruntime_HIPIFY_PERL)
-    set(onnxruntime_HIPIFY_PERL ${onnxruntime_ROCM_HOME}/hip/bin/hipify-perl)
+    find_path(HIPIFY_PERL_PATH
+      NAMES hipify-perl
+      HINTS
+      ${onnxruntime_ROCM_HOME}/bin
+      ${onnxruntime_ROCM_HOME}/hip/bin)
+    if (HIPIFY_PERL_PATH-NOTFOUND)
+      MESSAGE(FATAL_ERROR "hipify-perl not found")
+    endif()
+    set(onnxruntime_HIPIFY_PERL ${HIPIFY_PERL_PATH}/hipify-perl)
   endif()
 
   # replicate strategy used by pytorch to get ROCM_VERSION
@@ -1489,6 +1497,7 @@ if (UNIX AND onnxruntime_USE_MPI)
     find_path(NCCL_INCLUDE_DIR
       NAMES ${NCCL_LIBNAME}.h
       HINTS
+      ${onnxruntime_NCCL_HOME}/include/rccl
       ${onnxruntime_NCCL_HOME}/include
       $ENV{CUDA_ROOT}/include)
 

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1496,7 +1496,7 @@ if (onnxruntime_USE_ROCM)
   add_definitions(-DUSE_ROCM=1)
   include(onnxruntime_rocm_hipify.cmake)
 
-  list(APPEND CMAKE_PREFIX_PATH ${onnxruntime_ROCM_HOME}/rccl ${onnxruntime_ROCM_HOME}/roctracer)
+  list(APPEND CMAKE_PREFIX_PATH ${onnxruntime_ROCM_HOME})
 
   find_package(HIP)
   find_package(hiprand REQUIRED)
@@ -1505,12 +1505,21 @@ if (onnxruntime_USE_ROCM)
 
   # MIOpen version
   if(NOT DEFINED ENV{MIOPEN_PATH})
-    set(MIOPEN_PATH ${onnxruntime_ROCM_HOME}/miopen)
+    set(MIOPEN_PATH ${onnxruntime_ROCM_HOME})
   else()
     set(MIOPEN_PATH $ENV{MIOPEN_PATH})
   endif()
+  find_path(MIOPEN_VERSION_H_PATH
+    NAMES version.h
+    HINTS
+    ${MIOPEN_PATH}/include/miopen
+    ${MIOPEN_PATH}/miopen/include)
+  if (MIOPEN_VERSION_H_PATH-NOTFOUND)
+    MESSAGE(FATAL_ERROR "miopen version.h not found")
+  endif()
+  MESSAGE(STATUS "Found miopen version.h at ${MIOPEN_VERSION_H_PATH}")
 
-  file(READ ${MIOPEN_PATH}/include/miopen/version.h MIOPEN_HEADER_CONTENTS)
+  file(READ ${MIOPEN_VERSION_H_PATH}/version.h MIOPEN_HEADER_CONTENTS)
         string(REGEX MATCH "define MIOPEN_VERSION_MAJOR * +([0-9]+)"
                                  MIOPEN_VERSION_MAJOR "${MIOPEN_HEADER_CONTENTS}")
         string(REGEX REPLACE "define MIOPEN_VERSION_MAJOR * +([0-9]+)" "\\1"


### PR DESCRIPTION
This is in preparation for planned ROCm 6.0 changes that are not backward compatible. However, the adjustments made by this PR to the current onnxruntime cmake files will work with ROCm 5.x and 6.x.

CC @cloudhan @PeixuanZuo @TedThemistokleous @causten 