### PR TITLE
Basic RISC-V Support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -511,6 +511,10 @@ if (NOT MSVC AND NOT (CMAKE_SYSTEM_NAME STREQUAL "iOS"))
   endif()
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endif()
+# Some stable cross toolchains of RISC-V still need this
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv.*|RISCV.*)")
+  set(onnxruntime_LINK_LIBATOMIC true)
+endif()
 
 set(REPO_ROOT ${PROJECT_SOURCE_DIR}/..)
 set(ONNXRUNTIME_ROOT ${PROJECT_SOURCE_DIR}/../onnxruntime)

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -56,6 +56,9 @@ Abstract:
 #if defined(MLAS_TARGET_ARM64) || defined(MLAS_TARGET_ARM64EC) || defined(MLAS_TARGET_ARM)
 #define MLAS_TARGET_ARM_ANY
 #endif
+#if defined(__riscv__)
+#define MLAS_TARGET_SCALAR
+#endif
 
 #if defined(__VSX__)
 #define MLAS_TARGET_POWER
@@ -65,7 +68,7 @@ Abstract:
 #if defined(__wasm_simd128__)
 #define MLAS_TARGET_WASM_SIMD
 #else
-#define MLAS_TARGET_WASM_SCALAR
+#define MLAS_TARGET_SCALAR
 #endif
 #endif
 
@@ -751,7 +754,7 @@ enum MLAS_CONV_ALGORITHM {
     MlasConvAlgorithmGemmDirect,
     MlasConvAlgorithmExpandThenGemm,
     MlasConvAlgorithmExpandThenGemmSegmented,
-#if defined(MLAS_TARGET_WASM_SCALAR)
+#if defined(MLAS_TARGET_SCALAR)
     MlasConvAlgorithmDepthwise,
 #endif
 };

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -903,7 +903,7 @@ Return Value:
         return;
     }
 
-#if defined(MLAS_TARGET_WASM_SCALAR)
+#if defined(MLAS_TARGET_SCALAR)
 
     if (Algorithm == MlasConvAlgorithmDepthwise) {
         // Fill the Working Buffer with Zero for use by the depthwise kernel.
@@ -976,7 +976,7 @@ Return Value:
                     break;
                 }
 
-#if defined(MLAS_TARGET_WASM_SCALAR)
+#if defined(MLAS_TARGET_SCALAR)
 
                 case MlasConvAlgorithmDepthwise:
                 {
@@ -1224,7 +1224,7 @@ Return Value:
 
     } else {
 
-#if defined(MLAS_TARGET_WASM_SCALAR)
+#if defined(MLAS_TARGET_SCALAR)
 
         // Scalar direct conv for depthwise convolution.
         // Currently only support 3x3 kernel with padding <=1 and dilations = 1.

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1162,7 +1162,7 @@ MlasFp32FromBits(
 #pragma warning(pop)
 #endif
 
-#if defined(MLAS_TARGET_WASM_SCALAR)
+#if defined(MLAS_TARGET_SCALAR)
 
 void
 MLASCALL

--- a/onnxruntime/core/mlas/lib/sgemm.cpp
+++ b/onnxruntime/core/mlas/lib/sgemm.cpp
@@ -208,7 +208,7 @@ Return Value:
     }
 }
 
-#if !defined(MLAS_TARGET_WASM_SCALAR)
+#if !defined(MLAS_TARGET_SCALAR)
 
 void
 MlasSgemmCopyPackB(
@@ -734,7 +734,7 @@ Return Value:
     }
 }
 
-#else //defined(MLAS_TARGET_WASM_SCALAR)
+#else //defined(MLAS_TARGET_SCALAR)
 
 void
 MlasSgemmCopyPackB(

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -339,6 +339,11 @@ def parse_arguments():
         help="[cross-compiling] Create ARM64EC makefiles. Requires --update and no existing cache "
         "CMake setup. Delete CMakeCache.txt if needed",
     )
+    parser.add_argument("--riscv",
+        action='store_true',
+        help="[cross-compiling] Create RISC-V makefiles. Requires --update and no existing cache "
+        "CMake setup. Delete CMakeCache.txt if needed",
+    )
     parser.add_argument("--msvc_toolset", help="MSVC toolset to use. e.g. 14.11")
     parser.add_argument("--windows_sdk_version", help="Windows SDK version to use. e.g. 10.0.19041.0")
     parser.add_argument("--android", action="store_true", help="Build for Android")
