### PR TITLE
Move up members in Lite Custom Op hierarchy for possible memleaks.

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
+++ b/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
@@ -405,8 +405,8 @@ OrtLiteCustomOp inherits from OrtCustomOp to bridge tween a custom func/struct a
 The lifetime of an OrtLiteCustomOp instance is managed by customer code, not ort, so:
 1. DO NOT cast OrtLiteCustomOp to OrtCustomOp and release since there is no virtual destructor in the hierachy.
 2. OrtLiteCustomFunc and OrtLiteCustomStruct, as two sub-structs, can be released in form of OrtLiteCustomOp since all members are kept in the OrtLiteCustomOp,
-   memory could still be recycled properly.
-Finally, OrtCustomOp is a c struct bearing no v-table, so offspring structs are by design to be of zero virtual functions to maintain cast safety.
+   hence memory could still be recycled properly.
+Further, OrtCustomOp is a c struct bearing no v-table, so offspring structs are by design to be of zero virtual functions to maintain cast safety.
 */
 struct OrtLiteCustomOp : public OrtCustomOp {
   using ConstOptionalFloatTensor = std::optional<const Custom::Tensor<float>&>;

--- a/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
+++ b/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
@@ -405,8 +405,8 @@ OrtLiteCustomOp inherits from OrtCustomOp to bridge tween a custom func/struct a
 The lifetime of an OrtLiteCustomOp instance is managed by customer code, not ort, so:
 1. DO NOT cast OrtLiteCustomOp to OrtCustomOp and release since there is no virtual destructor in the hierachy.
 2. OrtLiteCustomFunc and OrtLiteCustomStruct, as two sub-structs, can be released in form of OrtLiteCustomOp since all members are kept in the OrtLiteCustomOp,
-   memory could be recycled propertly.
-Finally, OrtCustomOp is a c struct bears no v-table, so offspring structs are by design to bear no virtual functions to maintain cast integrity.
+   memory could still be recycled properly.
+Finally, OrtCustomOp is a c struct bearing no v-table, so offspring structs are by design to be of zero virtual functions to maintain cast safety.
 */
 struct OrtLiteCustomOp : public OrtCustomOp {
   using ConstOptionalFloatTensor = std::optional<const Custom::Tensor<float>&>;

--- a/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
+++ b/include/onnxruntime/core/session/onnxruntime_lite_custom_op.h
@@ -909,7 +909,7 @@ struct OrtLiteCustomFunc : public OrtLiteCustomOp {
                     ShapeInferFn shape_infer_fn = {},
                     int start_ver = 1,
                     int end_ver = MAX_CUSTOM_OP_END_VER) : OrtLiteCustomOp(op_name, execution_provider, shape_infer_fn, start_ver, end_ver) {
-    compute_fn_ = compute_fn;
+    compute_fn_ = reinterpret_cast<void*>(compute_fn);
     ParseArgs<Args...>(input_types_, output_types_);
 
     OrtCustomOp::KernelCompute = [](void* op_kernel, OrtKernelContext* context) {
@@ -949,7 +949,7 @@ struct OrtLiteCustomFunc : public OrtLiteCustomOp {
                     ShapeInferFn shape_infer_fn = {},
                     int start_ver = 1,
                     int end_ver = MAX_CUSTOM_OP_END_VER) : OrtLiteCustomOp(op_name, execution_provider, shape_infer_fn, start_ver, end_ver) {
-    compute_fn_return_status_ = compute_fn_return_status;
+    compute_fn_return_status_ = reinterpret_cast<void*>(compute_fn_return_status);
     ParseArgs<Args...>(input_types_, output_types_);
 
     OrtCustomOp::KernelComputeV2 = [](void* op_kernel, OrtKernelContext* context) -> OrtStatusPtr {


### PR DESCRIPTION
Move data member in LiteOpFunc to its parent to avoid possible mem leaks.