### PR TITLE
Fix build failure when specify msvc_toolset

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -339,7 +339,7 @@ def parse_arguments():
         help="[cross-compiling] Create ARM64EC makefiles. Requires --update and no existing cache "
         "CMake setup. Delete CMakeCache.txt if needed",
     )
-    parser.add_argument("--msvc_toolset", help="MSVC toolset to use. e.g. 14.11")
+    parser.add_argument("--msvc_toolset", help="MSVC toolset to use. e.g. v143, v142")
     parser.add_argument("--windows_sdk_version", help="Windows SDK version to use. e.g. 10.0.19041.0")
     parser.add_argument("--android", action="store_true", help="Build for Android")
     parser.add_argument(
@@ -2504,7 +2504,7 @@ def main():
                 else:
                     raise BuildError("unknown python arch")
                 if args.msvc_toolset:
-                    toolset = "host=" + host_arch + ",version=" + args.msvc_toolset
+                    toolset = args.msvc_toolset + ",host=" + host_arch
                 else:
                     toolset = "host=" + host_arch
                 if args.cuda_version:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
When specify MSVC toolset, use format `-T [v142|v143],host=[arch]` instead of  `-T host=[arch],version=[14.xx]`.




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fix issue #18014 .

