### PR TITLE
Enable cpp20 builds for DML EP and WinML API

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.cpp
@@ -13,7 +13,7 @@ namespace Dml
         ComPtr<ID3D12Resource> resource;
         auto buffer = CD3DX12_RESOURCE_DESC::Buffer(size, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
         ORT_THROW_IF_FAILED(m_device->CreateCommittedResource(
-            &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+            unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
             D3D12_HEAP_FLAG_NONE,
             &buffer,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
@@ -6,6 +6,11 @@
 #include <assert.h>
 #include "core/providers/dml/OperatorAuthorHelper/Common.h"
 
+template <class T>
+auto unmove_ptr(T&& t) {
+  return &static_cast<T&>(t);
+}
+
 namespace Dml
 {
     using namespace OperatorHelper;

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommon.h
@@ -6,9 +6,9 @@
 #include <assert.h>
 #include "core/providers/dml/OperatorAuthorHelper/Common.h"
 
-template <class T>
+template <typename T>
 auto unmove_ptr(T&& t) {
-  return &static_cast<T&>(t);
+    return &static_cast<T&>(t);
 }
 
 namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -636,7 +636,7 @@ namespace Dml
 
     bool IsCpuOnDmlOperator(const onnxruntime::Node& node)
     {
-        auto cpuOnDmlOperators = std::array<char*, 8>{
+        auto cpuOnDmlOperators = std::array<const char*, 8>{
             "SequenceAt",
             "SequenceConstruct",
             "SequenceEmpty",
@@ -659,7 +659,7 @@ namespace Dml
 
     bool IsDmlSequenceOperator(const onnxruntime::Node& node)
     {
-        auto sequence_ops = std::array<char*, 1>{
+        auto sequence_ops = std::array<const char*, 1>{
             "ConcatFromSequence"
         };
 
@@ -675,7 +675,7 @@ namespace Dml
 
     bool IsCustomOpShader(const onnxruntime::Node& node)
     {
-        auto custom_ops = std::array<char*, 3>{
+        auto custom_ops = std::array<const char*, 3>{
             "DFT",
             "STFT",
             "GridSample"

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBatchNormalization.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorBatchNormalization.cpp
@@ -143,7 +143,8 @@ public:
         );
 
         DML_EXECUTION_FLAGS executionFlags = GetExecutionFlags();
-        m_compiledOperator.Attach(graph.Compile(executionFlags, { batchNormalization }).Detach());
+        std::array<dml::Expression, 1> outputs = { batchNormalization };
+        m_compiledOperator.Attach(graph.Compile(executionFlags, outputs).Detach());
     }
 
     void Compute(const MLOperatorKernelContext& kernelContext) override

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorPooling.cpp
@@ -84,7 +84,7 @@ public:
             poolingDesc.EndPadding = m_kernel.endPadding;
 
             DML_OPERATOR_DESC opDesc = {};
-            opDesc.Type = ApiTraits::OperatorDescTraits<std::remove_reference<decltype(poolingDesc)>::type>::Type;
+            opDesc.Type = ApiTraits::OperatorDescTraits<typename std::remove_reference<decltype(poolingDesc)>::type>::Type;
             opDesc.Desc = &poolingDesc;
             SetDmlOperatorDesc(opDesc, kernelInfo);
         };

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -129,7 +129,7 @@ class CpuDetensorizer {
   }
 
   template <>
-#if __cplusplus < 202002L
+#if _MSVC_LANG < 202002L
   static
 #endif
   float ReadTensor<DirectX::PackedVector::HALF>(
@@ -172,7 +172,7 @@ class CpuDetensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
-#if __cplusplus < 202002L
+#if _MSVC_LANG < 202002L
   static
 #endif
   void InterleaveRowFloatToByte(

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -132,9 +132,10 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  float ReadTensor<DirectX::PackedVector::HALF>(
-    const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
-  ) {
+    float
+    ReadTensor<DirectX::PackedVector::HALF>(
+      const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
+    ) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
   }
 
@@ -175,15 +176,16 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  void InterleaveRowFloatToByte(
-    const float* xChannel,
-    const float* yChannel,
-    const float* zChannel,
-    uint32_t tensorWidth,
-    BYTE* pData,
-    uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter
-  ) {
+    void
+    InterleaveRowFloatToByte(
+      const float* xChannel,
+      const float* yChannel,
+      const float* zChannel,
+      uint32_t tensorWidth,
+      BYTE* pData,
+      uint32_t bytesPerPixel,
+      const NominalRangeConverter& nominalRangeConverter
+    ) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -12,18 +12,16 @@ class CpuDetensorizer {
  public:
   template <typename T>
   static HRESULT Detensorize(
-    _In_ ImageTensorChannelType formatFrom,
-    _In_ ImageTensorChannelType formatTo,
-    _In_ winml::LearningModelPixelRange pixelRange,
-    _In_ T* pCPUTensor,
-    _In_ uint32_t bufferWidth,
-    _In_ uint32_t tensorHeight,
-    _In_ uint32_t tensorWidth,
-    _Inout_ BYTE* pData
-  ) {
+      _In_ ImageTensorChannelType formatFrom,
+      _In_ ImageTensorChannelType formatTo,
+      _In_ winml::LearningModelPixelRange pixelRange,
+      _In_ T* pCPUTensor,
+      _In_ uint32_t bufferWidth,
+      _In_ uint32_t tensorHeight,
+      _In_ uint32_t tensorWidth,
+      _Inout_ BYTE* pData) {
 #pragma warning(push)
-#pragma warning(disable : 26014 \
-)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
+#pragma warning(disable : 26014)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
     // output is BGRA8: so blue at i, green is at i + 1, red is at i + 2
 
     uint32_t bytesPerPixel = formatTo == kImageTensorChannelTypeGRAY8 ? 1 : 4;
@@ -41,14 +39,13 @@ class CpuDetensorizer {
         BYTE* pPixel = pData;
 
         InterleaveRowFloatToByte(
-          pCPUTensor + i * tensorWidth,
-          pCPUTensor + tensorPlaneSize + i * tensorWidth,
-          pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
-          tensorWidth,
-          pPixel,
-          bytesPerPixel,
-          nominalRangeConverter
-        );
+            pCPUTensor + i * tensorWidth,
+            pCPUTensor + tensorPlaneSize + i * tensorWidth,
+            pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
+            tensorWidth,
+            pPixel,
+            bytesPerPixel,
+            nominalRangeConverter);
 
         pData += bufferWidth;
       }
@@ -57,14 +54,13 @@ class CpuDetensorizer {
         BYTE* pPixel = pData;
 
         InterleaveRowFloatToByte(
-          pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
-          pCPUTensor + tensorPlaneSize + i * tensorWidth,
-          pCPUTensor + i * tensorWidth,
-          tensorWidth,
-          pPixel,
-          bytesPerPixel,
-          nominalRangeConverter
-        );
+            pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
+            pCPUTensor + tensorPlaneSize + i * tensorWidth,
+            pCPUTensor + i * tensorWidth,
+            tensorWidth,
+            pPixel,
+            bytesPerPixel,
+            nominalRangeConverter);
 
         pData += bufferWidth;
       }
@@ -132,10 +128,9 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-    float
-    ReadTensor<DirectX::PackedVector::HALF>(
-      const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
-    ) {
+      float
+      ReadTensor<DirectX::PackedVector::HALF>(
+          const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
   }
 
@@ -146,14 +141,13 @@ class CpuDetensorizer {
 
   template <typename T>
   static void InterleaveRowFloatToByte(
-    const T* xChannel,
-    const T* yChannel,
-    const T* zChannel,
-    uint32_t tensorWidth,
-    BYTE* pData,
-    uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter
-  ) {
+      const T* xChannel,
+      const T* yChannel,
+      const T* zChannel,
+      uint32_t tensorWidth,
+      BYTE* pData,
+      uint32_t bytesPerPixel,
+      const NominalRangeConverter& nominalRangeConverter) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 
@@ -176,16 +170,15 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-    void
-    InterleaveRowFloatToByte(
-      const float* xChannel,
-      const float* yChannel,
-      const float* zChannel,
-      uint32_t tensorWidth,
-      BYTE* pData,
-      uint32_t bytesPerPixel,
-      const NominalRangeConverter& nominalRangeConverter
-    ) {
+      void
+      InterleaveRowFloatToByte(
+          const float* xChannel,
+          const float* yChannel,
+          const float* zChannel,
+          uint32_t tensorWidth,
+          BYTE* pData,
+          uint32_t bytesPerPixel,
+          const NominalRangeConverter& nominalRangeConverter) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 
@@ -201,7 +194,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from X channel
       __m128i vXIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel)), maxv));
       __m128i vXIntsHi =
-        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel + 4)), maxv));
+          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vXWords = _mm_packs_epi32(vXIntsLo, vXIntsHi);
@@ -209,7 +202,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from Y channel
       __m128i vYIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel)), maxv));
       __m128i vYIntsHi =
-        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel + 4)), maxv));
+          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vYWords = _mm_packs_epi32(vYIntsLo, vYIntsHi);
@@ -217,7 +210,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from Z channel
       __m128i vZIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel)), maxv));
       __m128i vZIntsHi =
-        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel + 4)), maxv));
+          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vZWords = _mm_packs_epi32(vZIntsLo, vZIntsHi);

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -129,7 +129,7 @@ class CpuDetensorizer {
   }
 
   template <>
-  static float ReadTensor<DirectX::PackedVector::HALF>(
+  float ReadTensor<DirectX::PackedVector::HALF>(
     const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
   ) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
@@ -169,7 +169,7 @@ class CpuDetensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
-  static void InterleaveRowFloatToByte(
+  void InterleaveRowFloatToByte(
     const float* xChannel,
     const float* yChannel,
     const float* zChannel,

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -132,10 +132,9 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  float
-  ReadTensor<DirectX::PackedVector::HALF>(
-      const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
-  ) {
+  float ReadTensor<DirectX::PackedVector::HALF>(
+    const DirectX::PackedVector::HALF* pCPUTensor,
+    const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
   }
 
@@ -176,16 +175,14 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  void
-  InterleaveRowFloatToByte(
+  void InterleaveRowFloatToByte(
     const float* xChannel,
     const float* yChannel,
     const float* zChannel,
     uint32_t tensorWidth,
     BYTE* pData,
     uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter
-  ) {
+    const NominalRangeConverter& nominalRangeConverter) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -129,6 +129,9 @@ class CpuDetensorizer {
   }
 
   template <>
+#if __cplusplus < 202002L
+  static
+#endif
   float ReadTensor<DirectX::PackedVector::HALF>(
     const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
   ) {
@@ -169,6 +172,9 @@ class CpuDetensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
+#if __cplusplus < 202002L
+  static
+#endif
   void InterleaveRowFloatToByte(
     const float* xChannel,
     const float* yChannel,

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -12,16 +12,18 @@ class CpuDetensorizer {
  public:
   template <typename T>
   static HRESULT Detensorize(
-      _In_ ImageTensorChannelType formatFrom,
-      _In_ ImageTensorChannelType formatTo,
-      _In_ winml::LearningModelPixelRange pixelRange,
-      _In_ T* pCPUTensor,
-      _In_ uint32_t bufferWidth,
-      _In_ uint32_t tensorHeight,
-      _In_ uint32_t tensorWidth,
-      _Inout_ BYTE* pData) {
+    _In_ ImageTensorChannelType formatFrom,
+    _In_ ImageTensorChannelType formatTo,
+    _In_ winml::LearningModelPixelRange pixelRange,
+    _In_ T* pCPUTensor,
+    _In_ uint32_t bufferWidth,
+    _In_ uint32_t tensorHeight,
+    _In_ uint32_t tensorWidth,
+    _Inout_ BYTE* pData
+  ) {
 #pragma warning(push)
-#pragma warning(disable : 26014)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
+#pragma warning(disable : 26014 \
+)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
     // output is BGRA8: so blue at i, green is at i + 1, red is at i + 2
 
     uint32_t bytesPerPixel = formatTo == kImageTensorChannelTypeGRAY8 ? 1 : 4;
@@ -39,13 +41,14 @@ class CpuDetensorizer {
         BYTE* pPixel = pData;
 
         InterleaveRowFloatToByte(
-            pCPUTensor + i * tensorWidth,
-            pCPUTensor + tensorPlaneSize + i * tensorWidth,
-            pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
-            tensorWidth,
-            pPixel,
-            bytesPerPixel,
-            nominalRangeConverter);
+          pCPUTensor + i * tensorWidth,
+          pCPUTensor + tensorPlaneSize + i * tensorWidth,
+          pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
+          tensorWidth,
+          pPixel,
+          bytesPerPixel,
+          nominalRangeConverter
+        );
 
         pData += bufferWidth;
       }
@@ -54,13 +57,14 @@ class CpuDetensorizer {
         BYTE* pPixel = pData;
 
         InterleaveRowFloatToByte(
-            pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
-            pCPUTensor + tensorPlaneSize + i * tensorWidth,
-            pCPUTensor + i * tensorWidth,
-            tensorWidth,
-            pPixel,
-            bytesPerPixel,
-            nominalRangeConverter);
+          pCPUTensor + tensorPlaneSize * 2 + i * tensorWidth,
+          pCPUTensor + tensorPlaneSize + i * tensorWidth,
+          pCPUTensor + i * tensorWidth,
+          tensorWidth,
+          pPixel,
+          bytesPerPixel,
+          nominalRangeConverter
+        );
 
         pData += bufferWidth;
       }
@@ -128,9 +132,10 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-      float
-      ReadTensor<DirectX::PackedVector::HALF>(
-          const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter) {
+  float
+  ReadTensor<DirectX::PackedVector::HALF>(
+      const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
+  ) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
   }
 
@@ -141,13 +146,14 @@ class CpuDetensorizer {
 
   template <typename T>
   static void InterleaveRowFloatToByte(
-      const T* xChannel,
-      const T* yChannel,
-      const T* zChannel,
-      uint32_t tensorWidth,
-      BYTE* pData,
-      uint32_t bytesPerPixel,
-      const NominalRangeConverter& nominalRangeConverter) {
+    const T* xChannel,
+    const T* yChannel,
+    const T* zChannel,
+    uint32_t tensorWidth,
+    BYTE* pData,
+    uint32_t bytesPerPixel,
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 
@@ -170,15 +176,16 @@ class CpuDetensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-      void
-      InterleaveRowFloatToByte(
-          const float* xChannel,
-          const float* yChannel,
-          const float* zChannel,
-          uint32_t tensorWidth,
-          BYTE* pData,
-          uint32_t bytesPerPixel,
-          const NominalRangeConverter& nominalRangeConverter) {
+  void
+  InterleaveRowFloatToByte(
+    const float* xChannel,
+    const float* yChannel,
+    const float* zChannel,
+    uint32_t tensorWidth,
+    BYTE* pData,
+    uint32_t bytesPerPixel,
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 
@@ -194,7 +201,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from X channel
       __m128i vXIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel)), maxv));
       __m128i vXIntsHi =
-          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel + 4)), maxv));
+        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(xChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vXWords = _mm_packs_epi32(vXIntsLo, vXIntsHi);
@@ -202,7 +209,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from Y channel
       __m128i vYIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel)), maxv));
       __m128i vYIntsHi =
