### PR TITLE
fix: typos inside docs/python/examples

### DIFF
--- a/docs/python/examples/plot_convert_pipeline_vectorizer.py
+++ b/docs/python/examples/plot_convert_pipeline_vectorizer.py
@@ -94,4 +94,4 @@ print(r2_score(pred, pred_onx))
 
 #########################
 # Very similar. *ONNX Runtime* uses floats instead of doubles,
-# that explains the small discrepencies.
+# that explains the small discrepancies.

--- a/docs/python/examples/plot_train_convert_predict.py
+++ b/docs/python/examples/plot_train_convert_predict.py
@@ -16,7 +16,7 @@ to its use in its converted from.
 Train a logistic regression
 +++++++++++++++++++++++++++
 
-The first step consists in retrieving the iris datset.
+The first step consists in retrieving the iris dataset.
 """
 
 from sklearn.datasets import load_iris


### PR DESCRIPTION
### Description
Multiple typos inside docs/python/examples have been fixed.


