### PR TITLE
fix: typos inside docs/ContribOperators.md

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -111,24 +111,24 @@ Do not modify directly.*
 ### <a name="com.microsoft.Attention"></a><a name="com.microsoft.attention">**com.microsoft.Attention**</a>
 
   Multi-Head Attention that can be either unidirectional (like GPT-2) or bidirectional (like BERT).
-  
+
   The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension. Its shape
   is (input_hidden_size, hidden_size + hidden_size + v_hidden_size). Here hidden_size is the hidden dimension of Q and K,
   and v_hidden_size is that of V.
-  
+
   The mask_index is optional. Besides raw attention mask with shape (batch_size, total_sequence_length)
   or (batch_size, sequence_length, total_sequence_length) with value 0 for masked and 1 otherwise,
   we support other two formats: When input has right-side padding, mask_index is one dimension with shape (batch_size),
   where value is actual sequence length excluding padding. When input has left-side padding, mask_index has
   shape (2 * batch_size), where the values are the exclusive end positions followed by the inclusive start positions.
-  
+
   When unidirectional is 1, each token only attends to previous tokens.
-  
+
   Both past and present state are optional. They shall be used together, and not allowed to use only one of them.
   The qkv_hidden_sizes is required only when K and V have different hidden sizes.
-  
+
   When there is past state, hidden dimension for Q, K and V shall be the same.
-  
+
   The total_sequence_length is past_sequence_length + kv_sequence_length. Here kv_sequence_length is the length of K or V.
   For self attention, kv_sequence_length equals to sequence_length (sequence length of Q).
   For cross attention, query and key might have different lengths.
@@ -198,133 +198,133 @@ This version of the operator has been available since version 1 of the 'com.micr
 
   Computes an one-layer RNN where its RNN Cell is an AttentionWrapper wrapped a LSTM Cell. The RNN layer
   contains following basic component: LSTM Cell, Bahdanau Attention Mechanism, AttentionWrapp.
-  
+
   Activation functions:
-  
+
     Relu(x)                - max(0, x)
-  
+
     Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
-  
+
     Sigmoid(x)             - 1/(1 + e^{-x})
-  
+
     (NOTE: Below are optional)
-  
+
     Affine(x)              - alpha*x + beta
-  
+
     LeakyRelu(x)           - x if x >= 0 else alpha * x
-  
+
     ThresholdedRelu(x)     - x if x >= alpha else 0
-  
+
     ScaledTanh(x)          - alpha*Tanh(beta*x)
-  
+
     HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
-  
+
     Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
-  
+
     Softsign(x)            - x/(1 + |x|)
-  
+
     Softplus(x)            - log(1 + e^x)
-  
+
     Softmax(x)             - exp(x) / sum(exp(x))
-  
+
   Bahdanau Attention Mechanism:
       `M` -  Memory tensor.
-  
+
       `VALUES` - masked Memory by its real sequence length.
-  
+
       `MW` - Memory layer weight.
-  
+
       `KEYS` - Processed memory tensor by the memory layer.
                KEYS = M * MW
-  
+
       `Query` - Query tensor, normally at specific time step in sequence.
-  
+
       `QW` - Query layer weight in the attention mechanism
-  
+
       `PQ` - processed query,  = `Query` * `QW`