-          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel + 4)), maxv));
+        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(yChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vYWords = _mm_packs_epi32(vYIntsLo, vYIntsHi);
@@ -210,7 +217,7 @@ class CpuDetensorizer {
       // Load, saturate, and convert to ints, 8 - 32 bit floats from Z channel
       __m128i vZIntsLo = _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel)), maxv));
       __m128i vZIntsHi =
-          _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel + 4)), maxv));
+        _mm_cvtps_epi32(_mm_min_ps(nominalRangeConverter.Denormalize(_mm_loadu_ps(zChannel + 4)), maxv));
 
       // Pack 32 bit ints into 16 bit ints
       __m128i vZWords = _mm_packs_epi32(vZIntsLo, vZIntsHi);

--- a/winml/lib/Api.Image/CpuDetensorizer.h
+++ b/winml/lib/Api.Image/CpuDetensorizer.h
@@ -128,13 +128,14 @@ class CpuDetensorizer {
     return nominalRangeConverter.Denormalize(*pCPUTensor);
   }
 
+  // clang-format off
   template <>
 #if _MSVC_LANG < 202002L
   static
 #endif
   float ReadTensor<DirectX::PackedVector::HALF>(
-    const DirectX::PackedVector::HALF* pCPUTensor,
-    const NominalRangeConverter& nominalRangeConverter) {
+    const DirectX::PackedVector::HALF* pCPUTensor, const NominalRangeConverter& nominalRangeConverter
+  ) {
     return nominalRangeConverter.Denormalize(DirectX::PackedVector::XMConvertHalfToFloat(*pCPUTensor));
   }
 
@@ -170,6 +171,7 @@ class CpuDetensorizer {
     }
   }
 
+  // clang-format off
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
 #if _MSVC_LANG < 202002L
