### PR TITLE
Remove axis=0 limit of concat op for symbolic shape inference script

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -868,7 +868,6 @@ class SymbolicShapeInference:
         if any([i in self.sympy_data_ or i in self.initializers_ for i in node.input]):
             values = self._get_int_or_float_values(node)
             if all([v is not None for v in values]):
-                assert get_attribute(node, "axis") == 0
                 self.sympy_data_[node.output[0]] = []
                 for i in range(len(node.input)):
                     value = values[i]


### PR DESCRIPTION
### Description
Remove limit of only shape-inferring concat op shape when axis=0, as this func supports all axis (including negative axis)




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


