### PR TITLE
Correct check for WebGPU support

### DIFF
--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -132,7 +132,8 @@ class ComputeContextImpl implements ComputeContext {
 
 export const init = async(module: OrtWasmModule, env: Env): Promise<void> => {
   const init = module.jsepInit;
-  if (init && navigator.gpu) {
+  const hasGpu = !!(navigator.gpu && await navigator.gpu.requestAdapter())
+  if (init && hasGpu) {
     if (!env.wasm.simd) {
       throw new Error(
           'Not supported for WebGPU=ON and SIMD=OFF. Please set `env.wasm.simd` to true when using WebGPU EP');


### PR DESCRIPTION
### Description

Augments the naive check for `navigator.gpu` with an `await navigator.gpu.requestAdapter` in jsep's `ComputeContextImpl`.

### Motivation and Context

Just testing for the presence of `navigator.gpu` is not sufficient to establish WebGPU support: in particular, at time of writing, Chrome on Android exposes a navigator.gpu but does not return anything from requestAdapter.

Context:
https://github.com/microsoft/onnxruntime/issues/15796#issuecomment-1783878252

