### PR TITLE
update onnx.patch to apply wasm build break fix

### DIFF
--- a/cmake/patches/onnx/onnx.patch
+++ b/cmake/patches/onnx/onnx.patch
@@ -38,7 +38,7 @@ index 0aab3e26..0f859267 100644
 @@ -47,10 +47,28 @@
  #define ONNX_API ONNX_IMPORT
  #endif
- 
+
 +#if defined(__GNUC__)
 +#pragma GCC diagnostic push
 +
@@ -58,9 +58,22 @@ index 0aab3e26..0f859267 100644
  #else
  #include "onnx/onnx.pb.h"
  #endif
- 
+
 +#if defined(__GNUC__)
 +#pragma GCC diagnostic pop
 +#endif
 +
  #endif // ! ONNX_ONNX_PB_H
+diff --git a/onnx/checker.cc b/onnx/checker.cc
+index 8fdaf037..1beb1b88 100644
+--- a/onnx/checker.cc
++++ b/onnx/checker.cc
+@@ -190,7 +190,7 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
+         }
+         std::string data_path = path_join(ctx.get_model_dir(), relative_path);
+         // use stat64 to check whether the file exists
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__wasm__)
+         struct stat buffer; // APPLE does not have stat64
+         if (stat((data_path).c_str(), &buffer) != 0) {
+ #else


### PR DESCRIPTION
### Description
This PR fixes build break for WebAssembly introduced in 6986981482086832d897a9b3241987c04c0a64cf (https://github.com/onnx/onnx/commit/435ad2b1d80f67e5e85e83092bbd6d3900f40806).

This change updates onnx.patch in onnxruntime repo. the corresponding PR in onnx repo is: https://github.com/onnx/onnx/pull/5495.

It may takes a while for the next onnx version bump.