### PR TITLE
[js/web] release session after use in npm test

### DIFF
--- a/js/web/test/test-main.ts
+++ b/js/web/test/test-main.ts
@@ -110,9 +110,9 @@ for (const group of ORT_WEB_TEST_CONFIG.model) {
               test, ORT_WEB_TEST_CONFIG.profile, ORT_WEB_TEST_CONFIG.options.sessionOptions);
         });
 
-        after('release session', () => {
+        after('release session', async () => {
           if (context) {
-            context.release();
+            await context.release();
           }
         });
 

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -210,11 +210,12 @@ export class ModelTestContext {
     Logger.verbose('TestRunner.Perf', '***Perf Data End');
   }
 
-  release(): void {
+  async release(): Promise<void> {
     if (this.profile) {
       this.session.endProfiling();
     }
     this.logPerfData();
+    await this.session.release();
   }
 
   /**


### PR DESCRIPTION
### Description
release session after use in npm test.

This is one of the prerequisites for supporting IO binding for WebGPU buffer in onnxruntime-web.

list of prerequisites PRs:
#17465
#17469
#17470 (this one)