### PR TITLE
Refine build script for adding disable selected data types option

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -139,7 +139,6 @@ option(onnxruntime_DISABLE_ML_OPS "Disable traditional ML ops" OFF)
 option(onnxruntime_DISABLE_SPARSE_TENSORS "Disable sparse tensors data types" OFF)
 option(onnxruntime_DISABLE_OPTIONAL_TYPE "Disable optional type" OFF)
 option(onnxruntime_DISABLE_FLOAT8_TYPES "Disable float 8 types" OFF)
-option(onnxruntime_DISABLE_FLOAT16_TYPES "Disable float 16 types" OFF)
 option(onnxruntime_MINIMAL_BUILD "Exclude as much as possible from the build. Support ORT format models. No support for ONNX format models." OFF)
 cmake_dependent_option(onnxruntime_DISABLE_RTTI "Disable RTTI" ON "NOT onnxruntime_ENABLE_PYTHON" OFF)
 # For now onnxruntime_DISABLE_EXCEPTIONS will only work with onnxruntime_MINIMAL_BUILD, more changes (ONNX, non-CPU EP, ...) are required to run this standalone
@@ -846,10 +845,6 @@ function(onnxruntime_set_compile_flags target_name)
 
     if (onnxruntime_DISABLE_FLOAT8_TYPES)
       target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT8_TYPES)
-    endif()
-
-    if (onnxruntime_DISABLE_FLOAT16_TYPES)
-      target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT16_TYPES)
     endif()
 
     if (onnxruntime_ENABLE_ATEN)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -139,6 +139,7 @@ option(onnxruntime_DISABLE_ML_OPS "Disable traditional ML ops" OFF)
 option(onnxruntime_DISABLE_SPARSE_TENSORS "Disable sparse tensors data types" OFF)
 option(onnxruntime_DISABLE_OPTIONAL_TYPE "Disable optional type" OFF)
 option(onnxruntime_DISABLE_FLOAT8_TYPES "Disable float 8 types" OFF)
+option(onnxruntime_DISABLE_FLOAT16_TYPES "Disable float 16 types" OFF)
 option(onnxruntime_MINIMAL_BUILD "Exclude as much as possible from the build. Support ORT format models. No support for ONNX format models." OFF)
 cmake_dependent_option(onnxruntime_DISABLE_RTTI "Disable RTTI" ON "NOT onnxruntime_ENABLE_PYTHON" OFF)
 # For now onnxruntime_DISABLE_EXCEPTIONS will only work with onnxruntime_MINIMAL_BUILD, more changes (ONNX, non-CPU EP, ...) are required to run this standalone
@@ -845,6 +846,10 @@ function(onnxruntime_set_compile_flags target_name)
 
     if (onnxruntime_DISABLE_FLOAT8_TYPES)
       target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT8_TYPES)
+    endif()
+
+    if (onnxruntime_DISABLE_FLOAT16_TYPES)
+      target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT16_TYPES)
     endif()
 
     if (onnxruntime_ENABLE_ATEN)

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -77,7 +77,6 @@ Abstract:
 #define MLAS_SUPPORTS_GEMM_DOUBLE
 #endif
 
-#if !defined(DISABLE_FLOAT16_TYPES)
 #if (!defined(_MSC_VER)) || (_MSC_VER >= 1930)
 #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC)
 #if !defined(__APPLE__)
@@ -91,7 +90,6 @@ Abstract:
 #endif // 
 #endif // ARM64
 #endif // Visual Studio 16 or earlier does not support fp16 intrinsic
-#endif // !defined(DISABLE_FLOAT16_TYPES)
 
 //
 // Basic Linear Algebra Subprograms (BLAS) types.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -77,7 +77,7 @@ Abstract:
 #define MLAS_SUPPORTS_GEMM_DOUBLE
 #endif
 
-#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+#if !defined(DISABLE_FLOAT16_TYPES)
 #if (!defined(_MSC_VER)) || (_MSC_VER >= 1930)
 #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC)
 #if !defined(__APPLE__)
@@ -91,7 +91,7 @@ Abstract:
 #endif // 
 #endif // ARM64
 #endif // Visual Studio 16 or earlier does not support fp16 intrinsic
-#endif // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+#endif // !defined(DISABLE_FLOAT16_TYPES)
 
 //
 // Basic Linear Algebra Subprograms (BLAS) types.

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -14,8 +14,6 @@ Abstract:
 
 --*/
 
-#if !defined(DISABLE_FLOAT16_TYPES)
-
 #include "mlasi.h"
 #include "halfgemm.h"
 
@@ -187,5 +185,3 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
     MLAS_HALF_GEMM_KERNEL_NEON::KernelMaxM,
     32 // kernel may read beyond buffer end by 32 bytes
 };
-
-#endif // !defined(DISABLE_FLOAT16_TYPES)

--- a/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm_kernel_neon.cpp
@@ -14,7 +14,7 @@ Abstract:
 
 --*/
 
