### PR TITLE
Fix typo in the TensorShape

### DIFF
--- a/onnxruntime/core/framework/tensor_shape.cc
+++ b/onnxruntime/core/framework/tensor_shape.cc
@@ -63,7 +63,7 @@ int64_t TensorShape::Size() const {
 int64_t TensorShape::SizeToDimension(size_t dimension) const {
   const size_t num_dims = values_.size();
   ORT_ENFORCE(dimension <= num_dims,
-              "Invalid dimension of ", dimension, " for SizeFromDimension. Tensor has ",
+              "Invalid dimension of ", dimension, " for SizeToDimension. Tensor has ",
               num_dims, " dimensions.");
 
   int64_t size = SizeHelper(0, dimension);


### PR DESCRIPTION
### Description
The function name in the log should be SizeToDimension



### Motivation and Context


