### PR TITLE
[js/web] update browser launch cmd flags

### DIFF
--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -493,12 +493,10 @@ async function main() {
         karmaArgs.push('--force-localhost');
       }
       if (webgpu) {
-        if (browser.includes('Canary')) {
-          chromiumFlags.push('--enable-dawn-features=allow_unsafe_apis,use_dxc');
-        } else {
+        if (!browser.includes('Canary')) {
           chromiumFlags.push('--enable-dawn-features=use_dxc');
-          chromiumFlags.push('--disable-dawn-features=disallow_unsafe_apis');
         }
+        chromiumFlags.push('--disable-dawn-features=disallow_unsafe_apis');
       }
       if (webnn) {
         chromiumFlags.push('--enable-experimental-web-platform-features');

--- a/js/web/script/test-runner-cli.ts
+++ b/js/web/script/test-runner-cli.ts
@@ -493,16 +493,12 @@ async function main() {
         karmaArgs.push('--force-localhost');
       }
       if (webgpu) {
-        if (!browser.includes('Canary')) {
-          chromiumFlags.push('--enable-dawn-features=use_dxc');
-        }
-        chromiumFlags.push('--disable-dawn-features=disallow_unsafe_apis');
+        // flag 'allow_unsafe_apis' is required to enable experimental features like fp16 and profiling inside pass.
+        // flag 'use_dxc' is required to enable DXC compiler.
+        chromiumFlags.push('--enable-dawn-features=allow_unsafe_apis,use_dxc');
       }
       if (webnn) {
         chromiumFlags.push('--enable-experimental-web-platform-features');
-      }
-      if (config.options.globalEnvFlags?.webgpu?.profilingMode === 'default') {
-        chromiumFlags.push('--disable-dawn-features=disallow_unsafe_apis');
       }
       karmaArgs.push(`--bundle-mode=${args.bundleMode}`);
       karmaArgs.push(...chromiumFlags.map(flag => `--chromium-flags=${flag}`));


### PR DESCRIPTION
### Description
update Chromium browser launch command line flags

Canary already using dxc so no need to specify '--enable-dawn-features=use_dxc' for canary.