### PR TITLE
run_CIs_for_external_pr.py: update required pipelines

### DIFF
--- a/tools/python/run_CIs_for_external_pr.py
+++ b/tools/python/run_CIs_for_external_pr.py
@@ -71,6 +71,7 @@ def main():
     pipelines = [
         # windows
         "Windows ARM64 QNN CI Pipeline",
+        "Windows x64 QNN CI Pipeline",
         "Windows CPU CI Pipeline",
         "Windows GPU CI Pipeline",
         "Windows GPU TensorRT CI Pipeline",


### PR DESCRIPTION
### Description
Add required pipeline "Windows x64 QNN CI Pipeline" to script "run_CIs_for_external_pr.py"