### PR TITLE
[VitisAI] fix doc after the support of Visual Studio 2019 is removed.

### DIFF
--- a/docs/execution-providers/Vitis-AI-ExecutionProvider.md
+++ b/docs/execution-providers/Vitis-AI-ExecutionProvider.md
@@ -75,7 +75,7 @@ Both C++ and Python APIs are supported.  The following instructions assume that 
 
 **1. Verify Pre-requisites:**
 
-- Visual Studio = 2019
+- Visual Studio = 2022
 - cmake (version >= 3.26)
 - python (version >= 3.9) (Python 3.9.13 64bit recommended)
 - AMD IPU driver >= 10.105.5.38 installed


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Update 2019 to 2022


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
It is required because Visual Studio is no longer a valid cmake generator for onnxruntime.