### PR TITLE
Update optimize_pipeline.py

### DIFF
--- a/onnxruntime/python/tools/transformers/models/stable_diffusion/optimize_pipeline.py
+++ b/onnxruntime/python/tools/transformers/models/stable_diffusion/optimize_pipeline.py
@@ -29,11 +29,11 @@ from typing import List
 
 import coloredlogs
 import onnx
-from fusion_options import FusionOptions
-from onnx_model_clip import ClipOnnxModel
-from onnx_model_unet import UnetOnnxModel
-from onnx_model_vae import VaeOnnxModel
-from optimizer import optimize_by_onnxruntime, optimize_model
+from onnxruntime.transformers.fusion_options import FusionOptions
+from onnxruntime.transformers.onnx_model_clip import ClipOnnxModel
+from onnxruntime.transformers.onnx_model_unet import UnetOnnxModel
+from onnxruntime.transformers.onnx_model_vae import VaeOnnxModel
+from onnxruntime.transformers.optimizer import optimize_by_onnxruntime, optimize_model
 from packaging import version
 
 import onnxruntime


### PR DESCRIPTION
Fixed the import statements causing the script not to run in standalone mode

### Description
<!-- Describe your changes. -->

In the Stable Diffusion optimize pipeline, few modules were imported, without providing the relative structure, causing the code not to work as intended, when running it standalone.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

After this change, the optimize pipeline can be called directly, without any issue, rather calling via the module.


