### PR TITLE
Remove unnecessary #incldue <stacktrace>

### DIFF
--- a/onnxruntime/core/platform/windows/stacktrace.cc
+++ b/onnxruntime/core/platform/windows/stacktrace.cc
@@ -10,7 +10,6 @@
 #include <stacktrace>
 #endif
 #endif
-#include <stacktrace>
 
 #include "core/common/logging/logging.h"
 #include "core/common/gsl.h"


### PR DESCRIPTION
Sorry I don't know what stacktrace is, but judging from [the above code](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/platform/windows/stacktrace.cc#L10), we have included it based on whether it exists. The file didn't seem to exist on my device, and I did get a compilation error, so I deleted it and it worked.