### PR TITLE
[QNN EP] Fix topological node unit traversal during validation

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -371,10 +371,14 @@ Status SimpleOpBuilder::ProcessSigmoidOrTanhOutput(QnnModelWrapper& qnn_model_wr
       const float scale = output_info.quant_param.scaleOffsetEncoding.scale;
 
       LOGS(logger, VERBOSE) << "QNN requires that 16-bit quantized " << op_type << " operators use offset/scale values "
-                            << "of <" << offset << ", " << scale << ">. QNN EP will override the original values.";
+                            << "of <" << offset << ", " << scale << ">. QNN EP will override the original values for output "
+                            << output_name;
     }
   }
 
+  ORT_RETURN_IF(qnn_model_wrapper.IsQnnTensorWrapperExist(output_name),
+                "QNN EP is unable to override output quantization parameters for ", op_type.c_str(),
+                " operator. Node name: ", node_unit.Name().c_str(), ", output name: ", output_name.c_str());
   Qnn_TensorType_t tensor_type = qnn_model_wrapper.IsGraphOutput(output_name) ? QNN_TENSOR_TYPE_APP_READ
                                                                               : QNN_TENSOR_TYPE_NATIVE;
   QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, output_info.qnn_data_type, output_info.quant_param,


### PR DESCRIPTION
### Description
We need to ensure that tensors are first created and validated by their producers. If we don't, then builders that need to modify their outputs may not be able to do so if consumers are processed first (due to caching of tensors). For example, the Tanh builder may need to override its output quant param for 16-bit QDQ. I've encountered a scenario (while working on a partner model) where the override was not being correctly applied due to the graph traversal order.

I tried to fix this bug in a previous [PR](https://github.com/microsoft/onnxruntime/pull/17877#discussion_r1353676802), but my fix was incorrect.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


