### PR TITLE
[VITISAI] add float16 and bfloat16 support

### DIFF
--- a/onnxruntime/core/providers/vitisai/README.md
+++ b/onnxruntime/core/providers/vitisai/README.md
@@ -1,4 +1,4 @@
-VitsAI Execution Prividers
+VitisAI Execution Provider
 ============================
 
 

--- a/onnxruntime/core/providers/vitisai/imp/register_xir_ops.cc
+++ b/onnxruntime/core/providers/vitisai/imp/register_xir_ops.cc
@@ -34,6 +34,8 @@ static void xir_shape_infer(ONNX_NAMESPACE::InferenceContext& ctx) {
     updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::INT64);
   } else if (data_type->s() == "int1") {
     updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::BOOL);
+  } else if (data_type->s() == "bfloat16") {
+    updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::BFLOAT16);
   } else {
     std::cerr << "not supported data_type " << data_type->s();
     abort();

--- a/onnxruntime/core/providers/vitisai/imp/register_xir_ops.cc
+++ b/onnxruntime/core/providers/vitisai/imp/register_xir_ops.cc
@@ -36,9 +36,10 @@ static void xir_shape_infer(ONNX_NAMESPACE::InferenceContext& ctx) {
     updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::BOOL);
   } else if (data_type->s() == "bfloat16") {
     updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::BFLOAT16);
+  } else if (data_type->s() == "float16") {
+    updateOutputElemType(ctx, 0, ONNX_NAMESPACE::TensorProto::FLOAT16);
   } else {
-    std::cerr << "not supported data_type " << data_type->s();
-    abort();
+    vai_assert(false, ", not supported data_type: " + data_type->s());
   }
   if (shape != nullptr) {
     for (auto i = 0; i < shape->ints_size(); ++i) {


### PR DESCRIPTION
### Description
Add float16 and bfloat16 data type support for VitisAI ep



### Motivation and Context
The VitisAI ep has added the bfloat datatype support. So we would like to register the datatype from onnxruntime side to enable them.


