### PR TITLE
Add debugging tools for intermediate outputs

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -246,6 +246,7 @@ option(onnxruntime_USE_LOCK_FREE_QUEUE "Build with lock-free task queue for thre
 
 # Debug options
 option(onnxruntime_PRINT_ERROR_VALUES "Insert nodes that will print potentially wrong values like NaN and INF." OFF)
+option(onnxruntime_PRINT_TOLERANCE_ERRORS "Insert nodes that will print values that exceed a tolerance threshold between float16 and float32." OFF)
 
 # ENABLE_TRAINING includes all training functionality
 # The following 2 entry points
@@ -1462,6 +1463,10 @@ endif()
 
 if (onnxruntime_PRINT_ERROR_VALUES)
   add_compile_definitions(PRINT_ERROR_VALUES)
+endif()
+
+if (onnxruntime_PRINT_TOLERANCE_ERRORS)
+  add_compile_definitions(PRINT_TOLERANCE_ERRORS)
 endif()
 
 if (onnxruntime_ENABLE_TRAINING)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -244,6 +244,9 @@ cmake_dependent_option(MSVC_Z7_OVERRIDE "replacing /Zi and /ZI with /Z7 when usi
 option(onnxruntime_USE_AZURE "Build with azure inferencing support" OFF)
 option(onnxruntime_USE_LOCK_FREE_QUEUE "Build with lock-free task queue for threadpool." OFF)
 
+# Debug options
+option(onnxruntime_PRINT_ERROR_VALUES "Insert nodes that will print potentially wrong values like NaN and INF." OFF)
+
 # ENABLE_TRAINING includes all training functionality
 # The following 2 entry points
 # 1. ORTModule
@@ -1455,6 +1458,10 @@ endif()
 
 if (onnxruntime_ENABLE_ROCM_PROFILING)
   add_compile_definitions(ENABLE_ROCM_PROFILING)
+endif()
+
+if (onnxruntime_PRINT_ERROR_VALUES)
+  add_compile_definitions(PRINT_ERROR_VALUES)
 endif()
 
 if (onnxruntime_ENABLE_TRAINING)

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -135,6 +135,10 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, PrintErrorValues);
 #endif
 
+#ifdef PRINT_TOLERANCE_ERRORS
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, PrintToleranceErrors);
+#endif
+
 template <>
 KernelCreateInfo BuildKernelCreateInfo<void>() {
   KernelCreateInfo info;
@@ -306,6 +310,10 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
 #ifdef PRINT_ERROR_VALUES
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, PrintErrorValues)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, PrintErrorValues)>,
+#endif
+
+#ifdef PRINT_TOLERANCE_ERRORS
+    BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, PrintToleranceErrors)>,
 #endif
 
   };

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -130,6 +130,11 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kPytorchAtenDomain,
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, ShrunkenGather);
 #endif
 
+#ifdef PRINT_ERROR_VALUES
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, PrintErrorValues);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, PrintErrorValues);
+#endif
+
 template <>
 KernelCreateInfo BuildKernelCreateInfo<void>() {
   KernelCreateInfo info;
@@ -296,6 +301,11 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
     // Should remove the shrunken_gather include from ENABLE_TRAINING_OPS once 1). compute optimizer is enabled for inference or
     // 2). this is needed by inference for other purpose.
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, ShrunkenGather)>,
+#endif
+
+#ifdef PRINT_ERROR_VALUES
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, PrintErrorValues)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, PrintErrorValues)>,
 #endif
 
   };

