### PR TITLE
Update protobuf python package's version

### DIFF
--- a/tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/inference/x64/python/cpu/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-git+http://github.com/onnx/onnx.git@b86cc54efce19530fb953e4b21f57e6b3888534c#egg=onnx
-protobuf==3.20.2
+onnx==1.15.0
+protobuf==4.21.12
 sympy==1.12
 flatbuffers

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -4,8 +4,8 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-git+http://github.com/onnx/onnx.git@b86cc54efce19530fb953e4b21f57e6b3888534c#egg=onnx
-protobuf==3.20.2
+onnx==1.15.0
+protobuf==4.21.12
 sympy==1.12
 flatbuffers
 neural-compressor>=2.2.1

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -5,9 +5,9 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel>=0.35.1
-git+http://github.com/onnx/onnx.git@b86cc54efce19530fb953e4b21f57e6b3888534c#egg=onnx
+onnx==1.15.0
 argparse
 sympy==1.12
 flatbuffers
-protobuf==3.20.2
+protobuf==4.21.12
 packaging

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.21.6 ; python_version < '3.11'
 numpy==1.24.2 ; python_version >= '3.11'
 transformers==v4.16.1
 rsa==4.9
-tensorboard>=2.2.0,<2.5.0
+tensorboard==2.13.0
 h5py
 wget
 pytorch-lightning


### PR DESCRIPTION
1. Now we use a released version of ONNX, so we can directly download a prebuilt package from pypi.org. We do not need to build one from source. 
2. Update protobuf python package's version to match the C/C++ version we are using. 
3. Update tensorboard python python because the current one is incompatible with the newer protobuf version.