### PR TITLE
Fix a memleak in RunAsync python

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4333,8 +4333,12 @@ struct OrtApi {
    * \param[in] input_len Number of elements in the input_names and inputs arrays
    * \param[in] output_names Array of null terminated UTF8 encoded strings of the output names
    * \param[in] output_names_len Number of elements in the output_names and outputs array
-   * \param[out] output Array of OrtValue* owned by customers, size to output_names_len. It could simply be an array of nullptr
-   *             The array will be passed back to run_async_callback
+   * \param[out] output OrtValue* array of size output_names_len.
+   *             On calling RunAsync, output[i] could either be a null or a pointer to an preallocated OrtValue.
+   *             Later, the output array will be passed to run_async_callback with all null(s) filled with valid
+   *             OrtValue pointer(s) allocated by onnxruntime.
+   *             NOTE: it is customer's duty to finally release the output array and each of its member,
+   *             regardless of whether the member (OrtValue*) is allocated by onnxruntime or preallocated by the customer.
    * \param[in] run_async_callback Callback function on model run completion
    * \param[in] user_data User data that pass back to run_async_callback
    */

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4334,7 +4334,7 @@ struct OrtApi {
    * \param[in] output_names Array of null terminated UTF8 encoded strings of the output names
    * \param[in] output_names_len Number of elements in the output_names and outputs array
    * \param[out] output OrtValue* array of size output_names_len.
-   *             On calling RunAsync, output[i] could either be a null or a pointer to an preallocated OrtValue.
+   *             On calling RunAsync, output[i] could either be a null or a pointer to a preallocated OrtValue.
    *             Later, the output array will be passed to run_async_callback with all null(s) filled with valid
    *             OrtValue pointer(s) allocated by onnxruntime.
    *             NOTE: it is customer's duty to finally release the output array and each of its member,

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1073,12 +1073,12 @@ struct SessionImpl : ConstSessionImpl<T> {
    *
    * \param[in] run_options
    * \param[in] input_names Array of null terminated UTF8 encoded strings of the input names
-   * \param[in] input_values Array of Value objects of length input_count that is the list of input values
+   * \param[in] input_values Array of Value objects of length input_count
    * \param[in] input_count Number of elements in the input_names and inputs arrays
    * \param[in] output_names Array of null terminated UTF8 encoded strings of the output names
    * \param[out] output_values Array of provided Values to be filled with outputs.
    *             On calling RunAsync, output_values[i] could either be initialized by a null pointer or a preallocated OrtValue*.
-   *             Later, on calling the callback, each output_values[i] of null will be filled with a OrtValue* allocated by onnxruntime.
+   *             Later, on invoking the callback, each output_values[i] of null will be filled with a OrtValue* allocated by onnxruntime.
    *             Then, an array of OrtValue* will be casted from output_values, and pass to the callback.
    *             NOTE: it is customer's duty to finally release output_values and each of its member,
    *             regardless of whether the member (Ort::Value) is allocated by onnxruntime or preallocated by the customer.

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1078,8 +1078,8 @@ struct SessionImpl : ConstSessionImpl<T> {
    * \param[in] output_names Array of null terminated UTF8 encoded strings of the output names
    * \param[out] output_values Array of provided Values to be filled with outputs.
    *             On calling RunAsync, output_values[i] could either be initialized by a null pointer or a preallocated OrtValue*.
-   *             Later, on invoking the callback, each output_values[i] of null will be filled with a OrtValue* allocated by onnxruntime.
-   *             Then, an array of OrtValue* will be casted from output_values, and pass to the callback.
+   *             Later, on invoking the callback, each output_values[i] of null will be filled with an OrtValue* allocated by onnxruntime.
+   *             Then, an OrtValue** pointer will be casted from output_values, and pass to the callback.
    *             NOTE: it is customer's duty to finally release output_values and each of its member,
    *             regardless of whether the member (Ort::Value) is allocated by onnxruntime or preallocated by the customer.
    * \param[in] output_count Number of elements in the output_names and outputs array

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1073,11 +1073,15 @@ struct SessionImpl : ConstSessionImpl<T> {
    *
    * \param[in] run_options
    * \param[in] input_names Array of null terminated UTF8 encoded strings of the input names
-   * \param[in] input_values Array of ::OrtValue%s of the input values
+   * \param[in] input_values Array of Value objects of length input_count that is the list of input values
    * \param[in] input_count Number of elements in the input_names and inputs arrays
    * \param[in] output_names Array of null terminated UTF8 encoded strings of the output names
-   * \param[out] output_values Array of ::OrtValue%s owned by customers, size to output_count. It could simply be an array of nullptr
-   *             The array will be passed back to the callback
+   * \param[out] output_values Array of provided Values to be filled with outputs.
+   *             On calling RunAsync, output_values[i] could either be initialized by a null pointer or a preallocated OrtValue*.
+   *             Later, on calling the callback, each output_values[i] of null will be filled with a OrtValue* allocated by onnxruntime.
+   *             Then, an array of OrtValue* will be casted from output_values, and pass to the callback.
+   *             NOTE: it is customer's duty to finally release output_values and each of its member,
+   *             regardless of whether the member (Ort::Value) is allocated by onnxruntime or preallocated by the customer.
    * \param[in] output_count Number of elements in the output_names and outputs array
    * \param[in] callback Callback function on model run completion
    * \param[in] user_data User data that pass back to the callback

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -85,7 +85,6 @@ struct AsyncResource {
   std::vector<std::string> feed_names;
   std::vector<const char*> feed_names_raw;
 
-  std::vector<OrtValue> fetches;
   std::vector<OrtValue*> fetches_raw;
 
   std::vector<std::string> fetch_names;
@@ -103,10 +102,17 @@ struct AsyncResource {
   }
 
   void ReserveFetches(size_t sz) {
-    fetches.reserve(sz);
     fetches_raw.reserve(sz);
     fetch_names.reserve(sz);
     fetch_names_raw.reserve(sz);
+  }
+
+  ~AsyncResource() {
+    for (auto* fetch : fetches_raw) {
+      if (fetch) {
+        std::unique_ptr<OrtValue> fetch_ptr(fetch);
+      }
+    }
   }
 };
 
@@ -1790,8 +1796,7 @@ including arg name, arg type (contains both type and shape).)pbdoc")
              for (auto& output_name : output_names) {
                async_resource->fetch_names.push_back(output_name);
                async_resource->fetch_names_raw.push_back(async_resource->fetch_names.back().c_str());
-               async_resource->fetches.push_back({});
-               async_resource->fetches_raw.push_back(&async_resource->fetches.back());
+               async_resource->fetches_raw.push_back({});
              }
              const RunOptions* run_async_option = run_options ? run_options : &async_resource->default_run_option;
              common::Status status = sess->GetSessionHandle()->RunAsync(run_async_option,

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -53,6 +53,7 @@ namespace onnxruntime {
 #endif  // _MSC_VER
 
 #include <iterator>
+#include <algorithm>
 
 #if defined(_MSC_VER)
 #pragma warning(disable : 4267 4996 4503 4003)
@@ -85,7 +86,7 @@ struct AsyncResource {
   std::vector<std::string> feed_names;
   std::vector<const char*> feed_names_raw;
 
-  std::vector<OrtValue*> fetches_raw;
+  std::vector<OrtValue*> fetches_raw;  // will be released during destruction
 
   std::vector<std::string> fetch_names;
   std::vector<const char*> fetch_names_raw;
@@ -108,11 +109,9 @@ struct AsyncResource {
   }
 
   ~AsyncResource() {
-    for (auto* fetch : fetches_raw) {
-      if (fetch) {
-        std::unique_ptr<OrtValue> fetch_ptr(fetch);
-      }
-    }
+    std::for_each(fetches_raw.begin(), fetches_raw.end(), [](OrtValue* fetch) {
+      std::unique_ptr<OrtValue> fetch_recycler(fetch);
+    });
   }
 };
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -85,6 +85,7 @@ struct AsyncResource {
   std::vector<std::string> feed_names;
   std::vector<const char*> feed_names_raw;
 
+  std::vector<OrtValue> fetches;
   std::vector<OrtValue*> fetches_raw;
 
   std::vector<std::string> fetch_names;
@@ -102,6 +103,7 @@ struct AsyncResource {
   }
 
   void ReserveFetches(size_t sz) {
+    fetches.reserve(sz);
     fetches_raw.reserve(sz);
     fetch_names.reserve(sz);
     fetch_names_raw.reserve(sz);
@@ -1788,7 +1790,8 @@ including arg name, arg type (contains both type and shape).)pbdoc")
              for (auto& output_name : output_names) {
                async_resource->fetch_names.push_back(output_name);
                async_resource->fetch_names_raw.push_back(async_resource->fetch_names.back().c_str());
-               async_resource->fetches_raw.push_back({});
+               async_resource->fetches.push_back({});
+               async_resource->fetches_raw.push_back(&async_resource->fetches.back());
              }
              const RunOptions* run_async_option = run_options ? run_options : &async_resource->default_run_option;
              common::Status status = sess->GetSessionHandle()->RunAsync(run_async_option,

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -109,9 +109,12 @@ struct AsyncResource {
   }
 
   ~AsyncResource() {
-    std::for_each(fetches_raw.begin(), fetches_raw.end(), [](OrtValue* fetch) {
-      std::unique_ptr<OrtValue> fetch_recycler(fetch);
+    std::for_each(fetches_raw.begin(), fetches_raw.end(), [](const OrtValue* fetch) {
+      if (fetch) {
+        std::unique_ptr<const OrtValue> fetch_recycler(fetch);
+      }
     });
+    fetches_raw.clear();
   }
 };
 


### PR DESCRIPTION
Release ort value outputs that are created and released from ort::run(...).