@@ -1054,7 +1059,7 @@ def generate_build_tree(
 
     # By default on Windows we currently support only cross compiling for ARM/ARM64
     # (no native compilation supported through this script).
-    if args.arm64 or args.arm64ec or args.arm:
+    if args.arm64 or args.arm64ec or args.arm or args.riscv:
         add_default_definition(cmake_extra_defines, "onnxruntime_CROSS_COMPILING", "ON")
         if args.use_extensions:
             add_default_definition(cmake_extra_defines, "OPENCV_SKIP_SYSTEM_PROCESSOR_DETECTION", "ON")


### PR DESCRIPTION
This PR is the proposal to contribute RISC-V support mentioned in #17466. The focus here is on the basic RISC-V ISA (rv64imafdc), excluding the V or other extensions.

This PR comprises two parts. Firstly, we explicitly set the atomic linking flag and include some RISC-V related arguments in the build scripts. Secondly, we implement a scalar MLAS for RISC-V by leveraging the existing implementation in the folder `onnxruntime/core/mlas/lib/scalar/`.

The benefit of this solution is that we can follow the build logic defined in `cmake/onnxruntime_mlas.cmake`. As shown in below, if `CMAKE_SYSTEM_PROCESSOR` is an unsupported architecture, the scalar kernels are compiled. However, in `onnxruntime/core/mlas/lib/sgemm.cpp`, the default function `MlasSgemmCopyPackB` assumes that the data can be packed with SIMD instructions, where data are encapsulated in type `MlasLoadFloat32x4`, which is incompatible with the scalar implementation. Therefore, we need an additional macro defined in `onnxruntime/core/mlas/inc/mlas.h` to ensure that `MlasSgemmCopyPackB` is compatible with the scalar version. Notably, we do not require the complex modifications proposed by #16768.
```diff
diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
index 6828dfd076..a5d6c28e8b 100644
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -571,7 +571,7 @@ else()
     endif()
-     if(NOT ONNXRUNTIME_MLAS_MULTI_ARCH AND MLAS_SOURCE_IS_NOT_SET)
+     if(NOT ONNXRUNTIME_MLAS_MULTI_ARCH AND MLAS_SOURCE_IS_NOT_SET) # Highlight
         file(GLOB_RECURSE mlas_platform_srcs
          "${MLAS_SRC_DIR}/scalar/*.cpp")
     endif()
     target_sources(onnxruntime_mlas PRIVATE ${mlas_platform_srcs})
 endif()
```

We conducted two CI tests (`./build.sh --test --config Release --allow_running_as_root` and `onnxruntime_mlas_test`) and encountered only one failure related to numerical compatibility.

This issue is caused by the inconsistent behavior of NaN propagation as delineated in the IEEE 754-2019 standard [2] and the RISC-V specification [3].

Specifally, the intricacies of NaN propagation are comprehensively outlined in chapter 6.2.3 of [2] and chapter 11.3 of [3]. The IEEE standard stipulates that "An operation that propagates a NaN operand to its result and has a single NaN as an input should produce a NaN with the payload of the input NaN if it's representable in the destination format." In contrast, the RISC-V specification defines that "Except when otherwise stated, if the result of a floating-point operation is NaN, it is the canonical NaN. The canonical NaN has a positive sign and all significand bits clear except the MSB, also known as the quiet bit. For single-precision floating-point, this corresponds to the pattern 0x7fc00000."

In summary, while the IEEE standard retains the remaining bits when propagating NaN, RISC-V converts NaNs to 0x7fc00000.

I am receptive to feedback, collaboration, and further guidance to effectively contribute to supporting the RISC-V architecture.

# References
[1] https://github.com/ucb-bar/onnxruntime-riscv

[2] Microprocessor Standards Committee. (2019). 754-2019-IEEE Standard for Floating-Point Arithmetic.

[3] The RISC-V Instruction Set Manual Volume I: Unprivileged ISA. (2019). https://riscv.org/wp-content/uploads/2019/06/riscv-spec.pdf