### PR TITLE
[js/common] clean up JSDoc

### DIFF
--- a/js/common/lib/backend-impl.ts
+++ b/js/common/lib/backend-impl.ts
@@ -23,7 +23,7 @@ const backendsSortedByPriority: string[] = [];
  * @param priority - an integer indicating the priority of the backend. Higher number means higher priority. if priority
  * < 0, it will be considered as a 'beta' version and will not be used as a fallback backend by default.
  *
- * @internal
+ * @ignore
  */
 export const registerBackend = (name: string, backend: Backend, priority: number): void => {
   if (backend && typeof backend.init === 'function' && typeof backend.createSessionHandler === 'function') {
@@ -65,7 +65,7 @@ export const registerBackend = (name: string, backend: Backend, priority: number
  * @param backendHints - a list of execution provider names to lookup. If omitted use registered backends as list.
  * @returns a promise that resolves to the backend.
  *
- * @internal
+ * @ignore
  */
 export const resolveBackend = async(backendHints: readonly string[]): Promise<Backend> => {
   const backendNames = backendHints.length === 0 ? backendsSortedByPriority : backendHints;

--- a/js/common/lib/backend.ts
+++ b/js/common/lib/backend.ts
@@ -5,7 +5,7 @@ import {InferenceSession} from './inference-session.js';
 import {OnnxValue} from './onnx-value.js';
 
 /**
- * @internal
+ * @ignore
  */
 export declare namespace SessionHandler {
   type FeedsType = {[name: string]: OnnxValue};
@@ -16,7 +16,7 @@ export declare namespace SessionHandler {
 /**
  * Represent a handler instance of an inference session.
  *
- * @internal
+ * @ignore
  */
 export interface SessionHandler {
   dispose(): Promise<void>;
@@ -34,7 +34,7 @@ export interface SessionHandler {
 /**
  * Represent a backend that provides implementation of model inferencing.
  *
- * @internal
+ * @ignore
  */
 export interface Backend {
   /**

--- a/js/common/lib/tensor-impl.ts
+++ b/js/common/lib/tensor-impl.ts
@@ -20,7 +20,7 @@ type TensorGpuBufferType = TensorInterface.GpuBufferType;
 /**
  * the implementation of Tensor interface.
  *
- * @internal
+ * @ignore
  */
 export class Tensor implements TensorInterface {
   // #region constructors
@@ -316,7 +316,7 @@ export class Tensor implements TensorInterface {
     if (!this.cpuData) {
       throw new Error(
           'The data is not on CPU. Use `getData()` to download GPU data to CPU, ' +
-          'or use `texture` property to access the GPU data directly.');
+          'or use `texture` or `gpuBuffer` property to access the GPU data directly.');
     }
     return this.cpuData;
   }


### PR DESCRIPTION
### Description
clean up JSDoc for onnxruntime-common:

- replace "@internal" to "@ignore" as JSDoc do not use "@internal". Using "@ignore" will let the content not show on the generated doc.