### PR TITLE
Kailums/add rotary emb

### DIFF
--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.cc
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/rocm/bert/rotary_embedding.h"
+#include "contrib_ops/rocm/bert/rotary_embedding_impl.h"
+#include "core/providers/rocm/rocm_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      RotaryEmbedding,                                            \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kRocmExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()) \
+          .TypeConstraint("M", DataTypeImpl::GetTensorType<int64_t>()), \
+      RotaryEmbedding<T>);
+
+REGISTER_KERNEL_TYPED(float)
+REGISTER_KERNEL_TYPED(MLFloat16)
+
+
+using namespace ONNX_NAMESPACE;
+
+template <typename T>
+Status RotaryEmbedding<T>::ComputeInternal(OpKernelContext* context) const {
+  const Tensor* input = context->Input<Tensor>(0);
+  const Tensor* position_ids = context->Input<Tensor>(1);
+  const Tensor* cos_cached = context->Input<Tensor>(2);
+  const Tensor* sin_cached = context->Input<Tensor>(3);
+  const Tensor* past_key = context->Input<Tensor>(4);
+
+  // input shape is [batch, num_head, seqlen, head_dim]
+  const TensorShape &in_shape = input->Shape();
+  int64_t batch_size = in_shape[0];
+  int64_t num_heads = in_shape[1];
+  int64_t seqlen = in_shape[2];
+  int64_t head_dim = in_shape[3];
+  int64_t seqlen_with_past = seqlen;
+
+  if (past_key != nullptr) {
+    // past_key with shape [batch, num_head, past_seqlen, head_dim]
+    const TensorShape &past_shape = past_key->Shape();
+    seqlen_with_past += past_shape[2];
+  }
+
+
+  Tensor* output = context->Output(0, input->Shape());
+
+  typedef typename ToHipType<T>::MappedType HipT;
+
+  const HipT* input_buffer = reinterpret_cast<const HipT*>(input->Data<T>());
+  const int64_t* pos_buffer = reinterpret_cast<const int64_t*>(position_ids->Data<int64_t>());
+
+  // cos and sin wit shape [1, 1, max_seq_len, head_dim]
+  // only use [1, 1, :seqlen, head_dim] of them, that is [0 ~ seqlen*head_dim)
+  const HipT* cos_buffer = reinterpret_cast<const HipT*>(cos_cached->Data<T>());
+  const HipT* sin_buffer = reinterpret_cast<const HipT*>(sin_cached->Data<T>());
+
+  return LaunchRotaryEmbeddingKernel<HipT>(
+      context->GetComputeStream(),
+      input_buffer, batch_size, num_heads, seqlen, head_dim, seqlen_with_past,
+      pos_buffer, cos_buffer, sin_buffer,
+      reinterpret_cast<HipT*>(output->MutableData<T>()));
+}
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.cc
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.cc
@@ -9,21 +9,20 @@ namespace onnxruntime {
 namespace contrib {
 namespace rocm {
 
-#define REGISTER_KERNEL_TYPED(T)                                  \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
-      RotaryEmbedding,                                            \
-      kMSDomain,                                                  \
-      1,                                                          \
-      T,                                                          \
-      kRocmExecutionProvider,                                     \
-      (*KernelDefBuilder::Create())                               \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()) \
+#define REGISTER_KERNEL_TYPED(T)                                        \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                        \
+      RotaryEmbedding,                                                  \
+      kMSDomain,                                                        \
+      1,                                                                \
+      T,                                                                \
+      kRocmExecutionProvider,                                           \
+      (*KernelDefBuilder::Create())                                     \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())        \
           .TypeConstraint("M", DataTypeImpl::GetTensorType<int64_t>()), \
       RotaryEmbedding<T>);
 
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
-
 
 using namespace ONNX_NAMESPACE;
 
