### PR TITLE
Fix NNAPI optional input handling checks and unblock Android CI pipeline test failures

### DIFF
--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/base_op_builder.cc
@@ -112,7 +112,7 @@ bool BaseOpBuilder::HasSupportedInputOutputs(const InitializedTensorSet& initial
   };
 
   for (const auto& input : node_unit.Inputs()) {
-    if (!has_supported_shape(input.node_arg, node_unit.Name(), node_unit.OpType()))
+    if (input.node_arg.Exists() && !has_supported_shape(input.node_arg, node_unit.Name(), node_unit.OpType()))
       return false;
 
     if (input.quant_param.has_value()) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/base_op_builder.cc
@@ -112,7 +112,10 @@ bool BaseOpBuilder::HasSupportedInputOutputs(const InitializedTensorSet& initial
   };
 
   for (const auto& input : node_unit.Inputs()) {
-    if (input.node_arg.Exists() && !has_supported_shape(input.node_arg, node_unit.Name(), node_unit.OpType()))
+    if (!input.node_arg.Exists()) {
+      continue;
+    }
+    if (!has_supported_shape(input.node_arg, node_unit.Name(), node_unit.OpType()))
       return false;
 
     if (input.quant_param.has_value()) {

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -185,8 +185,13 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
         return false;
       }
     }
+    // Note: For case ReduceMean 18+ with noop_with_empty_axes specifies as 1, should added as an identity op.
+    // Currently we hit an issue in NNAPI when adding an operand as both an input and output.
+    // This may arise from hadling no-ops like Identity and ReduceX with noop_with_empty_axes set.
+    // TODO: Support the case when a more complete solution is available.
     if (node_unit.SinceVersion() >= 18 && noop_with_empty_axes) {
-      LOGS_DEFAULT(VERBOSE) << "NNAPI currently doesn't support the case of ReduceMean-18 with noop_with_empty_axes specifies as 1.";
+      LOGS_DEFAULT(VERBOSE)
+          << "NNAPI currently doesn't support the case of ReduceMean-18 with noop_with_empty_axes specifies as 1.";
       return false;
     }
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -150,8 +150,8 @@ Status ReductionOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, co
     // an input and output.
     // Currently, we return not supported in NNAPI EP when `noop_with_empty_axes` is true.
 
-    // const OperandType output_operand_type(operand_types.at(inputs[0].node_arg.Name()).type, input_shape);
-    // model_builder.RegisterOperand(output, operand_indices.at(inputs[0].node_arg.Name()), output_operand_type);
+    // const OperandType output_operand_type(operand_types.at(input).type, input_shape);
+    // model_builder.RegisterOperand(output, operand_indices.at(input), output_operand_type);
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -184,7 +184,7 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
       }
     }
     if (node_unit.SinceVersion() >= 18 && noop_with_empty_axes) {
-      LOGS_DEFAULT(VERBOSE) << "NNAPI currently doesn't support ReduceMean-18 with noop_with_empty_axes";
+      LOGS_DEFAULT(VERBOSE) << "NNAPI currently doesn't support the case of ReduceMean-18 with noop_with_empty_axes specifies as 1.";
       return false;
     }
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -185,9 +185,9 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
         return false;
       }
     }
-    // Note: For case ReduceMean 18+ with noop_with_empty_axes specifies as 1, should added as an identity op.
-    // Currently we hit an issue in NNAPI when adding an operand as both an input and output.
-    // This may arise from hadling no-ops like Identity and ReduceX with noop_with_empty_axes set.
+    // Note: For the case - ReduceMean 18+ with noop_with_empty_axes attribute set as 1,
+    // currently we hit an issue in NNAPI where it does not allow adding an operand as both an input and output.
+    // This issue may arise from handling no-ops like Identity and ReduceX with noop_with_empty_axes set.
     // TODO: Support the case when a more complete solution is available.
     if (node_unit.SinceVersion() >= 18 && noop_with_empty_axes) {
       LOGS_DEFAULT(VERBOSE)

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -191,7 +191,7 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
     // TODO: Support the case when a more complete solution is available.
     if (node_unit.SinceVersion() >= 18 && noop_with_empty_axes) {
       LOGS_DEFAULT(VERBOSE)
-          << "NNAPI currently doesn't support the case of ReduceMean-18 with noop_with_empty_axes specifies as 1.";
+          << "NNAPI currently doesn't support the case for ReduceMean 18+ with noop_with_empty_axes attribute set as 1";
       return false;
     }
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -100,49 +100,59 @@ Status ReductionOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, co
   }
 
   // Add ReduceMean operation
