### PR TITLE
Add save_attribute option to quantize_static

### DIFF
--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -344,7 +344,7 @@ class ONNXModel:
         graph_path = [self.graph()]
         ONNXModel.__replace_gemm_with_matmul(graph_path)
 
-    def save_model_to_file(self, output_path, use_external_data_format=False, convert_attribute=False):
+    def save_model_to_file(self, output_path, use_external_data_format=False, include_attribute=False):
         """
         Save model to external data, which is needed for model size > 2GB
         """
@@ -354,7 +354,7 @@ class ONNXModel:
                 self.model,
                 all_tensors_to_one_file=True,
                 location=Path(output_path).name + ".data",
-                convert_attribute=convert_attribute
+                convert_attribute=include_attribute
             )
         for init in self.model.graph.initializer:
             self._check_init(init, "end")

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -354,7 +354,7 @@ class ONNXModel:
                 self.model,
                 all_tensors_to_one_file=True,
                 location=Path(output_path).name + ".data",
-                convert_attribute=include_attribute
+                convert_attribute=include_attribute,
             )
         for init in self.model.graph.initializer:
             self._check_init(init, "end")

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -354,7 +354,7 @@ class ONNXModel:
                 self.model,
                 all_tensors_to_one_file=True,
                 location=Path(output_path).name + ".data",
-                convert_attribute=include_attribute,
+                convert_attribute=include_attribute
             )
         for init in self.model.graph.initializer:
             self._check_init(init, "end")

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -344,7 +344,7 @@ class ONNXModel:
         graph_path = [self.graph()]
         ONNXModel.__replace_gemm_with_matmul(graph_path)
 
-    def save_model_to_file(self, output_path, use_external_data_format=False, include_attribute=False):
+    def save_model_to_file(self, output_path, use_external_data_format=False):
         """
         Save model to external data, which is needed for model size > 2GB
         """
@@ -354,7 +354,7 @@ class ONNXModel:
                 self.model,
                 all_tensors_to_one_file=True,
                 location=Path(output_path).name + ".data",
-                convert_attribute=include_attribute,
+                convert_attribute=True,
             )
         for init in self.model.graph.initializer:
             self._check_init(init, "end")

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -344,7 +344,7 @@ class ONNXModel:
         graph_path = [self.graph()]
         ONNXModel.__replace_gemm_with_matmul(graph_path)
 
-    def save_model_to_file(self, output_path, use_external_data_format=False):
+    def save_model_to_file(self, output_path, use_external_data_format=False, convert_attribute=False):
         """
         Save model to external data, which is needed for model size > 2GB
         """
@@ -354,6 +354,7 @@ class ONNXModel:
                 self.model,
                 all_tensors_to_one_file=True,
                 location=Path(output_path).name + ".data",
+                convert_attribute=convert_attribute
             )
         for init in self.model.graph.initializer:
             self._check_init(init, "end")

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -265,6 +265,7 @@ def quantize_static(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
+    convert_attribute=False,
     calibrate_method=CalibrationMethod.MinMax,
     extra_options=None,
 ):
