### PR TITLE
Fix a build error that happens when CPUINFO is disabled

### DIFF
--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -135,10 +135,6 @@ void CPUIDInfo::ArmLinuxInit() {
     LOGS_DEFAULT(WARNING) << "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
     return;
   }
-#else
-  pytorch_cpuinfo_init_ = false;
-#endif
-
   if (pytorch_cpuinfo_init_) {
     is_hybrid_ = cpuinfo_get_uarchs_count() > 1;
     has_arm_neon_dot_ = cpuinfo_has_arm_neon_dot();
@@ -163,7 +159,9 @@ void CPUIDInfo::ArmLinuxInit() {
         is_armv8_narrow_ld_[coreid] = true;
       }
     }
-  } else {
+  } else
+#endif
+  {
     has_arm_neon_dot_ = ((getauxval(AT_HWCAP) & HWCAP_ASIMDDP) != 0);
     has_fp16_ |= has_arm_neon_dot_;
   }


### PR DESCRIPTION
Even when CPUINFO is disabled, this file will still call "cpuinfo_get_uarchs_count", which will result a compile error.

Resolve issue #16308 

The problem has been fixed in the main branch. 