### PR TITLE
Fix compilation with newer flatbuffers

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -1799,7 +1799,7 @@ if (onnxruntime_USE_XNNPACK)
   source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_providers_xnnpack_cc_srcs})
   onnxruntime_add_static_library(onnxruntime_providers_xnnpack ${onnxruntime_providers_xnnpack_cc_srcs})
   onnxruntime_add_include_to_target(onnxruntime_providers_xnnpack
-    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} XNNPACK pthreadpool Boost::mp11 safeint_interface
+    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} XNNPACK pthreadpool flatbuffers::flatbuffers Boost::mp11 safeint_interface
   )
 
   add_dependencies(onnxruntime_providers_xnnpack onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -43,11 +43,7 @@
 #include "core/graph/node_arg.h"
 #include "core/graph/ort_format_load_options.h"
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 class Graph;

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -20,6 +20,8 @@
 #pragma warning(pop)
 #endif
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/gsl.h"
 
 #include "core/common/common.h"
@@ -42,8 +44,6 @@
 #include "core/graph/graph_nodes.h"
 #include "core/graph/node_arg.h"
 #include "core/graph/ort_format_load_options.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 class Graph;

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -9,21 +9,11 @@
 #include "core/common/path_string.h"
 #include "core/common/status.h"
 
+#include "flatbuffers/flatbuffers.h"
+
 namespace ONNX_NAMESPACE {
 class ValueInfoProto;
 }
-
-namespace flatbuffers {
-class FlatBufferBuilder;
-
-template <typename T>
-struct Offset;
-
-struct String;
-
-template <typename T>
-class Vector;
-}  // namespace flatbuffers
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -5,11 +5,11 @@
 
 #include <unordered_map>
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/common.h"
 #include "core/common/path_string.h"
 #include "core/common/status.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace ONNX_NAMESPACE {
 class ValueInfoProto;

--- a/onnxruntime/core/framework/kernel_type_str_resolver.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.h
@@ -18,11 +18,7 @@
 #include "core/graph/graph.h"
 #include "core/platform/ort_mutex.h"
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/framework/kernel_type_str_resolver.h
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.h
@@ -7,6 +7,8 @@
 #include <string_view>
 #include <utility>
 
+#include "flatbuffers/flatbuffers.h"
+
 #if !defined(ORT_MINIMAL_BUILD)
 #include "core/graph/onnx_protobuf.h"
 #endif  // !defined(ORT_MINIMAL_BUILD)
@@ -17,8 +19,6 @@
 #include "core/graph/op_identifier.h"
 #include "core/graph/graph.h"
 #include "core/platform/ort_mutex.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -8,6 +8,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/gsl.h"
 
 #include "core/common/common.h"
@@ -42,8 +44,6 @@
 #ifdef ENABLE_TRAINING
 #include "core/framework/program_region.h"
 #endif
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/framework/session_state.h
+++ b/onnxruntime/core/framework/session_state.h
@@ -43,11 +43,7 @@
 #include "core/framework/program_region.h"
 #endif
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.h
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.h
@@ -5,11 +5,11 @@
 
 #include <memory>
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/status.h"
 #include "core/graph/ort_format_load_options.h"
 #include "core/framework/tensor.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace ONNX_NAMESPACE {
 class AttributeProto;

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.h
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.h
@@ -9,6 +9,8 @@
 #include "core/graph/ort_format_load_options.h"
 #include "core/framework/tensor.h"
 
+#include "flatbuffers/flatbuffers.h"
+
 namespace ONNX_NAMESPACE {
 class AttributeProto;
 class TensorProto;
@@ -17,12 +19,6 @@ class TensorProto;
 class SparseTensorProto;
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 }  // namespace ONNX_NAMESPACE
-
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-}  // namespace flatbuffers
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -7,6 +7,9 @@
 #include <memory>
 #include <climits>
 #include <string>
+
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/path.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/ort_format_load_options.h"
@@ -14,8 +17,6 @@
 #if !defined(ORT_MINIMAL_BUILD)
 #include "core/graph/function_template.h"
 #endif
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -15,11 +15,7 @@
 #include "core/graph/function_template.h"
 #endif
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/op_identifier_utils.h
+++ b/onnxruntime/core/graph/op_identifier_utils.h
@@ -9,14 +9,7 @@
 #include "core/graph/graph.h"
 #include "core/graph/onnx_protobuf.h"
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-
-template <typename T>
-struct Offset;
-
-struct String;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/op_identifier_utils.h
+++ b/onnxruntime/core/graph/op_identifier_utils.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/graph/op_identifier.h"
 
 #include "core/common/status.h"
 #include "core/graph/graph.h"
 #include "core/graph/onnx_protobuf.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/runtime_optimization_record_container.h
+++ b/onnxruntime/core/graph/runtime_optimization_record_container.h
@@ -12,13 +12,7 @@
 #include "core/common/common.h"
 #include "core/graph/runtime_optimization_record.h"
 
-namespace flatbuffers {
-class FlatBufferBuilder;
-template <typename T>
-struct Offset;
-template <typename T>
-class Vector;
-}  // namespace flatbuffers
+#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/runtime_optimization_record_container.h
+++ b/onnxruntime/core/graph/runtime_optimization_record_container.h
@@ -9,10 +9,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include "flatbuffers/flatbuffers.h"
+
 #include "core/common/common.h"
 #include "core/graph/runtime_optimization_record.h"
-
-#include "flatbuffers/flatbuffers.h"
 
 namespace onnxruntime {
 


### PR DESCRIPTION
In flatbuffers@v23.5.9 was broken forward declaration for FlatBufferBuilder. Trying to compile onnxruntime falls with the following error:
```
flatbuffers/include/flatbuffers/flatbuffer_builder.h:1420:38: error: typedef redefinition with different types ('FlatBufferBuilderImpl<false>' vs 'flatbuffers::FlatBufferBuilder')
typedef FlatBufferBuilderImpl<false> FlatBufferBuilder;
                                     ^
onnx_runtime/include/onnxruntime/core/graph/graph.h:47:11: note: previous definition is here
    class FlatBufferBuilder;
```
This PR removes these declarations and puts includes instead
