### PR TITLE
Windows CI build steps template

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -20,11 +20,6 @@ parameters:
   default: ""
 
 steps:
-  - ${{if eq(parameters.With_Cache, true)}}:
-    - script: |
-        mkdir -p ${{ parameters.CacheDir }}
-      displayName: Create Cache Dir
-
   - ${{ if eq(parameters.WITH_CACHE, true) }}:
     - task: Cache@2
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -51,7 +51,7 @@ steps:
           key: ' "$(TODAY)" | ${{parameters.AdditionalKey}} | merge '
         ${{else}}:
           key: '"$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}} | $(Build.SourceVersion) '
-        path: $(ORT_CACHE_DIR)
+        path: ${{parameters.CacheDir}}
         restoreKeys: |
           "$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}}
       displayName: Cache Task

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -40,4 +40,4 @@ steps:
         ccache -z
       displayName: cache stat
       env:
-        CCACHE_DIR: $(ORT_CACHE_DIR)
+        CCACHE_DIR: ${{parameters.CacheDir}}

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -1,0 +1,44 @@
+parameters:
+- name: With_Cache
+  displayName: Build with Cache
+  type: boolean
+  default: false
+
+- name: BuildSteps
+  type: stepList
+
+- name: Today
+  type: string
+  default: ""
+
+- name: CacheDir
+  type: string
+  default: ""
+
+steps:
+  - ${{if eq(parameters.WithCache, true)}}:
+    - script: |
+        mkdir -p ${{ parameters.CacheDir }}
+      displayName: Create Cache Dir
+
+  - ${{ if eq(parameters.WITH_CACHE, true) }}:
+    - task: Cache@2
+      inputs:
+        ${{if eq(variables['Build.SourceBranchName'], 'merge')}}:
+          key: ' "$(TODAY)" |  $(System.StageName) | ${{ parameters.BuildConfig }} | merge '
+        ${{else}}:
+          key: '"$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }} | $(Build.SourceVersion) '
+        path: $(ORT_CACHE_DIR)
+        restoreKeys: |
+          "$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }}
+      displayName: Cache Task
+
+  - ${{ parameters.BuildStep }}
+
+  - ${{ if eq(parameters.WITH_CACHE, true) }}:
+    - powershell: |
+        ccache -sv
+        ccache -z
+      displayName: cache stat
+      env:
+        CCACHE_DIR: $(ORT_CACHE_DIR)

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -4,20 +4,40 @@ parameters:
   type: boolean
   default: false
 
-- name: BuildSteps
-  type: stepList
-
 - name: Today
   type: string
   default: ""
 
 - name: CacheDir
   type: string
-  default: ""
+  default: "$(Agent.TempDirectory)/ort_ccache"
 
 - name: AdditionalKey
   type: string
   default: ""
+
+# it is used to pass additional arguments to build.py
+- name: BuildPyArguments
+  type: string
+  default: ""
+
+# it is used to pass msbuild arguments to VSBuild@1
+- name: MsbuildArguments
+  type: string
+  default: ""
+
+# it is used to pass platform arguments to VSBuild@1
+- name: Platform
+  type: string
+  default: "x64"
+
+# it is used to pass configuration arguments to VSBuild@1
+- name: BuildConfig
+  type: string
+
+# it is used to pass msbuildArchitecture arguments to VSBuild@1
+- name: BuildArch
+  type: string
 
 steps:
   - ${{ if eq(parameters.WithCache, true) }}:
@@ -32,7 +52,33 @@ steps:
           "$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}}
       displayName: Cache Task
 
-  - ${{ parameters.BuildSteps }}
+  - task: PythonScript@0
+    displayName: 'Generate cmake config'
+    inputs:
+      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+      ${{ if eq(parameters.WithCache, true) }}:
+        arguments: '${{parameters.BuildPyArguments}} --use_cache'
+      ${{ else }}:
+        arguments: '${{parameters.BuildPyArguments}}'
+      workingDirectory: '$(Build.BinariesDirectory)'
+
+  - task: VSBuild@1
+    displayName: 'Build'
+    inputs:
+      solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
+      platform: ${{parameters.Platform}}}
+      configuration: ${{parameters.BuildConfig}}
+      ${{ if eq(parameters.WithCache, true) }}:
+        msbuildArgs: "${{parameters.MsbuildArguments}} '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'"
+      ${{ else }}:
+        arguments: '${{parameters.CMakeArguments}}'
+      msbuildArchitecture: ${{parameters.BuildArch}}
+      maximumCpuCount: true
+      logProjectEvents: false
+      workingFolder: '$(Build.BinariesDirectory)\${{parameters.BuildConfig}}'
+      createLogFile: true
+    env:
+      CCACHE_DIR: ${{parameters.CacheDir}}
 
   - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -37,7 +37,7 @@ steps:
           "$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}}
       displayName: Cache Task
 
