### PR TITLE
[js/web] JSEP node assignment optimization

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/gather.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/gather.ts
@@ -41,30 +41,21 @@ const createGatherProgramInfo =
       const gatheredBatchElements = N * block * elementSize;
       const axisDimLimit = inputShape[axis];
 
-      const inputIndices: number[] = [];
-      const inputIndicesArray = indicesElementSize === 2
-        ? inputs[1].getBigInt64Array()
-        : inputs[1].getInt32Array();
-      for (const i of inputIndicesArray[Symbol.iterator]()) {
-        let value = Number(i);
-        if (value < 0) {
-          value += axisDimLimit;
-        }
-        inputIndices.push(value);
-      }
-
       const inputSize = ShapeUtil.size(inputShape) * elementSize;
       const outputSize = ShapeUtil.size(outputShape) * elementSize;
 
       const totalGathers = M * N;
+      // int64 indices would be treated as little endian i32 with assumption they fall in i32 limits
+      // That assumption is safe as it's not possible to allocate >2gb buffer for input tensor
+      // Input data will be treated as u32 or two u32 for 8-byte tensors
       const getShaderSource = (shaderHelper: ShaderHelper) => `
   const N: u32 = ${N};
   const elementSize: u32 = ${elementSize};
   const indicesElementSize: u32 = ${indicesElementSize};
-  const inputIndices = array<u32, N>(${inputIndices.map(i => `${i}u`).join(',')});
 
   @group(0) @binding(0) var<storage, read> input : array<u32>;
-  @group(0) @binding(1) var<storage, read_write> output: array<u32>;
+  @group(0) @binding(1) var<storage, read> inputIndices : array<i32>;
+  @group(0) @binding(2) var<storage, read_write> output: array<u32>;
 
   ${shaderHelper.mainStart()}
     let batch: u32 = global_idx / N;
@@ -72,9 +63,12 @@ const createGatherProgramInfo =
 
     let srcOffsetBatch: u32 = batch * ${dataBatchElements};
     let dstOffsetBatch: u32 = batch * ${gatheredBatchElements};
-    var idx = inputIndices[i];
+    var idx = inputIndices[i * indicesElementSize];
+    if (idx < 0) {
+        idx = idx + ${axisDimLimit};
+    }
 
-    let srcOffset = srcOffsetBatch + idx * ${blockSize};
+    let srcOffset = srcOffsetBatch + u32(idx) * ${blockSize};
     let dstOffset = dstOffsetBatch + i * ${blockSize};
     if (srcOffset >= ${inputSize}) {
         return;
@@ -105,13 +99,9 @@ export const gather = (context: ComputeContext, attributes: GatherAttributes): v
 
   const metadata = {
     name: 'Gather',
-    inputTypes: [GpuDataType.default],
-    cacheHint: attributes.cacheKey + inputs[0].dataType.toString(10) + inputs[1].dataType.toString(10) +
-    inputs[1].dims.join(','),
+    inputTypes: [GpuDataType.default, GpuDataType.default],
+    cacheHint: attributes.cacheKey,
   };
 
-  context.compute(
-    createGatherProgramInfo(metadata, context.inputs, attributes),
-    { inputs: [inputs[0]] },
-  );
+  context.compute(createGatherProgramInfo(metadata, context.inputs, attributes));
 };

--- a/js/web/lib/wasm/jsep/webgpu/ops/gather.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/gather.ts
@@ -41,14 +41,14 @@ const createGatherProgramInfo =
       const gatheredBatchElements = N * block * elementSize;
       const axisDimLimit = inputShape[axis];
 
-        const inputIndices: number[] = [];
-        inputs[1].getBigInt64Array().forEach(v => {
-            let value = Number(v);
-            if (value < 0){
-                value += axisDimLimit;
-            }
-            inputIndices.push(value);
-        });
+      const inputIndices: number[] = [];
+      inputs[1].getBigInt64Array().forEach(v => {
+        let value = Number(v);
+        if (value < 0) {
+          value += axisDimLimit;
+        }
+        inputIndices.push(value);
+      });
 
       const inputSize = ShapeUtil.size(inputShape) * elementSize;
       const outputSize = ShapeUtil.size(outputShape) * elementSize;

--- a/onnxruntime/core/providers/js/js_data_types.cc
+++ b/onnxruntime/core/providers/js/js_data_types.cc
@@ -12,8 +12,7 @@ using SupportedTypes =
         int32_t,
         uint32_t>;
 
-std::vector<MLDataType> JsepSupportedDataTypes() {
-  return BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
-}
+const std::vector<MLDataType> JsepSupportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
+
 }  // namespace js
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/js_data_types.cc
+++ b/onnxruntime/core/providers/js/js_data_types.cc
@@ -12,7 +12,9 @@ using SupportedTypes =
         int32_t,
         uint32_t>;
 
-const std::vector<MLDataType> JsepSupportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
-
+const std::vector<MLDataType>& JsepSupportedDataTypes() {
+  static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
+  return supportedDataTypes;
+}
 }  // namespace js
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/js_data_types.cc
+++ b/onnxruntime/core/providers/js/js_data_types.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 #include "core/providers/cpu/tensor/shape_op.h"
 
 namespace onnxruntime {
@@ -14,5 +15,5 @@ using SupportedTypes =
 std::vector<MLDataType> JsepSupportedDataTypes() {
   return BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
 }
-}
-}
+}  // namespace js
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/js_data_types.cc
+++ b/onnxruntime/core/providers/js/js_data_types.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "core/providers/cpu/tensor/shape_op.h"
+
+namespace onnxruntime {
+namespace js {
+
+using SupportedTypes =
+    TypeList<
+        float,
+        int32_t,
+        uint32_t>;
+
+std::vector<MLDataType> JsepSupportedDataTypes() {
+  return BuildKernelDefConstraintsFromTypeList<SupportedTypes>();
+}
+}
+}

--- a/onnxruntime/core/providers/js/js_data_types.h
+++ b/onnxruntime/core/providers/js/js_data_types.h
@@ -5,6 +5,6 @@
 
 namespace onnxruntime {
 namespace js {
-std::vector<MLDataType> JsepSupportedDataTypes();
+const std::vector<MLDataType> JsepSupportedDataTypes;
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/js_data_types.h
+++ b/onnxruntime/core/providers/js/js_data_types.h
@@ -5,6 +5,6 @@
 
 namespace onnxruntime {
 namespace js {
-const std::vector<MLDataType> JsepSupportedDataTypes;
+std::vector<MLDataType>& JsepSupportedDataTypes();
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/js_data_types.h
+++ b/onnxruntime/core/providers/js/js_data_types.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/data_types.h"
+
+namespace onnxruntime {
+namespace js {
+  std::vector<MLDataType> JsepSupportedDataTypes();
+}
+}

--- a/onnxruntime/core/providers/js/js_data_types.h
+++ b/onnxruntime/core/providers/js/js_data_types.h
@@ -5,6 +5,6 @@
 
 namespace onnxruntime {
 namespace js {
-  std::vector<MLDataType> JsepSupportedDataTypes();
+std::vector<MLDataType> JsepSupportedDataTypes();
 }
-}
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/operators/gather.cc
+++ b/onnxruntime/core/providers/js/operators/gather.cc
@@ -24,7 +24,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
         .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);
@@ -36,7 +36,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
         .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);
@@ -47,7 +47,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
         .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);

--- a/onnxruntime/core/providers/js/operators/gather.cc
+++ b/onnxruntime/core/providers/js/operators/gather.cc
@@ -8,15 +8,6 @@
 namespace onnxruntime {
 namespace js {
 
-using AllSupportedSize =
-    TypeList<
-        float,
-        double,
-        int64_t,
-        uint64_t,
-        int32_t,
-        uint32_t>;
-
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     Gather,
     kOnnxDomain,
@@ -24,9 +15,8 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
-        .InputMemoryType(OrtMemTypeCPU, 1),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
     Gather);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
@@ -36,9 +26,8 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
-        .InputMemoryType(OrtMemTypeCPU, 1),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
     Gather);
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -47,9 +36,8 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
-        .InputMemoryType(OrtMemTypeCPU, 1),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
     Gather);
 
 }  // namespace js

--- a/onnxruntime/core/providers/js/operators/gather.cc
+++ b/onnxruntime/core/providers/js/operators/gather.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/js/js_kernel.h"
-
+#include "core/providers/js/js_data_types.h"
 #include "gather.h"
 
 namespace onnxruntime {
@@ -24,8 +24,9 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<AllSupportedSize>())
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+        .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);
 
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(
@@ -35,8 +36,9 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<AllSupportedSize>())
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+        .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -45,8 +47,9 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", BuildKernelDefConstraintsFromTypeList<AllSupportedSize>())
-        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()),
+        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+        .InputMemoryType(OrtMemTypeCPU, 1),
     Gather);
 
 }  // namespace js

--- a/onnxruntime/core/providers/js/operators/reshape.cc
+++ b/onnxruntime/core/providers/js/operators/reshape.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "reshape.h"
+#include "core/providers/js/js_data_types.h"
 
 namespace onnxruntime {
 namespace js {
@@ -12,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     14,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -24,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     13, 13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -36,7 +37,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     5, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),

--- a/onnxruntime/core/providers/js/operators/reshape.cc
+++ b/onnxruntime/core/providers/js/operators/reshape.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     14,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     13, 13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -37,7 +37,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     5, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),

--- a/onnxruntime/core/providers/js/operators/reshape.cc
+++ b/onnxruntime/core/providers/js/operators/reshape.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     14,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     13, 13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -37,7 +37,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     5, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),

--- a/onnxruntime/core/providers/js/operators/shape_op.cc
+++ b/onnxruntime/core/providers/js/operators/shape_op.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/js/js_kernel.h"
+#include "core/providers/js/js_data_types.h"
 #include "core/providers/cpu/tensor/shape_op.h"
 
 namespace onnxruntime {
@@ -15,7 +16,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -27,7 +28,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -39,7 +40,7 @@ ONNX_OPERATOR_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 

--- a/onnxruntime/core/providers/js/operators/shape_op.cc
+++ b/onnxruntime/core/providers/js/operators/shape_op.cc
@@ -16,7 +16,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -28,7 +28,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -40,7 +40,7 @@ ONNX_OPERATOR_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 

--- a/onnxruntime/core/providers/js/operators/shape_op.cc
+++ b/onnxruntime/core/providers/js/operators/shape_op.cc
@@ -16,7 +16,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -28,7 +28,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 
@@ -40,7 +40,7 @@ ONNX_OPERATOR_KERNEL_EX(
     (*KernelDefBuilder::Create())
         // properly force CPU/GPU synch inside the kernel
         .OutputMemoryType(OrtMemTypeCPU, 0)
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>()),
     Shape);
 

--- a/onnxruntime/core/providers/js/operators/squeeze.cc
+++ b/onnxruntime/core/providers/js/operators/squeeze.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "squeeze.h"
+#include "core/providers/js/js_data_types.h"
 
 namespace onnxruntime {
 namespace js {
@@ -12,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -24,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Squeeze);
 
@@ -34,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Squeeze);
 

--- a/onnxruntime/core/providers/js/operators/squeeze.cc
+++ b/onnxruntime/core/providers/js/operators/squeeze.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Squeeze);
 
@@ -35,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Squeeze);
 

--- a/onnxruntime/core/providers/js/operators/squeeze.cc
+++ b/onnxruntime/core/providers/js/operators/squeeze.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .Alias(0, 0),
     Squeeze);
 
@@ -35,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .Alias(0, 0),
     Squeeze);
 

--- a/onnxruntime/core/providers/js/operators/unsqueeze.cc
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "unsqueeze.h"
+#include "core/providers/js/js_data_types.h"
 
 namespace onnxruntime {
 namespace js {
@@ -12,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -24,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Unsqueeze);
 
@@ -34,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", DataTypeImpl::AllFixedSizeTensorTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Unsqueeze);
 

--- a/onnxruntime/core/providers/js/operators/unsqueeze.cc
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Unsqueeze);
 
@@ -35,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes)
+        .TypeConstraint("T", JsepSupportedDataTypes())
         .Alias(0, 0),
     Unsqueeze);
 

--- a/onnxruntime/core/providers/js/operators/unsqueeze.cc
+++ b/onnxruntime/core/providers/js/operators/unsqueeze.cc
@@ -13,7 +13,7 @@ ONNX_OPERATOR_KERNEL_EX(
     13,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .TypeConstraint("axes", DataTypeImpl::GetTensorType<int64_t>())
         .Alias(0, 0)
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -25,7 +25,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 12,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .Alias(0, 0),
     Unsqueeze);
 
@@ -35,7 +35,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     1, 10,
     kJsExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", JsepSupportedDataTypes())
+        .TypeConstraint("T", JsepSupportedDataTypes)
         .Alias(0, 0),
     Unsqueeze);
 


### PR DESCRIPTION
### Description
Since WebGPU supports only float32 and int32, having Gather, Reshape, Shape, Squeeze and Unsqueeze ops with other data types create additional MemCpy ops and slow down the overall execution as all other OPs with other tensor types will be done on CPU.

Before this patch SD Unet had these numbers:
Node(s) placed on [CPUExecutionProvider]. Number of nodes: 1141
Node(s) placed on [JsExecutionProvider]. Number of nodes: 4025
memcpy tokens: 2001

After patch:
Node(s) placed on [CPUExecutionProvider]. Number of nodes: 1735
Node(s) placed on [JsExecutionProvider]. Number of nodes: 2243
memcpu tokens: 813

It also gives more than 5X performance benefit. From 12sec for one Unet step to 2.2sec on RTX 3090 Ti, so we are almost getting to native performance.

UPD: with latest changes from main branch and multi-threading it went down to 1.6sec. Will try re-exporting my model to onnx with maximum optimizations, like using MultiHeadAttention to decrease node count. Maybe after implementing that it can go in less than 1 sec
