### PR TITLE
Enable verbose logging in unit test program with environment variable.

### DIFF
--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
 #ifndef USE_ONNXRUNTIME_DLL
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#else
 #endif
 #include <google/protobuf/message_lite.h>
 #ifdef __GNUC__
@@ -14,9 +17,10 @@
 #endif
 #endif
 
+#include "gtest/gtest.h"
+
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/util/thread_utils.h"
-#include "gtest/gtest.h"
 #include "test/test_environment.h"
 
 std::unique_ptr<Ort::Env> ort_env;
@@ -56,6 +60,13 @@ int TEST_MAIN(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
     ortenv_setup();
+
+    // allow verbose logging to be enabled by defining this environment variable
+    if (std::getenv("ORT_UNIT_TEST_MAIN_ENABLE_VERBOSE_LOGGING") != nullptr) {
+      std::cout << "Verbose logging is enabled.\n";
+      ort_env->UpdateEnvWithCustomLogLevel(ORT_LOGGING_LEVEL_VERBOSE);
+    }
+
     status = RUN_ALL_TESTS();
   }
   ORT_CATCH(const std::exception& ex) {

--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cstdlib>
-#include <iostream>
-#include <memory>
+#include <cstring>
 
 #ifndef USE_ONNXRUNTIME_DLL
 #ifdef __GNUC__
@@ -58,12 +57,13 @@ int TEST_MAIN(int argc, char** argv) {
 
   ORT_TRY {
     ::testing::InitGoogleTest(&argc, argv);
-
     ortenv_setup();
 
-    // allow verbose logging to be enabled by defining this environment variable
-    if (std::getenv("ORT_UNIT_TEST_MAIN_ENABLE_VERBOSE_LOGGING") != nullptr) {
-      std::cout << "Verbose logging is enabled.\n";
+    // allow verbose logging to be enabled by setting this environment variable to 1
+    constexpr auto kEnableVerboseLoggingEnvironmentVariableName = "ORT_UNIT_TEST_MAIN_ENABLE_VERBOSE_LOGGING";
+    if (const char* enable_verbose_logging_str = std::getenv(kEnableVerboseLoggingEnvironmentVariableName);
+        enable_verbose_logging_str != nullptr && std::strcmp(enable_verbose_logging_str, "1") == 0) {
+      std::cout << "Enabling verbose logging.\n";
       ort_env->UpdateEnvWithCustomLogLevel(ORT_LOGGING_LEVEL_VERBOSE);
     }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Enable verbose logging in unit test program with environment variable.
E.g., `ORT_UNIT_TEST_MAIN_ENABLE_VERBOSE_LOGGING=1 ./onnxruntime_test_all --gtest_filter="<test that I want to see more logs for>"`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Provide a way to enable verbose logging while running unit tests without changing the code.