### PR TITLE
Tune min version supporint custom op ComputeV2

### DIFF
--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -28,7 +28,7 @@ static constexpr uint32_t min_ort_version_with_variadic_io_support = 14;
 #endif
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
-static constexpr uint32_t min_ort_version_with_compute_v2_support = 17;
+static constexpr uint32_t min_ort_version_with_compute_v2_support = 16;
 static constexpr uint32_t min_ort_version_with_shape_inference = 17;
 #endif
 


### PR DESCRIPTION
Set min version supporting custom_op::ComputeV2 to 16, since the feature has been released since ort 1.16.

