### PR TITLE
Update TestCase.cc: exclude a test for DML

### DIFF
--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1230,6 +1230,7 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"candy", "Temporarily disabled pending investigation"});
     broken_tests->insert({"BERT_Squad", "Temporarily disabled pending investigation"});
     broken_tests->insert({"LSTM_Seq_lens_unpacked", "The parameter is incorrect"});
+    broken_tests->insert({"mlperf_ssd_resnet34_1200", "The parameter is incorrect"});
 
     broken_tests->insert({"resize_downsample_scales_linear",
                           "DML uses half_pixel and this test assumed \"asymmetric\" but does not include \"mode\""});


### PR DESCRIPTION
### Description
Update TestCase.cc: exclude a test for DML


### Motivation and Context
The test is failing due to GPU driver update.

