### PR TITLE
[CUDA] Fix performance bug in DecoderMaskedMultiheadAttention for BeamSearch

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/fastertransformer_decoder_attention/decoder_masked_multihead_attention_impl.cu
@@ -174,7 +174,6 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
     q = add_vec(q, q_bias);
   }
 
-
   T* params_k_cache = reinterpret_cast<T*>(params.k_cache);
 
   const float inv_sqrt_dh = params.scale;
@@ -350,24 +349,22 @@ __global__ void masked_multihead_attention_kernel(DecoderMaskedMultiHeadAttentio
 
     // The keys loaded from the key cache.
     K_vec_k k_vec[K_VECS_PER_THREAD];
+    if (ti < tlength) {
+      if (has_beams) {
+        const int beam_offset = beam_indices[ti] * params.num_heads * params.max_sequence_length * head_size;
 
-    if (has_beams) {
 #pragma unroll
-      for (int ii = 0; ii < K_VECS_PER_THREAD; ++ii) {
-        int jj = ii * params.max_sequence_length + ti;
+        for (int ii = 0; ii < K_VECS_PER_THREAD; ++ii) {
+          int jj = ii * params.max_sequence_length + ti;
 
-        if (ti < tlength) {
-          const int beam_offset = beam_indices[ti] * params.num_heads * params.max_sequence_length * head_size;
           k_vec[ii] = vec_conversion<K_vec_k, K_vec_m>(
               (*reinterpret_cast<const K_vec_m*>(&k_cache_batch[beam_offset + jj * QK_ELTS_IN_16B])));
         }
-      }
-    } else {
+      } else {
 #pragma unroll
-      for (int ii = 0; ii < K_VECS_PER_THREAD; ++ii) {
-        int jj = ii * params.max_sequence_length + ti;
+        for (int ii = 0; ii < K_VECS_PER_THREAD; ++ii) {
+          int jj = ii * params.max_sequence_length + ti;
 
-        if (ti < tlength) {
           k_vec[ii] = vec_conversion<K_vec_k, K_vec_m>(
               (*reinterpret_cast<const K_vec_m*>(&k_cache_batch[jj * QK_ELTS_IN_16B])));
         }


### PR DESCRIPTION
### Description

1) Minor change of moving a bounds checking `if` outside the some loops

2) Move out a global memory read outside an unrolled for loop. Reading in a loop is redundant as `ti` never changes in the loop. This seems to be a case for compiler optimization to move it outside the loop but the compiler doesn't seem to move it out and instead adds instructions for multiple redundant global memory reads

![image](https://github.com/microsoft/onnxruntime/assets/9969784/5c65e8a6-1b4c-4a24-a75d-ac9b2bb15aa4)

Illustrative profiling from HugingFace GPT-2

**Before instructions:** 

There are more such redundant reads than shown in the snippet as they are interleaved with other independently executing instructions based on compiler re-arrangement of instructions

![image](https://github.com/microsoft/onnxruntime/assets/9969784/762ee04a-436b-4743-b080-c4beb1a98d51)

**Before metrics:**

![image](https://github.com/microsoft/onnxruntime/assets/9969784/6bf957a3-1d2f-4c0a-8a27-1d64bb1378a8)

**After instructions:**
We have one load instead of the many above (not pasting for conciseness)

**After metrics:**
![image](https://github.com/microsoft/onnxruntime/assets/9969784/8178a154-0b27-4575-a4f6-3171fbc5e8b1)

**Commentary about metrics:**
As you can see, the number of cycles have decreased and latency has decreased (about 8.x micro-seconds to 7.x micro-seconds) and the memory throughput has gone down because we reduce the global memory read(s) mani-fold. This bug didn't impact perf much beause the redundant reads mostly happen in parallel (once the loop is unrolled) and I think the kernel wasn't nearing the global memory bandwidth ceiling yet. In any case, the ultimate perf impact will vary from model to model (based on head size, number of layers)

### Motivation and Context
Fix perf bug in decoder masked multihead attention


