### PR TITLE
[WebNN EP] Add a duplicate entry to support new "dataType"

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -145,7 +145,7 @@ bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
 bool SetWebnnDataType(emscripten::val& desc, const int32_t data_type) {
   // WebNN changed the name of the MLOperandDescriptor's data type from "type" to "dataType",
   // use a duplicate entry temporarily to workaround this API breaking issue.
-  // TODO: Remove lagecy "type" once all browsers implement the new "dataType".
+  // TODO: Remove legacy "type" once all browsers implement the new "dataType".
   switch (data_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
       desc.set("type", emscripten::val("uint8"));

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -142,5 +142,43 @@ bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
   return true;
 }
 
+bool SetWebnnDataType(emscripten::val& desc, const int32_t data_type) {
+  // WebNN changed the name of the MLOperandDescriptor's data type from "type" to "dataType",
+  // use a duplicate entry temporarily to workaround this API breaking issue.
+  // TODO: Remove lagecy "type" once all browsers implement the new "dataType".
+  switch (data_type) {
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+      desc.set("type", emscripten::val("uint8"));
+      desc.set("dataType", emscripten::val("uint8"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      desc.set("type", emscripten::val("float16"));
+      desc.set("dataType", emscripten::val("float16"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      desc.set("type", emscripten::val("float32"));
+      desc.set("dataType", emscripten::val("float32"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      desc.set("type", emscripten::val("int32"));
+      desc.set("dataType", emscripten::val("int32"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      desc.set("type", emscripten::val("int64"));
+      desc.set("dataType", emscripten::val("int64"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
+      desc.set("type", emscripten::val("uint32"));
+      desc.set("dataType", emscripten::val("uint32"));
+      return true;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      desc.set("type", emscripten::val("uint64"));
+      desc.set("dataType", emscripten::val("uint64"));
+      return true;
+    default:
+      return false;
+  }
+}
+
 }  // namespace webnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -231,5 +231,8 @@ bool IsSupportedDataType(const int32_t data_type, const WebnnDeviceType device_t
 bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
                                       std::vector<int64_t>& shape_b,
                                       const logging::Logger& logger);
+
+bool SetWebnnDataType(emscripten::val& desc, const int32_t data_type);
+
 }  // namespace webnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/shape_op_builder.cc
@@ -34,7 +34,7 @@ Status ShapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto rank = static_cast<int32_t>(input_shape.size());
 
   emscripten::val desc = emscripten::val::object();
-  desc.set("type", emscripten::val("int64"));
+  ORT_RETURN_IF_NOT(SetWebnnDataType(desc, ONNX_NAMESPACE::TensorProto_DataType_INT64), "Unsupported data type");
   emscripten::val dims = emscripten::val::array();
   dims.call<void>("push", rank);
   desc.set("dimensions", dims);


### PR DESCRIPTION
WebNN spec renames "type" as "dataType" at
https://github.com/webmachinelearning/webnn/pull/464, add a duplicate entry for "dataType" in order to workaround the compatibility issue.