### PR TITLE
Use Expand for Attention mask broadcasting instead of Concat

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_attention.py
@@ -233,7 +233,7 @@ class FusionAttention(Fusion):
         expand_node_name = self.model.create_node_name("Expand")
 
         expand_add_qk_shape = self.add_initializer(
-            name="expand_add_qk_shape",
+            name=mask_output_name + "_shape",
             data_type=TensorProto.INT64,
             dims=[4],
             vals=[1, self.num_heads, 1, 1],


### PR DESCRIPTION
Concatenating the same tensors many times with itself doesn't scale as well as simply broadcasting it using Expand. At least for DirectML, using Expand instead of Concat improves the perf quite a bite, but I can't imagine Concat being faster than Expand in any implementation since Expand can make more assumptions (e.g. it knows it has to deal with a single tensor).

It doesn't affect the GQA path since that path completely gets rid of the mask anyway.