### PR TITLE
Change QNN EP Profiling logs to output to CSV

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -959,25 +959,24 @@ Status QnnBackendManager::ExtractProfilingEventExtended(
 }
 
 const std::string& QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType) {
-    const auto& unitStringMap = GetUnitStringMap();
-    auto it = unitStringMap.find(unitType);
-    if (it != unitStringMap.end()) {
-        return it->second;
-    }
-    static const std::string unknown = "UNKNOWN";
-    return unknown;
+  const auto& unitStringMap = GetUnitStringMap();
+  auto it = unitStringMap.find(unitType);
+  if (it != unitStringMap.end()) {
+    return it->second;
+  }
+  static const std::string unknown = "UNKNOWN";
+  return unknown;
 }
 
 const std::unordered_map<QnnProfile_EventUnit_t, std::string>& QnnBackendManager::GetUnitStringMap() {
-    static const std::unordered_map<QnnProfile_EventUnit_t, std::string> unitStringMap = {
-        {QNN_PROFILE_EVENTUNIT_MICROSEC, "US"},
-        {QNN_PROFILE_EVENTUNIT_BYTES, "BYTES"},
-        {QNN_PROFILE_EVENTUNIT_CYCLES, "CYCLES"},
-        {QNN_PROFILE_EVENTUNIT_COUNT, "COUNT"},
-        {QNN_PROFILE_EVENTUNIT_OBJECT, "OBJECT"},
-        {QNN_PROFILE_EVENTUNIT_BACKEND, "BACKEND"}
-    };
-    return unitStringMap;
+  static const std::unordered_map<QnnProfile_EventUnit_t, std::string> unitStringMap = {
+      {QNN_PROFILE_EVENTUNIT_MICROSEC, "US"},
+      {QNN_PROFILE_EVENTUNIT_BYTES, "BYTES"},
+      {QNN_PROFILE_EVENTUNIT_CYCLES, "CYCLES"},
+      {QNN_PROFILE_EVENTUNIT_COUNT, "COUNT"},
+      {QNN_PROFILE_EVENTUNIT_OBJECT, "OBJECT"},
+      {QNN_PROFILE_EVENTUNIT_BACKEND, "BACKEND"}};
+  return unitStringMap;
 }
 
 const std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -843,10 +843,18 @@ Status QnnBackendManager::ExtractBackendProfilingInfo() {
       LOGS(*logger_, VERBOSE) << "The QNN backend does not support extended event data.";
     }
 
-    // Write to CSV
-    std::ofstream outfile("qnn-profiling-data.csv", std::ios_base::out);
+    // Write to CSV in append mode
+    const char* profilingCsvFilename = "qnn-profiling-data.csv";
+    std::ifstream infile(profilingCsvFilename);
+    bool exists = infile.good();
+    infile.close();
+
+    std::ofstream outfile(profilingCsvFilename, std::ios_base::app);
     ORT_RETURN_IF(!outfile.is_open(), "Failed to open qnn-profiling-data.csv");