-  
+
       `V' - attention vector
-  
+
       `ALIGN` - calculated alignment based on Query and KEYS
           ALIGN = softmax(reduce_sum(`V` * Tanh(`KEYS` + `PQ`)))
-  
+
       `CONTEXT` - context based on `ALIGN` and `VALUES`
           CONTEXT = `ALIGN` * `VALUES`
-  
-  
+
+
   LSTM Cell:
     `X` - input tensor concat with attention state in the attention wrapper
-  
+
     `i` - input gate
-  
+
     `o` - output gate
-  
+
     `f` - forget gate
-  
+
     `c` - cell gate
-  
+
     `t` - time step (t-1 means previous time step)
-  
+
     `W[iofc]` - W parameter weight matrix for input, output, forget, and cell gates
-  
+
     `R[iofc]` - R recurrence weight matrix for input, output, forget, and cell gates
-  
+
     `Wb[iofc]` - W bias vectors for input, output, forget, and cell gates
-  
+
     `Rb[iofc]` - R bias vectors for input, output, forget, and cell gates
-  
+
     `P[iof]`  - P peephole weight vector for input, output, and forget gates
-  
+
     `WB[iofc]` - W parameter weight matrix for backward input, output, forget, and cell gates
-  
+
     `RB[iofc]` - R recurrence weight matrix for backward input, output, forget, and cell gates
-  
+
     `WBb[iofc]` - W bias vectors for backward input, output, forget, and cell gates
-  
+
     `RBb[iofc]` - R bias vectors for backward input, output, forget, and cell gates
-  
+
     `PB[iof]`  - P peephole weight vector for backward input, output, and forget gates
-  
+
     `H` - Hidden state
-  
+
     `num_directions` - 2 if direction == bidirectional else 1
-  
+
     Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
-  
+
       - it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
-  
+
       - ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
-  
+
       - ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
-  
+
       - Ct = ft (.) Ct-1 + it (.) ct
-  
+
       - ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
-  
+
       - Ht = ot (.) h(Ct)
-  
-  
+
+
   AttentionWrapp Notations:
     `lstm()' - wrapped inner cell.
              Ht, Ct = lstm(concat(Xt, ATTNt-1), Ct-1)
-  
+
     `am()` - attention mechanism the wrapper used.
              CONTEXTt, ALIGNt = am(Ht, ALIGNt-1)
-  
+
     `AW` - attention layer weights, optional.
-  
+
     `ATTN` - attention state, initial is zero. If `AW` provided, it is the output of the attention layer,
                   ATTNt = concat(Ht, CONTEXTt) * AW
              otherwise,
                   ATTNt = CONTEXTt
-  
+
   RNN layer output:
     `Y` - if needed is the sequence of Ht from lstm cell.
-  
+
     `Y_h` - is the last valid H from lstm cell.
-  
+
     `Y_c` - is the last valid C from lstm cell.
-  
+
 
 #### Version
 
@@ -578,7 +578,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.BiasGelu"></a><a name="com.microsoft.biasgelu">**com.microsoft.BiasGelu**</a>
 
   Bias Gelu.
-  It's an extension of Gelu. It takes the sum of input A and bias input B as the input of Gelu activation. 
+  It's an extension of Gelu. It takes the sum of input A and bias input B as the input of Gelu activation.
 
 #### Version
 
@@ -803,7 +803,7 @@ This version of the operator has been available since version 1 of the 'com.micr
   ```
   scale = 1. / (1. - ratio).
   ```
-  
+
   This op functions in much the same was as Dropout-11 and Dropout-13 do, execpt that the mask is output as a bit-packed uint32 tensor, instead of a boolean tensor.
 
 #### Version
@@ -1199,17 +1199,17 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.DecoderMaskedSelfAttention"></a><a name="com.microsoft.decodermaskedselfattention">**com.microsoft.DecoderMaskedSelfAttention**</a>
 
   Self attention that supports input sequence length of 1.
-  
+
   The weights for input projection of Q, K and V are merged. The data is stacked on the second dimension. Its shape
   is (input_hidden_size, hidden_size + hidden_size + v_hidden_size). Here hidden_size is the hidden dimension of Q and K,
   and v_hidden_size is that of V.
-  
+
   The mask_index is optional. If it is provided, only raw attention mask with shape (batch_size, total_sequence_length) is supported currently.
-  
+
   Both past and present state need to be provided.
-  
+
   The qkv_hidden_sizes is required only when K and V have different hidden sizes.
-  
+
   The total_sequence_length is past_sequence_length + kv_sequence_length. Here kv_sequence_length is the length of K or V.
   Currently, only self attention is supported which means that kv_sequence_length equals to sequence_length (sequence length of Q).
 
