### PR TITLE
OrtMemoryInfo: support new name "WebGPU_Buffer"

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -48,6 +48,7 @@ constexpr const char* HIP = "Hip";
 constexpr const char* HIP_PINNED = "HipPinned";
 constexpr const char* OpenVINO_CPU = "OpenVINO_CPU";
 constexpr const char* OpenVINO_GPU = "OpenVINO_GPU";
+constexpr const char* WEBGPU_BUFFER = "WebGPU_Buffer";
 
 constexpr size_t kAllocAlignment = 256;
 

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -137,26 +137,18 @@ ORT_API_STATUS_IMPL(OrtApis::CreateMemoryInfo, _In_ const char* name1, enum OrtA
                     enum OrtMemType mem_type1, _Outptr_ OrtMemoryInfo** out) {
   if (strcmp(name1, onnxruntime::CPU) == 0) {
     *out = new OrtMemoryInfo(onnxruntime::CPU, type, OrtDevice(), id1, mem_type1);
-  } else if (strcmp(name1, onnxruntime::CUDA) == 0) {
+  } else if (strcmp(name1, onnxruntime::CUDA) == 0 ||
+             strcmp(name1, onnxruntime::OpenVINO_GPU) == 0 ||
+             strcmp(name1, onnxruntime::DML) == 0 ||
+             strcmp(name1, onnxruntime::HIP) == 0 ||
+             strcmp(name1, onnxruntime::WEBGPU_BUFFER) == 0) {
     *out = new OrtMemoryInfo(
-        onnxruntime::CUDA, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
+        name1, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
         mem_type1);
   } else if (strcmp(name1, onnxruntime::CUDA_PINNED) == 0) {
     *out = new OrtMemoryInfo(
         onnxruntime::CUDA_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, static_cast<OrtDevice::DeviceId>(id1)),
         id1, mem_type1);
-  } else if (strcmp(name1, onnxruntime::OpenVINO_GPU) == 0) {
-    *out = new OrtMemoryInfo(
-        onnxruntime::OpenVINO_GPU, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)),
-        id1, mem_type1);
-  } else if (strcmp(name1, onnxruntime::DML) == 0) {
-    *out = new OrtMemoryInfo(
-        onnxruntime::DML, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)),
-        id1, mem_type1);
-  } else if (strcmp(name1, onnxruntime::HIP) == 0) {
-    *out = new OrtMemoryInfo(
-        onnxruntime::HIP, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
-        mem_type1);
   } else if (strcmp(name1, onnxruntime::HIP_PINNED) == 0) {
     *out = new OrtMemoryInfo(
         onnxruntime::HIP_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, static_cast<OrtDevice::DeviceId>(id1)),


### PR DESCRIPTION
### Description
Add new name "WebGPU_Buffer" to OrtMemoryInfo.

This is one of the prerequisites for supporting IO binding for WebGPU buffer in onnxruntime-web.

list of prerequisites PRs:
#17465
#17469 (this one)