### PR TITLE
[js] fix linter out-of-memory issue

### DIFF
--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   root: true,
-  ignorePatterns: ['**/*.js', 'ort-schema/', 'common/test/type-tests/', 'node_modules/', 'types/', 'dist/'],
+  ignorePatterns: ['**/*.js', 'ort-schema/', 'common/test/type-tests/', 'test/data/', 'node_modules/', 'dist/'],
   env: { 'es6': true },
   parser: '@typescript-eslint/parser',
   parserOptions: { 'project': 'tsconfig.json', 'sourceType': 'module' },


### PR DESCRIPTION
### Description
fix linter out-of-memory issue by ignoring file pattern 'test/data/'.