@@ -182,7 +184,8 @@ class CpuDetensorizer {
     uint32_t tensorWidth,
     BYTE* pData,
     uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter) {
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     BYTE* pPixel = pData;
     uint32_t tensorWidthRemaining = tensorWidth;
 

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -113,14 +113,14 @@ class CpuTensorizer {
   static T ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter);
 
   template <>
-#if __cplusplus < 202002L
+#if _MSVC_LANG < 202002L
   static
 #endif
   float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
-#if __cplusplus < 202002L
+#if _MSVC_LANG  < 202002L
   static
 #endif
   DirectX::PackedVector::HALF ConvertByteToFloat(
@@ -167,7 +167,7 @@ class CpuTensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
-#if __cplusplus < 202002L
+#if _MSVC_LANG < 202002L
   static
 #endif
   void DeinterleaveRowByteToFloat(

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -116,16 +116,18 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  float
-  ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+  float ConvertByteToFloat(
+    const BYTE& input,
+    const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
 #if _MSVC_LANG < 202002L
   static
 #endif
-  DirectX::PackedVector::HALF
-  ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+  DirectX::PackedVector::HALF ConvertByteToFloat(
+    const BYTE& input,
+    const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(DirectX::PackedVector::XMConvertFloatToHalf(input));
   }
 
@@ -170,16 +172,14 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  void
-  DeinterleaveRowByteToFloat(
+  void DeinterleaveRowByteToFloat(
     _In_ BYTE* pBuffer,
     _Inout_ float* xChannel,
     _Inout_ float* yChannel,
     _Inout_ float* zChannel,
     uint32_t pixelElements,
     uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter
-  ) {
+    const NominalRangeConverter& nominalRangeConverter) {
     assert(bytesPerPixel == 4);
 
     __m128i ZeroVector = _mm_setzero_si128();

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -12,15 +12,17 @@ class CpuTensorizer {
  public:
   template <typename T>
   static HRESULT TensorizeData(
-      _In_ ImageTensorChannelType formatFrom,
-      _In_ ImageTensorChannelType formatTo,
-      _In_ winml::LearningModelPixelRange pixelRange,
-      _In_ BYTE* pBuffer,
-      _In_ UINT32 bufferWidth,
-      _In_ const wgi::BitmapBounds& inputBounds,
-      _Inout_ T* pCPUTensor) {
+    _In_ ImageTensorChannelType formatFrom,
+    _In_ ImageTensorChannelType formatTo,
+    _In_ winml::LearningModelPixelRange pixelRange,
+    _In_ BYTE* pBuffer,
+    _In_ UINT32 bufferWidth,
+    _In_ const wgi::BitmapBounds& inputBounds,
+    _Inout_ T* pCPUTensor
+  ) {
 #pragma warning(push)
-#pragma warning(disable : 26014)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
+#pragma warning(disable : 26014 \
+)  // warning about possible out of bounds accesing pData, but input is checked for BGRA8 format, so uiCapacity should be in multiples of 4 \
     // input is BGRA8: so blue at i, green is at i + 1, red is at i + 2
 
     uint32_t bytesPerPixel = formatFrom == kImageTensorChannelTypeGRAY8 ? 1 : 4;
@@ -41,25 +43,27 @@ class CpuTensorizer {
       // Convert BGR8 -> BGR8 or RGB8 -> RGB8
       for (uint64_t y = 0; y < yElements; y++) {
         DeinterleaveRowByteToFloat(
-            pBuffer + y * bufferWidth + start,
-            pCPUTensor + y * inputBounds.Width,
-            pCPUTensor + (inputBounds.Height * inputBounds.Width) + y * inputBounds.Width,
-            pCPUTensor + (inputBounds.Height * inputBounds.Width) * 2 + y * inputBounds.Width,
-            xElements,
-            bytesPerPixel,
-            nominalRangeConverter);
+          pBuffer + y * bufferWidth + start,
+          pCPUTensor + y * inputBounds.Width,
+          pCPUTensor + (inputBounds.Height * inputBounds.Width) + y * inputBounds.Width,
+          pCPUTensor + (inputBounds.Height * inputBounds.Width) * 2 + y * inputBounds.Width,
+          xElements,
+          bytesPerPixel,
+          nominalRangeConverter
+        );
       }
     } else if (formatFrom == kImageTensorChannelTypeBGR8 && formatTo == kImageTensorChannelTypeRGB8 || formatFrom == kImageTensorChannelTypeRGB8 && formatTo == kImageTensorChannelTypeBGR8) {
       // Convert RGB8 -> BGR8 or BGR8 -> RGB8
       for (uint32_t y = 0; y < yElements; y++) {
         DeinterleaveRowByteToFloat(
-            pBuffer + y * bufferWidth + start,
-            pCPUTensor + (inputBounds.Height * inputBounds.Width) * 2 + y * inputBounds.Width,
-            pCPUTensor + (inputBounds.Height * inputBounds.Width) + y * inputBounds.Width,
-            pCPUTensor + y * inputBounds.Width,
-            xElements,
-            bytesPerPixel,
-            nominalRangeConverter);
+          pBuffer + y * bufferWidth + start,
+          pCPUTensor + (inputBounds.Height * inputBounds.Width) * 2 + y * inputBounds.Width,
+          pCPUTensor + (inputBounds.Height * inputBounds.Width) + y * inputBounds.Width,
+          pCPUTensor + y * inputBounds.Width,
+          xElements,
+          bytesPerPixel,
+          nominalRangeConverter
+        );
       }
     } else if (formatTo == kImageTensorChannelTypeGRAY8 && (formatFrom == kImageTensorChannelTypeBGR8 || formatFrom == kImageTensorChannelTypeRGB8)) {
       // Convert BGR8 -> GRAY8 or RGB8 -> GRAY8
@@ -82,9 +86,9 @@ class CpuTensorizer {
         for (UINT32 j = i; j < i + bytesPerRow; j += bytesPerPixel) {
           pCPUTensor[pixelInd] = ConvertByteToFloat<T>(pBuffer[j], nominalRangeConverter);
           pCPUTensor[(inputBounds.Height * inputBounds.Width) + pixelInd] =
-              ConvertByteToFloat<T>(pBuffer[j], nominalRangeConverter);
+            ConvertByteToFloat<T>(pBuffer[j], nominalRangeConverter);
           pCPUTensor[(inputBounds.Height * inputBounds.Width * 2) + pixelInd] =
-              ConvertByteToFloat<T>(pBuffer[j], nominalRangeConverter);
+            ConvertByteToFloat<T>(pBuffer[j], nominalRangeConverter);
           pixelInd++;
         }
       }
@@ -112,28 +116,29 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-      float
-      ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+  float
+  ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
 #if _MSVC_LANG < 202002L
   static
 #endif
-      DirectX::PackedVector::HALF
-      ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+  DirectX::PackedVector::HALF
+  ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(DirectX::PackedVector::XMConvertFloatToHalf(input));
   }
 
   template <typename T>
   static void DeinterleaveRowByteToFloat(
-      _In_ BYTE* pBuffer,
-      _Inout_ T* xChannel,
-      _Inout_ T* yChannel,
-      _Inout_ T* zChannel,
-      uint32_t pixelElements,
-      uint32_t bytesPerPixel,
-      const NominalRangeConverter& nominalRangeConverter) {
+    _In_ BYTE* pBuffer,
+    _Inout_ T* xChannel,
+    _Inout_ T* yChannel,
+    _Inout_ T* zChannel,
+    uint32_t pixelElements,
+    uint32_t bytesPerPixel,
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     UINT32 j;
 
     for (j = 0; j < (pixelElements & 0xFFFFFFFC); j += 4) {
@@ -165,15 +170,16 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-      void
-      DeinterleaveRowByteToFloat(
-          _In_ BYTE* pBuffer,
-          _Inout_ float* xChannel,
-          _Inout_ float* yChannel,
-          _Inout_ float* zChannel,
-          uint32_t pixelElements,
-          uint32_t bytesPerPixel,
-          const NominalRangeConverter& nominalRangeConverter) {
+  void
+  DeinterleaveRowByteToFloat(
+    _In_ BYTE* pBuffer,
+    _Inout_ float* xChannel,
+    _Inout_ float* yChannel,
+    _Inout_ float* zChannel,
+    uint32_t pixelElements,
+    uint32_t bytesPerPixel,
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     assert(bytesPerPixel == 4);
 
     __m128i ZeroVector = _mm_setzero_si128();

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -113,10 +113,16 @@ class CpuTensorizer {
   static T ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter);
 
   template <>
+#if __cplusplus < 202002L
+  static
+#endif
   float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
+#if __cplusplus < 202002L
+  static
+#endif
   DirectX::PackedVector::HALF ConvertByteToFloat(
     const BYTE& input, const NominalRangeConverter& nominalRangeConverter
   ) {
@@ -161,6 +167,9 @@ class CpuTensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
+#if __cplusplus < 202002L
+  static
+#endif
   void DeinterleaveRowByteToFloat(
     _In_ BYTE* pBuffer,
     _Inout_ float* xChannel,

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -116,16 +116,16 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+    float
+    ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
-#if _MSVC_LANG  < 202002L
+#if _MSVC_LANG < 202002L
   static
 #endif
-  DirectX::PackedVector::HALF ConvertByteToFloat(
-    const BYTE& input, const NominalRangeConverter& nominalRangeConverter
-  ) {
+    DirectX::PackedVector::HALF
+    ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(DirectX::PackedVector::XMConvertFloatToHalf(input));
   }
 
@@ -170,15 +170,16 @@ class CpuTensorizer {
 #if _MSVC_LANG < 202002L
   static
 #endif
-  void DeinterleaveRowByteToFloat(
-    _In_ BYTE* pBuffer,
-    _Inout_ float* xChannel,
-    _Inout_ float* yChannel,
-    _Inout_ float* zChannel,
-    uint32_t pixelElements,
-    uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter
-  ) {
+    void
+    DeinterleaveRowByteToFloat(
+      _In_ BYTE* pBuffer,
+      _Inout_ float* xChannel,
+      _Inout_ float* yChannel,
+      _Inout_ float* zChannel,
+      uint32_t pixelElements,
+      uint32_t bytesPerPixel,
+      const NominalRangeConverter& nominalRangeConverter
+    ) {
     assert(bytesPerPixel == 4);
 
     __m128i ZeroVector = _mm_setzero_si128();

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -113,11 +113,11 @@ class CpuTensorizer {
   static T ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter);
 
   template <>
-  static float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
+  float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
   template <>
-  static DirectX::PackedVector::HALF ConvertByteToFloat(
+  DirectX::PackedVector::HALF ConvertByteToFloat(
     const BYTE& input, const NominalRangeConverter& nominalRangeConverter
   ) {
     return nominalRangeConverter.Normalize(DirectX::PackedVector::XMConvertFloatToHalf(input));
@@ -161,7 +161,7 @@ class CpuTensorizer {
 
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
-  static void DeinterleaveRowByteToFloat(
+  void DeinterleaveRowByteToFloat(
     _In_ BYTE* pBuffer,
     _Inout_ float* xChannel,
     _Inout_ float* yChannel,

--- a/winml/lib/Api.Image/CpuTensorizer.h
+++ b/winml/lib/Api.Image/CpuTensorizer.h
@@ -112,22 +112,24 @@ class CpuTensorizer {
   template <typename T>
   static T ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter);
 
+  // clang-format off
   template <>
 #if _MSVC_LANG < 202002L
   static
 #endif
-  float ConvertByteToFloat(
-    const BYTE& input,
-    const NominalRangeConverter& nominalRangeConverter) {
+  float ConvertByteToFloat(const BYTE& input, const NominalRangeConverter& nominalRangeConverter) {
     return nominalRangeConverter.Normalize(static_cast<float>(input));
   }
+
+  // clang-format off
   template <>
 #if _MSVC_LANG < 202002L
   static
 #endif
   DirectX::PackedVector::HALF ConvertByteToFloat(
     const BYTE& input,
-    const NominalRangeConverter& nominalRangeConverter) {
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     return nominalRangeConverter.Normalize(DirectX::PackedVector::XMConvertFloatToHalf(input));
   }
 
@@ -167,6 +169,7 @@ class CpuTensorizer {
     }
   }
 
+  // clang-format off
 #if defined(_M_AMD64) || defined(_M_IX86)
   template <>
 #if _MSVC_LANG < 202002L
@@ -179,7 +182,8 @@ class CpuTensorizer {
     _Inout_ float* zChannel,
     uint32_t pixelElements,
     uint32_t bytesPerPixel,
-    const NominalRangeConverter& nominalRangeConverter) {
+    const NominalRangeConverter& nominalRangeConverter
+  ) {
     assert(bytesPerPixel == 4);
 
     __m128i ZeroVector = _mm_setzero_si128();

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -689,7 +689,9 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   device_cache.SyncD3D12ToCPU();
 
   void* pCPUTensorBuffer = nullptr;
-  WINML_THROW_IF_FAILED(readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer));
+  WINML_THROW_IF_FAILED(
+    readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer)
+  );
 
   // We avoid the Video Frame pipeline by manually downloading the GPU data to the CPU and detensorize while we are filling the readback heap
   ConvertCPUTensorToSoftwareBitmap(pCPUTensorBuffer, tensorDesc, softwareBitmap);
@@ -733,9 +735,9 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
   device_cache.SyncD3D12ToCPU();
 
   byte* readback_buffer = nullptr;
-  WINML_THROW_IF_FAILED(
-    readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer))
-  );
+  WINML_THROW_IF_FAILED(readback_heap_->Map(
+    0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer)
+  ));
   auto readback_buffer_span = gsl::span<byte>(readback_buffer, buffer_size_in_bytes);
   _winml::StoreSpanIntoDisjointBuffers(
     buffers.size(),

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -30,27 +30,29 @@ class GPUTensorToDX12TextureTelemetryEvent {
   GPUTensorToDX12TextureTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "GPUTensorToDX12TextureStart",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "GPUTensorToDX12TextureStart",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
   ~GPUTensorToDX12TextureTelemetryEvent() {
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "GPUTensorToDX12TextureStop",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(S_OK, "HRESULT"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "GPUTensorToDX12TextureStop",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(S_OK, "HRESULT"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
 
  private:
@@ -62,27 +64,29 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
   ConvertGPUTensorToSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "ConvertGPUTensorToSoftwareBitmapStart",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "ConvertGPUTensorToSoftwareBitmapStart",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
   ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "ConvertGPUTensorToSoftwareBitmapStop",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(S_OK, "HRESULT"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "ConvertGPUTensorToSoftwareBitmapStop",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(S_OK, "HRESULT"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
 
  private:
@@ -94,27 +98,29 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
   ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStart",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStart",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
   ~ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
-        winml_trace_logging_provider,
-        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStop",
-        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-        TraceLoggingHexInt32(S_OK, "HRESULT"),
-        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+      winml_trace_logging_provider,
+      "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStop",
+      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+      TraceLoggingHexInt32(S_OK, "HRESULT"),
+      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
+    );
   }
 
  private:
@@ -122,11 +128,12 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
 };
 
 void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
-    _In_ UINT32 batchIdx,
-    _In_ winml::LearningModelSession& session,
-    _In_ ID3D12Resource* pInputTensor,
-    _In_ const _winml::ImageTensorDescription& tensorDesc,
-    _Inout_ wm::VideoFrame& destVideoFrame) {
+  _In_ UINT32 batchIdx,
+  _In_ winml::LearningModelSession& session,
+  _In_ ID3D12Resource* pInputTensor,
+  _In_ const _winml::ImageTensorDescription& tensorDesc,
+  _Inout_ wm::VideoFrame& destVideoFrame
+) {
   CWinMLAutoLock lock(&lock_);
 
   auto spDevice = session.Device().as<winmlp::LearningModelDevice>();
@@ -139,15 +146,16 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
     ConvertGPUTensorToSoftwareBitmap(batchIdx, pInputTensor, *pDeviceCache, tensorDesc, softwareBitmap);
   } else if (spDestDirect3DSurface) {
     bool isUAVSupportedFormat = _winmli::FormatSupportedForUAV(
-        pDeviceCache->GetD3D12Device(),
-        _winmli::GetDXGIFormatFromDirectXPixelFormat(spDestDirect3DSurface.Description().Format));
+      pDeviceCache->GetD3D12Device(),
+      _winmli::GetDXGIFormatFromDirectXPixelFormat(spDestDirect3DSurface.Description().Format)
+    );
 
     // UAV support for formats is device dependent
     if (!isUAVSupportedFormat) {
       ConvertDX12TensorToUnsupportedVideoFrameFormat(batchIdx, pInputTensor, *pDeviceCache, tensorDesc, destVideoFrame);
     } else {
       ComPtr<ID3D11Texture2D> spVideoFrameTexture =
-          _winmli::GetTextureFromDirect3DSurface(destVideoFrame.Direct3DSurface());
+        _winmli::GetTextureFromDirect3DSurface(destVideoFrame.Direct3DSurface());
 
       D3D11_TEXTURE2D_DESC videoFrameTextureDesc;
       spVideoFrameTexture->GetDesc(&videoFrameTextureDesc);
@@ -199,9 +207,11 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
 
           // Cache the shared texture on the video frame texture in order to tie their lifetime together
           WINML_THROW_IF_FAILED(
-              spVideoFrameTexture->SetPrivateDataInterface(_d3d11TextureGUID, spSharedD3D11Texture.Get()));
+            spVideoFrameTexture->SetPrivateDataInterface(_d3d11TextureGUID, spSharedD3D11Texture.Get())
+          );
           WINML_THROW_IF_FAILED(
-              spVideoFrameTexture->SetPrivateData(_handleGUID, sizeof(shared_handle_), &shared_handle_));
+            spVideoFrameTexture->SetPrivateData(_handleGUID, sizeof(shared_handle_), &shared_handle_)
+          );
         }
 
         // Detensorize
@@ -221,7 +231,8 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
 }
 
 ComPtr<ID3D12Resource> TensorToVideoFrameConverter::CreateShareableD3D12Texture(
-    const D3D11_TEXTURE2D_DESC& d3d11Desc, ID3D12Device* d3d12Device) {
+  const D3D11_TEXTURE2D_DESC& d3d11Desc, ID3D12Device* d3d12Device
+) {
   D3D12_HEAP_PROPERTIES heapProps{};
   heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
 
@@ -238,31 +249,35 @@ ComPtr<ID3D12Resource> TensorToVideoFrameConverter::CreateShareableD3D12Texture(
 
   ComPtr<ID3D12Resource> d3d12Resource;
   WINML_THROW_IF_FAILED(d3d12Device->CreateCommittedResource(
-      &heapProps, D3D12_HEAP_FLAG_SHARED, &resDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&d3d12Resource)));
+    &heapProps, D3D12_HEAP_FLAG_SHARED, &resDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&d3d12Resource)
+  ));
 
   return d3d12Resource;
 }
 
 void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat(
-    _In_ UINT32 batchIdx,
-    _In_ ID3D12Resource* pInputTensor,
-    _In_ _winml::D3DDeviceCache& device_cache,
-    _In_ const ImageTensorDescription& tensorDesc,
-    _Inout_ wm::VideoFrame& unsupportedVideoFrame) {
+  _In_ UINT32 batchIdx,
+  _In_ ID3D12Resource* pInputTensor,
+  _In_ _winml::D3DDeviceCache& device_cache,
+  _In_ const ImageTensorDescription& tensorDesc,
+  _Inout_ wm::VideoFrame& unsupportedVideoFrame
+) {
   assert(pInputTensor != nullptr);
 
   // Find the first supported format and convert to it
   auto supportedFormatIter = std::find_if(
-      _winmli::supportedWinMLFormats.begin(),
-      _winmli::supportedWinMLFormats.end(),
-      [&device_cache](DXGI_FORMAT format) {
-        return _winmli::FormatSupportedForUAV(device_cache.GetD3D12Device(), format);
-      });
+    _winmli::supportedWinMLFormats.begin(),
+    _winmli::supportedWinMLFormats.end(),
+    [&device_cache](DXGI_FORMAT format) {
+      return _winmli::FormatSupportedForUAV(device_cache.GetD3D12Device(), format);
+    }
+  );
 
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      supportedFormatIter != _winmli::supportedWinMLFormats.end(),
-      "Detensorization for this format is unsupported on the current device.");
+    E_INVALIDARG,
+    supportedFormatIter != _winmli::supportedWinMLFormats.end(),
+    "Detensorization for this format is unsupported on the current device."
+  );
 
   D3D11_TEXTURE2D_DESC supportedDesc{};
   supportedDesc.Width = unsupportedVideoFrame.Direct3DSurface().Description().Width;
@@ -275,7 +290,7 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
   supportedDesc.Usage = D3D11_USAGE_DEFAULT;
 
   ComPtr<ID3D11Texture2D> unsupportedTexture =
-      _winmli::GetTextureFromDirect3DSurface(unsupportedVideoFrame.Direct3DSurface());
+    _winmli::GetTextureFromDirect3DSurface(unsupportedVideoFrame.Direct3DSurface());
 
   ComPtr<ID3D11Device> d3d11Device;
   unsupportedTexture->GetDevice(&d3d11Device);
@@ -291,7 +306,8 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
 
   wgdx::Direct3D11::IDirect3DSurface surface;
   WINML_THROW_IF_FAILED(inspectableSurface->QueryInterface(
-      winrt::guid_of<decltype(surface)>(), reinterpret_cast<void**>(winrt::put_abi(surface))));
+    winrt::guid_of<decltype(surface)>(), reinterpret_cast<void**>(winrt::put_abi(surface))
+  ));
   converted_video_frame_ = wm::VideoFrame::CreateWithDirect3D11Surface(surface);
 
   // Detensorize
@@ -305,7 +321,8 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
 }
 
 ComPtr<ID3D11Texture2D> TensorToVideoFrameConverter::ShareD3D12Texture(
-    ID3D12Resource* pResource, ID3D11Device* pDevice) {
+  ID3D12Resource* pResource, ID3D11Device* pDevice
+) {
   assert(pResource != nullptr);
   assert(pDevice != nullptr);
 
@@ -329,10 +346,11 @@ ComPtr<ID3D11Texture2D> TensorToVideoFrameConverter::ShareD3D12Texture(
 }
 
 void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
-    _In_ winml::LearningModelSession& session,
-    _In_ BYTE* pCPUTensorToConvert,
-    _In_ ImageTensorDescription tensorDesc,
-    _Inout_ wm::VideoFrame& pDestVideoFrame) {
+  _In_ winml::LearningModelSession& session,
+  _In_ BYTE* pCPUTensorToConvert,
+  _In_ ImageTensorDescription tensorDesc,
+  _Inout_ wm::VideoFrame& pDestVideoFrame
+) {
   CWinMLAutoLock lock(&lock_);
   wm::IVideoFrame spTensorFrame;
   UINT32 outputWidth = 0;
@@ -361,10 +379,12 @@ void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
   }
 
   if (_winmli::NeedsVideoFrameConversion(
-          pDestVideoFrame, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight)) {
+        pDestVideoFrame, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight
+      )) {
     if (converted_video_frame_ == nullptr || _winmli::NeedsVideoFrameConversion(converted_video_frame_, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight)) {
       converted_video_frame_ = wm::VideoFrame::CreateWithSoftwareBitmap(
-          wgi::SoftwareBitmap(wgi::BitmapPixelFormat::Bgra8, tensorWidth, tensorHeight));
+        wgi::SoftwareBitmap(wgi::BitmapPixelFormat::Bgra8, tensorWidth, tensorHeight)
+      );
     }
 
     spTensorFrame = converted_video_frame_;
@@ -377,16 +397,18 @@ void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
 
   if (converted_video_frame_) {
     _winmli::ConvertVideoFrameToVideoFrame(
-        converted_video_frame_, inputBounds, outputWidth, outputHeight, pDestVideoFrame);
+      converted_video_frame_, inputBounds, outputWidth, outputHeight, pDestVideoFrame
+    );
   }
 }
 
 void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
-    _In_ UINT32 batchIdx,
-    _In_ ID3D12Resource* pInputResource,
-    _In_ _winml::D3DDeviceCache& device_cache,
-    _In_ const ImageTensorDescription& tensorDesc,
-    _Inout_ ID3D12Resource* pOutputResource) {
+  _In_ UINT32 batchIdx,
+  _In_ ID3D12Resource* pInputResource,
+  _In_ _winml::D3DDeviceCache& device_cache,
+  _In_ const ImageTensorDescription& tensorDesc,
+  _Inout_ ID3D12Resource* pOutputResource
+) {
   assert(pInputResource != nullptr);
   assert(pOutputResource != nullptr);
 
@@ -405,57 +427,68 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   }
 
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      outputDesc.Format == DXGI_FORMAT_B8G8R8A8_UNORM || outputDesc.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
-          outputDesc.Format == DXGI_FORMAT_R8_UNORM,
-      "Format was output image %d. Output image format must be Bgra8, Rgba8 or Gray8.",
-      outputDesc.Format);
+    E_INVALIDARG,
+    outputDesc.Format == DXGI_FORMAT_B8G8R8A8_UNORM || outputDesc.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
+      outputDesc.Format == DXGI_FORMAT_R8_UNORM,
+    "Format was output image %d. Output image format must be Bgra8, Rgba8 or Gray8.",
+    outputDesc.Format
+  );
 
   // Validate input description
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG, inputDesc.Height != 0, "Invalid input image height provided. Height is set to zero.");
+    E_INVALIDARG, inputDesc.Height != 0, "Invalid input image height provided. Height is set to zero."
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG, inputDesc.Width != 0, "Invalid input image height provided. Height is set to zero.");
+    E_INVALIDARG, inputDesc.Width != 0, "Invalid input image height provided. Height is set to zero."
+  );
 
   // Validate output description
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG, outputDesc.Height != 0, "Invalid input image height provided. Height is set to zero.");
+    E_INVALIDARG, outputDesc.Height != 0, "Invalid input image height provided. Height is set to zero."
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG, outputDesc.Width != 0, "Invalid input image height provided. Height is set to zero.");
+    E_INVALIDARG, outputDesc.Width != 0, "Invalid input image height provided. Height is set to zero."
+  );
 
   // Validate Tensor description
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
-      "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
-      tensorDesc.dataType);
+    E_INVALIDARG,
+    tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
+    "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
+    tensorDesc.dataType
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
-      "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
+    "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
-      "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
+    "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
-      "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
+    "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.sizes[2] == outputDesc.Height,
-      "Target tensor height (%lld) does not match input height (%lu).",
-      tensorDesc.sizes[2],
-      outputDesc.Height);
+    E_INVALIDARG,
+    tensorDesc.sizes[2] == outputDesc.Height,
+    "Target tensor height (%lld) does not match input height (%lu).",
+    tensorDesc.sizes[2],
+    outputDesc.Height
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.sizes[3] == (UINT)outputDesc.Width,
-      "Target tensor width (%lld) does not match input width (%lu).",
-      tensorDesc.sizes[3],
-      (UINT)outputDesc.Width);
+    E_INVALIDARG,
+    tensorDesc.sizes[3] == (UINT)outputDesc.Width,
+    "Target tensor width (%lld) does not match input width (%lu).",
+    tensorDesc.sizes[3],
+    (UINT)outputDesc.Width
+  );
 
   // Create descriptor heaps
   UINT srvUavDescriptorSize = spDx12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -467,12 +500,13 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   if (!UAV_resource_ || outputDesc.Format != UAV_resource_->GetDesc().Format ||
       outputDesc.Width != UAV_resource_->GetDesc().Width || outputDesc.Height != UAV_resource_->GetDesc().Height) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
