### PR TITLE
Fix regression in perf test runner

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -121,7 +121,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 
     buffer.emplace_back("do_copy_in_default_stream");
     option_keys.push_back(buffer.back().c_str());
-    buffer.emplace_back(performance_test_config.run_config.do_cuda_copy_in_separate_stream ? "1" : "0");
+    buffer.emplace_back(!performance_test_config.run_config.do_cuda_copy_in_separate_stream ? "1" : "0");
     option_values.push_back(buffer.back().c_str());
 
 #ifdef _MSC_VER


### PR DESCRIPTION
### Description

This is how the previous code read: 

![image](https://github.com/microsoft/onnxruntime/assets/9969784/b7512801-9ace-418b-b5d9-de282247846c)

In https://github.com/microsoft/onnxruntime/pull/17200/, we onboarded to using a newer API to update CUDA provider options, and related code change seems to have accidentally introduced the regression

CC: @gedoensmax
