### PR TITLE
Fix build - redefinition of default argument for ‘long unsigned int Extent’

### DIFF
--- a/include/onnxruntime/core/common/span_utils.h
+++ b/include/onnxruntime/core/common/span_utils.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <algorithm>
-//#include <cstddef>
+#include <cstddef>
 
 #include "core/common/gsl.h"
 

--- a/include/onnxruntime/core/common/span_utils.h
+++ b/include/onnxruntime/core/common/span_utils.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <algorithm>
-#include <cstddef>
+//#include <cstddef>
 
 #include "core/common/gsl.h"
 
@@ -80,7 +80,7 @@ template <class U, class T>
 }
 
 [[nodiscard]] inline gsl::span<const std::byte> AsByteSpan(const void* data, size_t length) {
-  return gsl::span(reinterpret_cast<const std::byte*>(data), length);
+  return gsl::span<const std::byte>(reinterpret_cast<const std::byte*>(data), length);
 }
 
 template <class T1, size_t Extent1, class T2, size_t Extent2>


### PR DESCRIPTION
### Fix build - redefinition of default argument for ‘long unsigned int Extent’

One of the training customer env, building ORT, there is such a build error. The GCC version are 

```
aiscuser@node-0:/tmp/onnxruntime$ gcc --version
gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0


aiscuser@node-0:/tmp/onnxruntime$ g++ --version
g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0


```

But on our dev node using same GCC/G++, we don't have build issue., not sure what's the difference but giving an explict type when creating `gsl::span` fixed the problem. 

```
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span:394:7: error: redefinition of default argument for ‘long unsigned int Extent’
  394 | class span
      |       ^~~~
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span_ext:46:51: note: original definition appeared here
   46 | template <class ElementType, std::size_t Extent = dynamic_extent>
      |                                                   ^~~~~~~~~~~~~~~
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h:82:93: error: return type ‘class gsl::span<const std::byte>’ is incomplete
   82 | [[nodiscard]] inline gsl::span<const std::byte> AsByteSpan(const void* data, size_t length) {
      |                                                                                             ^
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h: In function ‘void onnxruntime::AsByteSpan(const void*, size_t)’:
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h:83:68: error: class template argument deduction failed:
   83 |   return gsl::span(reinterpret_cast<const std::byte*>(data), length);
      |                                                                    ^
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h:83:68: error: no matching function for call to ‘span(const std::byte*, size_t&)’
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span:740:1: note: candidate: ‘template<class Type, long unsigned int Extent> gsl::span(Type (&)[Extent])-> gsl::span<ElementType, FirstExtent>’
  740 | span(Type (&)[Extent]) -> span<Type, Extent>;
      | ^~~~
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span:740:1: note:   template argument deduction/substitution failed:
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h:83:68: note:   mismatched types ‘Type [Extent]’ and ‘const std::byte*’
   83 |   return gsl::span(reinterpret_cast<const std::byte*>(data), length);
      |                                                                    ^
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span:743:1: note: candidate: ‘template<class Type, long unsigned int Size> gsl::span(std::array<_Tp, _Nm>&)-> gsl::span<ElementType, FirstExtent>’
  743 | span(std::array<Type, Size>&) -> span<Type, Size>;
      | ^~~~
/tmp/onnxruntime/build/Linux/RelWithDebInfo/_deps/gsl-src/include/gsl/span:743:1: note:   template argument deduction/substitution failed:
/tmp/onnxruntime/include/onnxruntime/core/common/span_utils.h:83:68: note:   mismatched types ‘std::array<_Tp, _Nm>’ and ‘const std::byte*’
   83 |   return gsl::span(reinterpret_cast<const std::byte*>(data), length);
      |                                                                    ^
```



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