-        D3D12_HEAP_FLAG_NONE,
-        &outputResourceDesc,
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        nullptr,
-        IID_PPV_ARGS(&UAV_resource_)));
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
+      D3D12_HEAP_FLAG_NONE,
+      &outputResourceDesc,
+      D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+      nullptr,
+      IID_PPV_ARGS(&UAV_resource_)
+    ));
   }
 
   if (descriptor_heap_ == nullptr) {
@@ -489,14 +523,16 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   {
     D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = CreateSRVDescriptor(batchIdx, inputDesc, tensorDesc);
     CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(
-        descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize);
+      descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize
+    );
     spDx12Device->CreateShaderResourceView(pInputResource, &srvDesc, srvHandle);
 
     D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
     uavDesc.Format = outputResourceDesc.Format;
     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
     CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle(
-        descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize);
+      descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize
+    );
     spDx12Device->CreateUnorderedAccessView(UAV_resource_.Get(), nullptr, &uavDesc, uavHandle);
   }
 
@@ -526,7 +562,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
 
   root_signature_ = device_cache.GetDetensorizeRootSignature();
   pipeline_state_ =
-      device_cache.GetCachedPipelineState(type, formatFrom, formatTo, PipelineStateCacheOperation::kDetensorize);
+    device_cache.GetCachedPipelineState(type, formatFrom, formatTo, PipelineStateCacheOperation::kDetensorize);
 
   ResetCommandList(device_cache);
 
@@ -543,9 +579,11 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     }
 
     CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(
-        descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize);
+      descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize
+    );
     CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(
-        descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize);
+      descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize
+    );
     {
       ConstantBufferCS constantBufferCS = {};
       constantBufferCS.height = static_cast<UINT>(tensorDesc.sizes[2]);
@@ -559,25 +597,33 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     auto dispatchHeight = static_cast<UINT>((tensorDesc.sizes[2] - 1) / 4 + 1);
 
     command_list_->ResourceBarrier(
-        1,
-        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-            pInputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)));
+      1,
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+        pInputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+      ))
+    );
     command_list_->Dispatch(dispatchWidth, dispatchHeight, 1);
     command_list_->ResourceBarrier(
-        1,
-        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-            pInputResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS)));
+      1,
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+        pInputResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+      ))
+    );
 
     // Copy the UAV data to the output resource after detensorization
     command_list_->ResourceBarrier(
-        1,
-        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-            UAV_resource_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE)));
+      1,
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+        UAV_resource_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
+      ))
+    );
     command_list_->CopyResource(pOutputResource, UAV_resource_.Get());
     command_list_->ResourceBarrier(
-        1,
-        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-            UAV_resource_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS)));
+      1,
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+        UAV_resource_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+      ))
+    );
 
     WINML_THROW_IF_FAILED(command_list_->Close());
     ID3D12CommandList* pComputeToGPUCLs[] = {command_list_.Get()};
@@ -587,11 +633,12 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
 }
 
 void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
-    _In_ UINT32 batchIdx,
-    _In_ ID3D12Resource* pInputTensor,
-    _In_ _winml::D3DDeviceCache& device_cache,
-    _In_ const ImageTensorDescription& tensorDesc,
-    _Inout_ wgi::SoftwareBitmap& softwareBitmap) {
+  _In_ UINT32 batchIdx,
+  _In_ ID3D12Resource* pInputTensor,
+  _In_ _winml::D3DDeviceCache& device_cache,
+  _In_ const ImageTensorDescription& tensorDesc,
+  _Inout_ wgi::SoftwareBitmap& softwareBitmap
+) {
   assert(pInputTensor != nullptr);
   assert(softwareBitmap != nullptr);
 
@@ -604,31 +651,34 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 
   uint32_t tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
   uint32_t singleVideoFramebufferSize =
-      static_cast<uint32_t>(tensorDesc.sizes[1] * tensorDesc.sizes[2] * tensorDesc.sizes[3] * tensorElementSize);
+    static_cast<uint32_t>(tensorDesc.sizes[1] * tensorDesc.sizes[2] * tensorDesc.sizes[3] * tensorElementSize);
 
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < singleVideoFramebufferSize) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
-        D3D12_HEAP_FLAG_NONE,
-        unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize)),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        nullptr,
-        IID_PPV_ARGS(&readback_heap_)));
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
+      D3D12_HEAP_FLAG_NONE,
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize)),
+      D3D12_RESOURCE_STATE_COPY_DEST,
+      nullptr,
+      IID_PPV_ARGS(&readback_heap_)
+    ));
   }
 
   ResetCommandList(device_cache);
 
   auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-      pInputTensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    pInputTensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
+  );
   command_list_->ResourceBarrier(1, &barrier);
 
   command_list_->CopyBufferRegion(
-      readback_heap_.Get(),
-      0,
-      pInputTensor,
-      static_cast<uint64_t>(singleVideoFramebufferSize) * batchIdx,
-      singleVideoFramebufferSize);
+    readback_heap_.Get(),
+    0,
+    pInputTensor,
+    static_cast<uint64_t>(singleVideoFramebufferSize) * batchIdx,
+    singleVideoFramebufferSize
+  );
 
   WINML_THROW_IF_FAILED(command_list_->Close());
   ID3D12CommandList* ppCommandLists[] = {command_list_.Get()};
@@ -639,7 +689,8 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 
   void* pCPUTensorBuffer = nullptr;
   WINML_THROW_IF_FAILED(
-      readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer));
+    readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer)
+  );
 
   // We avoid the Video Frame pipeline by manually downloading the GPU data to the CPU and detensorize while we are filling the readback heap
   ConvertCPUTensorToSoftwareBitmap(pCPUTensorBuffer, tensorDesc, softwareBitmap);
@@ -648,27 +699,30 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 }
 
 void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
-    _In_ ID3D12Resource* input_tensor,
-    _In_ size_t buffer_size_in_bytes,
-    _In_ _winml::D3DDeviceCache& device_cache,
-    _Inout_ const std::vector<wss::IBuffer>& buffers) {
+  _In_ ID3D12Resource* input_tensor,
+  _In_ size_t buffer_size_in_bytes,
+  _In_ _winml::D3DDeviceCache& device_cache,
+  _Inout_ const std::vector<wss::IBuffer>& buffers
+) {
   assert(input_tensor != nullptr);
 
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < buffer_size_in_bytes) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
-        D3D12_HEAP_FLAG_NONE,
-        unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        nullptr,
-        IID_PPV_ARGS(&readback_heap_)));
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
+      D3D12_HEAP_FLAG_NONE,
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
+      D3D12_RESOURCE_STATE_COPY_DEST,
+      nullptr,
+      IID_PPV_ARGS(&readback_heap_)
+    ));
   }
 
   ResetCommandList(device_cache);
 
   auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-      input_tensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    input_tensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
+  );
   command_list_->ResourceBarrier(1, &barrier);
   command_list_->CopyBufferRegion(readback_heap_.Get(), 0, input_tensor, 0, buffer_size_in_bytes);
 
@@ -681,23 +735,26 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
 
   byte* readback_buffer = nullptr;
   WINML_THROW_IF_FAILED(readback_heap_->Map(
-      0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer)));
+    0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer)
+  ));
   auto readback_buffer_span = gsl::span<byte>(readback_buffer, buffer_size_in_bytes);
   _winml::StoreSpanIntoDisjointBuffers(
-      buffers.size(),
-      [&](size_t i) {
-        byte* buffer_start = nullptr;
-        auto byte_access = buffers[i].as<Windows::Storage::Streams::IBufferByteAccess>();
-        byte_access->Buffer(&buffer_start);
-        return gsl::span<byte>(buffer_start, static_cast<size_t>(buffers[i].Capacity()));
-      },
-      readback_buffer_span);
+    buffers.size(),
+    [&](size_t i) {
+      byte* buffer_start = nullptr;
+      auto byte_access = buffers[i].as<Windows::Storage::Streams::IBufferByteAccess>();
+      byte_access->Buffer(&buffer_start);
+      return gsl::span<byte>(buffer_start, static_cast<size_t>(buffers[i].Capacity()));
+    },
+    readback_buffer_span
+  );
 
   readback_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, 0)));
 }
 
 D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor(
-    const UINT32 batchIdx, const D3D12_RESOURCE_DESC& resourceDesc, const _winml::ImageTensorDescription& desc) {
+  const UINT32 batchIdx, const D3D12_RESOURCE_DESC& resourceDesc, const _winml::ImageTensorDescription& desc
+) {
   UINT uiTensorElementSize = desc.dataType == kImageTensorDataTypeFloat32 ? sizeof(UINT) : sizeof(uint16_t);
 
   D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
@@ -721,16 +778,18 @@ D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor
     srvDesc.Buffer.StructureByteStride = 0;
   } else {
     WINML_THROW_HR_IF_FALSE_MSG(
-        E_INVALIDARG,
-        false,
-        "Tensorization conversion is only supported to kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16.");
+      E_INVALIDARG,
+      false,
+      "Tensorization conversion is only supported to kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16."
+    );
   }
 
   return srvDesc;
 }
 
 void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
-    _In_ void* pCPUTensor, _In_ const ImageTensorDescription& tensorDesc, _Inout_ wgi::SoftwareBitmap& softwareBitmap) {
+  _In_ void* pCPUTensor, _In_ const ImageTensorDescription& tensorDesc, _Inout_ wgi::SoftwareBitmap& softwareBitmap
+) {
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
   std::optional<ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent> telemetryLogger;
@@ -744,53 +803,61 @@ void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
 
   // Validate input description
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      format == wgi::BitmapPixelFormat::Bgra8 || format == wgi::BitmapPixelFormat::Rgba8 ||
-          format == wgi::BitmapPixelFormat::Gray8,
-      "Format was input image %d. Input image format must Bgra8, Rgba8 or Gray8.",
-      format);
+    E_INVALIDARG,
+    format == wgi::BitmapPixelFormat::Bgra8 || format == wgi::BitmapPixelFormat::Rgba8 ||
+      format == wgi::BitmapPixelFormat::Gray8,
+    "Format was input image %d. Input image format must Bgra8, Rgba8 or Gray8.",
+    format
+  );
   WINML_THROW_HR_IF_FALSE_MSG(E_INVALIDARG, height > 0, "Output input image height provided. Height is set to zero.");
   WINML_THROW_HR_IF_FALSE_MSG(E_INVALIDARG, width > 0, "Output input image width provided. Width is set to zero.");
 
   // Validate Tensor description
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
-      "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
-      tensorDesc.dataType);
+    E_INVALIDARG,
+    tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
+    "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
+    tensorDesc.dataType
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
-      "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
+    "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
-      "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
+    "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
-      "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
-      tensorDesc.sizes[1]);
+    E_INVALIDARG,
+    tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
+    "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
+    tensorDesc.sizes[1]
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.channelType == kImageTensorChannelTypeGRAY8 || tensorDesc.channelType == kImageTensorChannelTypeBGR8 ||
-          tensorDesc.channelType == kImageTensorChannelTypeRGB8,
-      "Target tensor description expects kImageTensorChannelTypeGRAY8, kImageTensorChannelTypeBGR8, or kImageTensorChannelTypeRGB8 but has %d was specified.",
-      tensorDesc.channelType);
+    E_INVALIDARG,
+    tensorDesc.channelType == kImageTensorChannelTypeGRAY8 || tensorDesc.channelType == kImageTensorChannelTypeBGR8 ||
+      tensorDesc.channelType == kImageTensorChannelTypeRGB8,
+    "Target tensor description expects kImageTensorChannelTypeGRAY8, kImageTensorChannelTypeBGR8, or kImageTensorChannelTypeRGB8 but has %d was specified.",
+    tensorDesc.channelType
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.sizes[2] == (UINT)height,
-      "Target tensor height (%lld) does not match input height (%lu).",
-      tensorDesc.sizes[2],
-      (UINT)height);
+    E_INVALIDARG,
+    tensorDesc.sizes[2] == (UINT)height,
+    "Target tensor height (%lld) does not match input height (%lu).",
+    tensorDesc.sizes[2],
+    (UINT)height
+  );
   WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      tensorDesc.sizes[3] == (UINT)width,
-      "Target tensor width (%lld) does not match input width (%lu).",
-      tensorDesc.sizes[3],
-      (UINT)width);
+    E_INVALIDARG,
+    tensorDesc.sizes[3] == (UINT)width,
+    "Target tensor width (%lld) does not match input width (%lu).",
+    tensorDesc.sizes[3],
+    (UINT)width
+  );
 
   // get the byte buffer out of a softwarebitmap
   BYTE* pData = nullptr;