-  - ${{ parameters.BuildStep }}
+  - ${{ parameters.BuildSteps }}
 
   - ${{ if eq(parameters.WITH_CACHE, true) }}:
     - powershell: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: With_Cache
+- name: WithCache
   displayName: Build with Cache
   type: boolean
   default: false
@@ -20,7 +20,7 @@ parameters:
   default: ""
 
 steps:
-  - ${{ if eq(parameters.WITH_CACHE, true) }}:
+  - ${{ if eq(parameters.WithCache, true) }}:
     - task: Cache@2
       inputs:
         ${{if eq(variables['Build.SourceBranchName'], 'merge')}}:
@@ -34,7 +34,7 @@ steps:
 
   - ${{ parameters.BuildSteps }}
 
-  - ${{ if eq(parameters.WITH_CACHE, true) }}:
+  - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |
         ccache -sv
         ccache -z

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -15,8 +15,12 @@ parameters:
   type: string
   default: ""
 
+- name: AdditionalKey
+  type: string
+  default: ""
+
 steps:
-  - ${{if eq(parameters.WithCache, true)}}:
+  - ${{if eq(parameters.With_Cache, true)}}:
     - script: |
         mkdir -p ${{ parameters.CacheDir }}
       displayName: Create Cache Dir
@@ -25,12 +29,12 @@ steps:
     - task: Cache@2
       inputs:
         ${{if eq(variables['Build.SourceBranchName'], 'merge')}}:
-          key: ' "$(TODAY)" |  $(System.StageName) | ${{ parameters.BuildConfig }} | merge '
+          key: ' "$(TODAY)" | ${{parameters.AdditionalKey}} | merge '
         ${{else}}:
-          key: '"$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }} | $(Build.SourceVersion) '
+          key: '"$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}} | $(Build.SourceVersion) '
         path: $(ORT_CACHE_DIR)
         restoreKeys: |
-          "$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }}
+          "$(TODAY)" | onnxruntime | ${{parameters.AdditionalKey}}
       displayName: Cache Task
 
   - ${{ parameters.BuildStep }}

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -39,6 +39,10 @@ parameters:
 - name: BuildArch
   type: string
 
+- name: CacheArg
+  type: string
+  default: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
+
 steps:
   - ${{ if eq(parameters.WithCache, true) }}:
     - task: Cache@2
@@ -69,7 +73,7 @@ steps:
       platform: ${{parameters.Platform}}}
       configuration: ${{parameters.BuildConfig}}
       ${{ if eq(parameters.WithCache, true) }}:
-        msbuildArgs: "${{parameters.MsbuildArguments}} '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'"
+        msbuildArgs: '${{parameters.MsbuildArguments}} ${{parameters.CacheArg}}}}'
       ${{ else }}:
         arguments: '${{parameters.CMakeArguments}}'
       msbuildArchitecture: ${{parameters.BuildArch}}

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -69,11 +69,11 @@ steps:
   - task: VSBuild@1
     displayName: 'Build'
     inputs:
-      solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
-      platform: ${{parameters.Platform}}}
+      solution: '$(Build.BinariesDirectory)\${{parameters.BuildConfig}}\onnxruntime.sln'
+      platform: ${{parameters.Platform}}
       configuration: ${{parameters.BuildConfig}}
       ${{ if eq(parameters.WithCache, true) }}:
-        msbuildArgs: '${{parameters.MsbuildArguments}} ${{parameters.CacheArg}}}}'
+        msbuildArgs: '${{parameters.MsbuildArguments}} ${{parameters.CacheArg}}'
       ${{ else }}:
         arguments: '${{parameters.CMakeArguments}}'
       msbuildArchitecture: ${{parameters.BuildArch}}

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
@@ -142,6 +142,7 @@ jobs:
       With_Cache: ${{ parameters.WITH_CACHE }}
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
+      AdditionalKey: " $(System.StageName) | ${{ parameters.BuildConfig }} "
       BuildSteps:
         - task: PythonScript@0
           displayName: 'Generate cmake config'

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
@@ -137,9 +137,9 @@ jobs:
       nugetConfigPath: '$(Build.SourcesDirectory)\NuGet.config'
       restoreDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
 
