### PR TITLE
Stop throwing exception on python binding when multiple EP available

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -438,7 +438,7 @@ class InferenceSession(Session):
 
         # Tensorrt can fall back to CUDA if it's explicitly assigned. All others fall back to CPU.
         if "TensorrtExecutionProvider" in available_providers:
-            if any(
+            if providers and any(
                 provider == "CUDAExecutionProvider"
                 or (isinstance(provider, tuple) and provider[0] == "CUDAExecutionProvider")
                 for provider in providers
@@ -448,7 +448,7 @@ class InferenceSession(Session):
                 self._fallback_providers = ["CPUExecutionProvider"]
         # MIGraphX can fall back to ROCM if it's explicitly assigned. All others fall back to CPU.
         elif "MIGraphXExecutionProvider" in available_providers:
-            if any(
+            if providers and any(
                 provider == "ROCMExecutionProvider"
                 or (isinstance(provider, tuple) and provider[0] == "ROCMExecutionProvider")
                 for provider in providers
@@ -463,8 +463,6 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(
             providers, provider_options, available_providers
         )
-        if not providers and len(available_providers) > 1:
-            providers = ["CPUExecutionProvider"]
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -463,8 +463,6 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(
             providers, provider_options, available_providers
         )
-        if not providers and len(available_providers) > 1:
-            self.disable_fallback()
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -465,7 +465,6 @@ class InferenceSession(Session):
         )
         if not providers and len(available_providers) > 1:
             self.disable_fallback()
-            warnings.warn(f"This ORT build has {available_providers} enabled, use CPUExecutionProvider as default")
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -465,12 +465,7 @@ class InferenceSession(Session):
         )
         if not providers and len(available_providers) > 1:
             self.disable_fallback()
-            raise ValueError(
-                f"This ORT build has {available_providers} enabled. "
-                "Since ORT 1.9, you are required to explicitly set "
-                "the providers parameter when instantiating InferenceSession. For example, "
-                f"onnxruntime.InferenceSession(..., providers={available_providers}, ...)"
-            )
+            warnings.warn(f"This ORT build has {available_providers} enabled, use CPUExecutionProvider as default")
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -463,6 +463,8 @@ class InferenceSession(Session):
         providers, provider_options = check_and_normalize_provider_args(
             providers, provider_options, available_providers
         )
+        if not providers and len(available_providers) > 1:
+            providers = ["CPUExecutionProvider"]
 
         session_options = self._sess_options if self._sess_options else C.get_default_session_options()
         if self._model_path:

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -82,8 +82,7 @@ class TestInferenceSession(unittest.TestCase):
             so.optimized_model_filepath = "./PythonApiTestOptimizedModel.onnx"
             onnxrt.InferenceSession(
                 get_name("mul_1.onnx"),
-                sess_options=so,
-                providers=["CPUExecutionProvider"],
+                sess_options=so
             )
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             os.remove(so.optimized_model_filepath)
@@ -109,8 +108,7 @@ class TestInferenceSession(unittest.TestCase):
             so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "100")
             onnxrt.InferenceSession(
                 get_name("mnist.onnx"),
-                sess_options=so,
-                providers=["CPUExecutionProvider"],
+                sess_options=so
             )
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             self.assertTrue(os.path.isfile(external_initializers_file))
@@ -137,7 +135,7 @@ class TestInferenceSession(unittest.TestCase):
                 "session.optimized_model_external_initializers_file_name", external_initializers_file
             )
             so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "100")
-            onnxrt.InferenceSession(get_name("mnist.onnx"), sess_options=so, providers=["CPUExecutionProvider"])
+            onnxrt.InferenceSession(get_name("mnist.onnx"), sess_options=so)
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             self.assertTrue(os.path.isfile(os.path.join(directory, external_initializers_file)))
             os.remove(so.optimized_model_filepath)
@@ -164,7 +162,7 @@ class TestInferenceSession(unittest.TestCase):
             )
             so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "100")
             onnxrt.InferenceSession(
-                get_name("model_with_orig_ext_data.onnx"), sess_options=so, providers=["CPUExecutionProvider"]
+                get_name("model_with_orig_ext_data.onnx"), sess_options=so
             )
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             self.assertTrue(os.path.isfile(os.path.join(directory, external_initializers_file)))
@@ -199,7 +197,7 @@ class TestInferenceSession(unittest.TestCase):
         # optimized model only refers to one external data file.
         so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "10")
         session1 = onnxrt.InferenceSession(
-            get_name("model_with_orig_ext_data.onnx"), sess_options=so, providers=["CPUExecutionProvider"]
+            get_name("model_with_orig_ext_data.onnx"), sess_options=so
         )
         del session1
         self.assertTrue(os.path.isfile(optimized_model_filepath))