+  if (!axes.empty()) {
+    InlinedVector<uint32_t> input_indices;
+    input_indices.push_back(operand_indices.at(input));  // data
 
-  InlinedVector<uint32_t> input_indices;
-  input_indices.push_back(operand_indices.at(input));  // data
+    const auto axes_name = model_builder.GetUniqueName(node_unit.Name() + inputs[0].node_arg.Name() + "_axes");
+    Shape axes_dimen = {static_cast<uint32_t>(axes.size())};
+    const OperandType axes_operand_type(Type::TENSOR_INT32, axes_dimen);
+    ORT_RETURN_IF_ERROR(model_builder.AddOperandFromPersistMemoryBuffer(axes_name, axes.data(), axes_operand_type));
 
-  const auto axes_name = model_builder.GetUniqueName(node_unit.Name() + inputs[0].node_arg.Name() + "_axes");
-  Shape axes_dimen = {static_cast<uint32_t>(axes.size())};
-  const OperandType axes_operand_type(Type::TENSOR_INT32, axes_dimen);
-  ORT_RETURN_IF_ERROR(model_builder.AddOperandFromPersistMemoryBuffer(axes_name, axes.data(), axes_operand_type));
+    input_indices.push_back(operand_indices.at(axes_name));  // axes
 
-  input_indices.push_back(operand_indices.at(axes_name));  // axes
+    int32_t input_rank = static_cast<int32_t>(input_shape.size());
 
-  int32_t input_rank = static_cast<int32_t>(input_shape.size());
-
-  // Make output dimensions
-  InlinedVector<uint32_t> output_dimen;
-  if (keepdims) {
-    output_dimen.reserve(input_rank);
-  } else {
-    output_dimen.reserve(input_rank - axes.size());
-  }
-
-  for (int32_t i = 0; i < input_rank; i++) {
-    if (std::find(axes.begin(), axes.end(), i) == axes.end()) {
-      output_dimen.push_back(input_shape[i]);
+    // Make output dimensions
+    InlinedVector<uint32_t> output_dimen;
+    if (keepdims) {
+      output_dimen.reserve(input_rank);
     } else {
-      if (keepdims) {
-        output_dimen.push_back(1);
+      output_dimen.reserve(input_rank - axes.size());
+    }
+
+    for (int32_t i = 0; i < input_rank; i++) {
+      if (std::find(axes.begin(), axes.end(), i) == axes.end()) {
+        output_dimen.push_back(input_shape[i]);
+      } else {
+        if (keepdims) {
+          output_dimen.push_back(1);
+        }
       }
     }
+
+    // In case of a tensor has all 1's in dimension such as {1,1,1,1} and gets all reduced,
+    // NNAPI requires the output shape to be {1}. (otherwise NNAPI will treat it as dynamic shape.)
+    if (output_dimen.empty())
+      output_dimen.push_back(1);
+
+    shaper.AddShape(output, output_dimen);
+
+    ADD_SCALAR_OPERAND(model_builder, input_indices, keepdims ? 1 : 0);
+
+    const OperandType output_operand_type(operand_types.at(inputs[0].node_arg.Name()).type, output_dimen);
+    ORT_RETURN_IF_ERROR(model_builder.AddOperation(op_code, input_indices,
+                                                   {output}, {output_operand_type}));
+  } else {
+    // Note: If `axes` is still empty at this point, meaning it's ReduceMean-18 and attribute `noop_with_empty_axes`
+    // specifies as 1. We treat this case as an Identity op in NNAPI EP.
+    // However, we hit an issue while adding no-ops operation in NNAPI because it doesn't allow adding an operand both as
+    // an input and output.
+    // Currently, we return not supported in NNAPI EP when `noop_with_empty_axes` is true.
+
+    // const OperandType output_operand_type(operand_types.at(inputs[0].node_arg.Name()).type, input_shape);
+    // model_builder.RegisterOperand(output, operand_indices.at(inputs[0].node_arg.Name()), output_operand_type);
   }
-
-  // In case of a tensor has all 1's in dimension such as {1,1,1,1} and gets all reduced,
-  // NNAPI requires the output shape to be {1}. (otherwise NNAPI will treat it as dynamic shape.)
-  if (output_dimen.empty())
-    output_dimen.push_back(1);
-
-  shaper.AddShape(output, output_dimen);
-
-  ADD_SCALAR_OPERAND(model_builder, input_indices, keepdims ? 1 : 0);
-
-  const OperandType output_operand_type(operand_types.at(inputs[0].node_arg.Name()).type, output_dimen);
-  ORT_RETURN_IF_ERROR(model_builder.AddOperation(op_code, input_indices,
-                                                 {output}, {output_operand_type}));
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -164,6 +164,8 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
   const auto& inputs = node_unit.Inputs();
   const auto& op(node_unit.OpType());
 
+  NodeAttrHelper helper(node_unit);
+
   Shape input_shape;
   if (!GetShape(inputs[0].node_arg, input_shape))
     return false;

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/reduction_op_builder.cc
@@ -191,7 +191,7 @@ bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializ
     // TODO: Support the case when a more complete solution is available.
     if (node_unit.SinceVersion() >= 18 && noop_with_empty_axes) {
       LOGS_DEFAULT(VERBOSE)
-          << "NNAPI currently doesn't support the case for ReduceMean 18+ with noop_with_empty_axes attribute set as 1";
+          << "ReduceMean 18+ with noop_with_empty_axes attribute set as 1 is not supported for now.";
       return false;
     }
   }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -214,15 +214,15 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
       const auto axes = helper.Get("axes", std::vector<int64_t>{});
       const auto keep_aspect_ratio_policy = helper.Get("keep_aspect_ratio_policy", "stretch");
       if (antialias != 0) {
-        LOGS_DEFAULT(VERBOSE) << "Resize 18+ antialias feature is not supported now by NNAPI.";
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ antialias feature is not currently supported by NNAPI.";
         return false;
       }
       if (!axes.empty()) {
-        LOGS_DEFAULT(VERBOSE) << "Resize 18+ axes attribute is not supported now by NNAPI.";
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ axes attribute is not currently supported by NNAPI EP.";
         return false;
       }
       if (keep_aspect_ratio_policy != "stretch") {
-        LOGS_DEFAULT(VERBOSE) << "Resize 18+ keep_aspect_ratio_policy attributed is not supported now by NNAPI.";
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ keep_aspect_ratio_policy attributed is not currently supported by NNAPI EP.";
         return false;
       }
     }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -207,8 +207,8 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
       }
     }
 
