### PR TITLE
[ROCm] add HIP language compile option -parallel-jobs=4

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -298,7 +298,7 @@ if (onnxruntime_USE_ROCM)
   if(NOT DEFINED _CMAKE_HIP_DEVICE_RUNTIME_TARGET)
     message(FATAL_ERROR "HIP Language is not properly configured.")
   endif()
-  add_compile_options("$<$<COMPILE_LANGUAGE:HIP>:SHELL:-x hip>")
+  add_compile_options("$<$<COMPILE_LANGUAGE:HIP>:SHELL:-x hip -parallel-jobs=4>")
 
   if (NOT onnxruntime_HIPIFY_PERL)
     find_path(HIPIFY_PERL_PATH


### PR DESCRIPTION
This should speed up the compilation of HIP files by compiling the various gfx targets in parallel. Otherwise, each gfx target is compiled one at a time, back to back. Setting this to 4 is usually sufficient without oversubscribing CPU resources during compilation.