### PR TITLE
Bugfix: Add initializer to model in AttentionMask directly

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -78,7 +78,15 @@ class AttentionMask:
             # ReduceSum-13: axes is moved from attribute to input
             axes_name = "ort_const_1_reduce_sum_axes"
             if self.model.get_initializer(axes_name) is None:
-                self.add_initializer(name=axes_name, data_type=TensorProto.INT64, dims=[1], vals=[1], raw=False)
+                self.model.add_initializer(
+                    helper.make_tensor(
+                        name=axes_name,
+                        data_type=TensorProto.INT64,
+                        dims=[1],
+                        vals=[1],
+                        raw=False,
+                    )
+                )
             mask_index_node = helper.make_node(
                 "ReduceSum",
                 inputs=[input_name, axes_name],


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fixes a bug introduced in PR https://github.com/microsoft/onnxruntime/pull/17427 where `self.add_initializer` is called in `AttentionMask` but the class doesn't have the given method. 

This adds the initializer directly to `self.model` as before but with `raw=False` as intended in the PR above. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes the bug described above. 
The bug was caught while running Olive tests with the latest ort-nightly builds. 
https://dev.azure.com/aiinfra/PublicPackages/_build/results?buildId=360918&view=logs&j=dbbdd4d8-ffd3-515a-31fd-659375dbdff8&t=13dad60e-7187-5e88-dbc0-776ed0850a3f&l=601