@@ -313,6 +314,8 @@ def quantize_static(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
+        convert_attribute (bool): If true, convert all tensors to external data
+                If false, convert only non-attribute tensors to external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -489,7 +492,7 @@ def quantize_static(
         )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format, convert_attribute)
     if not pre_processed:
         logging.warning(
             "Please consider pre-processing before quantization. See "
@@ -511,6 +514,7 @@ def quantize_dynamic(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
+    convert_attribute=False,
     extra_options=None,
 ):
     """Given an onnx model, create a quantized onnx model and save it into a file
@@ -540,6 +544,8 @@ def quantize_dynamic(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
+        convert_attribute (bool): If true, convert all tensors to external data
+                If false, convert only non-attribute tensors to external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -594,7 +600,7 @@ def quantize_dynamic(
     )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format, convert_attribute)
 
 
 def quantize(

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -265,7 +265,6 @@ def quantize_static(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
-    save_attributes=False,
     calibrate_method=CalibrationMethod.MinMax,
     extra_options=None,
 ):
@@ -314,9 +313,6 @@ def quantize_static(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
-        save_attributes (bool):
-            When `use_external_data_format` is True, attribute (constant) tensors are included in the external data
-            when this flag is True. Otherwise only non-attribute tensors are saved into the external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -493,7 +489,7 @@ def quantize_static(
         )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format, save_attributes)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format)
     if not pre_processed:
         logging.warning(
             "Please consider pre-processing before quantization. See "
@@ -515,7 +511,6 @@ def quantize_dynamic(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
-    save_attributes=False,
     extra_options=None,
 ):
     """Given an onnx model, create a quantized onnx model and save it into a file
@@ -545,9 +540,6 @@ def quantize_dynamic(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
-        save_attributes (bool):
-            When `use_external_data_format` is True, attribute (constant) tensors are included in the external data
-            when this flag is True. Otherwise only non-attribute tensors are saved into the external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -602,7 +594,7 @@ def quantize_dynamic(
     )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format, save_attributes)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format)
 
 
 def quantize(

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -265,7 +265,7 @@ def quantize_static(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
-    convert_attribute=False,
+    save_attributes=False,
     calibrate_method=CalibrationMethod.MinMax,
     extra_options=None,
 ):
@@ -314,8 +314,9 @@ def quantize_static(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
-        convert_attribute (bool): If true, convert all tensors to external data
-                If false, convert only non-attribute tensors to external data
+        save_attributes (bool):
+            When `use_external_data_format` is True, attribute (constant) tensors are included in the external data
+            when this flag is True. Otherwise only non-attribute tensors are saved into the external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -492,7 +493,7 @@ def quantize_static(
         )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format, convert_attribute)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format, save_attributes)
     if not pre_processed:
         logging.warning(
             "Please consider pre-processing before quantization. See "
@@ -514,7 +515,7 @@ def quantize_dynamic(
     nodes_to_quantize=None,
     nodes_to_exclude=None,
     use_external_data_format=False,
-    convert_attribute=False,
+    save_attributes=False,
     extra_options=None,
 ):
     """Given an onnx model, create a quantized onnx model and save it into a file
@@ -544,8 +545,9 @@ def quantize_dynamic(
             List of nodes names to exclude. The nodes in this list will be excluded from quantization
             when it is not None.
         use_external_data_format: option used for large size (>2GB) model. Set to False by default.
-        convert_attribute (bool): If true, convert all tensors to external data
-                If false, convert only non-attribute tensors to external data
+        save_attributes (bool):
+            When `use_external_data_format` is True, attribute (constant) tensors are included in the external data
+            when this flag is True. Otherwise only non-attribute tensors are saved into the external data
         extra_options:
             key value pair dictionary for various options in different case. Current used:
                 extra.Sigmoid.nnapi = True/False  (Default is False)
@@ -600,7 +602,7 @@ def quantize_dynamic(
     )
 
     quantizer.quantize_model()
-    quantizer.model.save_model_to_file(model_output, use_external_data_format, convert_attribute)
+    quantizer.model.save_model_to_file(model_output, use_external_data_format, save_attributes)
 
 
 def quantize(


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The model with big Constants tensors size: Estimate size of the RWKV model: ONNX graph (8MB), initializer tensors(200MB), constants (~5.7GB). The `onnx.save_model` will got error due to the Constants is not output in external data. Only the initializer tensors are output as external data. In this change, expose parameter to support the constants in external data. Model owner can customize the output behavior and still keep the default behavior.

Quantize the model and output it to local, got issue due to output size exceed 2GB even set `use_external_data_format=True`. The  `use_external_data_format` flag only outputs initializer tensors to external data. 
Use the falg `convert_attribute` flag to output all tensors to external data.
```
def convert_model_to_external_data(
    model: ModelProto,
    all_tensors_to_one_file: bool = True,
    location: Optional[str] = None,
    size_threshold: int = 1024,
    include_attribute: bool = False,
) -> None:
    tensors = _get_initializer_tensors(model)
    if include_attribute:
        tensors = _get_all_tensors(model)
        ...
```
The `onnx.external_data_helper.convert_model_to_external_data` support output the attribute to external with flag `include_attribute=True`. However, this parameter is hide by the `onnxruntime\quantization\onnx_model.py` and the constants(`5.7GB) within the model will got protobuf 2GB limitation issue with default parameters. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/microsoft/onnxruntime/issues/17944

