### PR TITLE
update build_jsep.bat to add release build flags

### DIFF
--- a/js/build_jsep.bat
+++ b/js/build_jsep.bat
@@ -22,7 +22,7 @@ if ["%~1"]==["d"] (
 )
 if ["%~1"]==["r"] (
     set CONFIG=Release
-    set CONFIG_EXTRA_FLAG=
+    set CONFIG_EXTRA_FLAG=--enable_wasm_api_exception_catching --disable_rtti
     goto :arg2
 )
 echo Invalid configuration "%~1", must be "d"(Debug) or "r"(Release)


### PR DESCRIPTION
### Description
flags `--enable_wasm_api_exception_catching --disable_rtti` are used in release build, so fix the build_jsep.bat script to make it more consistent with CI.