### PR TITLE
Close the JSON object in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,3 +40,4 @@
         "-build/include_subdir",
         "-runtime/references"
     ]
+}


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This patch adds a closing curly bracket at the end of `settings.json`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

`settings.json` is just not closed. It was accidentally removed at 4e6ea730d633756e9e04df8968304d11a575dde4

