### PR TITLE
Add CI and PR validation triggers to QNN Windows x64 Pipeline yaml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -1,3 +1,32 @@
+trigger:
+  branches:
+    include:
+    - main
+    - rel-*
+  paths:
+    exclude:
+    - docs/**
+    - README.md
+    - CONTRIBUTING.md
+    - BUILD.md
+    - 'js/web'
+    - 'js/node'
+    - 'onnxruntime/core/providers/js'
+pr:
+  branches:
+    include:
+    - main
+    - rel-*
+  paths:
+    exclude:
+    - docs/**
+    - README.md
+    - CONTRIBUTING.md
+    - BUILD.md
+    - 'js/web'
+    - 'js/node'
+    - 'onnxruntime/core/providers/js'
+
 parameters:
 
 - name: QnnSdk


### PR DESCRIPTION
### Description
Adds continuous integration and pull-requestion validation triggers directly to the yaml file for the Windows x64 QNN CI Pipeline.


### Motivation and Context
There have been various unit tests failures that break the QNN_Windows_Nuget pipeline, which builds QNN EP for Windows x64. This PR ensures that QNN EP is built and tested on a Windows x64 image for every pull request.