### PR TITLE
add check of legal quants

### DIFF
--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -386,6 +386,10 @@ def quantize_static(
         qdq_ops = list(QDQRegistry.keys())
         op_types_to_quantize = list(set(q_linear_ops + qdq_ops))
 
+    assert all(
+        x in list(QLinearOpsRegistry.keys()) + list(QDQRegistry.keys()) for x in op_types_to_quantize
+    ), f"Following op types to quantize are not in the set of quantizable ops: {set(op_types_to_quantize) - (QLinearOpsRegistry.keys() & QDQRegistry.keys())}"
+
     model = load_model_with_shape_infer(Path(model_input))
 
     pre_processed: bool = model_has_pre_process_metadata(model)
@@ -564,6 +568,10 @@ def quantize_dynamic(
 
     if not op_types_to_quantize or len(op_types_to_quantize) == 0:
         op_types_to_quantize = list(IntegerOpsRegistry.keys())
+
+    assert all(
+        x in list(QLinearOpsRegistry.keys()) + list(QDQRegistry.keys()) for x in op_types_to_quantize
+    ), f"Following op types to quantize are not in the set of quantizable ops: {set(op_types_to_quantize) - (QLinearOpsRegistry.keys() & QDQRegistry.keys())}"
 
     model = load_model_with_shape_infer(Path(model_input))
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds an assert to `quantize_static` and `quantize_dynamic` to check whether the ops given for quantization actually exist.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
When trying to quantize different ops from time to time I encountered the problem that I gave op names into `op_types_to_quantize` which are not the actual names of the op i wanted to quantize. (e.g. typo `Con` vs `Conv`). These would just be ignored in the current setting. Since there is no benefit of having unused ops in the list and could even be considered harmful, that some ops are "silently dropped" I propose this check to prevent these occurences. 