@@ -217,7 +215,7 @@ class TestInferenceSession(unittest.TestCase):
         # verify that we can load the optimized model with external data in current directory and save
         # optimized model with external data to current directory.
         session2 = onnxrt.InferenceSession(
-            optimized_model_filepath, sess_options=so2, providers=["CPUExecutionProvider"]
+            optimized_model_filepath, sess_options=so2
         )
         del session2
         self.assertTrue(os.path.isfile(optimized_model_filepath_2))
@@ -228,7 +226,7 @@ class TestInferenceSession(unittest.TestCase):
         os.remove(external_initializers_file)
 
         session3 = onnxrt.InferenceSession(
-            optimized_model_filepath_2, sess_options=onnxrt.SessionOptions(), providers=["CPUExecutionProvider"]
+            optimized_model_filepath_2, sess_options=onnxrt.SessionOptions()
         )
         del session3
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -213,9 +213,7 @@ class TestInferenceSession(unittest.TestCase):
         os.remove(optimized_model_filepath)
         os.remove(external_initializers_file)
 
-        session3 = onnxrt.InferenceSession(
-            optimized_model_filepath_2, sess_options=onnxrt.SessionOptions()
-        )
+        session3 = onnxrt.InferenceSession(optimized_model_filepath_2, sess_options=onnxrt.SessionOptions())
         del session3
 
         os.remove(optimized_model_filepath_2)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -80,10 +80,7 @@ class TestInferenceSession(unittest.TestCase):
             so.log_severity_level = 1
             so.logid = "TestModelSerialization"
             so.optimized_model_filepath = "./PythonApiTestOptimizedModel.onnx"
-            onnxrt.InferenceSession(
-                get_name("mul_1.onnx"),
-                sess_options=so
-            )
+            onnxrt.InferenceSession(get_name("mul_1.onnx"), sess_options=so)
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             os.remove(so.optimized_model_filepath)
         except Fail as onnxruntime_error:
@@ -106,10 +103,7 @@ class TestInferenceSession(unittest.TestCase):
                 "session.optimized_model_external_initializers_file_name", external_initializers_file
             )
             so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "100")
-            onnxrt.InferenceSession(
-                get_name("mnist.onnx"),
-                sess_options=so
-            )
+            onnxrt.InferenceSession(get_name("mnist.onnx"), sess_options=so)
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             self.assertTrue(os.path.isfile(external_initializers_file))
             os.remove(so.optimized_model_filepath)
@@ -161,9 +155,7 @@ class TestInferenceSession(unittest.TestCase):
                 "session.optimized_model_external_initializers_file_name", external_initializers_file
             )
             so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "100")
-            onnxrt.InferenceSession(
-                get_name("model_with_orig_ext_data.onnx"), sess_options=so
-            )
+            onnxrt.InferenceSession(get_name("model_with_orig_ext_data.onnx"), sess_options=so)
             self.assertTrue(os.path.isfile(so.optimized_model_filepath))
             self.assertTrue(os.path.isfile(os.path.join(directory, external_initializers_file)))
             os.remove(so.optimized_model_filepath)
@@ -196,9 +188,7 @@ class TestInferenceSession(unittest.TestCase):
         # still refers to the original external data file. We shall fix this issue so that the
         # optimized model only refers to one external data file.
         so.add_session_config_entry("session.optimized_model_external_initializers_min_size_in_bytes", "10")
-        session1 = onnxrt.InferenceSession(
-            get_name("model_with_orig_ext_data.onnx"), sess_options=so
-        )
+        session1 = onnxrt.InferenceSession(get_name("model_with_orig_ext_data.onnx"), sess_options=so)
         del session1
         self.assertTrue(os.path.isfile(optimized_model_filepath))
         self.assertTrue(os.path.isfile(external_initializers_file))
@@ -214,9 +204,7 @@ class TestInferenceSession(unittest.TestCase):
 
         # verify that we can load the optimized model with external data in current directory and save
         # optimized model with external data to current directory.
-        session2 = onnxrt.InferenceSession(
-            optimized_model_filepath, sess_options=so2
-        )
+        session2 = onnxrt.InferenceSession(optimized_model_filepath, sess_options=so2)
         del session2
         self.assertTrue(os.path.isfile(optimized_model_filepath_2))
         self.assertTrue(os.path.isfile(external_initializers_file_2))


### PR DESCRIPTION
Stop throwing the exception when the provider list is empty but there are multiple available EPs.
Other language bindings throw no exception at all, this change will align them up.