@@ -36,7 +35,7 @@ Status RotaryEmbedding<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* past_key = context->Input<Tensor>(4);
 
   // input shape is [batch, num_head, seqlen, head_dim]
-  const TensorShape &in_shape = input->Shape();
+  const TensorShape& in_shape = input->Shape();
   int64_t batch_size = in_shape[0];
   int64_t num_heads = in_shape[1];
   int64_t seqlen = in_shape[2];
@@ -45,10 +44,9 @@ Status RotaryEmbedding<T>::ComputeInternal(OpKernelContext* context) const {
 
   if (past_key != nullptr) {
     // past_key with shape [batch, num_head, past_seqlen, head_dim]
-    const TensorShape &past_shape = past_key->Shape();
+    const TensorShape& past_shape = past_key->Shape();
     seqlen_with_past += past_shape[2];
   }
-
 
   Tensor* output = context->Output(0, input->Shape());
 

--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.h
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/providers/rocm/rocm_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+using namespace onnxruntime::rocm;
+
+template <typename T>
+class RotaryEmbedding final : public RocmKernel {
+ public:
+  RotaryEmbedding(const OpKernelInfo& op_kernel_info) : RocmKernel(op_kernel_info) {}
+  Status ComputeInternal(OpKernelContext* ctx) const override;
+};
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.cu
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.cu
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/rocm/bert/rotary_embedding_impl.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+template <typename T>
+__global__ void RotaryEmbeddingKernel(
+		const T* input,
+		const int64_t* pos,
+		const T* cos_ptr,
+		const T* sin_ptr,
+		int64_t batch_size,
+		int64_t num_heads,
+		int64_t seqlen,
+		int64_t head_dim,
+                int64_t seqlen_with_past,
+		T* output) {
+  // each block handle one head_dim of input
+  // block size is same as head_dim, one thread handle one element.
+  // 1. get cos and sin from buffer with index from pos
+  // 2. in0 = input[i]
+  //    in1 = -input[(i + half) % dim] if i < half else input[(i+half) % dim]
+  // 3. output = in0 * cos + in1 * sin
+  const int batch_offset = blockIdx.z;
+  const int head_offset = blockIdx.y;
+  const int seqlen_offset = blockIdx.x;
+  const int i = threadIdx.x;
+
+  const int block_offset = batch_offset * num_heads * seqlen + head_offset * seqlen + seqlen_offset;
+  const auto* in_offset = input + head_dim * block_offset;
+  auto* out_offset = output + head_dim * block_offset;
+
+  int64_t pos_id = pos[batch_offset * seqlen + seqlen_offset];
+  if (pos_id >= seqlen_with_past) {
+    // TODO: may be need to assert pos_id < seqlen, this depends the input position_ids
+    // safe guard: when pos is invalid, use seqlen_with_past - 1
+    int64_t start_pos = seqlen_with_past - seqlen;
+    pos_id = start_pos + seqlen_offset;
+  }
+
+  // cos and sin with shape[seqlen, head_dim]
+  // cos = cos_ptr[pos_id][i]
+  auto cos = cos_ptr[pos_id * head_dim + i];
+  auto sin = sin_ptr[pos_id * head_dim + i];
+  auto in0 = in_offset[i];
+  const int half_dim = head_dim / 2;
+  const int i1 = (i + half_dim) % head_dim;
+  auto in1 = (i1 >= half_dim) ? -in_offset[i1] : in_offset[i1];
+
+  out_offset[i] = in0 * cos + in1 * sin;
+}
+
+
+template <typename T>
+Status LaunchRotaryEmbeddingKernel(
+		Stream* stream,
+		const T* input,
+		int64_t batch_size,
+		int64_t num_heads,
+		int64_t seqlen,
+		int64_t head_dim,
+		int64_t seqlen_with_past,
+                const int64_t* pos,
+		const T* cos_buffer,
+		const T* sin_buffer,
+		T* output) {
+  // TODO: check head_dim should less than kMaxThreadsPerBlock
+  const int blockSize = head_dim;
+  const dim3 gridSize(seqlen, num_heads, batch_size);
+  hipStream_t s = static_cast<hipStream_t>(stream->GetHandle());
+  RotaryEmbeddingKernel<T><<<gridSize, blockSize, 0, s>>>(
+		  input,
+		  pos,
+		  cos_buffer,
+		  sin_buffer,
+		  batch_size,
+		  num_heads,
+		  seqlen,
+		  head_dim,
+		  seqlen_with_past,
+		  output
+		  );
+
+  return HIP_CALL(hipGetLastError());
+}
+
+// instantiation
+template
+Status LaunchRotaryEmbeddingKernel<float>(
+		Stream* stream,
+		const float* input,
+		int64_t batch_size,
+		int64_t num_heads,
+		int64_t seqlen,
+		int64_t head_dim,
+		int64_t seqlen_with_past,
+                const int64_t* pos,
+		const float* cos_buffer,
+		const float* sin_buffer,
+		float* output);
+
+template
+Status LaunchRotaryEmbeddingKernel<half>(
+		Stream* stream,
+		const half* input,
+		int64_t batch_size,
+		int64_t num_heads,
+		int64_t seqlen,
+		int64_t head_dim,
+		int64_t seqlen_with_past,
+                const int64_t* pos,
+		const half* cos_buffer,
+		const half* sin_buffer,
+	        half* output);
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.h
@@ -12,7 +12,7 @@ namespace rocm {
 
 template <typename T>
 Status LaunchRotaryEmbeddingKernel(Stream* stream, const T* input, int64_t batch_size, int64_t num_heads, int64_t seqlen, int64_t head_dim, int64_t seqlen_with_past,
-                            const int64_t* pos, const T* cos_buffer, const T* sin_buffer, T* output);
+                                   const int64_t* pos, const T* cos_buffer, const T* sin_buffer, T* output);
 
 }  // namespace rocm
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.h
+++ b/onnxruntime/contrib_ops/rocm/bert/rotary_embedding_impl.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "core/common/common.h"
+#include "core/providers/rocm/rocm_kernel.h"
+#include "core/providers/rocm/rocm_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace rocm {
+
+template <typename T>
+Status LaunchRotaryEmbeddingKernel(Stream* stream, const T* input, int64_t batch_size, int64_t num_heads, int64_t seqlen, int64_t head_dim, int64_t seqlen_with_past,
+                            const int64_t* pos, const T* cos_buffer, const T* sin_buffer, T* output);
+
+}  // namespace rocm
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
@@ -116,6 +116,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, GemmFastGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, GemmFastGelu);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, GemmFastGelu);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, RotaryEmbedding);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, RotaryEmbedding);
 
 #ifdef ENABLE_ATEN
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kPytorchAtenDomain, 1, ATen);
@@ -262,6 +264,8 @@ Status RegisterRocmContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, GemmFastGelu)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, GemmFastGelu)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, BFloat16, GemmFastGelu)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, RotaryEmbedding)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, RotaryEmbedding)>,
 
 #ifdef ENABLE_ATEN
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kPytorchAtenDomain, 1, ATen)>,

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1364,5 +1364,26 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           }
         }));
 
