### PR TITLE
[js/webgpu] Choose best wasm backend

### DIFF
--- a/js/common/lib/backend-impl.ts
+++ b/js/common/lib/backend-impl.ts
@@ -82,7 +82,7 @@ export const resolveBackend = async(backendHints: readonly string[]): Promise<Ba
       const isInitializing = !!backendInfo.initPromise;
       try {
         if (!isInitializing) {
-          backendInfo.initPromise = backendInfo.backend.init();
+          backendInfo.initPromise = backendInfo.backend.init(backendName);
         }
         await backendInfo.initPromise;
         backendInfo.initialized = true;

--- a/js/common/lib/backend-impl.ts
+++ b/js/common/lib/backend-impl.ts
@@ -86,6 +86,7 @@ export const resolveBackend = async(backendHints: readonly string[]): Promise<Ba
         }
         await backendInfo.initPromise;
         backendInfo.initialized = true;
+        backendInfo.backend.name = backendName;
         return backendInfo.backend;
       } catch (e) {
         if (!isInitializing) {

--- a/js/common/lib/backend.ts
+++ b/js/common/lib/backend.ts
@@ -62,7 +62,7 @@ export interface Backend {
   /**
    * Initialize the backend asynchronously. Should throw when failed.
    */
-  init(): Promise<void>;
+  init(name: string): Promise<void>;
 
   createInferenceSessionHandler(uriOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions):
       Promise<InferenceSessionHandler>;

--- a/js/common/lib/backend.ts
+++ b/js/common/lib/backend.ts
@@ -71,6 +71,8 @@ export interface Backend {
       (checkpointStateUriOrBuffer: TrainingSession.URIorBuffer, trainModelUriOrBuffer: TrainingSession.URIorBuffer,
        evalModelUriOrBuffer: TrainingSession.URIorBuffer, optimizerModelUriOrBuffer: TrainingSession.URIorBuffer,
        options: InferenceSession.SessionOptions): Promise<TrainingSessionHandler>;
+
+  name: string;
 }
 
 export {registerBackend} from './backend-impl.js';

--- a/js/node/lib/backend.ts
+++ b/js/node/lib/backend.ts
@@ -49,6 +49,7 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
 }
 
 class OnnxruntimeBackend implements Backend {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async init(name: string): Promise<void> {
     return Promise.resolve();
   }

--- a/js/node/lib/backend.ts
+++ b/js/node/lib/backend.ts
@@ -49,7 +49,7 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
 }
 
 class OnnxruntimeBackend implements Backend {
-  async init(): Promise<void> {
+  async init(name: string): Promise<void> {
     return Promise.resolve();
   }
 

--- a/js/react_native/lib/backend.ts
+++ b/js/react_native/lib/backend.ts
@@ -161,6 +161,7 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
 }
 
 class OnnxruntimeBackend implements Backend {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async init(name: string): Promise<void> {
     return Promise.resolve();
   }

--- a/js/react_native/lib/backend.ts
+++ b/js/react_native/lib/backend.ts
@@ -161,7 +161,7 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
 }
 
 class OnnxruntimeBackend implements Backend {
-  async init(): Promise<void> {
+  async init(name: string): Promise<void> {
     return Promise.resolve();
   }
 

--- a/js/web/lib/backend-onnxjs.ts
+++ b/js/web/lib/backend-onnxjs.ts
@@ -8,7 +8,7 @@ import {Session} from './onnxjs/session';
 import {OnnxjsSessionHandler} from './onnxjs/session-handler';
 
 class OnnxjsBackend implements Backend {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   async init(name: string): Promise<void> {}
 
   async createInferenceSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions):

--- a/js/web/lib/backend-onnxjs.ts
+++ b/js/web/lib/backend-onnxjs.ts
@@ -9,7 +9,7 @@ import {OnnxjsSessionHandler} from './onnxjs/session-handler';
 
 class OnnxjsBackend implements Backend {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async init(): Promise<void> {}
+  async init(name: string): Promise<void> {}
 
   async createInferenceSessionHandler(pathOrBuffer: string|Uint8Array, options?: InferenceSession.SessionOptions):
       Promise<InferenceSessionHandler> {

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -39,11 +39,11 @@ export class OnnxruntimeWebAssemblyBackend implements Backend {
         throw new Error('navigator is not available');
       }
       if (!navigator.gpu) {
-        throw new Error('navigator.gpu not available.');
+        throw new Error('navigator.gpu is not available.');
       }
       if (!await navigator.gpu.requestAdapter()) {
         throw new Error(
-            'Failed to get GPU adapter. Maybe you need to enable flag "--enable-unsafe-webgpu" if you are using Chrome.');
+            'Failed to get GPU adapter. You may need to enable flag "--enable-unsafe-webgpu" if you are using Chrome.');
       }
       if (!env.wasm.simd) {
         throw new Error(

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -33,7 +33,19 @@ export const initializeFlags = (): void => {
 };
 
 export class OnnxruntimeWebAssemblyBackend implements Backend {
-  async init(): Promise<void> {
+  async init(name: string): Promise<void> {
+    if (name === 'webgpu') {
+      if (typeof navigator === 'undefined') {
+        throw new Error('navigator is not available');
+      }
+      if (!navigator.gpu) {
+        throw new Error('navigator.gpu not available.');
+      }
+      if (!await navigator.gpu.requestAdapter()) {
+        throw new Error('Failed to get GPU adapter.');
+      }
+    }
+
     // populate wasm flags
     initializeFlags();
 

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -42,7 +42,12 @@ export class OnnxruntimeWebAssemblyBackend implements Backend {
         throw new Error('navigator.gpu not available.');
       }
       if (!await navigator.gpu.requestAdapter()) {
-        throw new Error('Failed to get GPU adapter.');
+        throw new Error(
+            'Failed to get GPU adapter. Maybe you need to enable flag "--enable-unsafe-webgpu" if you are using Chrome.');
+      }
+      if (!env.wasm.simd) {
+        throw new Error(
+            'Not supported for WebGPU=ON and SIMD=OFF. Please set `env.wasm.simd` to true when using WebGPU EP');
       }
     }
 

--- a/js/web/lib/index.ts
+++ b/js/web/lib/index.ts
@@ -18,7 +18,7 @@ if (!BUILD_DEFS.DISABLE_WEBGL) {
 if (!BUILD_DEFS.DISABLE_WASM) {
   const wasmBackend = BUILD_DEFS.DISABLE_TRAINING ? require('./backend-wasm-inference').wasmBackend :
                                                     require('./backend-wasm-training').wasmBackend;
-  if (!BUILD_DEFS.DISABLE_WEBGPU && typeof navigator !== 'undefined' && navigator.gpu) {
+  if (!BUILD_DEFS.DISABLE_WEBGPU) {
     registerBackend('webgpu', wasmBackend, 5);
   }
   registerBackend('cpu', wasmBackend, 10);

--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -143,11 +143,6 @@ export class WebGpuBackend {
   sessionExternalDataMapping: Map<number, Map<number, [number, GPUBuffer]>> = new Map();
 
   async initialize(env: Env): Promise<void> {
-    if (!navigator.gpu) {
-      // WebGPU is not available.
-      throw new Error('WebGpuBackend: WebGPU is not available.');
-    }
-
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {
       throw new Error('WebGpuBackend: Failed to get GPU adapter.');

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -132,11 +132,7 @@ class ComputeContextImpl implements ComputeContext {
 
 export const init = async(module: OrtWasmModule, env: Env): Promise<void> => {
   const init = module.jsepInit;
-  if (init && navigator.gpu) {
-    if (!env.wasm.simd) {
-      throw new Error(
-          'Not supported for WebGPU=ON and SIMD=OFF. Please set `env.wasm.simd` to true when using WebGPU EP');
-    }
+  if (init) {
     const backend = new WebGpuBackend();
     await backend.initialize(env);
 

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -52,6 +52,10 @@ export const initRuntime = async(env: Env): Promise<void> => {
   // init ORT
   initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
 
+  /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+  // We use "require" instead of "import" here because import statement must be put in top level. Our current code does
+  // not allow bundler to tree-shaking code as expected because some codes are treated as having side effects.
+  // So we import code inside the if-clause to allow bundler remove the code safely.
   const wasmBackend = BUILD_DEFS.DISABLE_TRAINING ? require('../backend-wasm-inference').wasmBackend :
                                                     require('../backend-wasm-training').wasmBackend;
   if (wasmBackend.name === 'webgpu') {

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -52,7 +52,9 @@ export const initRuntime = async(env: Env): Promise<void> => {
   // init ORT
   initOrt(env.wasm.numThreads!, logLevelStringToEnum(env.logLevel));
 
-  if (!BUILD_DEFS.DISABLE_WEBGPU) {
+  const wasmBackend = BUILD_DEFS.DISABLE_TRAINING ? require('../backend-wasm-inference').wasmBackend :
+                                                    require('../backend-wasm-training').wasmBackend;
+  if (wasmBackend.name === 'webgpu') {
     // init JSEP if available
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -59,8 +59,6 @@ export const initRuntime = async(env: Env): Promise<void> => {
   const wasmBackend = BUILD_DEFS.DISABLE_TRAINING ? require('../backend-wasm-inference').wasmBackend :
                                                     require('../backend-wasm-training').wasmBackend;
   if (wasmBackend.name === 'webgpu') {
-    // init JSEP if available
-
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const initJsep = require('./jsep/init').init;
     await initJsep(getInstance(), env);


### PR DESCRIPTION
WebGPU Android in Chrome is still behind flag "--enable-unsafe-apis". Even without this flag, navigator.gpu is available, but navigator.gpu.requestAdapter() would fail. This PR checks the availability of WebGPU and choose the best wasm backend.

