### PR TITLE
Add noexcep_operators to onnxruntime internal libraries

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -217,6 +217,7 @@ if (onnxruntime_USE_EXTENSIONS)
   list(APPEND onnxruntime_INTERNAL_LIBRARIES
     onnxruntime_extensions
     ocos_operators
+    noexcep_operators
   )
 endif()
 

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -795,7 +795,6 @@ common::Status CreateCustomRegistry(gsl::span<OrtCustomOpDomain* const> op_domai
       // GetInputMemoryType was introduced in ver 13. This check allows custom ops compiled using older versions
       // to work with newer versions (> 12) of the ORT binary.
       if (op->version > 12) {
-        auto input_count = op->GetInputTypeCount(op);
         for (size_t i = 0; i < input_count; i++) {
           def_builder.InputMemoryType(op->GetInputMemoryType(op, i), i);
         }


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime-extensions/pull/367 introduced the `noexcep_operators` library in `onnxruntime-extensions`.

This library currently does not get linked against in ONNX Runtime when users build with `--use_extensions`. This pull request addresses that issue.

This pull request also fixes an issue with `onnxruntime/core/session/custom_ops.cc` where a variable was declared twice within the same scope leading to: `warning C4456: declaration of 'input_count' hides previous local declaration`