### PR TITLE
Align bins_space_ storage

### DIFF
--- a/onnxruntime/core/framework/bfc_arena.h
+++ b/onnxruntime/core/framework/bfc_arena.h
@@ -482,7 +482,7 @@ class BFCArena : public IAllocator {
 
   Bin* BinForSize(size_t bytes) { return BinFromIndex(BinNumForSize(bytes)); }
 
-  char bins_space_[sizeof(Bin) * kNumBins];
+  alignas(Bin) char bins_space_[sizeof(Bin) * kNumBins];
 
   // The size of the current region allocation.
   SafeInt<size_t> curr_region_allocation_bytes_;


### PR DESCRIPTION
Otherwise, `new (BinFromIndex(b)) Bin(this, bin_size);` in bfc_arena.cc would cause a -fsanitize=alignment (part of -fsanitize=undefined) failure like

    runtime error: constructor call on misaligned address 0xXXX for type 'Bin', which requires 8 byte alignment