### PR TITLE
Allow rocm ep to build with fp8

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -944,7 +944,7 @@ def generate_build_tree(
 
     types_to_disable = args.disable_types
     # enable/disable float 8 types
-    disable_float8_types = args.use_rocm or args.android or ("float8" in types_to_disable)
+    disable_float8_types = args.android or ("float8" in types_to_disable)
     disable_optional_type = "optional" in types_to_disable
     disable_sparse_tensors = "sparsetensor" in types_to_disable
 


### PR DESCRIPTION
There seems to be no problem for ROCm EP to enable fp8. So pick the change from my branch.