### PR TITLE
[WebNN EP] Fixed wasm heap overflow for big model

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -123,39 +123,37 @@ Status ModelBuilder::RegisterInitializers() {
     emscripten::val operand = emscripten::val::object();
     if (IsSupportedDataType(data_type, wnn_device_type_)) {
       ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
-      unpacked_tensors_.push_back({});
-      std::vector<uint8_t>& unpacked_tensor = unpacked_tensors_.back();
-      ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor));
+      auto * tensorPtr = (std::byte*)(tensor.raw_data().c_str());
       auto num_elements = SafeInt<size_t>(Product(tensor.dims()));
       emscripten::val view = emscripten::val::undefined();
       switch (data_type) {
         case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint8_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<uint8_t*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint16_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<uint16_t*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<float*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<float*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_INT32:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<int32_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<int32_t*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_INT64:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<int64_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<int64_t*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint32_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<uint32_t*>(tensorPtr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint64_t*>(unpacked_tensor.data()))};
+                                                               reinterpret_cast<uint64_t*>(tensorPtr))};
           break;
         default:
           break;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -123,37 +123,45 @@ Status ModelBuilder::RegisterInitializers() {
     emscripten::val operand = emscripten::val::object();
     if (IsSupportedDataType(data_type, wnn_device_type_)) {
       ORT_RETURN_IF_NOT(SetWebnnDataType(desc, data_type), "Unsupported data type");
-      auto * tensorPtr = (std::byte*)(tensor.raw_data().c_str());
       auto num_elements = SafeInt<size_t>(Product(tensor.dims()));
       emscripten::val view = emscripten::val::undefined();
+      std::byte* tensor_ptr = nullptr;
+      if (tensor.has_raw_data()) {
+        tensor_ptr = reinterpret_cast<std::byte*>(const_cast<char *>(tensor.raw_data().c_str()));
+      } else {
+        unpacked_tensors_.push_back({});
+        std::vector<uint8_t>& unpacked_tensor = unpacked_tensors_.back();
+        ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor));
+        tensor_ptr = reinterpret_cast<std::byte*>(unpacked_tensor.data());
+      }
       switch (data_type) {
         case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint8_t*>(tensorPtr))};
+                                                               reinterpret_cast<uint8_t*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint16_t*>(tensorPtr))};
+                                                               reinterpret_cast<uint16_t*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<float*>(tensorPtr))};
+                                                               reinterpret_cast<float*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_INT32:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<int32_t*>(tensorPtr))};
+                                                               reinterpret_cast<int32_t*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_INT64:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<int64_t*>(tensorPtr))};
+                                                               reinterpret_cast<int64_t*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint32_t*>(tensorPtr))};
+                                                               reinterpret_cast<uint32_t*>(tensor_ptr))};
           break;
         case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
-                                                               reinterpret_cast<uint64_t*>(tensorPtr))};
+                                                               reinterpret_cast<uint64_t*>(tensor_ptr))};
           break;
         default:
           break;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -127,7 +127,7 @@ Status ModelBuilder::RegisterInitializers() {
       emscripten::val view = emscripten::val::undefined();
       std::byte* tensor_ptr = nullptr;
       if (tensor.has_raw_data()) {
-        tensor_ptr = reinterpret_cast<std::byte*>(const_cast<char *>(tensor.raw_data().c_str()));
+        tensor_ptr = reinterpret_cast<std::byte*>(const_cast<char*>(tensor.raw_data().c_str()));
       } else {
         unpacked_tensors_.push_back({});
         std::vector<uint8_t>& unpacked_tensor = unpacked_tensors_.back();

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -71,7 +71,6 @@ class ModelBuilder {
   emscripten::val wnn_builder_ = emscripten::val::object();
   DataLayout preferred_layout_;
   WebnnDeviceType wnn_device_type_;
-  std::vector<std::vector<uint8_t>> unpacked_tensors_;
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -71,6 +71,7 @@ class ModelBuilder {
   emscripten::val wnn_builder_ = emscripten::val::object();
   DataLayout preferred_layout_;
   WebnnDeviceType wnn_device_type_;
+  std::vector<std::vector<uint8_t>> unpacked_tensors_;
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;
   std::vector<std::string> output_names_;


### PR DESCRIPTION
When processing initialized tensors, WebNN did unnecessary tensor unpacking as which is already stored as raw byte data. This would cause WASM heap overflow when running big model.

Fixed this issue by pointing directly to the tensor raw data.