### PR TITLE
only Flush once for the same stream in copyInputAcrossDevice()

### DIFF
--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -480,9 +480,9 @@ static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
   // other stream wait on the event of the memory copy stream, instead of host sync stream.
   std::unordered_set<Stream*> visited;
   for (auto* stream : feed_streams) {
-    if (stream && visited.find(stream) == visited.end()) {
-      visited.insert(stream);
-      stream->Flush();
+    if (stream) {
+      auto unique_stream = visited.insert(stream);
+      if (unique_stream.second) stream->Flush();
     }
   }
   return Status::OK();

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -480,10 +480,7 @@ static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
   // other stream wait on the event of the memory copy stream, instead of host sync stream.
   std::unordered_set<Stream*> visited;
   for (auto* stream : feed_streams) {
-    if (stream) {
-      auto unique_stream = visited.insert(stream);
-      if (unique_stream.second) stream->Flush();
-    }
+    if (stream && visited.insert(stream).second) stream->Flush();
   }
   return Status::OK();
 }

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -478,9 +478,12 @@ static common::Status CopyInputsAcrossDevices(const SessionState& session_state,
   // TODO: this sync is because the graph inputs can be consumed by multiple stream,
   // but we can only place the MemCpyAsync on one of the stream. Ideally we should make
   // other stream wait on the event of the memory copy stream, instead of host sync stream.
+  std::unordered_set<Stream*> visited;
   for (auto* stream : feed_streams) {
-    if (stream)
+    if (stream && visited.find(stream) == visited.end()) {
+      visited.insert(stream);
       stream->Flush();
+    }
   }
   return Status::OK();
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
In CopyInputAcrossDevice() function, we assign each feed a stream to copy across device, once the copy is done, each stream will trigger the Flush() function which is undesired. Same stream should be only flushed once


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This change is to address a perf issue of TLNGv4 inference which contains subgraph with many input feeds. 