### PR TITLE
[QNN EP] Handle implicit conversion loses when size_t is 32-bit

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -203,7 +203,7 @@ Status BaseOpBuilder::TransposeInitializer(const QnnModelWrapper& qnn_model_wrap
   std::vector<size_t> permutations;
   new_tensor_shape_dims.reserve(rank);
   permutations.reserve(rank);
-  for (int64_t p : perm) {
+  for (auto p : perm) {
     permutations.push_back(p);
     new_tensor_shape_dims.push_back(tensor_shape_dims[p]);
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -156,7 +156,7 @@ Status ProcessAlphaAttributeAsInput(QnnModelWrapper& qnn_model_wrapper,
   if (is_quantized_tensor) {
     float scale;
     uint8_t zero_point;
-    int64_t num_of_elements = 1;
+    constexpr size_t num_of_elements = 1;
     concurrency::ThreadPool* thread_pool = nullptr;
     GetQuantizationParameter(&tensor_data.alpha, num_of_elements, scale, zero_point, thread_pool);
     unpacked_data.resize(1);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -537,7 +537,8 @@ Status QnnBackendManager::LoadCachedQnnContext(QnnModel& qnn_model) {
   ORT_RETURN_IF(nullptr == buffer, "Failed to allocate memory for cache file.");
 
   // Load file into buffer
-  const auto& read_result = cache_file.read(reinterpret_cast<char*>(buffer.get()), gsl::narrow<size_t>(buffer_size));
+  const auto& read_result = cache_file.read(reinterpret_cast<char*>(buffer.get()),
+                                            gsl::narrow<std::streamsize>(buffer_size));
   cache_file.close();
   ORT_RETURN_IF(!read_result, "Failed to read contents from cached context file.");
 


### PR DESCRIPTION
### Description
Fixes #17778 



### Motivation and Context
When QNN EP is compiled with Clang (android target) with size_t == uint32_t, clang emits warnings/errors when converting `uint64_t` to `size_t/uint32_t`.


