### PR TITLE
Disable App Center tests to work around invalid provisioning profile.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/stages/mac-ios-packaging-build-stage.yml
@@ -95,42 +95,44 @@ stages:
           -b="--path_to_protoc_exe=$(Build.BinariesDirectory)/protobuf_install/bin/protoc"
       displayName: "Build iOS framework and assemble pod package files"
 
-    - script: |
-        python tools/ci_build/github/apple/test_ios_packages.py \
-          --fail_if_cocoapods_missing \
-          --framework_info_file "$(Build.BinariesDirectory)/ios_framework/framework_info.json" \
-          --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out" \
-          --variant ${{ parameters.packageVariant }} \
-          --test_project_stage_dir "$(Build.BinariesDirectory)/app_center_test" \
-          --prepare_test_project_only
-      displayName: "Assemble test project for App Center"
+    # disabling the app center test as the provisioning profile is not valid and we are blocked on getting a new one now
 
-    - task: Xcode@5
-      inputs:
-        actions: 'build-for-testing'
-        configuration: 'Debug'
-        xcWorkspacePath: '$(Build.BinariesDirectory)/app_center_test/ios_package_test/ios_package_test.xcworkspace'
-        sdk: 'iphoneos'
-        scheme: 'ios_package_test'
-        xcodeVersion: 'specifyPath'
-        xcodeDeveloperDir: '/Applications/Xcode_${{ variables.xcodeVersion }}.app/Contents/Developer'
-        signingOption: 'manual'
-        signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
-        provisioningProfileName: 'iOS Team Provisioning Profile'
-        args: '-derivedDataPath $(Build.BinariesDirectory)/app_center_test/ios_package_test/DerivedData'
-        workingDirectory: '$(Build.BinariesDirectory)/app_center_test/ios_package_test/'
-      displayName: 'Build App Center iPhone arm64 tests'
+    # - script: |
+    #     python tools/ci_build/github/apple/test_ios_packages.py \
+    #       --fail_if_cocoapods_missing \
+    #       --framework_info_file "$(Build.BinariesDirectory)/ios_framework/framework_info.json" \
+    #       --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out" \
+    #       --variant ${{ parameters.packageVariant }} \
+    #       --test_project_stage_dir "$(Build.BinariesDirectory)/app_center_test" \
+    #       --prepare_test_project_only
+    #   displayName: "Assemble test project for App Center"
 
-    - script: |
-        set -e -x
-        appcenter test run xcuitest \
-          --app "AI-Frameworks/ORT-Mobile-iOS" \
-          --devices $(app_center_test_devices) \
-          --test-series "master" \
-          --locale "en_US" \
-          --build-dir $(Build.BinariesDirectory)/app_center_test/ios_package_test/DerivedData/Build/Products/Debug-iphoneos \
-          --token $(app_center_api_token)
-      displayName: "Run E2E tests on App Center"
+    # - task: Xcode@5
+    #   inputs:
+    #     actions: 'build-for-testing'
+    #     configuration: 'Debug'
+    #     xcWorkspacePath: '$(Build.BinariesDirectory)/app_center_test/ios_package_test/ios_package_test.xcworkspace'
+    #     sdk: 'iphoneos'
+    #     scheme: 'ios_package_test'
+    #     xcodeVersion: 'specifyPath'
+    #     xcodeDeveloperDir: '/Applications/Xcode_${{ variables.xcodeVersion }}.app/Contents/Developer'
+    #     signingOption: 'manual'
+    #     signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
+    #     provisioningProfileName: 'iOS Team Provisioning Profile'
+    #     args: '-derivedDataPath $(Build.BinariesDirectory)/app_center_test/ios_package_test/DerivedData'
+    #     workingDirectory: '$(Build.BinariesDirectory)/app_center_test/ios_package_test/'
+    #   displayName: 'Build App Center iPhone arm64 tests'
+
+    # - script: |
+    #     set -e -x
+    #     appcenter test run xcuitest \
+    #       --app "AI-Frameworks/ORT-Mobile-iOS" \
+    #       --devices $(app_center_test_devices) \
+    #       --test-series "master" \
+    #       --locale "en_US" \
+    #       --build-dir $(Build.BinariesDirectory)/app_center_test/ios_package_test/DerivedData/Build/Products/Debug-iphoneos \
+    #       --token $(app_center_api_token)
+    #   displayName: "Run E2E tests on App Center"
 
     - script: |
         set -e -x


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Disable App Center tests to work around invalid provisioning profile.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Address packaging pipeline failure. If this is required, we will need to do a manual test on an iOS device.

Alternative to #17456. That one is preferred.