-    // The following new features introduced since opset 18 does not have a corresponding NNAPI mapping support yet.
-    // Exclude from NNAPI EP.
+    // The following new features introduced since opset 18 don't have a NNAPI mapping support yet.
+    // Marked as unsupported in NNAPI EP for now.
     if (node_unit.SinceVersion() >= 18) {
       const auto antialias = helper.Get("antialias", 0);
       const auto axes = helper.Get("axes", std::vector<int64_t>{});

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -207,8 +207,8 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
       }
     }
 
-    // The following new features introduced since opset 18 don't have a NNAPI mapping support yet.
-    // Marked as unsupported in NNAPI EP for now.
+    // The new feature - antialiasing introduced since opset 18 doesn't have a NNAPI mapping support yet.
+    // And a few other new attributes are currently not handled by NNAPI EP, can add support in the future if needed.
     if (node_unit.SinceVersion() >= 18) {
       const auto antialias = helper.Get("antialias", 0);
       const auto axes = helper.Get("axes", std::vector<int64_t>{});

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -206,6 +206,26 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
         return false;
       }
     }
+
+    // The following new features introduced since opset 18 does not have a corresponding NNAPI mapping support yet.
+    // Exclude from NNAPI EP.
+    if (node_unit.SinceVersion() >= 18) {
+      const auto antialias = helper.Get("antialias", 0);
+      const auto axes = helper.Get("axes", std::vector<int64_t>{});
+      const auto keep_aspect_ratio_policy = helper.Get("keep_aspect_ratio_policy", "stretch");
+      if (antialias != 0) {
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ antialias feature is not supported now by NNAPI.";
+        return false;
+      }
+      if (!axes.empty()) {
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ axes attribute is not supported now by NNAPI.";
+        return false;
+      }
+      if (keep_aspect_ratio_policy != "stretch") {
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ keep_aspect_ratio_policy attributed is not supported now by NNAPI.";
+        return false;
+      }
+    }
   }
 
   {  // scales and sizes (if present) must be initializers

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -222,7 +222,7 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
         return false;
       }
       if (keep_aspect_ratio_policy != "stretch") {
-        LOGS_DEFAULT(VERBOSE) << "Resize 18+ keep_aspect_ratio_policy attributed is not currently supported by NNAPI EP.";
+        LOGS_DEFAULT(VERBOSE) << "Resize 18+ keep_aspect_ratio_policy attribute is not currently supported by NNAPI EP.";
         return false;
       }
     }

