### PR TITLE
[JS/Web] The bias input is optional, not required, for LayerNormalization operator

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
@@ -58,17 +58,24 @@ const createLayerNormProgramInfo =
 
           const hasMeanDataOutput = outputCount > 1;
           const hasInvStdOutput = outputCount > 2;
+          let bindingIndex = 0;
           const getShaderSource = (shaderHelper: ShaderHelper) => `
   const normSize: u32 = ${normSize};
   const normSizeTyped: ${dataType} = ${normSize};
   const epsilon: f32 = ${attributes.epsilon};
 
-  @group(0) @binding(0) var<storage, read> x : array<${dataType}>;
-  @group(0) @binding(1) var<storage, read> scale : array<${dataType}>;
-  ${bias ? `@group(0) @binding(2) var<storage, read> bias : array<${dataType}>;` : ''}
-  @group(0) @binding(3) var<storage, read_write> output : array<${dataType}>;
-  ${hasMeanDataOutput ? `@group(0) @binding(4) var<storage, read_write> meanDataOutput : array<${dataType}>` : ''};
-  ${hasInvStdOutput ? `@group(0) @binding(5) var<storage, read_write> invStdOutput : array<${dataType}>` : ''};
+  @group(0) @binding(${bindingIndex++}) var<storage, read> x : array<${dataType}>;
+  @group(0) @binding(${bindingIndex++}) var<storage, read> scale : array<${dataType}>;
+  ${bias ? `@group(0) @binding(${bindingIndex++}) var<storage, read> bias : array<${dataType}>;` : ''}
+  @group(0) @binding(${bindingIndex++}) var<storage, read_write> output : array<${dataType}>;
+  ${
+              hasMeanDataOutput ?
+                  `@group(0) @binding(${bindingIndex++}) var<storage, read_write> meanDataOutput : array<${dataType}>` :
+                  ''};
+  ${
+              hasInvStdOutput ?
+                  `@group(0) @binding(${bindingIndex++}) var<storage, read_write> invStdOutput : array<${dataType}>` :
+                  ''};
 
   ${shaderHelper.mainStart()}
     let offset = global_idx * normSize;

--- a/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
@@ -118,7 +118,8 @@ export const layerNorm = (context: ComputeContext, attributes: LayerNormAttribut
 
   const metadata = {
     name: 'LayerNormalization',
-    inputTypes: [GpuDataType.default, GpuDataType.default, GpuDataType.default],
+    inputTypes: context.inputs.length === 2 ? [GpuDataType.default, GpuDataType.default] :
+                                              [GpuDataType.default, GpuDataType.default, GpuDataType.default],
     cacheHint: attributes.cacheKey + context.outputCount.toString(10) + context.inputs.length.toString(10),
   };
 

--- a/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/layer-norm.ts
@@ -15,7 +15,7 @@ export interface LayerNormAttributes extends AttributeWithCacheKey {
 }
 
 const validateInputs = (inputs: readonly TensorView[]): void => {
-  if (!inputs || inputs.length <= 2) {
+  if (!inputs || inputs.length < 2) {
     throw new Error('layerNorm requires at least 2 inputs.');
   }
 
@@ -41,7 +41,7 @@ const createLayerNormProgramInfo =
           const biasSize = bias ? ShapeUtil.size(bias.dims) : 0;
           if (scaleSize !== normSize || (bias && biasSize !== normSize)) {
             throw new Error(`Size of X.shape()[axis:] == ${normSize}.
-       Size of scale and bias (if provided) must match this. 
+       Size of scale and bias (if provided) must match this.
        Got scale size of ${scaleSize} and bias size of ${biasSize}`);
           }
 

--- a/js/web/test/data/ops/layer-norm.jsonc
+++ b/js/web/test/data/ops/layer-norm.jsonc
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "Simple test without bias",
+    "operator": "LayerNormalization",
+    "cases": [
+      {
+        "name": "Simple test without bias",
+        "inputs": [
+          {
+            "data": [1, 2, 3, 4, 5, 6, 7, 8],
+            "dims": [1, 2, 4],
+            "type": "float32"
+          },
+          {
+            "data": [1, 2, 3, 4],
+            "dims": [4],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [
+              -1.3416354656219482, -0.8944236636161804, 1.3416354656219482, 5.366541862487793, -1.3416354656219482,
+              -0.8944236636161804, 1.3416354656219482, 5.366541862487793
+            ],
+            "dims": [1, 2, 4],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/js/web/test/suite-test-list.jsonc
+++ b/js/web/test/suite-test-list.jsonc
@@ -1345,6 +1345,7 @@
       //"neg.jsonc",
       //"not.jsonc",
       //"or.jsonc",
+      "layer-norm.jsonc",
       "leaky-relu.jsonc",
       "reduce-min.jsonc",
       "relu.jsonc",


### PR DESCRIPTION
### Description
Fix a typo. LayerNormalization takes 2 or 3 inputs. The third input, bias, is optional.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


