### PR TITLE
Update tensorrt_dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ try:
                     "libhsa-runtime64.so.1",
                 ]
 
-                tensorrt_dependencies = ["libnvinfer.so.8.6", "libnvinfer_plugin.so.8.6", "libnvonnxparser.so.8.6"]
+                tensorrt_dependencies = ["libnvinfer.so.8", "libnvinfer_plugin.so.8", "libnvonnxparser.so.8"]
 
                 dest = "onnxruntime/capi/libonnxruntime_providers_openvino.so"
                 if path.isfile(dest):


### PR DESCRIPTION
### Description
The files should not have the minor version number.  The names were added in #17365 by mistake.


### Motivation and Context
We did not successfully exclude them out. 


