### PR TITLE
enable training for win-wasm-ci.yml

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-wasm-ci.yml
@@ -31,14 +31,18 @@ parameters:
   type: boolean
   default: false
 
+- name: BuildTraining
+  type: boolean
+  default: true
+
 - name: WithCache
   type: boolean
   default: false
 
 jobs:
 - job: build_WASM
-  pool: ${{ parameters.PoolName }}
-
+  pool:
+    name: ${{ parameters.PoolName }}
   variables:
     EnvSetupScript: setup_env.bat
     buildArch: x64
@@ -48,6 +52,9 @@ jobs:
   workspace:
     clean: all
   steps:
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    displayName: 'Clean Agent Directories'
+    condition: always()
   - checkout: self
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -108,6 +115,13 @@ jobs:
       scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
       arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)\wasm_simd --enable_wasm_simd'
       workingDirectory: '$(Build.BinariesDirectory)'
+  - ${{ if eq(parameters.BuildTraining, true) }}:
+    - task: PythonScript@0
+      displayName: 'Build (training + simd)'
+      inputs:
+        scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+        arguments: '$(CommonBuildArgs) --build_dir $(Build.BinariesDirectory)\training_wasm_simd --enable_training_apis --enable_wasm_simd --target onnxruntime_webassembly --skip_tests'
+        workingDirectory: '$(Build.BinariesDirectory)'
   - ${{ if eq(parameters.BuildJsep, true) }}:
     - task: PythonScript@0
       displayName: 'Build (simd + JSEP)'
@@ -137,6 +151,10 @@ jobs:
           copy $(Build.BinariesDirectory)\wasm_simd_threads_jsep\${{ parameters.BuildConfig }}\ort-wasm-simd-threaded.js $(Build.ArtifactStagingDirectory)\ort-wasm-simd-threaded.jsep.js
           copy $(Build.BinariesDirectory)\wasm_simd_threads_jsep\${{ parameters.BuildConfig }}\ort-wasm-simd-threaded.worker.js $(Build.ArtifactStagingDirectory)\ort-wasm-simd-threaded.jsep.worker.js
         )
+        if exist $(Build.BinariesDirectory)\training_wasm_simd (
+          copy $(Build.BinariesDirectory)\training_wasm_simd\${{ parameters.BuildConfig }}\ort-training-wasm-simd.wasm $(Build.ArtifactStagingDirectory)\ort-training-wasm-simd.wasm
+          copy $(Build.BinariesDirectory)\training_wasm_simd\${{ parameters.BuildConfig }}\ort-training-wasm-simd.js $(Build.ArtifactStagingDirectory)\ort-training-wasm-simd.js
+        )
       displayName: 'Create Artifacts'
   - ${{ if eq(parameters.SkipPublish, false) }}:
     - task: PublishPipelineArtifact@0
@@ -154,6 +172,3 @@ jobs:
   - template: component-governance-component-detection-steps.yml
     parameters :
       condition : 'succeeded'
-  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-    displayName: 'Clean Agent Directories'
-    condition: always()


### PR DESCRIPTION
### Description
**Fixes NPM Packaging pipeline.**

Training was enabled for linux-wasm-ci.yml but not enabled for win-wasm-ci.yml.

the web CI uses linux-wasm-ci.yml
NPM packaging pipeline uses win-wasm-ci.yml
