### PR TITLE
[js] update prepack script to use exact version

### DIFF
--- a/js/node/script/prepack.ts
+++ b/js/node/script/prepack.ts
@@ -11,7 +11,7 @@ function updatePackageJson() {
   const packageCommon = fs.readJSONSync(commonPackageJsonPath);
   const packageSelf = fs.readJSONSync(selfPackageJsonPath);
   const version = packageCommon.version;
-  packageSelf.dependencies['onnxruntime-common'] = `~${version}`;
+  packageSelf.dependencies['onnxruntime-common'] = `${version}`;
   fs.writeJSONSync(selfPackageJsonPath, packageSelf, {spaces: 2});
   console.log('=== finished updating package.json.');
 }

--- a/js/react_native/scripts/prepack.ts
+++ b/js/react_native/scripts/prepack.ts
@@ -18,7 +18,7 @@ function updatePackageJson() {
     delete packageSelf.dependencies['onnxruntime-common'];
   } else {
     const version = packageCommon.version;
-    packageSelf.dependencies['onnxruntime-common'] = `~${version}`;
+    packageSelf.dependencies['onnxruntime-common'] = `${version}`;
   }
   fs.writeJSONSync(selfPackageJsonPath, packageSelf, {spaces: 2});
   console.log('=== finished updating package.json.');

--- a/js/web/script/prepack.ts
+++ b/js/web/script/prepack.ts
@@ -11,7 +11,7 @@ function updatePackageJson() {
   const packageCommon = fs.readJSONSync(commonPackageJsonPath);
   const packageSelf = fs.readJSONSync(selfPackageJsonPath);
   const version = packageCommon.version;
-  packageSelf.dependencies['onnxruntime-common'] = `~${version}`;
+  packageSelf.dependencies['onnxruntime-common'] = `${version}`;
   fs.writeJSONSync(selfPackageJsonPath, packageSelf, {spaces: 2});
   console.log('=== finished updating package.json.');
 }


### PR DESCRIPTION
### Description
update prepack script to use exact version.

the prepack script for onnxruntime-node, onnxruntime-web and onnxruntime-react-native is used to update their referencing version of dependency "onnxruntime-common".

Previously "~" (tilde symbol) is used. This may cause NPM choose an older version (if the old version matches the version requirement and was previously installed already so hit the cache). see also https://semver.npmjs.com/. [This build](https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1134671&view=results) is caused by this issue.

