### PR TITLE
Move a nodejs test to a different machine pool

### DIFF
--- a/tools/ci_build/github/azure-pipelines/nodejs/templates/test_linux.yml
+++ b/tools/ci_build/github/azure-pipelines/nodejs/templates/test_linux.yml
@@ -1,5 +1,5 @@
 parameters:
-  AgentPool: 'onnxruntime-Ubuntu2004-AMD-CPU'
+  AgentPool: 'Azure-Pipelines-EO-Ubuntu-2004-aiinfra'
   StageSuffix: ''
 stages:
 - stage: Nodejs_Test_${{ parameters.StageSuffix }}

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -804,7 +804,7 @@ stages:
 
 - template: ../nodejs/templates/test_linux.yml
   parameters:
-    AgentPool : 'onnxruntime-Ubuntu2004-AMD-CPU'
+    AgentPool : 'Azure-Pipelines-EO-Ubuntu-2004-aiinfra'
     StageSuffix : 'Linux_CPU_x64'
 
 - template: ../nodejs/templates/test_macos.yml


### PR DESCRIPTION
### Description
This is a temp fix for the failing "Zip-Nuget-Java-Nodejs Packaging Pipeline". The pipeline is failing because I removed NodeJS from the build machine pool's image, to reduce the number of dependencies we need to maintain in VMs. 
So this PR will temporarily move the test to a different machine pool to get the test passed. Then I will move the test to docker. Docker images are relatively easier to update and maintain. 


### Motivation and Context



