### PR TITLE
[Rust] fix ORT_RUST_STRATEGY env var in rust ci

### DIFF
--- a/.github/actions/rust-toolchain-setup/action.yml
+++ b/.github/actions/rust-toolchain-setup/action.yml
@@ -20,8 +20,7 @@ runs:
       # We need to use the nightly rust tool change to enable registry-auth / to connect to ADO feeds.
       if: ${{ (runner.os == 'Linux') }}
       run: |
-        rustup set profile minimal
-        rustup install
+        rustup toolchain install stable --profile minimal
       shell: bash
     # - name: Cargo login
     #   if: ${{ (runner.os == 'Linux') }}
@@ -35,8 +34,7 @@ runs:
       # We need to use the nightly rust tool change to enable registry-auth / to connect to ADO feeds.
       if: ${{ (runner.os == 'Windows') }}
       run: |
-        rustup set profile minimal
-        rustup install
+        rustup toolchain install stable --profile minimal
       shell: pwsh
     # - name: Cargo login
     #   if: ${{ (runner.os == 'Windows') }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -24,55 +24,6 @@ jobs:
       - name: fmt
         run: cargo fmt --all -- --check
 
-  download:
-    name: Download prebuilt ONNX Runtime archive from build.rs
-    runs-on: ubuntu-latest
-    env:
-      ORT_RUST_STRATEGY: download
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/rust-toolchain-setup
-      - name: vendor onnxruntime source
-        run: just vendor
-      - run: rustup target install x86_64-unknown-linux-gnu
-      - run: rustup target install x86_64-apple-darwin
-      - run: rustup target install i686-pc-windows-msvc
-      - run: rustup target install x86_64-pc-windows-msvc
-      # ******************************************************************
-      - name: Download prebuilt archive (CPU, x86_64-unknown-linux-gnu)
-        run: cargo build --target x86_64-unknown-linux-gnu  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (CPU, x86_64-unknown-linux-gnu)
-        run: ls -lh target/x86_64-unknown-linux-gnu/debug/build/onnxruntime-sys-*/out/onnxruntime-linux-x64-1.*.tgz
-      # ******************************************************************
-      - name: Download prebuilt archive (CPU, x86_64-apple-darwin)
-        run: cargo build --target x86_64-apple-darwin  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (CPU, x86_64-apple-darwin)
-        run: ls -lh target/x86_64-apple-darwin/debug/build/onnxruntime-sys-*/out/onnxruntime-osx-x64-1.*.tgz
-      # ******************************************************************
-      - name: Download prebuilt archive (CPU, i686-pc-windows-msvc)
-        run: cargo build --target i686-pc-windows-msvc  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (CPU, i686-pc-windows-msvc)
-        run: ls -lh target/i686-pc-windows-msvc/debug/build/onnxruntime-sys-*/out/onnxruntime-win-x86-1.*.zip
-      # ******************************************************************
-      - name: Download prebuilt archive (CPU, x86_64-pc-windows-msvc)
-        run: cargo build --target x86_64-pc-windows-msvc  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (CPU, x86_64-pc-windows-msvc)
-        run: ls -lh target/x86_64-pc-windows-msvc/debug/build/onnxruntime-sys-*/out/onnxruntime-win-x64-1.*.zip
-      # ******************************************************************
-      - name: Download prebuilt archive (GPU, x86_64-unknown-linux-gnu)
-        env:
-          ORT_USE_CUDA: "yes"
-        run: cargo build --target x86_64-unknown-linux-gnu  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (GPU, x86_64-unknown-linux-gnu)
-        run: ls -lh target/x86_64-unknown-linux-gnu/debug/build/onnxruntime-sys-*/out/onnxruntime-linux-x64-gpu-1.*.tgz
-      # ******************************************************************
-      - name: Download prebuilt archive (GPU, x86_64-pc-windows-msvc)
-        env:
-          ORT_USE_CUDA: "yes"
-        run: cargo build --target x86_64-pc-windows-msvc  --manifest-path ${{ env.MANIFEST_PATH }}
-      - name: Verify prebuilt archive downloaded (GPU, x86_64-pc-windows-msvc)
-        run: ls -lh target/x86_64-pc-windows-msvc/debug/build/onnxruntime-sys-*/out/onnxruntime-win-gpu-x64-1.*.zip
-
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,6 +2,10 @@ name: Rust
 
 on: [pull_request]
 
+defaults:
+ run:
+  working-directory: ./rust/
+
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: onnxruntime=debug,onnxruntime-sys=debug

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build onnxruntime with 'model-fetching' feature
         run: cargo build --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching
       - name: Test onnxruntime-sys
-        run: cargo build --package onnxruntime-sys -- --test-threads=1 --nocapture
+        run: cargo test --package onnxruntime-sys -- --test-threads=1 --nocapture
       - name: Test onnxruntime
         run: cargo test --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching -- --test-threads=1 --nocapture
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -58,15 +58,15 @@ jobs:
         if: contains(matrix.target, 'x86_64-apple-darwin')
         run: brew install libomp
       - name: Build (cargo build)
-        run: cargo build --all --manifest-path ${{ env.MANIFEST_PATH }}
+        run: cargo build --all --target ${{ matrix.target }} --manifest-path ${{ env.MANIFEST_PATH }}
       - name: Build tests (cargo test)
-        run: cargo test --no-run --manifest-path ${{ env.MANIFEST_PATH }}
+        run: cargo test --target ${{ matrix.target }} --no-run --manifest-path ${{ env.MANIFEST_PATH }}
       - name: Build onnxruntime with 'model-fetching' feature
