### PR TITLE
[js/web] fix a few package consuming problems

### DIFF
--- a/js/web/.npmignore
+++ b/js/web/.npmignore
@@ -4,6 +4,26 @@
 
 /dist/**/*.report.html
 
+# We remove some of the files in NPM packages because restrictions in jsdelivr:
+#
+# "Packages larger than 150 MB or single files larger than 20 MB (in the case of GitHub) are not supported"
+#
+# from https://www.jsdelivr.com/documentation
+#
+# We only include development build in the NPM package for the following targets:
+# - /dist/ort.js
+# - /dist/ort.all.js
+#
+/dist/cjs/ort.js
+/dist/esm/ort.js
+/dist/cjs/ort.all.js
+/dist/esm/ort.all.js
+/dist/**/ort.wasm.js
+/dist/**/ort.wasm-core.js
+/dist/**/ort.webgl.js
+/dist/**/ort.webgpu.js
+/dist/**/ort.training.wasm.js
+
 /types/
 
 karma.conf.js

--- a/js/web/lib/index.ts
+++ b/js/web/lib/index.ts
@@ -7,6 +7,9 @@
 // So we import code inside the if-clause to allow bundler remove the code safely.
 
 export * from 'onnxruntime-common';
+import * as ort from 'onnxruntime-common';
+export default ort;
+
 import {registerBackend, env} from 'onnxruntime-common';
 import {version} from './version';
 

--- a/js/web/package.json
+++ b/js/web/package.json
@@ -68,14 +68,8 @@
     ".": {
       "node": "./dist/ort.node.min.js",
       "default": {
-        "import": {
-          "development": "./dist/esm/ort.js",
-          "default": "./dist/esm/ort.min.js"
-        },
-        "require": {
-          "development": "./dist/cjs/ort.js",
-          "default": "./dist/cjs/ort.min.js"
-        },
+        "import": "./dist/esm/ort.min.js",
+        "require": "./dist/cjs/ort.min.js",
         "default": {
           "development": "./dist/ort.js",
           "default": "./dist/ort.min.js"
@@ -83,88 +77,37 @@
       }
     },
     "./experimental": {
-      "import": {
-        "development": "./dist/esm/ort.all.js",
-        "default": "./dist/esm/ort.all.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.all.js",
-        "default": "./dist/cjs/ort.all.min.js"
-      },
+      "import": "./dist/esm/ort.all.min.js",
+      "require": "./dist/cjs/ort.all.min.js",
       "default": {
         "development": "./dist/ort.all.js",
         "default": "./dist/ort.all.min.js"
       }
     },
     "./wasm": {
-      "import": {
-        "development": "./dist/esm/ort.wasm.js",
-        "default": "./dist/esm/ort.wasm.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.wasm.js",
-        "default": "./dist/cjs/ort.wasm.min.js"
-      },
-      "default": {
-        "development": "./dist/ort.wasm.js",
-        "default": "./dist/ort.wasm.min.js"
-      }
+      "import": "./dist/esm/ort.wasm.min.js",
+      "require": "./dist/cjs/ort.wasm.min.js",
+      "default": "./dist/ort.wasm.min.js"
     },
     "./wasm-core": {
-      "import": {
-        "development": "./dist/esm/ort.wasm-core.js",
-        "default": "./dist/esm/ort.wasm-core.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.wasm-core.js",
-        "default": "./dist/cjs/ort.wasm-core.min.js"
-      },
-      "default": {
-        "development": "./dist/ort.wasm-core.js",
-        "default": "./dist/ort.wasm-core.min.js"
-      }
+      "import": "./dist/esm/ort.wasm-core.min.js",
+      "require": "./dist/cjs/ort.wasm-core.min.js",
+      "default": "./dist/ort.wasm-core.min.js"
     },
     "./webgl": {
-      "import": {
-        "development": "./dist/esm/ort.webgl.js",
-        "default": "./dist/esm/ort.webgl.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.webgl.js",
-        "default": "./dist/cjs/ort.webgl.min.js"
-      },
-      "default": {
-        "development": "./dist/ort.webgl.js",
-        "default": "./dist/ort.webgl.min.js"
-      }
+      "import": "./dist/esm/ort.webgl.min.js",
+      "require": "./dist/cjs/ort.webgl.min.js",
+      "default": "./dist/ort.webgl.min.js"
     },
     "./webgpu": {
-      "import": {
-        "development": "./dist/esm/ort.webgpu.js",
-        "default": "./dist/esm/ort.webgpu.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.webgpu.js",
-        "default": "./dist/cjs/ort.webgpu.min.js"
-      },
-      "default": {
-        "development": "./dist/ort.webgpu.js",
-        "default": "./dist/ort.webgpu.min.js"
-      }
+      "import": "./dist/esm/ort.webgpu.min.js",
+      "require": "./dist/cjs/ort.webgpu.min.js",
+      "default": "./dist/ort.webgpu.min.js"
     },
     "./training": {
-      "import": {
-        "development": "./dist/esm/ort.training.wasm.js",
-        "default": "./dist/esm/ort.training.wasm.min.js"
-      },
-      "require": {
-        "development": "./dist/cjs/ort.training.wasm.js",
-        "default": "./dist/cjs/ort.training.wasm.min.js"
-      },
-      "default": {
-        "development": "./dist/ort.training.wasm.js",
-        "default": "./dist/ort.training.wasm.min.js"
-      }
+      "import": "./dist/esm/ort.training.wasm.min.js",
+      "require": "./dist/cjs/ort.training.wasm.min.js",
+      "default": "./dist/ort.training.wasm.min.js"
     }
   },
   "types": "./types.d.ts",


### PR DESCRIPTION
### Description
This PR tries to fix a part of the NPM package consuming problems for onnxruntime-web (ES module) as described in #10913:

- reduce the package size to fit the 150MB restriction in jsdelivr, by removing dev build targets for uncommon exports
- add default export to support `import ort from 'onnxruntime-web';` (currently only support `import * as ort from 'onnxruntime-web';`