### PR TITLE
Avoid pushing cpu package to https://download.onnxruntime.ai/

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-py-packaging-pipeline-cpu.yml
@@ -1,14 +1,5 @@
 trigger: none
 
-variables:
-  - name: isMain
-    value: ${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}
-  - name: finalStorage
-    ${{ if eq(variables['isMain'], 'true') }}:
-      value: '--final_storage'
-    ${{ else }}:
-      value: ''
-
 resources:
   repositories:
   - repository: manylinux
@@ -39,14 +30,6 @@ stages:
             PythonVersion: '3.11'
 
       steps:
-      - task: CmdLine@2
-        displayName: 'check variables'
-        inputs:
-          script: |
-            echo "Branch is "${{ variables['Build.SourceBranch'] }} && \
-            echo "isMain is "${{ variables['isMain'] }} && \
-            echo "final_storage is "${{ variables['finalStorage'] }}
-
       - checkout: self
         clean: true
         submodules: recursive
@@ -101,17 +84,6 @@ stages:
         displayName: 'Publish Artifact: ONNXRuntime python wheel and documentation'
         inputs:
           ArtifactName: onnxruntime_training_cpu
-
-      - task: CmdLine@2
-        condition: succeeded()
-        displayName: 'Upload wheel'
-        inputs:
-          script: |
-            files=($(Build.ArtifactStagingDirectory)/Release/dist/*.whl) && \
-            echo ${files[0]} && \
-            echo ${{ variables['finalStorage'] }} && \
-            tools/ci_build/upload_python_package_to_azure_storage.py \
-                --python_wheel_path ${files[0]} ${{ variables['finalStorage'] }}
 
       - template: templates/component-governance-component-detection-steps.yml
         parameters:


### PR DESCRIPTION
onnxruntime_training_cpu package is meant for ADO feeds and not for azure storage feed.

Since the azure storage script is expecting a local version:

https://github.com/microsoft/onnxruntime/blob/08ca624d2b65142218a5128bd20787cecb4e1591/tools/ci_build/upload_python_package_to_azure_storage.py#L17

The package upload fails since it cannot find the local version in the package name.

We no longer will push the cpu python package to https://download.onnxruntime.ai/ and will mark it as inactive.