-        run: cargo build --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching
+        run: cargo build --target ${{ matrix.target }} --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching
       - name: Test onnxruntime-sys
-        run: cargo test --package onnxruntime-sys -- --test-threads=1 --nocapture
+        run: cargo test --target ${{ matrix.target }} --package onnxruntime-sys -- --test-threads=1 --nocapture
       - name: Test onnxruntime
-        run: cargo test --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching -- --test-threads=1 --nocapture
+        run: cargo test --target ${{ matrix.target }} --manifest-path ${{ env.MANIFEST_PATH }} --features model-fetching -- --test-threads=1 --nocapture
 
   clippy:
     name: Clippy

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rust-toolchain-setup
+      - name: vendor onnxruntime source
+        run: just vendor
       - run: rustup target install x86_64-unknown-linux-gnu
       - run: rustup target install x86_64-apple-darwin
       - run: rustup target install i686-pc-windows-msvc
@@ -123,7 +125,7 @@ jobs:
       - uses: ./.github/actions/rust-toolchain-setup
       - name: vendor onnxruntime source
         run: just vendor
-      - run: clippy --all-features --manifest-path ${{ env.MANIFEST_PATH }} -- -D warnings
+      - run: cargo clippy --all-features --manifest-path ${{ env.MANIFEST_PATH }} -- -D warnings
 
   package-sys:
     name: Package onnxruntime-sys

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Download prebuilt ONNX Runtime archive from build.rs
     runs-on: ubuntu-latest
     env:
-      ORT_RUST_STRATEGY=download
+      ORT_RUST_STRATEGY: download
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rust-toolchain-setup

--- a/rust/onnxruntime-sys/.cargo.config
+++ b/rust/onnxruntime-sys/.cargo.config
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     println!("Lib directory: {:?}", lib_dir);
 
     // Tell cargo to tell rustc to link onnxruntime shared library.
-    println!("cargo:rustc-link-lib=onnxruntime");
+    println!("cargo:rustc-link-lib=dylib=onnxruntime");
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
     println!("cargo:rerun-if-env-changed={}", ORT_RUST_ENV_STRATEGY);

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -421,6 +421,9 @@ fn prepare_libort_dir_compiled() -> Result<PathBuf> {
     ));
 
     config.define("onnxruntime_BUILD_SHARED_LIB", "ON");
+    config.define("ONNX_USE_MSVC_STATIC_RUNTIME", "OFF");
+    config.define("protobuf_MSVC_STATIC_RUNTIME", "OFF");
+    config.define("gtest_force_shared_crt", "ON");
 
     if let Ok(Accelerator::Cuda) = env::var(ORT_RUST_ENV_GPU).unwrap_or_default().parse() {
         config.define("onnxruntime_USE_CUDA", "ON");

--- a/rust/onnxruntime/src/session.rs
+++ b/rust/onnxruntime/src/session.rs
@@ -231,7 +231,7 @@ impl<'a> SessionBuilder<'a> {
         assert_null_pointer(status, "SessionStatus")?;
         assert_not_null_pointer(allocator_ptr, "Allocator")?;
 
-        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default, &self.env)?;
+        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default, self.env)?;
         unsafe {
             // Extract input and output properties
             let num_input_nodes =
@@ -295,7 +295,7 @@ impl<'a> SessionBuilder<'a> {
         assert_null_pointer(status, "SessionStatus")?;
         assert_not_null_pointer(allocator_ptr, "Allocator")?;
 
-        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default, &self.env)?;
+        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default, self.env)?;
         unsafe {
             // Extract input and output properties
             let num_input_nodes =
@@ -444,7 +444,7 @@ impl Session {
             let arr = input_arrays.as_mut();
 
             let input_tensors = arr
-                .into_iter()
+                .iter_mut()
                 .map(|v| v.construct(memory_info, allocator))
                 .collect::<Result<Vec<_>>>()?;
 
@@ -513,10 +513,7 @@ impl Session {
             .collect();
         cstrings?;
 
-        outputs?
-            .into_iter()
-            .map(|v| OrtOutput::try_from(v))
-            .collect()
+        outputs?.into_iter().map(OrtOutput::try_from).collect()
     }
 
     fn validate_input_shapes(&self, input_array_shapes: &[Vec<usize>]) -> Result<()> {
@@ -618,7 +615,7 @@ unsafe fn get_tensor_dimensions(
         .then_some(())
         .ok_or(OrtError::InvalidDimensions)?;
 
-    let mut node_dims: Vec<i64> = vec![0; num_dims as usize];
+    let mut node_dims: Vec<i64> = vec![0; num_dims];
     let status = env.env().api().GetDimensions.unwrap()(
         tensor_info_ptr,
         node_dims.as_mut_ptr(), // FIXME: UB?

--- a/rust/onnxruntime/src/tensor/ort_input_tensor.rs
+++ b/rust/onnxruntime/src/tensor/ort_input_tensor.rs
@@ -46,6 +46,7 @@ where
     T: TypeToTensorElementDataType + Debug,
     D: Dimension,
 {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn construct<'a>(
         &'a mut self,
         memory_info: &MemoryInfo,


### PR DESCRIPTION
### Description
Fix the env var in the Rust CI GitHub Action



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

In #18346 the GH action contained a badly formatted env var. This is a follow up PR to fix that issue.