@@ -807,23 +874,25 @@ void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
 
   if (tensorDesc.dataType == kImageTensorDataTypeFloat32) {
     WINML_THROW_IF_FAILED(CpuDetensorizer::Detensorize<float>(
-        tensorDesc.channelType,
-        targetChannelType,
-        tensorDesc.pixelRange,
-        static_cast<float*>(pCPUTensor),
-        bufferWidth,
-        height,
-        width,
-        pData));
+      tensorDesc.channelType,
+      targetChannelType,
+      tensorDesc.pixelRange,
+      static_cast<float*>(pCPUTensor),
+      bufferWidth,
+      height,
+      width,
+      pData
+    ));
   } else if (tensorDesc.dataType == kImageTensorDataTypeFloat16) {
     WINML_THROW_IF_FAILED(CpuDetensorizer::Detensorize<DirectX::PackedVector::HALF>(
-        tensorDesc.channelType,
-        targetChannelType,
-        tensorDesc.pixelRange,
-        static_cast<DirectX::PackedVector::HALF*>(pCPUTensor),
-        bufferWidth,
-        height,
-        width,
-        pData));
+      tensorDesc.channelType,
+      targetChannelType,
+      tensorDesc.pixelRange,
+      static_cast<DirectX::PackedVector::HALF*>(pCPUTensor),
+      bufferWidth,
+      height,
+      width,
+      pData
+    ));
   }
 }

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -501,7 +501,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   if (!UAV_resource_ || outputDesc.Format != UAV_resource_->GetDesc().Format ||
         outputDesc.Width != UAV_resource_->GetDesc().Width || outputDesc.Height != UAV_resource_->GetDesc().Height) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
       D3D12_HEAP_FLAG_NONE,
       &outputResourceDesc,
       D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
@@ -599,31 +599,31 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
 
     command_list_->ResourceBarrier(
       1,
-      &CD3DX12_RESOURCE_BARRIER::Transition(
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
         pInputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
-      )
+      ))
     );
     command_list_->Dispatch(dispatchWidth, dispatchHeight, 1);
     command_list_->ResourceBarrier(
       1,
-      &CD3DX12_RESOURCE_BARRIER::Transition(
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
         pInputResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
-      )
+      ))
     );
 
     // Copy the UAV data to the output resource after detensorization
     command_list_->ResourceBarrier(
       1,
-      &CD3DX12_RESOURCE_BARRIER::Transition(
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
         UAV_resource_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
-      )
+      ))
     );
     command_list_->CopyResource(pOutputResource, UAV_resource_.Get());
     command_list_->ResourceBarrier(
       1,
-      &CD3DX12_RESOURCE_BARRIER::Transition(
+      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
         UAV_resource_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
-      )
+      ))
     );
 
     WINML_THROW_IF_FAILED(command_list_->Close());
@@ -657,9 +657,9 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < singleVideoFramebufferSize) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
       D3D12_HEAP_FLAG_NONE,
-      &CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize),
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize)),
       D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr,
       IID_PPV_ARGS(&readback_heap_)
@@ -689,12 +689,12 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
   device_cache.SyncD3D12ToCPU();
 
   void* pCPUTensorBuffer = nullptr;
-  WINML_THROW_IF_FAILED(readback_heap_->Map(0, &CD3DX12_RANGE(0, singleVideoFramebufferSize), &pCPUTensorBuffer));
+  WINML_THROW_IF_FAILED(readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer));
 
   // We avoid the Video Frame pipeline by manually downloading the GPU data to the CPU and detensorize while we are filling the readback heap
   ConvertCPUTensorToSoftwareBitmap(pCPUTensorBuffer, tensorDesc, softwareBitmap);
 
-  readback_heap_->Unmap(0, &CD3DX12_RANGE(0, 0));
+  readback_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, 0)));
 }
 
 void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
@@ -708,9 +708,9 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < buffer_size_in_bytes) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
       D3D12_HEAP_FLAG_NONE,
-      &CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes),
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
       D3D12_RESOURCE_STATE_COPY_DEST,
       nullptr,
       IID_PPV_ARGS(&readback_heap_)
@@ -734,7 +734,7 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
 
   byte* readback_buffer = nullptr;
   WINML_THROW_IF_FAILED(
-    readback_heap_->Map(0, &CD3DX12_RANGE(0, buffer_size_in_bytes), reinterpret_cast<void**>(&readback_buffer))
+    readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer))
   );
   auto readback_buffer_span = gsl::span<byte>(readback_buffer, buffer_size_in_bytes);
   _winml::StoreSpanIntoDisjointBuffers(
@@ -748,7 +748,7 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
     readback_buffer_span
   );
 
-  readback_heap_->Unmap(0, &CD3DX12_RANGE(0, 0));
+  readback_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, 0)));
 }
 
 D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor(

--- a/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
+++ b/winml/lib/Api.Image/TensorToVideoFrameConverter.cpp
@@ -30,29 +30,27 @@ class GPUTensorToDX12TextureTelemetryEvent {
   GPUTensorToDX12TextureTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "GPUTensorToDX12TextureStart",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "GPUTensorToDX12TextureStart",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~GPUTensorToDX12TextureTelemetryEvent() {
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "GPUTensorToDX12TextureStop",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(S_OK, "HRESULT"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "GPUTensorToDX12TextureStop",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
  private:
@@ -64,29 +62,27 @@ class ConvertGPUTensorToSoftwareBitmapTelemetryEvent {
   ConvertGPUTensorToSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "ConvertGPUTensorToSoftwareBitmapStart",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "ConvertGPUTensorToSoftwareBitmapStart",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertGPUTensorToSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "ConvertGPUTensorToSoftwareBitmapStop",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(S_OK, "HRESULT"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "ConvertGPUTensorToSoftwareBitmapStop",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
  private:
@@ -98,29 +94,27 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
   ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent(const ImageTensorDescription& tensorDesc) {
     runtime_session_id_ = telemetry_helper.GetRuntimeSessionId();
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStart",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
-      TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
-      TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStart",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(tensorDesc.channelType, "Type"),
+        TraceLoggingInt64(tensorDesc.sizes[2], "Height"),
+        TraceLoggingInt64(tensorDesc.sizes[3], "Width"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
   ~ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent() {
     TraceLoggingWrite(
-      winml_trace_logging_provider,
-      "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStop",
-      TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
-      TraceLoggingHexInt32(S_OK, "HRESULT"),
-      TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
-      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-      TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
-      TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES)
-    );
+        winml_trace_logging_provider,
+        "ConvertCPUTensorToVideoFrameWithSoftwareBitmapStop",
+        TraceLoggingKeyword(WINML_PROVIDER_KEYWORD_DEFAULT),
+        TraceLoggingHexInt32(S_OK, "HRESULT"),
+        TraceLoggingInt32(runtime_session_id_, "runtimeSessionId"),
+        TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+        TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
   }
 
  private:
@@ -128,12 +122,11 @@ class ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent {
 };
 
 void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
-  _In_ UINT32 batchIdx,
-  _In_ winml::LearningModelSession& session,
-  _In_ ID3D12Resource* pInputTensor,
-  _In_ const _winml::ImageTensorDescription& tensorDesc,
-  _Inout_ wm::VideoFrame& destVideoFrame
-) {
+    _In_ UINT32 batchIdx,
+    _In_ winml::LearningModelSession& session,
+    _In_ ID3D12Resource* pInputTensor,
+    _In_ const _winml::ImageTensorDescription& tensorDesc,
+    _Inout_ wm::VideoFrame& destVideoFrame) {
   CWinMLAutoLock lock(&lock_);
 
   auto spDevice = session.Device().as<winmlp::LearningModelDevice>();
@@ -146,16 +139,15 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
     ConvertGPUTensorToSoftwareBitmap(batchIdx, pInputTensor, *pDeviceCache, tensorDesc, softwareBitmap);
   } else if (spDestDirect3DSurface) {
     bool isUAVSupportedFormat = _winmli::FormatSupportedForUAV(
-      pDeviceCache->GetD3D12Device(),
-      _winmli::GetDXGIFormatFromDirectXPixelFormat(spDestDirect3DSurface.Description().Format)
-    );
+        pDeviceCache->GetD3D12Device(),
+        _winmli::GetDXGIFormatFromDirectXPixelFormat(spDestDirect3DSurface.Description().Format));
 
     // UAV support for formats is device dependent
     if (!isUAVSupportedFormat) {
       ConvertDX12TensorToUnsupportedVideoFrameFormat(batchIdx, pInputTensor, *pDeviceCache, tensorDesc, destVideoFrame);
     } else {
       ComPtr<ID3D11Texture2D> spVideoFrameTexture =
-        _winmli::GetTextureFromDirect3DSurface(destVideoFrame.Direct3DSurface());
+          _winmli::GetTextureFromDirect3DSurface(destVideoFrame.Direct3DSurface());
 
       D3D11_TEXTURE2D_DESC videoFrameTextureDesc;
       spVideoFrameTexture->GetDesc(&videoFrameTextureDesc);
@@ -170,8 +162,8 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
           D3D12_RESOURCE_DESC cachedTextureDesc = output_resource_->GetDesc();
 
           if (cachedTextureDesc.Width != videoFrameTextureDesc.Width ||
-                        cachedTextureDesc.Height != videoFrameTextureDesc.Height ||
-                        cachedTextureDesc.Format != videoFrameTextureDesc.Format) {
+              cachedTextureDesc.Height != videoFrameTextureDesc.Height ||
+              cachedTextureDesc.Format != videoFrameTextureDesc.Format) {
             // The dimensions or format don't match, so we need to re-create our texture
             output_resource_ = CreateShareableD3D12Texture(videoFrameTextureDesc, pDeviceCache->GetD3D12Device());
             D3D11_cached_texture_ = ShareD3D12Texture(output_resource_.Get(), pDeviceCache->GetD3D11Device());
@@ -197,22 +189,19 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
         UINT handleSize = static_cast<UINT>(sizeof(sharedHandle));
 
         if ((FAILED(spVideoFrameTexture->GetPrivateData(
-                         _d3d11TextureGUID, &comPtrSize, spSharedD3D11Texture.GetAddressOf()
-                     )) ||
-                     !spSharedD3D11Texture.Get()) ||
-                    (FAILED(spVideoFrameTexture->GetPrivateData(_handleGUID, &handleSize, &sharedHandle)) ||
-                     sharedHandle != shared_handle_)) {
+                 _d3d11TextureGUID, &comPtrSize, spSharedD3D11Texture.GetAddressOf())) ||
+             !spSharedD3D11Texture.Get()) ||
+            (FAILED(spVideoFrameTexture->GetPrivateData(_handleGUID, &handleSize, &sharedHandle)) ||
+             sharedHandle != shared_handle_)) {
           // Create a new shared texture that we cache on the video frame texture
           output_resource_ = CreateShareableD3D12Texture(videoFrameTextureDesc, pDeviceCache->GetD3D12Device());
           spSharedD3D11Texture = ShareD3D12Texture(output_resource_.Get(), spTextureDevice.Get());
 
           // Cache the shared texture on the video frame texture in order to tie their lifetime together
           WINML_THROW_IF_FAILED(
-            spVideoFrameTexture->SetPrivateDataInterface(_d3d11TextureGUID, spSharedD3D11Texture.Get())
-          );
+              spVideoFrameTexture->SetPrivateDataInterface(_d3d11TextureGUID, spSharedD3D11Texture.Get()));
           WINML_THROW_IF_FAILED(
-            spVideoFrameTexture->SetPrivateData(_handleGUID, sizeof(shared_handle_), &shared_handle_)
-          );
+              spVideoFrameTexture->SetPrivateData(_handleGUID, sizeof(shared_handle_), &shared_handle_));
         }
 
         // Detensorize
@@ -232,8 +221,7 @@ void TensorToVideoFrameConverter::DX12TensorToVideoFrame(
 }
 
 ComPtr<ID3D12Resource> TensorToVideoFrameConverter::CreateShareableD3D12Texture(
-  const D3D11_TEXTURE2D_DESC& d3d11Desc, ID3D12Device* d3d12Device
-) {
+    const D3D11_TEXTURE2D_DESC& d3d11Desc, ID3D12Device* d3d12Device) {
   D3D12_HEAP_PROPERTIES heapProps{};
   heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
 
@@ -250,35 +238,31 @@ ComPtr<ID3D12Resource> TensorToVideoFrameConverter::CreateShareableD3D12Texture(
 
   ComPtr<ID3D12Resource> d3d12Resource;
   WINML_THROW_IF_FAILED(d3d12Device->CreateCommittedResource(
-    &heapProps, D3D12_HEAP_FLAG_SHARED, &resDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&d3d12Resource)
-  ));
+      &heapProps, D3D12_HEAP_FLAG_SHARED, &resDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&d3d12Resource)));
 
   return d3d12Resource;
 }
 
 void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat(
-  _In_ UINT32 batchIdx,
-  _In_ ID3D12Resource* pInputTensor,
-  _In_ _winml::D3DDeviceCache& device_cache,
-  _In_ const ImageTensorDescription& tensorDesc,
-  _Inout_ wm::VideoFrame& unsupportedVideoFrame
-) {
+    _In_ UINT32 batchIdx,
+    _In_ ID3D12Resource* pInputTensor,
+    _In_ _winml::D3DDeviceCache& device_cache,
+    _In_ const ImageTensorDescription& tensorDesc,
+    _Inout_ wm::VideoFrame& unsupportedVideoFrame) {
   assert(pInputTensor != nullptr);
 
   // Find the first supported format and convert to it
   auto supportedFormatIter = std::find_if(
-    _winmli::supportedWinMLFormats.begin(),
-    _winmli::supportedWinMLFormats.end(),
-    [&device_cache](DXGI_FORMAT format) {
-      return _winmli::FormatSupportedForUAV(device_cache.GetD3D12Device(), format);
-    }
-  );
+      _winmli::supportedWinMLFormats.begin(),
+      _winmli::supportedWinMLFormats.end(),
+      [&device_cache](DXGI_FORMAT format) {
+        return _winmli::FormatSupportedForUAV(device_cache.GetD3D12Device(), format);
+      });
 
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    supportedFormatIter != _winmli::supportedWinMLFormats.end(),
-    "Detensorization for this format is unsupported on the current device."
-  );
+      E_INVALIDARG,
+      supportedFormatIter != _winmli::supportedWinMLFormats.end(),
+      "Detensorization for this format is unsupported on the current device.");
 
   D3D11_TEXTURE2D_DESC supportedDesc{};
   supportedDesc.Width = unsupportedVideoFrame.Direct3DSurface().Description().Width;
@@ -291,7 +275,7 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
   supportedDesc.Usage = D3D11_USAGE_DEFAULT;
 
   ComPtr<ID3D11Texture2D> unsupportedTexture =
-    _winmli::GetTextureFromDirect3DSurface(unsupportedVideoFrame.Direct3DSurface());
+      _winmli::GetTextureFromDirect3DSurface(unsupportedVideoFrame.Direct3DSurface());
 
   ComPtr<ID3D11Device> d3d11Device;
   unsupportedTexture->GetDevice(&d3d11Device);
