### PR TITLE
[js/web] NCHW as a default for JSEP, fixed InstanceNormalization for NCHW

### DIFF
--- a/onnxruntime/core/providers/js/js_execution_provider.h
+++ b/onnxruntime/core/providers/js/js_execution_provider.h
@@ -39,7 +39,7 @@ class JsExecutionProvider : public IExecutionProvider {
   std::shared_ptr<KernelRegistry> GetKernelRegistry() const override;
   std::unique_ptr<onnxruntime::IDataTransfer> GetDataTransfer() const override;
 
-  DataLayout GetPreferredLayout() const override { return DataLayout::NHWC; }
+  DataLayout GetPreferredLayout() const override { return DataLayout::NCHW; }
 
   FusionStyle GetFusionStyle() const override { return FusionStyle::FilteredGraphViewer; }
 


### PR DESCRIPTION
### Description
Since webgpu ops don't have specific hardware optimizations for NHWC format (this is my assumption, correct me if i'm wrong), having NHWC as a default for JSEP creates additional Transpose nodes and slows down session creation as written here onnxruntime/core/optimizer/layout_transformation/layout_transformation_dev_notes.md

Disabling those transformations gave these results:
Before:
Node(s) placed on [CPUExecutionProvider]. Number of nodes: 1735
Node(s) placed on [JsExecutionProvider]. Number of nodes: 2243
memcpy tokens: 813

After:
Node(s) placed on [CPUExecutionProvider]. Number of nodes: 1669
Node(s) placed on [JsExecutionProvider]. Number of nodes: 1895
memcpy tokens: 254

However, I havent seen any speed increase during inference, so maybe NHWC is faster a bit.
This change also fixes my issues with Conv and StableDiffusion Unet. Everything works fine now

Also, this patch breaks all tests for ConvTranspose, so there should be an issue for NCHW and I might need some help from you to fix it

