### PR TITLE
[website] Updated ORT-training installation instructions

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -25,8 +25,8 @@ Details on OS versions, compilers, language versions, dependent libraries, etc c
 * All builds require the English language package with `en_US.UTF-8` locale. On Linux, install [language-pack-en package](https://packages.ubuntu.com/search?keywords=language-pack-en)
 by running `locale-gen en_US.UTF-8` and `update-locale LANG=en_US.UTF-8`
 
-* Windows builds require [Visual C++ 2019 runtime](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads). The latest version is recommended. 
- 
+* Windows builds require [Visual C++ 2019 runtime](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads). The latest version is recommended.
+
 ## Python Installs
 
 ### Install ONNX Runtime (ORT)
@@ -185,7 +185,8 @@ If the pre-built training package supports your model but is too large, you can 
 ### Offline Phase - Prepare for Training
 
 ```bash
-pip install onnxruntime-training
+python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0
+pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu
 ```
 
 ### Training Phase - On-Device Training
@@ -275,12 +276,12 @@ dependencies {
     <td>iOS</td>
     <td>C, C++</td>
     <td><b>CocoaPods: onnxruntime-training-c</b></td>
-    <td> 
+    <td>
       <ul>
         <li>In your CocoaPods <code>Podfile</code>, add the <code>onnxruntime-training-c</code> pod:
           <pre>
 use_frameworks!
-pod 'onnxruntime-training-c' 
+pod 'onnxruntime-training-c'
           </pre>
         </li>
         <li>Run <code>pod install</code>.</li>
@@ -297,7 +298,7 @@ pod 'onnxruntime-training-c'
           In your CocoaPods <code>Podfile</code>, add the <code>onnxruntime-training-objc</code> pod:
             <pre>
 use_frameworks!
-pod 'onnxruntime-training-objc' 
+pod 'onnxruntime-training-objc'
             </pre>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -709,8 +709,8 @@ Console.WriteLine(outputs[0].AsTensor<float>()[0]);</code>
 												aria-describedby="ot_decriptionHardwareAcceleration">
 												<div class="row ot_hardwareAcceleration">
 													<div class="col r-option version" role="option" tabindex="0"
-														aria-selected="true" id="ot_CUDA">
-														<span><abbr>CUDA</abbr></span>
+														aria-selected="true" id="ot_CUDA118">
+														<span><abbr>CUDA 11.8</abbr></span>
 													</div>
 													<div class="col r-option version" role="option" tabindex="-1"
 														aria-selected="false" id="ot_ROCm">

--- a/js/script.js
+++ b/js/script.js
@@ -583,7 +583,7 @@ function ot_buildMatcher() {
 var ot_validCombos = {
 
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_stable":
-    "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_stable_<b>&lt;cu_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
+    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_nightly":
     "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",

--- a/js/script.js
+++ b/js/script.js
@@ -600,10 +600,10 @@ var ot_validCombos = {
     "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_stable":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training",
 
     "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_stable":
     "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",

--- a/js/script.js
+++ b/js/script.js
@@ -150,7 +150,7 @@ ot_hardwareAcceleration.on("keypress keyup", function (event) {
 //     var ot_userOsOption = document.getElementById(ot_opts.ot_os);
 //     if (userOsOption) {
 //         selectedOption(os, userOsOption, "os");
-        
+
 //     }
 //     if (ot_userOsOption) {
 //         ot_selectedOption(ot_os, ot_userOsOption, "ot_os");
@@ -172,7 +172,7 @@ ot_hardwareAcceleration.on("keypress keyup", function (event) {
 
 // determine os based on location hash
 // function getAnchorSelectedOS() {
-//     var anchor = location.hash; 
+//     var anchor = location.hash;
 //     var ANCHOR_REGEX = /^#[^ ]+$/;
 //     // Look for anchor in the href
 //     if (!ANCHOR_REGEX.test(anchor)) {
@@ -193,9 +193,9 @@ function checkValidity(){
     var current_lang = opts['language'];
     var current_arch = opts['architecture'];
     var current_hw = opts['hardwareAcceleration'];
-    
+
     var valid = Object.getOwnPropertyNames(validCombos);
-  
+
     //os section
     for(var i =0; i<os.length; i++){
         //disable other selections once item in category selected
@@ -207,11 +207,11 @@ function checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(os[i].id)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && os[i].id!=current_os){
-            $(os[i]).addClass("gray"); 
+            $(os[i]).addClass("gray");
         }
     }
 
@@ -221,16 +221,16 @@ function checkValidity(){
             //  if(language[i].id!=current_lang && current_lang!=''){
             //     $(language[i]).addClass("gray");
             //      continue;
-            //   }   
+            //   }
             var isvalidcombo=false;
             for(var k=0; k<valid.length;k++){
                 if(valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(language[i].id)!=-1 && valid[k].indexOf(current_hw)!=-1){
                     isvalidcombo=true;
-                    break;       
+                    break;
                 }
             }
             if(isvalidcombo==false && language[i].id!=current_lang){
-                $(language[i]).addClass("gray"); 
+                $(language[i]).addClass("gray");
             }
         }
 
@@ -245,11 +245,11 @@ function checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(architecture[i].id)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && architecture[i].id!=current_arch){
-            $(architecture[i]).addClass("gray"); 
+            $(architecture[i]).addClass("gray");
         }
     }
 
@@ -261,22 +261,22 @@ function checkValidity(){
         //       continue;
         // }
             var isvalidcombo=false;
-    
+
 
             //go thru all valid options
             for(var k=0; k<valid.length;k++){
-   
+
                 if(valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(hardwareAcceleration[i].id)!=-1){
                     isvalidcombo=true;
-                    break;       
+                    break;
                 }
 
             }
 
             if(isvalidcombo==false && hardwareAcceleration[i].id!=current_hw){
-                $(hardwareAcceleration[i]).addClass("gray"); 
+                $(hardwareAcceleration[i]).addClass("gray");
             }
-        } 
+        }
 }
 
 function ot_checkValidity(){
@@ -286,7 +286,7 @@ function ot_checkValidity(){
     var current_arch = ot_opts['ot_architecture'];
     var current_hw = ot_opts['ot_hardwareAcceleration'];
     var current_build = ot_opts['ot_build'];
-    
+
     var valid = Object.getOwnPropertyNames(ot_validCombos);
 
     // scenario section
@@ -295,11 +295,11 @@ function ot_checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(ot_scenario[i].id)!=-1 && valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1 && valid[k].indexOf(current_build)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && ot_scenario[i].id!=current_scenario){
-            $(ot_scenario[i]).addClass("gray"); 
+            $(ot_scenario[i]).addClass("gray");
         }
     }
 
@@ -314,11 +314,11 @@ function ot_checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(current_scenario)!=-1 && valid[k].indexOf(ot_os[i].id)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1 && valid[k].indexOf(current_build)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && ot_os[i].id!=current_os){
-            $(ot_os[i]).addClass("gray"); 
+            $(ot_os[i]).addClass("gray");
         }
     }
 
@@ -328,16 +328,16 @@ function ot_checkValidity(){
             //  if(ot_language[i].id!=current_lang && current_lang!=''){
             //     $(ot_language[i]).addClass("gray");
             //      continue;
-            //   }   
+            //   }
             var isvalidcombo=false;
             for(var k=0; k<valid.length;k++){
                 if(valid[k].indexOf(current_scenario)!=-1 && valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(ot_language[i].id)!=-1 && valid[k].indexOf(current_hw)!=-1 && valid[k].indexOf(current_build)!=-1){
                     isvalidcombo=true;
-                    break;       
+                    break;
                 }
             }
             if(isvalidcombo==false && ot_language[i].id!=current_lang){
-                $(ot_language[i]).addClass("gray"); 
+                $(ot_language[i]).addClass("gray");
             }
         }
 
@@ -352,11 +352,11 @@ function ot_checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(current_scenario)!=-1 && valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(ot_architecture[i].id)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1 && valid[k].indexOf(current_build)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && ot_architecture[i].id!=current_arch){
-            $(ot_architecture[i]).addClass("gray"); 
+            $(ot_architecture[i]).addClass("gray");
         }
     }
 
@@ -371,14 +371,14 @@ function ot_checkValidity(){
             for(var k=0; k<valid.length;k++){
                 if(valid[k].indexOf(current_scenario)!=-1 && valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(ot_hardwareAcceleration[i].id)!=-1 && valid[k].indexOf(current_build)!=-1){
                     isvalidcombo=true;
-                    break;       
+                    break;
                 }
             }
-            
+
             if(isvalidcombo==false && ot_hardwareAcceleration[i].id!=current_hw){
-                $(ot_hardwareAcceleration[i]).addClass("gray"); 
+                $(ot_hardwareAcceleration[i]).addClass("gray");
             }
-        } 
+        }
 
     // build section
     for(var i =0; i<ot_build.length; i++){
@@ -386,11 +386,11 @@ function ot_checkValidity(){
         for(var k=0; k<valid.length;k++){
             if(valid[k].indexOf(current_scenario)!=-1 && valid[k].indexOf(current_os)!=-1 && valid[k].indexOf(current_arch)!=-1 && valid[k].indexOf(current_lang)!=-1 && valid[k].indexOf(current_hw)!=-1 && valid[k].indexOf(ot_build[i].id)!=-1){
                 isvalidcombo=true;
-                break;       
+                break;
             }
         }
         if(isvalidcombo==false && ot_build[i].id!=current_build){
-            $(ot_build[i]).addClass("gray"); 
+            $(ot_build[i]).addClass("gray");
         }
     }
 }