-  - template: templates/linux-build-step-with-cache.yml
+  - template: win-ci-build-steps.yml
     parameters:
-      WithCache: true
+      With_Cache: ${{ parameters.WITH_CACHE }}
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
       BuildSteps:

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
@@ -137,48 +137,34 @@ jobs:
       nugetConfigPath: '$(Build.SourcesDirectory)\NuGet.config'
       restoreDirectory: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
 
-  - ${{ if eq(parameters.WITH_CACHE, true) }}:
-    - task: Cache@2
-      inputs:
-        ${{if eq(variables['Build.SourceBranchName'], 'merge')}}:
-          key: ' "$(TODAY)" |  $(System.StageName) | ${{ parameters.BuildConfig }} | merge '
-        ${{else}}:
-          key: '"$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }} | $(Build.SourceVersion) '
-        path: $(ORT_CACHE_DIR)
-        restoreKeys: |
-          "$(TODAY)" | onnxruntime | $(System.StageName) | ${{ parameters.BuildConfig }}
-      displayName: Cache Task
+  - template: templates/linux-build-step-with-cache.yml
+    parameters:
+      WithCache: true
+      Today: $(TODAY)
+      CacheDir: $(ORT_CACHE_DIR)
+      BuildSteps:
+        - task: PythonScript@0
+          displayName: 'Generate cmake config'
+          inputs:
+            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+            arguments: '--config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_csharp --update --parallel --cmake_generator "Visual Studio 17 2022" --build_shared_lib --enable_onnx_tests ${{ variables.PY_CACHE_ARG }} ${{ parameters.additionalBuildFlags }}'
+            workingDirectory: '$(Build.BinariesDirectory)'
 
-  - task: PythonScript@0
-    displayName: 'Generate cmake config'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_csharp --update --parallel --cmake_generator "Visual Studio 17 2022" --build_shared_lib --enable_onnx_tests ${{ variables.PY_CACHE_ARG }} ${{ parameters.additionalBuildFlags }}'
-      workingDirectory: '$(Build.BinariesDirectory)'
-
-  - task: VSBuild@1
-    displayName: 'Build'
-    inputs:
-      solution: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\onnxruntime.sln'
-      platform: ${{ parameters.msbuildPlatform }}
-      configuration: ${{ parameters.BuildConfig }}
-      msbuildArgs: '-maxcpucount ${{ variables.MSBUILD_CACHE_ARG }}'
-      msbuildArchitecture: ${{ parameters.buildArch }}
-      maximumCpuCount: true
-      logProjectEvents: false
-      workingFolder: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
-      createLogFile: true
-    ${{ if eq(parameters.WITH_CACHE, true) }}:
-      env:
-        CCACHE_DIR: $(ORT_CACHE_DIR)
-
-  - ${{ if eq(parameters.WITH_CACHE, true) }}:
-    - powershell: |
-        ccache -sv
-        ccache -z
-      displayName: cache stat
-      env:
-        CCACHE_DIR: $(ORT_CACHE_DIR)
+        - task: VSBuild@1
+          displayName: 'Build'
+          inputs:
+            solution: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\onnxruntime.sln'
+            platform: ${{ parameters.msbuildPlatform }}
+            configuration: ${{ parameters.BuildConfig }}
+            msbuildArgs: '-maxcpucount ${{ variables.MSBUILD_CACHE_ARG }}'
+            msbuildArchitecture: ${{ parameters.buildArch }}
+            maximumCpuCount: true
+            logProjectEvents: false
+            workingFolder: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
+            createLogFile: true
+          ${{ if eq(parameters.WITH_CACHE, true) }}:
+            env:
+              CCACHE_DIR: $(ORT_CACHE_DIR)
 
   - powershell: |
       Get-Volume $("$(Build.BinariesDirectory)")[0]

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
@@ -78,7 +78,6 @@ jobs:
     ${{ if eq(parameters.WITH_CACHE, true) }}:
       PS_CACHE_ARG: '-use_cache'
       PY_CACHE_ARG: '--use_cache'