+constexpr const char* RotaryEmbedding_ver1_doc = R"DOC(
+  y = x * cos + rotary_half(x) * sin
+)DOC";
+
+ONNX_MS_OPERATOR_SET_SCHEMA(
+    RotaryEmbedding, 1,
+    OpSchema()
+        .SetDoc(RotaryEmbedding_ver1_doc)
+        .Input(0, "input", "tensor with shape (batch_size, num_heads, seq_len, head_dim)", "T")
+        .Input(1, "position_ids", "2-d tensor with shape (batch_size, seq_len)", "M")
+        .Input(2, "cos_cached", "tensor with shape (1, 1, max_seq_len, head_dim)", "T")
+        .Input(3, "sin_cached", "tensor with shape (1, 1, max_seq_len, head_dim)", "T")
+        .Input(4, "past_key", "past key tensor with shape (batch_size, num_heads, past_seq_len, head_dim)", "T", OpSchema::Optional)
+        .Output(0, "output", "output tensor with shape (batch_size, num_heads, seq_len, head_dim)", "T")
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float tensors.")
+        .TypeConstraint("M", {"tensor(int64)"}, "Constrain token_offset to integer types")
+        .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          propagateShapeFromInputToOutput(ctx, 0, 0);
+        }));
+
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1376,7 +1376,11 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Input(1, "position_ids", "2-d tensor with shape (batch_size, seq_len)", "M")
         .Input(2, "cos_cached", "tensor with shape (1, 1, max_seq_len, head_dim)", "T")
         .Input(3, "sin_cached", "tensor with shape (1, 1, max_seq_len, head_dim)", "T")
