### PR TITLE
[JSEP] allow JsCustomAllocator to deal with zero sized input

### DIFF
--- a/onnxruntime/core/providers/js/allocator.cc
+++ b/onnxruntime/core/providers/js/allocator.cc
@@ -10,6 +10,10 @@ namespace onnxruntime {
 namespace js {
 
 void* JsCustomAllocator::Alloc(size_t size) {
+  if (size == 0) {
+    return nullptr;
+  }
+
   void* p = EM_ASM_PTR({ return Module.jsepAlloc($0); }, size);
   stats_.num_allocs++;
   stats_.bytes_in_use += size;
@@ -17,8 +21,10 @@ void* JsCustomAllocator::Alloc(size_t size) {
 }
 
 void JsCustomAllocator::Free(void* p) {
-  size_t size = (size_t)(void*)EM_ASM_PTR({ return Module.jsepFree($0); }, p);
-  stats_.bytes_in_use -= size;
+  if (p != nullptr) {
+    size_t size = (size_t)(void*)EM_ASM_PTR({ return Module.jsepFree($0); }, p);
+    stats_.bytes_in_use -= size;
+  }
 }
 
 void JsCustomAllocator::GetStats(AllocatorStats* stats) {


### PR DESCRIPTION
### Description
allow JsCustomAllocator to deal with zero sized input.

This is a standalone fix for zero-sized tensor handling for JsCustomAllocator. There are other components in JSEP not supporting zero-sized tensors need to be fixed.