### PR TITLE
Update quant_utils.py/write_calibration_table

### DIFF
--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -470,7 +470,7 @@ def apply_plot(hist, hist_edges):
     plt.show()
 
 
-def write_calibration_table(calibration_cache):
+def write_calibration_table(calibration_cache, saving_path = "."):
     """
     Helper function to write calibration table to files.
     """
@@ -484,7 +484,7 @@ def write_calibration_table(calibration_cache):
 
     logging.info(f"calibration cache: {calibration_cache}")
 
-    with open("calibration.json", "w") as file:
+    with open(os.path.join(saving_path, "calibration.json"), "w") as file:
         file.write(json.dumps(calibration_cache))  # use `json.loads` to do the reverse
 
     # Serialize data using FlatBuffers
@@ -516,7 +516,7 @@ def write_calibration_table(calibration_cache):
     builder.Finish(cal_table)
     buf = builder.Output()
 
-    with open("calibration.flatbuffers", "wb") as file:
+    with open(os.path.join(saving_path, "calibration.flatbuffers"), "wb") as file:
         file.write(buf)
 
     # Deserialize data (for validation)
@@ -529,7 +529,7 @@ def write_calibration_table(calibration_cache):
             logging.info(key_value.Value())
 
     # write plain text
-    with open("calibration.cache", "w") as file:
+    with open(os.path.join(saving_path, "calibration.cache"), "w") as file:
         for key in sorted(calibration_cache.keys()):
             value = calibration_cache[key]
             s = key + " " + str(max(abs(value[0]), abs(value[1])))

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -470,7 +470,7 @@ def apply_plot(hist, hist_edges):
     plt.show()
 
 
-def write_calibration_table(calibration_cache, saving_path = "."):
+def write_calibration_table(calibration_cache, dir = "."):
     """
     Helper function to write calibration table to files.
     """
@@ -484,7 +484,7 @@ def write_calibration_table(calibration_cache, saving_path = "."):
 
     logging.info(f"calibration cache: {calibration_cache}")
 
-    with open(os.path.join(saving_path, "calibration.json"), "w") as file:
+    with open(os.path.join(dir, "calibration.json"), "w") as file:
         file.write(json.dumps(calibration_cache))  # use `json.loads` to do the reverse
 
     # Serialize data using FlatBuffers
@@ -516,7 +516,7 @@ def write_calibration_table(calibration_cache, saving_path = "."):
     builder.Finish(cal_table)
     buf = builder.Output()
 
-    with open(os.path.join(saving_path, "calibration.flatbuffers"), "wb") as file:
+    with open(os.path.join(dir, "calibration.flatbuffers"), "wb") as file:
         file.write(buf)
 
     # Deserialize data (for validation)
@@ -529,7 +529,7 @@ def write_calibration_table(calibration_cache, saving_path = "."):
             logging.info(key_value.Value())
 
     # write plain text
-    with open(os.path.join(saving_path, "calibration.cache"), "w") as file:
+    with open(os.path.join(dir, "calibration.cache"), "w") as file:
         for key in sorted(calibration_cache.keys()):
             value = calibration_cache[key]
             s = key + " " + str(max(abs(value[0]), abs(value[1])))

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -470,7 +470,7 @@ def apply_plot(hist, hist_edges):
     plt.show()
 
 
-def write_calibration_table(calibration_cache, dir = "."):
+def write_calibration_table(calibration_cache, dir="."):
     """
     Helper function to write calibration table to files.
     """


### PR DESCRIPTION


Adding a saving path allows to dictate where the calibration files will be saved.

### Description
<!-- Describe your changes. -->

Added a saving_path as an argument to the write_calibration_table function. That way, the files are not strictly saved on the currect running directory


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

I run into an issue where I wanted to use the write_calibration_table and I was unable to open a file to the current directory, because of permission limitations.

Adding a saving path allows to dictate where the calibration files will be saved, therefore I can suggest a directory I know I have permissions