--- a/onnxruntime/contrib_ops/cpu/print_error_values.cc
+++ b/onnxruntime/contrib_ops/cpu/print_error_values.cc
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_ERROR_VALUES
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cpu/tensor/utils.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+class PrintErrorValues : public OpKernel {
+ public:
+  PrintErrorValues(const OpKernelInfo& info) : OpKernel(info) {
+    ORT_ENFORCE(info.GetAttr<std::string>("node_name", &node_name_).IsOK());
+    ORT_ENFORCE(info.GetAttr<std::string>("node_type", &node_type_).IsOK());
+    ORT_ENFORCE(info.GetAttr<std::string>("execution_provider", &execution_provider_).IsOK());
+    ORT_ENFORCE(info.GetAttr<int64_t>("node_output_index", &node_output_index_).IsOK());
+  }
+
+  Status Compute(OpKernelContext* context) const override {
+    const Tensor* X = context->Input<Tensor>(0);
+
+    auto elements = X->DataAsSpan<T>();
+    bool has_nan = false;
+    bool has_inf = false;
+
+    for (T element : elements) {
+      if (std::isnan(element)) {
+        has_nan = true;
+      }
+
+      if (std::isinf(element)) {
+        has_inf = true;
+      }
+
+      if (has_nan && has_inf) {
+        break;
+      }
+    }
+
+    if (has_nan) {
+      printf("%s (%s) produced one or more NaN values for output %lld on %s\n",
+             node_name_.c_str(),
+             node_type_.c_str(),
+             node_output_index_,
+             execution_provider_.c_str());
+    }
+
+    if (has_inf) {
+      printf("%s (%s) produced one or more INF values for output %lld on %s\n",
+             node_name_.c_str(),
+             node_type_.c_str(),
+             node_output_index_,
+             execution_provider_.c_str());
+    }
+
+    Tensor* Y = context->Output(0, X->Shape());
+    CopyCpuTensor(X, Y);
+
+    return Status::OK();
+  }
+
+ private:
+  std::string node_name_;
+  std::string node_type_;
+  std::string execution_provider_;
+  int64_t node_output_index_;
+};
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    PrintErrorValues,
+    1,
+    MLFloat16,
+    KernelDefBuilder()
+        .Alias(0, 0)
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>()),
+    PrintErrorValues<MLFloat16>);
+
+ONNX_CPU_OPERATOR_TYPED_MS_KERNEL(
+    PrintErrorValues,
+    1,
+    float,
+    KernelDefBuilder()
+        .Alias(0, 0)
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>()),
+    PrintErrorValues<float>);
+}  // namespace contrib
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/contrib_ops/cpu/print_tolerance_errors.cc
+++ b/onnxruntime/contrib_ops/cpu/print_tolerance_errors.cc
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_TOLERANCE_ERRORS
+
+#include "core/common/common.h"
+#include "core/framework/op_kernel.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cpu/tensor/utils.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+class PrintToleranceErrors : public OpKernel {
+ public:
+  PrintToleranceErrors(const OpKernelInfo& info) : OpKernel(info) {
+    ORT_ENFORCE(info.GetAttr<std::string>("node_name", &node_name_).IsOK());
+    ORT_ENFORCE(info.GetAttr<std::string>("node_type", &node_type_).IsOK());
+    ORT_ENFORCE(info.GetAttr<std::string>("execution_provider", &execution_provider_).IsOK());
+    ORT_ENFORCE(info.GetAttr<int64_t>("node_output_index", &node_output_index_).IsOK());
+  }
+
+  Status Compute(OpKernelContext* context) const override {
+    const Tensor* float16_input = context->Input<Tensor>(0);
+    const Tensor* float32_input = context->Input<Tensor>(1);
+
+    auto float16_elements = float16_input->DataAsSpan<MLFloat16>();
+    auto float32_elements = float32_input->DataAsSpan<float>();
+
+    if (float16_elements.size() != float32_elements.size()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "float16_input and float32_input need to have the same number of elements.",
+                             " float16_input: ", float16_elements.size(), " elements",
+                             " float32_input: ", float32_elements.size(), " elements");
+    }
+
+    constexpr float relative_tolerance = 1e-2f;
+    constexpr float absolute_tolerance = 1e-2f;
+    float biggest_absolute_error = 0;
+    float biggest_relative_error = 0;
+    float biggest_float16_value = 0;
+    float biggest_float32_value = 0;
+    bool has_tolerance_error = false;
+
+    for (int i = 0; i < float16_elements.size(); ++i) {
+      float float16_element = static_cast<float>(float16_elements[i]);
+      float float32_element = float32_elements[i];
+      float relative_error = std::abs((float16_element - float32_element) / float32_element);
+      float absolute_error = std::abs(float16_element - float32_element);
+
+      if (relative_error > relative_tolerance && absolute_error > absolute_tolerance) {
+        if (absolute_error > biggest_absolute_error) {
+          biggest_float16_value = float16_element;
+          biggest_float32_value = float32_element;
+        }
+
+        biggest_relative_error = std::max(biggest_relative_error, std::abs((biggest_float16_value - biggest_float32_value) / biggest_float32_value));
+        biggest_absolute_error = std::max(biggest_absolute_error, std::abs(biggest_float16_value - biggest_float32_value));
+        has_tolerance_error = true;
+      }
+    }
+
+    if (has_tolerance_error) {
+      printf("%s (%s) produced values with relative errors higher than relative tolerance %f and absolute tolerance %f for output %lld on %s. Biggest relative error: %f. Biggest absolute error: %f. float16 value: %f, float32 value: %f\n",
+             node_name_.c_str(),
+             node_type_.c_str(),
+             relative_tolerance,
+             absolute_tolerance,
+             node_output_index_,
+             execution_provider_.c_str(),
+             biggest_relative_error,
+             biggest_absolute_error,
+             biggest_float16_value,
+             biggest_float32_value);
+    }
+
+    Tensor* Y = context->Output(0, float16_input->Shape());
+    CopyCpuTensor(float16_input, Y);
+
+    return Status::OK();
+  }
+
+ private:
+  std::string node_name_;
+  std::string node_type_;
+  std::string execution_provider_;
+  int64_t node_output_index_;
+};
+
+ONNX_CPU_OPERATOR_MS_KERNEL(
+    PrintToleranceErrors,
+    1,
+    KernelDefBuilder()
+        .Alias(0, 0)
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<MLFloat16>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<float>()),
+    PrintToleranceErrors);
+}  // namespace contrib
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2412,6 +2412,39 @@ ONNX_MS_OPERATOR_SET_SCHEMA(PrintErrorValues, 1,
                                 .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
 #endif
 
+#ifdef PRINT_TOLERANCE_ERRORS
+ONNX_MS_OPERATOR_SET_SCHEMA(PrintToleranceErrors, 1,
+                            OpSchema()
+                                .Input(0, "float16_input", "float16 input", "T1")
+                                .Input(1, "float32_input", "float32 input", "T2")
+                                .Output(0, "Y", "output", "T1")
+                                .TypeConstraint(
+                                    "T1",
+                                    {"tensor(float16)"},
+                                    "Constrain the first input and output to float16.")
+                                .TypeConstraint(
+                                    "T2",
+                                    {"tensor(float)"},
+                                    "Constrain the second input to float.")
+                                .Attr(
+                                    "node_name",
+                                    "Name of the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "node_type",
+                                    "Type of the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "execution_provider",
+                                    "Execution provider that executed the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "node_output_index",
+                                    "Index of the output that feeds into X.",
+                                    AttributeProto::INT)
+                                .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
+#endif
+
 void RegisterContribSchemas() {
   ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
   ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2384,6 +2384,34 @@ ONNX_MS_OPERATOR_SET_SCHEMA(CropAndResize, 1,
         a fixed size = [crop_height, crop_width]. The result is a 4-D tensor [num_boxes, crop_height, crop_width, depth].
         The resizing is corner aligned.)DOC"));
 
+#ifdef PRINT_ERROR_VALUES
+ONNX_MS_OPERATOR_SET_SCHEMA(PrintErrorValues, 1,
+                            OpSchema()
+                                .Input(0, "X", "input", "T")
+                                .Output(0, "Y", "output", "T")
+                                .TypeConstraint(
+                                    "T",
+                                    {"tensor(float16)", "tensor(float)"},
+                                    "Constrain input and output types to float tensors.")
+                                .Attr(
+                                    "node_name",
+                                    "Name of the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "node_type",
+                                    "Type of the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "execution_provider",
+                                    "Execution provider that executed the node.",
+                                    AttributeProto::STRING)
+                                .Attr(
+                                    "node_output_index",
+                                    "Index of the output that feeds into X.",
+                                    AttributeProto::INT)
+                                .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
+#endif
+
 void RegisterContribSchemas() {
   ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(AttnLSTM, RegisterAttnLSTMContribOpSchema);
   ONNX_CONTRIB_OPERATOR_SCHEMA_ELSEWHERE(Range, RegisterRangeOpSchema);

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -107,8 +107,13 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, WordConvEmbedding);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention);
+
 #ifdef PRINT_ERROR_VALUES
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintErrorValues);
+#endif
+
+#ifdef PRINT_TOLERANCE_ERRORS
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintToleranceErrors);
 #endif
 
 class OpSet_Microsoft_ver1 {
@@ -211,8 +216,13 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention)>());
+
 #ifdef PRINT_ERROR_VALUES
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintErrorValues)>());
+#endif
+
+#ifdef PRINT_TOLERANCE_ERRORS
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintToleranceErrors)>());
 #endif
   }
 };

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -107,6 +107,9 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, WordConvEmbedding);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention);
+#ifdef PRINT_ERROR_VALUES
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintErrorValues);
+#endif
 
 class OpSet_Microsoft_ver1 {
  public:
@@ -208,6 +211,9 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention)>());
+#ifdef PRINT_ERROR_VALUES
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PrintErrorValues)>());
+#endif
   }
 };
 }  // namespace contrib

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -88,6 +88,10 @@
 #include "core/optimizer/print_error_values_transformer.h"
 #endif
 
