### PR TITLE
Fix insufficient space error in Android CI

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1639,6 +1639,10 @@ def run_android_tests(args, source_dir, build_dir, config, cwd):
             adb_shell(f"chmod +x {device_dir}/onnx_test_runner")
             run_adb_shell(f"{device_dir}/onnxruntime_test_all")
 
+            # remove onnxruntime_test_all as it takes up a _lot_ of space and can cause insufficient storage errors
+            # when we try to copy the java app to the device.
+            adb_shell(f"rm {device_dir}/onnxruntime_test_all")
+
             if args.build_java:
                 # use the gradle wrapper under <repo root>/java
                 gradle_executable = os.path.join(source_dir, "java", "gradlew.bat" if is_windows() else "gradlew")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Remove onnxruntime_test_all from emulator once tests have finished as it's 1.2GB and takes up too much space given the 2GB maximum partition size for the emulator.

Side issue is the java build isn't able to strip the binaries in the java apk which causes that to be 800MB (exceeding the 2GB max). That may require an Android/Gradle fix as I don't think we can hardcode an NDK version into our build files. https://issuetracker.google.com/issues/237187538?pli=1


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix Android CI build failures for

