### PR TITLE
Update onnxruntime_perf_test to allow dml device selection, and DX interop binding

### DIFF
--- a/include/onnxruntime/core/providers/dml/dml_provider_factory.h
+++ b/include/onnxruntime/core/providers/dml/dml_provider_factory.h
@@ -131,6 +131,20 @@ struct OrtDmlApi {
    * (high power, low power, or defult) and a device filter (None, GPU, or NPU).
    */
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_DML2, _In_ OrtSessionOptions* options, OrtDmlDeviceOptions* device_opts);
+
+  /**
+   * GetDeviceForSessionInput
+   * Get the obtain the optimal device for a given model input.
+   * The device returned will be nullptr when the input should be created on CPU.
+   */
+  ORT_API2_STATUS(GetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12Device** device);
+
+  /**
+   * GetDeviceForSessionOutput
+   * Get the obtain the optimal device for a given model output.
+   * The device returned will be nullptr when the output should be created on CPU.
+   */
+  ORT_API2_STATUS(GetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12Device** device);
 };
 
 #ifdef __cplusplus

--- a/include/onnxruntime/core/providers/dml/dml_provider_factory.h
+++ b/include/onnxruntime/core/providers/dml/dml_provider_factory.h
@@ -133,18 +133,18 @@ struct OrtDmlApi {
   ORT_API2_STATUS(SessionOptionsAppendExecutionProvider_DML2, _In_ OrtSessionOptions* options, OrtDmlDeviceOptions* device_opts);
 
   /**
-   * GetDeviceForSessionInput
-   * Get the obtain the optimal device for a given model input.
+   * GetCommandQueueForSessionInput
+   * Get the obtain the command queue for a given model input.
    * The device returned will be nullptr when the input should be created on CPU.
    */
-  ORT_API2_STATUS(GetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12Device** device);
+  ORT_API2_STATUS(GetCommandQueueForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12CommandQueue** queue);
 
   /**
-   * GetDeviceForSessionOutput
-   * Get the obtain the optimal device for a given model output.
+   * GetCommandQueueForSessionOutput
+   * Get the obtain the command queue for a given model output.
    * The device returned will be nullptr when the output should be created on CPU.
    */
-  ORT_API2_STATUS(GetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12Device** device);
+  ORT_API2_STATUS(GetCommandQueueForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12CommandQueue** queue);
 };
 
 #ifdef __cplusplus

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.cpp
@@ -89,5 +89,9 @@ namespace Dml
         }
     }
 
+    HRESULT CommandQueue::GetCommandQueue(ID3D12CommandQueue** queue)
+    {
+        return m_queue.CopyTo(queue);
+    }
 
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/CommandQueue.h
@@ -47,6 +47,8 @@ namespace Dml
         void Close();
         void ReleaseCompletedReferences();
 
+        HRESULT GetCommandQueue(ID3D12CommandQueue** queue);
+
     private:
         struct QueuedReference
         {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.cpp
@@ -223,4 +223,9 @@ namespace Dml
         return m_queue->GetType();
     }
 
+    
+    HRESULT ExecutionContext::GetCommandQueue(ID3D12CommandQueue** queue)
+    {
+        return m_queue->GetCommandQueue(queue);
+    }
 } // namespace Dml

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionContext.h
@@ -85,6 +85,8 @@ namespace Dml
 
         D3D12_COMMAND_LIST_TYPE GetCommandListTypeForQueue() const;
 
+        HRESULT GetCommandQueue(ID3D12CommandQueue** queue);
+
     private:
         ComPtr<ID3D12Device> m_d3dDevice;
 

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -218,6 +218,11 @@ namespace Dml
         _Analysis_assume_(*d3dDevice != nullptr);
         return S_OK;
     }
