### PR TITLE
update acpt image for the training ci nightly

### DIFF
--- a/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/orttraining-linux-nightly-ortmodule-test-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         --rm \
         --volume $(Build.SourcesDirectory)/orttraining/orttraining/test/python:/onnxruntime_src \
         --volume $(Build.SourcesDirectory)/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage1/requirements_torch_nightly:/requirements_torch_nightly \
-        ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu118-py38-torch210dev \
+        ptebic.azurecr.io/internal/aifx/acpt/nightly-ubuntu-cuda-torch-dev \
          bash -c "python3 -m pip install -r /requirements_torch_nightly/requirements.txt && python3 -m pytest -sv /onnxruntime_src/orttraining_test_ortmodule_api.py"
     displayName: 'Run ORTModule Tests'
     condition: succeededOrFailed()


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

The name of nightly ACPT image has been updated to `ptebic.azurecr.io/internal/aifx/acpt/nightly-ubuntu-cuda-torch-dev`

 As the previous image alias had `cu118`, `torch210dev` or `py38`, any version update will break the training nightly pipeline



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Using constant image alias to avoid pipeline failure. 

