### PR TITLE
Add training WASM generation to Web CI pipeline

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -283,23 +283,23 @@ else()
     )
   endif()
 
-  set(target_name ort)
+  set(target_name_list ort)
 
   if (onnxruntime_ENABLE_TRAINING_APIS)
-    list(APPEND target_name "training")
+    list(APPEND target_name_list  "training")
   endif()
 
-  list(APPEND target_name "wasm")
+  list(APPEND target_name_list  "wasm")
 
   if (onnxruntime_ENABLE_WEBASSEMBLY_SIMD)
-    list(APPEND target_name "simd")
+    list(APPEND target_name_list  "simd")
   endif()
 
   if (onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
-    list(APPEND target_name "threaded")
+    list(APPEND target_name_list  "threaded")
   endif()
 
-  list(JOIN target_name "-" target_name)
+  list(JOIN target_name_list  "-" target_name)
 
   set_target_properties(onnxruntime_webassembly PROPERTIES OUTPUT_NAME ${target_name})
 endif()

--- a/js/web/script/pull-prebuilt-wasm-artifacts.ts
+++ b/js/web/script/pull-prebuilt-wasm-artifacts.ts
@@ -145,12 +145,14 @@ downloadJson(
                 extractFile(zip, WASM_FOLDER, 'ort-wasm-simd-threaded.wasm', folderName);
                 extractFile(zip, WASM_FOLDER, 'ort-wasm-simd.jsep.wasm', folderName);
                 extractFile(zip, WASM_FOLDER, 'ort-wasm-simd-threaded.jsep.wasm', folderName);
+                extractFile(zip, WASM_FOLDER, 'ort-training-wasm-simd.wasm', folderName);
 
                 extractFile(zip, JS_FOLDER, 'ort-wasm.js', folderName);
                 extractFile(zip, JS_FOLDER, 'ort-wasm-threaded.js', folderName);
                 extractFile(zip, JS_FOLDER, 'ort-wasm-threaded.worker.js', folderName);
                 extractFile(zip, JS_FOLDER, 'ort-wasm-simd.jsep.js', folderName);
                 extractFile(zip, JS_FOLDER, 'ort-wasm-simd-threaded.jsep.js', folderName);
+                extractFile(zip, JS_FOLDER, 'ort-training-wasm-simd.js', folderName);
               });
             });
           });

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -394,9 +394,11 @@ char* OrtEndProfiling(ort_session_handle_t session) {
 #define CHECK_TRAINING_STATUS(ORT_API_NAME, ...) \
   CheckStatus(Ort::GetTrainingApi().ORT_API_NAME(__VA_ARGS__))
 
-ort_training_checkpoint_handle_t EMSCRIPTEN_KEEPALIVE OrtTrainingLoadCheckpoint(void* checkpoint_data_buffer, size_t checkpoint_size) {
+ort_training_checkpoint_handle_t EMSCRIPTEN_KEEPALIVE OrtTrainingLoadCheckpoint(void* checkpoint_data_buffer,
+                                                                                size_t checkpoint_size) {
   OrtCheckpointState* checkpoint_state = nullptr;
-  return (CHECK_TRAINING_STATUS(LoadCheckpointFromBuffer, checkpoint_data_buffer, checkpoint_size, &checkpoint_state) == ORT_OK)
+  return (CHECK_TRAINING_STATUS(LoadCheckpointFromBuffer, checkpoint_data_buffer,
+                                checkpoint_size, &checkpoint_state) == ORT_OK)
              ? checkpoint_state
              : nullptr;
 }
@@ -414,7 +416,7 @@ ort_training_session_handle_t EMSCRIPTEN_KEEPALIVE OrtTrainingCreateSession(cons
                                                                             void* optimizer_model,
                                                                             size_t optimizer_size) {
   OrtTrainingSession* training_session = nullptr;
-  return (CHECK_TRAINING_STATUS(CreateTrainingSessionFromArray, g_env, options,
+  return (CHECK_TRAINING_STATUS(CreateTrainingSessionFromBuffer, g_env, options,
                                 training_checkpoint_state_handle, train_model, train_size,
                                 eval_model, eval_size, optimizer_model, optimizer_size,
                                 &training_session) == ORT_OK)

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -31,6 +31,10 @@ parameters:
   type: boolean
   default: false
 
+- name: BuildTraining
+  type: boolean
+  default: true
+
 - name: WithCache
   type: boolean
   default: false

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -146,6 +146,19 @@ jobs:
       DisplayName: 'Build and test (node) (simd)'
       WithCache: ${{ parameters.WithCache }}
 
+  - ${{ if eq(parameters.BuildTraining, true) }}:
+    - template: build-linux-wasm-step.yml
+      parameters:
+        Today: $(Today)
+        ${{ if eq(parameters.BuildStaticLib, true)}}:
+          AdditionalKey: training_wasm_simd | ${{ parameters.BuildConfig }} | static
+        ${{ else }}:
+          AdditionalKey: training_wasm_simd | ${{ parameters.BuildConfig }}
+        CacheDir: $(ORT_CACHE_DIR)/training_wasm_simd
+        Arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)/training_wasm_simd --enable_training_apis --enable_wasm_simd --target onnxruntime_webassembly --skip_tests'
+        DisplayName: 'Build (training + simd)'
+        WithCache: ${{ parameters.WithCache }}
+
   - ${{ if eq(parameters.BuildJsep, true) }}:
     - template: build-linux-wasm-step.yml
       parameters:
@@ -184,6 +197,10 @@ jobs:
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.wasm $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.wasm
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.js
           cp $(Build.BinariesDirectory)/wasm_simd_threads_jsep/${{ parameters.BuildConfig }}/ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)/ort-wasm-simd-threaded.jsep.worker.js
+        fi
+        if [ -d $(Build.BinariesDirectory)/training_wasm_simd ]; then
+          cp $(Build.BinariesDirectory)/training_wasm_simd/${{ parameters.BuildConfig }}/ort-training-wasm-simd.wasm $(Build.ArtifactStagingDirectory)/ort-training-wasm-simd.wasm
+          cp $(Build.BinariesDirectory)/training_wasm_simd/${{ parameters.BuildConfig }}/ort-training-wasm-simd.js $(Build.ArtifactStagingDirectory)/ort-training-wasm-simd.js
         fi
       displayName: 'Create Artifacts'
   - ${{ if eq(parameters.SkipPublish, false) }}:

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -23,6 +23,10 @@ parameters:
   displayName: 'Build JSEP'
   type: boolean
   default: true
+- name: BuildTraining
+  displayName: 'Build training'
+  type: boolean
+  default: true
 
 - name: WASMTemplate
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/web-ci.yml
@@ -23,10 +23,6 @@ parameters:
   displayName: 'Build JSEP'
   type: boolean
   default: true
-- name: BuildTraining
-  displayName: 'Build training'
-  type: boolean
-  default: true
 
 - name: WASMTemplate
   type: string


### PR DESCRIPTION
### Description
[Successful pipeline run](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1123141&view=results)

Added flag to build the training artifacts & updated the pull-wasm-artifacts script to pull the training artifacts as well. 

Bundled into this PR are minor formatting fixes + naming fixes.

### Motivation and Context
[This PR](https://github.com/microsoft/onnxruntime/pull/16521) extended the WASM API wrapper to build training WASM artifacts as well.
The ORT training WASM artifacts are required to support ORT training web bindings.