### PR TITLE
Clean IndexedSubGraph's unused properties for the coming EPv2 feature

### DIFF
--- a/include/onnxruntime/core/graph/indexed_sub_graph.h
+++ b/include/onnxruntime/core/graph/indexed_sub_graph.h
@@ -34,7 +34,6 @@ struct IndexedSubGraph {
     std::vector<std::string> inputs;                 ///< Inputs of customized SubGraph/FunctionProto.
     std::vector<std::string> outputs;                ///< Outputs of customized SubGraph/FunctionProto.
     std::vector<std::string> constant_initializers;  ///< Constant initializers of customized SubGraph/FunctionProto.
-    NodeAttributes attributes;                       ///< Attributes of customized SubGraph/FunctionProto.
 
     std::string doc_string;  ///< Doc string of customized SubGraph/FunctionProto.
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3897,7 +3897,7 @@ Node& Graph::CreateFusedSubGraphNode(const IndexedSubGraph& sub_graph, const std
                              func_meta_def->doc_string,
                              input_args,
                              output_args,
-                             &func_meta_def->attributes,
+                             nullptr,
                              func_meta_def->domain);
 
   fused_node.SetNodeType(Node::Type::Fused);

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -454,7 +454,6 @@ struct ProviderHost {
   virtual std::vector<std::string>& IndexedSubGraph_MetaDef__inputs(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::vector<std::string>& IndexedSubGraph_MetaDef__outputs(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::vector<std::string>& IndexedSubGraph_MetaDef__constant_initializers(IndexedSubGraph_MetaDef* p) = 0;
-  virtual NodeAttributes& IndexedSubGraph_MetaDef__attributes(IndexedSubGraph_MetaDef* p) = 0;
   virtual std::string& IndexedSubGraph_MetaDef__doc_string(IndexedSubGraph_MetaDef* p) = 0;
 
   // IndexedSubGraph

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -373,7 +373,6 @@ struct IndexedSubGraph_MetaDef final {
   const std::vector<std::string>& constant_initializers() const { return g_host->IndexedSubGraph_MetaDef__constant_initializers(const_cast<IndexedSubGraph_MetaDef*>(this)); }
   std::vector<std::string>& constant_initializers() { return g_host->IndexedSubGraph_MetaDef__constant_initializers(this); }
   std::vector<std::string>& outputs() { return g_host->IndexedSubGraph_MetaDef__outputs(this); }
-  NodeAttributes& attributes() { return g_host->IndexedSubGraph_MetaDef__attributes(this); }
 
   std::string& doc_string() { return g_host->IndexedSubGraph_MetaDef__doc_string(this); }
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -559,7 +559,6 @@ struct ProviderHostImpl : ProviderHost {
   std::vector<std::string>& IndexedSubGraph_MetaDef__inputs(IndexedSubGraph_MetaDef* p) override { return p->inputs; }
   std::vector<std::string>& IndexedSubGraph_MetaDef__outputs(IndexedSubGraph_MetaDef* p) override { return p->outputs; }
   std::vector<std::string>& IndexedSubGraph_MetaDef__constant_initializers(IndexedSubGraph_MetaDef* p) override { return p->constant_initializers; }
-  NodeAttributes& IndexedSubGraph_MetaDef__attributes(IndexedSubGraph_MetaDef* p) override { return p->attributes; }
   std::string& IndexedSubGraph_MetaDef__doc_string(IndexedSubGraph_MetaDef* p) override { return p->doc_string; }
 
   // IndexedSubGraph (wrapped)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR is to clean up the IndexSubGraph's unused properties for the coming EPv2 feature


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This PR is to clean up the IndexSubGraph's unused properties for the coming EPv2 feature. This change will simplify the logic of handling the return value of the function ExecutionProvider::GetCapability() and the following Compile() function.

