### PR TITLE
output all parameters in the bert_perf_test tool

### DIFF
--- a/onnxruntime/python/tools/transformers/bert_perf_test.py
+++ b/onnxruntime/python/tools/transformers/bert_perf_test.py
@@ -235,7 +235,12 @@ def to_string(model_path, session, test_setting):
     option += "graph_optimization_level={},intra_op_num_threads={},".format(
         sess_options.graph_optimization_level, sess_options.intra_op_num_threads
     ).replace("GraphOptimizationLevel.ORT_", "")
-    option += f"batch_size={test_setting.batch_size},sequence_length={test_setting.sequence_length},test_cases={test_setting.test_cases},test_times={test_setting.test_times},use_gpu={test_setting.use_gpu}"
+
+    option += f"batch_size={test_setting.batch_size},sequence_length={test_setting.sequence_length},"
+    option += f"test_cases={test_setting.test_cases},test_times={test_setting.test_times},"
+    option += f"use_gpu={test_setting.use_gpu},use_io_binding={test_setting.use_io_binding},"
+    option += f"average_sequence_length={test_setting.average_sequence_length},"
+    option += f"random_sequence_length={test_setting.random_sequence_length}"
     return option
 
 


### PR DESCRIPTION
### Description
Currently, there are some parameters missing in output file. This output all parameters.

Example output:

Latency(ms) | Latency_P50 | Latency_P75 | Latency_P90 | Latency_P95 | Latency_P99 | Throughput(QPS) | model | graph_optimization_level | intra_op_num_threads | batch_size | sequence_length | test_cases | test_times | use_gpu | use_io_binding | average_sequence_length | random_sequence_length
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
10.91 | 11.16 | 11.3 | 11.7 | 11.78 | 11.84 | 91.66 | model.onnx | ENABLE_ALL | 4 | 1 | 512 | 1 | 10 | TRUE | TRUE | 64 | FALSE

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