-        .Input(4, "past_key", "past key tensor with shape (batch_size, num_heads, past_seq_len, head_dim)", "T", OpSchema::Optional)
+        .Input(4,
+               "past_key",
+               "past key tensor with shape (batch_size, num_heads, past_seq_len, head_dim)",
+               "T",
+               OpSchema::Optional)
         .Output(0, "output", "output tensor with shape (batch_size, num_heads, seq_len, head_dim)", "T")
         .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float tensors.")
         .TypeConstraint("M", {"tensor(int64)"}, "Constrain token_offset to integer types")

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -107,6 +107,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, WordConvEmbedding);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, RotaryEmbedding);
 
 class OpSet_Microsoft_ver1 {
  public:
@@ -208,6 +209,7 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GemmFastGelu)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedSelfAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, DecoderMaskedMultiHeadAttention)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, RotaryEmbedding)>());
   }
 };
 }  // namespace contrib

--- a/onnxruntime/core/providers/rocm/tunable/gemm_hipblaslt.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_hipblaslt.h
@@ -232,7 +232,7 @@ auto GetHipBlasLtTypeStringAndOps(ActivationType activation_type = ActivationTyp
                                                 &algo_i,
                                                 nullptr,
                                                 0,
-                                                params->stream));
+                                                params->StreamHandle()));
 
       HIPBLASLT_RETURN_IF_ERROR(hipblasLtMatmulDescDestroy(matmul));
       HIPBLASLT_RETURN_IF_ERROR(hipblasLtMatrixLayoutDestroy(mat_a));

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -147,6 +147,8 @@ class SymbolicShapeInference:
             "GatherElements": self._infer_GatherElements,
             "GatherND": self._infer_GatherND,
             "Identity": self._pass_on_shape_and_type,
+            "AllReduce": self._pass_on_shape_and_type,
+            "RotaryEmbedding": self._pass_on_shape_and_type,
             "If": self._infer_If,
             "Loop": self._infer_Loop,
             "MatMul": self._infer_MatMul,

--- a/onnxruntime/test/python/transformers/test_parity_rotary_embedding.py
+++ b/onnxruntime/test/python/transformers/test_parity_rotary_embedding.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-import math
 import os
 import unittest
 
@@ -14,7 +13,7 @@ from parity_utilities import compare_outputs, create_ort_session, parse_argument
 from torch import nn
 
 
-class LlamaRotaryEmbedding(torch.nn.Module):
+class LlamaRotaryEmbedding(nn.Module):
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
         super().__init__()
 
@@ -91,7 +90,7 @@ class RotaryEmbedding(torch.autograd.Function):
             return g.op("com.microsoft::RotaryEmbedding", q, position_ids, cos_cache, sin_cache, past_key)
 
 
-class TestRotaryEmbedding(torch.nn.Module):
+class TestRotaryEmbedding(nn.Module):
     def __init__(self, dim):
         super().__init__()
         self.emb = LlamaRotaryEmbedding(dim)

