### PR TITLE
[js/webgpu] add label for some webgpu APIs

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -49,7 +49,8 @@ export class ProgramManager {
     for (const output of outputs) {
       entries.push({binding: entries.length, resource: {buffer: output.buffer}});
     }
-    const bindGroup = device.createBindGroup({layout: buildArtifact.computePipeline.getBindGroupLayout(0), entries});
+    const bindGroup = device.createBindGroup(
+        {layout: buildArtifact.computePipeline.getBindGroupLayout(0), entries, label: buildArtifact.programInfo.name});
     computePassEncoder.setBindGroup(0, bindGroup);
 
     computePassEncoder.dispatchWorkgroups(...dispatchGroup);
@@ -117,11 +118,11 @@ export class ProgramManager {
     const shaderHelper = createShaderHelper(normalizedDispatchGroupSize);
     const userCode = programInfo.getShaderSource(shaderHelper);
     const code = `${shaderHelper.additionalImplementations}\n${userCode}`;
-    const shaderModule = device.createShaderModule({code});
+    const shaderModule = device.createShaderModule({code, label: programInfo.name});
     LOG_DEBUG('verbose', () => `[WebGPU] shader code: ${code}`);
 
-    const computePipeline =
-        device.createComputePipeline({compute: {module: shaderModule, entryPoint: 'main'}, layout: 'auto'});
+    const computePipeline = device.createComputePipeline(
+        {compute: {module: shaderModule, entryPoint: 'main'}, layout: 'auto', label: programInfo.name});
 
     return {programInfo, computePipeline};
   }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
With the label, it's more easier to identify which op causes the error.

Without the label, the error message is like below: 
```
Tint WGSL reader failure: :12:5 error: return statement type must match its function return type, returned 'vec4<f32>', expected 'f32'
    return W[i2o_W(indices)];
    ^^^^^^

 - While validating [ShaderModuleDescriptor]
 - While calling [Device].CreateShaderModule([ShaderModuleDescriptor]).
```
With the label, the error message is like below:
```
Tint WGSL reader failure: :12:5 error: return statement type must match its function return type, returned 'vec4<f32>', expected 'f32'
    return W[i2o_W(indices)];
    ^^^^^^

 - While validating [ShaderModuleDescriptor "ConvTranspose2D"]
 - While calling [Device].CreateShaderModule([ShaderModuleDescriptor "ConvTranspose2D"]).
```
### Motivation and Context
This change is mainly for debugging. With this change, we can easily know that `ConvTranspose2D`'s shader has problem from above message.


