### PR TITLE
Mark end of version 16 C API

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2659,7 +2659,6 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::ReleaseKernelInfo,
     // End of Version 12 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Start of Version 13 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::GetTrainingApi,
     &OrtApis::SessionOptionsAppendExecutionProvider_CANN,
     &OrtApis::CreateCANNProviderOptions,
@@ -2668,7 +2667,6 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::ReleaseCANNProviderOptions,
     // End of Version 13 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Start of Version 14 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::MemoryInfoGetDeviceType,
     &OrtApis::UpdateEnvWithCustomLogLevel,
     &OrtApis::SetGlobalIntraOpThreadAffinity,
@@ -2685,7 +2683,6 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::GetSessionConfigEntry,
     // End of Version 14 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Start of Version 15 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::SessionOptionsAppendExecutionProvider_Dnnl,
     &OrtApis::CreateDnnlProviderOptions,
     &OrtApis::UpdateDnnlProviderOptions,
@@ -2704,7 +2701,6 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::GetBuildInfoString,
     // End of Version 15 - DO NOT MODIFY ABOVE (see above text for more information)
 
-    // Start of Version 16 API in progress, safe to modify/rename/rearrange until we ship
     &OrtApis::CreateROCMProviderOptions,
     &OrtApis::UpdateROCMProviderOptions,
     &OrtApis::GetROCMProviderOptionsAsString,
@@ -2715,6 +2711,7 @@ static constexpr OrtApi ort_api_1_to_16 = {
     &OrtApis::GetTensorRTProviderOptionsByName,
     &OrtApis::UpdateCUDAProviderOptionsWithValue,
     &OrtApis::GetCUDAProviderOptionsByName,
+    // End of Version 16 - DO NOT MODIFY ABOVE (see above text for more information)
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.
@@ -2743,6 +2740,7 @@ static_assert(offsetof(OrtApi, ReleaseKernelInfo) / sizeof(void*) == 218, "Size 
 static_assert(offsetof(OrtApi, ReleaseCANNProviderOptions) / sizeof(void*) == 224, "Size of version 13 API cannot change");
 static_assert(offsetof(OrtApi, GetSessionConfigEntry) / sizeof(void*) == 238, "Size of version 14 API cannot change");
 static_assert(offsetof(OrtApi, GetBuildInfoString) / sizeof(void*) == 254, "Size of version 15 API cannot change");
+static_assert(offsetof(OrtApi, GetCUDAProviderOptionsByName) / sizeof(void*) == 264, "Size of version 16 API cannot change");
 
 // So that nobody forgets to finish an API version, this check will serve as a reminder:
 static_assert(std::string_view(ORT_VERSION) == "1.16.0",


### PR DESCRIPTION
Mark end of version 16 C API in preparation for ORT 1.16 release.