--- a/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/nnapi/nnapi_builtin/builders/impl/resize_op_builder.cc
@@ -153,10 +153,10 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
   if (!GetShape(node_unit.Inputs()[0].node_arg, input_shape))
     return false;
 
-  const auto input_dim = input_shape.size();
-  if (input_dim != 4) {
+  const auto input_rank = input_shape.size();
+  if (input_rank != 4) {
     LOGS_DEFAULT(VERBOSE) << "Resize only support 4d shape, input is "
-                          << input_dim << "d shape";
+                          << input_rank << "d shape";
     return false;
   }
 
@@ -216,7 +216,7 @@ bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers
     }
 
     // scales
-    bool using_scales = (inputs.size() == 3 && inputs[2].node_arg.Exists());
+    bool using_scales = (inputs.size() > 2 && inputs[2].node_arg.Exists());
     if (using_scales && !Contains(initializers, inputs[2].node_arg.Name())) {
       LOGS_DEFAULT(VERBOSE) << "Input scales of Resize must be known";
       return false;

--- a/onnxruntime/test/providers/checkers.cc
+++ b/onnxruntime/test/providers/checkers.cc
@@ -202,19 +202,19 @@ struct TensorCheck<double> {
       // NOTE: Check isnan first to work around MSVC linker bug when /LTCG:incremental is specified.
       // If the isinf check is first the isnan check and branch gets omitted
       if (std::isnan(cur_expected[i])) {
-        ASSERT_TRUE(std::isnan(cur_actual[i])) << "Expected NaN. i:" << i;
+        EXPECT_TRUE(std::isnan(cur_actual[i])) << "Expected NaN. i:" << i;
       } else if (std::isinf(cur_expected[i])) {  // Test infinity for equality
-        ASSERT_EQ(cur_expected[i], cur_actual[i]) << "Expected infinity. i:" << i;
+        EXPECT_EQ(cur_expected[i], cur_actual[i]) << "Expected infinity. i:" << i;
       } else {
         if (!has_abs_err && !has_rel_err) {
           // the default for existing tests
-          ASSERT_NEAR(cur_expected[i], cur_actual[i], threshold) << "i:" << i;
+          EXPECT_NEAR(cur_expected[i], cur_actual[i], threshold) << "i:" << i;
         } else {
           if (has_abs_err) {
-            ASSERT_NEAR(cur_expected[i], cur_actual[i], *(params.absolute_error)) << "i:" << i;
+            EXPECT_NEAR(cur_expected[i], cur_actual[i], *(params.absolute_error)) << "i:" << i;
           }
           if (has_rel_err) {
-            ASSERT_NEAR(cur_expected[i], cur_actual[i], *(params.relative_error) * std::abs(cur_expected[i]))
+            EXPECT_NEAR(cur_expected[i], cur_actual[i], *(params.relative_error) * std::abs(cur_expected[i]))
                 << "i:" << i;
           }
         }
@@ -256,20 +256,20 @@ void InternalNumericalCheck(const Tensor& expected,
     // NOTE: Check isnan first to work around MSVC linker bug when /LTCG:incremental is specified.
     // If the isinf check is first the isnan check and branch gets omitted
     if (std::isnan(cur_expected[i])) {
-      ASSERT_TRUE(std::isnan(cur_actual[i])) << "Expected NaN. i:" << i;
+      EXPECT_TRUE(std::isnan(cur_actual[i])) << "Expected NaN. i:" << i;
     } else if (std::isinf(cur_expected[i])) {  // Test infinity for equality
-      ASSERT_EQ(cur_expected[i], cur_actual[i]) << "Expected infinity. i:" << i;
+      EXPECT_EQ(cur_expected[i], cur_actual[i]) << "Expected infinity. i:" << i;
     } else {
       if (!has_abs_err && !has_rel_err) {
         // the default for existing tests
-        ASSERT_NEAR(cur_expected[i], cur_actual[i], threshold) << "i:" << i;
+        EXPECT_NEAR(cur_expected[i], cur_actual[i], threshold) << "i:" << i;
       } else {
         if (has_abs_err) {
-          ASSERT_NEAR(cur_expected[i], cur_actual[i], *(params.absolute_error))
+          EXPECT_NEAR(cur_expected[i], cur_actual[i], *(params.absolute_error))
               << "i:" << i;
         }
         if (has_rel_err) {
-          ASSERT_NEAR(cur_expected[i], cur_actual[i], *(params.relative_error) * std::abs(cur_expected[i]))
+          EXPECT_NEAR(cur_expected[i], cur_actual[i], *(params.relative_error) * std::abs(cur_expected[i]))
               << "i:" << i;
         }
       }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -3465,10 +3465,6 @@ TEST(ReductionOpTest, ReduceMax_empty_axes_input_initializer_opset_18) {
 }
 
 TEST(ReductionOpTest, ReduceMean_noop_axes_input_initializer_opset_18) {
-  // Note: Temporarily disabled NNAPI EP in this unit test case.
-  // for ReduceMean-18 NoOP, NNAPI EP treats it as an identity op and NNAPI doesn't like
-  // specifying an operand both as an input and output.
-  // TODO: Enable NNAPI EP for this test case when the actual fix is available.
   OpTester test("ReduceMean", 18);
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddAttribute("noop_with_empty_axes", (int64_t)1);
@@ -3483,8 +3479,7 @@ TEST(ReductionOpTest, ReduceMean_noop_axes_input_initializer_opset_18) {
       {kTensorrtExecutionProvider,
        kOpenVINOExecutionProvider,
        kDnnlExecutionProvider,
-       kDmlExecutionProvider,
-       kNnapiExecutionProvider});
+       kDmlExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceMean_empty_axes_input_initializer_opset_18) {

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -3465,6 +3465,10 @@ TEST(ReductionOpTest, ReduceMax_empty_axes_input_initializer_opset_18) {
 }
 
 TEST(ReductionOpTest, ReduceMean_noop_axes_input_initializer_opset_18) {
+  // Note: Temporarily disabled NNAPI EP in this unit test case.
+  // for ReduceMean-18 NoOP, NNAPI EP treats it as an identity op and NNAPI doesn't like
+  // specifying an operand both as an input and output.
+  // TODO: Enable NNAPI EP for this test case when the actual fix is available.
   OpTester test("ReduceMean", 18);
   test.AddAttribute("keepdims", (int64_t)0);
   test.AddAttribute("noop_with_empty_axes", (int64_t)1);
@@ -3479,7 +3483,8 @@ TEST(ReductionOpTest, ReduceMean_noop_axes_input_initializer_opset_18) {
       {kTensorrtExecutionProvider,
        kOpenVINOExecutionProvider,
        kDnnlExecutionProvider,
-       kDmlExecutionProvider});
+       kDmlExecutionProvider,
+       kNnapiExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceMean_empty_axes_input_initializer_opset_18) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Fix missing optional input checks originally coming from a github issue for no shape on Resize Op.
- Exclude Antialias support for Opset 18 + Resize for NNAPI
- Unblock Android CI pipeline tests failure. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Bug fixes.

Issue:
https://github.com/microsoft/onnxruntime/issues/17035

thanks @skottmckay for pointing out the cause.
