### PR TITLE
Do not run AOT function inlining when the model does not define any local functions

### DIFF
--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -799,6 +799,15 @@ static Status PartitionOrtFormatModel(const PartitionParams& partition_params,
 Status GraphPartitioner::InlineFunctionsAOT(Model& model,
                                             const ExecutionProviders& execution_providers,
                                             const KernelRegistryManager& kernel_registry_manager) const {
+
+  // To enhance compatibility with some EPs we choose not to inline anything
+  // including schema based functions when the model does not have any local functions defined.
+  const bool is_there_local_functions = !model.GetModelLocalFunctionTemplates().empty();
+
+  if (!is_there_local_functions) {
+    return Status::OK();
+  }
+
   auto& graph = model.MainGraph();
   InlinedHashSet<std::string> not_inlined;
   do {

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -800,7 +800,7 @@ Status GraphPartitioner::InlineFunctionsAOT(Model& model,
                                             const ExecutionProviders& execution_providers,
                                             const KernelRegistryManager& kernel_registry_manager,
                                             const logging::Logger& logger) const {
-  // To enhance compatibility with some EPs we choose not to inline anything
+  // To enhance compatibility with models exported via torchscript we choose to not inline model local functions. Schema based functions get inlined as before during partitioning.
   // including schema based functions when the model does not have any local functions defined.
   const bool is_there_local_functions = !model.GetModelLocalFunctionTemplates().empty();
 

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -800,9 +800,8 @@ Status GraphPartitioner::InlineFunctionsAOT(Model& model,
                                             const ExecutionProviders& execution_providers,
                                             const KernelRegistryManager& kernel_registry_manager,
                                             const logging::Logger& logger) const {
-  // To enhance compatibility with models exported via torchscript we choose to not inline model local functions. Schema based functions get inlined as before during partitioning.
-  // including schema based functions when the model does not have any local functions defined.
-  const bool is_there_local_functions = !model.GetModelLocalFunctionTemplates().empty();
+  const auto local_functions_num = model.GetModelLocalFunctionTemplates().size();
+  const bool is_there_local_functions = local_functions_num > 0;
 
   if (!is_there_local_functions) {
     LOGS(logger, INFO) << "This model does not have any local functions defined. AOT Inlining is not performed";
@@ -828,7 +827,11 @@ Status GraphPartitioner::InlineFunctionsAOT(Model& model,
 
   model.RemoveLocalFunctionsProtos(not_inlined);
 
-  LOGS(logger, INFO) << "AOT inlining completed. Inlined local function definitions have been pruned.";
+  LOGS(logger, INFO)
+      << "AOT inlining completed. (" << (local_functions_num - model.GetModelLocalFunctionTemplates().size())
+      << ") functions of ("
+      << local_functions_num
+      << ") pruned.";
 
   return Status::OK();
 }

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -798,12 +798,14 @@ static Status PartitionOrtFormatModel(const PartitionParams& partition_params,
 
 Status GraphPartitioner::InlineFunctionsAOT(Model& model,
                                             const ExecutionProviders& execution_providers,
-                                            const KernelRegistryManager& kernel_registry_manager) const {
+                                            const KernelRegistryManager& kernel_registry_manager,
+                                            const logging::Logger& logger) const {
   // To enhance compatibility with some EPs we choose not to inline anything
   // including schema based functions when the model does not have any local functions defined.
   const bool is_there_local_functions = !model.GetModelLocalFunctionTemplates().empty();
 
   if (!is_there_local_functions) {
+    LOGS(logger, INFO) << "This model does not have any local functions defined. AOT Inlining is not performed";
     return Status::OK();
   }
 
@@ -825,6 +827,8 @@ Status GraphPartitioner::InlineFunctionsAOT(Model& model,
   } while (true);
 
   model.RemoveLocalFunctionsProtos(not_inlined);
+
+  LOGS(logger, INFO) << "AOT inlining completed. Inlined local function definitions have been pruned.";
 
   return Status::OK();
 }

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -799,7 +799,6 @@ static Status PartitionOrtFormatModel(const PartitionParams& partition_params,
 Status GraphPartitioner::InlineFunctionsAOT(Model& model,
                                             const ExecutionProviders& execution_providers,
                                             const KernelRegistryManager& kernel_registry_manager) const {
-
   // To enhance compatibility with some EPs we choose not to inline anything
   // including schema based functions when the model does not have any local functions defined.
   const bool is_there_local_functions = !model.GetModelLocalFunctionTemplates().empty();

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -48,10 +48,12 @@ class GraphPartitioner {
   /// <param name="model">model instance</param>
   /// <param name="execution_providers">execution providers considered</param>
   /// <param name="kernel_registry_manager">registry manager</param>
+  /// <param name="logger">session logger</param>
   /// <returns></returns>
   Status InlineFunctionsAOT(Model& model,
                             const ExecutionProviders& execution_providers,
-                            const KernelRegistryManager& kernel_registry_manager) const;
+                            const KernelRegistryManager& kernel_registry_manager,
+                            const logging::Logger& logger) const;
 #endif
 
  private:

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1029,7 +1029,9 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
               kOrtSessionOptionsDisableAheadOfTimeFunctionInlining, "0") == "1";
       !disable_aot_function_inlining) {
     ORT_RETURN_IF_ERROR_SESSIONID_(partitioner.InlineFunctionsAOT(*model_,
-                                                                  execution_providers_, kernel_registry_manager_));
+                                                                  execution_providers_,
+                                                                  kernel_registry_manager_,
+                                                                  *session_logger_));
   }
 
   auto apply_transformer_once = [](const GraphTransformer& transformer, const logging::Logger& logger,


### PR DESCRIPTION
### Description
Check if the model defines any local functions.
if not, skip AOT inlining including any schema based functions.
The latter would be inlined during partitioning.

### Motivation and Context
This prevents calls GetCapability() to EPs and enhahces  compatibility.
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


