### PR TITLE
Rework WIL dependency retrieval/usage

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -462,7 +462,7 @@ endif()
 #onnxruntime_EXTERNAL_LIBRARIES could contain onnx, onnx_proto,libprotobuf, cuda/cudnn,
 # dnnl/mklml, onnxruntime_codegen_tvm, tvm and pthread
 # pthread is always at the last
-set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK} WIL::WIL nlohmann_json::nlohmann_json onnx onnx_proto ${PROTOBUF_LIB} re2::re2 Boost::mp11 safeint_interface flatbuffers::flatbuffers ${GSL_TARGET} ${ABSEIL_LIBS} date_interface)
+set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK} ${WIL_TARGET} nlohmann_json::nlohmann_json onnx onnx_proto ${PROTOBUF_LIB} re2::re2 Boost::mp11 safeint_interface flatbuffers::flatbuffers ${GSL_TARGET} ${ABSEIL_LIBS} date_interface)
 # The source code of onnx_proto is generated, we must build this lib first before starting to compile the other source code that uses ONNX protobuf types.
 # The other libs do not have the problem. All the sources are already there. We can compile them in any order.
 set(onnxruntime_EXTERNAL_DEPENDENCIES onnx_proto flatbuffers::flatbuffers)

--- a/cmake/external/wil.cmake
+++ b/cmake/external/wil.cmake
@@ -4,19 +4,13 @@ set(WIL_BUILD_PACKAGING OFF CACHE BOOL "" FORCE)
 set(WIL_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
-    microsoft_wil
-    URL ${DEP_URL_microsoft_wil}
-	URL_HASH SHA1=${DEP_SHA1_microsoft_wil}
-    FIND_PACKAGE_ARGS NAMES wil
+  microsoft_wil
+  URL ${DEP_URL_microsoft_wil}
+  URL_HASH SHA1=${DEP_SHA1_microsoft_wil}
+  FIND_PACKAGE_ARGS NAMES wil
 )
-#We can not use FetchContent_MakeAvailable(microsoft_wil) at here, since their cmake file
-#always executes install command without conditions.
-FetchContent_Populate(microsoft_wil)
-if(NOT wil_FOUND)
-  add_library(WIL INTERFACE)
-  add_library(WIL::WIL ALIAS WIL)
 
-  # The interface's include directory.
-  target_include_directories(WIL INTERFACE
-    $<BUILD_INTERFACE:${microsoft_wil_SOURCE_DIR}/include>)
+if(WIN32)
+  onnxruntime_fetchcontent_makeavailable(microsoft_wil)
+  set(WIL_TARGET "WIL::WIL")
 endif()

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -116,7 +116,7 @@ if (MSVC)
     endif()
 endif()
 
-onnxruntime_add_include_to_target(onnxruntime_common date_interface WIL::WIL)
+onnxruntime_add_include_to_target(onnxruntime_common date_interface ${WIL_TARGET})
 target_include_directories(onnxruntime_common
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT} ${eigen_INCLUDE_DIRS}
     # propagate include directories of dependencies that are part of public interface

--- a/cmake/onnxruntime_graph.cmake
+++ b/cmake/onnxruntime_graph.cmake
@@ -87,7 +87,7 @@ endif()
 
 onnxruntime_add_static_library(onnxruntime_graph ${onnxruntime_graph_lib_src})
 add_dependencies(onnxruntime_graph onnx_proto flatbuffers::flatbuffers)
-onnxruntime_add_include_to_target(onnxruntime_graph onnxruntime_common WIL::WIL onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers safeint_interface Boost::mp11)
+onnxruntime_add_include_to_target(onnxruntime_graph onnxruntime_common ${WIL_TARGET} onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers safeint_interface Boost::mp11)
 
 if (MSVC)
   set(ONNX_PROTOBUF_NATVIS_FILE "onnx_protobuf.natvis")