@@ -2211,7 +2211,7 @@ This version of the operator has been available since version 1 of the 'com.micr
         which are used to interpolate the output value `output[n, :, h, w]`.
         The GridSample operator is often used in doing grid generator and sampler in the [Spatial Transformer Networks](https://arxiv.org/abs/1506.02025).
         See also in [torch.nn.functional.grid_sample](https://pytorch.org/docs/master/generated/torch.nn.functional.grid_sample.html#torch-nn-functional-grid-sample).
-        
+
 
 #### Version
 
@@ -2257,13 +2257,13 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.GroupNorm"></a><a name="com.microsoft.groupnorm">**com.microsoft.GroupNorm**</a>
 
   Applies Group Normalization over a mini-batch of inputs as described in the paper Group Normalization (https://arxiv.org/abs/1803.08494).
-  
+
   This operator transforms input according to
     y = gamma * (x - mean) / sqrt(variance + epsilon) + beta
-  
+
   The input channels are separated into num_groups groups, each containing num_channels / num_groups channels. num_channels must be divisible by num_groups. The mean and standard-deviation are calculated separately over the each group.
   The weight and bias are per-channel affine transform parameter vectors of size num_channels.
-  
+
   The activation attribute can be used to enable activation after group normalization.
 
 #### Version
@@ -2314,7 +2314,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.GroupQueryAttention"></a><a name="com.microsoft.groupqueryattention">**com.microsoft.GroupQueryAttention**</a>
 
   Group Query Self/Cross Attention.
-  
+
   Supports different number of heads for q and kv.
 
 #### Version
@@ -2448,10 +2448,10 @@ This version of the operator has been available since version 1 of the 'com.micr
   Longformer Self Attention with a local context and a global context. Tokens attend locally: Each token
   attends to its W previous tokens and W succeeding tokens with W being the window length. A selected few tokens
   attend globally to all other tokens.
-  
+
   The attention mask is of shape (batch_size, sequence_length), where sequence_length is a multiple of 2W after padding.
   Mask value < 0 (like -10000.0) means the token is masked, 0 otherwise.
-  
+
   Global attention flags have value 1 for the tokens attend globally and 0 otherwise.
 
 #### Version
@@ -2507,7 +2507,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
   Matrix product with right hand matrix being pre-packed and quantized int4 data blob.
   During quantization, the matrix is divided into blocks, where each block is a
-  continguous subset inside each column. Each block is quantized into a
+  contiguous subset inside each column. Each block is quantized into a
   sequence of 4b integers with a scaling factor and an optional offset.
   Currently 3 quantization types are supported:
   (0): block size 32, no offset, (1): block size 32, with offset, (2): block size 64,
@@ -2642,23 +2642,23 @@ This version of the operator has been available since version 1 of the 'com.micr
     2. Input B is quantized with x bits which is specified by attribute 'bits'. It is quantized blockwisely along dimension 0 (e.g. column) with block size specified by attribute block_size.
        And block_size is not an arbitrary number and must be a power of 2 and not smaller than 16, like 16, 32, 64, 128,..
     3. Input B's scale and zero point are specified by input scales and zero_points.
-  
+
   Input B is stored as uint8_t with shape: [N][n_blocks_per_col][blob_size] in which:
   - n_blocks_per_col = (K + block_size - 1) / block_size
   - blob_size = block_size / 8 * bits
-  
+
     For a block blob. It is stored in format:
     struct Blob {
       uint8 one_bits[(bits & 0x1) * 1 * block_size / 8];  // highest 1 bit for 3, 5, 7 bits quantization
       uint8 two_bits[(bits & 0x2) * 2 * block_size / 8];  // high 2 bits for 2, 6, 7 bits quantization
       uint8 four_bits[(bits & 0x4) * 4 * block_size / 8]; // low 4 bits for 4, 5, 6 bits quantization
     }
-  
+
   Input scales is stored in same type as original type of B(float32, float16) with shape like: [N * n_blocks_per_col]
   Input zero_points is stored as uint8_t. If bits <= 4, two zero points are stored as one unit8_t. If bits > 4, one zero point is stored with one unit8_t. Thus, its shape is:
     - [(N * n_blocks_per_col + 1) / 2] if bits <=4
     - [N * n_blocks_per_col] if bits > 4
-  
+
 
 #### Version
 
@@ -2759,11 +2759,11 @@ This version of the operator has been available since version 1 of the 'com.micr
   Performs element-wise binary quantized multiplication (with Numpy-style broadcasting support).
   "This operator supports **multidirectional (i.e., Numpy-style) broadcasting**"
   The output of this op is the int32 accumulated result of the mul operation
-  
+
   ```
   C (int32) = (A - A_zero_point) * (B - B_zero_point)
   ```
-  
+
 
 #### Version
 
@@ -2802,7 +2802,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.MultiHeadAttention"></a><a name="com.microsoft.multiheadattention">**com.microsoft.MultiHeadAttention**</a>
 
   Multi-Head Self/Cross Attention. Bias from input projection is included.
-  
+
   The key padding mask is optional. When its shape is (batch_size, kv_sequence_length), value 0
   means padding or 1 otherwise. When key has right-side padding, its shape could be (batch_size): it is actual length of
   each key sequence excluding paddings.
@@ -3101,25 +3101,25 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.PackedAttention"></a><a name="com.microsoft.packedattention">**com.microsoft.PackedAttention**</a>
 
   This is the packed version of Attention.
-  
+
   Sequences in one batch usually don't have same length and they are padded to have same length,
   e.g., below is a batch with 3 sequences and tokens* are padded.
     Sequence_0:   0,  1*, 2*,  3*
     Sequence_1:   4,  5,  6*,  7*
     Sequence_2:   8,  9,  10,  11
-  
+
   PackedAttention is designed to takes in packed input, i.e., only the real tokens without padding.
   An input as above will be packed into 3 tensors like below:
    - input ([h0, h4, h5, h8, h9, h10, h11])
    - token_offset: 0, 4, 5, 8, 9, 10, 11,  1*, 2*, 3*, 6*, 7*
    - cumulated_token_count: 0, 1, 1+2, 1+2+4
-  
+
   Input tensors contains the hidden embedding of real tokens.
   Token_offset records the offset of token in the unpacked input.
-  cumulated_token_count records cumulated length of each sequnces length.
-  
+  cumulated_token_count records cumulated length of each sequences length.
+
   The operator only supports BERT like model with padding on right now.
-  
+
 
 #### Version
 
@@ -3173,13 +3173,13 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.PackedMultiHeadAttention"></a><a name="com.microsoft.packedmultiheadattention">**com.microsoft.PackedMultiHeadAttention**</a>
 
   This is the packed version of MultiHeadAttention.
-  
+
   Sequences in one batch usually don't have same length and they are padded to have same length,
   e.g., below is a batch with 3 sequences and * is padding token.
     Sequence_0:   0,  1*, 2*,  3*
     Sequence_1:   4,  5,  6*,  7*
     Sequence_2:   8,  9,  10,  11
-  
+
   PackedMultiHeadAttention is designed to takes in packed input, i.e., only the real tokens without padding.
   An input as above will be packed into 3 tensors like below:
    - query ([q0, q4, q5, q8, q9, q10, q11])
@@ -3187,11 +3187,11 @@ This version of the operator has been available since version 1 of the 'com.micr
    - value ([v0, v4, v5, v8, v9, v10, v11])
    - token_offset: 0, 4, 5, 8, 9, 10, 11,  1*, 2*, 3*, 6*, 7*
    - cumulative_sequence_length: 0, 1, 1+2, 1+2+4
-  
+
   The query, key and value tensors contain result of hidden embedding of real tokens after input projections.
   Token_offset records the offset of token in the unpacked input.
-  cumulative_sequence_length records cumulated length of each sequnces length.
-  
+  cumulative_sequence_length records cumulated length of each sequences length.
+
   The operator only supports BERT like model with padding on right now.
 
 #### Version
@@ -3263,7 +3263,7 @@ This version of the operator has been available since version 1 of the 'com.micr
                       [0.0, 0.0, 4.5, 5.7],
                       ],
                       ]
-              
+
 
 #### Version
 
@@ -3443,7 +3443,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.QLinearAdd"></a><a name="com.microsoft.qlinearadd">**com.microsoft.QLinearAdd**</a>
 
   Performs element-wise binary addition on 8 bit data types (with Numpy-style broadcasting support).
-  
+
   C = (A_scale * (A - A_zero_point) + B_scale * (B - B_zero_point))/C_scale + C_zero_point
 
 #### Version
@@ -3501,11 +3501,11 @@ This version of the operator has been available since version 1 of the 'com.micr
    output_spatial_shape[i] = ceil((input_spatial_shape[i] + pad_shape[i] - kernel_spatial_shape[i]) / strides_spatial_shape[i] + 1)
    ```
    if ceil_mode is enabled
-  
+
    ```
    * pad_shape[i] is sum of pads along axis i
    ```
-  
+
    `auto_pad` is a DEPRECATED attribute. If you are using them currently, the output spatial shape will be following:
    ```
    VALID: output_spatial_shape[i] = ceil((input_spatial_shape[i] - kernel_spatial_shape[i] + 1) / strides_spatial_shape[i])
@@ -3515,9 +3515,9 @@ This version of the operator has been available since version 1 of the 'com.micr
    ```
    pad_shape[i] = (output_spatial_shape[i] - 1) * strides_spatial_shape[i] + kernel_spatial_shape[i] - input_spatial_shape[i]
    ```
-  
+
   The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).
