### PR TITLE
Change RuntimeError to ImportError

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/__init__.py
+++ b/orttraining/orttraining/python/training/ortmodule/__init__.py
@@ -18,7 +18,7 @@ from ._fallback import ORTModuleFallbackException, ORTModuleInitException, _Fall
 from .torch_cpp_extensions import is_installed as is_torch_cpp_extensions_installed
 
 if not is_ortmodule_available():
-    raise RuntimeError("ORTModule is not supported on this platform.")
+    raise ImportError("ORTModule is not supported on this platform.")
 
 
 def _defined_from_envvar(name, default_value, warn=True):


### PR DESCRIPTION
The `onnxruntime-validation` for ORTModule checks for `ImportError`:

https://github.com/microsoft/onnxruntime/blob/44101e877125eaa18e191793973a4e1a002c6eca/onnxruntime/python/onnxruntime_validation.py#L73-L75

If any other kind of error is raised, it does not silently fail and will raise an exception. This causes a problem when ortmodule is explicitly not made available on win/mac packages since we currently raise a RuntimeError.

Resolves issue: https://github.com/microsoft/onnxruntime-training-examples/issues/161