### PR TITLE
Improve Win QNNEP pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -95,6 +95,8 @@ steps:
       createLogFile: true
     env:
       CCACHE_DIR: ${{parameters.CacheDir}}
+      CCACHE_DEBUG: 1
+      CCACHE_DEBUGDIR: $(Agent.TempDirectory)/cache_debug
 
   - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |
@@ -103,3 +105,9 @@ steps:
       displayName: cache stat
       env:
         CCACHE_DIR: ${{parameters.CacheDir}}
+
+    - task: PublishPipelineArtifact@0
+      displayName: 'publish cache log'
+      inputs:
+        artifactName: 'cache-log'
+        targetPath: $(Agent.TempDirectory)/cache_debug

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -45,6 +45,18 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.WithCache, true) }}:
+    - powershell: |
+        if ([string]::IsNullOrEmpty((Get-Command ccache -errorAction SilentlyContinue)))
+        {
+          choco install ccache -y --version 4.7.4
+          $ccache_path = (Get-Command ccache).Source
+          $ccache_parent_dir = (Split-Path -parent $ccache_path)
+          Copy-Item "C:\ProgramData\chocolatey\lib\ccache\tools\ccache-4.7.4-windows-x86_64\ccache.exe" -Destination "C:\ProgramData\chocolatey\bin\cl.exe"
+          Get-ChildItem $ccache_parent_dir
+          ccache --version
+        }
+      displayName: Install ccache
+
     - task: Cache@2
       inputs:
         ${{if eq(variables['Build.SourceBranchName'], 'merge')}}:

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -97,6 +97,8 @@ steps:
       CCACHE_DIR: ${{parameters.CacheDir}}
       CCACHE_DEBUG: 1
       CCACHE_DEBUGDIR: $(Agent.TempDirectory)/cache_debug
+      CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime,include_file_ctime
+      CCACHE_COMPILERCHECK: content
 
   - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -12,6 +12,10 @@ parameters:
   type: string
   default: "$(Agent.TempDirectory)/ort_ccache"
 
+- name: DebugCache
+  type: boolean
+  default: false
+
 - name: AdditionalKey
   type: string
   default: ""
@@ -95,11 +99,11 @@ steps:
       createLogFile: true
     env:
       CCACHE_DIR: ${{parameters.CacheDir}}
-      CCACHE_DEBUG: 1
-      CCACHE_DEBUGDIR: $(Agent.TempDirectory)/cache_debug
       CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime,include_file_ctime
       CCACHE_COMPILERCHECK: content
-
+      ${{if eq(parameters.DebugCache, true)}}:
+        CCACHE_DEBUG: 1
+        CCACHE_DEBUGDIR: $(Agent.TempDirectory)/cache_debug
 
   - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |
@@ -109,8 +113,9 @@ steps:
       env:
         CCACHE_DIR: ${{parameters.CacheDir}}
 
-    - task: PublishPipelineArtifact@0
-      displayName: 'publish cache log'
-      inputs:
-        artifactName: 'cache-log'
-        targetPath: $(Agent.TempDirectory)/cache_debug
+    - ${{if eq(parameters.DebugCache, true)}}:
+      - task: PublishPipelineArtifact@0
+        displayName: 'publish cache log'
+        inputs:
+          artifactName: 'cache-log'
+          targetPath: $(Agent.TempDirectory)/cache_debug

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-build-steps.yml
@@ -100,6 +100,7 @@ steps:
       CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime,include_file_ctime
       CCACHE_COMPILERCHECK: content
 
+
   - ${{ if eq(parameters.WithCache, true) }}:
     - powershell: |
         ccache -sv

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/win-ci-prebuild-steps.yml
@@ -1,6 +1,7 @@
 parameters:
 - name: EnvSetupScript
   type: string
+  default: setup_env.bat
 
 - name: BuildConfig
   type: string

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
     QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-  timeoutInMinutes: 150