-  
+
   Input and output scales and zero points are used to convert the output to a new quantization range.
   Output = Dequantize(Input) -> AveragePool on fp32 data -> Quantize(output)
 
@@ -3785,7 +3785,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.QLinearMul"></a><a name="com.microsoft.qlinearmul">**com.microsoft.QLinearMul**</a>
 
   Performs element-wise binary multiplication on 8 bit data types (with Numpy-style broadcasting support).
-  
+
   C = ((A - A_zero_point) * (B - B_zero_point)) * (A_scale * B_scale)/C_scale + C_zero_point
 
 #### Version
@@ -3836,10 +3836,10 @@ This version of the operator has been available since version 1 of the 'com.micr
   with the exception that numpy default keepdims to False instead of True.
   Input and Output scales and zero points are used to requantize the output in a new range.
   This helps to improve accuracy as after ReduceMean operation the range of the output is expected to decrease.
-  
+
   ```
   "Output = Dequantize(Input) -> ReduceMean on fp32 data -> Quantize(output)",
-  
+
   ```
 
 #### Version
@@ -3889,7 +3889,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
   QLinearSigmoid takes quantized input data (Tensor), and quantize parameter for output, and produces one output data
   (Tensor<T>) where the function `f(x) = quantize(Sigmoid(dequantize(x)))`, is applied to the data tensor elementwise.
