### PR TITLE
[hotfix] fix session option access in Node.js binding

### DIFF
--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -68,7 +68,7 @@ Napi::Value InferenceSessionWrap::LoadModel(const Napi::CallbackInfo &info) {
       int64_t bytesOffset = info[1].As<Napi::Number>().Int64Value();
       int64_t bytesLength = info[2].As<Napi::Number>().Int64Value();
 
-      ParseSessionOptions(info[1].As<Napi::Object>(), sessionOptions);
+      ParseSessionOptions(info[3].As<Napi::Object>(), sessionOptions);
       this->session_.reset(
           new Ort::Session(OrtEnv(), reinterpret_cast<char *>(buffer) + bytesOffset, bytesLength, sessionOptions));
     } else {


### PR DESCRIPTION
### Description
fix session option access in Node.js binding



### Motivation and Context
This is a bug that affect transformer.js using ONNX Runtime Node.js binding. Issue: #17377

This bug is already fixed in main branch, but it is not picked in 1.16 release.