### PR TITLE
Remove Node.js tool installer task from web ci pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
@@ -38,6 +38,7 @@ steps:
 
   - ${{if eq(parameters.WithCache, true)}}:
     - script: |
+        set -e -x
         pushd '$(Build.SourcesDirectory)/cmake/external/emsdk'
         source ./emsdk_env.sh
         export PATH=$(Build.SourcesDirectory)/cmake/external/emsdk/:$PATH

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -81,9 +81,6 @@ jobs:
       versionSpec: '3.8'
       addToPath: true
       architecture: $(buildArch)
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '18.x'
   - template: download-deps.yml
 
   - task: PythonScript@0


### PR DESCRIPTION
EMSDK already has a nodejs. We will use that one to be more consistent(the CI build pipeline would be less dependent on the VM image).