+    
+    HRESULT __stdcall ExecutionProviderImpl::GetCommandQueue(_COM_Outptr_ ID3D12CommandQueue** queue) const noexcept
+    {
+        return m_context->GetCommandQueue(queue);
+    }
 
     HRESULT __stdcall ExecutionProviderImpl::GetDmlDevice(_COM_Outptr_ IDMLDevice** dmlDevice) const noexcept
     {

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -43,6 +43,8 @@ namespace Dml
 
         STDMETHOD(GetDmlDevice)(_COM_Outptr_ IDMLDevice** dmlDevice) const noexcept final;
 
+        STDMETHOD(GetCommandQueue)(_COM_Outptr_ ID3D12CommandQueue** queue) const noexcept final;
+
         STDMETHOD(ExecuteCommandList)(
             ID3D12GraphicsCommandList* commandList,
             _Outptr_ ID3D12Fence** fence,

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -26,6 +26,10 @@ using Microsoft::WRL::ComPtr;
 #include "DmlExecutionProvider/inc/DmlExecutionProvider.h"
 #include "core/platform/env.h"
 
+#include "core/session/inference_session.h"
+#include "DmlExecutionProvider/src/IExecutionProvider.h"
+#include "DmlExecutionProvider/src/ExecutionProvider.h"
+
 namespace onnxruntime {
 
 struct DMLProviderFactory : IExecutionProviderFactory {
@@ -542,31 +546,26 @@ ORT_API_STATUS_IMPL(GetD3D12ResourceFromAllocation, _In_ OrtAllocator* ort_alloc
   API_IMPL_END
 }
 
-
-#include "core/session/inference_session.h"
-#include "DmlExecutionProvider/src/IExecutionProvider.h"
-#include "DmlExecutionProvider/src/ExecutionProvider.h"
-
-ORT_API_STATUS_IMPL(OrtGetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* /*input*/, _Out_ ID3D12Device** device) {
+ORT_API_STATUS_IMPL(OrtGetCommandQueueForSessionInput, _In_ OrtSession* session, _In_ const char* /*input*/, _Out_ ID3D12CommandQueue** queue) {
   API_IMPL_BEGIN
-  *device = nullptr;
+  *queue = nullptr;
 #ifdef USE_DML
   auto inference_session = reinterpret_cast<::onnxruntime::InferenceSession*>(session);
   const auto& session_state = inference_session->GetSessionState();
   auto& provider_id = session_state.GetExecutionProviders().GetIds().at(0);
   const auto& provider = session_state.GetExecutionProviders().Get(provider_id);
   auto dml_execution_provider = static_cast<const Dml::ExecutionProvider*>(provider);
-  dml_execution_provider->GetImpl()->GetD3DDevice(device);
+  dml_execution_provider->GetImpl()->GetCommandQueue(queue);
 #endif
   return nullptr;
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtGetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* /*output*/, _Out_ ID3D12Device** device) {
+ORT_API_STATUS_IMPL(OrtGetCommandQueueForSessionOutput, _In_ OrtSession* session, _In_ const char* /*output*/, _Out_ ID3D12CommandQueue** queue) {
   API_IMPL_BEGIN
-  *device = nullptr;
+  *queue = nullptr;
 #ifdef USE_DML
-  return OrtGetDeviceForSessionInput(session, nullptr, device);
+  return OrtGetCommandQueueForSessionInput(session, nullptr, queue);
 #endif
   return nullptr;
   API_IMPL_END
@@ -580,8 +579,8 @@ static constexpr OrtDmlApi ort_dml_api_10_to_x = {
   &FreeGPUAllocation,
   &GetD3D12ResourceFromAllocation,
   &OrtSessionOptionsAppendExecutionProvider_DML2,
-  &OrtGetDeviceForSessionInput,
-  &OrtGetDeviceForSessionOutput,
+  &OrtGetCommandQueueForSessionInput,
+  &OrtGetCommandQueueForSessionOutput,
 };
 
 const OrtDmlApi* GetOrtDmlApi(_In_ uint32_t /*version*/) NO_EXCEPTION {

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -542,7 +542,7 @@ ORT_API_STATUS_IMPL(GetD3D12ResourceFromAllocation, _In_ OrtAllocator* ort_alloc
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(GetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12Device** device) {
+ORT_API_STATUS_IMPL(OrtGetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12Device** device) {
   API_IMPL_BEGIN
   *device = nullptr;
 #ifdef USE_DML
@@ -552,7 +552,7 @@ ORT_API_STATUS_IMPL(GetDeviceForSessionInput, _In_ OrtSession* session, _In_ con
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(GetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12Device** device) {
+ORT_API_STATUS_IMPL(OrtGetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12Device** device) {
   API_IMPL_BEGIN
   *device = nullptr;
 #ifdef USE_DML

--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -542,6 +542,27 @@ ORT_API_STATUS_IMPL(GetD3D12ResourceFromAllocation, _In_ OrtAllocator* ort_alloc
   API_IMPL_END
 }
 
+ORT_API_STATUS_IMPL(GetDeviceForSessionInput, _In_ OrtSession* session, _In_ const char* input, _Out_ ID3D12Device** device) {
+  API_IMPL_BEGIN
+  *device = nullptr;
+#ifdef USE_DML
+
+#endif
+  return nullptr;
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(GetDeviceForSessionOutput, _In_ OrtSession* session, _In_ const char* output, _Out_ ID3D12Device** device) {
+  API_IMPL_BEGIN
+  *device = nullptr;
+#ifdef USE_DML
+
+#endif
+  return nullptr;
+  API_IMPL_END
+}
+
+
 static constexpr OrtDmlApi ort_dml_api_10_to_x = {
   &OrtSessionOptionsAppendExecutionProvider_DML,
   &OrtSessionOptionsAppendExecutionProviderEx_DML,
@@ -549,6 +570,8 @@ static constexpr OrtDmlApi ort_dml_api_10_to_x = {
   &FreeGPUAllocation,
   &GetD3D12ResourceFromAllocation,
   &OrtSessionOptionsAppendExecutionProvider_DML2,
+  &OrtGetDeviceForSessionInput,
+  &OrtGetDeviceForSessionOutput,
 };
 
 const OrtDmlApi* GetOrtDmlApi(_In_ uint32_t /*version*/) NO_EXCEPTION {

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -140,7 +140,7 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
 
 /*static*/ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int argc, ORTCHAR_T* argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, ORT_TSTR("z:b:m:e:r:t:p:x:y:c:d:o:u:i:f:F:S:T:AMPIDZvhsqz"))) != -1) {
+  while ((ch = getopt(argc, argv, ORT_TSTR("k:b:m:e:r:t:p:x:y:c:d:o:u:i:f:F:S:T:AMPIDZvhsqz"))) != -1) {
     switch (ch) {
       case 'f': {
         std::basic_string<ORTCHAR_T> dim_name;
@@ -290,7 +290,7 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
         }
         break;
       }
-      case 'z': {
+      case 'k': {
         if (!CompareCString(optarg, ORT_TSTR("cpu"))) {
           test_config.run_config.native_inputs = false;
         } else if (!CompareCString(optarg, ORT_TSTR("native"))) {

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -58,7 +58,7 @@ namespace perftest {
       "\t-z: Set denormal as zero. When turning on this option reduces latency dramatically, a model may have denormals.\n"
       "\t-i: Specify EP specific runtime options as key value pairs. Different runtime options available are: \n"
       "\t    [DML only] [performance_preference]: DML device performance prefernce, options: 'default', 'minimum_power', 'high_performance', \n"
-      "\t    [DML only] [filter]: DML device filter, options: 'any', 'gpu', 'npu', \n"
+      "\t    [DML only] [device_filter]: DML device filter, options: 'any', 'gpu', 'npu', \n"
       "\t    [OpenVINO only] [device_type]: Overrides the accelerator hardware type and precision with these values at runtime.\n"
       "\t    [OpenVINO only] [device_id]: Selects a particular hardware device for inference.\n"
       "\t    [OpenVINO only] [enable_vpu_fast_compile]: Optionally enabled to speeds up the model's compilation on VPU device targets.\n"
@@ -292,9 +292,9 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
       }
       case 'k': {
         if (!CompareCString(optarg, ORT_TSTR("cpu"))) {
-          test_config.run_config.native_inputs = false;
+          test_config.run_config.native_bindings= false;
         } else if (!CompareCString(optarg, ORT_TSTR("native"))) {
-          test_config.run_config.native_inputs = true;
+          test_config.run_config.native_bindings = true;
         }
         break;
       }

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -57,6 +57,8 @@ namespace perftest {
       "\t-q: [CUDA only] use separate stream for copy. \n"
       "\t-z: Set denormal as zero. When turning on this option reduces latency dramatically, a model may have denormals.\n"
       "\t-i: Specify EP specific runtime options as key value pairs. Different runtime options available are: \n"
+      "\t    [DML only] [performance_preference]: DML device performance prefernce, options: 'default', 'minimum_power', 'high_performance', \n"
+      "\t    [DML only] [filter]: DML device filter, options: 'any', 'gpu', 'npu', \n"
       "\t    [OpenVINO only] [device_type]: Overrides the accelerator hardware type and precision with these values at runtime.\n"
       "\t    [OpenVINO only] [device_id]: Selects a particular hardware device for inference.\n"
       "\t    [OpenVINO only] [enable_vpu_fast_compile]: Optionally enabled to speeds up the model's compilation on VPU device targets.\n"
@@ -138,7 +140,7 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
 
 /*static*/ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int argc, ORTCHAR_T* argv[]) {
   int ch;
-  while ((ch = getopt(argc, argv, ORT_TSTR("b:m:e:r:t:p:x:y:c:d:o:u:i:f:F:S:T:AMPIDZvhsqz"))) != -1) {
+  while ((ch = getopt(argc, argv, ORT_TSTR("z:b:m:e:r:t:p:x:y:c:d:o:u:i:f:F:S:T:AMPIDZvhsqz"))) != -1) {
     switch (ch) {
       case 'f': {
         std::basic_string<ORTCHAR_T> dim_name;
@@ -285,6 +287,14 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
               return false;
             }
           }
+        }
+        break;
+      }
+      case 'z': {
+        if (!CompareCString(optarg, ORT_TSTR("cpu"))) {
+          test_config.run_config.native_inputs = false;
+        } else if (!CompareCString(optarg, ORT_TSTR("native"))) {
+          test_config.run_config.native_inputs = true;
         }
         break;
       }

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -25,7 +25,7 @@ class OnnxRuntimeTestSession : public TestSession {
     test_inputs_[test_data_id][input_id] = std::move(value);
   }
 
-  bool PopulateGeneratedInputTestData(int32_t seed);
+  bool PopulateGeneratedInputTestData(int32_t seed, bool use_native_inputs);
 
   ~OnnxRuntimeTestSession() = default;
 

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -19,13 +19,16 @@ class OnnxRuntimeTestSession : public TestSession {
       test_inputs_.resize(test_data_id + 1);
     }
     if (test_inputs_.at(test_data_id).size() == 0) {
-      for (int i = 0; i < input_length_; i++)
+      for (int i = 0; i < input_length_; i++) {
         test_inputs_[test_data_id].emplace_back(nullptr);
+      }
     }
     test_inputs_[test_data_id][input_id] = std::move(value);
   }
 
-  bool PopulateGeneratedInputTestData(int32_t seed, bool use_native_inputs);
+  bool PopulateGeneratedInputTestData(int32_t seed, bool use_native_bindings);
+
+  bool PopulateOutputs(bool use_native_bindings);
 
   ~OnnxRuntimeTestSession() = default;
 
@@ -33,11 +36,16 @@ class OnnxRuntimeTestSession : public TestSession {
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OnnxRuntimeTestSession);
 
+ public:
+  using UniqueNativePtr = std::unique_ptr<void, void (*)(void*)>;
+
  private:
   Ort::Session session_{nullptr};
   std::mt19937 rand_engine_;
   std::uniform_int_distribution<int> dist_;
   std::vector<std::vector<Ort::Value>> test_inputs_;
+  std::vector<Ort::Value> test_outputs_;
+  std::vector<UniqueNativePtr> native_test_bindings_;
   std::vector<std::string> output_names_;
   // The same size with output_names_.
   // TODO: implement a customized allocator, then we can remove output_names_ to simplify this code

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -320,11 +320,17 @@ bool PerformanceRunner::Initialize() {
   TestModelInfo* test_model_info = test_model_info_.get();
   test_case_ = CreateOnnxTestCase(narrow_model_name, std::move(test_model_info_), 0.0, 0.0);
 
+  if (performance_test_config_.run_config.native_bindings) {
+    static_cast<OnnxRuntimeTestSession*>(
+        session_.get())
+        ->PopulateOutputs(performance_test_config_.run_config.native_bindings);
+  }
+
   if (performance_test_config_.run_config.generate_model_input_binding) {
     return static_cast<OnnxRuntimeTestSession*>(
                session_.get())
         ->PopulateGeneratedInputTestData(performance_test_config_.run_config.random_seed_for_input_data,
-            performance_test_config_.run_config.native_inputs);
+                                         performance_test_config_.run_config.native_bindings);
   }
 
   // TODO: Place input tensor on cpu memory if dnnl provider type to avoid CopyTensor logic in CopyInputAcrossDevices

--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -323,7 +323,8 @@ bool PerformanceRunner::Initialize() {
   if (performance_test_config_.run_config.generate_model_input_binding) {
     return static_cast<OnnxRuntimeTestSession*>(
                session_.get())
-        ->PopulateGeneratedInputTestData(performance_test_config_.run_config.random_seed_for_input_data);
+        ->PopulateGeneratedInputTestData(performance_test_config_.run_config.random_seed_for_input_data,
+            performance_test_config_.run_config.native_inputs);
   }
 
   // TODO: Place input tensor on cpu memory if dnnl provider type to avoid CopyTensor logic in CopyInputAcrossDevices

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -61,7 +61,7 @@ struct RunConfig {
   std::string intra_op_thread_affinities;
   bool disable_spinning = false;
   bool disable_spinning_between_run = false;
-  bool native_inputs = false;
+  bool native_bindings = false;
 };
 
 struct PerformanceTestConfig {

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -61,6 +61,7 @@ struct RunConfig {
   std::string intra_op_thread_affinities;
   bool disable_spinning = false;
   bool disable_spinning_between_run = false;
+  bool native_inputs = false;
 };
 
 struct PerformanceTestConfig {

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -268,8 +268,9 @@ std::unique_ptr<IExecutionProvider> DefaultCannExecutionProvider() {
 
 std::unique_ptr<IExecutionProvider> DefaultDmlExecutionProvider() {
 #ifdef USE_DML
-  if (auto factory = DMLProviderFactoryCreator::Create(0))
+  if (auto factory = DMLProviderFactoryCreator::CreateFromOptions(nullptr)) {
     return factory->CreateProvider();
+  }
 #endif
   return nullptr;
 }


### PR DESCRIPTION
Update onnxruntime_perf_test to allow dml device selection, and DX interop binding