-    outfile << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier\n";
+    // If file didn't exist before, write the header
+    if (!exists) {
+      outfile << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier\n";
+    }
 
     for (size_t event_idx = 0; event_idx < num_events; event_idx++) {
       ORT_RETURN_IF_ERROR(

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -897,7 +897,7 @@ Status QnnBackendManager::ExtractProfilingSubEvents(
 
 Status QnnBackendManager::ExtractProfilingEvent(
     QnnProfile_EventId_t profile_event_id,
-    std::string eventLevel,
+    const std::string& eventLevel,
     std::ofstream& outfile,
     bool useExtendedEventData) {
   if (useExtendedEventData) {
@@ -909,7 +909,7 @@ Status QnnBackendManager::ExtractProfilingEvent(
 
 Status QnnBackendManager::ExtractProfilingEventBasic(
     QnnProfile_EventId_t profile_event_id,
-    std::string eventLevel,
+    const std::string& eventLevel,
     std::ofstream& outfile) {
   QnnProfile_EventData_t event_data;
   auto result = qnn_interface_.profileGetEventData(profile_event_id, &event_data);
@@ -934,7 +934,7 @@ Status QnnBackendManager::ExtractProfilingEventBasic(
 
 Status QnnBackendManager::ExtractProfilingEventExtended(
     QnnProfile_EventId_t profile_event_id,
-    std::string eventLevel,
+    const std::string& eventLevel,
     std::ofstream& outfile) {
   QnnProfile_ExtendedEventData_t event_data_extended;
   auto resultGetExtendedEventData = qnn_interface_.profileGetExtendedEventData(profile_event_id, &event_data_extended);
@@ -958,27 +958,29 @@ Status QnnBackendManager::ExtractProfilingEventExtended(
   return Status::OK();
 }
 
-std::string QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType) {
-  // Interpret the unit of measurement using the macros
-  switch (unitType) {
-    case QNN_PROFILE_EVENTUNIT_MICROSEC:
-      return "US";
-    case QNN_PROFILE_EVENTUNIT_BYTES:
-      return "BYTES";
-    case QNN_PROFILE_EVENTUNIT_CYCLES:
-      return "CYCLES";
-    case QNN_PROFILE_EVENTUNIT_COUNT:
-      return "COUNT";
-    case QNN_PROFILE_EVENTUNIT_OBJECT:
-      return "OBJECT";
-    case QNN_PROFILE_EVENTUNIT_BACKEND:
-      return "BACKEND";
-    default:
-      return "UNKNOWN";
-  }
+const std::string& QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType) {
+    const auto& unitStringMap = GetUnitStringMap();
+    auto it = unitStringMap.find(unitType);
+    if (it != unitStringMap.end()) {
+        return it->second;
+    }
+    static const std::string unknown = "UNKNOWN";
+    return unknown;
 }
 
-std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType) {
+const std::unordered_map<QnnProfile_EventUnit_t, std::string>& QnnBackendManager::GetUnitStringMap() {
+    static const std::unordered_map<QnnProfile_EventUnit_t, std::string> unitStringMap = {
+        {QNN_PROFILE_EVENTUNIT_MICROSEC, "US"},
+        {QNN_PROFILE_EVENTUNIT_BYTES, "BYTES"},
+        {QNN_PROFILE_EVENTUNIT_CYCLES, "CYCLES"},
+        {QNN_PROFILE_EVENTUNIT_COUNT, "COUNT"},
+        {QNN_PROFILE_EVENTUNIT_OBJECT, "OBJECT"},
+        {QNN_PROFILE_EVENTUNIT_BACKEND, "BACKEND"}
+    };
+    return unitStringMap;
+}
+
+const std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType) {
   // Interpret the event type
   switch (eventType) {
     case QNN_PROFILE_EVENTTYPE_INIT:
@@ -1030,7 +1032,7 @@ const char* QnnBackendManager::QnnProfileErrorToString(QnnProfile_Error_t error)
   }
 }
 
-std::string QnnBackendManager::ExtractQnnScalarValue(const Qnn_Scalar_t& scalar) {
+const std::string QnnBackendManager::ExtractQnnScalarValue(const Qnn_Scalar_t& scalar) {
   switch (scalar.dataType) {
     case QNN_DATATYPE_INT_8:
       return std::to_string(static_cast<int>(scalar.int8Value));

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -829,6 +829,7 @@ Status QnnBackendManager::ExtractBackendProfilingInfo() {
   auto result = qnn_interface_.profileGetEvents(profile_backend_handle_, &profile_events, &num_events);
   ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != result, "Failed to get profile events.");
 
+
   if (num_events > 0) {
     LOGS(*logger_, VERBOSE) << "profile_events: " << profile_events << " num_events: " << num_events;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -829,7 +829,6 @@ Status QnnBackendManager::ExtractBackendProfilingInfo() {
   auto result = qnn_interface_.profileGetEvents(profile_backend_handle_, &profile_events, &num_events);
   ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != result, "Failed to get profile events.");
 
-
   if (num_events > 0) {
     LOGS(*logger_, VERBOSE) << "profile_events: " << profile_events << " num_events: " << num_events;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -4,7 +4,6 @@
 #include "qnn_backend_manager.h"
 #include "qnn_model.h"
 #include <filesystem>
-#include <iostream>
 #include <fstream>
 #include <string>
 #include "QnnOpDef.h"
@@ -1023,22 +1022,17 @@ std::string QnnBackendManager::ExtractQnnScalarValue(const Qnn_Scalar_t& scalar)
         case QNN_DATATYPE_UINT_64:
             return std::to_string(scalar.uint64Value);
         case QNN_DATATYPE_FLOAT_16:
-            // Assuming Qnn_Scalar_t uses float for FLOAT_16, though this is not standard.
             return std::to_string(scalar.floatValue);
         case QNN_DATATYPE_FLOAT_32:
             return std::to_string(scalar.floatValue);
         case QNN_DATATYPE_SFIXED_POINT_8:
         case QNN_DATATYPE_SFIXED_POINT_16:
         case QNN_DATATYPE_SFIXED_POINT_32:
-            // Assuming Qnn_Scalar_t uses int types for signed fixed points.
-            // You might need to adjust this based on how fixed point values should be displayed.
-            return std::to_string(scalar.int32Value); // Adjust as needed
+            return std::to_string(scalar.int32Value); // Assume using int types for signed fixed points.
         case QNN_DATATYPE_UFIXED_POINT_8:
         case QNN_DATATYPE_UFIXED_POINT_16:
         case QNN_DATATYPE_UFIXED_POINT_32:
-            // Assuming Qnn_Scalar_t uses unsigned int types for unsigned fixed points.
-            // You might need to adjust this based on how fixed point values should be displayed.
-            return std::to_string(scalar.uint32Value); // Adjust as needed
+            return std::to_string(scalar.uint32Value); // Assume using unsigned int types for unsigned fixed points.
         case QNN_DATATYPE_BOOL_8:
             return scalar.bool8Value ? "true" : "false";
         case QNN_DATATYPE_STRING:

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -829,7 +829,6 @@ Status QnnBackendManager::ExtractBackendProfilingInfo() {
   auto result = qnn_interface_.profileGetEvents(profile_backend_handle_, &profile_events, &num_events);
   ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != result, "Failed to get profile events.");
 
-
   if (num_events > 0) {
     LOGS(*logger_, VERBOSE) << "profile_events: " << profile_events << " num_events: " << num_events;
 
@@ -837,10 +836,10 @@ Status QnnBackendManager::ExtractBackendProfilingInfo() {
     Qnn_ErrorHandle_t resultPropertyHasCapability = qnn_interface_.propertyHasCapability(QNN_PROPERTY_PROFILE_SUPPORTS_EXTENDED_EVENT);
     uint16_t errorCodePropertyHasCapability = static_cast<uint16_t>(resultPropertyHasCapability & 0xFFFF);
     if (errorCodePropertyHasCapability == QNN_PROFILE_NO_ERROR) {
-        LOGS(*logger_, VERBOSE) << "The QNN backend supports extended event data.";
-        backendSupportsExtendedEventData = true;
+      LOGS(*logger_, VERBOSE) << "The QNN backend supports extended event data.";
+      backendSupportsExtendedEventData = true;
     } else {
-        LOGS(*logger_, VERBOSE) << "The QNN backend does not support extended event data.";
+      LOGS(*logger_, VERBOSE) << "The QNN backend does not support extended event data.";
     }
 
     // Write to CSV
@@ -883,8 +882,7 @@ Status QnnBackendManager::ExtractProfilingSubEvents(QnnProfile_EventId_t profile
 Status QnnBackendManager::ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile, bool backendSupportsExtendedEventData) {
   if (backendSupportsExtendedEventData) {
     return ExtractProfilingEventExtended(profile_event_id, eventLevel, outfile);
-  }
-  else {
+  } else {
     return ExtractProfilingEventBasic(profile_event_id, eventLevel, outfile);
   }
 }
@@ -898,11 +896,13 @@ Status QnnBackendManager::ExtractProfilingEventBasic(QnnProfile_EventId_t profil
   std::string message = GetEventTypeString(event_data.type);
   std::string unit = GetUnitString(event_data.unit);
 
-  outfile << "UNKNOWN" << ","
+  outfile << "UNKNOWN"
+          << ","
           << message << ","
           << event_data.value << ","
           << unit << ","
-          << "BACKEND" << ","
+          << "BACKEND"
+          << ","
           << eventLevel << ","
           << (event_data.identifier ? event_data.identifier : "NULL") << "\n";
 
@@ -910,136 +910,137 @@ Status QnnBackendManager::ExtractProfilingEventBasic(QnnProfile_EventId_t profil
 }
 
 Status QnnBackendManager::ExtractProfilingEventExtended(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile) {
-    QnnProfile_ExtendedEventData_t event_data_extended;
-    auto resultGetExtendedEventData = qnn_interface_.profileGetExtendedEventData(profile_event_id, &event_data_extended);
-    QnnProfile_Error_t errorCode = static_cast<QnnProfile_Error_t>(resultGetExtendedEventData & 0xFFFF);
-    ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != errorCode, "Failed to get profile event data: " + std::string(QnnProfileErrorToString(errorCode)));
+  QnnProfile_ExtendedEventData_t event_data_extended;
+  auto resultGetExtendedEventData = qnn_interface_.profileGetExtendedEventData(profile_event_id, &event_data_extended);
+  QnnProfile_Error_t errorCode = static_cast<QnnProfile_Error_t>(resultGetExtendedEventData & 0xFFFF);
+  ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != errorCode, "Failed to get profile event data: " + std::string(QnnProfileErrorToString(errorCode)));
 
-    std::string message = GetEventTypeString(event_data_extended.v1.type);
-    std::string unit = GetUnitString(event_data_extended.v1.unit);
+  std::string message = GetEventTypeString(event_data_extended.v1.type);
+  std::string unit = GetUnitString(event_data_extended.v1.unit);
 
-    if (event_data_extended.version == QNN_PROFILE_DATA_VERSION_1) {
-        outfile << event_data_extended.v1.timestamp << ","
-               << message << ","
-               << ExtractQnnScalarValue(event_data_extended.v1.value) << ","
-               << unit << ","
-               << "BACKEND" << ","
-               << eventLevel << ","
-               << (event_data_extended.v1.identifier ? event_data_extended.v1.identifier : "NULL") << "\n";
-    }
+  if (event_data_extended.version == QNN_PROFILE_DATA_VERSION_1) {
+    outfile << event_data_extended.v1.timestamp << ","
+            << message << ","
+            << ExtractQnnScalarValue(event_data_extended.v1.value) << ","
+            << unit << ","
+            << "BACKEND"
+            << ","
+            << eventLevel << ","
+            << (event_data_extended.v1.identifier ? event_data_extended.v1.identifier : "NULL") << "\n";
+  }
 
-    return Status::OK();
+  return Status::OK();
 }
 
 std::string QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType) {
-    // Interpret the unit of measurement using the macros
-    switch (unitType) {
-        case QNN_PROFILE_EVENTUNIT_MICROSEC:
-            return "US";
-        case QNN_PROFILE_EVENTUNIT_BYTES:
-            return "BYTES";
-        case QNN_PROFILE_EVENTUNIT_CYCLES:
-            return "CYCLES";
-        case QNN_PROFILE_EVENTUNIT_COUNT:
-            return "COUNT";
-        case QNN_PROFILE_EVENTUNIT_OBJECT:
-            return "OBJECT";
-        case QNN_PROFILE_EVENTUNIT_BACKEND:
-            return "BACKEND";
-        default:
-            return "UNKNOWN";
-    }
+  // Interpret the unit of measurement using the macros
+  switch (unitType) {
+    case QNN_PROFILE_EVENTUNIT_MICROSEC:
+      return "US";
+    case QNN_PROFILE_EVENTUNIT_BYTES:
+      return "BYTES";
+    case QNN_PROFILE_EVENTUNIT_CYCLES:
+      return "CYCLES";
+    case QNN_PROFILE_EVENTUNIT_COUNT:
+      return "COUNT";
+    case QNN_PROFILE_EVENTUNIT_OBJECT:
+      return "OBJECT";
+    case QNN_PROFILE_EVENTUNIT_BACKEND:
+      return "BACKEND";
+    default:
+      return "UNKNOWN";
+  }
 }
 
 std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType) {
-    // Interpret the event type
-    switch (eventType) {
-        case QNN_PROFILE_EVENTTYPE_INIT:
-            return "INIT";
-        case QNN_PROFILE_EVENTTYPE_FINALIZE:
-            return "FINALIZE";
-        case QNN_PROFILE_EVENTTYPE_EXECUTE:
-            return "EXECUTE";
-        case QNN_PROFILE_EVENTTYPE_NODE:
-            return "NODE";
-        case QNN_PROFILE_EVENTTYPE_EXECUTE_QUEUE_WAIT:
-            return "EXECUTE QUEUE WAIT";
-        case QNN_PROFILE_EVENTTYPE_EXECUTE_PREPROCESS:
-            return "EXECUTE PREPROCESS";
-        case QNN_PROFILE_EVENTTYPE_EXECUTE_DEVICE:
-            return "EXECUTE DEVICE";
-        case QNN_PROFILE_EVENTTYPE_EXECUTE_POSTPROCESS:
-            return "EXECUTE POSTPROCESS";
-        case QNN_PROFILE_EVENTTYPE_DEINIT:
-            return "DE-INIT";
-        case QNN_PROFILE_EVENTTYPE_BACKEND:
-            return "BACKEND";
-        default:
-            if (eventType > QNN_PROFILE_EVENTTYPE_BACKEND) {
-                return "BACKEND";
-            }
-            return "UNKNOWN";
-    }
+  // Interpret the event type
+  switch (eventType) {
+    case QNN_PROFILE_EVENTTYPE_INIT:
+      return "INIT";
+    case QNN_PROFILE_EVENTTYPE_FINALIZE:
+      return "FINALIZE";
+    case QNN_PROFILE_EVENTTYPE_EXECUTE:
+      return "EXECUTE";
+    case QNN_PROFILE_EVENTTYPE_NODE:
+      return "NODE";
+    case QNN_PROFILE_EVENTTYPE_EXECUTE_QUEUE_WAIT:
+      return "EXECUTE QUEUE WAIT";
+    case QNN_PROFILE_EVENTTYPE_EXECUTE_PREPROCESS:
+      return "EXECUTE PREPROCESS";
+    case QNN_PROFILE_EVENTTYPE_EXECUTE_DEVICE:
+      return "EXECUTE DEVICE";
+    case QNN_PROFILE_EVENTTYPE_EXECUTE_POSTPROCESS:
+      return "EXECUTE POSTPROCESS";
+    case QNN_PROFILE_EVENTTYPE_DEINIT:
+      return "DE-INIT";
+    case QNN_PROFILE_EVENTTYPE_BACKEND:
+      return "BACKEND";
+    default:
+      if (eventType > QNN_PROFILE_EVENTTYPE_BACKEND) {
+        return "BACKEND";
+      }
+      return "UNKNOWN";
+  }
 }
 
 const char* QnnBackendManager::QnnProfileErrorToString(QnnProfile_Error_t error) {
-    switch (error) {
-        case QNN_PROFILE_NO_ERROR:
-            return "QNN_PROFILE_NO_ERROR";
-        case QNN_PROFILE_ERROR_UNSUPPORTED:
-            return "QNN_PROFILE_ERROR_UNSUPPORTED";
-        case QNN_PROFILE_ERROR_INVALID_ARGUMENT:
-            return "QNN_PROFILE_ERROR_INVALID_ARGUMENT";
-        case QNN_PROFILE_ERROR_MEM_ALLOC:
-            return "QNN_PROFILE_ERROR_MEM_ALLOC";
-        case QNN_PROFILE_ERROR_INVALID_HANDLE:
-            return "QNN_PROFILE_ERROR_INVALID_HANDLE";
-        case QNN_PROFILE_ERROR_HANDLE_IN_USE:
-            return "QNN_PROFILE_ERROR_HANDLE_IN_USE";
-        case QNN_PROFILE_ERROR_INCOMPATIBLE_EVENT:
-            return "QNN_PROFILE_ERROR_INCOMPATIBLE_EVENT";
-        default:
-            return "UNKNOWN_ERROR";
-    }
+  switch (error) {
+    case QNN_PROFILE_NO_ERROR:
+      return "QNN_PROFILE_NO_ERROR";
+    case QNN_PROFILE_ERROR_UNSUPPORTED:
+      return "QNN_PROFILE_ERROR_UNSUPPORTED";
+    case QNN_PROFILE_ERROR_INVALID_ARGUMENT:
+      return "QNN_PROFILE_ERROR_INVALID_ARGUMENT";
+    case QNN_PROFILE_ERROR_MEM_ALLOC:
+      return "QNN_PROFILE_ERROR_MEM_ALLOC";
+    case QNN_PROFILE_ERROR_INVALID_HANDLE:
+      return "QNN_PROFILE_ERROR_INVALID_HANDLE";
+    case QNN_PROFILE_ERROR_HANDLE_IN_USE:
+      return "QNN_PROFILE_ERROR_HANDLE_IN_USE";
+    case QNN_PROFILE_ERROR_INCOMPATIBLE_EVENT:
+      return "QNN_PROFILE_ERROR_INCOMPATIBLE_EVENT";
+    default:
+      return "UNKNOWN_ERROR";
+  }
 }
 
 std::string QnnBackendManager::ExtractQnnScalarValue(const Qnn_Scalar_t& scalar) {
-    switch (scalar.dataType) {
-        case QNN_DATATYPE_INT_8:
-            return std::to_string(static_cast<int>(scalar.int8Value));
-        case QNN_DATATYPE_INT_16:
-            return std::to_string(scalar.int16Value);
-        case QNN_DATATYPE_INT_32:
-            return std::to_string(scalar.int32Value);
-        case QNN_DATATYPE_INT_64:
-            return std::to_string(scalar.int64Value);
-        case QNN_DATATYPE_UINT_8:
-            return std::to_string(static_cast<unsigned int>(scalar.uint8Value));
-        case QNN_DATATYPE_UINT_16:
-            return std::to_string(scalar.uint16Value);
-        case QNN_DATATYPE_UINT_32:
-            return std::to_string(scalar.uint32Value);
-        case QNN_DATATYPE_UINT_64:
-            return std::to_string(scalar.uint64Value);
-        case QNN_DATATYPE_FLOAT_16:
-            return std::to_string(scalar.floatValue);
-        case QNN_DATATYPE_FLOAT_32:
-            return std::to_string(scalar.floatValue);
-        case QNN_DATATYPE_SFIXED_POINT_8:
-        case QNN_DATATYPE_SFIXED_POINT_16:
-        case QNN_DATATYPE_SFIXED_POINT_32:
-            return std::to_string(scalar.int32Value); // Assume using int types for signed fixed points.
-        case QNN_DATATYPE_UFIXED_POINT_8:
-        case QNN_DATATYPE_UFIXED_POINT_16:
-        case QNN_DATATYPE_UFIXED_POINT_32:
-            return std::to_string(scalar.uint32Value); // Assume using unsigned int types for unsigned fixed points.
-        case QNN_DATATYPE_BOOL_8:
-            return scalar.bool8Value ? "true" : "false";
-        case QNN_DATATYPE_STRING:
-            return scalar.stringValue ? scalar.stringValue : "NULL";
-        default:
-            return "UNKNOWN";
-    }
+  switch (scalar.dataType) {
+    case QNN_DATATYPE_INT_8:
+      return std::to_string(static_cast<int>(scalar.int8Value));
+    case QNN_DATATYPE_INT_16:
+      return std::to_string(scalar.int16Value);
+    case QNN_DATATYPE_INT_32:
+      return std::to_string(scalar.int32Value);
+    case QNN_DATATYPE_INT_64:
+      return std::to_string(scalar.int64Value);
+    case QNN_DATATYPE_UINT_8:
+      return std::to_string(static_cast<unsigned int>(scalar.uint8Value));
+    case QNN_DATATYPE_UINT_16:
+      return std::to_string(scalar.uint16Value);
+    case QNN_DATATYPE_UINT_32:
+      return std::to_string(scalar.uint32Value);
+    case QNN_DATATYPE_UINT_64:
+      return std::to_string(scalar.uint64Value);
+    case QNN_DATATYPE_FLOAT_16:
+      return std::to_string(scalar.floatValue);
+    case QNN_DATATYPE_FLOAT_32:
+      return std::to_string(scalar.floatValue);
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+      return std::to_string(scalar.int32Value);  // Assume using int types for signed fixed points.
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      return std::to_string(scalar.uint32Value);  // Assume using unsigned int types for unsigned fixed points.
+    case QNN_DATATYPE_BOOL_8:
+      return scalar.bool8Value ? "true" : "false";
+    case QNN_DATATYPE_STRING:
+      return scalar.stringValue ? scalar.stringValue : "NULL";
+    default:
+      return "UNKNOWN";
+  }
 }
 
 QnnBackendManager::~QnnBackendManager() {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -914,9 +914,6 @@ Status QnnBackendManager::ExtractProfilingEventExtended(QnnProfile_EventId_t pro
     QnnProfile_ExtendedEventData_t event_data_extended;
     auto resultGetExtendedEventData = qnn_interface_.profileGetExtendedEventData(profile_event_id, &event_data_extended);
     QnnProfile_Error_t errorCode = static_cast<QnnProfile_Error_t>(resultGetExtendedEventData & 0xFFFF);
-    if (QNN_PROFILE_NO_ERROR != errorCode) {
-      outfile << "Failed to get profile event data: " + std::string(QnnProfileErrorToString(errorCode));
-    }
     ORT_RETURN_IF(QNN_PROFILE_NO_ERROR != errorCode, "Failed to get profile event data: " + std::string(QnnProfileErrorToString(errorCode)));
 
     std::string message = GetEventTypeString(event_data_extended.v1.type);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -118,8 +118,8 @@ class QnnBackendManager {
   void Split(std::vector<std::string>& split_string, const std::string& tokenized_string, const char separator);
 
   Status ExtractBackendProfilingInfo();
-  Status ExtractProfilingSubEvents(QnnProfile_EventId_t profile_event_id);
-  Status ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id);
+  Status ExtractProfilingSubEvents(QnnProfile_EventId_t profile_event_id, std::ofstream& outfile, bool backendSupportsExtendedEventData);
+  Status ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile, bool backendSupportsExtendedEventData);
 
   void SetQnnBackendType(uint32_t backend_id);
   QnnBackendType GetQnnBackendType() { return qnn_backend_type_; }
@@ -175,6 +175,13 @@ class QnnBackendManager {
     }
     return (backend_build_id == nullptr ? std::string("") : std::string(backend_build_id));
   }
+
+  Status ExtractProfilingEventBasic(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
+  Status ExtractProfilingEventExtended(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
+  std::string QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType);
+  std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType);
+  std::string ExtractQnnScalarValue(const Qnn_Scalar_t& scalar);
+  const char* QnnBackendManager::QnnProfileErrorToString(QnnProfile_Error_t error);
 
  private:
   const std::string backend_path_;

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -178,10 +178,10 @@ class QnnBackendManager {
 
   Status ExtractProfilingEventBasic(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
   Status ExtractProfilingEventExtended(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
-  std::string QnnBackendManager::GetUnitString(QnnProfile_EventUnit_t unitType);
-  std::string QnnBackendManager::GetEventTypeString(QnnProfile_EventType_t eventType);
+  std::string GetUnitString(QnnProfile_EventUnit_t unitType);
+  std::string GetEventTypeString(QnnProfile_EventType_t eventType);
   std::string ExtractQnnScalarValue(const Qnn_Scalar_t& scalar);
-  const char* QnnBackendManager::QnnProfileErrorToString(QnnProfile_Error_t error);
+  const char* QnnProfileErrorToString(QnnProfile_Error_t error);
 
  private:
   const std::string backend_path_;

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -119,7 +119,7 @@ class QnnBackendManager {
 
   Status ExtractBackendProfilingInfo();
   Status ExtractProfilingSubEvents(QnnProfile_EventId_t profile_event_id, std::ofstream& outfile, bool backendSupportsExtendedEventData);
-  Status ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile, bool backendSupportsExtendedEventData);
+  Status ExtractProfilingEvent(QnnProfile_EventId_t profile_event_id, const std::string& eventLevel, std::ofstream& outfile, bool backendSupportsExtendedEventData);
 
   void SetQnnBackendType(uint32_t backend_id);
   QnnBackendType GetQnnBackendType() { return qnn_backend_type_; }
@@ -176,11 +176,12 @@ class QnnBackendManager {
     return (backend_build_id == nullptr ? std::string("") : std::string(backend_build_id));
   }
 
-  Status ExtractProfilingEventBasic(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
-  Status ExtractProfilingEventExtended(QnnProfile_EventId_t profile_event_id, std::string eventLevel, std::ofstream& outfile);
-  std::string GetUnitString(QnnProfile_EventUnit_t unitType);
-  std::string GetEventTypeString(QnnProfile_EventType_t eventType);
-  std::string ExtractQnnScalarValue(const Qnn_Scalar_t& scalar);
+  Status ExtractProfilingEventBasic(QnnProfile_EventId_t profile_event_id, const std::string& eventLevel, std::ofstream& outfile);
+  Status ExtractProfilingEventExtended(QnnProfile_EventId_t profile_event_id, const std::string& eventLevel, std::ofstream& outfile);
+  static const std::string& GetUnitString(QnnProfile_EventUnit_t unitType);
+  static const std::unordered_map<QnnProfile_EventUnit_t, std::string>& GetUnitStringMap();
+  static const std::string GetEventTypeString(QnnProfile_EventType_t eventType);
+  static const std::string ExtractQnnScalarValue(const Qnn_Scalar_t& scalar);
   const char* QnnProfileErrorToString(QnnProfile_Error_t error);
 
  private:


### PR DESCRIPTION
### Description
Change QNN EP Profiling logs to output to CSV. Output is in a similar format to QNN SDK Tools (instead of to ORT logs)
https://onnxruntime.ai/docs/execution-providers/QNN-ExecutionProvider.html#configuration-options (profiling_level)

### Motivation and Context
It is hard to read and interpret QNN profiling logs in the ORT logs.




