### PR TITLE
[FIX] reorder initializer

### DIFF
--- a/onnxruntime/contrib_ops/cuda/collective/sharding_spec.h
+++ b/onnxruntime/contrib_ops/cuda/collective/sharding_spec.h
@@ -117,7 +117,7 @@ class AxisPartitionSpec {
   // A normal ctor.
   // TODO(wechi): Consider to hide it and revise the `public` members/functions
   // exposed to the user.
-  AxisPartitionSpec(Condition cond_, int device_mesh_axis_) : device_mesh_axis(device_mesh_axis_), cond(cond_) {}
+  AxisPartitionSpec(Condition cond_, int device_mesh_axis_) : cond(cond_), device_mesh_axis(device_mesh_axis_) {}
 
   // Helper to debug and generate error message; e.g.,
   // "RS[0]".


### PR DESCRIPTION
### Description
Fix building error when with collective ops: error is thrown because `device_mesh_axis` will be initialized after `cond`.


<details>
<summary> error detail (found when building in ROCm) </summary>

```
...
In file included from /ws/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/contrib_ops/rocm/collective/sharding_spec.cc:4:
/ws/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/contrib_ops/rocm/collective/sharding_spec.h: In constructor ‘onnxruntime::contrib::rocm::AxisPartitionSpec::AxisPartitionSpec(onnxruntime::contrib::rocm::AxisPartitionSpec::Condition, int)’:
/ws/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/contrib_ops/rocm/collective/sharding_spec.h:104:7: error: ‘onnxruntime::contrib::rocm::AxisPartitionSpec::device_mesh_axis’ will be initialized after [-Werror=reorder]
  104 |   int device_mesh_axis;
      |       ^~~~~~~~~~~~~~~~
/ws/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/contrib_ops/rocm/collective/sharding_spec.h:99:13: error:   ‘onnxruntime::contrib::rocm::AxisPartitionSpec::Condition onnxruntime::contrib::rocm::AxisPartitionSpec::cond’ [-Werror=reorder]
   99 |   Condition cond;
      |             ^~~~
/ws/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/contrib_ops/rocm/collective/sharding_spec.h:120:3: error:   when initialized here [-Werror=reorder]
  120 |   AxisPartitionSpec(Condition cond_, int device_mesh_axis_) : device_mesh_axis(device_mesh_axis_), cond(cond_) {}
      |   ^~~~~~~~~~~~~~~~~
At global scope:
cc1plus: error: unrecognized command line option ‘-Wno-undefined-var-template’ [-Werror]
...
```
</details>