### PR TITLE
Create InferenceSession from Promise

### DIFF
--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -4,6 +4,8 @@
 import {InferenceSession as InferenceSessionImpl} from './inference-session-impl.js';
 import {OnnxValue, OnnxValueDataLocation} from './onnx-value.js';
 
+export type MaybePromise<T> = T|Promise<T>;
+
 /* eslint-disable @typescript-eslint/no-redeclare */
 
 export declare namespace InferenceSession {
@@ -424,7 +426,7 @@ export interface InferenceSessionFactory {
    * @param options - specify configuration for creating a new inference session.
    * @returns A promise that resolves to an InferenceSession object.
    */
-  create(buffer: ArrayBufferLike, options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
+  create(buffer: MaybePromise<ArrayBufferLike>, options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
 
   /**
    * Create a new inference session and load model asynchronously from segment of an array bufer.
@@ -435,8 +437,9 @@ export interface InferenceSessionFactory {
    * @param options - specify configuration for creating a new inference session.
    * @returns A promise that resolves to an InferenceSession object.
    */
-  create(buffer: ArrayBufferLike, byteOffset: number, byteLength?: number, options?: InferenceSession.SessionOptions):
-      Promise<InferenceSession>;
+  create(
+      buffer: MaybePromise<ArrayBufferLike>, byteOffset: number, byteLength?: number,
+      options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
 
   /**
    * Create a new inference session and load model asynchronously from a Uint8Array.
@@ -445,7 +448,7 @@ export interface InferenceSessionFactory {
    * @param options - specify configuration for creating a new inference session.
    * @returns A promise that resolves to an InferenceSession object.
    */
-  create(buffer: Uint8Array, options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
+  create(buffer: MaybePromise<Uint8Array>, options?: InferenceSession.SessionOptions): Promise<InferenceSession>;
 
   // #endregion
 }

--- a/js/node/src/inference_session_wrap.h
+++ b/js/node/src/inference_session_wrap.h
@@ -23,7 +23,11 @@ private:
 
   /**
    * [sync] create the session.
-   * @param arg0 either a string (file path) or a Uint8Array
+   * @param arg0 either a string (file path) or an ArrayBuffer.
+   * @param arg1 either SessionOptions (if arg0 is string) or byte offset (if
+   *             arg0 is ArrayBuffer.)
+   * @param arg2 byte length (if arg0 is ArrayBuffer.)
+   * @param arg3 SessionOptions (if arg0 is ArrayBuffer.)
    * @returns nothing
    * @throw error if status code != 0
    */

--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -52,6 +52,11 @@ describe('UnitTests - InferenceSession.create()', () => {
       await createAny(modelBuffer, 'cpu');
     }, {name: 'TypeError', message: /'options'/});
   });
+  it('BAD CALL - options type mismatch (Promise<Uint8Array>, string)', async () => {
+    await assert.rejects(async () => {
+      await createAny(Promise.resolve(modelBuffer), 'cpu');
+    }, {name: 'TypeError', message: /'options'/});
+  });
   it('BAD CALL - options type mismatch (ArrayBuffer, number, number, string)', async () => {
     await assert.rejects(async () => {
       await createAny(modelBuffer.buffer, modelBuffer.byteOffset, modelBuffer.byteLength, 'cpu');
@@ -66,6 +71,11 @@ describe('UnitTests - InferenceSession.create()', () => {
   it('EXPECTED FAILURE - empty buffer', async () => {
     await assert.rejects(async () => {
       await InferenceSession.create(new Uint8Array(0));
+    }, {name: 'Error', message: /No graph was found in the protobuf/});
+  });
+  it('EXPECTED FAILURE - empty buffer promise', async () => {
+    await assert.rejects(async () => {
+      await InferenceSession.create(Promise.resolve(new Uint8Array(0)));
     }, {name: 'Error', message: /No graph was found in the protobuf/});
   });
   // #endregion


### PR DESCRIPTION
This changes `InferenceSessionFactory.create` to optionally take
its buffer argument as a Promise, i.e., it adds new overloads
taking `Promise<Uint8Array>`, `Promise<ArrayBufferLike>`, and
`Promise<ArrayBufferLike>` plus `byteOffset` and `byteLength`. The
Promise is awaited after calling `resolveBackend` so that the wasm can
be downloaded, and the library initialized, prior to the model buffer
becoming available. No API changes below `InferenceSession` are needed.

To support this change, I split the `InferenceSession.create` argument
parsing code into two phases. The first assigns the appropriate
numerical argument to `byteOffset`, `byteLength`, and `options`, based
only on the type of `arg1` (which the API specifies as `number` in the
overloads taking `byteOffset`, and `SessionOptions` or `undefined`
otherwise). The second is done dependently on the (potentially
Promise-resolved) type of `arg0`, and validates everything else
about the arguments, including that `options` comes from the correct
positional argument for the overload in question.  This was done because
we need `options` prior to `resolveBackend` and we want to delay
awaiting `arg0` until afterwards.

I've attempted to both preserve the old behavior of the argument parsing
code and also clean it up somewhat. Mistakes aside, the only behavior
change I'm aware of having introduced is that now, if the user has
passed some invalid arguments, `resolveBackend` may be called with an
`options` that comes from the wrong positional argument. But its type is
exactly as constrained as before, so this shouldn't ever matter.

Other changes:

- Adds a couple of unit tests to verify that the Promise interface works
  on a rudimentary level. As the Promise code is also exercised in
  non-Promise cases (thanks to `Promise.resolve`), any regressions that
  might have been introduced should be caught by existing tests.

- In the process of writing this change, I previously attempted to pass
  the Promise down into `createInferenceSessionHandler` and resolve it
  prior to `loadModel`. In the course of writing this, I got confused by
  the Node C++ `LoadModel` comment, which turned out to be out of step
  with its implementation; I have attempted to adjust the comment to
  match the implementation, and included that as part of this change.

Closes https://github.com/microsoft/onnxruntime/issues/18364.