### PR TITLE
Configure StringNormalizer `default_locale` for _APPLE_ system 

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -202,11 +202,14 @@ class Utf8Converter {
 #endif
 
 #if defined(__APPLE__)
+#if TARGET_OS_IPHONE
 const std::string default_locale("en-US.UTF-8");
 #else
-const std::string default_locale("en_US.UTF-8"); // All non-MS and not Apple
+const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platforms including MacOS, iphone simulator,etc
 #endif
-
+#else
+const std::string default_locale("en_US.UTF-8");  // All non-MS and not Apple
+#endif
 
 #endif  // _MSC_VER
 

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -202,6 +202,7 @@ class Utf8Converter {
 #endif
 
 #if defined(__APPLE__)
+#include <TargetConditionals.h>
 #if TARGET_OS_IPHONE
 const std::string default_locale("en-US.UTF-8");
 #else

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -201,7 +201,12 @@ class Utf8Converter {
 
 #endif
 
-const std::string default_locale("en_US.UTF-8");  // All non-MS
+#if defined(__APPLE__)
+const std::string default_locale("en");
+#else
+const std::string default_locale("en_US.UTF-8"); // All non-MS and not Apple
+#endif
+
 
 #endif  // _MSC_VER
 

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -202,7 +202,7 @@ class Utf8Converter {
 #endif
 
 #if defined(__APPLE__)
-const std::string default_locale("en.UTF-8");
+const std::string default_locale("en-US.UTF-8");
 #else
 const std::string default_locale("en_US.UTF-8"); // All non-MS and not Apple
 #endif

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -202,7 +202,7 @@ class Utf8Converter {
 #endif
 
 #if defined(__APPLE__)
-const std::string default_locale("en");
+const std::string default_locale("en.UTF-8");
 #else
 const std::string default_locale("en_US.UTF-8"); // All non-MS and not Apple
 #endif

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -207,7 +207,7 @@ class Utf8Converter {
 const std::string default_locale("en-US.UTF-8");
 #else
 const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platforms including MacOS, etc
-#endif // __APPLE__
+#endif
 #else
 const std::string default_locale("en_US.UTF-8");  // All non-MS and not Apple
 #endif

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -203,11 +203,11 @@ class Utf8Converter {
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 const std::string default_locale("en-US.UTF-8");
 #else
-const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platforms including MacOS, iphone simulator,etc
-#endif
+const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platforms including MacOS, etc
+#endif // __APPLE__
 #else
 const std::string default_locale("en_US.UTF-8");  // All non-MS and not Apple
 #endif

--- a/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/string_normalizer.cc
@@ -203,7 +203,7 @@ class Utf8Converter {
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 const std::string default_locale("en-US.UTF-8");
 #else
 const std::string default_locale("en_US.UTF-8");  // Other kinds of Apple Platforms including MacOS, etc


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

As title.

iOS language code uses different syntax for specifying language code/region code: https://developer.apple.com/documentation/xcode/choosing-localization-regions-and-scripts

current `default_locale` is not working for iOS.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Issue:
https://github.com/microsoft/onnxruntime/issues/17017
