### PR TITLE
Bump clang-format to 16.0.6 in CI

### DIFF
--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -8,4 +8,4 @@ isort==5.12.0
 # PYLINT
 pylint==2.17.2
 # CLANGFORMAT
-clang-format==16.0.1
+clang-format==16.0.6


### PR DESCRIPTION
### Description

Bump clang-format to 16.0.6 in CI to take in fixes.

### Motivation and Context

Potentially help https://github.com/microsoft/onnxruntime/pull/17030

