### PR TITLE
Revert "Disable dml stage in windows GPU pipeline temporarily. (#18034)" (#18150)

### DIFF
--- a/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-gpu-ci-pipeline.yml
@@ -72,6 +72,23 @@ stages:
         MachinePool: onnxruntime-Win2022-GPU-T4
         isTraining: true
 
+- stage: dml
+  dependsOn: []
+  jobs:
+    - template: templates/jobs/win-ci-vs-2022-job.yml
+      parameters:
+        BuildConfig: 'RelWithDebInfo'
+        EnvSetupScript: setup_env.bat
+        buildArch: x64
+        additionalBuildFlags: --enable_pybind --use_dml --enable_wcos  --use_winml
+        msbuildPlatform: x64
+        isX86: false
+        job_name_suffix: x64_RelWithDebInfo
+        RunOnnxRuntimeTests: ${{ parameters.RunOnnxRuntimeTests }}
+        ORT_EP_NAME: DML
+        WITH_CACHE: true
+        MachinePool: onnxruntime-Win2022-GPU-dml-A10
+
 - stage: kernelDocumentation
   dependsOn: []
   jobs:

--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -121,6 +121,8 @@ std::unordered_map<std::string, std::string> disabledTests({
    "Bug 31005388: mask_rcnn opset 10 onnx zoo model fails to evaluate on DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005388"                                                        },
   {                                                        "faster_rcnn_opset10_GPU",
    "Bug 31005511: Failed to extract tensor data from evaluate result of faster_rcnn opset 10 model in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005511"                           },
+  {                                                       "mlperf_ssd_resnet34_1200",                                                                                           disabledTestDefaultReason},
+
  // ONNX model zoo's int8/qdq models generally do not work on CPUs that lack 8-bit instructions.
   {                                                         "YOLOv3_12_int8_opset12",                                                                                           disabledTestDefaultReason},
   {                                                            "VGG_16_int8_opset12",                                                                                           disabledTestDefaultReason},

--- a/winml/test/model/skip_model_tests.h
+++ b/winml/test/model/skip_model_tests.h
@@ -121,8 +121,6 @@ std::unordered_map<std::string, std::string> disabledTests({
    "Bug 31005388: mask_rcnn opset 10 onnx zoo model fails to evaluate on DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005388"                                                        },
   {                                                        "faster_rcnn_opset10_GPU",
    "Bug 31005511: Failed to extract tensor data from evaluate result of faster_rcnn opset 10 model in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005511"                           },
-  {                                                       "mlperf_ssd_resnet34_1200",                                                                                           disabledTestDefaultReason},
-
  // ONNX model zoo's int8/qdq models generally do not work on CPUs that lack 8-bit instructions.
   {                                                         "YOLOv3_12_int8_opset12",                                                                                           disabledTestDefaultReason},
   {                                                            "VGG_16_int8_opset12",                                                                                           disabledTestDefaultReason},
@@ -148,6 +146,8 @@ std::unordered_map<std::string, std::string> disabledTests({
    "Bug 31005780: Result of fp16_test_tiny_yolov2_opset7 and fp16_coreml_FNS_Candy_opset7 models on DirectML aren't as accurate as on CPU https://microsoft.visualstudio.com/OS/_workitems/edit/31005780"},
   {                                           "mlperf_ssd_mobilenet_300_opset10_GPU",
    "Bug 31005624: mlperf_ssd_mobilenet_300 opset 10 model fails to evaluate in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005624"                                                  },
+  {                                           "mlperf_ssd_resnet34_1200_opset10_GPU",
+   "Bug 31005624: mlperf_ssd_resnet34_1200_opset10_GPU opset 10 model fails to evaluate in DirectML https://microsoft.visualstudio.com/OS/_workitems/edit/31005624"                                                  },
 });
 
 /*


### PR DESCRIPTION
This reverts commit 99b8dcaae2ac033b10880bc5bc7b0e89b37fe466.

### Description
<!-- Describe your changes. -->



### Motivation and Context
Restore the dml stage in windows GPU  pipeline.
Agent issue is solved by adding Feature.DisableGpuDriver in pool
properties.