### PR TITLE
Add website publish placeholder

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,4 +1,4 @@
-# This is a placeholder workflow only. Its purpose for manual runs to show up
+# This is a placeholder workflow only. Its purpose is for manual runs to show up
 # in the GitHub web UI. It is not used for any automated runs.
 name: Publish site
 

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,0 +1,17 @@
+# Workflow for building and deploying the ORT GitHub Pages site
+name: Publish site
+
+on:
+  # Runs on pushes targeting the branch where the website sources live
+  push:
+    branches: ["gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder step to have workflow included in the GitHub web UI
+        run: echo "Placeholder step to have workflow included in the GitHub web UI"

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,11 +1,8 @@
-# Workflow for building and deploying the ORT GitHub Pages site
+# This is a placeholder workflow only. Its purpose for manual runs to show up
+# in the GitHub web UI. It is not used for any automated runs.
 name: Publish site
 
 on:
-  # Runs on pushes targeting the branch where the website sources live
-  push:
-    branches: ["gh-pages"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -14,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Placeholder step to have workflow included in the GitHub web UI
-        run: echo "Placeholder step to have workflow included in the GitHub web UI"
+        run: echo "Placeholder step to have workflow included in the GitHub web UI


### PR DESCRIPTION
This workflow enables the Run Workflow button in the GitHub web UI

![image](https://github.com/microsoft/onnxruntime/assets/3302433/0723f9e0-b5a8-46d8-8c3b-a3d2ba9f806a)

The actual publish workflow always runs from the gh-pages branch (or branches created from gh-pages).