-      MSBUILD_CACHE_ARG: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
   workspace:
     clean: all
   pool: ${{ parameters.MachinePool }}
@@ -143,29 +142,11 @@ jobs:
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
       AdditionalKey: " $(System.StageName) | ${{ parameters.BuildConfig }} "
-      BuildSteps:
-        - task: PythonScript@0
-          displayName: 'Generate cmake config'
-          inputs:
-            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-            arguments: '--config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_csharp --update --parallel --cmake_generator "Visual Studio 17 2022" --build_shared_lib --enable_onnx_tests ${{ variables.PY_CACHE_ARG }} ${{ parameters.additionalBuildFlags }}'
-            workingDirectory: '$(Build.BinariesDirectory)'
-
-        - task: VSBuild@1
-          displayName: 'Build'
-          inputs:
-            solution: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}\onnxruntime.sln'
-            platform: ${{ parameters.msbuildPlatform }}
-            configuration: ${{ parameters.BuildConfig }}
-            msbuildArgs: '-maxcpucount ${{ variables.MSBUILD_CACHE_ARG }}'
-            msbuildArchitecture: ${{ parameters.buildArch }}
-            maximumCpuCount: true
-            logProjectEvents: false
-            workingFolder: '$(Build.BinariesDirectory)\${{ parameters.BuildConfig }}'
-            createLogFile: true
-          ${{ if eq(parameters.WITH_CACHE, true) }}:
-            env:
-              CCACHE_DIR: $(ORT_CACHE_DIR)
+      BuildPyArguments: '--config ${{ parameters.BuildConfig }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_csharp --update --parallel --cmake_generator "Visual Studio 17 2022" --build_shared_lib --enable_onnx_tests ${{ parameters.additionalBuildFlags }}'
+      MsbuildArguments: '-maxcpucount'
+      BuildArch: ${{ parameters.buildArch }}
+      Platform: ${{ parameters.msbuildPlatform }}
+      BuildConfig: ${{ parameters.BuildConfig }}
 
   - powershell: |
       Get-Volume $("$(Build.BinariesDirectory)")[0]

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-vs-2022-job.yml
@@ -139,7 +139,7 @@ jobs:
 
   - template: win-ci-build-steps.yml
     parameters:
-      With_Cache: ${{ parameters.WITH_CACHE }}
+      WithCache: ${{ parameters.WITH_CACHE }}
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
       AdditionalKey: " $(System.StageName) | ${{ parameters.BuildConfig }} "

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -12,9 +12,7 @@ jobs:
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     EnvSetupScript: setup_env_cuda_11.bat
     buildArch: x64
-    ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-    MSBUILD_CACHE_ARG: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
   timeoutInMinutes: 120
   workspace:
     clean: all
@@ -34,16 +32,12 @@ jobs:
       WithCache: True
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
-      AdditionalKey: "gpu-reduced-ops"
-      BuildSteps:
-        - task: PythonScript@0
-          displayName: 'Build and test'
-          inputs:
-            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config" --use_cache'
-            workingDirectory: '$(Build.BinariesDirectory)'
-          env:
-            CCACHE_DIR: $(ORT_CACHE_DIR)
+      AdditionalKey: "gpu-reduced-ops | $(BuildConfig)"
+      BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config"'
+      MsbuildArguments: $(MsbuildArguments)
+      BuildArch: $(buildArch)
+      Platform: 'x64'
+      BuildConfig: $(BuildConfig)
 
   - template: templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
     EnvSetupScript: setup_env_cuda_11.bat
     buildArch: x64
     setVcvars: true
+    ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 120
   workspace:
@@ -31,12 +32,19 @@ jobs:
       WithCache: true
       Today: $(Today)
 
-  - task: PythonScript@0
-    displayName: 'Build and test'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config"'
-      workingDirectory: '$(Build.BinariesDirectory)'
+  - template: win-ci-build-steps.yml
+    parameters:
+      WithCache: True
+      Today: $(TODAY)
+      CacheDir: $(ORT_CACHE_DIR)
+      AdditionalKey: "gpu-reduced-ops"
+      BuildSteps:
+        - task: PythonScript@0
+          displayName: 'Build and test'
+          inputs:
+            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config"'
+            workingDirectory: '$(Build.BinariesDirectory)'
 
   - template: templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -12,10 +12,8 @@ jobs:
     OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
     OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     EnvSetupScript: setup_env_cuda_11.bat
     buildArch: x64