+#ifdef PRINT_TOLERANCE_ERRORS
+#include "core/optimizer/print_tolerance_errors_transformer.h"
+#endif
+
 namespace onnxruntime::optimizer_utils {
 
 static void FilterTransformers(InlinedVector<std::unique_ptr<GraphTransformer>>& transformers,
@@ -362,9 +366,14 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<MemoryOptimizer>(enable_memory_optimizer, probe_level));
 #endif
 
+#ifdef PRINT_TOLERANCE_ERRORS
+      // This needs to be at the end to make sure that all fused nodes are covered
+      transformers.emplace_back(std::make_unique<PrintToleranceErrorsTransformer>(cpu_cuda_rocm_acl_armnn_eps));
+#endif
+
 #ifdef PRINT_ERROR_VALUES
       // This needs to be at the end to make sure that all fused nodes are covered
-      transformers.emplace_back(std::make_unique<PrintErrorValuesTransformer>(dml_ep));
+      transformers.emplace_back(std::make_unique<PrintErrorValuesTransformer>(cpu_cuda_rocm_acl_armnn_eps));
 #endif
 
     } break;

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -84,6 +84,10 @@
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
+#ifdef PRINT_ERROR_VALUES
+#include "core/optimizer/print_error_values_transformer.h"
+#endif
+
 namespace onnxruntime::optimizer_utils {
 
 static void FilterTransformers(InlinedVector<std::unique_ptr<GraphTransformer>>& transformers,
@@ -356,6 +360,11 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       const std::string probe_level =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsMemoryOptimizerProbeLevel, "0");
       transformers.emplace_back(std::make_unique<MemoryOptimizer>(enable_memory_optimizer, probe_level));
+#endif
+
+#ifdef PRINT_ERROR_VALUES
+      // This needs to be at the end to make sure that all fused nodes are covered
+      transformers.emplace_back(std::make_unique<PrintErrorValuesTransformer>(dml_ep));
 #endif
 
     } break;

