### PR TITLE
Align context virtuals

### DIFF
--- a/include/onnxruntime/core/providers/rocm/rocm_context.h
+++ b/include/onnxruntime/core/providers/rocm/rocm_context.h
@@ -18,7 +18,7 @@ struct RocmContext : public CustomOpContext {
   miopenHandle_t miopen_handle = {};
   rocblas_handle rblas_handle = {};
 
-  void Init(const OrtKernelContext& kernel_ctx) override {
+  void Init(const OrtKernelContext& kernel_ctx) {
     const auto& ort_api = Ort::GetApi();
     void* resource = {};
     OrtStatus* status = nullptr;


### PR DESCRIPTION
Deprecate ROCM context virtual function, to align with CUDA.

