### PR TITLE
[js/common] prepare work for supporting webgpu IO binding implementation

### DIFF
--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -109,11 +109,11 @@ export class InferenceSession implements InferenceSessionInterface {
     const returnValue: {[name: string]: OnnxValue} = {};
     for (const key in results) {
       if (Object.hasOwnProperty.call(results, key)) {
-        const tensorInResults = results[key];
-        if (tensorInResults instanceof Tensor) {
-          returnValue[key] = tensorInResults;
+        const result = results[key];
+        if (result instanceof Tensor) {
+          returnValue[key] = result;
         } else {
-          returnValue[key] = new Tensor(results[key].type, results[key].data, results[key].dims);
+          returnValue[key] = new Tensor(result.type, result.data, result.dims);
         }
       }
     }

--- a/js/common/lib/inference-session-impl.ts
+++ b/js/common/lib/inference-session-impl.ts
@@ -109,7 +109,12 @@ export class InferenceSession implements InferenceSessionInterface {
     const returnValue: {[name: string]: OnnxValue} = {};
     for (const key in results) {
       if (Object.hasOwnProperty.call(results, key)) {
-        returnValue[key] = new Tensor(results[key].type, results[key].data, results[key].dims);
+        const tensorInResults = results[key];
+        if (tensorInResults instanceof Tensor) {
+          returnValue[key] = tensorInResults;
+        } else {
+          returnValue[key] = new Tensor(results[key].type, results[key].data, results[key].dims);
+        }
       }
     }
     return returnValue;

--- a/js/common/lib/tensor-factory-impl.ts
+++ b/js/common/lib/tensor-factory-impl.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {GpuBufferDataTypes, OptionsDimensions, OptionsFormat, OptionsNormalizationParameters, OptionsTensorFormat, OptionsTensorLayout, TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions, TextureDataTypes} from './tensor-factory.js';
+import {OptionsDimensions, OptionsFormat, OptionsNormalizationParameters, OptionsTensorFormat, OptionsTensorLayout, TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions} from './tensor-factory.js';
 import {Tensor} from './tensor-impl.js';
 import {Tensor as TensorInterface} from './tensor.js';
 
@@ -239,7 +239,7 @@ export const tensorFromImage = async(
 /**
  * implementation of Tensor.fromTexture().
  */
-export const tensorFromTexture = <T extends TextureDataTypes>(
+export const tensorFromTexture = <T extends TensorInterface.TextureDataTypes>(
     texture: TensorInterface.TextureType, options: TensorFromTextureOptions<T>): Tensor => {
   const {width, height, download, dispose} = options;
   // Always assume RGBAF32. TODO: support different texture format
@@ -250,7 +250,7 @@ export const tensorFromTexture = <T extends TextureDataTypes>(
 /**
  * implementation of Tensor.fromGpuBuffer().
  */
-export const tensorFromGpuBuffer = <T extends GpuBufferDataTypes>(
+export const tensorFromGpuBuffer = <T extends TensorInterface.GpuBufferDataTypes>(
     gpuBuffer: TensorInterface.GpuBufferType, options: TensorFromGpuBufferOptions<T>): Tensor => {
   const {dataType, dims, download, dispose} = options;
   return new Tensor({location: 'gpu-buffer', type: dataType ?? 'float32', gpuBuffer, dims, download, dispose});
@@ -259,6 +259,6 @@ export const tensorFromGpuBuffer = <T extends GpuBufferDataTypes>(
 /**
  * implementation of Tensor.fromPinnedBuffer().
  */
-export const tensorFromPinnedBuffer = <T extends Exclude<TensorInterface.Type, 'string'>>(
+export const tensorFromPinnedBuffer = <T extends TensorInterface.CpuPinnedDataTypes>(
     type: T, buffer: TensorInterface.DataTypeMap[T], dims?: readonly number[]): Tensor =>
     new Tensor({location: 'cpu-pinned', type, data: buffer, dims: dims ?? [buffer.length]});

--- a/js/common/lib/tensor-factory.ts
+++ b/js/common/lib/tensor-factory.ts
@@ -40,14 +40,9 @@ interface GpuResourceConstructorParameters<T extends Tensor.Type> {
 }
 
 /**
- * supported data types for constructing a tensor from a pinned CPU buffer
- */
-export type CpuPinnedDataTypes = Exclude<Tensor.Type, 'string'>;
-
-/**
  * represent the parameter for constructing a tensor from a pinned CPU buffer
  */
-export interface CpuPinnedConstructorParameters<T extends CpuPinnedDataTypes = CpuPinnedDataTypes> extends
+export interface CpuPinnedConstructorParameters<T extends Tensor.CpuPinnedDataTypes = Tensor.CpuPinnedDataTypes> extends
     CommonConstructorParameters<T> {
   /**
    * Specify the location of the data to be 'cpu-pinned'.
@@ -60,14 +55,9 @@ export interface CpuPinnedConstructorParameters<T extends CpuPinnedDataTypes = C
 }
 
 /**
- * supported data types for constructing a tensor from a WebGL texture
- */
-export type TextureDataTypes = 'float32';
-
-/**
  * represent the parameter for constructing a tensor from a WebGL texture
  */
-export interface TextureConstructorParameters<T extends TextureDataTypes = TextureDataTypes> extends
+export interface TextureConstructorParameters<T extends Tensor.TextureDataTypes = Tensor.TextureDataTypes> extends
     CommonConstructorParameters<T>, GpuResourceConstructorParameters<T> {
   /**
    * Specify the location of the data to be 'texture'.
@@ -80,14 +70,9 @@ export interface TextureConstructorParameters<T extends TextureDataTypes = Textu
 }
 
 /**
- * supported data types for constructing a tensor from a WebGPU buffer
- */
-export type GpuBufferDataTypes = 'float32'|'int32';
-
-/**
  * represent the parameter for constructing a tensor from a WebGPU buffer
  */
-export interface GpuBufferConstructorParameters<T extends GpuBufferDataTypes = GpuBufferDataTypes> extends
+export interface GpuBufferConstructorParameters<T extends Tensor.GpuBufferDataTypes = Tensor.GpuBufferDataTypes> extends
     CommonConstructorParameters<T>, GpuResourceConstructorParameters<T> {
   /**
    * Specify the location of the data to be 'gpu-buffer'.
@@ -203,11 +188,11 @@ export interface TensorFromUrlOptions extends OptionsDimensions, OptionResizedDi
 export interface TensorFromImageBitmapOptions extends OptionResizedDimensions, OptionsTensorFormat, OptionsTensorLayout,
                                                       OptionsTensorDataType, OptionsNormalizationParameters {}
 
-export interface TensorFromTextureOptions<T extends TextureDataTypes> extends
+export interface TensorFromTextureOptions<T extends Tensor.TextureDataTypes> extends
     Required<OptionsDimensions>, OptionsFormat, GpuResourceConstructorParameters<T>/* TODO: add more */ {}
 
-export interface TensorFromGpuBufferOptions<T extends GpuBufferDataTypes> extends Pick<Tensor, 'dims'>,
-                                                                                  GpuResourceConstructorParameters<T> {
+export interface TensorFromGpuBufferOptions<T extends Tensor.GpuBufferDataTypes> extends
+    Pick<Tensor, 'dims'>, GpuResourceConstructorParameters<T> {
   /**
    * Describes the data type of the tensor.
    */
@@ -298,7 +283,7 @@ export interface TensorFactory {
    *
    * @returns a tensor object
    */
-  fromTexture<T extends TextureDataTypes = 'float32'>(
+  fromTexture<T extends Tensor.TextureDataTypes = 'float32'>(
       texture: Tensor.TextureType, options: TensorFromTextureOptions<T>): TypedTensor<'float32'>;
 
   /**
@@ -318,7 +303,7 @@ export interface TensorFactory {
    *
    * @returns a tensor object
    */
-  fromGpuBuffer<T extends GpuBufferDataTypes = 'float32'>(
+  fromGpuBuffer<T extends Tensor.GpuBufferDataTypes>(
       buffer: Tensor.GpuBufferType, options: TensorFromGpuBufferOptions<T>): TypedTensor<T>;
 
   /**

--- a/js/common/lib/tensor-impl.ts
+++ b/js/common/lib/tensor-impl.ts
@@ -4,7 +4,7 @@
 import {tensorToDataURL, tensorToImageData} from './tensor-conversion-impl.js';
 import {TensorToDataUrlOptions, TensorToImageDataOptions} from './tensor-conversion.js';
 import {tensorFromGpuBuffer, tensorFromImage, tensorFromPinnedBuffer, tensorFromTexture} from './tensor-factory-impl.js';
-import {CpuPinnedConstructorParameters, CpuPinnedDataTypes, GpuBufferConstructorParameters, GpuBufferDataTypes, TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions, TextureConstructorParameters} from './tensor-factory.js';
+import {CpuPinnedConstructorParameters, GpuBufferConstructorParameters, TensorFromGpuBufferOptions, TensorFromImageBitmapOptions, TensorFromImageDataOptions, TensorFromImageElementOptions, TensorFromTextureOptions, TensorFromUrlOptions, TextureConstructorParameters} from './tensor-factory.js';
 import {checkBigInt, NUMERIC_TENSOR_TYPE_TO_TYPEDARRAY_MAP, NUMERIC_TENSOR_TYPEDARRAY_TO_TYPE_MAP, SupportedTypedArray, SupportedTypedArrayConstructors} from './tensor-impl-type-mapping.js';
 import {calculateSize, tensorReshape} from './tensor-utils-impl.js';
 import {Tensor as TensorInterface} from './tensor.js';
@@ -102,7 +102,8 @@ export class Tensor implements TensorInterface {
           break;
         }
         case 'gpu-buffer': {
-          if (type !== 'float32' && type !== 'int32') {
+          if ((type !== 'float32' && type !== 'float16' && type !== 'int32' && type !== 'int64' && type !== 'uint32' &&
+               type !== 'bool')) {
             throw new TypeError(`unsupported type "${type}" to create tensor from gpu buffer`);
           }
           this.gpuBufferData = arg0.gpuBuffer;
@@ -240,16 +241,17 @@ export class Tensor implements TensorInterface {
     return tensorFromImage(image, options);
   }
 
-  static fromTexture(texture: TensorTextureType, options: TensorFromTextureOptions<'float32'>): TensorInterface {
+  static fromTexture<T extends TensorInterface.TextureDataTypes>(
+      texture: TensorTextureType, options: TensorFromTextureOptions<T>): TensorInterface {
     return tensorFromTexture(texture, options);
   }
 
-  static fromGpuBuffer<T extends GpuBufferDataTypes>(
+  static fromGpuBuffer<T extends TensorInterface.GpuBufferDataTypes>(
       gpuBuffer: TensorGpuBufferType, options: TensorFromGpuBufferOptions<T>): TensorInterface {
     return tensorFromGpuBuffer(gpuBuffer, options);
   }
 
-  static fromPinnedBuffer<T extends CpuPinnedDataTypes>(
+  static fromPinnedBuffer<T extends TensorInterface.CpuPinnedDataTypes>(
       type: T, buffer: TensorInterface.DataTypeMap[T], dims?: readonly number[]): Tensor {
     return tensorFromPinnedBuffer(type, buffer, dims);
   }

--- a/js/common/lib/tensor.ts
+++ b/js/common/lib/tensor.ts
@@ -106,9 +106,19 @@ export declare namespace Tensor {
   type ElementType = ElementTypeMap[Type];
 
   /**
+   * supported data types for constructing a tensor from a pinned CPU buffer
+   */
+  export type CpuPinnedDataTypes = Exclude<Tensor.Type, 'string'>;
+
+  /**
    * type alias for WebGL texture
    */
   export type TextureType = WebGLTexture;
+
+  /**
+   * supported data types for constructing a tensor from a WebGL texture
+   */
+  export type TextureDataTypes = 'float32';
 
   /**
    * type alias for WebGPU buffer
@@ -121,6 +131,11 @@ export declare namespace Tensor {
    * for more info see https://github.com/gpuweb/types/issues/127
    */
   export type GpuBufferType = {size: number; mapState: 'unmapped' | 'pending' | 'mapped'};
+
+  /**
+   * supported data types for constructing a tensor from a WebGPU buffer
+   */
+  export type GpuBufferDataTypes = 'float32'|'float16'|'int32'|'int64'|'uint32'|'bool';
 
   /**
    * represent where the tensor data is stored


### PR DESCRIPTION
### Description
This PR contains a few changes in /js/common/ to support a coming PR for a full implementation of webgpu IO binding.

- allows pass-through if value is already a Tensor instance in return value of  `handler.run()` called by `InferenceSession.run()` (inference-session-impl.ts). Specifically, onnxruntime-node and onnxruntime-react-native uses native bindings to generate a Tensor-like object so we need to create a real Tensor instance here; for onnxruntime-web the return value is already a Tensor instance.

- adds new types for GPU buffer supported types: `'float32'|'int32'` -> `'float32'|'float16'|'int32'|'int64'|'uint32'|'bool'`

- exposes types `GpuBufferDataTypes` together with `CpuPinnedDataTypes` and `TextureDataTypes` as exported