### PR TITLE
Issue #17098: Shape inferencing fails during quantization for large models

### DIFF
--- a/onnxruntime/python/tools/quantization/shape_inference.py
+++ b/onnxruntime/python/tools/quantization/shape_inference.py
@@ -81,7 +81,17 @@ def quant_pre_process(
             if not skip_symbolic_shape:
                 # Need to save the inferenced model to file so as to run the optimizer
                 input_model_path = str(temp_path / "symbolic_shape_inferred.onnx")
-                onnx.save(model, input_model_path)
+                if save_as_external_data:
+                    onnx.save_model(
+                        model,
+                        input_model_path,
+                        save_as_external_data=True,
+                        all_tensors_to_one_file=all_tensors_to_one_file,
+                        size_threshold=external_data_size_threshold,
+                        convert_attribute=False,
+                    )
+                else:
+                    onnx.save(model, input_model_path)
                 model = None
 
             opt_model_path = str(temp_path / "optimized.onnx")


### PR DESCRIPTION
Issue #17098: Shape inferencing fails during quantization for large models

Quantization call accepts a 'save_as_external_data' but is ignored while saving intermediate model for shape inferencing.

### Description
<!-- Describe your changes. -->
Save uding external data format when the input args dictate it.


### Motivation and Context
Fixes issue #17098 - Fixes quantization of large Llama models
