### PR TITLE
Change _mm512_setzero to _mm512_setzero_ps

### DIFF
--- a/onnxruntime/core/mlas/lib/q4gemm_avx512.cpp
+++ b/onnxruntime/core/mlas/lib/q4gemm_avx512.cpp
@@ -85,10 +85,10 @@ MlasQ4GemmKernelAvx512f(
 
         int64_t nblk = (int64_t)(CountN) - 4;
         while (nblk >= 0) {
-            __m512 acc_lo0 = _mm512_setzero();
-            __m512 acc_lo1 = _mm512_setzero();
-            __m512 acc_lo2 = _mm512_setzero();
-            __m512 acc_lo3 = _mm512_setzero();
+            __m512 acc_lo0 = _mm512_setzero_ps();
+            __m512 acc_lo1 = _mm512_setzero_ps();
+            __m512 acc_lo2 = _mm512_setzero_ps();
+            __m512 acc_lo3 = _mm512_setzero_ps();
             const auto* b = b_col;
 
             for (size_t k = 0; k < CountK; k += Q4Type::BlkLen) {
@@ -1092,7 +1092,7 @@ MlasQ80BlkQuantRow(const float* A, void* Qblob, size_t size)
     for (size_t k = 0; k < size; k += QType::BlkLen) {
         const size_t step = std::min(QType::BlkLen, size - k);
 
-        __m512 maxAbs = _mm512_setzero();
+        __m512 maxAbs = _mm512_setzero_ps();
         for (size_t kk = 0; kk < step; kk += 16) {
             const size_t klen = std::min(size_t(16), step - kk);
 


### PR DESCRIPTION
### Description
_mm512_setzero is just an alias of _mm512_setzero_ps, and it is a wrong one.
See: https://gcc.gnu.org/legacy-ml/gcc-patches/2018-05/msg00338.html
And https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/avx512fintrin.h


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


