### PR TITLE
[js/web] add CI steps to log info for test failure investigating

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -158,7 +158,7 @@ jobs:
     displayName: 'Pack NPM packages'
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Dump active Edge processes (before tests 0)'
@@ -174,7 +174,7 @@ jobs:
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Dump active Edge processes (before tests 1)'
@@ -189,7 +189,7 @@ jobs:
     continueOnError: true
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
@@ -201,7 +201,7 @@ jobs:
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Dump active Edge processes (before tests 3)'
@@ -211,7 +211,7 @@ jobs:
     displayName: 'Run ort-web tests - WebGL: packed mode'
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Dump active Edge processes (before tests 4)'
@@ -222,13 +222,13 @@ jobs:
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Dump active Edge processes (before E2E tests)'
   - task: PowerShell@2
     inputs:
-      scriptType: 'inline'
+      targetType: 'inline'
       script: dir -r $(Build.SourcesDirectory)\build\js\e2e
       workingDirectory: '$(Build.SourcesDirectory)\js\web'
       errorActionPreference: continue

--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -156,18 +156,28 @@ jobs:
       workingDirectory: $(Build.BinariesDirectory)
       errorActionPreference: stop
     displayName: 'Pack NPM packages'
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Dump active Edge processes (before tests 0)'
   - script: |
      npm test -- -e=edge -b=webgl,wasm,xnnpack
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (wasm,webgl,xnnpack backend)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'false')
-    retryCountOnTaskFailure: 3
   - script: |
      npm test -- -e=edge -b=webgl,wasm,xnnpack,webgpu $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (ALL backends)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-    retryCountOnTaskFailure: 3
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Dump active Edge processes (before tests 1)'
   - script: |
      npm test -- suite1 -e=edge -b=webgpu --io-binding=gpu-tensor $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
@@ -177,22 +187,52 @@ jobs:
     # investigation is ongoing for the root cause of the random failure (Edge crash).
     # TODO: remove this line once the root cause is found and fixed.
     continueOnError: true
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
+    displayName: 'Dump active Edge processes (before tests 2)'
   - script: |
      npm test -- suite1 -e=edge -b=webgpu --io-binding=gpu-location $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (Suite1, webgpu, IO-binding=gpu-location)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-    retryCountOnTaskFailure: 3
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Dump active Edge processes (before tests 3)'
   - script: |
      npm test -- --webgl-texture-pack-mode -b=webgl -e=edge
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - WebGL: packed mode'
-    retryCountOnTaskFailure: 3
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Dump active Edge processes (before tests 4)'
   - script: |
      npm test -- --wasm-enable-proxy -b=wasm -e=edge
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - WebAssembly: proxy'
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+    displayName: 'Dump active Edge processes (before E2E tests)'
+  - task: PowerShell@2
+    inputs:
+      scriptType: 'inline'
+      script: dir -r $(Build.SourcesDirectory)\build\js\e2e
+      workingDirectory: '$(Build.SourcesDirectory)\js\web'
+      errorActionPreference: continue
+    displayName: 'Dump E2E test folder (before E2E tests)'
   - script: |
       npm run test:e2e -- --browser=Edge_default
     workingDirectory: '$(Build.SourcesDirectory)\js\web'


### PR DESCRIPTION
### Description
add CI steps to log info for test failure investigating.

Currently Web CI is marked as 'optional'. This change adds some script to dump debug info for investigating the random test failure