-  Wwhere the function `Sigmoid(x) = 1 / (1 + exp(-x))` 
+  Wwhere the function `Sigmoid(x) = 1 / (1 + exp(-x))`
 
 #### Version
 
@@ -4675,10 +4675,10 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.RemovePadding"></a><a name="com.microsoft.removepadding">**com.microsoft.RemovePadding**</a>
 
   Compress transformer input by removing paddings. It assumes padding is on the right side of sequence.
-  
+
   The input has padding with shape (batch_size, sequence_length, hidden_size). This will generate two outputs:
   output has shape (total_tokens, hidden_size); token_offset with shape (batch_size, sequence_length).
-  
+
   token_offset has offsets of all non-padding tokens first, then offset of all padding tokens. It is
   a list of batch_size * sequence_length elements, which is reshaped to 2D for convenience of shape inference.
 
@@ -4721,7 +4721,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 ### <a name="com.microsoft.RestorePadding"></a><a name="com.microsoft.restorepadding">**com.microsoft.RestorePadding**</a>
 
   Restore paddings and fill padding with zeros.
-  
+
   The input has padding with shape (total_tokens, hidden_size) and token_offset with shape (batch_size, sequence_length).
   The output has shape (batch_size, sequence_length, hidden_size).
 
@@ -5179,7 +5179,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
   Based on Torch operator Embedding, creates a lookup table of embedding vectors of fixed size,
          for a dictionary of fixed size.
