### PR TITLE
[CUDA] Fix SkipLayerNorm strict mode when skip has broadcast

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm.cc
@@ -50,6 +50,11 @@ template <typename T, bool Simplified>
 Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor* input = ctx->Input<Tensor>(0);
   const Tensor* skip = ctx->Input<Tensor>(1);
+  if (strict_ && skip->Shape() != input->Shape()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "'input' and 'skip' shall have same shape when enable_skip_layer_norm_strict_mode is True");
+  }
+
   const Tensor* gamma = ctx->Input<Tensor>(2);
 
   const Tensor* beta = Simplified ? nullptr : ctx->Input<Tensor>(3);
@@ -57,17 +62,13 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
 
   Tensor* output = ctx->Output(0, input->Shape());
 
-  // For inferencing, we support one more optional output which is the sum
-  // of the input and skip tensors
-  Tensor* skip_input_bias_add_output = ctx->Output(3, input->Shape());
+  // Optional output for the sum of skip, input and bias tensors (It is also the input of Layer Normalization).
+  Tensor* sum_output = ctx->Output(3, input->Shape());
 
   const auto& input_dims = input->Shape().GetDims();
   size_t input_dims_size = input_dims.size();
-  const auto& skip_dims = skip->Shape().GetDims();
-  size_t skip_dims_size = skip_dims.size();
 
   int hidden_size = static_cast<int>(input_dims[input_dims_size - 1]);
-
   ORT_RETURN_IF_ERROR(onnxruntime::contrib::skip_layer_norm_helper::CheckInputs<Tensor>(input,
                                                                                         skip,
                                                                                         gamma,
@@ -76,11 +77,14 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
                                                                                         hidden_size,
                                                                                         input_dims_size));
 
-  const bool skip_broadcasted = (skip_dims[0] == 1 || skip_dims_size == 2) ? true : false;
-  const int skip_size = static_cast<int>(skip_dims[skip_dims_size - 1] * skip_dims[skip_dims_size - 2]);
-
   int row_count = gsl::narrow<int>(input->Shape().SizeToDimension(input_dims_size - 1));
+  if (row_count == 0) {
+    return Status::OK();
+  }
+
   typedef typename ToCudaType<T>::MappedType CudaT;
