### PR TITLE
Avoid `get_logger` overriding root logger level

### DIFF
--- a/tools/python/util/logger.py
+++ b/tools/python/util/logger.py
@@ -5,6 +5,7 @@ import logging
 
 
 def get_logger(name):
-    logging.basicConfig(format="%(asctime)s %(name)s [%(levelname)s] - %(message)s", level=logging.DEBUG)
-
-    return logging.getLogger(name)
+    logging.basicConfig(format="%(asctime)s %(name)s [%(levelname)s] - %(message)s")
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    return logger


### PR DESCRIPTION
### Description
Instead, set level to DEBUG for the logger returned.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Otherwise, this function call overrides root logger level setting, which affects logging facility of other python packages.