### PR TITLE
Enable onnx_test_runner to run the whole models dir in CI machine

### DIFF
--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -770,16 +770,6 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       }
       if (disabled_tests.find(test_case_name) != disabled_tests.end()) return true;
 
-      if (broken_tests_keyword_set) {
-        for (auto iter2 = broken_tests_keyword_set->begin(); iter2 != broken_tests_keyword_set->end(); ++iter2) {
-          std::string keyword = *iter2;
-          if (ToUTF8String(test_case_name).find(keyword) != std::string::npos) {
-            LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name) << " as it is in broken test keywords";
-            return true;
-          }
-        }
-      }
-
       std::basic_string<PATH_CHAR_TYPE> p = ConcatPathComponent(node_data_root_path, filename_str);
 
       std::unique_ptr<TestModelInfo> model_info;
@@ -803,7 +793,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       // to skip some models like *-int8 or *-qdq
       if ((reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_TRAINING_DOMAIN) ||
           (reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_PREVIEW_TRAINING_DOMAIN)) {
-        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " as it has training domain";
+        fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " as it has training domain");
         return true;
       }
 #endif
@@ -818,7 +808,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         return true;
       });
       if (!has_test_data) {
-        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " due to no test data";
+        fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " due to no test data");
         return true;
       }
 
@@ -829,8 +819,18 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         if (iter != broken_tests->end() &&
             (opset_version == TestModelInfo::unknown_version || iter->broken_opset_versions_.empty() ||
              iter->broken_opset_versions_.find(opset_version) != iter->broken_opset_versions_.end())) {
-          LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " due to broken_tests";
+          fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " due to broken_tests");
           return true;
+        }
+      }
+
+      if (broken_tests_keyword_set) {
+        for (auto iter2 = broken_tests_keyword_set->begin(); iter2 != broken_tests_keyword_set->end(); ++iter2) {
+          std::string keyword = *iter2;
+          if (ToUTF8String(test_case_name).find(keyword) != std::string::npos) {
+            fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " as it is in broken test keywords");
+            return true;
+          }
         }
       }
 

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -6,6 +6,7 @@
 #include "TestCase.h"
 
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -797,13 +797,13 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       }
 
       auto test_case_dir = model_info->GetDir();
-      auto full_test_case_name = test_case_name + ORT_TSTR(" in ") + test_case_dir;
+      auto test_case_name_in_log = test_case_name + ORT_TSTR(" in ") + test_case_dir;
 
-#if !defined(ORT_MINIMAL_BUILD)
+#if !defined(ORT_MINIMAL_BUILD) && !defined(USE_QNN)
       // to skip some models like *-int8 or *-qdq
       if ((reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_TRAINING_DOMAIN) ||
           (reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_PREVIEW_TRAINING_DOMAIN)) {
-        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(full_test_case_name) << " as it has training domain";
+        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " as it has training domain";
         return true;
       }
 #endif
@@ -818,7 +818,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         return true;
       });
       if (!has_test_data) {
-        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(full_test_case_name) << " due to no test data";
+        LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " due to no test data";
         return true;
       }
 
@@ -829,7 +829,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
         if (iter != broken_tests->end() &&
             (opset_version == TestModelInfo::unknown_version || iter->broken_opset_versions_.empty() ||
              iter->broken_opset_versions_.find(opset_version) != iter->broken_opset_versions_.end())) {
-          LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(full_test_case_name) << " due to broken_tests";
+          LOGS_DEFAULT(ERROR) << "Skip test case: " << ToUTF8String(test_case_name_in_log) << " due to broken_tests";
           return true;
         }
       }
@@ -839,7 +839,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       std::unique_ptr<ITestCase> l = CreateOnnxTestCase(ToUTF8String(test_case_name), std::move(model_info),
                                                         tolerances.absolute(tolerance_key),
                                                         tolerances.relative(tolerance_key));
-      fprintf(stdout, "Load Test Case: %s\n", ToUTF8String(full_test_case_name).c_str());
+      fprintf(stdout, "Load Test Case: %s\n", ToUTF8String(test_case_name_in_log).c_str());
       process_function(std::move(l));
       return true;
     });

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -797,7 +797,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       }
 
       auto test_case_dir = model_info->GetDir();
-      auto full_test_case_name = test_case_name + L" in " + test_case_dir;
+      auto full_test_case_name = test_case_name + ORT_TSTR(" in ") + test_case_dir;
 
 #if !defined(ORT_MINIMAL_BUILD)
       // to skip some models like *-int8 or *-qdq

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -831,6 +831,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       std::unique_ptr<ITestCase> l = CreateOnnxTestCase(ToUTF8String(test_case_name), std::move(model_info),
                                                         tolerances.absolute(tolerance_key),
                                                         tolerances.relative(tolerance_key));
+      fprintf(stdout, "Load Test Case: %s\n", ToUTF8String(full_test_case_name).c_str());
       process_function(std::move(l));
       return true;
     });

--- a/onnxruntime/test/onnx/TestCase.h
+++ b/onnxruntime/test/onnx/TestCase.h
@@ -101,12 +101,6 @@ class TestTolerances {
   const Map relative_overrides_;
 };
 
-void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths,
-               const std::vector<std::basic_string<PATH_CHAR_TYPE>>& whitelisted_test_cases,
-               const TestTolerances& tolerances,
-               const std::unordered_set<std::basic_string<ORTCHAR_T>>& disabled_tests,
-               const std::function<void(std::unique_ptr<ITestCase>)>& process_function);
-
 struct BrokenTest {
   std::string test_name_;
   std::string reason_;
@@ -118,6 +112,16 @@ struct BrokenTest {
   }
 };
 