@@ -307,8 +291,7 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
 
   wgdx::Direct3D11::IDirect3DSurface surface;
   WINML_THROW_IF_FAILED(inspectableSurface->QueryInterface(
-    winrt::guid_of<decltype(surface)>(), reinterpret_cast<void**>(winrt::put_abi(surface))
-  ));
+      winrt::guid_of<decltype(surface)>(), reinterpret_cast<void**>(winrt::put_abi(surface))));
   converted_video_frame_ = wm::VideoFrame::CreateWithDirect3D11Surface(surface);
 
   // Detensorize
@@ -322,8 +305,7 @@ void TensorToVideoFrameConverter::ConvertDX12TensorToUnsupportedVideoFrameFormat
 }
 
 ComPtr<ID3D11Texture2D> TensorToVideoFrameConverter::ShareD3D12Texture(
-  ID3D12Resource* pResource, ID3D11Device* pDevice
-) {
+    ID3D12Resource* pResource, ID3D11Device* pDevice) {
   assert(pResource != nullptr);
   assert(pDevice != nullptr);
 
@@ -347,11 +329,10 @@ ComPtr<ID3D11Texture2D> TensorToVideoFrameConverter::ShareD3D12Texture(
 }
 
 void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
-  _In_ winml::LearningModelSession& session,
-  _In_ BYTE* pCPUTensorToConvert,
-  _In_ ImageTensorDescription tensorDesc,
-  _Inout_ wm::VideoFrame& pDestVideoFrame
-) {
+    _In_ winml::LearningModelSession& session,
+    _In_ BYTE* pCPUTensorToConvert,
+    _In_ ImageTensorDescription tensorDesc,
+    _Inout_ wm::VideoFrame& pDestVideoFrame) {
   CWinMLAutoLock lock(&lock_);
   wm::IVideoFrame spTensorFrame;
   UINT32 outputWidth = 0;
@@ -380,12 +361,10 @@ void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
   }
 
   if (_winmli::NeedsVideoFrameConversion(
-        pDestVideoFrame, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight
-      )) {
+          pDestVideoFrame, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight)) {
     if (converted_video_frame_ == nullptr || _winmli::NeedsVideoFrameConversion(converted_video_frame_, {}, {0, 0, (UINT32)tensorWidth, (UINT32)tensorHeight}, tensorWidth, tensorHeight)) {
       converted_video_frame_ = wm::VideoFrame::CreateWithSoftwareBitmap(
-        wgi::SoftwareBitmap(wgi::BitmapPixelFormat::Bgra8, tensorWidth, tensorHeight)
-      );
+          wgi::SoftwareBitmap(wgi::BitmapPixelFormat::Bgra8, tensorWidth, tensorHeight));
     }
 
     spTensorFrame = converted_video_frame_;
@@ -398,18 +377,16 @@ void TensorToVideoFrameConverter::SoftwareTensorToVideoFrame(
 
   if (converted_video_frame_) {
     _winmli::ConvertVideoFrameToVideoFrame(
-      converted_video_frame_, inputBounds, outputWidth, outputHeight, pDestVideoFrame
-    );
+        converted_video_frame_, inputBounds, outputWidth, outputHeight, pDestVideoFrame);
   }
 }
 
 void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
-  _In_ UINT32 batchIdx,
-  _In_ ID3D12Resource* pInputResource,
-  _In_ _winml::D3DDeviceCache& device_cache,
-  _In_ const ImageTensorDescription& tensorDesc,
-  _Inout_ ID3D12Resource* pOutputResource
-) {
+    _In_ UINT32 batchIdx,
+    _In_ ID3D12Resource* pInputResource,
+    _In_ _winml::D3DDeviceCache& device_cache,
+    _In_ const ImageTensorDescription& tensorDesc,
+    _Inout_ ID3D12Resource* pOutputResource) {
   assert(pInputResource != nullptr);
   assert(pOutputResource != nullptr);
 
@@ -428,68 +405,57 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   }
 
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    outputDesc.Format == DXGI_FORMAT_B8G8R8A8_UNORM || outputDesc.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
-      outputDesc.Format == DXGI_FORMAT_R8_UNORM,
-    "Format was output image %d. Output image format must be Bgra8, Rgba8 or Gray8.",
-    outputDesc.Format
-  );
+      E_INVALIDARG,
+      outputDesc.Format == DXGI_FORMAT_B8G8R8A8_UNORM || outputDesc.Format == DXGI_FORMAT_R8G8B8A8_UNORM ||
+          outputDesc.Format == DXGI_FORMAT_R8_UNORM,
+      "Format was output image %d. Output image format must be Bgra8, Rgba8 or Gray8.",
+      outputDesc.Format);
 
   // Validate input description
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG, inputDesc.Height != 0, "Invalid input image height provided. Height is set to zero."
-  );
+      E_INVALIDARG, inputDesc.Height != 0, "Invalid input image height provided. Height is set to zero.");
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG, inputDesc.Width != 0, "Invalid input image height provided. Height is set to zero."
-  );
+      E_INVALIDARG, inputDesc.Width != 0, "Invalid input image height provided. Height is set to zero.");
 
   // Validate output description
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG, outputDesc.Height != 0, "Invalid input image height provided. Height is set to zero."
-  );
+      E_INVALIDARG, outputDesc.Height != 0, "Invalid input image height provided. Height is set to zero.");
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG, outputDesc.Width != 0, "Invalid input image height provided. Height is set to zero."
-  );
+      E_INVALIDARG, outputDesc.Width != 0, "Invalid input image height provided. Height is set to zero.");
 
   // Validate Tensor description
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
-    "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
-    tensorDesc.dataType
-  );
+      E_INVALIDARG,
+      tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
+      "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
+      tensorDesc.dataType);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
-    "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
+      "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
-    "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
+      "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
-    "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
+      "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.sizes[2] == outputDesc.Height,
-    "Target tensor height (%lld) does not match input height (%lu).",
-    tensorDesc.sizes[2],
-    outputDesc.Height
-  );
+      E_INVALIDARG,
+      tensorDesc.sizes[2] == outputDesc.Height,
+      "Target tensor height (%lld) does not match input height (%lu).",
+      tensorDesc.sizes[2],
+      outputDesc.Height);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.sizes[3] == (UINT)outputDesc.Width,
-    "Target tensor width (%lld) does not match input width (%lu).",
-    tensorDesc.sizes[3],
-    (UINT)outputDesc.Width
-  );
+      E_INVALIDARG,
+      tensorDesc.sizes[3] == (UINT)outputDesc.Width,
+      "Target tensor width (%lld) does not match input width (%lu).",
+      tensorDesc.sizes[3],
+      (UINT)outputDesc.Width);
 
   // Create descriptor heaps
   UINT srvUavDescriptorSize = spDx12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -499,15 +465,14 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   outputResourceDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
 
   if (!UAV_resource_ || outputDesc.Format != UAV_resource_->GetDesc().Format ||
-        outputDesc.Width != UAV_resource_->GetDesc().Width || outputDesc.Height != UAV_resource_->GetDesc().Height) {
+      outputDesc.Width != UAV_resource_->GetDesc().Width || outputDesc.Height != UAV_resource_->GetDesc().Height) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
-      D3D12_HEAP_FLAG_NONE,
-      &outputResourceDesc,
-      D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-      nullptr,
-      IID_PPV_ARGS(&UAV_resource_)
-    ));
+        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT)),
+        D3D12_HEAP_FLAG_NONE,
+        &outputResourceDesc,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        nullptr,
+        IID_PPV_ARGS(&UAV_resource_)));
   }
 
   if (descriptor_heap_ == nullptr) {
@@ -524,16 +489,14 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
   {
     D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = CreateSRVDescriptor(batchIdx, inputDesc, tensorDesc);
     CD3DX12_CPU_DESCRIPTOR_HANDLE srvHandle(
-      descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize
-    );
+        descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize);
     spDx12Device->CreateShaderResourceView(pInputResource, &srvDesc, srvHandle);
 
     D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
     uavDesc.Format = outputResourceDesc.Format;
     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
     CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle(
-      descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize
-    );
+        descriptor_heap_->GetCPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize);
     spDx12Device->CreateUnorderedAccessView(UAV_resource_.Get(), nullptr, &uavDesc, uavHandle);
   }
 
@@ -563,7 +526,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
 
   root_signature_ = device_cache.GetDetensorizeRootSignature();
   pipeline_state_ =
-    device_cache.GetCachedPipelineState(type, formatFrom, formatTo, PipelineStateCacheOperation::kDetensorize);
+      device_cache.GetCachedPipelineState(type, formatFrom, formatTo, PipelineStateCacheOperation::kDetensorize);
 
   ResetCommandList(device_cache);
 
@@ -580,11 +543,9 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     }
 
     CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(
-      descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize
-    );
+        descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), SrvBufferIdx, srvUavDescriptorSize);
     CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandle(
-      descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize
-    );
+        descriptor_heap_->GetGPUDescriptorHandleForHeapStart(), UavBufferIdx, srvUavDescriptorSize);
     {
       ConstantBufferCS constantBufferCS = {};
       constantBufferCS.height = static_cast<UINT>(tensorDesc.sizes[2]);
@@ -598,33 +559,25 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
     auto dispatchHeight = static_cast<UINT>((tensorDesc.sizes[2] - 1) / 4 + 1);
 
     command_list_->ResourceBarrier(
-      1,
-      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-        pInputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
-      ))
-    );
+        1,
+        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+            pInputResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)));
     command_list_->Dispatch(dispatchWidth, dispatchHeight, 1);
     command_list_->ResourceBarrier(
-      1,
-      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-        pInputResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
-      ))
-    );
+        1,
+        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+            pInputResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS)));
 
     // Copy the UAV data to the output resource after detensorization
     command_list_->ResourceBarrier(
-      1,
-      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-        UAV_resource_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
-      ))
-    );
+        1,
+        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+            UAV_resource_.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE)));
     command_list_->CopyResource(pOutputResource, UAV_resource_.Get());
     command_list_->ResourceBarrier(
-      1,
-      unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
-        UAV_resource_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS
-      ))
-    );
+        1,
+        unmove_ptr(CD3DX12_RESOURCE_BARRIER::Transition(
+            UAV_resource_.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS)));
 
     WINML_THROW_IF_FAILED(command_list_->Close());
     ID3D12CommandList* pComputeToGPUCLs[] = {command_list_.Get()};
@@ -634,12 +587,11 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToDX12Texture(
 }
 
 void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
-  _In_ UINT32 batchIdx,
-  _In_ ID3D12Resource* pInputTensor,
-  _In_ _winml::D3DDeviceCache& device_cache,
-  _In_ const ImageTensorDescription& tensorDesc,
-  _Inout_ wgi::SoftwareBitmap& softwareBitmap
-) {
+    _In_ UINT32 batchIdx,
+    _In_ ID3D12Resource* pInputTensor,
+    _In_ _winml::D3DDeviceCache& device_cache,
+    _In_ const ImageTensorDescription& tensorDesc,
+    _Inout_ wgi::SoftwareBitmap& softwareBitmap) {
   assert(pInputTensor != nullptr);
   assert(softwareBitmap != nullptr);
 
@@ -652,34 +604,31 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 
   uint32_t tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
   uint32_t singleVideoFramebufferSize =
-    static_cast<uint32_t>(tensorDesc.sizes[1] * tensorDesc.sizes[2] * tensorDesc.sizes[3] * tensorElementSize);
+      static_cast<uint32_t>(tensorDesc.sizes[1] * tensorDesc.sizes[2] * tensorDesc.sizes[3] * tensorElementSize);
 
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < singleVideoFramebufferSize) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
-      D3D12_HEAP_FLAG_NONE,
-      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize)),
-      D3D12_RESOURCE_STATE_COPY_DEST,
-      nullptr,
-      IID_PPV_ARGS(&readback_heap_)
-    ));
+        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
+        D3D12_HEAP_FLAG_NONE,
+        unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(singleVideoFramebufferSize)),
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        IID_PPV_ARGS(&readback_heap_)));
   }
 
   ResetCommandList(device_cache);
 
   auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-    pInputTensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
-  );
+      pInputTensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
   command_list_->ResourceBarrier(1, &barrier);
 
   command_list_->CopyBufferRegion(
-    readback_heap_.Get(),
-    0,
-    pInputTensor,
-    static_cast<uint64_t>(singleVideoFramebufferSize) * batchIdx,
-    singleVideoFramebufferSize
-  );
+      readback_heap_.Get(),
+      0,
+      pInputTensor,
+      static_cast<uint64_t>(singleVideoFramebufferSize) * batchIdx,
+      singleVideoFramebufferSize);
 
   WINML_THROW_IF_FAILED(command_list_->Close());
   ID3D12CommandList* ppCommandLists[] = {command_list_.Get()};
@@ -690,8 +639,7 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 
   void* pCPUTensorBuffer = nullptr;
   WINML_THROW_IF_FAILED(
-    readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer)
-  );
+      readback_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, singleVideoFramebufferSize)), &pCPUTensorBuffer));
 
   // We avoid the Video Frame pipeline by manually downloading the GPU data to the CPU and detensorize while we are filling the readback heap
   ConvertCPUTensorToSoftwareBitmap(pCPUTensorBuffer, tensorDesc, softwareBitmap);
@@ -700,30 +648,27 @@ void TensorToVideoFrameConverter::ConvertGPUTensorToSoftwareBitmap(
 }
 
 void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
-  _In_ ID3D12Resource* input_tensor,
-  _In_ size_t buffer_size_in_bytes,
-  _In_ _winml::D3DDeviceCache& device_cache,
-  _Inout_ const std::vector<wss::IBuffer>& buffers
-) {
+    _In_ ID3D12Resource* input_tensor,
+    _In_ size_t buffer_size_in_bytes,
+    _In_ _winml::D3DDeviceCache& device_cache,
+    _Inout_ const std::vector<wss::IBuffer>& buffers) {
   assert(input_tensor != nullptr);
 
   // TODO: Make an allocator for readback heaps
   if (!readback_heap_ || readback_heap_->GetDesc().Width < buffer_size_in_bytes) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
-      D3D12_HEAP_FLAG_NONE,
-      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
-      D3D12_RESOURCE_STATE_COPY_DEST,
-      nullptr,
-      IID_PPV_ARGS(&readback_heap_)
-    ));
+        unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK)),
+        D3D12_HEAP_FLAG_NONE,
+        unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        IID_PPV_ARGS(&readback_heap_)));
   }
 
   ResetCommandList(device_cache);
 
   auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-    input_tensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE
