### PR TITLE
Python API has no `AddConfigEntry` and `kOrtSessionOptionsConfigAllowIntraOpSpinning`

### DIFF
--- a/docs/performance/tune-performance/threading.md
+++ b/docs/performance/tune-performance/threading.md
@@ -25,7 +25,7 @@ sess_options = rt.SessionOptions()
 sess_options.intra_op_num_threads = 0
 sess_options.execution_mode = rt.ExecutionMode.ORT_SEQUENTIAL
 sess_options.graph_optimization_level = rt.GraphOptimizationLevel.ORT_ENABLE_ALL
-sess_options.AddConfigEntry(kOrtSessionOptionsConfigAllowIntraOpSpinning, "1")
+sess_options.add_session_config_entry("session.intra_op.allow_spinning", "1")
 ```
 
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

https://github.com/microsoft/onnxruntime/blob/bcc6205161969b292c66601ef9b080dd418d21a2/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h#L94C74-L94C105

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


@ivberg


