### PR TITLE
[js/webgpu] Add input/output shapes information to profiling

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -286,7 +286,7 @@ export class WebGpuBackend {
         'info',
         () => `[ProgramManager] run "${programInfo.name}" (key=${key}) with ${normalizedDispatchGroup[0]}x${
             normalizedDispatchGroup[1]}x${normalizedDispatchGroup[2]}`);
-    this.programManager.run(artifact, inputDatas, outputDatas, normalizedDispatchGroup);
+    this.programManager.run(artifact, inputs, inputDatas, outputDatas, normalizedDispatchGroup);
 
     return outputTensorViews;
   }

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -105,14 +105,14 @@ export class ProgramManager {
         this.backend.gpuDataManager.release(syncData.id);
         let inputShapes = '';
         inputsTensorView.forEach((value, i) => {
-          inputShapes += `input[${i}]: ${value.dims} | ${tensorDataTypeEnumToString(value.dataType)}, `;
+          inputShapes += `input[${i}]: [${value.dims}] | ${tensorDataTypeEnumToString(value.dataType)}, `;
         });
         let outputShapes = '';
         buildArtifact.programInfo.outputs.forEach((value, i) => {
-          outputShapes += `output[${i}]: ${value.dims} | ${tensorDataTypeEnumToString(value.dataType)}, `;
+          outputShapes += `output[${i}]: [${value.dims}] | ${tensorDataTypeEnumToString(value.dataType)}, `;
         });
         // eslint-disable-next-line no-console
-        console.log(`[profiling] kernel "${kernelName}" ${inputShapes}${outputShapes}execution time: ${
+        console.log(`[profiling] kernel "${kernelId}|${kernelName}" ${inputShapes}${outputShapes}execution time: ${
             endTime - startTime} ns`);
       });
     }

--- a/js/web/lib/wasm/jsep/webgpu/program-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/program-manager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import {tensorDataTypeEnumToString} from '../../wasm-common';
 import {WebGpuBackend} from '../backend-webgpu';
 import {LOG_DEBUG} from '../log';
 import {TensorView} from '../tensor';
@@ -104,11 +105,11 @@ export class ProgramManager {
         this.backend.gpuDataManager.release(syncData.id);
         let inputShapes = '';
         inputsTensorView.forEach((value, i) => {
-          inputShapes += `input[${i}]: ${value.dims}, `;
+          inputShapes += `input[${i}]: ${value.dims} | ${tensorDataTypeEnumToString(value.dataType)}, `;
         });
         let outputShapes = '';
         buildArtifact.programInfo.outputs.forEach((value, i) => {
-          outputShapes += `output[${i}]: ${value.dims}, `;
+          outputShapes += `output[${i}]: ${value.dims} | ${tensorDataTypeEnumToString(value.dataType)}, `;
         });
         // eslint-disable-next-line no-console
         console.log(`[profiling] kernel "${kernelName}" ${inputShapes}${outputShapes}execution time: ${


### PR DESCRIPTION
### Description
This PR is to enhance the profiling information.
With the PR, the profiling result is like below:
```
[profiling] kernel "[Split] 51288384" input[0]: 1,256,64,64, output[0]: 1,256,64,64, execution time: 37135 ns
program-manager.ts:114 
[profiling] kernel "[Concat] 52361040" input[0]: 1,256,64,64, output[0]: 1,256,64,64, execution time: 50833 ns
program-manager.ts:114 
[profiling] kernel "[Transpose] 52375264" input[0]: 1,256,64,64, output[0]: 1,64,64,256, execution time: 99791 ns
program-manager.ts:114 
[profiling] kernel "[Sub] 51098472" input[0]: , input[1]: 1, output[0]: 1, execution time: 7448 ns
program-manager.ts:114 
[profiling] kernel "[Mul] 51344440" input[0]: 1, input[1]: 1,256,1,1, output[0]: 1,256,1,1, execution time: 8334 ns
```
Without this PR, the profiling result is like below:
```
[profiling] kernel "52097928|[Split] 52097928" execution time: 37760 ns
program-manager.ts:105 
[profiling] kernel "41898328|[Concat] 41898328" execution time: 51666 ns
program-manager.ts:105 
[profiling] kernel "41915648|[Transpose] 41915648" execution time: 95416 ns
program-manager.ts:105 
[profiling] kernel "49757856|[Sub] 49757856" execution time: 7969 ns
program-manager.ts:105 
[profiling] kernel "51680504|[Mul] 51680504" execution time: 8906 ns
```
With the new information, we can easily know what kind of shape ops have poor performance. Also it can help us to check whether too small shape ops run on gpu.