### PR TITLE
[CUDA] Remove shape warnings in NHWC <> NCHW unit tests

### DIFF
--- a/onnxruntime/test/providers/cuda/nhwc/conv_transpose_test.cc
+++ b/onnxruntime/test/providers/cuda/nhwc/conv_transpose_test.cc
@@ -42,12 +42,16 @@ struct ConvTransposeOp {
     test->AddAttribute("pads", padding);
     if (!output_padding.empty()) {
       test->AddAttribute("output_padding", output_padding);
+    } else {
+      output_padding = {0, 0, 0, 0};
     }
 
     std::vector<int64_t> output_dims = {
         input_dims[0], channels,
-        (kernel_shape[1] - 1) * dilations[1] + (input_dims[2] - 1) * strides[1] - (padding[1] + padding[0]) + 1,
-        (kernel_shape[0] - 1) * dilations[0] + (input_dims[3] - 1) * strides[0] - (padding[3] + padding[2]) + 1};
+        (kernel_shape[1] - 1) * dilations[1] + (input_dims[2] - 1) * strides[1] - (padding[1] + padding[0]) + 1 +
+        output_padding[2],
+        (kernel_shape[0] - 1) * dilations[0] + (input_dims[3] - 1) * strides[0] - (padding[3] + padding[2]) + 1 +
+        output_padding[3]};
     std::vector<T> output_data = FillZeros<T>(output_dims);
 
     test->AddOutput<T>("Y", output_dims, output_data);

--- a/onnxruntime/test/providers/cuda/nhwc/conv_transpose_test.cc
+++ b/onnxruntime/test/providers/cuda/nhwc/conv_transpose_test.cc
@@ -49,9 +49,9 @@ struct ConvTransposeOp {
     std::vector<int64_t> output_dims = {
         input_dims[0], channels,
         (kernel_shape[1] - 1) * dilations[1] + (input_dims[2] - 1) * strides[1] - (padding[1] + padding[0]) + 1 +
-        output_padding[2],
+            output_padding[2],
         (kernel_shape[0] - 1) * dilations[0] + (input_dims[3] - 1) * strides[0] - (padding[3] + padding[2]) + 1 +
-        output_padding[3]};
+            output_padding[3]};
     std::vector<T> output_data = FillZeros<T>(output_dims);
 
     test->AddOutput<T>("Y", output_dims, output_data);

--- a/onnxruntime/test/providers/cuda/nhwc/pool_test.cc
+++ b/onnxruntime/test/providers/cuda/nhwc/pool_test.cc
@@ -31,8 +31,8 @@ struct PoolOp {
 
     std::vector<int64_t> output_dims = {
         input_dims[0], channels,
-        (kernel_shape[1] - 1) + (input_dims[2] - 1) * strides[1] - (padding[1] + padding[0]) + 1,
-        (kernel_shape[0] - 1) + (input_dims[3] - 1) * strides[0] - (padding[3] + padding[2]) + 1};
+        (input_dims[2] - (kernel_shape[0] - 1) + padding[1] + padding[0] - 1) / strides[0] + 1,
+        (input_dims[3] - (kernel_shape[1] - 1) + padding[3] + padding[2] - 1) / strides[1] + 1};
     std::vector<T> output_data = FillZeros<T>(output_dims);
 
     test->AddOutput<T>("Y", output_dims, output_data);


### PR DESCRIPTION
### Description

There were some warning in https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=1170770 e.g.
```
[ RUN      ] CudaNhwcTypedTest/1.AveragePoolNhwcPad @ /home/administrator/onnxruntime/onnxruntime/test/providers/cuda/nhwc/pool_test.cc:84
[W:onnxruntime:Default, graph.cc:108 MergeShapeInfo] Error merging shape info for output. 'Y' source:{1,16,66,66} target:{1,16,67,67}. Falling back to lenient merge.
```
These warnings where not specific to NHWC or NCHW but were just a miscalculation of output shape in some tests.
