### PR TITLE
Fix model serialization with external data in current directory

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1492,7 +1492,7 @@ Status UnpackInitializerData(const onnx::TensorProto& initializer,
   if (initializer.data_location() == TensorProto_DataLocation_EXTERNAL) {
     ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(
         initializer,
-        model_path.IsEmpty() ? nullptr : model_path.ParentPath().ToPathString().c_str(),
+        (model_path.IsEmpty() || model_path.ParentPath().IsEmpty()) ? nullptr : model_path.ParentPath().ToPathString().c_str(),
         unpacked_tensor));
     return Status::OK();
   }


### PR DESCRIPTION
### Description

When original model has external data in current directory, saving the optimized model will raise File not found exception during looking for external data file under root directory "/". This fix will look under current directory for this case.

I manually tested an extra case and it is working: Original model with external data in root directory ("/"), and save optimized to current directory.

BTW, there is another bug found: when "session.optimized_model_external_initializers_min_size_in_bytes" is set a large value, some tensor is still pointed to the original external data file. Add a TODO in unit test for this bug. Possible solution: load external data into memory before saving model.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


