### PR TITLE
[TensorRT EP] Disable QDQ optimization when TensorRT EP is enabled

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1420,7 +1420,7 @@ if (onnxruntime_USE_TENSORRT)
     endif()
   endif()
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${FS_STDLIB})
-  add_compile_options(ENABLE_TENSORRT)
+  add_compile_definitions(ENABLE_TENSORRT)
 endif()
 
 if (onnxruntime_USE_MIGRAPHX)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1420,6 +1420,7 @@ if (onnxruntime_USE_TENSORRT)
     endif()
   endif()
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${FS_STDLIB})
+  add_compile_options(ENABLE_TENSORRT)
 endif()
 
 if (onnxruntime_USE_MIGRAPHX)

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -209,7 +209,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
         // We need to remove the duplicated QDQ Pairs before all other GraphTransformation.
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
-      
+
       // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
       // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by
       // default, CSE will not merge them, because the different initializers are represented by different NodeArg.
@@ -248,6 +248,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       // We will also benefit by using a local allocator as we don't need to pass allocator as parameter for EP API refactor
       AllocatorPtr cpu_allocator = std::make_shared<CPUAllocator>();
       transformers.emplace_back(std::make_unique<TransposeOptimizer>(std::move(cpu_allocator)));
+#endif
     } break;
 
     case TransformerLevel::Level2: {

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -248,7 +248,6 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       // We will also benefit by using a local allocator as we don't need to pass allocator as parameter for EP API refactor
       AllocatorPtr cpu_allocator = std::make_shared<CPUAllocator>();
       transformers.emplace_back(std::make_unique<TransposeOptimizer>(std::move(cpu_allocator)));
-#endif
     } break;
 
     case TransformerLevel::Level2: {

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -206,7 +206,6 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
         // We need to remove the duplicated QDQ Pairs before all other GraphTransformation.
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
-#endif
 
       // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
       // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -201,12 +201,13 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
 
       // no filtering on execution provider for L1 optimizations as they only use official ONNX operators
 
-#if !defined(ENABLE_TENSORRT)
+#ifndef ENABLE_TENSORRT
       if (session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableDoubleQDQRemover, "0") == "0") {
         // We need to remove the duplicated QDQ Pairs before all other GraphTransformation.
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
-
+#endif
+      
       // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
       // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by
       // default, CSE will not merge them, because the different initializers are represented by different NodeArg.

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -183,8 +183,12 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
     const IExecutionProvider& cpu_execution_provider, /*required by constant folding*/
     const InlinedHashSet<std::string>& rules_and_transformers_to_disable) {
   InlinedVector<std::unique_ptr<GraphTransformer>> transformers;
+#ifdef ENABLE_TENSORRT
+  const bool disable_quant_qdq = true;
+#else 
   const bool disable_quant_qdq =
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableQuantQDQ, "0") == "1";
+#endif
 #ifndef DISABLE_CONTRIB_OPS
   const InlinedHashSet<std::string_view> cpu_ep = {onnxruntime::kCpuExecutionProvider};
 #endif
@@ -201,12 +205,10 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
 
       // no filtering on execution provider for L1 optimizations as they only use official ONNX operators
 
-#ifndef ENABLE_TENSORRT
       if (session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableDoubleQDQRemover, "0") == "0") {
         // We need to remove the duplicated QDQ Pairs before all other GraphTransformation.
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
-#endif
       
       // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
       // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -185,7 +185,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
   InlinedVector<std::unique_ptr<GraphTransformer>> transformers;
 #ifdef ENABLE_TENSORRT
   const bool disable_quant_qdq = true;
-#else 
+#else
   const bool disable_quant_qdq =
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableQuantQDQ, "0") == "1";
 #endif

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -201,10 +201,12 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
 
       // no filtering on execution provider for L1 optimizations as they only use official ONNX operators
 
+#if !defined(ENABLE_TENSORRT)
       if (session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableDoubleQDQRemover, "0") == "0") {
         // We need to remove the duplicated QDQ Pairs before all other GraphTransformation.
         transformers.emplace_back(std::make_unique<DoubleQDQPairsRemover>());
       }
+#endif
 
       // Put ConstantSharing before CommonSubexpressionElimination by intention as it can create more opportunities for
       // CSE. For example, if A and B nodes both do Add operation with a same value but different initializers, by


### PR DESCRIPTION
### Description
Disable onnx QDQ optimization when TensorRT EP is enabled, as there are overlaps between ONNXRT and TensorRT’s built-in optimizations.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/onnxruntime/issues/17312
This QDQ model user can't initiate trt engine build, unless ONNX graph optimization is disabled (trtexec can build trt engine)

