### PR TITLE
Improve comments in winml/

### DIFF
--- a/winml/adapter/winml_adapter_c_api.h
+++ b/winml/adapter/winml_adapter_c_api.h
@@ -7,9 +7,9 @@
 #include "winrt/windows.foundation.collections.h"
 
 /**
- * All APIs exported by winml_adapter_c_api.h are part of the private interface dedicated to supporting the WinML API.
- * This contract is subject to change based on the needs of the WinML API and is not intended for direct use by callers
- * of the onnxruntime c-api and usage of APIs in this header are *not* supported by the onnxruntime product.
+  * All APIs exported by winml_adapter_c_api.h are part of the private interface dedicated to supporting the WinML API.
+  * This contract is subject to change based on the needs of the WinML API and is not intended for direct use by callers
+  * of the onnxruntime c-api and usage of APIs in this header are *not* supported by the onnxruntime product.
   */
 
 ORT_RUNTIME_CLASS(Model);
@@ -75,18 +75,18 @@ struct OrtThreadPoolOptions {
 struct WinmlAdapterApi {
   /**
     * OverrideSchema
-	 * This api is used to override schema inference functions for a variety of ops across opsets.
-	 * This exists because certain ops were failing to infer schemas and caused performance
-	 * issues for DML as it was forced to create resources during evaluation.
-	 * This can be removed when schema inference functions have been updated.
+    * This api is used to override schema inference functions for a variety of ops across opsets.
+    * This exists because certain ops were failing to infer schemas and caused performance
+    * issues for DML as it was forced to create resources during evaluation.
+    * This can be removed when schema inference functions have been updated.
     */
   OrtStatus*(ORT_API_CALL* OverrideSchema)() NO_EXCEPTION;
 
   /**
-     * EnvConfigureCustomLoggerAndProfiler
-	 * This api is used to add a custom logger and profiler to the ors environment.
-	 * This exists because existing methods on the c-abi to create the environment only support a custom logger.
-	 * Since WinML hooks the profiler events, we expose the profiler and an associated profiling function.
+    * EnvConfigureCustomLoggerAndProfiler
+    * This api is used to add a custom logger and profiler to the ors environment.
+    * This exists because existing methods on the c-abi to create the environment only support a custom logger.
+    * Since WinML hooks the profiler events, we expose the profiler and an associated profiling function.
     */
   OrtStatus*(ORT_API_CALL* EnvConfigureCustomLoggerAndProfiler)(
     _In_ OrtEnv* env,
@@ -102,34 +102,34 @@ struct WinmlAdapterApi {
 
   /**
     * CreateModelFromPath
-	 * This api creates an OrtModel based on a specified model path.
-	 * There is no inferencing or evaluation setup performed. Only ONNX load is done to reflect on the model's inputs/outputs and other properties.
-	 * This is used by WinML to support model reflection APIs.
+    * This api creates an OrtModel based on a specified model path.
+    * There is no inferencing or evaluation setup performed. Only ONNX load is done to reflect on the model's inputs/outputs and other properties.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* CreateModelFromPath)(_In_ const char* model_path, _In_ size_t size, _Outptr_ OrtModel** out)
     NO_EXCEPTION;
 
   /**
     * CreateModelFromData
-	 * This api creates an OrtModel from a buffer.
-	 * There is no inferencing or evaluation setup performed. Only ONNX load is done to reflect on the model's inputs/outputs and other properties.
-	 * This is used by WinML to support model reflection APIs.
+    * This api creates an OrtModel from a buffer.
+    * There is no inferencing or evaluation setup performed. Only ONNX load is done to reflect on the model's inputs/outputs and other properties.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* CreateModelFromData)(_In_opt_ void* data, _In_ size_t size, _Outptr_ OrtModel** out)
     NO_EXCEPTION;
 
   /**
     * CloneModel
-	 * This api copies the OrtModel along with its internal proto buffer and cached metadata.
-	 * The OrtSession type expects to own the model proto buffer.
-	 * WinML uses this to yield copies of the model proto held by OrtModel to OrtSession.
+    * This api copies the OrtModel along with its internal proto buffer and cached metadata.
+    * The OrtSession type expects to own the model proto buffer.
+    * WinML uses this to yield copies of the model proto held by OrtModel to OrtSession.
     */
   OrtStatus*(ORT_API_CALL* CloneModel)(_In_ const OrtModel* in, _Outptr_ OrtModel** out)NO_EXCEPTION;
 
   /**
     * ModelGetAuthor
-	 * This api gets the model author from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the model author from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetAuthor)(
     _In_ const OrtModel* model, _Out_ const char** const author, _Out_ size_t* len
@@ -137,23 +137,23 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetName
-	 * This api gets the model name from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the model name from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetName)(_In_ const OrtModel* model, _Out_ const char** const name, _Out_ size_t* len)
     NO_EXCEPTION;
 
   /**
     * ModelSetName
-	* This api set the model name from the OrtModel.
-	* This is used by the Windows ML Samples Gallery to change the model name for telemetry.
+    * This api set the model name from the OrtModel.
+    * This is used by the Windows ML Samples Gallery to change the model name for telemetry.
     */
   OrtStatus*(ORT_API_CALL* ModelSetName)(_In_ const OrtModel* model, _In_ const char* name)NO_EXCEPTION;
 
   /**
     * ModelGetDomain
-	 * This api gets the model domain from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the model domain from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetDomain)(
     _In_ const OrtModel* model, _Out_ const char** const domain, _Out_ size_t* len
@@ -161,8 +161,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetDescription
-	 * This api gets the model description from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the model description from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetDescription)(
     _In_ const OrtModel* model, _Out_ const char** const description, _Out_ size_t* len
@@ -170,29 +170,29 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetVersion
-	 * This api gets the model version from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the model version from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetVersion)(_In_ const OrtModel* model, _Out_ int64_t* version)NO_EXCEPTION;
 
   /**
     * ModelGetInputCount
-	 * This api gets the number of inputs from the OrtModel. It closely matches the API of a similar name similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the number of inputs from the OrtModel. It closely matches the API of a similar name similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetInputCount)(_In_ const OrtModel* model, _Out_ size_t* count)NO_EXCEPTION;
 
   /**
     * ModelGetOutputCount
-	 * This api gets the number of outputs from the OrtModel. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the number of outputs from the OrtModel. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetOutputCount)(_In_ const OrtModel* model, _Out_ size_t* count)NO_EXCEPTION;
 
   /**
     * ModelGetInputName
-	 * This api gets the input name from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the input name from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetInputName)(
     _In_ const OrtModel* model, _In_ size_t index, _Out_ const char** input_name, _Out_ size_t* count
@@ -200,8 +200,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetOutputName
-	 * This api gets the output name from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the output name from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetOutputName)(
     _In_ const OrtModel* model, _In_ size_t index, _Out_ const char** output_name, _Out_ size_t* count
@@ -209,8 +209,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetInputDescription
-	 * This api gets the input description from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the input description from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetInputDescription)(
     _In_ const OrtModel* model, _In_ size_t index, _Out_ const char** input_description, _Out_ size_t* count
@@ -218,8 +218,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetOutputDescription
-	 * This api gets the output description from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the output description from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetOutputDescription)(
     _In_ const OrtModel* model, _In_ size_t index, _Out_ const char** output_description, _Out_ size_t* count
@@ -227,8 +227,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetInputTypeInfo
-	 * This api gets the input OrtTypeInfo from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the input OrtTypeInfo from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetInputTypeInfo)(
     _In_ const OrtModel* model, _In_ size_t index, _Outptr_ OrtTypeInfo** type_info
@@ -236,8 +236,8 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetOutputTypeInfo
-	 * This api gets the output OrtTypeInfo from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the output OrtTypeInfo from the OrtModel given an index. It closely matches the API of a similar name for retrieving model metadata from OrtSession.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetOutputTypeInfo)(
     _In_ const OrtModel* model, _In_ size_t index, _Outptr_ OrtTypeInfo** type_info
@@ -245,15 +245,15 @@ struct WinmlAdapterApi {
 
   /**
     * ModelGetMetadataCount
-	 * This api gets the number of metadata entries from the OrtModel.
-	 * This is used by WinML to support model reflection APIs.
+    * This api gets the number of metadata entries from the OrtModel.
+    * This is used by WinML to support model reflection APIs.
     */
   OrtStatus*(ORT_API_CALL* ModelGetMetadataCount)(_In_ const OrtModel* model, _Out_ size_t* count)NO_EXCEPTION;
 
   /**
     * ModelGetMetadata
-	 * This api gets the model metadata from the OrtModel.
-	 * This is used by WinML to deduce whether model input and output formats are supported by the WinML tensorization code paths.
+    * This api gets the model metadata from the OrtModel.
+    * This is used by WinML to deduce whether model input and output formats are supported by the WinML tensorization code paths.
     */
   OrtStatus*(ORT_API_CALL* ModelGetMetadata)(
     _In_ const OrtModel* model,
@@ -266,17 +266,17 @@ struct WinmlAdapterApi {
 
   /**
     * ModelEnsureNoFloat16
-	 * This api checks whether the model requires float 16 support.
-	 * This is used by WinML to fail gracefully when float 16 support is not available on the device.
+    * This api checks whether the model requires float 16 support.
+    * This is used by WinML to fail gracefully when float 16 support is not available on the device.
     *
     * Can this API be moved into the EP during session initialization. Currently we do an early fp16 check to avoid initialization when it is not supported.
     */
   OrtStatus*(ORT_API_CALL* ModelEnsureNoFloat16)(_In_ const OrtModel* model)NO_EXCEPTION;
 
   /**
-  * SaveModel
-  * This api save the model to the fiven file
-  */
+    * SaveModel
+    * This api save the model to the fiven file
+    */
   OrtStatus*(ORT_API_CALL* SaveModel)(_In_ const OrtModel* in, _In_ const wchar_t* const file_name, _In_ size_t len)
     NO_EXCEPTION;
 
@@ -284,14 +284,14 @@ struct WinmlAdapterApi {
 
   /**
     * OrtSessionOptionsAppendExecutionProvider_CPU
-	 * This api is used to add the cpu EP to OrtSessionOptions so that WinML Gpu session are configures with CPU fallback.
+    * This api is used to add the cpu EP to OrtSessionOptions so that WinML Gpu session are configures with CPU fallback.
     */
   OrtStatus*(ORT_API_CALL* OrtSessionOptionsAppendExecutionProvider_CPU)(_In_ OrtSessionOptions* options, int use_arena)
     NO_EXCEPTION;
 
   /**
     * OrtSessionOptionsAppendExecutionProvider_DML
-	 * This api is used to add the DML EP to OrtSessionOptions.
+    * This api is used to add the DML EP to OrtSessionOptions.
     */
   OrtStatus*(ORT_API_CALL* OrtSessionOptionsAppendExecutionProvider_DML)(
     _In_ OrtSessionOptions* options, ID3D12Device* device, ID3D12CommandQueue* queue, bool metacommands_enabled
@@ -301,7 +301,7 @@ struct WinmlAdapterApi {
 
   /**
     * CreateSessionWithoutModel
-	 * This api is used to create a Session that is completely uninitialized. While there are other Session creation APIs in the
+    * This api is used to create a Session that is completely uninitialized. While there are other Session creation APIs in the
     * c-abi, WinML uses this so that it can perform optimizations prior to loading the model, and initializing.
     * Moreover, WinML needs a new api to support the OrtModel type, and prevent the parsing model protobufs again on session creation.
     */
@@ -315,7 +315,7 @@ struct WinmlAdapterApi {
 
   /**
     * SessionGetExecutionProvider
-	 * This api is used to get a handle to an OrtExecutionProvider.
+    * This api is used to get a handle to an OrtExecutionProvider.
     * Currently WinML uses this to talk directly to the DML EP and configure settings on it.
     */
   OrtStatus*(ORT_API_CALL* SessionGetExecutionProvider)(
@@ -324,14 +324,14 @@ struct WinmlAdapterApi {
 
   /**
     * SessionInitialize
-	 * This api is used to initialize an OrtSession. This is one component of creating a usable OrtSession, and is a part of CreateSession in the c-abi.
+    * This api is used to initialize an OrtSession. This is one component of creating a usable OrtSession, and is a part of CreateSession in the c-abi.
     * Currently WinML uses this to finalize session creation, after configuring a variety of properties on the OrtSession.
     */
   OrtStatus*(ORT_API_CALL* SessionInitialize)(_In_ OrtSession* session)NO_EXCEPTION;
 
   /**
     * SessionRegisterGraphTransformers
-	 * This api is used to enable DML specific graph transformations on an OrtSession.
+    * This api is used to enable DML specific graph transformations on an OrtSession.
     *
     * Ideally these transformations should be configured by the contract between the runtime and the EP and not overridden by WinML.
     */
@@ -339,40 +339,40 @@ struct WinmlAdapterApi {
 
   /**
     * SessionRegisterCustomRegistry
-	 * This api is used to support custom operators as they were shipped in WinML RS5.
+    * This api is used to support custom operators as they were shipped in WinML RS5.
     */
   OrtStatus*(ORT_API_CALL* SessionRegisterCustomRegistry)(_In_ OrtSession* session, _In_ IMLOperatorRegistry* registry)
     NO_EXCEPTION;
 
   /**
     * SessionLoadAndPurloinModel
-	 * This api is used to load an OrtModel into an OrtSession.
+    * This api is used to load an OrtModel into an OrtSession.
     *
- 	 * Don't free the 'out' value as this API will defunct and release the OrtModel internally.
+    * Don't free the 'out' value as this API will defunct and release the OrtModel internally.
     */
   OrtStatus*(ORT_API_CALL* SessionLoadAndPurloinModel)(_In_ OrtSession* session, _In_ OrtModel* model)NO_EXCEPTION;
 
   /**
     * SessionStartProfiling
-	 * This api is used to start profiling OrtSession. The existing mechanism only allows configuring profiling at session creation.
+    * This api is used to start profiling OrtSession. The existing mechanism only allows configuring profiling at session creation.
     *
- 	 * WinML uses this to toggle profilling on and off based on if a telemetry providers are being listened to.
+    * WinML uses this to toggle profilling on and off based on if a telemetry providers are being listened to.
     */
   OrtStatus*(ORT_API_CALL* SessionStartProfiling)(_In_ OrtEnv* env, _In_ OrtSession* session)NO_EXCEPTION;
 
   /**
     * SessionEndProfiling
-	 * This api is used to end profiling OrtSession. The existing mechanism only allows configuring profiling at session creation.
+    * This api is used to end profiling OrtSession. The existing mechanism only allows configuring profiling at session creation.
     *
- 	 * WinML uses this to toggle profilling on and off based on if a telemetry providers are being listened to.
+    * WinML uses this to toggle profilling on and off based on if a telemetry providers are being listened to.
     */
   OrtStatus*(ORT_API_CALL* SessionEndProfiling)(_In_ OrtSession* session)NO_EXCEPTION;
 
   /**
     * SessionCopyOneInputAcrossDevices
-	 * This api is used to copy and create an OrtValue input to prepare the input on the correct device.
+    * This api is used to copy and create an OrtValue input to prepare the input on the correct device.
     *
- 	 * WinML uses this to copy gpu device OrtValues to the CPU and vice-versa.
+    * WinML uses this to copy gpu device OrtValues to the CPU and vice-versa.
     */
   OrtStatus*(ORT_API_CALL* SessionCopyOneInputAcrossDevices)(
     _In_ OrtSession* session,
@@ -385,7 +385,7 @@ struct WinmlAdapterApi {
 
   /**
     * SessionGetNumberOfIntraOpThreads
-     * This api returns the number of intra operator threads set on the OrtSession.
+    * This api returns the number of intra operator threads set on the OrtSession.
     *
     * WinML uses this to determine that the correct number of threads was set correctly through OrtSessionOptions.
     */
@@ -394,7 +394,7 @@ struct WinmlAdapterApi {
 
   /**
     * SessionGetIntrapOpThreadSpinning
-     * This api returns false if the ort session options config entry "session.intra_op.allow_spinning" is set to "0", and true otherwise
+    * This api returns false if the ort session options config entry "session.intra_op.allow_spinning" is set to "0", and true otherwise
     *
     * WinML uses this to determine that the intra op thread spin policy was set correctly through OrtSessionOptions
     */
@@ -403,7 +403,7 @@ struct WinmlAdapterApi {
 
   /**
     * SessionGetNamedDimensionsOverrides
-     * This api returns the named dimension overrides that are specified for this session
+    * This api returns the named dimension overrides that are specified for this session
     *
     * WinML uses this to determine that named dimension overrides were set correctly through OrtSessionOptions.
     */
@@ -414,7 +414,7 @@ struct WinmlAdapterApi {
 
   /**
     * DmlExecutionProviderFlushContext
-	 * This api is used to flush the DML EP.
+    * This api is used to flush the DML EP.
     *
     * WinML communicates directly with DML to perform this as an optimization.
     */
@@ -422,7 +422,7 @@ struct WinmlAdapterApi {
 
   /**
     * DmlExecutionProviderReleaseCompletedReferences
-	 * This api is used to release completed references after first run the DML EP.
+    * This api is used to release completed references after first run the DML EP.
     *
     * WinML communicates directly with DML to perform this as an optimization.
     */
@@ -431,7 +431,7 @@ struct WinmlAdapterApi {
 
   /**
     * DmlCopyTensor
-	 * This api is used copy a tensor allocated by the DML EP Allocator to the CPU.
+    * This api is used copy a tensor allocated by the DML EP Allocator to the CPU.
     *
     * WinML uses this when graphs are evaluated with DML, and their outputs remain on the GPU but need to be copied back to the CPU.
     */
@@ -440,7 +440,7 @@ struct WinmlAdapterApi {
 
   /**
     * GetProviderMemoryInfo
-	 * This api gets the memory info object associated with an EP.
+    * This api gets the memory info object associated with an EP.
     *
     * WinML uses this to manage caller specified D3D12 inputs/outputs. It uses the memory info here to call DmlCreateGPUAllocationFromD3DResource.
     */
@@ -449,7 +449,7 @@ struct WinmlAdapterApi {
 
   /**
     * GetProviderAllocator
-	 * This api gets associated allocator used by a provider.
+    * This api gets associated allocator used by a provider.
     *
     * WinML uses this to create tensors, and needs to hold onto the allocator for the duration of the associated value's lifetime.
     */
@@ -459,7 +459,7 @@ struct WinmlAdapterApi {
 
   /**
     * FreeProviderAllocator
-	 * This api frees an allocator.
+    * This api frees an allocator.
     *
     * WinML uses this to free the associated allocator for an ortvalue when creating tensors.
     * Internally this derefs a shared_ptr.
@@ -468,7 +468,7 @@ struct WinmlAdapterApi {
 
   /**
     * ExecutionProviderSync
-	 * This api syncs the EP.
+    * This api syncs the EP.
     *
     * WinML uses this to sync EP inputs/outputs directly.
     */
@@ -476,7 +476,7 @@ struct WinmlAdapterApi {
 
   /**
     * CreateCustomRegistry
-	 * This api creates a custom registry that callers can populate with custom ops.
+    * This api creates a custom registry that callers can populate with custom ops.
     *
     * WinML uses this to support custom ops.
     */
@@ -484,7 +484,7 @@ struct WinmlAdapterApi {
 
   /**
     * ValueGetDeviceId
-	 * This api returns the device id of the OrtValue.
+    * This api returns the device id of the OrtValue.
     *
     * WinML uses this to determine if an OrtValue is created on the needed device.
     */
@@ -492,7 +492,7 @@ struct WinmlAdapterApi {
 
   /**
     * SessionGetInputRequiredDeviceId
-	 * This api returns the required device id for a model input.
+    * This api returns the required device id for a model input.
     *
     * WinML uses this to determine if an OrtValue is created on the needed device.
     */

--- a/winml/test/api/LearningModelBindingAPITest.cpp
+++ b/winml/test/api/LearningModelBindingAPITest.cpp
@@ -368,8 +368,8 @@ static void VerifyInvalidBindExceptions() {
   auto ensureWinmlInvalidBinding = std::bind(matchException, std::placeholders::_1, WINML_ERR_INVALID_BINDING);
 
   /*
-        Verify tensor bindings throw correct bind exceptions
-    */
+    Verify tensor bindings throw correct bind exceptions
+  */
 
   // Bind invalid image as tensorfloat input
   auto image = FileHelpers::LoadImageFeatureValue(L"227x227.png");
@@ -394,8 +394,8 @@ static void VerifyInvalidBindExceptions() {
   WINML_EXPECT_THROW_SPECIFIC(binding.Bind(L"X", tensorInvalidShape), winrt::hresult_error, ensureWinmlInvalidBinding);
 
   /*
-        Verify sequence bindings throw correct bind exceptions
-    */
+    Verify sequence bindings throw correct bind exceptions
+  */
 
   // Bind invalid image as sequence<map<int, float> output
   WINML_EXPECT_THROW_SPECIFIC(binding.Bind(L"Y", image), winrt::hresult_error, ensureWinmlInvalidBinding);
@@ -410,35 +410,8 @@ static void VerifyInvalidBindExceptions() {
   WINML_EXPECT_THROW_SPECIFIC(binding.Bind(L"Y", tensorBoolean), winrt::hresult_error, ensureWinmlInvalidBinding);
 
   /*
-        Verify image bindings throw correct bind exceptions
-    */
-
-  // WINML_EXPECT_NO_THROW(LoadModel(L"fns-candy.onnx"));
-
-  // LearningModelSession imageSession(m_model);
-  // LearningModelBinding imageBinding(imageSession);
-
-  // auto inputName = m_model.InputFeatures().First().Current().Name();
-
-  // // Bind invalid map as image input
-  // WINML_EXPECT_THROW_SPECIFIC(imageBinding.Bind(inputName, abiMap), winrt::hresult_error, ensureWinmlInvalidBinding);
-
-  // // Bind invalid sequence as image input
-  // WINML_EXPECT_THROW_SPECIFIC(imageBinding.Bind(inputName, abiSequence), winrt::hresult_error, ensureWinmlInvalidBinding);
-
-  // // Bind invalid tensor type as image input
-  // WINML_EXPECT_THROW_SPECIFIC(imageBinding.Bind(inputName, tensorBoolean), winrt::hresult_error, ensureWinmlInvalidBinding);
-
-  // // Bind invalid tensor size as image input
-  // auto tensorFloat = TensorFloat::Create(std::vector<int64_t> { 1, 1, 100, 100 });
-  // WINML_EXPECT_THROW_SPECIFIC(imageBinding.Bind(inputName, tensorFloat), winrt::hresult_error, ensureWinmlInvalidBinding);
-
-  // // Bind invalid tensor shape as image input
-  // WINML_EXPECT_THROW_SPECIFIC(imageBinding.Bind(inputName, tensorInvalidShape), winrt::hresult_error, ensureWinmlInvalidBinding);
-
-  /*
-        Verify map bindings throw correct bind exceptions
-    */
+    Verify map bindings throw correct bind exceptions
+  */
   WINML_EXPECT_NO_THROW(APITest::LoadModel(L"dictvectorizer-int64.onnx", learningModel));
 
   LearningModelSession mapSession(learningModel);


### PR DESCRIPTION
Follow up of #17144. Manually fixed indentation in block comments and replaced all tabs with spaces.