+
+  const int skip_size = static_cast<int>(skip->Shape().Size());
 
   if (strict_) {
     HostApplyLayerNorm<CudaT, float, CudaT, Simplified>(
@@ -97,21 +101,20 @@ Status SkipLayerNorm<T, Simplified>::ComputeInternal(OpKernelContext* ctx) const
         (beta != nullptr) ? reinterpret_cast<const CudaT*>(beta->Data<T>()) : nullptr,  // beta
         reinterpret_cast<const CudaT*>(skip->Data<T>()),                                // skip or residual to add
         (bias != nullptr) ? reinterpret_cast<const CudaT*>(bias->Data<T>()) : nullptr,  // bias to add
-        skip_input_bias_add_output != nullptr ? reinterpret_cast<CudaT*>(skip_input_bias_add_output->MutableData<T>()) : nullptr);
+        sum_output != nullptr ? reinterpret_cast<CudaT*>(sum_output->MutableData<T>()) : nullptr);
   } else {
     LaunchSkipLayerNormKernel<CudaT, Simplified>(
         Stream(ctx),
         reinterpret_cast<CudaT*>(output->MutableData<T>()),
-        skip_input_bias_add_output != nullptr ? reinterpret_cast<CudaT*>(skip_input_bias_add_output->MutableData<T>()) : nullptr,
+        sum_output != nullptr ? reinterpret_cast<CudaT*>(sum_output->MutableData<T>()) : nullptr,
         reinterpret_cast<const CudaT*>(input->Data<T>()),
         reinterpret_cast<const CudaT*>(skip->Data<T>()),
+        (bias != nullptr) ? reinterpret_cast<const CudaT*>(bias->Data<T>()) : nullptr,
         reinterpret_cast<const CudaT*>(gamma->Data<T>()),
         (beta != nullptr) ? reinterpret_cast<const CudaT*>(beta->Data<T>()) : nullptr,
-        (bias != nullptr) ? reinterpret_cast<const CudaT*>(bias->Data<T>()) : nullptr,
         epsilon_,
         hidden_size,
         row_count,
-        skip_broadcasted,
         skip_size);
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.h
@@ -11,18 +11,17 @@ namespace cuda {
 template <typename T, bool Simplified>
 void LaunchSkipLayerNormKernel(
     cudaStream_t stream,
-    T* output,                      // normalized output tensor
-    T* skip_input_bias_add_output,  // sum of the input and skip (and bias if it exists) tensors output
-    const T* input,                 // input tensor
-    const T* skip,                  // skip tensor
-    const T* gamma,                 // Layer normalization gamma tensor
-    const T* beta,                  // Layer normalization beta tensor
-    const T* bias,                  // Layer normalization beta tensor
-    float epsilon,                  // Layer normalization epsilon
-    int hidden_size,                // hidden size, it is the leading dimension (ld)
-    int row_count,                  // number of rows. That is total number of elements divided by hidden size.
-    bool skip_broadcasted,          // determines if broadcasting should be implemented
-    int skip_size);                 // determines size of the skip tensor
+    T* output,        // normalized output tensor
+    T* sum_output,    // sum of the input and skip (and bias if it exists) tensors output
+    const T* input,   // input tensor
+    const T* skip,    // skip tensor
+    const T* bias,    // bias tensor
+    const T* gamma,   // Layer normalization gamma tensor
+    const T* beta,    // Layer normalization beta tensor
+    float epsilon,    // Layer normalization epsilon
+    int hidden_size,  // hidden size, it is the leading dimension (ld)
+    int row_count,    // number of rows. That is total number of elements divided by hidden size.
+    int skip_size);   // number of elements of the skip tensor
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/core/providers/cuda/nn/layer_norm_impl.h
+++ b/onnxruntime/core/providers/cuda/nn/layer_norm_impl.h
@@ -43,9 +43,7 @@ void HostApplyLayerNorm(
     const V* beta,
     const T* skip = nullptr,
     const T* bias = nullptr,
-    T* skip_input_bias_add_output = nullptr,
-    const bool skip_broadcasted = false,
-    const int skip_size = 0);
+    T* skip_input_bias_add_output = nullptr);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -11,14 +11,15 @@ namespace onnxruntime {
 namespace test {
 constexpr float epsilon_ = 1e-12f;
 
-static void RunTest(
+static void RunOneTest(
+    bool strict,
     const std::vector<float>& input_data,
     const std::vector<float>& skip_data,
     const std::vector<float>& gamma_data,
     const std::vector<float>& beta_data,
     const std::vector<float>& bias_data,
     const std::vector<float>& output_data,
-    const std::vector<float>& skip_input_bias_add_output_data,
+    const std::vector<float>& sum_output_data,
     float epsilon,
     int batch_size,
     int sequence_length,
@@ -27,7 +28,6 @@ static void RunTest(
     bool no_beta = false,
     bool simplified = false,
     bool use_token_count = false,
-    bool strict = false,
     bool broadcast_skip = false,
     bool no_batch_size = false) {
   // Input and output shapes
@@ -82,14 +82,14 @@ static void RunTest(
 
     test.AddOutput<float>("output", output_dims, output_data);
 
-    if (skip_input_bias_add_output_data.size() != 0) {
+    if (sum_output_data.size() != 0) {
       // The second and third outputs are reserved for something else
       test.AddOptionalOutputEdge<float>();
       test.AddOptionalOutputEdge<float>();
 
       test.AddOutput<float>("skip_input_bias_add_output",
                             output_dims,
-                            skip_input_bias_add_output_data);
+                            sum_output_data);
     }
 
     if (cpu_ep != nullptr) {
@@ -117,14 +117,19 @@ static void RunTest(
 
     test.AddOutput<MLFloat16>("output", output_dims, ToFloat16(output_data));
 
-    if (skip_input_bias_add_output_data.size() != 0) {
+    // Use larger threshold for fp16
+    if (use_float16) {
+      test.SetOutputAbsErr("output", 0.01f);
+    }
+
+    if (sum_output_data.size() != 0) {
       // The second and third outputs are reserved for something else
       test.AddOptionalOutputEdge<MLFloat16>();
       test.AddOptionalOutputEdge<MLFloat16>();
 
       test.AddOutput<MLFloat16>("skip_input_bias_add_output",
                                 output_dims,
-                                ToFloat16(skip_input_bias_add_output_data));
+                                ToFloat16(sum_output_data));
     }
 
     if (dml_ep != nullptr) {
@@ -148,6 +153,36 @@ static void RunTest(
     }
 
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+static void RunTest(
+    const std::vector<float>& input_data,
+    const std::vector<float>& skip_data,
+    const std::vector<float>& gamma_data,
+    const std::vector<float>& beta_data,
+    const std::vector<float>& bias_data,
+    const std::vector<float>& output_data,
+    const std::vector<float>& sum_output_data,
+    float epsilon,
+    int batch_size,
+    int sequence_length,
+    int hidden_size,
+    bool use_float16 = false,
+    bool no_beta = false,
+    bool simplified = false,
+    bool use_token_count = false,
+    bool broadcast_skip = false,
+    bool no_batch_size = false) {
+  RunOneTest(false, input_data, skip_data, gamma_data, beta_data, bias_data, output_data, sum_output_data,
+             epsilon, batch_size, sequence_length, hidden_size, use_float16, no_beta, simplified,
+             use_token_count, broadcast_skip, no_batch_size);
+
+  // strict mode does not support skip broadcasting.
+  if (!broadcast_skip) {
+    RunOneTest(true, input_data, skip_data, gamma_data, beta_data, bias_data, output_data, sum_output_data,
+               epsilon, batch_size, sequence_length, hidden_size, use_float16, no_beta, simplified,
+               use_token_count, broadcast_skip, no_batch_size);
   }
 }
 
@@ -359,8 +394,7 @@ TEST(SkipLayerNormTest, SkipLayerNormBatch1_Float16_vec) {
           true /*use_float16*/,
           false /*no_beta*/,
           false /*simplified*/,
-          false /*use_token_count*/,
-          true /*strict*/);
+          false /*use_token_count*/);
 }
 
 TEST(SkipLayerNormTest, SkipLayerNormBatch1_NoBeta) {
@@ -648,8 +682,7 @@ TEST(SkipLayerNormTest, SkipLayerNormBatch1_Float16_vec_token_count) {
           true /*use_float16*/,
           false /*no_beta*/,
           false /*simplified*/,
-          true /*use_token_count*/,
-          true /*strict*/);
+          true /*use_token_count*/);
 }
 
 TEST(SkipLayerNormTest, SkipLayerNormBatch2_TokenCount) {
@@ -776,13 +809,12 @@ TEST(SkipLayerNormTest, SkipLayerNormBatch2_Skip_Broadcast_No_Batch_Size) {
           batch_size,
           sequence_length,
           hidden_size,
-          false,
-          false,
-          false,
-          false,
-          false,
-          false,
-          true);
+          false,  // use_float16
+          false,  // no_beta
+          false,  // simplified
+          false,  // use_token_count
+          true,   // broadcast_skip
+          true);  // no_batch_size
 }
 
 TEST(SkipLayerNormTest, SkipLayerNormBatch2_Skip_Broadcast_Batch_Size_1) {
@@ -823,13 +855,12 @@ TEST(SkipLayerNormTest, SkipLayerNormBatch2_Skip_Broadcast_Batch_Size_1) {
           batch_size,
           sequence_length,
           hidden_size,
-          false,
-          false,
-          false,
-          false,
-          false,
-          true,
-          false);
+          false,   // use_float16
+          false,   // no_beta
+          false,   // simplified
+          false,   // use_token_count
+          true,    // broadcast_skip
+          false);  // no_batch_size
 }
 #endif
 


### PR DESCRIPTION
### Description

In SLN strict mode, current code (#16510) does not handle skip broadcast nicely . There are two issues:
(1) skip related parameters is not passed to cuda kernel in strict mode
(2) Strict mode kernel also has bug in handling skip broadcasting (like cuWelfordMuSigma2 does not handle skip broadcasting).

Here we remove the support of skip broadcasting in strict mode, and operator will return error message that strict mode only support same shape of input and skip.

Other changes:
* skip_size is misleading when there is no broadcasting. Change to correct value.
* Refactor the code to be more efficient: (1) no need to check whether there is broadcasting in kernel. (2) remove one local buffer (load input to sum_v directly to save a local buffer copy).
* compute input + bias + skip instead of input + skip + bias. The order is followed common pattern in transformers model (Here assume graph fusion will distinguish input and skip correctly, need double check fusion code later).
* update unit test so that strict mode is triggered in each test case (unless skip broadcasting) to have higher test coverage.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

SLN strict mode does not support skip broadcast but current code will silently run (kernel might fail)

