### PR TITLE
Change how "NPM packaging pipeline" downloads packages from another pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -67,12 +67,11 @@ stages:
     steps:
     - download: build
       artifact: 'NPM_packages'
-      targetPath: '$(Pipeline.Workspace)'
       displayName: 'Download onnxruntime-node Pipeline Artifact'
 
     - task: CopyFiles@2
       inputs:
-        sourceFolder: $(Pipeline.Workspace)
+        sourceFolder: '$(Pipeline.Workspace)\NPM_packages'
         contents: onnxruntime-*.tgz
         targetFolder: $(Build.ArtifactStagingDirectory)\node-artifacts
       displayName: 'Copy onnxruntime-node Artifacts'

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -9,10 +9,14 @@ parameters:
   - 'custom'
   default: 'nightly (@dev)'
 
-- name: NodePipelineId
-  displayName: 'Node npm package build Id'
-  type: string
-  default: 'latest'
+
+resources:
+  pipelines:
+  - pipeline: build
+    source: 'Zip-Nuget-Java-Nodejs Packaging Pipeline'
+    trigger: true
+    branch: main
+
 
 variables:
   # pipeline should define the following varaibles
@@ -65,31 +69,10 @@ stages:
       runCodesignValidationInjection: false
     timeoutInMinutes: 10
     steps:
-
-    - ${{ if eq(parameters.NodePipelineId, 'latest') }}:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: 'specific'
-          project: '530acbc4-21bc-487d-8cd8-348ff451d2ff'
-          definition: '940'
-          specificBuildWithTriggering: true
-          buildVersionToDownload: 'latestFromBranch'
-          branchName: 'refs/heads/main'
-          artifactName: 'NPM_packages'
-          targetPath: '$(Pipeline.Workspace)'
-        displayName: 'Download onnxruntime-node Pipeline Artifact'
-
-    - ${{ if ne(parameters.NodePipelineId, 'latest') }}:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: 'specific'
-          project: '530acbc4-21bc-487d-8cd8-348ff451d2ff'
-          definition: '940'
-          buildVersionToDownload: 'specific'
-          pipelineId: '${{ parameters.NodePipelineId }}'
-          artifactName: 'NPM_packages'
-          targetPath: '$(Pipeline.Workspace)'
-        displayName: 'Download onnxruntime-node Pipeline Artifact'
+    - download: build
+      artifact: 'NPM_packages'
+      targetPath: '$(Pipeline.Workspace)'
+      displayName: 'Download onnxruntime-node Pipeline Artifact'
 
     - task: CopyFiles@2
       inputs:

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -71,7 +71,7 @@ stages:
 
     - task: CopyFiles@2
       inputs:
-        sourceFolder: '$(Pipeline.Workspace)\NPM_packages'
+        sourceFolder: '$(Pipeline.Workspace)\build\NPM_packages'
         contents: onnxruntime-*.tgz
         targetFolder: $(Build.ArtifactStagingDirectory)\node-artifacts
       displayName: 'Copy onnxruntime-node Artifacts'

--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -9,15 +9,6 @@ parameters:
   - 'custom'
   default: 'nightly (@dev)'
 
-
-resources:
-  pipelines:
-  - pipeline: build
-    source: 'Zip-Nuget-Java-Nodejs Packaging Pipeline'
-    trigger: true
-    branch: main
-
-
 variables:
   # pipeline should define the following varaibles
   #   ExtraBuildArgs
@@ -33,6 +24,11 @@ variables:
     NpmPackagingMode: '$(VersionSuffix)'
 
 resources:
+  pipelines:
+  - pipeline: build
+    source: 'Zip-Nuget-Java-Nodejs Packaging Pipeline'
+    trigger: true
+    branch: main
   repositories:
   - repository: manylinux
     type: Github


### PR DESCRIPTION
### Description
"NPM packaging pipeline" needs to download an artifact from "Zip-Nuget-Java-Nodejs Packaging Pipeline". 
It has been a long-time issue that they two pipelines often use different commit ids, or even their branch names are different. 
This change declares 'Zip-Nuget-Java-Nodejs Packaging Pipeline' as a resource, so that "NPM packaging pipeline" will always fetch from the pipeline run that triggers this NPM pipeline.  
Their official document says:
"When you define a resource trigger, if its pipeline resource is from the same repo as the current pipeline, triggering follows the same branch and commit on which the event is raised."


### Motivation and Context


