### PR TITLE
Workaround for cuda ubuntu repo package failure

### DIFF
--- a/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu_training
+++ b/tools/ci_build/github/linux/docker/Dockerfile.ubuntu_gpu_training
@@ -7,6 +7,12 @@ ARG INSTALL_DEPS_EXTRA_ARGS
 ARG USE_CONDA=false
 
 ADD scripts /tmp/scripts
+
+# TODO: Remove. It's a workaround for issue where apt fails to fetch cuda repo packages
+# with the error "File has unexpected size (1127072 != 1126689). Mirror sync in progress?"
+# See: https://github.com/NVIDIA/cuda-repo-management/issues/10
+RUN rm -f /etc/apt/sources.list.d/cuda.list
+
 RUN /tmp/scripts/install_ubuntu.sh -p $PYTHON_VERSION && \
     /tmp/scripts/install_os_deps.sh -d gpu $INSTALL_DEPS_EXTRA_ARGS
 


### PR DESCRIPTION
### Description
Tries the workaround from https://github.com/NVIDIA/cuda-repo-management/issues/10 to enable the orttraining-linux-gpu-ci pipeline to fetch cuda packages on ubuntu.


### Motivation and Context
The orttraining-linux-gpu-ci pipeline is unable to fetch cuda packages. This is blocking PRs.


