### PR TITLE
Remove onnxruntime extensions from list of gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 	path = cmake/external/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
 	branch = 3.1.44
-[submodule "cmake/external/onnxruntime-extensions"]
-	path = cmake/external/onnxruntime-extensions
-	url = https://github.com/microsoft/onnxruntime-extensions.git


### PR DESCRIPTION
The extensions submodule was removed in [this PR](https://github.com/microsoft/onnxruntime/pull/17097) but not deleted from the list of git modules. This causes breaks in code ingesting ORT that references the git modules for an accurate list of submodules.

This change removes the extensions from the list of git modules to resolve this issue.

