### PR TITLE
Update quantization preprocessing command in docs

### DIFF
--- a/docs/performance/model-optimizations/quantization.md
+++ b/docs/performance/model-optimizations/quantization.md
@@ -88,7 +88,7 @@ To read about additional options and finer controls available to pre-processing,
 run the following command:
 
 ```console
-python -m onnxruntime.quantization.shape_inference --help
+python -m onnxruntime.quantization.preprocess --help
 ```
 
 Model optimization may also be performed during quantization. However, this is *NOT* recommended,


### PR DESCRIPTION
Command was split from `shape_inference.py` to address import sequence warnings in 8004db4bf18635451870bee8a07b8f80b0bafec1 and was not updated.

Anyone following the docs prior to this change would have encountered;

```
root@Raze:~# python -m onnxruntime.quantization.shape_inference --help
/usr/lib/python3.10/runpy.py:126: RuntimeWarning: 'onnxruntime.quantization.shape_inference' found in sys.modules after import of package 'onnxruntime.quantization', but prior to execution of 'onnxruntime.quantization.shape_inference'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
```

Instead of the expected;

```
root@Raze:~# ./onnxtesting/bin/python -m onnxruntime.quantization.preprocess --help
usage: preprocess.py [-h] --input INPUT --output OUTPUT [--skip_optimization SKIP_OPTIMIZATION] [--skip_onnx_shape SKIP_ONNX_SHAPE]
                     [--skip_symbolic_shape SKIP_SYMBOLIC_SHAPE] [--auto_merge] [--int_max INT_MAX] [--guess_output_rank]
                     [--verbose VERBOSE] [--save_as_external_data] [--all_tensors_to_one_file]
                     [--external_data_location EXTERNAL_DATA_LOCATION]
                     [--external_data_size_threshold EXTERNAL_DATA_SIZE_THRESHOLD]

Model optimizer and shape inferencer[continues]
```