-    setVcvars: true
     ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 120
@@ -32,7 +30,7 @@ jobs:
       WithCache: true
       Today: $(Today)
 
-  - template: win-ci-build-steps.yml
+  - template: templates/jobs/win-ci-build-steps.yml
     parameters:
       WithCache: True
       Today: $(TODAY)

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -31,7 +31,6 @@ jobs:
     parameters:
       WithCache: True
       Today: $(TODAY)
-      CacheDir: $(ORT_CACHE_DIR)
       AdditionalKey: "gpu-reduced-ops | $(BuildConfig)"
       BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --update --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config"'
       MsbuildArguments: $(MsbuildArguments)

--- a/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-reduce-op-ci-pipeline.yml
@@ -9,13 +9,12 @@ jobs:
       minsizerel:
         BuildConfig: 'MinSizeRel'
   variables:
-    OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
-    OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
     EnvSetupScript: setup_env_cuda_11.bat
     buildArch: x64
     ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
+    MSBUILD_CACHE_ARG: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
   timeoutInMinutes: 120
   workspace:
     clean: all
@@ -41,8 +40,10 @@ jobs:
           displayName: 'Build and test'
           inputs:
             scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config"'
+            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --cmake_generator "Visual Studio 17 2022" --build_wheel --use_cuda --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=75" --include_ops_by_config="$(Build.SourcesDirectory)\onnxruntime\test\testdata\required_ops.config" --use_cache'
             workingDirectory: '$(Build.BinariesDirectory)'
+          env:
+            CCACHE_DIR: $(ORT_CACHE_DIR)
 
   - template: templates/component-governance-component-detection-steps.yml
     parameters :

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -27,9 +27,7 @@ jobs:
     buildArch: x64
     BuildConfig: 'RelWithDebInfo'
     skipComponentGovernanceDetection: true
-    ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-    MSBUILD_CACHE_ARG: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
   timeoutInMinutes: 150
   workspace:
     clean: all
@@ -50,28 +48,11 @@ jobs:
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
       AdditionalKey: "gpu-reduced-ops | $(BuildConfig)"
-      BuildSteps:
-        - task: PythonScript@0
-          displayName: 'Generate cmake config'
-          inputs:
-            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75 --use_cache'
-            workingDirectory: '$(Build.BinariesDirectory)'
-
-        - task: VSBuild@1
-          displayName: 'Build'
-          inputs:
-            solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
-            platform: 'x64'
-            configuration: $(BuildConfig)
-            msbuildArgs: "$(MsbuildArguments) $(MSBUILD_CACHE_ARG)"
-            msbuildArchitecture: $(buildArch)
-            maximumCpuCount: true
-            logProjectEvents: false
-            workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
-            createLogFile: true
-          env:
-            CCACHE_DIR: $(ORT_CACHE_DIR)
+      BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
+      MsbuildArguments: $(MsbuildArguments)
+      BuildArch: $(buildArch)
+      Platform: 'x64'
+      BuildConfig: $(BuildConfig)
 
   - task: PythonScript@0
     displayName: 'Build wheel'

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       WithCache: True
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
-      AdditionalKey: "gpu-reduced-ops | $(BuildConfig)"
+      AdditionalKey: "gpu-tensorrt | $(BuildConfig)"
       BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
       MsbuildArguments: $(MsbuildArguments)
       BuildArch: $(buildArch)

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -22,16 +22,12 @@ jobs:
 - job: 'build'
   pool: 'onnxruntime-Win2022-GPU-T4'
   variables:
-    OrtPackageId: 'Microsoft.ML.OnnxRuntime'
     MsbuildArguments: '-detailedsummary -maxcpucount -consoleloggerparameters:PerformanceSummary'
-    OnnxRuntimeBuildDirectory: '$(Build.BinariesDirectory)'
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     EnvSetupScript: setup_env_trt.bat
     buildArch: x64
-    setVcvars: true
     BuildConfig: 'RelWithDebInfo'
-    ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
     skipComponentGovernanceDetection: true
+    ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 150
   workspace:
@@ -47,25 +43,32 @@ jobs:
       WithCache: true
       Today: $(Today)
 