+  timeoutInMinutes: 180
   workspace:
     clean: all
   steps:

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -71,7 +71,6 @@ jobs:
   # '_Ret &std::_Visit_strategy<1>::_Visit2<_Ret,_ListOfIndexVectors,_Callable,const
   # std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver>&>(size_t,_Callable &&,
   # const std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver> &)'
-
   - template: templates/jobs/win-ci-build-steps.yml
     parameters:
       WithCache: True
@@ -85,7 +84,6 @@ jobs:
 
   - powershell: |
      python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --test --cmake_generator "Visual Studio 17 2022" --enable_onnx_tests
-
     workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
     displayName: 'Run unit tests'
 

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -52,6 +52,12 @@ jobs:
     clean: all
   steps:
 
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      addToPath: true
+      architecture: $(buildArch)
+
   # TODO: Remove --compile_no_warning_as_error once we update from MSVC Runtime library version 14.32 or we
   # fix/silence the following warning from the <variant> STL header. This warning halts compilation due to
   # the /external:templates- option, which allows warnings from external libs for template instantiations.
@@ -65,14 +71,6 @@ jobs:
   # '_Ret &std::_Visit_strategy<1>::_Visit2<_Ret,_ListOfIndexVectors,_Callable,const
   # std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver>&>(size_t,_Callable &&,
   # const std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver> &)'
-  - template: templates/jobs/win-ci-prebuild-steps.yml
-    parameters:
-      DownloadCUDA: false
-      BuildArch: $(buildArch)
-      BuildConfig: $(BuildConfig)
-      MachinePool: 'Onnxruntime-QNNEP-Windows-2022-CPU'
-      WithCache: true
-      Today: $(Today)
 
   - template: templates/jobs/win-ci-build-steps.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
     QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
     TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
-  timeoutInMinutes: 180
+  timeoutInMinutes: 120
   workspace:
     clean: all
   steps:

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -82,3 +82,19 @@ jobs:
       BuildArch: $(buildArch)
       Platform: 'x64'
       BuildConfig: $(BuildConfig)
+
+  - powershell: |
+     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --test --cmake_generator "Visual Studio 17 2022" --enable_onnx_tests
+
+    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
+    displayName: 'Run unit tests'
+
+  - script: |
+      .\$(BuildConfig)\onnx_test_runner -j 1 -c 1 -v -e qnn -i "backend_path|$(QNN_SDK_ROOT)\lib\x86_64-windows-msvc\QnnCpu.dll" $(Build.SourcesDirectory)\cmake\external\onnx\onnx\backend\test\data\node
+    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)'
+    displayName: 'Run ONNX Tests'
+
+  - script: |
+      .\$(BuildConfig)\onnx_test_runner -j 1 -c 1 -v -e qnn -i "backend_path|$(QNN_SDK_ROOT)\lib\x86_64-windows-msvc\QnnCpu.dll" C:\data\float32_models
+    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)'
+    displayName: 'Run float32 model tests'

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -67,8 +67,7 @@ jobs:
   # const std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver> &)'
   - template: templates/jobs/win-ci-prebuild-steps.yml
     parameters:
-      EnvSetupScript: $(EnvSetupScript)
-      DownloadCUDA: true
+      DownloadCUDA: false
       BuildArch: $(buildArch)
       BuildConfig: $(BuildConfig)
       MachinePool: 'Onnxruntime-QNNEP-Windows-2022-CPU'

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -46,16 +46,11 @@ jobs:
     BuildConfig: 'RelWithDebInfo'
     ALLOW_RELEASED_ONNX_OPSET_ONLY: '1'
     QNN_SDK_ROOT: 'C:\data\qnnsdk\${{parameters.QnnSdk}}'
+    TODAY: $[format('{0:dd}{0:MM}{0:yyyy}', pipeline.startTime)]
   timeoutInMinutes: 150
   workspace:
     clean: all
   steps:
-
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.8'
-      addToPath: true
-      architecture: $(buildArch)
 
   # TODO: Remove --compile_no_warning_as_error once we update from MSVC Runtime library version 14.32 or we
   # fix/silence the following warning from the <variant> STL header. This warning halts compilation due to
@@ -70,25 +65,26 @@ jobs:
   # '_Ret &std::_Visit_strategy<1>::_Visit2<_Ret,_ListOfIndexVectors,_Callable,const
   # std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver>&>(size_t,_Callable &&,
   # const std::variant<onnxruntime::OpSchemaKernelTypeStrResolver,onnxruntime::KernelTypeStrResolver> &)'
-  - task: PythonScript@0
-    displayName: 'Generate cmake config'
-    inputs:
-      scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
-      arguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --compile_no_warning_as_error --update --cmake_generator "Visual Studio 17 2022" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel'
-      workingDirectory: '$(Build.BinariesDirectory)'
+  - template: templates/jobs/win-ci-prebuild-steps.yml
+    parameters:
+      EnvSetupScript: $(EnvSetupScript)
+      DownloadCUDA: true
+      BuildArch: $(buildArch)
+      BuildConfig: $(BuildConfig)
+      MachinePool: 'Onnxruntime-QNNEP-Windows-2022-CPU'
+      WithCache: true
+      Today: $(Today)
 
-  - task: VSBuild@1
-    displayName: 'Build'
-    inputs:
-      solution: '$(Build.BinariesDirectory)\$(BuildConfig)\onnxruntime.sln'
-      platform: 'x64'
-      configuration: $(BuildConfig)
-      msbuildArgs: $(MsbuildArguments)
-      msbuildArchitecture: $(buildArch)
-      maximumCpuCount: true
-      logProjectEvents: false
-      workingFolder: '$(Build.BinariesDirectory)\$(BuildConfig)'
-      createLogFile: true
+  - template: templates/jobs/win-ci-build-steps.yml
+    parameters:
+      WithCache: True
+      Today: $(TODAY)
+      AdditionalKey: "win-qnn | $(BuildConfig)"
+      BuildPyArguments: '--config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --compile_no_warning_as_error --update --cmake_generator "Visual Studio 17 2022" --use_qnn --qnn_home $(QNN_SDK_ROOT) --parallel'
+      MsbuildArguments: $(MsbuildArguments)
+      BuildArch: $(buildArch)
+      Platform: 'x64'
+      BuildConfig: $(BuildConfig)
 
   - powershell: |
      python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --test --cmake_generator "Visual Studio 17 2022" --enable_onnx_tests

--- a/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-ci-pipeline.yml
@@ -84,19 +84,3 @@ jobs:
       BuildArch: $(buildArch)
       Platform: 'x64'
       BuildConfig: $(BuildConfig)
-
-  - powershell: |
-     python $(Build.SourcesDirectory)\tools\ci_build\build.py --config $(BuildConfig) --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --test --cmake_generator "Visual Studio 17 2022" --enable_onnx_tests
-
-    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)\$(BuildConfig)'
-    displayName: 'Run unit tests'
-
-  - script: |
-      .\$(BuildConfig)\onnx_test_runner -j 1 -c 1 -v -e qnn -i "backend_path|$(QNN_SDK_ROOT)\lib\x86_64-windows-msvc\QnnCpu.dll" $(Build.SourcesDirectory)\cmake\external\onnx\onnx\backend\test\data\node
-    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)'
-    displayName: 'Run ONNX Tests'
-
-  - script: |
-      .\$(BuildConfig)\onnx_test_runner -j 1 -c 1 -v -e qnn -i "backend_path|$(QNN_SDK_ROOT)\lib\x86_64-windows-msvc\QnnCpu.dll" C:\data\float32_models
-    workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)'
-    displayName: 'Run float32 model tests'


### PR DESCRIPTION
### Description
1. use standard win build template
2. enable compiler cache

### Motivation and Context
Make win build task easy to maintain and accelerate the pipeline.