+void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths,
+               const std::vector<std::basic_string<PATH_CHAR_TYPE>>& whitelisted_test_cases,
+               const TestTolerances& tolerances,
+               const std::unordered_set<std::basic_string<ORTCHAR_T>>& disabled_tests,
+               std::unique_ptr<std::set<BrokenTest>> broken_test_list,
+               std::unique_ptr<std::set<std::string>> broken_tests_keyword_set,
+               const std::function<void(std::unique_ptr<ITestCase>)>& process_function);
+
 std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider_name);
+
+std::unique_ptr<std::set<std::string>> GetBrokenTestsKeyWordSet(const std::string& provider_name);
 
 std::unique_ptr<std::set<std::string>> GetBrokenTestsKeyWordSet(const std::string& provider_name);

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -783,10 +783,14 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     all_disabled_tests.insert(std::begin(x86_disabled_tests), std::end(x86_disabled_tests));
 #endif
 
+    auto broken_tests = GetBrokenTests(provider_name);
+    auto broken_tests_keyword_set = GetBrokenTestsKeyWordSet(provider_name);
     std::vector<ITestCase*> tests;
     LoadTests(data_dirs, whitelisted_test_cases,
               LoadTestTolerances(enable_cuda, enable_openvino, override_tolerance, atol, rtol),
               all_disabled_tests,
+              std::move(broken_tests),
+              std::move(broken_tests_keyword_set),
               [&owned_tests, &tests](std::unique_ptr<ITestCase> l) {
                 tests.push_back(l.get());
                 owned_tests.push_back(std::move(l));
@@ -803,18 +807,10 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     fwrite(res.c_str(), 1, res.size(), stdout);
   }
 
-  auto broken_tests = GetBrokenTests(provider_name);
   int result = 0;
   for (const auto& p : stat.GetFailedTest()) {
-    BrokenTest t = {p.first, ""};
-    auto iter = broken_tests->find(t);
-    if (iter == broken_tests->end() || (p.second != TestModelInfo::unknown_version && !iter->broken_opset_versions_.empty() &&
-                                        iter->broken_opset_versions_.find(p.second) == iter->broken_opset_versions_.end())) {
-      fprintf(stderr, "test %s failed, please fix it\n", p.first.c_str());
-      result = -1;
-    } else {
-      fprintf(stderr, "test %s failed, but it is a known broken test, so we ignore it\n", p.first.c_str());
-    }
+    fprintf(stderr, "test %s failed, please fix it\n", p.first.c_str());
+    result = -1;
   }
   return result;
 }

--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -238,13 +238,16 @@ static std::vector<ITestCase*> GetAllTestCases() {
   // Bad onnx test output caused by previously wrong SAME_UPPER/SAME_LOWER for ConvTranspose
   allDisabledTests.insert(ORT_TSTR("cntk_simple_seg"));
 
+  auto broken_tests = GetBrokenTests("dml");
+  auto broken_tests_keyword_set = GetBrokenTestsKeyWordSet("dml");
+
   WINML_EXPECT_NO_THROW(LoadTests(
     dataDirs,
     whitelistedTestCases,
     TestTolerances(1e-3, 1e-3, {}, {}),
     allDisabledTests,
-    nullptr,
-    nullptr,
+    std::move(broken_tests),
+    std::move(broken_tests_keyword_set),
     [&tests](std::unique_ptr<ITestCase> l) {
       tests.push_back(l.get());
       ownedTests.push_back(std::move(l));

--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -238,11 +238,16 @@ static std::vector<ITestCase*> GetAllTestCases() {
   // Bad onnx test output caused by previously wrong SAME_UPPER/SAME_LOWER for ConvTranspose
   allDisabledTests.insert(ORT_TSTR("cntk_simple_seg"));
 
+  auto broken_tests = std::make_unique<std::set<BrokenTest>>();
+  auto broken_tests_keyword_set = std::make_unique<std::set<std::string>>();
+
   WINML_EXPECT_NO_THROW(LoadTests(
     dataDirs,
     whitelistedTestCases,
     TestTolerances(1e-3, 1e-3, {}, {}),
     allDisabledTests,
+    std::move(broken_tests),
+    std::move(broken_tests_keyword_set),
     [&tests](std::unique_ptr<ITestCase> l) {
       tests.push_back(l.get());
       ownedTests.push_back(std::move(l));

--- a/winml/test/model/model_tests.cpp
+++ b/winml/test/model/model_tests.cpp
@@ -238,16 +238,13 @@ static std::vector<ITestCase*> GetAllTestCases() {
   // Bad onnx test output caused by previously wrong SAME_UPPER/SAME_LOWER for ConvTranspose
   allDisabledTests.insert(ORT_TSTR("cntk_simple_seg"));
 
-  auto broken_tests = std::make_unique<std::set<BrokenTest>>();
-  auto broken_tests_keyword_set = std::make_unique<std::set<std::string>>();
-
   WINML_EXPECT_NO_THROW(LoadTests(
     dataDirs,
     whitelistedTestCases,
     TestTolerances(1e-3, 1e-3, {}, {}),
     allDisabledTests,
-    std::move(broken_tests),
-    std::move(broken_tests_keyword_set),
+    nullptr,
+    nullptr,
     [&tests](std::unique_ptr<ITestCase> l) {
       tests.push_back(l.get());
       ownedTests.push_back(std::move(l));


### PR DESCRIPTION
### Description
1. If the model should be skipped, don't load it.
2. print loaded tests and skipped tests
3. add more same filters as of the onnxruntime_test_all.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


