### PR TITLE
Provide kwargs to remove_shared_initializers

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_generation.py
+++ b/onnxruntime/python/tools/transformers/convert_generation.py
@@ -993,7 +993,11 @@ def get_shared_initializers(encoder_model: ModelProto, decoder_model: ModelProto
     encoder.remove_duplicated_initializer(signature_cache1)
     decoder.remove_duplicated_initializer(signature_cache2)
     initializers = remove_shared_initializers(
-        decoder.model.graph, encoder.model.graph, "s_", signature_cache1, signature_cache2
+        decoder.model.graph,
+        encoder.model.graph,
+        shared_prefix="s_",
+        signature_cache1=signature_cache1,
+        signature_cache2=signature_cache2,
     )
     return initializers
 


### PR DESCRIPTION
### Description
Fixes a bug in `get_shared_initializers` where `signature_cache1, signature_cache2` are passed as positional arguments to `remove_shared_initializers` but their positions don't match the function signature. So `signature_cache1` is passed to `min_elements` and causes comparison error at line 907.

Pass the arguments as kwargs so that it doesn't rely on their positions.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes the bug described above.