@@ -398,7 +398,7 @@ function ot_checkValidity(){
 
 
 function mark_unsupported(selection, training){
-    
+
     if(training==true){
         for(var i = 0; i<selection.length; i++){
             if(selection[i].id.indexOf('ot_') != -1){
@@ -417,7 +417,7 @@ function mark_unsupported(selection, training){
 }
 
 function selectedOption(option, selection, category) {
-    //allow deselect   
+    //allow deselect
    if(selection.id==opts[category]){
        $(selection).removeClass("selected");
        $(selection).removeClass("unsupported");
@@ -436,7 +436,7 @@ function selectedOption(option, selection, category) {
 
    //get list of supported combos
    var isSupported = commandMessage(buildMatcher());
- 
+
    //mark unsupported for selected elements
    if (isSupported==false){
        mark_unsupported(all_selected, false);
@@ -476,7 +476,7 @@ function ot_selectedOption(option, selection, category) {
 
     var all_selected = document.getElementsByClassName('selected r-option');
     var isSupported = ot_commandMessage(ot_buildMatcher());
-  
+
     //mark unsupported combos
     if (isSupported==false){
         mark_unsupported(all_selected, true);
@@ -487,7 +487,7 @@ function ot_selectedOption(option, selection, category) {
         }
     }
 
-    ot_checkValidity();  
+    ot_checkValidity();
 
         //if full selection is valid, don't gray out other options
         if(ot_opts['scenario']!="" && ot_opts['os']!="" && ot_opts['architecture']!="" && ot_opts['hardwareAcceleration']!="" && ot_opts['language']!="" && isSupported==true){
@@ -509,7 +509,7 @@ function resetOptions(){
     for(var i=0; i<hardwareAcceleration.length;i++){
       $(hardwareAcceleration[i]).removeClass("gray");
     }
-  
+
   }
 
   function ot_resetOptions(){
@@ -559,9 +559,9 @@ function buildMatcher() {
         "," +
         opts.architecture +
         "," +
-        opts.hardwareAcceleration 
+        opts.hardwareAcceleration
     );
-    
+
 }
 
 function ot_buildMatcher() {
@@ -576,39 +576,38 @@ function ot_buildMatcher() {
         "," +
         ot_opts.ot_hardwareAcceleration +
         "," +
-        ot_opts.ot_build 
+        ot_opts.ot_build
     );
 }
 
 var ot_validCombos = {
-
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_stable":
-    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_nightly":
-    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_ROCm,ot_stable":
     "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_stable_<b>&lt;rocm_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*<a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
-    
+
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_ROCm,ot_nightly":
     "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_<b>&lt;rocm_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*<a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
-    
+
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_stable":
-    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_nightly":
-    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_stable":
     "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
-    
+
     "ot_linux,ot_on_device,ot_csharp,ot_X64,ot_CPU,ot_stable":
     "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Training' target='_blank'>Microsoft.ML.OnnxRuntime.Training</a>",
 
@@ -617,7 +616,7 @@ var ot_validCombos = {
 
     "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
-    
+
     "ot_linux,ot_on_device,ot_csharp,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
@@ -625,10 +624,10 @@ var ot_validCombos = {
     "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
     "ot_windows,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_windows,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_windows,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
@@ -647,7 +646,7 @@ var ot_validCombos = {
 
     "ot_windows,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
-    
+
     "ot_windows,ot_on_device,ot_csharp,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
@@ -656,7 +655,7 @@ var ot_validCombos = {
 
     "ot_android,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_stable":
     "Follow installation instructions from&nbsp;<a href='https://onnxruntime.ai/docs/install/#install-for-on-device-training' target='_blank'>here</a>",
-    
+
     "ot_android,ot_on_device,ot_java,ot_X64,ot_CPU,ot_stable":
     "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-training-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-training-android</a> using Maven/Gradle and refer to the instructions <a href='https://onnxruntime.ai/docs/install/#install-for-on-device-training' target='_blank'>here.</a>",
 
@@ -665,34 +664,33 @@ var ot_validCombos = {
 
     "ot_android,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_nightly":
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/android.html' target='_blank'>here</a>",
-    
+
     "ot_android,ot_on_device,ot_java,ot_X64,ot_CPU,ot_nightly":
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/android.html' target='_blank'>here</a>",
 
     "ot_mac,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_mac,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
+    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
 
     "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU,ot_stable":
         "Add 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ot_ios,ot_on_device,ot_c,ot_X64,ot_CPU,ot_stable":
         "Add 'onnxruntime-training-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ot_ios,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_stable":
         "Add 'onnxruntime-training-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU,ot_nightly":
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>",
-    
+
     "ot_ios,ot_on_device,ot_c,ot_X64,ot_CPU,ot_nightly":
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>",
-    
+
     "ot_ios,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_nightly":
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/ios.html' target='_blank'>here</a>",
-    
 };
 
 function ot_commandMessage(key) {
@@ -702,12 +700,12 @@ function ot_commandMessage(key) {
     if(ot_opts['ot_os']=='' || ot_opts['ot_scenario'] == '' || ot_opts['ot_architecture'] == '' || ot_opts['ot_language']=='' || ot_opts['ot_hardwareAcceleration'] == '' || ot_opts['ot_build'] == ''){
         $("#ot_command span").html(
             "Please select a combination of resources"
-        ) 
+        )
     }
     else if (!ot_validCombos.hasOwnProperty(key)) {
         $("#ot_command span").html(
             "This combination is not supported. De-select to make another selection."
-        ) 
+        )
         $("#ot_command").addClass("invalid");
         return false;
     }
@@ -720,7 +718,7 @@ function ot_commandMessage(key) {
 }
 
 var validCombos = {
-       
+
     "windows,C-API,X64,CUDA":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Gpu' target='_blank'>Microsoft.ML.OnnxRuntime.Gpu</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
@@ -735,7 +733,7 @@ var validCombos = {
 
     "linux,Python,ARM64,CUDA":
         "For Jetpack 4.4+, follow installation instructions from <a href='https://elinux.org/Jetson_Zoo#ONNX_Runtime' target='_blank'>here</a>",
-    
+
     "linux,C-API,X64,CUDA":
         "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
@@ -765,31 +763,31 @@ var validCombos = {
 
     "windows,C-API,ARM32,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C++,ARM32,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C#,ARM32,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C-API,ARM64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-     
+
     "windows,C++,ARM64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C#,ARM64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C++,X64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C++,X86,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-    
+
     "windows,C#,X64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
-        
+
     "windows,C#,X86,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
@@ -829,7 +827,7 @@ var validCombos = {
     "windows,C-API,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
-    "windows,C++,X64,DNNL": 
+    "windows,C++,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
     "windows,C#,X64,DNNL":
@@ -838,7 +836,7 @@ var validCombos = {
     "windows,Python,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
-    "linux,C-API,X64,DNNL": 
+    "linux,C-API,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
     "linux,C++,X64,DNNL":
@@ -847,7 +845,7 @@ var validCombos = {
     "linux,C#,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
-    "linux,Python,X64,DNNL": 
+    "linux,Python,X64,DNNL":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-mkldnn' target='_blank'>here</a>",
 
     "linux,Python,X64,TVM":
@@ -858,10 +856,10 @@ var validCombos = {
 
     "linux,Python,ARM32,TVM":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-stvm' target='_blank'>here</a>",
-        
+
     "linux,Python,ARM64,TVM":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-stvm' target='_blank'>here</a>",
-        
+
     "windows,Python,X64,TVM":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-stvm' target='_blank'>here</a>",
 
@@ -870,10 +868,10 @@ var validCombos = {
 
     "windows,Python,ARM32,TVM":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-stvm' target='_blank'>here</a>",
-        
+
     "windows,Python,ARM64,TVM":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-stvm' target='_blank'>here</a>",
-        
+
     "linux,C-API,X64,OpenVINO":
         "Follow build instructions from&nbsp;<a href='https://aka.ms/build-ort-openvino' target='_blank'>here</a>",
 
@@ -930,7 +928,7 @@ var validCombos = {
 
     "windows,C-API,X86,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
-    
+
     "windows,C++,X86,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
 
@@ -939,65 +937,65 @@ var validCombos = {
 
     "windows,Python,X86,DirectML":
     "Follow build instructions from <a href='https://aka.ms/build-ort-directml' target='_blank'>here</a>",
-    
+
     "windows,C-API,X64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-        
+
     "windows,C++,X64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-    
+
     "windows,C#,X64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-    
+
     "windows,Python,X64,DirectML":
         "pip install onnxruntime-directml",
-    
+
     "windows,C-API,ARM64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-        
+
     "windows,C++,ARM64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-    
+
     "windows,C#,ARM64,DirectML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML' target='_blank'>Microsoft.ML.OnnxRuntime.DirectML</a>",
-    
+
     "windows,Python,ARM64,DirectML":
         "Follow build instructions from <a href='https://aka.ms/build-ort-directml' target='_blank'>here</a>",
-    
+
     "linux,Java,X64,DefaultCPU":
         "Add a dependency on <a href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
-        
+
     "linux,Java,X64,CUDA":
         "Add a dependency on <a href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime_gpu' target='_blank'>com.microsoft.onnxruntime:onnxruntime_gpu</a> using Maven/Gradle. <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
-        
+
     "mac,Java,X64,DefaultCPU":
         "Add a dependency on <a href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
 
     //javascript
     "linux,JS,X64,DefaultCPU":
         "npm install onnxruntime-node",
-    
+
     "mac,JS,X64,DefaultCPU":
         "npm install onnxruntime-node",
 
     "windows,JS,X64,DefaultCPU":
         "npm install onnxruntime-node",
-    
+
     "web,JS,,":
         "npm install onnxruntime-web",
-    
+
     "android,JS,ARM64,DefaultCPU":
         "npm install onnxruntime-react-native",
-    
+
     "android,JS,X64,DefaultCPU":
         "npm install onnxruntime-react-native",
-    
+
     "android,JS,X86,DefaultCPU":
         "npm install onnxruntime-react-native",
-    
+
     "ios,JS,ARM64,DefaultCPU":
         "npm install onnxruntime-react-native",
-    
+
     "windows,WinRT,X86,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.AI.MachineLearning' target='_blank'>Microsoft.AI.MachineLearning</a>",
 
@@ -1042,55 +1040,55 @@ var validCombos = {
 
     "linux,Java,X64,OpenVINO":
         "Follow <a href='http://www.onnxruntime.ai/docs/build/inferencing.html#common-build-instructions' target='_blank'>build</a> and <a href='https://aka.ms/onnxruntime-java' target='_blank'>API instructions</a>",
-    
+
     "android,C-API,ARM64,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C++,ARM64,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,Java,ARM64,NNAPI":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C-API,X86,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C++,X86,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C#,X86,NNAPI":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "android,Java,X64,NNAPI":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C-API,X64,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C++,X64,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C#,X64,NNAPI":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
 
     "android,Java,X86,NNAPI":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C-API,ARM32,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
-    
+
     "android,C++,ARM32,NNAPI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-nnapi' target='_blank'>here</a>",
 
     "android,C#,ARM32,NNAPI":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "android,Java,ARM32,NNAPI":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C-API,ARM64,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
-    
+
     "android,C++,ARM64,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
 
@@ -1099,73 +1097,73 @@ var validCombos = {
 
     "android,C-API,ARM32,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
-    
+
     "android,C++,ARM32,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
 
     "android,C#,ARM32,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "android,Java,ARM32,DefaultCPU":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
 
     "android,C-API,X86,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
-    
+
     "android,C++,X86,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
 
     "android,C#,X86,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "android,Java,X86,DefaultCPU":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C-API,X64,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
-    
+
     "android,C++,X64,DefaultCPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-android' target='_blank'>here</a>",
-    
+
     "android,C#,X64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
 
     "android,Java,X64,DefaultCPU":
         "Add a dependency on <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-android' target='_blank'>com.microsoft.onnxruntime:onnxruntime-android</a> or <a href='https://mvnrepository.com/artifact/com.microsoft.onnxruntime/onnxruntime-mobile' target='_blank'>com.microsoft.onnxruntime:onnxruntime-mobile</a> using Maven/Gradle and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "android,C#,ARM64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "android,C#,ARM64,NNAPI":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
- 
+
     "ios,C-API,ARM64,DefaultCPU":
         "Add 'onnxruntime-c' or 'onnxruntime-mobile-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,C++,ARM64,DefaultCPU":
         "Add 'onnxruntime-c' or 'onnxruntime-mobile-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,C-API,ARM64,CoreML":
         "Add 'onnxruntime-c' or 'onnxruntime-mobile-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,C++,ARM64,CoreML":
         "Add 'onnxruntime-c' or 'onnxruntime-mobile-c' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,objectivec,ARM64,DefaultCPU":
         "Add 'onnxruntime-objc' or 'onnxruntime-mobile-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,objectivec,ARM64,CoreML":
         "Add 'onnxruntime-objc' or 'onnxruntime-mobile-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",
-    
+
     "ios,C#,ARM64,DefaultCPU":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
-    
+
     "ios,C#,ARM64,CoreML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>.",
- 
+
     "windows,Python,X64,VitisAI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-vitisai' target='_blank'>here</a>",
-    
+
     "windows,C++,X64,VitisAI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-vitisai' target='_blank'>here</a>",
 
@@ -1174,67 +1172,67 @@ var validCombos = {
 
     "linux,Python,ARM64,VitisAI":
         "Follow build instructions from <a href='https://aka.ms/build-ort-vitisai' target='_blank'>here</a>",
-    
+
     "linux,Python,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
-    
+
     "linux,C-API,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
-    
+
     "linux,C++,X64,MIGraphX":
         "Follow build instructions from <a href='https://aka.ms/build-ort-migraphx' target='_blank'>here</a>",
-    
+
     "linux,Python,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
-    
+
     "linux,C-API,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
-    
+
     "linux,C++,X64,ROCm":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rocm' target='_blank'>here</a>",
 
     "linux,Python,ARM64,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,C-API,ARM64,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,C++,ARM64,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,Python,ARM32,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,C-API,ARM32,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,C++,ARM32,ACL":
         "Follow build instructions from <a href='https://aka.ms/build-ort-acl' target='_blank'>here</a>",
-    
+
     "linux,Python,ARM64,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,C-API,ARM64,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,C++,ARM64,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,Python,ARM32,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,C-API,ARM32,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,C++,ARM32,ArmNN":
         "Follow build instructions from <a href='https://aka.ms/build-ort-armnn' target='_blank'>here</a>",
-    
+
     "linux,Python,ARM64,RockchipNPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rknpu' target='_blank'>here</a>",
-    
+
     "linux,C-API,ARM64,RockchipNPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rknpu' target='_blank'>here</a>",
-    
+
     "linux,C++,ARM64,RockchipNPU":
         "Follow build instructions from <a href='https://aka.ms/build-ort-rknpu' target='_blank'>here</a>",
 
@@ -1250,13 +1248,13 @@ var validCombos = {
 
     "mac,Java,ARM64,CoreML":
         "Add a dependency on <a href='https://search.maven.org/artifact/com.microsoft.onnxruntime/onnxruntime' target='_blank'>com.microsoft.onnxruntime:onnxruntime</a> using Maven/Gradle",
-    
+
     "mac,C-API,ARM64,CoreML":
         "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime' target='_blank'>Microsoft.ML.OnnxRuntime</a>",
 
     "mac,Python,ARM64,DefaultCPU":
         "pip install onnxruntime",
-    
+
     "mac,Python,ARM64,DefaultCPU":
         "pip install onnxruntime",
 
@@ -1275,10 +1273,10 @@ var validCombos = {
     //power
     "linux,C-API,Power,DefaultCPU":
         "Follow build instructions from <a href='https://onnxruntime.ai/docs/build/inferencing.html#build-instructions' target='_blank'>here</a>",
-    
+
     "linux,C++,Power,DefaultCPU":
         "Follow build instructions from <a href='https://onnxruntime.ai/docs/build/inferencing.html#build-instructions' target='_blank'>here</a>",
-    
+
     "linux,Python,Power,DefaultCPU":
         "pip install onnxruntime-powerpc64le",
 
@@ -1288,7 +1286,7 @@ var validCombos = {
 
     "windows,C++,ARM64,QNN":
     "View installation instructions <a href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
-    
+
     "windows,C#,ARM64,QNN":
     "View installation instructions <a href='https://aka.ms/build-ort-qnn' target='_blank'>here</a>",
 
@@ -1378,15 +1376,15 @@ function commandMessage(key) {
         return true;
     }
     else if(opts['os']=='' || opts['architecture'] == '' || opts['language']=='' || opts['hardwareAcceleration'] == ''){
-         
+
          $("#command span").html(
            "Please select a combination of resources"
-        )             
+        )
     }
     else if (!validCombos.hasOwnProperty(key)) {
         $("#command span").html(
             "This combination is not supported. De-select to make another selection."
-        ) 
+        )
         $("#command").addClass("invalid");
         return false;
     } else {
@@ -1471,7 +1469,7 @@ function getImage(node) {
 }
 
 function setRadioButton(node, state) {
-    
+
     var image = getImage(node);
     if (state == 'true') {
         node.setAttribute('aria-selected', 'true');
@@ -1502,7 +1500,7 @@ function clickRadioGroup(event) {
 }
 
 function keyDownRadioGroup(event) {
-    
+
     var type = event.type;
     var next = false;
     if (type === "keydown") {
@@ -1553,17 +1551,17 @@ function blurRadioButton(event) {
       var tabpan = $("#" + tabpanid);
       $("div[role='tabpanel']:not(tabpan)").attr("aria-hidden", "true");
       $("div[role='tabpanel']:not(tabpan)").addClass("hidden");
-  
+
       tabpan.removeClass("hidden");
       tabpan.attr("aria-hidden", "false");
     });
-  
+
     $(".tbl_tablist li[role='tab']").keydown(function (ev) {
       if (ev.which == 13) {
         $(this).click();
       }
     });
-  
+
     //This adds keyboard function that pressing an arrow left or arrow right from the tabs toggel the tabs.
     $(".tbl_tablist li[role='tab']").keydown(function (ev) {
       if (ev.which == 39 || ev.which == 37) {
@@ -1571,12 +1569,12 @@ function blurRadioButton(event) {
         if (selected == "true") {
           $("li[aria-selected='false']").attr("aria-selected", "true").focus();
           $(this).attr("aria-selected", "false");
-  
+
           var tabpanid = $("li[aria-selected='true']").attr("aria-controls");
           var tabpan = $("#" + tabpanid);
           $("div[role='tabpanel']:not(tabpan)").attr("aria-hidden", "true");
           $("div[role='tabpanel']:not(tabpan)").addClass("hidden");
-  
+
           tabpan.attr("aria-hidden", "false");
           tabpan.removeClass("hidden");
         }
@@ -1617,27 +1615,27 @@ function blurRadioButton(event) {
 
       $(function() {
         var tabs = $(".custom-tab");
-      
+
         // For each individual tab DIV, set class and aria role attributes, and hide it
         $(tabs).find(".tab-content > div.tab-pane").attr({
           "class": "tabPanel",
           "role": "tabpanel",
           "aria-hidden": "true"
         }).hide();
-      
+
         // Get the list of tab links
-        var tabsList = tabs.find("ul:first").attr({    
+        var tabsList = tabs.find("ul:first").attr({
           "role": "tablist"
         });
-      
+
         // For each item in the tabs list...
         $(tabsList).find("li > a").each(
           function(a) {
             var tab = $(this);
-      
+
             // Create a unique id using the tab link's href
             var tabId = "tab-" + tab.attr("href").slice(1);
-      
+
             // Assign tab id, aria and tabindex attributes to the tab control, but do not remove the href
             tab.attr({
               "id": tabId,
@@ -1645,28 +1643,28 @@ function blurRadioButton(event) {
               "aria-selected": "false",
             //   "tabindex": "-1"
             }).parent().attr("role", "presentation");
-      
+
             // Assign aria attribute to the relevant tab panel
             $(tabs).find(".tabPanel").eq(a).attr("aria-labelledby", tabId);
-      
+
             // Set the click event for each tab link
             tab.click(
               function(e) {
                 // Prevent default click event
                 e.preventDefault();
-      
+
                 // Change state of previously selected tabList item
                 $(tabsList).find("> li.active").removeClass("active").find("> a").attr({
                   "aria-selected": "false",
                 //   "tabindex": "-1"
                 });
-      
+
                 // Hide previously selected tabPanel
                 $(tabs).find(".tabPanel:visible").attr("aria-hidden", "true").hide();
-      
+
                 // Show newly selected tabPanel
                 $(tabs).find(".tabPanel").eq(tab.parent().index()).attr("aria-hidden", "false").show();
-      
+
                 // Set state of newly selected tab list item
                 tab.attr({
                   "aria-selected": "true",
@@ -1677,7 +1675,7 @@ function blurRadioButton(event) {
             );
           }
         );
-      
+
         // Set keydown events on tabList item for navigating tabs
         $(tabsList).delegate("a", "keydown",
           function(e) {
@@ -1702,10 +1700,10 @@ function blurRadioButton(event) {
             }
           }
         );
-      
+
         // Show the first tabPanel
         $(tabs).find(".tabPanel:first").attr("aria-hidden", "false").show();
-      
+
         // Set state for the first tabsList li
         $(tabsList).find("li:first").addClass("active").find(" > a").attr({
           "aria-selected": "true",

--- a/js/script.js
+++ b/js/script.js
@@ -582,11 +582,11 @@ function ot_buildMatcher() {
 
 var ot_validCombos = {
 
-    "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA,ot_stable":
+    "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_stable":
     "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_stable_<b>&lt;cu_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*</b><a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
 
-    "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-nightly/pypi/simple/ onnxruntime-training<br/>pip install torch-ort<br/>python -m torch_ort.configure",
+    "ot_linux,ot_large_model,ot_python,ot_X64,ot_CUDA118,ot_nightly":
+    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_large_model,ot_python,ot_X64,ot_ROCm,ot_stable":
     "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_stable_<b>&lt;rocm_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*<a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
@@ -595,17 +595,16 @@ var ot_validCombos = {
     "pip install onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_<b>&lt;rocm_version*</b>&gt;.html<br/>pip install torch-ort<br/>python -m torch_ort.configure<br/><br/>*<a href='https://download.onnxruntime.ai/' target='blank'>Available versions</a>",
     
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
 
     "ot_linux,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-nightly/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
 
-    "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA,ot_stable":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training",
+    "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_stable":
+    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
-    "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training",
-
+    "ot_linux,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_nightly":
+    "pip install --pre onnxruntime-training --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/<br/>pip install torch-ort<br/>python -m torch_ort.configure",
 
     "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CPU,ot_stable":
     "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
@@ -613,25 +612,25 @@ var ot_validCombos = {
     "ot_linux,ot_on_device,ot_csharp,ot_X64,ot_CPU,ot_stable":
     "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Training' target='_blank'>Microsoft.ML.OnnxRuntime.Training</a>",
 
-    "ot_linux,ot_on_device,ot_c,ot_X64,ot_CUDA,ot_stable":
+    "ot_linux,ot_on_device,ot_c,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
-    "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA,ot_stable":
+    "ot_linux,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
     
-    "ot_linux,ot_on_device,ot_csharp,ot_X64,ot_CUDA,ot_stable":
+    "ot_linux,ot_on_device,ot_csharp,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
     "ot_linux,ot_on_device,ot_c,ot_X64,ot_CPU,ot_stable":
     "Download .tgz file from&nbsp;<a href='https://github.com/microsoft/onnxruntime/releases' target='_blank'>Github</a> <br/>Refer to <a href='http://www.onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements' target='_blank'>docs</a> for requirements.",
 
     "ot_windows,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
 
     "ot_windows,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
 
-    "ot_windows,ot_on_device,ot_python,ot_X64,ot_CUDA,ot_stable":
+    "ot_windows,ot_on_device,ot_python,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
     "ot_windows,ot_on_device,ot_c,ot_X64,ot_CPU,ot_stable":
@@ -643,13 +642,13 @@ var ot_validCombos = {
     "ot_windows,ot_on_device,ot_csharp,ot_X64,ot_CPU,ot_stable":
     "Install Nuget package&nbsp;<a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.Training' target='_blank'>Microsoft.ML.OnnxRuntime.Training</a>",
 
-    "ot_windows,ot_on_device,ot_c,ot_X64,ot_CUDA,ot_stable":
+    "ot_windows,ot_on_device,ot_c,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
-    "ot_windows,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA,ot_stable":
+    "ot_windows,ot_on_device,ot_cplusplus,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
     
-    "ot_windows,ot_on_device,ot_csharp,ot_X64,ot_CUDA,ot_stable":
+    "ot_windows,ot_on_device,ot_csharp,ot_X64,ot_CUDA118,ot_stable":
     "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/training.html' target='_blank'>here</a>",
 
     "ot_android,ot_on_device,ot_c,ot_X64,ot_CPU,ot_stable":
@@ -671,10 +670,10 @@ var ot_validCombos = {
         "Follow build instructions from&nbsp;<a href='https://onnxruntime.ai/docs/build/android.html' target='_blank'>here</a>",
 
     "ot_mac,ot_on_device,ot_python,ot_X64,ot_CPU,ot_stable":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/",
 
     "ot_mac,ot_on_device,ot_python,ot_X64,ot_CPU,ot_nightly":
-    "python -m pip install cerberus flatbuffers h5py numpy>=1.16.6 onnx packaging protobuf sympy setuptools>=41.4.0<br/>pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ onnxruntime-training-cpu",
+    "pip install --pre onnxruntime-training-cpu --extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT_Nightly/pypi/simple/",
 
     "ot_ios,ot_on_device,ot_objc,ot_X64,ot_CPU,ot_stable":
         "Add 'onnxruntime-training-objc' using CocoaPods and refer to the <a href='https://onnxruntime.ai/docs/tutorials/mobile/' target='_blank'>mobile deployment guide</a>",


### PR DESCRIPTION
### Description
Live preview [here](https://carzh.github.io/onnxruntime/).

* uses a different installation command so that users don't have to manually install pre-reqs
* updates CUDA option in training to be a specific CUDA version
* updates with the now-preferred devops source for stable version for 1.16.0

### Motivation and Context
* less maintenance work in the future -- will no longer have to update the installation instructions when the requirements change