-        
+
 
 #### Version
 
@@ -5269,7 +5269,7 @@ This version of the operator has been available since version 1 of the 'com.micr
         the main diagonal. A negative k value includes as many diagonals below the main diagonal.
         If upper is set to false, a positive k retains the lower triangular matrix including k diagonals above
         the main diagonal. A negative k value excludes as many diagonals below the main diagonal.
-        
+
 
 #### Version
 
@@ -5361,7 +5361,7 @@ This version of the operator has been available since version 1 of the 'com.micr
                   output_uniques = [2, 1, 3, 4]
                   output_idx = [0, 1, 1, 2, 3, 2]
                   output_counts = [1, 2, 2, 1]
-                
+
 
 #### Version
 
@@ -5661,5 +5661,3 @@ No versioning maintained for experimental ops.
 <dt><tt>T</tt> : tensor(float)</dt>
 <dd>Constrain input and output types to float32 tensors.</dd>
 </dl>
-
-

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -425,7 +425,7 @@ An input as above will be packed into 3 tensors like below:
 
 Input tensors contains the hidden embedding of real tokens.
 Token_offset records the offset of token in the unpacked input.
-cumulated_token_count records cumulated length of each sequnces length.
+cumulated_token_count records cumulated length of each sequences length.
 
 The operator only supports BERT like model with padding on right now.
 
@@ -554,7 +554,7 @@ An input as above will be packed into 3 tensors like below:
 
 The query, key and value tensors contain result of hidden embedding of real tokens after input projections.
 Token_offset records the offset of token in the unpacked input.
-cumulative_sequence_length records cumulated length of each sequnces length.
+cumulative_sequence_length records cumulated length of each sequences length.
 
 The operator only supports BERT like model with padding on right now.
 )DOC";

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1900,7 +1900,7 @@ static void matmulQ4ShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, int in
 
   const TensorProto* b_shape_tensor = ctx.getInputData(input_bshape_idx);
   if (nullptr == b_shape_tensor) {
-    // Can't find shape info, quiting
+    // Can't find shape info, quitting
     return;
   }
 
@@ -1974,7 +1974,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(MatMulFpQ4, 1,
                                 .SetDoc(R"DOC(
 Matrix product with right hand matrix being pre-packed and quantized int4 data blob.
 During quantization, the matrix is divided into blocks, where each block is a
-continguous subset inside each column. Each block is quantized into a
+contiguous subset inside each column. Each block is quantized into a
 sequence of 4b integers with a scaling factor and an optional offset.
 Currently 3 quantization types are supported:
 (0): block size 32, no offset, (1): block size 32, with offset, (2): block size 64,
@@ -2812,7 +2812,7 @@ void RegisterContribSchemas() {
         }
       });
 
-  // ORT will not regsiter TRT plugins as contrib ops, instead it will use custom ops handled by TRT EP.
+  // ORT will not register TRT plugins as contrib ops, instead it will use custom ops handled by TRT EP.
   // In order not to break the old models using those TRT plugins which were registered with ONNX domain and maintain backward compatible,
   // we still keep EfficientNMS_TRT, MultilevelCropAndResize_TRT, PyramidROIAlign_TRT and DisentangledAttention_TRT as legacy code.
   // We don't need to add new schema definition when a new TRT plugin is introduced, TRT EP will register it as custom op for us.


### PR DESCRIPTION
### Description
typos inside docs/ContribOperators.md have been fixed



