### PR TITLE
Move some tests from CUDA only to CPU

### DIFF
--- a/orttraining/orttraining/test/training_api/core/checkpoint_test.cc
+++ b/orttraining/orttraining/test/training_api/core/checkpoint_test.cc
@@ -281,9 +281,7 @@ TEST(CheckpointApiTest, LoadCheckpointToModel) {
  * Save Optimizer states into ORT checkpoint files,
  * Then load it into ORT, compare with the initial optimizer states values.
  */
-#if defined(USE_CUDA)
-
-TEST(CheckpointApiTest, SaveOptimizerStateAsCheckpoint_ThenLoad_CUDA) {
+TEST(CheckpointApiTest, SaveOptimizerStateAsCheckpoint_ThenLoad) {
   /// Phase 1 - Test Preparation
   /// Prepare the data and dest folder for saving checkpoint.
   /// Also cooked the data for test result comparison.
@@ -329,11 +327,14 @@ TEST(CheckpointApiTest, SaveOptimizerStateAsCheckpoint_ThenLoad_CUDA) {
   onnxruntime::SessionOptions session_option;
   std::unique_ptr<Environment> env;
   ORT_THROW_IF_ERROR(Environment::Create(nullptr, env));
-  std::vector<std::shared_ptr<IExecutionProvider>> cuda_provider{onnxruntime::test::DefaultCudaExecutionProvider()};
+  std::vector<std::shared_ptr<IExecutionProvider>> providers;
+#if defined(USE_CUDA)
+  providers.push_back(onnxruntime::test::DefaultCudaExecutionProvider());
+#endif
   auto model = std::make_unique<Module>(model_uri, &state, session_option,
-                                        *env, cuda_provider);
+                                        *env, providers);
   auto optimizer = std::make_unique<Optimizer>(optim_uri, &state, session_option,
-                                               *env, cuda_provider);
+                                               *env, providers);
 
   // Remove the temporary directory if it already exists.
   auto ckpt_test_root_dir = ORT_TSTR("checkpointing_api_test_dir");
@@ -373,7 +374,6 @@ TEST(CheckpointApiTest, SaveOptimizerStateAsCheckpoint_ThenLoad_CUDA) {
 
       ASSERT_EQ(param_tensor.DataType(), restored_tensor.DataType());
       ASSERT_EQ(param_tensor.SizeInBytes(), restored_tensor.SizeInBytes());
-      ASSERT_EQ(param_tensor.DataType(), restored_tensor.DataType());
 
       std::vector<float> state_vect;
       CpuOrtValueToVec(restored_ort_value, state_vect);
@@ -383,8 +383,6 @@ TEST(CheckpointApiTest, SaveOptimizerStateAsCheckpoint_ThenLoad_CUDA) {
     }
   }
 }
-
-#endif
 
 /**
  * Create PropertyBag with sets of properties,

--- a/orttraining/orttraining/test/training_api/core/training_api_tests.cc
+++ b/orttraining/orttraining/test/training_api/core/training_api_tests.cc
@@ -458,9 +458,7 @@ TEST(TrainingApiTest, OptimStep) {
       std::array<int64_t, 1>{2}, std::vector<int32_t>(2, 1));
   auto data_loader = std::vector<std::vector<OrtValue>>(4, std::vector<OrtValue>{input, target});
 
-  size_t step = 0;
   std::string param_name = "fc2.weight";
-
   // before training, check if optim state is initialized to 0
   onnxruntime::training::api::OptimizerCheckpointState& optimizer_states = state.optimizer_checkpoint_state;
   onnxruntime::training::api::ParameterOptimizerState& param_state =
@@ -482,7 +480,6 @@ TEST(TrainingApiTest, OptimStep) {
   }
 
   for (auto it = data_loader.begin(); it != data_loader.end(); ++it) {
-    step += 1;
     std::vector<OrtValue>& inputs = *it;
     std::vector<OrtValue> fetches;
     ASSERT_STATUS_OK(model->TrainStep(inputs, fetches));
@@ -491,11 +488,11 @@ TEST(TrainingApiTest, OptimStep) {
     // get gradients and optim state and check if it is updated
     std::vector<float> grads;
 #if defined(USE_CUDA)
-  CudaOrtValueToCpuVec(model->NamedParameters().at(param_name)->Gradient(), grads);
-  CudaOrtValueToCpuVec(moment_1, moment_1_vec);
+    CudaOrtValueToCpuVec(model->NamedParameters().at(param_name)->Gradient(), grads);
+    CudaOrtValueToCpuVec(moment_1, moment_1_vec);
 #else
-  CpuOrtValueToVec(model->NamedParameters().at(param_name)->Gradient(), grads);
-  CpuOrtValueToVec(moment_1, moment_1_vec);
+    CpuOrtValueToVec(model->NamedParameters().at(param_name)->Gradient(), grads);
+    CpuOrtValueToVec(moment_1, moment_1_vec);
 #endif
     for (size_t i = 0; i < moment_1_vec.size(); i++) {
       if (grads[i] != 0.0f) {
@@ -504,10 +501,10 @@ TEST(TrainingApiTest, OptimStep) {
     }
 
     std::vector<float> param_vec_after_optimizer_step;
-    #if defined(USE_CUDA)
-  CudaOrtValueToCpuVec(model->NamedParameters().at(param_name)->Data(), param_vec_after_optimizer_step);
+#if defined(USE_CUDA)
+    CudaOrtValueToCpuVec(model->NamedParameters().at(param_name)->Data(), param_vec_after_optimizer_step);
 #else
-  CpuOrtValueToVec(model->NamedParameters().at(param_name)->Data(), param_vec_after_optimizer_step);
+    CpuOrtValueToVec(model->NamedParameters().at(param_name)->Data(), param_vec_after_optimizer_step);
 #endif
     for (size_t i = 0; i < param_vec_after_optimizer_step.size(); ++i) {
       if (grads[i] != 0.0f && moment_1_vec[i] != 0.0f) {

--- a/orttraining/orttraining/training_api/checkpoint.cc
+++ b/orttraining/orttraining/training_api/checkpoint.cc
@@ -332,9 +332,11 @@ Status FromOptimizerState(const OptimizerCheckpointState& optimizer_state,
           optimizer_state.optimizer_session_data_transfer_mgr,
           builder, momentums));
 
+      const auto fbs_param_name = builder.CreateString(param_name);
+      const auto fbs_momentums = builder.CreateVector(momentums);
       fbs::ParameterOptimizerStateBuilder optimizer_state_builder(builder);
-      optimizer_state_builder.add_param_name(builder.CreateString(param_name));
-      optimizer_state_builder.add_momentums(builder.CreateVector(momentums));
+      optimizer_state_builder.add_param_name(fbs_param_name);
+      optimizer_state_builder.add_momentums(fbs_momentums);
 
       flatbuffers::Offset<fbs::ParameterOptimizerState> fbs_optimizer_state = optimizer_state_builder.Finish();
       optimizer_states.push_back(fbs_optimizer_state);


### PR DESCRIPTION
### Description
Minor PR to move some CUDA only on-device training tests to CPU as well. This is to make sure we have good coverage for CPU too. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