-  );
+      input_tensor, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
   command_list_->ResourceBarrier(1, &barrier);
   command_list_->CopyBufferRegion(readback_heap_.Get(), 0, input_tensor, 0, buffer_size_in_bytes);
 
@@ -736,26 +681,23 @@ void TensorToVideoFrameConverter::ConvertBatchedDX12TensorToBuffers(
 
   byte* readback_buffer = nullptr;
   WINML_THROW_IF_FAILED(readback_heap_->Map(
-    0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer)
-  ));
+      0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)), reinterpret_cast<void**>(&readback_buffer)));
   auto readback_buffer_span = gsl::span<byte>(readback_buffer, buffer_size_in_bytes);
   _winml::StoreSpanIntoDisjointBuffers(
-    buffers.size(),
-    [&](size_t i) {
-      byte* buffer_start = nullptr;
-      auto byte_access = buffers[i].as<Windows::Storage::Streams::IBufferByteAccess>();
-      byte_access->Buffer(&buffer_start);
-      return gsl::span<byte>(buffer_start, static_cast<size_t>(buffers[i].Capacity()));
-    },
-    readback_buffer_span
-  );
+      buffers.size(),
+      [&](size_t i) {
+        byte* buffer_start = nullptr;
+        auto byte_access = buffers[i].as<Windows::Storage::Streams::IBufferByteAccess>();
+        byte_access->Buffer(&buffer_start);
+        return gsl::span<byte>(buffer_start, static_cast<size_t>(buffers[i].Capacity()));
+      },
+      readback_buffer_span);
 
   readback_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, 0)));
 }
 
 D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor(
-  const UINT32 batchIdx, const D3D12_RESOURCE_DESC& resourceDesc, const _winml::ImageTensorDescription& desc
-) {
+    const UINT32 batchIdx, const D3D12_RESOURCE_DESC& resourceDesc, const _winml::ImageTensorDescription& desc) {
   UINT uiTensorElementSize = desc.dataType == kImageTensorDataTypeFloat32 ? sizeof(UINT) : sizeof(uint16_t);
 
   D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
@@ -779,18 +721,16 @@ D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor
     srvDesc.Buffer.StructureByteStride = 0;
   } else {
     WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG,
-      false,
-      "Tensorization conversion is only supported to kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16."
-    );
+        E_INVALIDARG,
+        false,
+        "Tensorization conversion is only supported to kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16.");
   }
 
   return srvDesc;
 }
 
 void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
-  _In_ void* pCPUTensor, _In_ const ImageTensorDescription& tensorDesc, _Inout_ wgi::SoftwareBitmap& softwareBitmap
-) {
+    _In_ void* pCPUTensor, _In_ const ImageTensorDescription& tensorDesc, _Inout_ wgi::SoftwareBitmap& softwareBitmap) {
   // we're inside a lock from the caller of this function, so it's ok to use this static
   static EventTimer eventTimer;
   std::optional<ConvertCPUTensorToVideoFrameWithSoftwareBitmapTelemetryEvent> telemetryLogger;
@@ -804,61 +744,53 @@ void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
 
   // Validate input description
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    format == wgi::BitmapPixelFormat::Bgra8 || format == wgi::BitmapPixelFormat::Rgba8 ||
-      format == wgi::BitmapPixelFormat::Gray8,
-    "Format was input image %d. Input image format must Bgra8, Rgba8 or Gray8.",
-    format
-  );
+      E_INVALIDARG,
+      format == wgi::BitmapPixelFormat::Bgra8 || format == wgi::BitmapPixelFormat::Rgba8 ||
+          format == wgi::BitmapPixelFormat::Gray8,
+      "Format was input image %d. Input image format must Bgra8, Rgba8 or Gray8.",
+      format);
   WINML_THROW_HR_IF_FALSE_MSG(E_INVALIDARG, height > 0, "Output input image height provided. Height is set to zero.");
   WINML_THROW_HR_IF_FALSE_MSG(E_INVALIDARG, width > 0, "Output input image width provided. Width is set to zero.");
 
   // Validate Tensor description
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
-    "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
-    tensorDesc.dataType
-  );
+      E_INVALIDARG,
+      tensorDesc.dataType == kImageTensorDataTypeFloat32 || tensorDesc.dataType == kImageTensorDataTypeFloat16,
+      "Target tensor description must either be kImageTensorDataTypeFloat32, or kImageTensorDataTypeFloat16. %d was supplied.",
+      tensorDesc.dataType);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
-    "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeRGB8 || tensorDesc.sizes[1] == 3,
+      "Target tensor description expects kImageTensorChannelTypeRGB8, but has %lld channels specified instead of 3.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
-    "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeBGR8 || tensorDesc.sizes[1] == 3,
+      "Target tensor description expects kImageTensorChannelTypeBGR8, but has %lld channels specified instead of 3.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
-    "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
-    tensorDesc.sizes[1]
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType != kImageTensorChannelTypeGRAY8 || tensorDesc.sizes[1] == 1,
+      "Target tensor description expects kImageTensorChannelTypeGRAY8, but has %lld channels specified instead of 1.",
+      tensorDesc.sizes[1]);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.channelType == kImageTensorChannelTypeGRAY8 || tensorDesc.channelType == kImageTensorChannelTypeBGR8 ||
-      tensorDesc.channelType == kImageTensorChannelTypeRGB8,
-    "Target tensor description expects kImageTensorChannelTypeGRAY8, kImageTensorChannelTypeBGR8, or kImageTensorChannelTypeRGB8 but has %d was specified.",
-    tensorDesc.channelType
-  );
+      E_INVALIDARG,
+      tensorDesc.channelType == kImageTensorChannelTypeGRAY8 || tensorDesc.channelType == kImageTensorChannelTypeBGR8 ||
+          tensorDesc.channelType == kImageTensorChannelTypeRGB8,
+      "Target tensor description expects kImageTensorChannelTypeGRAY8, kImageTensorChannelTypeBGR8, or kImageTensorChannelTypeRGB8 but has %d was specified.",
+      tensorDesc.channelType);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.sizes[2] == (UINT)height,
-    "Target tensor height (%lld) does not match input height (%lu).",
-    tensorDesc.sizes[2],
-    (UINT)height
-  );
+      E_INVALIDARG,
+      tensorDesc.sizes[2] == (UINT)height,
+      "Target tensor height (%lld) does not match input height (%lu).",
+      tensorDesc.sizes[2],
+      (UINT)height);
   WINML_THROW_HR_IF_FALSE_MSG(
-    E_INVALIDARG,
-    tensorDesc.sizes[3] == (UINT)width,
-    "Target tensor width (%lld) does not match input width (%lu).",
-    tensorDesc.sizes[3],
-    (UINT)width
-  );
+      E_INVALIDARG,
+      tensorDesc.sizes[3] == (UINT)width,
+      "Target tensor width (%lld) does not match input width (%lu).",
+      tensorDesc.sizes[3],
+      (UINT)width);
 
   // get the byte buffer out of a softwarebitmap
   BYTE* pData = nullptr;
@@ -875,25 +807,23 @@ void TensorToVideoFrameConverter::ConvertCPUTensorToSoftwareBitmap(
 
   if (tensorDesc.dataType == kImageTensorDataTypeFloat32) {
     WINML_THROW_IF_FAILED(CpuDetensorizer::Detensorize<float>(
-      tensorDesc.channelType,
-      targetChannelType,
-      tensorDesc.pixelRange,
-      static_cast<float*>(pCPUTensor),
-      bufferWidth,
-      height,
-      width,
-      pData
-    ));
+        tensorDesc.channelType,
+        targetChannelType,
+        tensorDesc.pixelRange,
+        static_cast<float*>(pCPUTensor),
+        bufferWidth,
+        height,
+        width,
+        pData));
   } else if (tensorDesc.dataType == kImageTensorDataTypeFloat16) {
     WINML_THROW_IF_FAILED(CpuDetensorizer::Detensorize<DirectX::PackedVector::HALF>(
-      tensorDesc.channelType,
-      targetChannelType,
-      tensorDesc.pixelRange,
-      static_cast<DirectX::PackedVector::HALF*>(pCPUTensor),
-      bufferWidth,
-      height,
-      width,
-      pData
-    ));
+        tensorDesc.channelType,
+        targetChannelType,
+        tensorDesc.pixelRange,
+        static_cast<DirectX::PackedVector::HALF*>(pCPUTensor),
+        bufferWidth,
+        height,
+        width,
+        pData));
   }
 }

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -600,9 +600,9 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   // TODO: Make an allocator for upload heaps
   if (!upload_heap_ || upload_heap_->GetDesc().Width < bufferSize) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD)),
       D3D12_HEAP_FLAG_NONE,
-      &CD3DX12_RESOURCE_DESC::Buffer(bufferSize),
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(bufferSize)),
       D3D12_RESOURCE_STATE_GENERIC_READ,
       nullptr,
       IID_PPV_ARGS(&upload_heap_)
@@ -610,14 +610,14 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   }
 
   void* pCPUTensorBuffer = nullptr;
-  WINML_THROW_IF_FAILED(upload_heap_->Map(0, &CD3DX12_RANGE(0, 0), &pCPUTensorBuffer));
+  WINML_THROW_IF_FAILED(upload_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, 0)), unmove_ptr(pCPUTensorBuffer)));
 
   // We avoid the Video Frame pipeline by manually sending the CPU data to the GPU, and we tensorize while we are filling the
   // upload heap. The image may already have been cropped/scaled by the video frame pipeline, so we send the scaled bounds
   // instead of the initial input bounds
   ConvertSoftwareBitmapToCPUTensor(convertedSoftwareBitmap, tensorDesc, scaledBounds, pCPUTensorBuffer);
 
-  upload_heap_->Unmap(0, &CD3DX12_RANGE(0, bufferSize));
+  upload_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, bufferSize)));
 
   ResetCommandList(device_cache);
 
@@ -642,9 +642,9 @@ void VideoFrameToTensorConverter::ConvertBuffersToBatchedGPUTensor(
   // Copy the cpu memory into the gpu resource
   if (!upload_heap_ || upload_heap_->GetDesc().Width < buffer_size_in_bytes) {
     WINML_THROW_IF_FAILED(device_cache.GetD3D12Device()->CreateCommittedResource(
-      &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+      unmove_ptr(CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD)),
       D3D12_HEAP_FLAG_NONE,
-      &CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes),
+      unmove_ptr(CD3DX12_RESOURCE_DESC::Buffer(buffer_size_in_bytes)),
       D3D12_RESOURCE_STATE_GENERIC_READ,
       nullptr,
       IID_PPV_ARGS(&upload_heap_)
@@ -652,7 +652,7 @@ void VideoFrameToTensorConverter::ConvertBuffersToBatchedGPUTensor(
   }
 
   byte* gpu_buffer = nullptr;
-  WINML_THROW_IF_FAILED(upload_heap_->Map(0, &CD3DX12_RANGE(0, 0), reinterpret_cast<void**>(&gpu_buffer)));
+  WINML_THROW_IF_FAILED(upload_heap_->Map(0, unmove_ptr(CD3DX12_RANGE(0, 0)), reinterpret_cast<void**>(&gpu_buffer)));
   auto gpu_buffer_span = gsl::span<byte>(gpu_buffer, buffer_size_in_bytes);
 
   _winml::LoadSpanFromDisjointBuffers(
@@ -666,7 +666,7 @@ void VideoFrameToTensorConverter::ConvertBuffersToBatchedGPUTensor(
     gpu_buffer_span
   );
 
-  upload_heap_->Unmap(0, &CD3DX12_RANGE(0, buffer_size_in_bytes));
+  upload_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, buffer_size_in_bytes)));
 
   ResetCommandList(device_cache);
 

--- a/winml/lib/Api.Image/inc/D3DDeviceCache.h
+++ b/winml/lib/Api.Image/inc/D3DDeviceCache.h
@@ -40,7 +40,6 @@ constexpr auto to_underlying_integer(E e) noexcept {
   return static_cast<typename std::underlying_type<E>::type>(e);
 }
 
