### PR TITLE
[QNN EP] Add better unit tests for rank 5 ReduceSum

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -188,13 +188,6 @@ Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "QNN EP: ReduceProd operator not supported by HTP backend.");
   }
 
-  if (is_npu_backend) {
-    std::vector<uint32_t> input_shape;
-    ORT_RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].node_arg, input_shape),
-                      "QNN EP: Cannot get input shape for");
-    ORT_RETURN_IF(input_shape.size() > 4, "QNN EP: HTP backend does not support Reduce ops with rank > 4.");
-  }
-
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
 }
 

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -482,6 +482,16 @@ TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumS8Opset13_Rank5) {
                              ExpectedEPNodeAssignment::All);
 }
 
+// Test that QNN validation APIs reject inputs of unsupported ranks.
+TEST_F(QnnHTPBackendTests, ReduceSumS8Opset13_Rank6_Unsupported) {
+  RunReduceOpQDQTest<int8_t>("ReduceSum",
+                             TestInputDef<float>({1, 3, 4, 4, 2, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 96)),
+                             {-1},                             // axes
+                             false,                            // keepdims
+                             13,                               // opset
+                             ExpectedEPNodeAssignment::None);  // Not assigned to QNN EP
+}
+
 // Test rank 5 ReduceSum (u8 quant) with axes = [-1], keep_dims = false
 // TODO: Enable on QNN 2.15.1 (works fine)
 TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumS8Opset13_Rank5_LastAxis) {

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -465,14 +465,34 @@ TEST_F(QnnHTPBackendTests, ReduceSumS8Opset13_NoKeepDims) {
                              ExpectedEPNodeAssignment::All);
 }
 
-// Test that we don't support rank 5 Reduce ops.
-TEST_F(QnnHTPBackendTests, ReduceSumS8Opset13_Rank5Unsupported) {
+// Test rank 5 ReduceSum (s8 quant) with axes = [0, 1, 2, 3, 4], keep_dims = true
+// TODO: QNN 2.15.1 Graph finalization error:
+// graph_prepare.cc:234:ERROR:could not create op: q::Sum
+// graph_prepare.cc:1093:ERROR:Op 0x102500000011 preparation failed with err:-1
+// Completed stage: Graph Transformations and Optimizations (17163 us)
+// QnnDsp <E> "node_token_3" generated: could not create op
+// QnnDsp <E> RouterWindows graph prepare failed 12
+// QnnDsp <E> Failed to finalize graph (id: 1) with err 1002{}
+TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumS8Opset13_Rank5) {
   RunReduceOpQDQTest<int8_t>("ReduceSum",
-                             TestInputDef<float>({1, 3, 4, 4, 2}, false, -10.0f, 10.0f),
+                             TestInputDef<float>({1, 3, 4, 4, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 96)),
                              {0, 1, 2, 3, 4},  // axes
                              true,             // keepdims
                              13,               // opset
-                             ExpectedEPNodeAssignment::None);
+                             ExpectedEPNodeAssignment::All);
+}
+
+// Test rank 5 ReduceSum (u8 quant) with axes = [-1], keep_dims = false
+// TODO: Enable on QNN 2.15.1 (works fine)
+TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumS8Opset13_Rank5_LastAxis) {
+  constexpr size_t num_elems = 2ULL * 12 * 124 * 2 * 4;
+  std::vector<float> input_data = GetFloatDataInRange(-100.0f, 100.0f, num_elems);
+  RunReduceOpQDQTest<uint8_t>("ReduceSum",
+                              TestInputDef<float>({2, 12, 124, 2, 4}, false, input_data),
+                              {-1},   // axes
+                              false,  // keepdims
+                              13,     // opset
+                              ExpectedEPNodeAssignment::All);
 }
 
 //

--- a/onnxruntime/test/providers/qnn/reduce_op_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_op_test.cc
@@ -494,7 +494,7 @@ TEST_F(QnnHTPBackendTests, ReduceSumS8Opset13_Rank6_Unsupported) {
 
 // Test rank 5 ReduceSum (u8 quant) with axes = [-1], keep_dims = false
 // TODO: Enable on QNN 2.15.1 (works fine)
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumS8Opset13_Rank5_LastAxis) {
+TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumU8Opset13_Rank5_LastAxis) {
   constexpr size_t num_elems = 2ULL * 12 * 124 * 2 * 4;
   std::vector<float> input_data = GetFloatDataInRange(-100.0f, 100.0f, num_elems);
   RunReduceOpQDQTest<uint8_t>("ReduceSum",


### PR DESCRIPTION
### Description
We previously had a unit test that checked that QNN EP rejected rank 5 reduce ops. This PR:
- Allows the underlying QNN APIs to validate the input rank for Reduce ops.
- Modifies a rank 5 ReduceSum unit test so that it can be used to reproduce a graph finalization error on QNN SDK 2.15.1.
- Adds a new rank 5 ReduceSum unit test with a configuration that is known to work in QNN SDK 2.15.1.



### Motivation and Context
Allows us to more easily test/verify rank 5 support for ReduceSum.


