### PR TITLE
Proof-of-concept Inference Session Memory Residency API

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -326,6 +326,9 @@ class IExecutionProvider {
    */
   virtual std::vector<AllocatorPtr> CreatePreferredAllocators() { return std::vector<AllocatorPtr>(); };
 
+  virtual common::Status MakeResident() { return Status::OK(); };
+  virtual common::Status Evict() { return Status::OK(); };
+
  private:
   const std::string type_;
 

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4512,6 +4512,16 @@ struct OrtApi {
    * \since Version 1.17.
    */
   ORT_API2_STATUS(ReadOpAttr, _In_ const OrtOpAttr* op_attr, _In_ OrtOpAttrType type, _Inout_ void* data, _In_ size_t len, _Out_ size_t* out);
+
+  /** \brief Evict execution provider resources of the session
+   * \note Call this to release memory while a session is unused.
+   * This allows to reduce memory use (e.g. VRAM) when a session is not in used, without requiring lengthy session recreation.
+   *
+   * \param[in] session
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   */
+  ORT_API2_STATUS(EvictSession, _In_ OrtSession* session);
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1117,6 +1117,8 @@ struct Session : detail::SessionImpl<OrtSession> {
 
   ConstSession GetConst() const { return ConstSession{this->p_}; }
   UnownedSession GetUnowned() const { return UnownedSession{this->p_}; }
+
+  void Evict(); ///< Wraps OrtApi::EvictSession
 };
 
 namespace detail {

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1044,6 +1044,10 @@ inline Session::Session(const Env& env, const void* model_data, size_t model_dat
                                                                             prepacked_weights_container, &this->p_));
 }
 
+inline void Session::Evict() {
+  ThrowOnError(GetApi().EvictSession(this->p_));
+}
+
 inline AllocatedStringPtr ModelMetadata::GetProducerNameAllocated(OrtAllocator* allocator) const {
   char* out;
   ThrowOnError(GetApi().ModelMetadataGetProducerName(p_, allocator, &out));

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.cpp
@@ -7,6 +7,8 @@
 
 #include "BucketizedBufferAllocator.h"
 #include "DmlSubAllocator.h"
+#include "ReadbackHeap.h"
+#include "PooledUploadHeap.h"
 // #define PRINT_OUTSTANDING_ALLOCATIONS
 
 namespace Dml
@@ -133,8 +135,8 @@ namespace Dml
             resourceId = ++m_currentResourceId;
         }
 
-        assert(resourceWrapper->GetD3D12Resource()->GetDesc().Width == bucketSize);
         assert(resourceWrapper != nullptr);
+        assert(resourceWrapper->GetD3D12Resource()->GetDesc().Width == bucketSize);
 
         ComPtr<AllocationInfo> allocInfo = wil::MakeOrThrow<AllocationInfo>(
             this,
@@ -218,6 +220,121 @@ namespace Dml
     void BucketizedBufferAllocator::SetDefaultRoundingMode(AllocatorRoundingMode roundingMode)
     {
         m_defaultRoundingMode = roundingMode;
+    }
+
+    void BucketizedBufferAllocator::SetResidency(bool value)
+    {
+      //Check if we need to change residency
+      if (m_isResident == value) return;
+      m_isResident = value;
+
+      //Collect all pageables
+      std::vector<ID3D12Pageable*> pageables;
+      std::vector<D3D12_RESIDENCY_PRIORITY> priorities;
+
+      pageables.reserve(m_pool.size());
+      priorities.reserve(m_pool.size());
+
+      for (auto& bucket : m_pool)
+      {
+        for (auto& resource : bucket.resources)
+        {
+          auto d3d12Resource = resource.resource.Get()->GetD3D12Resource();
+
+          ID3D12Pageable* d3d12Pageable = nullptr;
+          d3d12Resource->QueryInterface<ID3D12Pageable>(&d3d12Pageable);
+
+          if (d3d12Pageable)
+          {
+            pageables.push_back(d3d12Pageable);
+            priorities.push_back(value ? D3D12_RESIDENCY_PRIORITY_MAXIMUM : D3D12_RESIDENCY_PRIORITY_MINIMUM);
+          }
+        }
+      }
+
+      //Set residency
+      if (value)
+      {
+        ORT_THROW_IF_FAILED(m_device->MakeResident(uint32_t(pageables.size()), pageables.data()));
+      }
+      else
+      {
+        ORT_THROW_IF_FAILED(m_device->Evict(uint32_t(pageables.size()), pageables.data()));
+      }
+
+      //Set residency priority      
+      ID3D12Device1* d3d12Device1 = nullptr;
+      if(m_device->QueryInterface<ID3D12Device1>(&d3d12Device1))
+      {
+        ORT_THROW_IF_FAILED(d3d12Device1->SetResidencyPriority(uint32_t(pageables.size()), pageables.data(), priorities.data()));
+      }
+
+      //Release handles
+      for (auto pageable : pageables)
+      {
+        pageable->Release();
+      }
+    }
+
+    void BucketizedBufferAllocator::SetResidency2(bool value)
+    {
+      m_subAllocator->SetResidency(value);
+    }
+
+    void BucketizedBufferAllocator::PageOutAll(ReadbackHeap * readbackHeap)
+    {
+      //Enumerate all buckets
+      for (auto& bucket : m_pool)
+      {
+        //Enumerate resources in bucket
+        for (auto& item : bucket.resources)
+        {
+          //Get resource
+          auto resource = item.resource->GetD3D12Resource();
+
+          //Determine size
+          auto resourceDesc = resource->GetDesc();
+          item.resourceBackup.resize(resourceDesc.Width);
+
+          //Copy data from GPU to CPU
+          readbackHeap->ReadbackFromGpu(
+            item.resourceBackup,
+            resource,
+            0,
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+          //Release GPU memory
+          //m_context->QueueReference(resource);
+          item.resource.Reset();
+        }
+      }
+    }
+
+    void BucketizedBufferAllocator::PageInAll(PooledUploadHeap * uploadHeap)
+    {
+      //Enumerate all buckets
+      for (auto& bucket : m_pool)
+      {
+        //Enumerate resources in bucket
+        for (auto& item : bucket.resources)
+        {
+          //Allocate GPU memory
+          item.resource = m_subAllocator->Alloc(item.resourceBackup.size());
+
+          //Get resource
+          auto resource = item.resource->GetD3D12Resource();
+
+          //Copy data from CPU to GPU
+          uploadHeap->BeginUploadToGpu(
+            resource,
+            0,
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+            item.resourceBackup);
+          
+          //Release CPU memory
+          item.resourceBackup.clear();
+        }
+      }
     }
 
     CPUAllocator::CPUAllocator(OrtMemType memType)

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
@@ -11,6 +11,8 @@
 namespace Dml
 {
     class DmlSubAllocator;
+    class ReadbackHeap;
+    class PooledUploadHeap;
 
     class CPUAllocator : public onnxruntime::IAllocator
     {
@@ -46,6 +48,11 @@ namespace Dml
 
         void SetDefaultRoundingMode(AllocatorRoundingMode roundingMode);
 
+        void SetResidency(bool value);
+        void SetResidency2(bool value);
+        void PageOutAll(ReadbackHeap* readbackHeap);
+        void PageInAll(PooledUploadHeap* uploadHeap);
+
     public: // onnxruntime::IAllocator
         void* Alloc(size_t size, AllocatorRoundingMode roundingMode);
         void* Alloc(size_t size) final;
@@ -61,6 +68,7 @@ namespace Dml
         {
             ComPtr<DmlResourceWrapper> resource;
             uint64_t resourceId;
+            std::vector<std::byte> resourceBackup;
         };
 
         struct Bucket
@@ -83,6 +91,7 @@ namespace Dml
         std::vector<Bucket> m_pool;
         size_t m_currentAllocationId = 0;
         uint64_t m_currentResourceId = 0;
+        bool m_isResident = true;
 
         // Unless specifically requested, allocation sizes are not rounded to enable pooling
         // until SetDefaultRoundingMode is called.  This should be done at completion of session

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/BucketizedBufferAllocator.h
@@ -11,8 +11,6 @@
 namespace Dml
 {
     class DmlSubAllocator;
-    class ReadbackHeap;
-    class PooledUploadHeap;
 
     class CPUAllocator : public onnxruntime::IAllocator
     {
@@ -48,10 +46,8 @@ namespace Dml
 
         void SetDefaultRoundingMode(AllocatorRoundingMode roundingMode);
 
+        // Sets the residency of allocated GPU memory
         void SetResidency(bool value);
-        void SetResidency2(bool value);
-        void PageOutAll(ReadbackHeap* readbackHeap);
-        void PageInAll(PooledUploadHeap* uploadHeap);
 
     public: // onnxruntime::IAllocator
         void* Alloc(size_t size, AllocatorRoundingMode roundingMode);
@@ -68,7 +64,6 @@ namespace Dml
         {
             ComPtr<DmlResourceWrapper> resource;
             uint64_t resourceId;
-            std::vector<std::byte> resourceBackup;
         };
 
         struct Bucket
@@ -91,7 +86,6 @@ namespace Dml
         std::vector<Bucket> m_pool;
         size_t m_currentAllocationId = 0;
         uint64_t m_currentResourceId = 0;
-        bool m_isResident = true;
 
         // Unless specifically requested, allocation sizes are not rounded to enable pooling
         // until SetDefaultRoundingMode is called.  This should be done at completion of session

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.h
@@ -15,7 +15,14 @@ namespace Dml
         DmlCommittedResourceAllocator(ID3D12Device* device) : m_device(device) {}
         Microsoft::WRL::ComPtr<DmlResourceWrapper> Alloc(size_t size) final;
 
+        ~DmlCommittedResourceAllocator();
+
+        void SetResidency(bool value) final;
+
     private:
         ID3D12Device* m_device = nullptr;
+        std::vector<ID3D12Pageable*> m_resources;
+
+        static void OnResourceRelease(void* context, ID3D12Resource* resource);
     };
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceAllocator.h
@@ -22,6 +22,7 @@ namespace Dml
     private:
         ID3D12Device* m_device = nullptr;
         std::vector<ID3D12Pageable*> m_resources;
+        bool m_isResident = true;
 
         static void OnResourceRelease(void* context, ID3D12Resource* resource);
     };

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceWrapper.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceWrapper.h
@@ -13,15 +13,15 @@ namespace Dml
 
         void AddReleaseCallback(ResourceCallback callback, void* context = nullptr) final
         {
-          m_releaseCallbacks.push_back(std::pair{callback, context});
+            m_releaseCallbacks.push_back(std::pair{callback, context});
         }
 
         ~DmlCommittedResourceWrapper()
-        { 
-          for(auto [callback, context] : m_releaseCallbacks)
-          {
-            callback(context, m_d3d12Resource.Get());
-          }
+        {
+            for(auto [callback, context] : m_releaseCallbacks)
+            {
+                callback(context, m_d3d12Resource.Get());
+            }
         }
 
     private:

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceWrapper.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlCommittedResourceWrapper.h
@@ -11,7 +11,21 @@ namespace Dml
         DmlCommittedResourceWrapper(Microsoft::WRL::ComPtr<ID3D12Resource>&& d3d12Resource) : m_d3d12Resource(std::move(d3d12Resource)) {}
         ID3D12Resource* GetD3D12Resource() const final { return m_d3d12Resource.Get(); }
 
+        void AddReleaseCallback(ResourceCallback callback, void* context = nullptr) final
+        {
+          m_releaseCallbacks.push_back(std::pair{callback, context});
+        }
+
+        ~DmlCommittedResourceWrapper()
+        { 
+          for(auto [callback, context] : m_releaseCallbacks)
+          {
+            callback(context, m_d3d12Resource.Get());
+          }
+        }
+
     private:
         Microsoft::WRL::ComPtr<ID3D12Resource> m_d3d12Resource;
+        std::vector<std::pair<ResourceCallback, void*>> m_releaseCallbacks;
     };
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlResourceWrapper.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlResourceWrapper.h
@@ -7,11 +7,14 @@ struct ID3D12Resource;
 
 namespace Dml
 {
+    typedef void (*ResourceCallback)(void* context, ID3D12Resource* resource);
+
     interface __declspec(uuid("d430f6f1-5c43-48d1-97e6-f080cc7fa0c5"))
     DmlResourceWrapper : public IUnknown
     {
     public:
         virtual ID3D12Resource* GetD3D12Resource() const = 0;
+        virtual void AddReleaseCallback(ResourceCallback callback, void* context = nullptr) = 0;
         virtual ~DmlResourceWrapper(){}
     };
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlSubAllocator.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlSubAllocator.h
@@ -11,6 +11,7 @@ namespace Dml
     {
     public:
         virtual Microsoft::WRL::ComPtr<DmlResourceWrapper> Alloc(size_t size) = 0;
+        virtual void SetResidency(bool value) = 0;
         virtual ~DmlSubAllocator(){}
     };
 }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -212,6 +212,20 @@ namespace Dml
         return std::vector<onnxruntime::AllocatorPtr>{m_allocator, m_cpuInputAllocator,};
     }
 
+    void ExecutionProviderImpl::Evict()
+    {
+      //m_allocator->SetResidency(false);
+      m_allocator->SetResidency2(false);
+      //m_allocator->PageOutAll(m_readbackHeap.get());
+    }
+
+    void ExecutionProviderImpl::MakeResident()
+    {
+      //m_allocator->SetResidency(true);
+      m_allocator->SetResidency2(true);
+      //m_allocator->PageInAll(m_uploadHeap.get());
+    }
+
     HRESULT __stdcall ExecutionProviderImpl::GetD3DDevice(_COM_Outptr_ ID3D12Device** d3dDevice) const noexcept
     {
         m_d3d12Device.CopyTo(d3dDevice);

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp
@@ -214,16 +214,12 @@ namespace Dml
 
     void ExecutionProviderImpl::Evict()
     {
-      //m_allocator->SetResidency(false);
-      m_allocator->SetResidency2(false);
-      //m_allocator->PageOutAll(m_readbackHeap.get());
+        m_allocator->SetResidency(false);
     }
 
     void ExecutionProviderImpl::MakeResident()
     {
-      //m_allocator->SetResidency(true);
-      m_allocator->SetResidency2(true);
-      //m_allocator->PageInAll(m_uploadHeap.get());
+        m_allocator->SetResidency(true);
     }
 
     HRESULT __stdcall ExecutionProviderImpl::GetD3DDevice(_COM_Outptr_ ID3D12Device** d3dDevice) const noexcept

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -314,16 +314,16 @@ namespace Dml
 
         virtual Status MakeResident()
         {
-          m_impl->MakeResident();
-          m_impl->WaitForOutstandingWork();
-          return Status::OK(); 
+            m_impl->MakeResident();
+            m_impl->WaitForOutstandingWork();
+            return Status::OK();
         };
 
         virtual Status Evict()
         {
-          m_impl->WaitForOutstandingWork();
-          m_impl->Evict();
-          return Status::OK(); 
+            m_impl->WaitForOutstandingWork();
+            m_impl->Evict();
+            return Status::OK();
         };
 
     private:

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.h
@@ -169,6 +169,9 @@ namespace Dml
         onnxruntime::common::Status OnSessionInitializationEnd();
         std::vector<onnxruntime::AllocatorPtr> CreatePreferredAllocators();
 
+        void Evict();
+        void MakeResident();
+
     private:
         void Initialize(ID3D12CommandQueue* queue, ExecutionProvider& executionProvider);
 
@@ -308,6 +311,20 @@ namespace Dml
         {
             return m_impl->CreatePreferredAllocators();
         }
+
+        virtual Status MakeResident()
+        {
+          m_impl->MakeResident();
+          m_impl->WaitForOutstandingWork();
+          return Status::OK(); 
+        };
+
+        virtual Status Evict()
+        {
+          m_impl->WaitForOutstandingWork();
+          m_impl->Evict();
+          return Status::OK(); 
+        };
 
     private:
         ComPtr<ExecutionProviderImpl> m_impl;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -652,15 +652,6 @@ common::Status InferenceSession::AddCustomOpDomains(gsl::span<OrtCustomOpDomain*
   return Status::OK();
 }
 
-common::Status InferenceSession::RegisterExecutionProviderFactories(const std::vector<std::shared_ptr<IExecutionProviderFactory>>& p_exec_provider_factories) {
-  execution_provider_factories_.insert(
-    execution_provider_factories_.end(), 
-    p_exec_provider_factories.begin(), 
-    p_exec_provider_factories.end());
-
-  return Status::OK();
-}
-
 common::Status InferenceSession::RegisterCustomRegistry(std::shared_ptr<CustomRegistry> custom_registry) {
   if (custom_registry == nullptr) {
     return Status(common::ONNXRUNTIME, common::FAIL, "Received nullptr for custom registry");
@@ -1459,24 +1450,8 @@ common::Status InferenceSession::Initialize() {
       have_cpu_ep = execution_providers_.Get(onnxruntime::kCpuExecutionProvider) != nullptr;
     }
 
-    //Register execution providers
-    if (!execution_provider_factories_.empty())
-    {
-      LOGS(*session_logger_, INFO) << "instantiating execution providers";
-
-      for (auto& factory : execution_provider_factories_) {
-        if (!factory) continue;
-
-        auto provider = factory->CreateProvider();
-        if (provider) {
-          ORT_RETURN_IF_ERROR_SESSIONID_(RegisterExecutionProvider(std::move(provider)));
-        }
-      }
-    }
-
     // Verify that there are no external initializers in the graph if external data is disabled.
     onnxruntime::Graph& graph = model_->MainGraph();
-    
 #ifdef DISABLE_EXTERNAL_INITIALIZERS
     const InitializedTensorSet& initializers = graph.GetAllInitializedTensors();
     for (const auto& it : initializers) {
@@ -1616,15 +1591,11 @@ common::Status InferenceSession::Initialize() {
       }
 #endif
 
-      if (!is_graph_optimized_) {
-        // apply any transformations to the main graph and any subgraphs
-        ORT_RETURN_IF_ERROR_SESSIONID_(TransformGraph(graph, saving_ort_format));
+      // apply any transformations to the main graph and any subgraphs
+      ORT_RETURN_IF_ERROR_SESSIONID_(TransformGraph(graph, saving_ort_format));
 
-        // now that all the transforms are done, call Resolve on the main graph. this will recurse into the subgraphs.
-        ORT_RETURN_IF_ERROR_SESSIONID_(graph.Resolve());
-
-        //is_graph_optimized_ = true;
-      }
+      // now that all the transforms are done, call Resolve on the main graph. this will recurse into the subgraphs.
+      ORT_RETURN_IF_ERROR_SESSIONID_(graph.Resolve());
 
       // Currently CUDA graph is only considered by CUDA EP and TRT EP.
       //
@@ -1865,42 +1836,29 @@ common::Status InferenceSession::Initialize() {
 
   return status;
 }
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 
-common::Status InferenceSession::Uninitialize() {
+common::Status InferenceSession::Evict() {
   Status status = Status::OK();
 
   ORT_TRY {
-    LOGS(*session_logger_, INFO) << "Uninitializing session.";
+    LOGS(*session_logger_, INFO) << "Evicting session.";
     std::lock_guard<onnxruntime::OrtMutex> lock(session_mutex_);
-
-    /*is_inited_ = false;
-    session_state_.reset();
-
-    delete &execution_providers_;
-    new (&execution_providers_) ExecutionProviders;
-
-    delete &kernel_registry_manager_;
-    new (&kernel_registry_manager_) KernelRegistryManager;
-
-    delete &graph_transformer_mgr_;
-    new (&graph_transformer_mgr_) onnxruntime::GraphTransformerManager(session_options_.max_num_graph_transformation_steps);*/
 
     for (auto& provider : execution_providers_)
     {
-      auto x = provider->Evict();
+      ORT_THROW_IF_ERROR(provider->Evict());
     }
   }
   ORT_CATCH(...) {
-    status = ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Encountered unknown exception in Uninitialize()");
+    status = ORT_MAKE_STATUS(ONNXRUNTIME, RUNTIME_EXCEPTION, "Encountered unknown exception in Evict()");
     LOGS(*session_logger_, ERROR) << status.ErrorMessage();
   }
 
   return status;
 }
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
 
 int InferenceSession::GetCurrentNumRuns() const {
   return current_num_runs_.load();
@@ -2269,12 +2227,13 @@ Status InferenceSession::Run(const RunOptions& run_options,
     InlinedVector<AllocatorPtr> arenas_to_shrink;
 
     ORT_TRY {
-      for (auto& provider : execution_providers_) {
-        auto x = provider->MakeResident();
+      if (!is_inited_) {
+        LOGS(*session_logger_, ERROR) << "Session was not initialized";
+        return Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
       }
 
-      if (!is_inited_) {
-        ORT_RETURN_IF_ERROR_SESSIONID_(Initialize());
+      for (auto& provider : execution_providers_) {
+        ORT_RETURN_IF_ERROR_SESSIONID_(provider->MakeResident());
       }
 
       // log evaluation start to trace logging provider
@@ -2611,15 +2570,13 @@ std::pair<common::Status, const OutputDefList*> InferenceSession::GetModelOutput
 }
 
 common::Status InferenceSession::NewIOBinding(std::unique_ptr<IOBinding>* io_binding) {
-  bool is_inited = false;
 
   {
     std::lock_guard<onnxruntime::OrtMutex> l(session_mutex_);
-    is_inited = is_inited_;
-  }
-
-  if (!is_inited) {
-    ORT_RETURN_IF_ERROR_SESSIONID_(Initialize());
+    if (!is_inited_) {
+      LOGS(*session_logger_, ERROR) << "Session was not initialized";
+      return common::Status(common::ONNXRUNTIME, common::FAIL, "Session not initialized.");
+    }
   }
 
   *io_binding = std::make_unique<IOBinding>(*session_state_);

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -26,6 +26,7 @@
 #include "core/optimizer/graph_transformer_mgr.h"
 #include "core/optimizer/insert_cast_transformer.h"
 #include "core/framework/session_options.h"
+#include "core/providers/providers.h"
 #ifdef ENABLE_LANGUAGE_INTEROP_OPS
 #include "core/language_interop_ops/language_interop_ops.h"
 #endif
@@ -215,6 +216,11 @@ class InferenceSession {
    */
   [[nodiscard]] common::Status RegisterExecutionProvider(const std::shared_ptr<IExecutionProvider>& p_exec_provider);
 
+  /*
+   * Register execution provider factories, similar to RegisterExecutionProvider, but these will be reused after eviction.
+   */
+  [[nodiscard]] common::Status RegisterExecutionProviderFactories(const std::vector<std::shared_ptr<IExecutionProviderFactory>>& p_exec_provider_factories);
+
 #if !defined(ORT_MINIMAL_BUILD)
   /**
     * Register a graph transformer. If you've one to register, call this before invoking Initialize().
@@ -316,6 +322,7 @@ class InferenceSession {
    * @return OK if success
    */
   [[nodiscard]] common::Status Initialize();
+  [[nodiscard]] common::Status Uninitialize();
 
   [[nodiscard]] common::Status Run(const RunOptions& run_options, gsl::span<const std::string> feed_names,
                                    gsl::span<const OrtValue> feeds, gsl::span<const std::string> output_names,
@@ -592,6 +599,11 @@ class InferenceSession {
 
   // The list of execution providers.
   ExecutionProviders execution_providers_;
+
+  // The list of execution provider factories.
+  std::vector<std::shared_ptr<IExecutionProviderFactory>> execution_provider_factories_;
+
+  bool is_graph_optimized_ = false;
 
  private:
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(InferenceSession);

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -46,6 +46,8 @@ ORT_API_STATUS_IMPL(CreateSession, _In_ const OrtEnv* env, _In_ const ORTCHAR_T*
 ORT_API_STATUS_IMPL(CreateSessionFromArray, _In_ const OrtEnv* env, _In_ const void* model_data, size_t model_data_length,
                     _In_ const OrtSessionOptions* options, _Outptr_ OrtSession** out);
 
+ORT_API_STATUS_IMPL(EvictSession, _In_ OrtSession* session);
+
 ORT_API_STATUS_IMPL(Run, _Inout_ OrtSession* sess, _In_opt_ const OrtRunOptions* run_options,
                     _In_reads_(input_len) const char* const* input_names,
                     _In_reads_(input_len) const OrtValue* const* input, size_t input_len,


### PR DESCRIPTION
### Description
This PR showcases a simple prototype implementation for https://github.com/microsoft/onnxruntime/issues/18142.
It adds an EvictSession API, which allows the user to tell the ONNX runtime that the given session will not be used for a while, so the related execution providers can page out related memory allocations when the system or video memory is low. 

#### A usage example
You are running an Olive optimized float16 version of Stable Diffusion XL with DirectML on a GPU with 12GB VRAM. If you try to load both the Unet and the VAE decoder models at the same time, you ran out of video memory by a significant margin, which make the OS become unresponsive and subsequent inference performance is significantly slower. You could recreate the U-net session each time you use it, but it will take around 10-20 seconds to do that, which will double the time taken to generate each image.

With this API you can mark the U-net session for eviction before VAE. If the machine would run out of VRAM, parts of the U-net will be transferred to system RAM, so VAE can run at full speed. Then when generating the next image, the VAE is moved out and the U-net back in. This data transfer is very fast, so no need to wait for a long reload.

### Motivation and Context
See the more about the motivation [here](https://github.com/microsoft/onnxruntime/issues/18142).

Please note that this is a prototype only and has no unit tests yet, but I tested it with my [Unpaint project](https://github.com/axodox/unpaint) and it works as intended and improves the inference performance and responsiveness on my PC drastically.

The current API is very simple:
- Call EvictSession when not needing a session for a while
- The EPs are notified about it this, and can schedule the affected memory for eviction, if they implement the related API (or if not then the call has no effect). 
- In my DirectML example this API only marks the heaps for eviction, so they can be reclaimed if we would run out of memory. If there is enough memory, then there is no change in behavior.
- Interacting with the session, through Run or IOBinding will make the pages resident again.

Some changes I could see the API:
- We could call also add a MakeResident() or SetResidency(bool isResident) API so we can page back a model before it is used
- We could add a more complex APIs which can force the paging even if we are not out of memory, so it can be more deterministic, and can act earlier, 
I think the simple approach I took now, can cover most cases though.

I am not sure what could be the best way to automated test this - I mean calling Evict might do nothing if we have enough memory, and have no real benefit if even the single model does not fit in memory.


