### PR TITLE
[TensorRT EP] Fallback to CUDA EP if it's explicitly assigned

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -420,8 +420,10 @@ class InferenceSession(Session):
         except (ValueError, RuntimeError) as e:
             if self._enable_fallback:
                 try:
+                    print("*************** EP Error ***************")
                     print(f"EP Error {e} when using {providers}")
                     print(f"Falling back to {self._fallback_providers} and retrying.")
+                    print("****************************************")
                     self._create_inference_session(self._fallback_providers, None)
                     # Fallback only once.
                     self.disable_fallback()

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -444,8 +444,14 @@ class InferenceSession(Session):
                 for provider in providers
             ):
                 self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        # MIGraphX can fall back to ROCM if it's explicitly assigned. All others fall back to CPU.
         elif "MIGraphXExecutionProvider" in available_providers:
-            self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
+            if any(
+                provider == "ROCMExecutionProvider"
+                or (isinstance(provider, tuple) and provider[0] == "ROCMExecutionProvider")
+                for provider in providers
+            ):
+                self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
         else:
             self._fallback_providers = ["CPUExecutionProvider"]
 

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -436,7 +436,7 @@ class InferenceSession(Session):
 
         # Tensorrt can fall back to CUDA if it's explicitly assigned. All others fall back to CPU.
         if "TensorrtExecutionProvider" in available_providers:
-            if "CUDAExecutionProvider" in available_providers:
+            if any(provider == "CUDAExecutionProvider" or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider") for provider in providers):
                 self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
         elif "MIGraphXExecutionProvider" in available_providers:
             self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -438,7 +438,11 @@ class InferenceSession(Session):
 
         # Tensorrt can fall back to CUDA if it's explicitly assigned. All others fall back to CPU.
         if "TensorrtExecutionProvider" in available_providers:
-            if any(provider == "CUDAExecutionProvider" or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider") for provider in providers):
+            if any(
+                provider == "CUDAExecutionProvider"
+                or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider")
+                for provider in providers
+            ):
                 self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
         elif "MIGraphXExecutionProvider" in available_providers:
             self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -444,6 +444,8 @@ class InferenceSession(Session):
                 for provider in providers
             ):
                 self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            else:
+                self._fallback_providers = ["CPUExecutionProvider"]
         # MIGraphX can fall back to ROCM if it's explicitly assigned. All others fall back to CPU.
         elif "MIGraphXExecutionProvider" in available_providers:
             if any(
@@ -452,6 +454,8 @@ class InferenceSession(Session):
                 for provider in providers
             ):
                 self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
+            else:
+                self._fallback_providers = ["CPUExecutionProvider"]
         else:
             self._fallback_providers = ["CPUExecutionProvider"]
 

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -434,9 +434,10 @@ class InferenceSession(Session):
     def _create_inference_session(self, providers, provider_options, disabled_optimizers=None):
         available_providers = C.get_available_providers()
 
-        # Tensorrt can fall back to CUDA. All others fall back to CPU.
+        # Tensorrt can fall back to CUDA if it's explicitly assigned. All others fall back to CPU.
         if "TensorrtExecutionProvider" in available_providers:
-            self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            if "CUDAExecutionProvider" in available_providers:
+                self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
         elif "MIGraphXExecutionProvider" in available_providers:
             self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
         else:


### PR DESCRIPTION
### Description
* TensorRT EP can fall back to CUDA EP if it's explicitly assigned
* MIGraphX can fall back to ROCM if it's explicitly assigned

Test cases:
| When user specifies providers=                               | self._fallback_providers=                         |
| ------------------------------------------------------------ | ------------------------------------------------- |
| ["TensorrtExecutionProvider", "CUDAExecutionProvider"]       | ["CUDAExecutionProvider", "CPUExecutionProvider"] |
| ["TensorrtExecutionProvider",("CUDAExecutionProvider", cuda_options)] | ["CUDAExecutionProvider", "CPUExecutionProvider"] |
| ["TensorrtExecutionProvider"]                                | ["CPUExecutionProvider"]                          |
| [("TensorrtExecutionProvider", trt_options)]                 | ["CPUExecutionProvider"]                          |
| [("TensorrtExecutionProvider", trt_options), ("CUDAExecutionProvider", cuda_options)] | ["CUDAExecutionProvider", "CPUExecutionProvider"] |
| ["TensorrtExecutionProvider", "CPUExecutionProvider"]        | ["CPUExecutionProvider"]                          |





### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Apply comments of https://github.com/microsoft/onnxruntime/issues/17394 and unify the logic to [MIGraphX, ROCM]

