### PR TITLE
[VITISAI] 1. Fix reading .dat and .onnx on Linux 2. Fix issue of compiling graph twice

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -195,6 +195,9 @@ Node& graph_fuse(Graph& graph, const std::string& name,
     *proto.mutable_name() = name;
     fused_node.AddAttribute("body", proto);
   }
+  for (auto&& o : fused_node.OutputDefs()) {
+    graph.UpdateProducerNode(o->Name(), fused_node.Index());
+  }
   return fused_node;
 }
 }  // namespace vaip

--- a/onnxruntime/core/providers/vitisai/imp/tensor_proto.cc
+++ b/onnxruntime/core/providers/vitisai/imp/tensor_proto.cc
@@ -14,7 +14,7 @@ gsl::span<const char> tensor_proto_as_raw(
   auto& mut_tensor = const_cast<ONNX_NAMESPACE::TensorProto&>(tensor);
   if (!tensor.has_raw_data()) {
     std::vector<uint8_t> unpacked_tensor;
-    auto s = onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor);
+    auto s = onnxruntime::utils::UnpackInitializerData(tensor, onnxruntime::Path(), unpacked_tensor);
     mut_tensor.mutable_raw_data()->resize(unpacked_tensor.size());
     memcpy(mut_tensor.mutable_raw_data()->data(), unpacked_tensor.data(), unpacked_tensor.size());
   }

--- a/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
+++ b/onnxruntime/core/providers/vitisai/vitisai_execution_provider.cc
@@ -96,6 +96,10 @@ VitisAIExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
     // VITIS AI EP not support sungraph. Assigned to CPU.
     return {};
   }
+  if (execution_providers_) {
+    // Only compiling a model once is currently supported
+    return {};
+  }
   auto opt_str = info_.get_json_config_str();  // String
   execution_providers_ =
       std::make_unique<my_ep_t>(compile_onnx_model(graph, *GetLogger(), opt_str));


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
1. Fix reading .dat and .onnx on Linux 2. Fix issue of compiling graph twice


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
1. Previous we have not tested large model on Linux. When the model is sperate into .dat and .onnx, it failed to load the model.
2. Check if the provider pointer is already existed. If existed, do not create again.


