### PR TITLE
Run nightly pipeline tests from the commit id.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
   - script: |
       COMMIT_ID=$(python3 -c "import onnxruntime; print(onnxruntime.get_build_info().split('git-commit-id=')[1].split(',')[0])")
       cd $(Build.SourcesDirectory)
-      $(Build.SourcesDirectory)
+      git checkout $COMMIT_ID
       docker run \
         --gpus all \
         --rm \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -13,6 +13,9 @@ jobs:
 
   # Entry point for all ortmodule training tests
   - script: |
+      COMMIT_ID=$(python3 -c "import onnxruntime; print(onnxruntime.get_build_info().split('git-commit-id=')[1].split(',')[0])")
+      cd $(Build.SourcesDirectory)
+      $(Build.SourcesDirectory)
       docker run \
         --gpus all \
         --rm \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
       COMMIT_ID=$(python3 -c "import onnxruntime; print(onnxruntime.get_build_info().split('git-commit-id=')[1].split(',')[0])")
       cd $(Build.SourcesDirectory)
       git checkout $COMMIT_ID
+      git branch
       echo "Retrieved ONNX Runtime Commit ID: $COMMIT_ID"
       docker run \
         --gpus all \

--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
       COMMIT_ID=$(python3 -c "import onnxruntime; print(onnxruntime.get_build_info().split('git-commit-id=')[1].split(',')[0])")
       cd $(Build.SourcesDirectory)
       git checkout $COMMIT_ID
+      echo "Retrieved ONNX Runtime Commit ID: $COMMIT_ID"
       docker run \
         --gpus all \
         --rm \


### PR DESCRIPTION
### Description

The onnxruntime-CI-nightly-ort-pipeline encounters occasional failures due to synchronization discrepancies between the ACPT nightly image and the repository. We are addressing this by executing tests using the commit ID associated with the ort build within the ACPT image.