### PR TITLE
Tolerant ORTModule no exist for inference build in Python3.6

### DIFF
--- a/onnxruntime/python/onnxruntime_validation.py
+++ b/onnxruntime/python/onnxruntime_validation.py
@@ -73,6 +73,9 @@ def validate_build_package_info():
     except ImportError:
         # ORTModule not present
         has_ortmodule = False
+    except AttributeError:
+        # ORTModule not present, this is for Python3.6 compatibility.
+        has_ortmodule = False
     except Exception as e:
         # this may happen if Cuda is not installed, we want to raise it after
         # for any exception other than not having ortmodule, we want to continue


### PR DESCRIPTION
### Tolerant ORTModule no exist for inference build in Python3.6

In Python3.6, the import failure is treated as a AttributeError instead of Import Error. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


