### PR TITLE
Refactor should_quantize method to use and operator

### DIFF
--- a/onnxruntime/python/tools/quantization/operators/base_operator.py
+++ b/onnxruntime/python/tools/quantization/operators/base_operator.py
@@ -4,10 +4,7 @@ class QuantOperatorBase:
         self.node = onnx_node
 
     def should_quantize(self):
-        if not self.quantizer.should_quantize_node(self.node):
-            return False
-
-        return self.quantizer.is_float_tensor(self.node.input[0])
+        return self.quantizer.should_quantize_node(self.node) and self.quantizer.is_float_tensor(self.node.input[0])
 
     def quantize(self):
         """


### PR DESCRIPTION
### Description
Refactor the `should_quantize` method to use an and statement.



### Motivation and Context
The current code is already functionally equivalent to an and-statement. I just think it is cleaner and more readable like this, but it's a small thing :)


