### PR TITLE
Update cmake's hash in android custom build

### DIFF
--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
 # cmake
 RUN CMAKE_VERSION=3.27.3 && \
   aria2c -q -d /tmp -o cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
-  --checksum=sha-256=28d4d1d0db94b47d8dfd4f7dec969a3c747304f4a28ddd6fd340f553f2384dc2 \
+  --checksum=sha-256=62e7819fe0867658b6ea765a711686d637dce76cdf6eb0a6b0f1b879e0344fa7 \
   https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
   tar -zxf /tmp/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz --strip=1 -C /usr
 


### PR DESCRIPTION
### Description
Update cmake's hash in android custom build


### Motivation and Context

see : 
https://github.com/microsoft/onnxruntime/pull/16856/files?diff=unified&w=0#r1317668749


