### PR TITLE
[VitisAI] graph_save only saves proto of the graph instead of entire model

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/graph.cc
+++ b/onnxruntime/core/providers/vitisai/imp/graph.cc
@@ -151,8 +151,10 @@ void graph_save(const Graph& graph, const std::string& filename, const std::stri
     }
   }
   // use relative path as data storage.
-  for (auto i = 0; i < model_proto.graph().initializer_size(); ++i) {
-    auto initializer = model_proto.mutable_graph()->mutable_initializer(i);
+  auto graph_proto = model_proto.mutable_graph();
+  *graph_proto = graph.ToGraphProto();
+  for (auto i = 0; i < graph_proto->initializer_size(); ++i) {
+    auto initializer = graph_proto->mutable_initializer(i);
     for (auto j = 0; j < initializer->external_data_size(); ++j) {
       auto external_data = initializer->mutable_external_data(j);
       if (external_data->key() == "location") {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
graph_save only saves proto of the graph instead of entire model.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
We would like to export a part of a model as a new model for unit test. Therefore, we have to change the API to support such need.

