### PR TITLE
Explicitly set JDK version when building ORT java package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -85,6 +85,13 @@ stages:
 
       - template: telemetry-steps.yml
 
+      - ${{ if eq(parameters['buildJava'], 'true') }}:
+        - task: JavaToolInstaller@0
+          inputs:
+            versionSpec: "11"
+            jdkArchitectureOption: ${{ parameters.buildArch }}
+            jdkSourceOption: 'PreInstalled'
+
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.8'


### PR DESCRIPTION
### Description
Explicitly set JDK version when building ORT java package.  This is to fix an internal build error.

### Motivation and Context



