### PR TITLE
[DML EP] Enable dim overriding for overridable initializers

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -734,6 +734,11 @@ class Graph {
   */
   bool GetInitializedTensor(const std::string& tensor_name, const ONNX_NAMESPACE::TensorProto*& value) const;
 
+  /** Overrides the initialized tensors's dimensions. Can be used when a model's input also has a default initializer
+   * that the user decides to override with AddFreeDimensionOverrideByName.
+   */
+  void OverrideInitializedTensorDim(const std::string& tensor_name, int dim_index, int64_t override);
+
   /** Gets all the initializer tensors in this Graph. */
   const InitializedTensorSet& GetAllInitializedTensors() const noexcept { return name_to_initial_tensor_; }
 
@@ -1572,6 +1577,7 @@ class Graph {
   ONNX_NAMESPACE::GraphProto deserialized_proto_data_;
 
   InitializedTensorSet name_to_initial_tensor_;
+  std::unordered_map<std::string, ONNX_NAMESPACE::TensorShapeProto> name_to_overriden_initial_tensor_shape_;
 
   std::unordered_set<std::reference_wrapper<const std::string>,
                      std::hash<std::string>, std::equal_to<std::string>>

--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1577,7 +1577,7 @@ class Graph {
   ONNX_NAMESPACE::GraphProto deserialized_proto_data_;
 
   InitializedTensorSet name_to_initial_tensor_;
-  std::unordered_map<std::string, ONNX_NAMESPACE::TensorShapeProto> name_to_overriden_initial_tensor_shape_;
+  std::unordered_map<std::string, ONNX_NAMESPACE::TensorShapeProto> name_to_overridden_initial_tensor_shape_;
 
   std::unordered_set<std::reference_wrapper<const std::string>,
                      std::hash<std::string>, std::equal_to<std::string>>

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2464,12 +2464,12 @@ common::Status Graph::TypeCheckInputsAndInitializers() {
       // Set shape accordingly.
       TensorShapeProto inferred_shape;
 
-      auto overriden_shape_iter = name_to_overriden_initial_tensor_shape_.find(name);
+      auto overridden_shape_iter = name_to_overridden_initial_tensor_shape_.find(name);
 
-      // If the initializer's shape was overriden (e.g. via AddFreeDimensionOverrideByName), we use the overriden shape
+      // If the initializer's shape was overridden (e.g. via AddFreeDimensionOverrideByName), we use the overridden shape
       // instead of the initial one
-      if (overriden_shape_iter != name_to_overriden_initial_tensor_shape_.end()) {
-        inferred_shape = overriden_shape_iter->second;
+      if (overridden_shape_iter != name_to_overridden_initial_tensor_shape_.end()) {
+        inferred_shape = overridden_shape_iter->second;
       } else {
         for (auto dim : tensor_proto->dims()) {
           inferred_shape.add_dim()->set_dim_value(dim);
@@ -2981,10 +2981,10 @@ bool Graph::GetInitializedTensor(const std::string& tensor_name, const TensorPro
 }
 
 void Graph::OverrideInitializedTensorDim(const std::string& tensor_name, int dim_index, int64_t override) {
-  auto iter = name_to_overriden_initial_tensor_shape_.find(tensor_name);
+  auto iter = name_to_overridden_initial_tensor_shape_.find(tensor_name);
 
-  if (iter == name_to_overriden_initial_tensor_shape_.end()) {
-    // Initialize the overriden shape to the initial shape, which will be overriden below
+  if (iter == name_to_overridden_initial_tensor_shape_.end()) {
+    // Initialize the overridden shape to the initial shape, which will be overridden below
     const ONNX_NAMESPACE::TensorProto* tensor_proto = nullptr;
     ORT_ENFORCE(GetInitializedTensor(tensor_name, tensor_proto), "No initializers found with name ", tensor_name, ".");
 
@@ -2993,7 +2993,7 @@ void Graph::OverrideInitializedTensorDim(const std::string& tensor_name, int dim
       initial_shape.add_dim()->set_dim_value(dim);
     }
 
-    iter = name_to_overriden_initial_tensor_shape_.emplace(tensor_name, std::move(initial_shape)).first;
+    iter = name_to_overridden_initial_tensor_shape_.emplace(tensor_name, std::move(initial_shape)).first;
   }
 
   ORT_ENFORCE(

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -2463,8 +2463,17 @@ common::Status Graph::TypeCheckInputsAndInitializers() {
 
       // Set shape accordingly.
       TensorShapeProto inferred_shape;
-      for (auto dim : tensor_proto->dims()) {
-        inferred_shape.add_dim()->set_dim_value(dim);
+
+      auto overriden_shape_iter = name_to_overriden_initial_tensor_shape_.find(name);
+
+      // If the initializer's shape was overriden (e.g. via AddFreeDimensionOverrideByName), we use the overriden shape
+      // instead of the initial one
+      if (overriden_shape_iter != name_to_overriden_initial_tensor_shape_.end()) {
+        inferred_shape = overriden_shape_iter->second;
+      } else {
+        for (auto dim : tensor_proto->dims()) {
+          inferred_shape.add_dim()->set_dim_value(dim);
+        }
       }
 
       const TensorShapeProto* p_existing_shape = node_arg->Shape();
@@ -2477,12 +2486,13 @@ common::Status Graph::TypeCheckInputsAndInitializers() {
       } else {
         bool invalid = false;
 
-        if (p_existing_shape->dim_size() != tensor_proto->dims_size()) {
+        if (p_existing_shape->dim_size() != inferred_shape.dim_size()) {
           invalid = true;
         } else {
           for (int i = 0; i < p_existing_shape->dim_size(); ++i) {
-            auto& d = p_existing_shape->dim(i);
-            if (utils::HasDimValue(d) && (d.dim_value() != tensor_proto->dims(i))) {
+            auto& existing_dim = p_existing_shape->dim(i);
+            auto& inferred_dim = inferred_shape.dim(i);
+            if (utils::HasDimValue(existing_dim) && utils::HasDimValue(inferred_dim) && (existing_dim.dim_value() != inferred_dim.dim_value())) {
               invalid = true;
               break;
             }
@@ -2968,6 +2978,29 @@ bool Graph::GetInitializedTensor(const std::string& tensor_name, const TensorPro
   }
   value = iter->second;
   return true;
+}
+
+void Graph::OverrideInitializedTensorDim(const std::string& tensor_name, int dim_index, int64_t override) {
+  auto iter = name_to_overriden_initial_tensor_shape_.find(tensor_name);
+
+  if (iter == name_to_overriden_initial_tensor_shape_.end()) {
+    // Initialize the overriden shape to the initial shape, which will be overriden below
+    const ONNX_NAMESPACE::TensorProto* tensor_proto = nullptr;
+    ORT_ENFORCE(GetInitializedTensor(tensor_name, tensor_proto), "No initializers found with name ", tensor_name, ".");
+
+    TensorShapeProto initial_shape;
+    for (auto dim : tensor_proto->dims()) {
+      initial_shape.add_dim()->set_dim_value(dim);
+    }
+
+    iter = name_to_overriden_initial_tensor_shape_.emplace(tensor_name, std::move(initial_shape)).first;
+  }
+
+  ORT_ENFORCE(
+      dim_index < iter->second.dim_size(),
+      "dim_index ", dim_index, " should be smaller than the number of dimensions ", iter->second.dim_size(), ".");
+
+  iter->second.mutable_dim(dim_index)->set_dim_value(override);
 }
 
 void Graph::CleanAllInitializedTensors() noexcept {

--- a/onnxruntime/core/optimizer/free_dim_override_transformer.cc
+++ b/onnxruntime/core/optimizer/free_dim_override_transformer.cc
@@ -33,7 +33,7 @@ FreeDimensionOverrideTransformer::FreeDimensionOverrideTransformer(gsl::span<con
 }
 
 Status FreeDimensionOverrideTransformer::ApplyImpl(Graph& graph, bool& modified, int /*graph_level*/, const logging::Logger& logger) const {
-  for (const onnxruntime::NodeArg* graph_input : graph.GetInputs()) {
+  for (const onnxruntime::NodeArg* graph_input : graph.GetInputsIncludingInitializers()) {
     // Get the current input's type and shape
     const auto* input_type = graph_input->TypeAsProto();
     const auto* input_shape = graph_input->Shape();
@@ -90,6 +90,11 @@ Status FreeDimensionOverrideTransformer::ApplyImpl(Graph& graph, bool& modified,
         } else {
           // Set the dimension override
           new_dimension->set_dim_value(dimension_override);
+
+          if (graph.IsInitializedTensor(graph_input->Name())) {
+            graph.OverrideInitializedTensorDim(graph_input->Name(), dim_index, dimension_override);
+          }
+
           shape_modified = true;
         }
       }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionTransformer.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionTransformer.cpp
@@ -101,8 +101,8 @@ namespace Dml
                     // populate isInitializerTransferable
                     for (const auto& input : partition->GetInputs())
                     {
-                        const onnx::TensorProto* tensor = nullptr;
-                        if (graph.GetInitializedTensor(input, tensor))
+                        const onnx::TensorProto* tensor = graph.GetConstantInitializer(input, false);
+                        if (tensor != nullptr)
                         {
                             // It's only safe to transfer tensors which are used by this partition alone.
                             auto iter = initializerPartitionMap.find(tensor);


### PR DESCRIPTION
### Description
Overridable initializers that can be overridden by graph inputs, which means that the free dims should be allowed to be overridden like normal inputs.



### Motivation and Context
It can be used for example on models with LoRA weights, to change  the weights at runtime without having to reload the session.


