### PR TITLE
nodejs: Release Ort Env before main function returns

### DIFF
--- a/js/node/script/build.ts
+++ b/js/node/script/build.ts
@@ -41,7 +41,7 @@ const args = [
   'cmake-js',
   (REBUILD ? 'reconfigure' : 'configure'),
   `--arch=${ARCH}`,
-  '--CDnapi_build_version=3',
+  '--CDnapi_build_version=6',
   `--CDCMAKE_BUILD_TYPE=${CONFIG}`,
 ];
 if (ONNXRUNTIME_BUILD_DIR && typeof ONNXRUNTIME_BUILD_DIR === 'string') {

--- a/js/node/src/inference_session_wrap.h
+++ b/js/node/src/inference_session_wrap.h
@@ -54,10 +54,6 @@ private:
   // persistent constructor
   static Napi::FunctionReference constructor;
 
-  // global env
-  static Ort::Env *ortEnv;
-  static Ort::Env &OrtEnv() { return *ortEnv; }
-
   // session objects
   bool initialized_;
   std::unique_ptr<Ort::Session> session_;


### PR DESCRIPTION
### Description
Release OrtEnv before main function returns. Before this change, OrtEnv is deleted when C/C++ runtime destructs all global variables in ONNX Runtime's core framework.
The callstack is like this:
```
  * frame #0: 0x00007fffee39f5a6 libonnxruntime.so.1.16.0`onnxruntime::Environment::~Environment(this=0x00007fffee39fbf2) at environment.h:20:7
    frame #1: 0x00007fffee39f614 libonnxruntime.so.1.16.0`std::default_delete<onnxruntime::Environment>::operator()(this=0x00007ffff4c30e50, __ptr=0x0000000005404b00) const at unique_ptr.h:85:2
    frame #2: 0x00007fffee39edca libonnxruntime.so.1.16.0`std::unique_ptr<onnxruntime::Environment, std::default_delete<onnxruntime::Environment>>::~unique_ptr(this=0x5404b00) at unique_ptr.h:361:17
    frame #3: 0x00007fffee39e2ab libonnxruntime.so.1.16.0`OrtEnv::~OrtEnv(this=0x00007ffff4c30e50) at ort_env.cc:43:1
    frame #4: 0x00007fffee39fa96 libonnxruntime.so.1.16.0`std::default_delete<OrtEnv>::operator()(this=0x00007fffefff8f78, __ptr=0x00007ffff4c30e50) const at unique_ptr.h:85:2
    frame #5: 0x00007fffee39f394 libonnxruntime.so.1.16.0`std::unique_ptr<OrtEnv, std::default_delete<OrtEnv>>::~unique_ptr(this=0x7ffff4c30e50) at unique_ptr.h:361:17
    frame #6: 0x00007ffff78574b5 libc.so.6`__run_exit_handlers + 261
    frame #7: 0x00007ffff7857630 libc.so.6`exit + 32
    frame #8: 0x00007ffff783feb7 libc.so.6`__libc_start_call_main + 135
    frame #9: 0x00007ffff783ff60 libc.so.6`__libc_start_main@@GLIBC_2.34 + 128
    frame #10: 0x0000000000abbdee node`_start + 46
```
After this change, OrtEnv will be deleted before the main function returns and nodejs is still alive. 

The main reason of having this change is: we should avoid using global variables since it will make construction/destruction order very complicated. On different operating systems it may have different behavior. On the other hand, if we explictly call the "delete" operator, it is very deterministic and just works as everyone expected.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


