### PR TITLE
fix: Run 'build.bat --use_openvino CPU_FP16 --build_nuget' using OpenVINO 2023. show error message '--execution_provider openvino exited with code 1

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -706,7 +706,7 @@ def generate_files(line_list, args):
         )
 
         if is_windows():
-            if "2022" in openvino_path:
+            if "2022" in openvino_path or "2023" in openvino_path:
                 dll_list_path = os.path.join(openvino_path, "runtime\\bin\\intel64\\Release\\")
                 tbb_list_path = os.path.join(openvino_path, "runtime\\3rdparty\\tbb\\bin\\")
             else:
@@ -746,7 +746,7 @@ def generate_files(line_list, args):
             )
             # usb-ma2x8x.mvcmd
             # OpenVINO 2022.3 doesn't have usb-ma2x8x.mvcmd
-            if "2022.3" not in openvino_path:
+            if "2022.3" not in openvino_path and "2023" not in openvino_path:
                 files_list.append(
                     "<file src="
                     + '"'

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -745,7 +745,7 @@ def generate_files(line_list, args):
                 + '\\native" />'
             )
             # usb-ma2x8x.mvcmd
-            # OpenVINO 2022.3 doesn't have usb-ma2x8x.mvcmd
+            # OpenVINO 2022.3 and 2023 doesn't have usb-ma2x8x.mvcmd
             if "2022.3" not in openvino_path and "2023" not in openvino_path:
                 files_list.append(
                     "<file src="


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Modify `tools\nuget\generate_nuspec_for_native_nuget.py` for OpenVINO 2023.
Because there are some paths and files are different from other OpenVINO version.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

If no change. when run `.\build.bat --config RelWithDebInfo --use_openvino CPU_FP16 --build_shared_lib --build_nuget --skip_tests`  will show error message as below

```sh
  Generating nuspec for the native Nuget package ...
  Traceback (most recent call last):
    File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\nuget\generate_nuspec_for_native_nuget.py", line 1188, in <module>
      sys.exit(main())
    File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\nuget\generate_nuspec_for_native_nuget.py", line 1176, in main
      lines = generate_nuspec(args)
    File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\nuget\generate_nuspec_for_native_nuget.py", line 1126, in generate_nuspec
      generate_files(lines, args)
onfig RelWithDebInfo --native_build_path C:\Users\kimi0\D
esktop\Kimi\intel_onnxruntime\build\Windows\RelWithDebInfo\RelWithDebInfo --packages_path C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\build\Windows\packages --ort_build_path C:\Use
rs\kimi0\Desktop\Kimi\intel_onnxruntime\build\Windows --sources_path C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime --commit_id b7ae293be05c89a0cb623feec4d2d2cbf006e4c3 --is_release_b
uild false --execution_provider openvino" exited with code 1.
Traceback (most recent call last):
  File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\ci_build\build.py", line 2699, in <module>
    sys.exit(main())
  File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\ci_build\build.py", line 2648, in main
    build_nuget_package(
  File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\ci_build\build.py", line 2183, in build_nuget_package
    run_subprocess(cmd_args, cwd=csharp_build_dir)
  File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\ci_build\build.py", line 801, in run_subprocess
    return run(*args, cwd=cwd, capture_stdout=capture_stdout, shell=shell, env=my_env)
  File "C:\Users\kimi0\Desktop\Kimi\intel_onnxruntime\tools\python\util\run.py", line 49, in run
    completed_process = subprocess.run(
  File "C:\Users\kimi0\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['dotnet', 'msbuild', 'OnnxRuntime.CSharp.proj', '/t:CreatePackage', '/p:OrtPackageId="Microsoft.ML.OnnxRuntime.OpenVino"', '/p:Configuration="RelWithDebInfo"', '/p:ExecutionProvider="openvino"', '/p:IsLinuxBuild="false"', '/p:OnnxRuntimeBuildDirectory="C:\\Users\\kimi0\\Desktop\\Kimi\\intel_onnxruntime\\build\\Windows"', '/p:NugetExe="nuget.exe"']' returned non-zero exit status 1.
```

<img width="790" alt="Screenshot 2023-10-24 094533" src="https://github.com/microsoft/onnxruntime/assets/10182019/9936f241-5728-4174-a9fb-d20e62cfc38b">

