### PR TITLE
Always run emsdk_env.sh before build.py, even when ccache is disabled

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
@@ -40,8 +40,6 @@ steps:
     - script: |
         set -e -x
         pushd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-        ./emsdk install 3.1.44
-        ./emsdk activate 3.1.44
         source ./emsdk_env.sh
         export PATH=$(Build.SourcesDirectory)/cmake/external/emsdk/:$PATH
         export PATH=$(Build.SourcesDirectory)/cmake/external/emsdk/ccache/git-emscripten_64bit/bin:$PATH
@@ -71,16 +69,7 @@ steps:
   - ${{if eq(parameters.WithCache, false)}}:
     - script: |
         set -e -x
-        pushd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-        ./emsdk install 3.1.44
-        ./emsdk activate 3.1.44
-        source ./emsdk_env.sh
+        source $(Build.SourcesDirectory)/cmake/external/emsdk/emsdk_env.sh
         cd '$(Build.BinariesDirectory)'
         python3 '$(Build.SourcesDirectory)/tools/ci_build/build.py' ${{parameters.Arguments}}
       displayName: ${{parameters.DisplayName}}
-      env:
-        CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime,time_macros
-        CCACHE_DIR: ${{parameters.CacheDir}}
-        _EMCC_CCACHE: 1
-        EM_COMPILER_WRAPPER: ccache
-        EM_DIR: '$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten'

--- a/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/build-linux-wasm-step.yml
@@ -40,6 +40,8 @@ steps:
     - script: |
         set -e -x
         pushd '$(Build.SourcesDirectory)/cmake/external/emsdk'
+        ./emsdk install 3.1.44
+        ./emsdk activate 3.1.44
         source ./emsdk_env.sh
         export PATH=$(Build.SourcesDirectory)/cmake/external/emsdk/:$PATH
         export PATH=$(Build.SourcesDirectory)/cmake/external/emsdk/ccache/git-emscripten_64bit/bin:$PATH
@@ -67,9 +69,18 @@ steps:
         EM_DIR: '$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten'
 
   - ${{if eq(parameters.WithCache, false)}}:
-    - task: PythonScript@0
-      displayName: '${{parameters.DisplayName}}'
-      inputs:
-        scriptPath: '$(Build.SourcesDirectory)/tools/ci_build/build.py'
-        arguments: ${{parameters.Arguments}}
-        workingDirectory: '$(Build.BinariesDirectory)'
+    - script: |
+        set -e -x
+        pushd '$(Build.SourcesDirectory)/cmake/external/emsdk'
+        ./emsdk install 3.1.44
+        ./emsdk activate 3.1.44
+        source ./emsdk_env.sh
+        cd '$(Build.BinariesDirectory)'
+        python3 '$(Build.SourcesDirectory)/tools/ci_build/build.py' ${{parameters.Arguments}}
+      displayName: ${{parameters.DisplayName}}
+      env:
+        CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime,time_macros
+        CCACHE_DIR: ${{parameters.CacheDir}}
+        _EMCC_CCACHE: 1
+        EM_COMPILER_WRAPPER: ccache
+        EM_DIR: '$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten'

--- a/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/linux-wasm-ci.yml
@@ -90,13 +90,20 @@ jobs:
       arguments: --new_dir $(Build.BinariesDirectory)/deps
       workingDirectory: $(Build.BinariesDirectory)
 
-  - script: |
-      set -ex
-      cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
-      ./emsdk install 3.1.44 ccache-git-emscripten-64bit
-      ./emsdk activate 3.1.44 ccache-git-emscripten-64bit
-    displayName: 'emsdk install and activate ccache for emscripten'
-    condition: eq('${{ parameters.WithCache }}', 'true')
+  - ${{if eq(parameters.WithCache, true)}}:
+      - script: |
+          set -ex
+          cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
+          ./emsdk install 3.1.44 ccache-git-emscripten-64bit
+          ./emsdk activate 3.1.44 ccache-git-emscripten-64bit
+        displayName: 'emsdk install and activate ccache for emscripten'
+  - ${{if eq(parameters.WithCache, false)}}:
+      - script: |
+          set -ex
+          cd '$(Build.SourcesDirectory)/cmake/external/emsdk'
+          ./emsdk install 3.1.44
+          ./emsdk activate 3.1.44
+        displayName: 'emsdk install and activate ccache for emscripten'
 
   - template: build-linux-wasm-step.yml
     parameters:


### PR DESCRIPTION
### Description
Always run emsdk_env.sh before build.py, even when ccache is disabled

This is a follow up to #18434. That PR didn't handle the case when ccache was disabled. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


