### PR TITLE
[C#]Fix API Comment

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -743,7 +743,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <summary>
         /// Creates an OrtValue that contains a string tensor of specified shape, and
         /// containing empty strings. String tensors are always on CPU.
-        /// Use FillStringTensorElement to assign individual elements values.
+        /// Use StringTensorSetElementAt to assign individual elements values.
         /// </summary>
         /// <param name="allocator"></param>
         /// <returns>disposable OrtValue</returns>


### PR DESCRIPTION
### Description
Fix comment reference to a renamed public API.

### Motivation and Context
Avoid confusion of incorrect docs.

We want this in 1.16 release

