### PR TITLE
Remove 52 from CMAKE_CUDA_ARCHITECTURES from  Linux Nuget package

### DIFF
--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -7,4 +7,4 @@ $BUILD_SOURCESDIRECTORY:/onnxruntime_src --volume $BUILD_BINARIESDIRECTORY:/buil
 python3 /onnxruntime_src/tools/ci_build/build.py --build_java --build_dir /build --config Release \
 --skip_submodule_sync  --parallel --build_shared_lib --use_cuda --cuda_version=$CUDA_VERSION \
 --cuda_home=/usr/local/cuda-$CUDA_VERSION --cudnn_home=/usr/local/cuda-$CUDA_VERSION \
---cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;80'
+--cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=60;61;70;75;80'


### PR DESCRIPTION
### Description
Remove 52 from CMAKE_CUDA_ARCHITECTURES from  build_cuda_c_api_package.sh to reduce binary size.

52 is for [Tesla M60](https://www.nvidia.com/object/tesla-m60.html), which will be retired from Azure in a few weeks.

### Motivation and Context


