### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -24,7 +24,7 @@ if platform.system() == "Windows":
         if not os.path.isfile(os.path.join(system_root, "System32", "vcruntime140_1.dll")):
             warnings.warn("Please install the 2019 Visual C++ runtime and then try again. "
                           "If you've installed the runtime in a non-standard location "
-                          r"(other than %SystemRoot%\System32), "
+                          "(other than %SystemRoot%\\System32), "
                           "make sure it can be found by setting the correct path.")
 
 @ONNXRUNTIME_IMPORT_PYTORCH_TO_RESOLVE_DLLS@

--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -24,7 +24,7 @@ if platform.system() == "Windows":
         if not os.path.isfile(os.path.join(system_root, "System32", "vcruntime140_1.dll")):
             warnings.warn("Please install the 2019 Visual C++ runtime and then try again. "
                           "If you've installed the runtime in a non-standard location "
-                          "(other than %SystemRoot%\System32), "
+                          r"(other than %SystemRoot%\System32), "
                           "make sure it can be found by setting the correct path.")
 
 @ONNXRUNTIME_IMPORT_PYTORCH_TO_RESOLVE_DLLS@

--- a/onnxruntime/python/_pybind_state.py.in
+++ b/onnxruntime/python/_pybind_state.py.in
@@ -7,7 +7,6 @@ Ensure that dependencies are available and then load the extension module.
 """
 import os
 import platform
-import sys
 import warnings
 
 from . import _ld_preload  # noqa: F401


### PR DESCRIPTION
### Description
- Removed one unused import
- Escaped a backslash in a path

### Motivation and Context
I see this `DeprecationWarning` when I import `onnxruntime`:

```
onnxruntime/capi/_pybind_state.py:28: DeprecationWarning: invalid escape sequence '\S'
    "(other than %SystemRoot%\System32), "
```

A future version of Python (maybe 3.13?) will raise a `SyntaxError` for invalid escape sequences.