### PR TITLE
try to find patch.exe in git default installation folder

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,5 +2,9 @@
 :: Licensed under the MIT License.
 
 @echo off
+
+setlocal
+set PATH=C:\Program Files\Git\usr\bin;%PATH%
+
 rem Requires a Python install to be available in your PATH
 python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" %*


### PR DESCRIPTION
### Description
updates the build.bat file in root folder to try best efforts to locate patch.exe.

patch.exe is needed to apply patches to some of the dependencies. for example, #17104. However, patch.exe is not available on every windows developer's search path, and if cannot find patch.exe, the build will continue silently. ( as a result, patch is not applied and for patches like #17104, this will cause a build break )

This change adds folder `C:\Program Files\Git\usr\bin` to the PATH, which is the default git installation directory. This may resolve the patch not found issue for most (hopefully) users.