-  - task: PythonScript@0
-    displayName: 'Generate cmake config'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
-      workingDirectory: '$(Build.BinariesDirectory)'
+  - template: win-ci-build-steps.yml
+    parameters:
+      WithCache: True
+      Today: $(TODAY)
+      CacheDir: $(ORT_CACHE_DIR)
+      AdditionalKey: "gpu-reduced-ops"
+      BuildSteps:
+        - task: PythonScript@0
+          displayName: 'Generate cmake config'
+          inputs:
+            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
+            workingDirectory: '$(Build.BinariesDirectory)'
 
-  - task: VSBuild@1
-    displayName: 'Build'
-    inputs:
-      solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
-      platform: 'x64'
-      configuration: $(BuildConfig)
-      msbuildArgs: $(MsbuildArguments)
-      msbuildArchitecture: $(buildArch)
-      maximumCpuCount: true
-      logProjectEvents: false
-      workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
-      createLogFile: true
+        - task: VSBuild@1
+          displayName: 'Build'
+          inputs:
+            solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
+            platform: 'x64'
+            configuration: $(BuildConfig)
+            msbuildArgs: $(MsbuildArguments)
+            msbuildArchitecture: $(buildArch)
+            maximumCpuCount: true
+            logProjectEvents: false
+            workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
+            createLogFile: true
 
   - task: PythonScript@0
     displayName: 'Build wheel'

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -43,7 +43,7 @@ jobs:
       WithCache: true
       Today: $(Today)
 
-  - template: win-ci-build-steps.yml
+  - template: templates/jobs/win-ci-build-steps.yml
     parameters:
       WithCache: True
       Today: $(TODAY)

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -46,7 +46,6 @@ jobs:
     parameters:
       WithCache: True
       Today: $(TODAY)
-      CacheDir: $(ORT_CACHE_DIR)
       AdditionalKey: "gpu-tensorrt | $(BuildConfig)"
       BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
       MsbuildArguments: $(MsbuildArguments)

--- a/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml
@@ -29,6 +29,7 @@ jobs:
     skipComponentGovernanceDetection: true
     ORT_CACHE_DIR: $(Agent.TempDirectory)/ort_ccache
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
+    MSBUILD_CACHE_ARG: '/p:CLToolExe=cl.exe /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:TrackFileAccess=false /p:UseMultiToolTask=true /p:DebugInformationFormat=OldStyle'
   timeoutInMinutes: 150
   workspace:
     clean: all
@@ -48,13 +49,13 @@ jobs:
       WithCache: True
       Today: $(TODAY)
       CacheDir: $(ORT_CACHE_DIR)
-      AdditionalKey: "gpu-reduced-ops"
+      AdditionalKey: "gpu-reduced-ops | $(BuildConfig)"
       BuildSteps:
         - task: PythonScript@0
           displayName: 'Generate cmake config'
           inputs:
             scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75'
+            arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --update --cmake_generator "Visual Studio 17 2022" --build_wheel --enable_onnx_tests --use_tensorrt --tensorrt_home="C:\local\TensorRT-8.6.1.6.Windows10.x86_64.cuda-11.8" --cuda_version=11.8 --cuda_home="$(Agent.TempDirectory)\v11.8" --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=75 --use_cache'
             workingDirectory: '$(Build.BinariesDirectory)'
 
         - task: VSBuild@1
@@ -63,12 +64,14 @@ jobs:
             solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
             platform: 'x64'
             configuration: $(BuildConfig)
-            msbuildArgs: $(MsbuildArguments)
+            msbuildArgs: "$(MsbuildArguments) $(MSBUILD_CACHE_ARG)"
             msbuildArchitecture: $(buildArch)
             maximumCpuCount: true
             logProjectEvents: false
             workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
             createLogFile: true
+          env:
+            CCACHE_DIR: $(ORT_CACHE_DIR)
 
   - task: PythonScript@0
     displayName: 'Build wheel'


### PR DESCRIPTION
### Description
1. New windows ci build steps template.
2. Remove useless variables.

### Motivation and Context
1. Make it easier to apply build cache to all windows CIs.
2. Other team's devs only need to take care of build options


###Comparision
Before: 
https://github.com/microsoft/onnxruntime/blob/9f21f694cf939a960f5b516ba5ff9675fc3ec6d1/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml#L19-L82 

After:        https://github.com/microsoft/onnxruntime/blob/b4c1f2261bbc282139e46c0d68520f65940883f3/tools/ci_build/github/azure-pipelines/win-gpu-tensorrt-ci-pipeline.yml#L35-L54 