-
 class D3DDeviceCache {
  public:
   ~D3DDeviceCache();
@@ -110,11 +109,9 @@ class D3DDeviceCache {
   winrt::com_ptr<ID3D12RootSignature> tensorize_root_signature_;
   winrt::com_ptr<ID3D12RootSignature> detensorize_root_signature_;
 
-  winrt::com_ptr<ID3D12PipelineState>
-    cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount)]
-                         [to_underlying_integer(PipelineStateCacheFormat::kCount)]
-                         [to_underlying_integer(PipelineStateCacheFormat::kCount)]
-                         [to_underlying_integer(PipelineStateCacheOperation::kCount)];
+  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount
+  )][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
+                                                           [to_underlying_integer(PipelineStateCacheOperation::kCount)];
 
   winrt::com_ptr<ID3D12Resource> detensorize_vertex_buffer_;
 

--- a/winml/lib/Api.Image/inc/D3DDeviceCache.h
+++ b/winml/lib/Api.Image/inc/D3DDeviceCache.h
@@ -35,6 +35,12 @@ enum class PipelineStateCacheOperation : unsigned char {
   kCount = 2
 };
 
+template <typename E>
+constexpr auto to_underlying_integer(E e) noexcept {
+  return static_cast<typename std::underlying_type<E>::type>(e);
+}
+
+
 class D3DDeviceCache {
  public:
   ~D3DDeviceCache();
@@ -105,8 +111,10 @@ class D3DDeviceCache {
   winrt::com_ptr<ID3D12RootSignature> detensorize_root_signature_;
 
   winrt::com_ptr<ID3D12PipelineState>
-    cached_pipeline_state[PipelineStateCacheType::kCount][PipelineStateCacheFormat::kCount]
-                         [PipelineStateCacheFormat::kCount][PipelineStateCacheOperation::kCount];
+    cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount)]
+                         [to_underlying_integer(PipelineStateCacheFormat::kCount)]
+                         [to_underlying_integer(PipelineStateCacheFormat::kCount)]
+                         [to_underlying_integer(PipelineStateCacheOperation::kCount)];
 
   winrt::com_ptr<ID3D12Resource> detensorize_vertex_buffer_;
 

--- a/winml/lib/Api.Image/inc/D3DDeviceCache.h
+++ b/winml/lib/Api.Image/inc/D3DDeviceCache.h
@@ -36,7 +36,7 @@ enum class PipelineStateCacheOperation : unsigned char {
 };
 
 template <typename E>
-constexpr auto to_underlying_integer(E e) noexcept {
+constexpr auto underlying(E e) noexcept {
   return static_cast<typename std::underlying_type<E>::type>(e);
 }
 
@@ -109,9 +109,10 @@ class D3DDeviceCache {
   winrt::com_ptr<ID3D12RootSignature> tensorize_root_signature_;
   winrt::com_ptr<ID3D12RootSignature> detensorize_root_signature_;
 
-  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount
-  )][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
-                                                           [to_underlying_integer(PipelineStateCacheOperation::kCount)];
+  // clang-format off
+  winrt::com_ptr<ID3D12PipelineState>
+    cached_pipeline_state[underlying(PipelineStateCacheType::kCount)][underlying(PipelineStateCacheFormat::kCount)]
+                         [underlying(PipelineStateCacheFormat::kCount)][underlying(PipelineStateCacheOperation::kCount)];
 
   winrt::com_ptr<ID3D12Resource> detensorize_vertex_buffer_;
 

--- a/winml/lib/Api.Image/inc/D3DDeviceCache.h
+++ b/winml/lib/Api.Image/inc/D3DDeviceCache.h
@@ -58,11 +58,10 @@ class D3DDeviceCache {
   ID3D12RootSignature* GetTensorizeRootSignature();
   ID3D12RootSignature* GetDetensorizeRootSignature();
   ID3D12PipelineState* GetCachedPipelineState(
-    PipelineStateCacheType type,
-    PipelineStateCacheFormat format_from,
-    PipelineStateCacheFormat format_to,
-    PipelineStateCacheOperation operation
-  );
+      PipelineStateCacheType type,
+      PipelineStateCacheFormat format_from,
+      PipelineStateCacheFormat format_to,
+      PipelineStateCacheOperation operation);
 
   ID3D12Resource* GetDetensorizeVertexBuffer(_Out_ UINT* vertex_buffer_size);
 
@@ -92,11 +91,9 @@ class D3DDeviceCache {
   void InitializeCommandQueue(ID3D12Device1* device);
 
   ID3D12PipelineState* CreateTensorizePipelineState(
-    PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to
-  );
+      PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to);
   ID3D12PipelineState* CreateDetensorizePipelineState(
-    PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to
-  );
+      PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to);
 
   winrt::com_ptr<ID3D12Device1> device_;
   winrt::com_ptr<ID3D12CommandQueue> command_queue_;
@@ -109,8 +106,7 @@ class D3DDeviceCache {
   winrt::com_ptr<ID3D12RootSignature> tensorize_root_signature_;
   winrt::com_ptr<ID3D12RootSignature> detensorize_root_signature_;
 
-  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount
-  )][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
+  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
                                                            [to_underlying_integer(PipelineStateCacheOperation::kCount)];
 
   winrt::com_ptr<ID3D12Resource> detensorize_vertex_buffer_;

--- a/winml/lib/Api.Image/inc/D3DDeviceCache.h
+++ b/winml/lib/Api.Image/inc/D3DDeviceCache.h
@@ -58,10 +58,11 @@ class D3DDeviceCache {
   ID3D12RootSignature* GetTensorizeRootSignature();
   ID3D12RootSignature* GetDetensorizeRootSignature();
   ID3D12PipelineState* GetCachedPipelineState(
-      PipelineStateCacheType type,
-      PipelineStateCacheFormat format_from,
-      PipelineStateCacheFormat format_to,
-      PipelineStateCacheOperation operation);
+    PipelineStateCacheType type,
+    PipelineStateCacheFormat format_from,
+    PipelineStateCacheFormat format_to,
+    PipelineStateCacheOperation operation
+  );
 
   ID3D12Resource* GetDetensorizeVertexBuffer(_Out_ UINT* vertex_buffer_size);
 
@@ -91,9 +92,11 @@ class D3DDeviceCache {
   void InitializeCommandQueue(ID3D12Device1* device);
 
   ID3D12PipelineState* CreateTensorizePipelineState(
-      PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to);
+    PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to
+  );
   ID3D12PipelineState* CreateDetensorizePipelineState(
-      PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to);
+    PipelineStateCacheType type, PipelineStateCacheFormat format_from, PipelineStateCacheFormat format_to
+  );
 
   winrt::com_ptr<ID3D12Device1> device_;
   winrt::com_ptr<ID3D12CommandQueue> command_queue_;
@@ -106,7 +109,8 @@ class D3DDeviceCache {
   winrt::com_ptr<ID3D12RootSignature> tensorize_root_signature_;
   winrt::com_ptr<ID3D12RootSignature> detensorize_root_signature_;
 
-  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
+  winrt::com_ptr<ID3D12PipelineState> cached_pipeline_state[to_underlying_integer(PipelineStateCacheType::kCount
+  )][to_underlying_integer(PipelineStateCacheFormat::kCount)][to_underlying_integer(PipelineStateCacheFormat::kCount)]
                                                            [to_underlying_integer(PipelineStateCacheOperation::kCount)];
 
   winrt::com_ptr<ID3D12Resource> detensorize_vertex_buffer_;

--- a/winml/lib/Api.Image/inc/TensorToVideoFrameConverter.h
+++ b/winml/lib/Api.Image/inc/TensorToVideoFrameConverter.h
@@ -80,7 +80,7 @@ class TensorToVideoFrameConverter : public ImageConverter {
     _Inout_ wm::VideoFrame& unsupported_video_frame
   );
 
-  static D3D12_SHADER_RESOURCE_VIEW_DESC TensorToVideoFrameConverter::CreateSRVDescriptor(
+  static D3D12_SHADER_RESOURCE_VIEW_DESC CreateSRVDescriptor(
     const UINT32 batch_index, const D3D12_RESOURCE_DESC& resource_description, const ImageTensorDescription& description
   );
 

--- a/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
+++ b/winml/lib/Api.Image/inc/VideoFrameToTensorConverter.h
@@ -86,7 +86,7 @@ class VideoFrameToTensorConverter : public ImageConverter {
     const UINT32 batch_index, const D3D12_RESOURCE_DESC& resource_description, const ImageTensorDescription& description
   );
 
-  static void VideoFrameToTensorConverter::ConvertSoftwareBitmapToCPUTensor(
+  static void ConvertSoftwareBitmapToCPUTensor(
     _In_ const wgi::SoftwareBitmap& software_bitmap,
     _In_ const ImageTensorDescription& tensor_description,
     _In_ const wgi::BitmapBounds& input_bounds,

--- a/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeEngine.cpp
@@ -862,12 +862,12 @@ struct FillMapTensors {
   static HRESULT Run(
     const OrtApi* ort_api, IInspectable* map_insp, OrtValue* keys_ort_value, OrtValue* values_ort_value
   ) {
-    AbiTypeInfo<TAbiKey>::OrtType* keys_mutable_data;
+    typename AbiTypeInfo<TAbiKey>::OrtType* keys_mutable_data;
     RETURN_HR_IF_NOT_OK_MSG(
       ort_api->GetTensorMutableData(keys_ort_value, reinterpret_cast<void**>(&keys_mutable_data)), ort_api
     );
 
-    AbiTypeInfo<TAbiValue>::OrtType* values_mutable_data;
+    typename AbiTypeInfo<TAbiValue>::OrtType* values_mutable_data;
     RETURN_HR_IF_NOT_OK_MSG(
       ort_api->GetTensorMutableData(values_ort_value, reinterpret_cast<void**>(&values_mutable_data)), ort_api
     );
@@ -888,7 +888,7 @@ struct FillMapTensors<HSTRING, TAbiValue> {
   static HRESULT Run(
     const OrtApi* ort_api, IInspectable* map_insp, OrtValue* keys_ort_value, OrtValue* values_ort_value
   ) {
-    AbiTypeInfo<TAbiValue>::OrtType* values_mutable_data;
+    typename AbiTypeInfo<TAbiValue>::OrtType* values_mutable_data;
     RETURN_HR_IF_NOT_OK_MSG(
       ort_api->GetTensorMutableData(values_ort_value, reinterpret_cast<void**>(&values_mutable_data)), ort_api
     );
@@ -916,7 +916,7 @@ struct FillMapTensors<TAbiKey, HSTRING> {
   static HRESULT Run(
     const OrtApi* ort_api, IInspectable* map_insp, OrtValue* keys_ort_value, OrtValue* values_ort_value
   ) {
-    AbiTypeInfo<TAbiKey>::OrtType* keys_mutable_data;
+    typename AbiTypeInfo<TAbiKey>::OrtType* keys_mutable_data;
     RETURN_HR_IF_NOT_OK_MSG(
       ort_api->GetTensorMutableData(keys_ort_value, reinterpret_cast<void**>(&keys_mutable_data)), ort_api
     );

--- a/winml/lib/Api/ImageFeatureValue.h
+++ b/winml/lib/Api/ImageFeatureValue.h
@@ -23,7 +23,7 @@ struct ImageFeatureValue : ImageFeatureValueT<ImageFeatureValue, _winml::ILotusV
   wfc::IIterable<Windows::Media::VideoFrame> VideoFrames();
   winml::LearningModelFeatureKind Kind();
 
-  static winml::ImageFeatureValue ImageFeatureValue::Create(
+  static winml::ImageFeatureValue Create(
     uint32_t batchSize, Windows::Graphics::Imaging::BitmapPixelFormat format, uint32_t width, uint32_t height
   );
   static winml::ImageFeatureValue CreateFromVideoFrame(Windows::Media::VideoFrame const& image);

--- a/winml/lib/Api/impl/MapBase.h
+++ b/winml/lib/Api/impl/MapBase.h
@@ -7,6 +7,8 @@
 
 #include "MapFeatureDescriptor.h"
 #include "TensorFeatureDescriptor.h"
+#include "LearningModelSession.h"
+#include "IMapFeatureValue.h"
 
 namespace _winml {
 

--- a/winml/lib/Api/impl/SequenceBase.h
+++ b/winml/lib/Api/impl/SequenceBase.h
@@ -6,6 +6,10 @@
 #include "MapFeatureDescriptor.h"
 #include "SequenceFeatureDescriptor.h"
 #include "TensorFeatureDescriptor.h"
+#include "LearningModelSession.h"
+#include "ISequenceFeatureValue.h"
+
+#include "FeatureValues.h"
 
 namespace _winml {
 
@@ -169,55 +173,55 @@ struct SequenceBase : public winrt::implements<
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorBoolean>() {
-    return winmlp::TensorBoolean::Create();
+    return winml::TensorBoolean::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorFloat>() {
-    return winmlp::TensorFloat::Create();
+    return winml::TensorFloat::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorDouble>() {
-    return winmlp::TensorDouble::Create();
+    return winml::TensorDouble::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorInt8Bit>() {
-    return winmlp::TensorInt8Bit::Create();
+    return winml::TensorInt8Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorUInt8Bit>() {
-    return winmlp::TensorUInt8Bit::Create();
+    return winml::TensorUInt8Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorUInt16Bit>() {
-    return winmlp::TensorUInt16Bit::Create();
+    return winml::TensorUInt16Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorInt16Bit>() {
-    return winmlp::TensorInt16Bit::Create();
+    return winml::TensorInt16Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorUInt32Bit>() {
-    return winmlp::TensorUInt32Bit::Create();
+    return winml::TensorUInt32Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorInt32Bit>() {
-    return winmlp::TensorInt32Bit::Create();
+    return winml::TensorInt32Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorUInt64Bit>() {
-    return winmlp::TensorUInt64Bit::Create();
+    return winml::TensorUInt64Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorInt64Bit>() {
-    return winmlp::TensorInt64Bit::Create();
+    return winml::TensorInt64Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorFloat16Bit>() {
-    return winmlp::TensorFloat16Bit::Create();
+    return winml::TensorFloat16Bit::Create();
   }
   template <>
   auto CreatePlaceholderTensor<winml::TensorString>() {
-    return winmlp::TensorString::Create();
+    return winml::TensorString::Create();
   }
 
   void AppendValue(_winml::BindingContext& context, wfc::IVector<T> data, winrt::com_ptr<_winml::IValue> value) {

--- a/winml/lib/Api/impl/TensorBase.h
+++ b/winml/lib/Api/impl/TensorBase.h
@@ -875,7 +875,7 @@ struct TensorBase : TBase {
 
     WINML_THROW_HR_IF_TRUE_MSG(
       E_ILLEGAL_METHOD_CALL,
-      std::is_same<T, std::string>::value,
+      (std::is_same<T, std::string>::value),
       "TensorString objects cannot be created from IBuffers!"
     );
   }

--- a/winml/lib/Api/impl/TensorKindFrom.h
+++ b/winml/lib/Api/impl/TensorKindFrom.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "TensorFeatureDescriptor.h"
+
 namespace _winml {
 
 // We need to define our own type for Half since DirectX::PackedVector::Half resolves to uint16_t per its typedef declaration.

--- a/winml/lib/Api/pch/pch.h
+++ b/winml/lib/Api/pch/pch.h
@@ -12,5 +12,6 @@
 
 #include "cppwinrt_onnx.h"
 #include "dx.h"
+#include "FeatureValues.h"
 
 #pragma warning(pop)

--- a/winml/lib/Common/inc/common.h
+++ b/winml/lib/Common/inc/common.h
@@ -51,3 +51,8 @@ TRACELOGGING_DECLARE_PROVIDER(winml_trace_logging_provider);
 #include "NamespaceAliases.h"
 #include "StringHelpers.h"
 #include "WinML_Lock.h"
+
+template <class T>
+auto unmove_ptr(T&& t) {
+  return &static_cast<T&>(t);
+}

--- a/winml/lib/Common/inc/common.h
+++ b/winml/lib/Common/inc/common.h
@@ -52,7 +52,7 @@ TRACELOGGING_DECLARE_PROVIDER(winml_trace_logging_provider);
 #include "StringHelpers.h"
 #include "WinML_Lock.h"
 
-template <class T>
+template <typename T>
 auto unmove_ptr(T&& t) {
   return &static_cast<T&>(t);
 }


### PR DESCRIPTION
Enable cpp20 builds for DML EP and WinML API

1) Missing typename for templated types
2) unmove helper for inline references to rvalue temporaries
This is okay since per the standard a temporary bound to a reference parameter in a function call exists until the end of the full expression containing that function call: if the function returns a reference, which outlives the full expression, it becomes a dangling reference.

3) static now not needed for template specializations