### PR TITLE
Sync on CUDA EP level stream only if really needed

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -391,7 +391,7 @@ Status CUDAExecutionProvider::OnRunEnd(bool sync_stream) {
     }
   }
 
-  if (sync_stream) {
+  if (use_ep_level_unified_stream_ && sync_stream) {
     CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(static_cast<cudaStream_t>(stream_)));
   }
 


### PR DESCRIPTION
### Description
If my understanding is right, after the multi-stream execution support (#13495), there is a need to synchronize on the CUDA EP level `stream_` within `OnRunEnd()` **if and only if** `use_ep_level_unified_stream_ ` is set to true. As it stands today, we will be doing 2 syncs - one on the stream that was used to queue tasks for `Run()` and then this within `OnRunEnd()` which will synchronize the tasks queued on the default stream (if `use_ep_level_unified_stream_` is false which is the default case unless the user provides their own stream or chooses to use CUDA Graph). Hypothetically, if there is another app using the default stream, we will wait until all the tasks queued on the default stream by that app have completed and then return from `Run()`


### Motivation and Context
This will lead to strange perf of ORT's CUDA EP if used in tandem with another app using the default stream.

Noticed while reviewing https://github.com/microsoft/onnxruntime/pull/17200

