### PR TITLE
Set default value for NVCC threads

### DIFF
--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -122,6 +122,7 @@
     # CUDA 11.3+ supports parallel compilation
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-threads
     if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.3)
+      option(onnxruntime_NVCC_THREADS "Number of threads that NVCC can use for compilation." 1)
       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--threads \"${onnxruntime_NVCC_THREADS}\">")
     endif()
     if (UNIX)


### PR DESCRIPTION
### Description

Without doing this CMake gives a miscellaneous error on windows when checking if NVCC is functional. It will be missing a number after `--threads`.

I have no strong opinion on setting this to 1 (needed to limit memory consumption) or 0 to use the maximum threads on the given CPU. @tianleiwu maybe you could comment on this. But currently it is only possible to configure through the python build scripts and not CMake only configure - which is what I am usually doing through CLion.