-#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+#if !defined(DISABLE_FLOAT16_TYPES)
 
 #include "mlasi.h"
 #include "halfgemm.h"
@@ -188,4 +188,4 @@ const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon = {
     32 // kernel may read beyond buffer end by 32 bytes
 };
 
-#endif // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+#endif // !defined(DISABLE_FLOAT16_TYPES)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -635,7 +635,9 @@ def parse_arguments():
         "--disable_types",
         nargs="+",
         default=[],
-        choices=["float8", "float16", "optional", "sparsetensor"], help="Disable selected data types (reduces binary size)")
+        choices=["float8", "float16", "optional", "sparsetensor"],
+        help="Disable selected data types (reduces binary size)",
+    )
     parser.add_argument(
         "--disable_exceptions",
         action="store_true",

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -635,7 +635,7 @@ def parse_arguments():
         "--disable_types",
         nargs="+",
         default=[],
-        choices=["float8", "float16", "optional", "sparsetensor"],
+        choices=["float8", "optional", "sparsetensor"],
         help="Disable selected data types (reduces binary size)",
     )
     parser.add_argument(
@@ -904,7 +904,6 @@ def generate_build_tree(
     types_to_disable = args.disable_types
     # enable/disable float 8 types
     disable_float8_types = args.use_rocm or args.android or ("float8" in types_to_disable)
-    disable_float16_types = "float16" in types_to_disable
     disable_optional_type = "optional" in types_to_disable
     disable_sparse_tensors = "sparsetensor" in types_to_disable
 
@@ -1006,7 +1005,6 @@ def generate_build_tree(
         "-Donnxruntime_USE_CANN=" + ("ON" if args.use_cann else "OFF"),
         "-Donnxruntime_USE_TRITON_KERNEL=" + ("ON" if args.use_triton_kernel else "OFF"),
         "-Donnxruntime_DISABLE_FLOAT8_TYPES=" + ("ON" if disable_float8_types else "OFF"),
-        "-Donnxruntime_DISABLE_FLOAT16_TYPES=" + ("ON" if disable_float16_types else "OFF"),
         "-Donnxruntime_DISABLE_SPARSE_TENSORS=" + ("ON" if disable_sparse_tensors else "OFF"),
         "-Donnxruntime_DISABLE_OPTIONAL_TYPE=" + ("ON" if disable_optional_type else "OFF"),
     ]

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -276,10 +276,9 @@ jobs:
               --disable_ml_ops \
               --skip_tests \
               --enable_reduced_operator_type_support \
+              --disable_types sparsetensor optional \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
-              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
-                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
-                                    onnxruntime_BUILD_UNIT_TESTS=OFF
+              --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2
@@ -306,10 +305,9 @@ jobs:
               --disable_ml_ops \
               --skip_tests \
               --enable_reduced_operator_type_support \
+              --disable_types sparsetensor optional \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
-              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
-                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
-                                    onnxruntime_BUILD_UNIT_TESTS=OFF
+              --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -247,11 +247,9 @@ jobs:
               --parallel \
               --skip_tests \
               --disable_ml_ops \
+              --disable_types sparsetensor float8 float16 optioal \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
-              --cmake_extra_defines onnxruntime_DISABLE_SPARSE_TENSORS=ON \
-                                    onnxruntime_DISABLE_FLOAT8_TYPES=ON \
-                                    onnxruntime_DISABLE_OPTIONAL_TYPE=ON \
-                                    onnxruntime_BUILD_UNIT_TESTS=OFF
+              --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)
 
   - task: CmdLine@2

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -247,7 +247,7 @@ jobs:
               --parallel \
               --skip_tests \
               --disable_ml_ops \
-              --disable_types sparsetensor float8 float16 optional \
+              --disable_types sparsetensor float8 optional \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
               --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)
@@ -276,7 +276,7 @@ jobs:
               --disable_ml_ops \
               --skip_tests \
               --enable_reduced_operator_type_support \
-              --disable_types sparsetensor optional \
+              --disable_types sparsetensor optional float8 \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
               --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)
@@ -305,7 +305,7 @@ jobs:
               --disable_ml_ops \
               --skip_tests \
               --enable_reduced_operator_type_support \
-              --disable_types sparsetensor optional \
+              --disable_types sparsetensor optional float8 \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
               --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)

--- a/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-cpu-minimal-build-ci-pipeline.yml
@@ -247,7 +247,7 @@ jobs:
               --parallel \
               --skip_tests \
               --disable_ml_ops \
-              --disable_types sparsetensor float8 float16 optioal \
+              --disable_types sparsetensor float8 float16 optional \
               --include_ops_by_config /home/onnxruntimedev/.test_data/include_no_operators.config \
               --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
       workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As title. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Now we have multiple data types that we want to disable for minimal build and to reduce binary size. may be worth adding an argument in the build script for specifying that.

Also for fp16 type stuff, it may be too restrict to disable that for all minimal build.
