### PR TITLE
Remove the extensions submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 	path = cmake/external/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
 	branch = 3.1.37
-[submodule "cmake/external/onnxruntime-extensions"]
-	path = cmake/external/onnxruntime-extensions
-	url = https://github.com/microsoft/onnxruntime-extensions.git

--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -112,16 +112,6 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "81e7799c69044c745239202085eb0a98f102937b",
-          "repositoryUrl": "https://github.com/microsoft/onnxruntime-extensions.git"
-        },
-        "comments": "git submodule at cmake/external/onnxruntime-extensions"
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "commitHash": "8c0b94e793a66495e0b1f34a5eb26bd7dc672db0",
           "repositoryUrl": "https://github.com/abseil/abseil-cpp.git"
         },

--- a/docs/onnxruntime_extensions.md
+++ b/docs/onnxruntime_extensions.md
@@ -6,7 +6,7 @@ ONNXRuntime Extensions is a comprehensive package to extend the capability of th
 onnxruntime-extensions supports many useful custom operators to enhance the text processing capability of ONNXRuntime, which include some widely used **string operators** and popular **tokenizers**. For custom operators supported and how to use them, please check the documentation [custom operators](https://github.com/microsoft/onnxruntime-extensions/blob/main/docs/custom_text_ops.md).
 
 ## Build ONNXRuntime with Extensions
-We have supported build onnxruntime-extensions as a static library and link it into ONNXRuntime. To enable custom operators from onnxruntime-extensions, you should add argument `--use_extensions`, which will use onnxruntime-extensions from git submodule in path cmake/external/onnxruntime-extensions **by default**.
+We have supported build onnxruntime-extensions as a static library and link it into ONNXRuntime. To enable custom operators from onnxruntime-extensions, you should add argument `--use_extensions`, which will fetch onnxruntime-extensions and build it as static library from https://github.com/microsoft/onnxruntime-extensions **by default**.
 
 If you want to build ONNXRuntime with a pre-pulled onnxruntime-extensions, pass extra argument `--extensions_overridden_path <path-to-onnxruntime-extensions>`.
 


### PR DESCRIPTION
### Description
Remove the onnxruntime-extensions submodule since it now was used via cmake FetchContent


### Motivation and Context
The submodule relies on an outdated version of the extensions, and the build instructions should be updated to eliminate any confusion.