--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1276,7 +1276,7 @@ if (onnxruntime_USE_DML)
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_dml_cc_srcs})
   onnxruntime_add_static_library(onnxruntime_providers_dml ${onnxruntime_providers_dml_cc_srcs})
   onnxruntime_add_include_to_target(onnxruntime_providers_dml
-    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface WIL::WIL
+    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface ${WIL_TARGET}
   )
   add_dependencies(onnxruntime_providers_dml ${onnxruntime_EXTERNAL_DEPENDENCIES})
   target_include_directories(onnxruntime_providers_dml PRIVATE

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -202,7 +202,7 @@ add_dependencies(winml_lib_telemetry winml_api_native)
 add_dependencies(winml_lib_telemetry winml_api_native_internal)
 
 # Link libraries
-target_link_libraries(winml_lib_telemetry PRIVATE WIL::WIL)
+target_link_libraries(winml_lib_telemetry PRIVATE ${WIL_TARGET})
 
 ###########################
 # Add winml_lib_ort
@@ -282,7 +282,7 @@ add_dependencies(winml_lib_ort winml_api_native_internal)
 if (onnxruntime_USE_DML)
   target_add_dml(winml_lib_ort)
 endif()
-target_link_libraries(winml_lib_ort PRIVATE WIL::WIL)
+target_link_libraries(winml_lib_ort PRIVATE ${WIL_TARGET})
 target_link_libraries(winml_lib_ort INTERFACE winml_lib_api)
 target_link_libraries(winml_lib_ort INTERFACE winml_lib_telemetry)
 
@@ -339,7 +339,7 @@ set_target_properties(winml_adapter
   ${target_folder})
 
 # Link libraries
-target_link_libraries(winml_adapter PRIVATE WIL::WIL)
+target_link_libraries(winml_adapter PRIVATE ${WIL_TARGET})
 if (onnxruntime_USE_DML)
   target_add_dml(winml_adapter)
 endif()
@@ -423,7 +423,7 @@ add_dependencies(winml_lib_image winml_api_native)
 add_dependencies(winml_lib_image winml_api_native_internal)
 
 # Link libraries
-target_link_libraries(winml_lib_image PRIVATE dxgi d3d11 d3d12 WIL::WIL winml_lib_common)
+target_link_libraries(winml_lib_image PRIVATE dxgi d3d11 d3d12 ${WIL_TARGET} winml_lib_common)
 
 get_target_property(winml_lib_image_include_directories winml_lib_image INCLUDE_DIRECTORIES)
 
@@ -531,7 +531,7 @@ add_dependencies(winml_lib_api winml_api_native)
 add_dependencies(winml_lib_api winml_api_native_internal)
 
 # Link libraries
-target_link_libraries(winml_lib_api PRIVATE WIL::WIL winml_lib_telemetry)
+target_link_libraries(winml_lib_api PRIVATE ${WIL_TARGET} winml_lib_telemetry)
 if (onnxruntime_USE_DML)
   target_add_dml(winml_lib_api)
 endif(onnxruntime_USE_DML)
@@ -619,7 +619,7 @@ add_dependencies(winml_lib_api_experimental winml_api_native_internal)
 add_dependencies(winml_lib_api_experimental winml_api_experimental)
 
 # Link libraries
-target_link_libraries(winml_lib_api_experimental PRIVATE WIL::WIL winml_lib_telemetry)
+target_link_libraries(winml_lib_api_experimental PRIVATE ${WIL_TARGET} winml_lib_telemetry)
 if (onnxruntime_USE_DML)
   target_add_dml(winml_lib_api_experimental)
 endif(onnxruntime_USE_DML)
@@ -648,7 +648,7 @@ onnxruntime_add_static_library(winml_lib_common
 set_target_properties(winml_lib_common PROPERTIES CXX_STANDARD 17)
 set_target_properties(winml_lib_common PROPERTIES CXX_STANDARD_REQUIRED ON)
 target_compile_options(winml_lib_common PRIVATE /GR- /await /bigobj /wd4238)
-target_link_libraries(winml_lib_common PRIVATE WIL::WIL)
+target_link_libraries(winml_lib_common PRIVATE ${WIL_TARGET})
 target_include_directories(winml_lib_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/winml_api)
 
 # Compiler flags
@@ -786,7 +786,7 @@ add_dependencies(winml_dll winml_api_native_internal)
 
 # Link libraries
 target_link_libraries(winml_dll PRIVATE re2)
-target_link_libraries(winml_dll PRIVATE WIL::WIL)
+target_link_libraries(winml_dll PRIVATE ${WIL_TARGET})
 target_link_libraries(winml_dll PRIVATE winml_lib_api)
 if (NOT winml_is_inbox)
   target_link_libraries(winml_dll PRIVATE winml_lib_api_experimental)

--- a/cmake/winml_unittests.cmake
+++ b/cmake/winml_unittests.cmake
@@ -180,7 +180,7 @@ add_dependencies(winml_test_common
   winml_dll
 )
 
-onnxruntime_add_include_to_target(winml_test_common onnx_proto gtest ${PROTOBUF_LIB} WIL::WIL safeint_interface ${GSL_TARGET})
+onnxruntime_add_include_to_target(winml_test_common onnx_proto gtest ${PROTOBUF_LIB} ${WIL_TARGET} safeint_interface ${GSL_TARGET})
 onnxruntime_add_static_library(winml_google_test_lib ${WINML_TEST_SRC_DIR}/common/googletest/main.cpp)
 onnxruntime_add_include_to_target(winml_google_test_lib gtest)
 set_winml_target_properties(winml_google_test_lib)


### PR DESCRIPTION
### Description
1. `onnxruntime_fetchcontent_makeavailable` works around unconditional install commands so that can be used instead of `FetchContent_Populate`
2. This dependency is Windows specific, mark it as such.

### Motivation and Context
1. This simplifies `cmake/external/wil.cmake` not to do anything specific wether WIL was fetched or found
2. Given it's specific to Windows, it might not be available on other OS in specific air-gapped environment such as [conan-center-index](https://github.com/conan-io/conan-center-index). This allows downstream builds not to require specific patches for something not required by the build in the first place.


