### PR TITLE
[DML EP] Call SetDmlOperatorDesc in Dml::DmlOperatorMemcpy::DmlOperatorMemcpy

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMemcpy.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorMemcpy.cpp
@@ -17,6 +17,17 @@ public:
     {
         ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetInputCount() == 1, "MemcpyFromHost/ToHost expects 1 input tensor.");
         ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetOutputCount() == 1, "MemcpyFromHost/ToHost expects 1 output tensor.");
+
+        Initialize(kernelCreationContext);
+
+        std::vector<DML_TENSOR_DESC> inputDescs = GetDmlInputDescs();
+        std::vector<DML_TENSOR_DESC> outputDescs = GetDmlOutputDescs();
+
+        DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC opDesc = {};
+        opDesc.InputTensor = inputDescs.data();
+        opDesc.OutputTensor = outputDescs.data();
+
+        SetDmlOperatorDesc({ DML_OPERATOR_ELEMENT_WISE_IDENTITY, &opDesc }, kernelCreationContext);
     }
 
     void Compute(const MLOperatorKernelContext& kernelContext)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add a call to `SetDmlOperatorDesc` in `Dml::DmlOperatorMemcpy::DmlOperatorMemcpy` and try to fix #17516.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

If `SetDmlOperatorDesc` (and `SetDmlOperator`) is not called in the class, an out_of_range exception will be thrown in `Dml::GraphDescBuilder::BuildGraphDesc`. To fix the issue, I added it to the constructor.


