### PR TITLE
[QNN EP] Skip Op validation for Q & DQ node with 5D data

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -236,6 +236,17 @@ Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_w
     if (node_unit.Domain() != kMSInternalNHWCDomain && (op_type == "DepthToSpace" || op_type == "SpaceToDepth" || op_type == "GridSample")) {
       return Status::OK();
     }
+
+    // Explicitly skip the Op validation for Q & DQ node with 5D because of QNN bug.
+    // TODO (hecli), remove once QNN v2.17 is ready
+    if (op_type == "QuantizeLinear" || op_type == "DequantizeLinear") {
+      std::vector<uint32_t> input_shape;
+      ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].node_arg, input_shape),
+                        "QNN EP: Cannot get input shape");
+      if (input_shape.size() == 5) {
+        return Status::OK();
+      }
+    }
   }
 
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/test/providers/qnn/pad_op_test.cpp
+++ b/onnxruntime/test/providers/qnn/pad_op_test.cpp
@@ -329,8 +329,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_Pad4dOutOfRangePadConstantValue) {
                            ExpectedEPNodeAssignment::All);
 }
 
-// Pad 5d supported, but Quantize & Dequantize doesn't support 5d
-TEST_F(QnnHTPBackendTests, DISABLED_Pad5d) {
+TEST_F(QnnHTPBackendTests, Pad5d) {
   RunQDQPadOpTest<uint8_t>(TestInputDef<float>({1, 2, 2, 2, 2}, false, GetFloatDataInRange(1.0f, 10.0f, 16)),
                            TestInputDef<int64_t>({10}, true, {0, 0, 0, 1, 0, 0, 0, 1, 0, 0}),
                            TestInputDef<float>({1}, true, {2.0f}),


### PR DESCRIPTION
[QNN EP] Skip Op validation for Q & DQ node with 5D data

### Description
Skip Op validation for Q & DQ node with 5D data to walk around a bug in QNN