--- a/onnxruntime/test/python/transformers/test_parity_rotary_embedding.py
+++ b/onnxruntime/test/python/transformers/test_parity_rotary_embedding.py
@@ -1,0 +1,308 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import math
+import os
+import unittest
+
+import torch
+from parity_utilities import parse_arguments, create_ort_session, compare_outputs
+from torch import nn
+import numpy
+
+
+class LlamaRotaryEmbedding(torch.nn.Module):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
+        super().__init__()
+
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+        # Build here to make `torch.jit.trace` work.
+        self._set_cos_sin_cache(
+            seq_len=max_position_embeddings, device=self.inv_freq.device, dtype=torch.get_default_dtype()
+        )
+
+    def _set_cos_sin_cache(self, seq_len, device, dtype):
+        self.max_seq_len_cached = seq_len
+        t = torch.arange(self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype)
+
+        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos()[None, None, :, :].to(dtype), persistent=False)
+        self.register_buffer("sin_cached", emb.sin()[None, None, :, :].to(dtype), persistent=False)
+
+    def forward(self, x, seq_len=None):
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        if seq_len > self.max_seq_len_cached:
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+
+        return (
+            self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+            self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+        )
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, cos, sin, position_ids):
+    # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
+    cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
+    sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
+    cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+    sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    return q_embed
+
+class RotaryEmbedding(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, position_ids, cos_cache, sin_cache, past_key) -> torch.Tensor:
+        seq_len = q.shape[-2]
+        if past_key is not None:
+            seq_len += past_key.shape[-2]
+        cos = cos_cache[:,:,:seq_len,...].to(q.dtype)
+        sin = sin_cache[:,:,:seq_len,...].to(q.dtype)
+
+        cos = cos.reshape(cos.shape[2], cos.shape[3])
+        sin = sin.reshape(sin.shape[2], sin.shape[3])
+        cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+        sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+        q_embed = (q * cos) + (rotate_half(q) * sin)
+        return q_embed
+
+
+    @staticmethod
+    def symbolic(g: torch.Graph, q, position_ids, cos_cache, sin_cache, past_key) -> (torch.Value, torch.Value):
+        if past_key is None:
+            return g.op('com.microsoft::RotaryEmbedding', q, position_ids, cos_cache, sin_cache)
+        else:
+            return g.op('com.microsoft::RotaryEmbedding', q, position_ids, cos_cache, sin_cache, past_key)
+
+class TestRotaryEmbedding(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.emb = LlamaRotaryEmbedding(dim)
+
+    def forward(self, x, position_ids, past_key=None):
+        return RotaryEmbedding.apply(x, position_ids, self.emb.cos_cached, self.emb.sin_cached, past_key)
+
+
+def create_inputs(batch_size, num_heads, seqlen, hidden_size, dtype, device, past_seqlen=0):
+    in_tensor = torch.randn(batch_size, num_heads, seqlen, hidden_size).to(dtype).to(device)
+    position_ids = torch.stack([torch.arange(0, seqlen) for _ in range(batch_size)]).to(device)
+    inputs = {"x": in_tensor, "position_ids": position_ids}
+    if past_seqlen > 0:
+        past_key = torch.randn(batch_size, num_heads, past_seqlen, hidden_size).to(dtype)
+        inputs['past_key']=past_key
+        seqlen_with_past = seqlen + past_seqlen
+        inputs['position_ids'] = torch.stack([torch.tensor([seqlen_with_past - 1], dtype=torch.int64) for _ in range(batch_size)]).to(device)
+
+    return inputs
+
+def onnxruntime_inference(ort_session, inputs):
+    ort_inputs = {k: numpy.ascontiguousarray(v.cpu().numpy()) for k,v in inputs.items()}
+    ort_outputs = ort_session.run(None, ort_inputs)
+    return ort_outputs
+
+
+def run_parity(
+    model,
+    onnx_model_path,
+    batch_size,
+    hidden_size,
+    sequence_length,
+    num_heads,
+    float16,
+    device,
+    past_key_seqlen=0,
+    test_cases=100,
+    verbose=False,
+    tolerance=None,
+):
+    passed_cases = 0
+    max_diffs = []
+    printed = False  # print only one sample
+    ort_session = create_ort_session(onnx_model_path, device.type == "cuda", verbose=verbose)
+    for _i in range(test_cases):
+        inputs = create_inputs(batch_size, num_heads, sequence_length, hidden_size, dtype=torch.float16 if float16 else torch.float32, device=device, past_seqlen=past_key_seqlen)
+
+        with torch.no_grad():
+            torch_outputs = model(**inputs)
+            if not isinstance(torch_outputs, (list, tuple)):
+                torch_outputs = [torch_outputs,]
+
+        ort_outputs = onnxruntime_inference(ort_session, inputs)
+
+        if tolerance is None:
+            tolerance = 2e-02 if float16 else 1e-05
+        is_all_close, max_diff = compare_outputs(torch_outputs, ort_outputs, atol=tolerance, verbose=verbose)
+        max_diffs.append(max_diff)
+        if is_all_close:
+            passed_cases += 1
+        elif verbose and not printed:
+            printed = True
+            numpy.set_printoptions(precision=10, floatmode="fixed")
+            torch.set_printoptions(precision=10)
+            print("input", inputs)
+            print('diff: ', max_diff)
+            print("torch_outputs", torch_outputs)
+            print("ort_outputs", ort_outputs)
+
+    max_diff = max(max_diffs)
+    diff_count = len([i for i in max_diffs if i > 0])
+    success_flag = "[FAILED]" if passed_cases < test_cases else "[OK]"
+    print(f"{success_flag} Passed_cases={passed_cases}/{test_cases}; Max_diff={max_diff}; Diff_count={diff_count}")
+    return test_cases - passed_cases
+
+def run(
+    batch_size,
+    float16,
+    hidden_size,
+    device,
+    test_cases,
+    sequence_length=2,
+    num_heads=16,
+    past_key_seqlen=0,
+    verbose=False,
+):
+    test_name = f"device={device}, float16={float16}, batch_size={batch_size}, sequence_length={sequence_length}, hidden_size={hidden_size}, num_heads={num_heads}, past_key={past_key_seqlen}"
+    print(f"\nTesting: {test_name}")
+
+    model = TestRotaryEmbedding(hidden_size)
+    model.eval()
+    model.to(device)
+    if float16:
+        model.half()
+
+    inputs = create_inputs(batch_size, num_heads, sequence_length, hidden_size, dtype=torch.float16 if float16 else torch.float32, device=device, past_seqlen=past_key_seqlen)
+
+    # Do not re-use onnx file from previous test since weights of model are random.
+    onnx_model_path = "./temp/rotary_emb_{}_{}.onnx".format(sequence_length, "fp16" if float16 else "fp32")
+
+    torch.onnx.export(
+        model,
+        args=inputs,
+        f=onnx_model_path,
+        input_names=tuple(inputs.keys()),
+        output_names=["output"],
+        opset_version=17,
+        do_constant_folding=True,
+    )
+
+    num_failure = run_parity(
+        model,
+        onnx_model_path,
+        batch_size,
+        hidden_size,
+        sequence_length,
+        num_heads,
+        float16,
+        device,
+        past_key_seqlen,
+        test_cases,
+        verbose,
+    )
+
+    # clean up onnx file
+    os.remove(onnx_model_path)
+
+    return num_failure, test_name
+
+
+class TestParity(unittest.TestCase):
+    verbose = True
+    def setUp(self):
+        self.test_cases = 100  # Number of test cases per test run
+        self.sequence_length = 2
+        self.hidden_size = 768
+        self.num_heads=8
+
+    def run_test(
+        self,
+        batch_size,
+        float16,
+        device,
+        seq_len,
+        past_key_seqlen=0,
+        enable_assert=True,
+        verbose=True,
+    ):
+        if float16 and device.type == "cpu":  # CPU does not support FP16
+            return
+        num_failure, test_name = run(
+            batch_size,
+            float16,
+            hidden_size=self.hidden_size,
+            device=device,
+            test_cases=self.test_cases,
+            sequence_length=seq_len,
+            num_heads=self.num_heads,
+            past_key_seqlen=past_key_seqlen,
+            verbose=verbose,
+        )
+        if enable_assert:
+            self.assertTrue(num_failure == 0, "Failed: " + test_name)
+
+    def run_one(self, device, verbose=False):
+        for batch_size in [1,2,4]:
+            self.run_test(
+                batch_size,
+                float16=False,
+                device=device,
+                seq_len=15,
+                past_key_seqlen=0,
+                verbose=verbose,
+            )
+
+            self.run_test(
+                batch_size,
+                float16=False,
+                device=device,
+                seq_len=1,
+                past_key_seqlen=15,
+                verbose=verbose,
+            )
+
+            self.run_test(
+                batch_size,
+                float16=True,
+                device=device,
+                seq_len=15,
+                past_key_seqlen=0,
+                verbose=verbose,
+            )
+
+            self.run_test(
+                batch_size,
+                float16=True,
+                device=device,
+                seq_len=1,
+                past_key_seqlen=15,
+                verbose=verbose,
+            )
+
+    def test_cuda(self):
+        if not torch.cuda.is_available():
+            self.skipTest("test requires GPU and torch+cuda")
+        else:
+            gpu = torch.device("cuda")
+            self.run_one(gpu, verbose=self.verbose)
+
+
+if __name__ == "__main__":
+    args, remaining_args = parse_arguments(namespace_filter=unittest)
+
+    TestParity.verbose = args.log_verbose
+
+    unittest.main(argv=remaining_args)


### PR DESCRIPTION
### Description
Add op schema and implementation for RotaryEmbedding.

The schema look like this:
1. `input` x is a tensor with shape [batch, num_heads, seqlen, head_dim]
2. `position_ids` is a tensor of dtype=int64, with shape [batch, seqlen]. It contains position_ids that used for cos and sin index.
3. input 3 and 4 are `cos_cached` and `sin_cached` is precomputed by torch RotaryEmbedding model, they are constant values in onnx model. The shape is [1,1, max_seq_len, head_dim].
4. the `past_key` is optional, it is used to the total sequence length.
5. the `output` is with same shape and dtype of input.
<img width="699" alt="image" src="https://github.com/microsoft/onnxruntime/assets/109063327/36b39bd4-c95a-4118-ba70-ae921cb925e5">


The algo is same as that of huggingface llama model, but not same as the standard RoPE from RoFormer. 
```
def forward(ctx, q, position_ids, cos_cache, sin_cache, past_key) -> torch.Tensor:
        seq_len = q.shape[-2]
        if past_key is not None:
            seq_len += past_key.shape[-2]
        cos = cos_cache[:,:,:seq_len,...].to(q.dtype)
        sin = sin_cache[:,:,:seq_len,...].to(q.dtype)

        cos = cos.reshape(cos.shape[2], cos.shape[3])
        sin = sin.reshape(sin.shape[2], sin.shape[3])
        cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
        sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
        q_embed = (q * cos) + (rotate_half(q) * sin)
        return q_embed
```

The huggingface compute `q = q * cos + rotate_half(q) * sin` that the first half multiply `cos` and second half multiply `sin`, while RoFormer compute `q = q[0] * cos + q[1] * sin` that cos and sin are interleaved. The cos_cached and sin_cached are in different permutation, so this op can't be used for RoFormer model.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