--- a/onnxruntime/core/optimizer/print_error_values_transformer.cc
+++ b/onnxruntime/core/optimizer/print_error_values_transformer.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_ERROR_VALUES
+
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/print_error_values_transformer.h"
+#include "core/graph/graph_utils.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace ::onnxruntime::common;
+namespace onnxruntime {
+
+Status PrintErrorValuesTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
+                                              const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& order = graph_viewer.GetNodesInTopologicalOrder();
+
+  for (auto index : order) {
+    auto* node_ptr = graph.GetNode(index);
+    if (!node_ptr) {
+      continue;
+    }
+
+    auto& node = *node_ptr;
+    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+
+    if (graph.NodeProducesGraphOutput(node)) {
+      continue;
+    }
+
+    if (node.OpType() == "PrintErrorValues") {
+      continue;
+    }
+
+    std::vector<NodeArg*>& output_args = node.MutableOutputDefs();
+
+    for (auto output_edge_iter = node.OutputEdgesBegin(); output_edge_iter != node.OutputEdgesEnd(); ++output_edge_iter) {
+      int output_src_arg_index = output_edge_iter->GetSrcArgIndex();
+      int output_dst_arg_index = output_edge_iter->GetDstArgIndex();
+
+      auto output_src_arg = output_args[output_src_arg_index];
+      auto proto_type = output_src_arg->TypeAsProto();
+
+      if (!proto_type || !proto_type->tensor_type().has_elem_type()) {
+        continue;
+      }
+
+      auto data_type = proto_type->tensor_type().elem_type();
+      if (data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 &&
+          data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+        continue;
+      }
+
+      Node* output_node = graph.GetNode(output_edge_iter->GetNode().Index());
+
+      if (output_node->OpType() == "PrintErrorValues") {
+        continue;
+      }
+
+      NodeArg& output_dst_arg = graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("PrintErrorValues"), proto_type);
+
+      std::array<NodeArg*, 1> inputs{output_src_arg};
+      std::array<NodeArg*, 1> outputs{&output_dst_arg};
+
+      const std::string op_type = "PrintErrorValues";
+      Node& print_error_values_node = graph.AddNode(
+          graph.GenerateNodeName(op_type),
+          op_type,
+          "",
+          inputs,
+          outputs,
+          nullptr,
+          kMSDomain);
+      print_error_values_node.AddAttribute("node_name", node.Name());
+      print_error_values_node.AddAttribute("node_type", node.OpType());
+      print_error_values_node.AddAttribute("execution_provider", node.GetExecutionProviderType());
+      print_error_values_node.AddAttribute("node_output_index", static_cast<int64_t>(output_src_arg_index));
+      print_error_values_node.SetExecutionProviderType(kCpuExecutionProvider);
+
+      graph.RemoveEdge(node.Index(), output_node->Index(), output_src_arg_index, output_dst_arg_index);
+      graph.AddEdge(node.Index(), print_error_values_node.Index(), output_src_arg_index, 0);
+      graph.AddEdge(print_error_values_node.Index(), output_node->Index(), 0, output_dst_arg_index);
+
+      // We modified the node's output nodes, so reset the iterator
+      output_edge_iter = node.OutputEdgesBegin();
+
+      modified = true;
+    }
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/optimizer/print_error_values_transformer.cc
+++ b/onnxruntime/core/optimizer/print_error_values_transformer.cc
@@ -47,8 +47,7 @@ Status PrintErrorValuesTransformer::ApplyImpl(Graph& graph, bool& modified, int 
       }
 
       auto data_type = proto_type->tensor_type().elem_type();
-      if (data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 &&
-          data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+      if (data_type != TensorProto_DataType_FLOAT16 && data_type != TensorProto_DataType_FLOAT) {
         continue;
       }
 

--- a/onnxruntime/core/optimizer/print_error_values_transformer.h
+++ b/onnxruntime/core/optimizer/print_error_values_transformer.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_ERROR_VALUES
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+class PrintErrorValuesTransformer : public GraphTransformer {
+ public:
+  PrintErrorValuesTransformer(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("PrintErrorValuesTransformer", compatible_execution_providers) {}
+
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/optimizer/print_tolerance_errors_transformer.cc
+++ b/onnxruntime/core/optimizer/print_tolerance_errors_transformer.cc
@@ -1,0 +1,448 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_TOLERANCE_ERRORS
+
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/print_tolerance_errors_transformer.h"
+#include "core/graph/graph_utils.h"
+
+using namespace ONNX_NAMESPACE;
+using namespace ::onnxruntime::common;
+namespace onnxruntime {
+
+static bool HasFloat16Inputs(const Node& node) {
+  auto input_args = node.InputDefs();
+
+  for (const NodeArg* input_arg : input_args) {
+    auto proto_type = input_arg->TypeAsProto();
+
+    if (!proto_type || !proto_type->tensor_type().has_elem_type()) {
+      continue;
+    }
+
+    if (proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+static bool HasFloat16Outputs(const Node& node) {
+  auto output_args = node.OutputDefs();
+
+  for (const NodeArg* output_arg : output_args) {
+    auto proto_type = output_arg->TypeAsProto();
+
+    if (!proto_type || !proto_type->tensor_type().has_elem_type()) {
+      continue;
+    }
+
+    if (proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+static bool HasPrintToleranceErrorsOutput(const Node& node) {
+  for (auto output_edge_iter = node.OutputEdgesBegin(); output_edge_iter != node.OutputEdgesEnd(); ++output_edge_iter) {
+    if (output_edge_iter->GetNode().OpType() == "PrintToleranceErrors") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static void CastNodeInputsToFloat32(Graph& graph, Node& node) {
+  std::vector<NodeArg*>& input_args = node.MutableInputDefs();
+
+  // Add fp16 -> fp32 cast nodes to all inputs
+  for (auto input_edge_iter = node.InputEdgesBegin(); input_edge_iter != node.InputEdgesEnd();) {
+    int src_arg_index = input_edge_iter->GetSrcArgIndex();
+    int dst_arg_index = input_edge_iter->GetDstArgIndex();
+    auto proto_type = input_args[dst_arg_index]->TypeAsProto();
+
+    if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+      ++input_edge_iter;
+      continue;
+    }
+
+    const Node& prev_node = input_edge_iter->GetNode();
+
+    // Remove the fp16 input edge
+    graph.RemoveEdge(prev_node.Index(), node.Index(), src_arg_index, dst_arg_index);
+
+    TypeProto fp32_proto_type;
+    fp32_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+    NodeArg& cast_output_node_arg = graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("Cast"), &fp32_proto_type);
+
+    std::array<NodeArg*, 1> cast_inputs = {input_args[dst_arg_index]};
+    std::array<NodeArg*, 1> cast_outputs = {&cast_output_node_arg};
+
+    Node& cast_node = graph.AddNode(
+        graph.GenerateNodeName("Cast"),
+        "Cast",
+        "",
+        cast_inputs,
+        cast_outputs);
+
+    cast_node.AddAttribute("to", static_cast<int64_t>(TensorProto_DataType_FLOAT));
+    cast_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+    // Change the datatype of the current input
+    input_args[dst_arg_index] = &cast_output_node_arg;
+
+    // Add the Cast edges
+    graph.AddEdge(prev_node.Index(), cast_node.Index(), src_arg_index, 0);
+    graph.AddEdge(cast_node.Index(), node.Index(), 0, dst_arg_index);
+
+    input_edge_iter = node.InputEdgesBegin();
+  }
+
+  // 3. Add fp16 -> fp32 cast nodes for every float16 initializer
+  for (int input_arg_index = 0; input_arg_index < input_args.size(); ++input_arg_index) {
+    auto proto_type = input_args[input_arg_index]->TypeAsProto();
+
+    if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+      continue;
+    }
+
+    if (!graph.IsInitializedTensor(input_args[input_arg_index]->Name())) {
+      continue;
+    }
+
+    TypeProto fp32_proto_type;
+    fp32_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+    NodeArg& cast_output_node_arg = graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("Cast"), &fp32_proto_type);
+
+    std::array<NodeArg*, 1> cast_inputs = {input_args[input_arg_index]};
+    std::array<NodeArg*, 1> cast_outputs = {&cast_output_node_arg};
+
+    Node& cast_node = graph.AddNode(
+        graph.GenerateNodeName("Cast"),
+        "Cast",
+        "",
+        cast_inputs,
+        cast_outputs);
+    cast_node.AddAttribute("to", static_cast<int64_t>(TensorProto_DataType_FLOAT));
+    cast_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+    // Change the datatype of the current initializer
+    input_args[input_arg_index] = &cast_output_node_arg;
+
+    // Add the cast edge
+    graph.AddEdge(cast_node.Index(), node.Index(), 0, input_arg_index);
+  }
+}
+
+static void CastNodeOutputsToFloat16(Graph& graph, Node& node) {
+  std::vector<NodeArg*>& output_args = node.MutableOutputDefs();
+  std::vector<std::tuple<int, int, const Node*>> removed_edges;
+
+  // Remove all fp16 output edges
+  for (auto output_edge_iter = node.OutputEdgesBegin(); output_edge_iter != node.OutputEdgesEnd();) {
+    int src_arg_index = output_edge_iter->GetSrcArgIndex();
+    int dst_arg_index = output_edge_iter->GetDstArgIndex();
+    auto proto_type = output_args[src_arg_index]->TypeAsProto();
+
+    if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+      ++output_edge_iter;
+      continue;
+    }
+
+    const Node& next_node = output_edge_iter->GetNode();
+
+    // Remove the fp16 output edge
+    graph.RemoveEdge(node.Index(), next_node.Index(), src_arg_index, dst_arg_index);
+
+    removed_edges.emplace_back(src_arg_index, dst_arg_index, &next_node);
+    output_edge_iter = node.OutputEdgesBegin();
+  }
+
+  // Convert all fp16 output defs to fp32
+  for (NodeArg*& output_arg : output_args) {
+    auto proto_type = output_arg->TypeAsProto();
+
+    if (proto_type && proto_type->tensor_type().has_elem_type() && proto_type->tensor_type().elem_type() == TensorProto_DataType_FLOAT16) {
+      TypeProto fp32_proto_type;
+      fp32_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+      output_arg = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(node.OpType()), &fp32_proto_type);
+    }
+  }
+
+  // Add the fp32 -> fp16 cast edges
+  for (const auto& removed_edge : removed_edges) {
+    const auto& [src_arg_index, dst_arg_index, next_node] = removed_edge;
+
+    TypeProto fp16_proto_type;
+    fp16_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT16);
+    NodeArg& cast_output_node_arg = graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("Cast"), &fp16_proto_type);
+
+    std::array<NodeArg*, 1> cast_inputs = {output_args[src_arg_index]};
+    std::array<NodeArg*, 1> cast_outputs = {&cast_output_node_arg};
+
+    Node& cast_node = graph.AddNode(
+        graph.GenerateNodeName("Cast"),
+        "Cast",
+        "",
+        cast_inputs,
+        cast_outputs);
+
+    cast_node.AddAttribute("to", static_cast<int64_t>(TensorProto_DataType_FLOAT16));
+    cast_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+    // Add the cast nodes
+    graph.AddEdge(node.Index(), cast_node.Index(), src_arg_index, 0);
+    graph.AddEdge(cast_node.Index(), next_node->Index(), 0, dst_arg_index);
+  }
+}
+
+Status PrintToleranceErrorsTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
+                                                  const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& order = graph_viewer.GetNodesInTopologicalOrder();
+
+  // Nodes to force fp32 execution for. When a node has a a huge difference between its fp16 and fp32 results,
+  // adding it to this list can help figure out whether keeping the node in fp32 would fix issues in the model.
+  std::unordered_set<std::string> force_fp32_ops;
+  auto force_fp32_ops_var = Env::Default().GetEnvironmentVar("ORT_DEBUG_FORCE_FP32_OPS");
+  std::stringstream ops_ss(force_fp32_ops_var);
+
+  while (ops_ss.good()) {
+    std::string operator_name;
+    getline(ops_ss, operator_name, ',');
+    force_fp32_ops.insert(operator_name);
+  }
+
+  std::unordered_set<std::string> force_fp32_nodes;
+  auto force_fp32_nodes_var = Env::Default().GetEnvironmentVar("ORT_DEBUG_FORCE_FP32_NODES");
+  std::stringstream nodes_ss(force_fp32_nodes_var);
+
+  while (nodes_ss.good()) {
+    std::string node_name;
+    getline(nodes_ss, node_name, ',');
+    force_fp32_nodes.insert(node_name);
+  }
+
+  for (auto index : order) {
+    auto* node_ptr = graph.GetNode(index);
+    if (!node_ptr) {
+      continue;
+    }
+
+    auto& node = *node_ptr;
+    ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+
+    if (node.OpType() == "PrintToleranceErrors" || node.OpType() == "Cast") {
+      continue;
+    }
+
+    if (graph.NodeProducesGraphOutput(node)) {
+      continue;
+    }
+
+    if (force_fp32_ops.count(node.OpType())) {
+      CastNodeInputsToFloat32(graph, node);
+      CastNodeOutputsToFloat16(graph, node);
+      continue;
+    }
+
+    if (force_fp32_nodes.count(node.Name())) {
+      CastNodeInputsToFloat32(graph, node);
+      CastNodeOutputsToFloat16(graph, node);
+      continue;
+    }
+
+    // Don't re-process the node if it already has the print node as an output
+    if (HasPrintToleranceErrorsOutput(node)) {
+      continue;
+    }
+
+    // Skip nodes that don't have float16 inputs/outputs
+    if (!HasFloat16Inputs(node) || !HasFloat16Outputs(node)) {
+      continue;
+    }
+
+    // Convert the cloned node's fp16 inputs to fp32
+    std::vector<NodeArg*>& input_args = node.MutableInputDefs();
+    std::vector<NodeArg*> clone_input_args;
+
+    for (NodeArg* input_arg : input_args) {
+      auto proto_type = input_arg->TypeAsProto();
+      NodeArg* clone_input_arg = nullptr;
+
+      if (proto_type && proto_type->tensor_type().has_elem_type() && proto_type->tensor_type().elem_type() == TensorProto_DataType_FLOAT16) {
+        TypeProto clone_proto_type;
+        clone_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+        clone_input_arg = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(node.OpType()), &clone_proto_type);
+      } else {
+        clone_input_arg = input_arg;
+      }
+
+      clone_input_args.push_back(clone_input_arg);
+    }
+
+    // Convert the cloned node's fp16 outputs to fp32
+    std::vector<NodeArg*>& output_args = node.MutableOutputDefs();
+    std::vector<NodeArg*> clone_output_args;
+
+    for (const NodeArg* output_arg : output_args) {
+      auto proto_type = output_arg->TypeAsProto();
+      NodeArg* clone_output_arg = nullptr;
+
+      if (proto_type && proto_type->tensor_type().has_elem_type() && proto_type->tensor_type().elem_type() == TensorProto_DataType_FLOAT16) {
+        TypeProto clone_proto_type;
+        clone_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+        clone_output_arg = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(node.OpType()), &clone_proto_type);
+      } else {
+        clone_output_arg = &graph.GetOrCreateNodeArg(graph.GenerateNodeArgName(node.OpType()), proto_type);
+      }
+
+      clone_output_args.push_back(clone_output_arg);
+    }
+
+    // Clone the current node
+    Node& cloned_node = graph.AddNode(
+        graph.GenerateNodeName(node.OpType()),
+        node.OpType(),
+        "",
+        clone_input_args,
+        clone_output_args,
+        &node.GetAttributes(),
+        node.Domain());
+    cloned_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+    // Add fp16 -> fp32 cast edges to all fp32 inputs of the cloned node, and normal edges to other nodes
+    for (auto input_edge_iter = node.InputEdgesBegin(); input_edge_iter != node.InputEdgesEnd(); ++input_edge_iter) {
+      int src_arg_index = input_edge_iter->GetSrcArgIndex();
+      int dst_arg_index = input_edge_iter->GetDstArgIndex();
+      auto proto_type = input_args[dst_arg_index]->TypeAsProto();
+
+      if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+        const Node& prev_node = input_edge_iter->GetNode();
+        graph.AddEdge(prev_node.Index(), cloned_node.Index(), src_arg_index, dst_arg_index);
+      } else {
+        std::array<NodeArg*, 1> cast_inputs = {input_args[dst_arg_index]};
+        std::array<NodeArg*, 1> cast_outputs = {clone_input_args[dst_arg_index]};
+
+        Node& cast_node = graph.AddNode(
+            graph.GenerateNodeName("Cast"),
+            "Cast",
+            "",
+            cast_inputs,
+            cast_outputs);
+
+        cast_node.AddAttribute("to", static_cast<int64_t>(TensorProto_DataType_FLOAT));
+        cast_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+        // Add the Cast edges
+        const Node& prev_node = input_edge_iter->GetNode();
+        graph.AddEdge(prev_node.Index(), cast_node.Index(), src_arg_index, 0);
+        graph.AddEdge(cast_node.Index(), cloned_node.Index(), 0, dst_arg_index);
+      }
+    }
+
+    // Convert the cloned node's initializers to fp32
+    for (int input_arg_index = 0; input_arg_index < input_args.size(); ++input_arg_index) {
+      auto proto_type = input_args[input_arg_index]->TypeAsProto();
+
+      if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+        continue;
+      }
+
+      if (!graph.IsInitializedTensor(input_args[input_arg_index]->Name())) {
+        continue;
+      }
+
+      std::array<NodeArg*, 1> cast_inputs = {input_args[input_arg_index]};
+      std::array<NodeArg*, 1> cast_outputs = {clone_input_args[input_arg_index]};
+
+      Node& cast_node = graph.AddNode(
+          graph.GenerateNodeName("Cast"),
+          "Cast",
+          "",
+          cast_inputs,
+          cast_outputs);
+      cast_node.AddAttribute("to", static_cast<int64_t>(TensorProto_DataType_FLOAT));
+      cast_node.SetExecutionProviderType(node.GetExecutionProviderType());
+
+      // Add the cast edge
+      graph.AddEdge(cast_node.Index(), cloned_node.Index(), 0, input_arg_index);
+    }
+
+    // For each float16 output in the original node, we create a PrintToleranceErrors node that takes the float16 and float32 result as inputs
+    for (auto output_edge_iter = node.OutputEdgesBegin(); output_edge_iter != node.OutputEdgesEnd();) {
+      int output_src_arg_index = output_edge_iter->GetSrcArgIndex();
+      int output_dst_arg_index = output_edge_iter->GetDstArgIndex();
+      auto proto_type = output_args[output_src_arg_index]->TypeAsProto();
+
+      if (!proto_type || !proto_type->tensor_type().has_elem_type() || proto_type->tensor_type().elem_type() != TensorProto_DataType_FLOAT16) {
+        ++output_edge_iter;
+        continue;
+      }
+
+      Node* output_node = graph.GetNode(output_edge_iter->GetNode().Index());
+
+      if (output_node->OpType() == "PrintToleranceErrors") {
+        ++output_edge_iter;
+        continue;
+      }
+
+      TypeProto float16_proto_type;
+      float16_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT16);
+
+      TypeProto float32_proto_type;
+      float32_proto_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+
+      NodeArg& print_tolerance_errors_output = graph.GetOrCreateNodeArg(graph.GenerateNodeArgName("PrintToleranceErrors"), &float16_proto_type);
+
+      std::array<NodeArg*, 2> print_tolerance_errors_inputs = {output_args[output_src_arg_index], clone_output_args[output_src_arg_index]};
+      std::array<NodeArg*, 1> print_tolerance_errors_outputs = {&print_tolerance_errors_output};
+
+      const std::string op_type = "PrintToleranceErrors";
+      Node& print_tolerance_errors_node = graph.AddNode(
+          graph.GenerateNodeName(op_type),
+          op_type,
+          "",
+          print_tolerance_errors_inputs,
+          print_tolerance_errors_outputs,
+          nullptr,
+          kMSDomain);
+      print_tolerance_errors_node.AddAttribute("node_name", node.Name());
+      print_tolerance_errors_node.AddAttribute("node_type", node.OpType());
+      print_tolerance_errors_node.AddAttribute("execution_provider", node.GetExecutionProviderType());
+      print_tolerance_errors_node.AddAttribute("node_output_index", static_cast<int64_t>(output_src_arg_index));
+      print_tolerance_errors_node.SetExecutionProviderType(kCpuExecutionProvider);
+
+      // Remove the link between the original node and its output node
+      graph.RemoveEdge(node.Index(), output_node->Index(), output_src_arg_index, output_dst_arg_index);
+
+      // Link the float16 node to the first input of PrintToleranceErrors
+      graph.AddEdge(node.Index(), print_tolerance_errors_node.Index(), output_src_arg_index, 0);
+
+      // Link the float32 node to the second input of PrintToleranceErrors
+      graph.AddEdge(cloned_node.Index(), print_tolerance_errors_node.Index(), output_src_arg_index, 1);
+
+      // Link PrintToleranceErrors to the output of the original node
+      graph.AddEdge(print_tolerance_errors_node.Index(), output_node->Index(), 0, output_dst_arg_index);
+
+      // We modified the original node's output nodes, so reset the iterator
+      output_edge_iter = node.OutputEdgesBegin();
+    }
+
+    modified = true;
+  }
+
+  return Status::OK();
+}
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/core/optimizer/print_tolerance_errors_transformer.h
+++ b/onnxruntime/core/optimizer/print_tolerance_errors_transformer.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifdef PRINT_TOLERANCE_ERRORS
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+class PrintToleranceErrorsTransformer : public GraphTransformer {
+ public:
+  PrintToleranceErrorsTransformer(const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("PrintToleranceErrorsTransformer", compatible_execution_providers) {}
+
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime
+
+#endif

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -688,6 +688,7 @@ def parse_arguments():
     parser.add_argument("--use_lock_free_queue", action="store_true", help="Use lock-free task queue for threadpool.")
 
     parser.add_argument("--print_error_values", action="store_true", help="Insert nodes that will print potentially wrong values like NaN and INF.")
+    parser.add_argument("--print_tolerance_errors", action="store_true", help="Insert nodes that will print values that exceed a tolerance threshold between float16 and float32.")
 
     if not is_windows():
         parser.add_argument(
@@ -998,6 +999,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_TRITON_KERNEL=" + ("ON" if args.use_triton_kernel else "OFF"),
         "-Donnxruntime_DISABLE_FLOAT8_TYPES=" + ("ON" if disable_float8_types else "OFF"),
         "-Donnxruntime_PRINT_ERROR_VALUES=" + ("ON" if args.print_error_values else "OFF"),
+        "-Donnxruntime_PRINT_TOLERANCE_ERRORS=" + ("ON" if args.print_tolerance_errors else "OFF"),
     ]
 
     # By default on Windows we currently support only cross compiling for ARM/ARM64

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -687,6 +687,8 @@ def parse_arguments():
     parser.add_argument("--use_triton_kernel", action="store_true", help="Use triton compiled kernels")
     parser.add_argument("--use_lock_free_queue", action="store_true", help="Use lock-free task queue for threadpool.")
 
+    parser.add_argument("--print_error_values", action="store_true", help="Insert nodes that will print potentially wrong values like NaN and INF.")
+
     if not is_windows():
         parser.add_argument(
             "--allow_running_as_root",
@@ -995,6 +997,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_CANN=" + ("ON" if args.use_cann else "OFF"),
         "-Donnxruntime_USE_TRITON_KERNEL=" + ("ON" if args.use_triton_kernel else "OFF"),
         "-Donnxruntime_DISABLE_FLOAT8_TYPES=" + ("ON" if disable_float8_types else "OFF"),
+        "-Donnxruntime_PRINT_ERROR_VALUES=" + ("ON" if args.print_error_values else "OFF"),
     ]
 
     # By default on Windows we currently support only cross compiling for ARM/ARM64


### PR DESCRIPTION
This adds debugging tools for intermediate outputs when specific build flavors are specified (so it doesn't affect the final product at all). This allows us to easily figure out which nodes are producing NaN or INF numbers, and which float16 nodes are producing outputs that are too different from their expected "perfect precision" outputs.