### PR TITLE
Bfloat16 support for MatMulBnb4, Training support bitsandbytes>=0.41.2

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -2649,8 +2649,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float), tensor(float16)</dt>
-<dd>Constrain input and output types to float/half_float tensors.</dd>
+<dt><tt>T1</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
+<dd>Constrain input and output types to float/half_float/brain_float tensors.</dd>
 <dt><tt>T2</tt> : tensor(uint8)</dt>
 <dd>Constrain quantized weight types to uint8.</dd>
 </dl>

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -840,7 +840,7 @@ Do not modify directly.*
 |Inverse|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
 |Irfft|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
 |LongformerAttention|*in* input:**T**<br> *in* weight:**T**<br> *in* bias:**T**<br> *in* mask:**T**<br> *in* global_weight:**T**<br> *in* global_bias:**T**<br> *in* global:**G**<br> *out* output:**T**|1+|**T** = tensor(float), tensor(float16)|
-|MatMulBnb4|*in* A:**T1**<br> *in* B:**T2**<br> *in* absmax:**T1**<br> *out* Y:**T1**|1+|**T1** = tensor(float), tensor(float16)<br/> **T2** = tensor(uint8)|
+|MatMulBnb4|*in* A:**T1**<br> *in* B:**T2**<br> *in* absmax:**T1**<br> *out* Y:**T1**|1+|**T1** = tensor(bfloat16), tensor(float), tensor(float16)<br/> **T2** = tensor(uint8)|
 |MatMulNBits|*in* A:**T1**<br> *in* B:**T2**<br> *in* scales:**T1**<br> *in* zero_points:**T2**<br> *out* Y:**T1**|1+|**T1** = tensor(float), tensor(float16)<br/> **T2** = tensor(uint8)|
 |MoE|*in* input:**T**<br> *in* router_probs:**T**<br> *in* fc1_experts_weights:**T**<br> *in* fc2_experts_weights:**T**<br> *in* fc1_experts_bias:**T**<br> *in* fc2_experts_bias:**T**<br> *out* output:**T**|1+|**T** = tensor(float), tensor(float16)|
 |MultiHeadAttention|*in* query:**T**<br> *in* key:**T**<br> *in* value:**T**<br> *in* bias:**T**<br> *in* key_padding_mask:**M**<br> *in* relative_position_bias:**T**<br> *in* past_key:**T**<br> *in* past_value:**T**<br> *out* output:**T**<br> *out* present_key:**T**<br> *out* present_value:**T**|1+|**T** = tensor(float), tensor(float16)|

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -121,6 +121,7 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain,
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, Inverse);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, MatMulNBits);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MatMulNBits);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, MatMulBnb4);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, MatMulBnb4);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MatMulBnb4);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, Trilu);
@@ -313,6 +314,7 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, Inverse)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, MatMulNBits)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MatMulNBits)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BFloat16, MatMulBnb4)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, MLFloat16, MatMulBnb4)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, float, MatMulBnb4)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kMSDomain, 1, BiasSoftmax)>,

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
@@ -3,7 +3,7 @@
 
 #include <cub/cub.cuh>
 #include <cuda_fp16.h>
-#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
 #include "contrib_ops/cpu/quantization/blockwise_quant_block_bnb4.h"
 #include "dequantize_blockwise_bnb4.cuh"
 
@@ -71,8 +71,8 @@ __global__ void kDequantizeBlockwise(
 
     #pragma unroll NUM_PER_TH
     for (int j = 0; j < NUM_PER_TH; j++) {
-      vals[j * 2] = quant_map[qvals[j] >> 4] * local_abs_max;
-      vals[j * 2 + 1] = quant_map[qvals[j] & 0x0F] * local_abs_max;
+      vals[j * 2] = ScalarMul(quant_map[qvals[j] >> 4], local_abs_max);
+      vals[j * 2 + 1] = ScalarMul(quant_map[qvals[j] & 0x0F], local_abs_max);
     }
 
     __syncthreads();

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
@@ -35,6 +35,8 @@ template Status SetBnbQuantMap<float>(int quant_type, float* quant_map_buffer, c
 
 template Status SetBnbQuantMap<half>(int quant_type, half* quant_map_buffer, cudaStream_t stream);
 
+template Status SetBnbQuantMap<BFloat16>(int quant_type, BFloat16* quant_map_buffer, cudaStream_t stream);
+
 template <class T, int TILE_SIZE, int THREADS, int NUM_PER_TH>
 __global__ void kDequantizeBlockwise(
     const T* quant_map,
@@ -62,22 +64,15 @@ __global__ void kDequantizeBlockwise(
     valid_items_load = (n + 1) / 2 - i > TILE_SIZE ? TILE_SIZE : (n + 1) / 2 - i;
     valid_items_store = n - i * 2 > TILE_SIZE * 2 ? TILE_SIZE * 2 : n - i * 2;
 
-    local_abs_max = __ldg(&absmax[(i + threadIdx.x * NUM_PER_TH) / (block_size)]);
+    local_abs_max = absmax[(i + threadIdx.x * NUM_PER_TH) / (block_size)];
 
     __syncthreads();
     LoadChar(loadchar).Load(&(quant_data[i]), qvals, valid_items_load, 128);
 
     #pragma unroll NUM_PER_TH
     for (int j = 0; j < NUM_PER_TH; j++) {
-      #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530
-        vals[j * 2] = quant_map[qvals[j] >> 4] * local_abs_max;
-        vals[j * 2 + 1] = quant_map[qvals[j] & 0x0F] * local_abs_max;
-      #else
-        // half multiplication not supported
-        vals[j * 2] = static_cast<T>(static_cast<float>(quant_map[qvals[j] >> 4]) * static_cast<float>(local_abs_max));
-        vals[j * 2 + 1] =
-            static_cast<T>(static_cast<float>(quant_map[qvals[j] & 0x0F]) * static_cast<float>(local_abs_max));
-      #endif
+      vals[j * 2] = ScalarMul(quant_map[qvals[j] >> 4], local_abs_max);
+      vals[j * 2 + 1] = ScalarMul(quant_map[qvals[j] & 0x0F], local_abs_max);
     }
 
     __syncthreads();
@@ -86,7 +81,7 @@ __global__ void kDequantizeBlockwise(
 }
 
 template <class T>
-Status DequantizeBnb4(
+void CallkDequantizeBlockwise(
     const T* quant_map,
     T* output,
     const uint8_t* quant_data,
@@ -102,6 +97,18 @@ Status DequantizeBnb4(
       absmax,
       block_size / 2,
       numel);
+}
+
+template <class T>
+Status DequantizeBnb4(
+    const T* quant_map,
+    T* output,
+    const uint8_t* quant_data,
+    const T* absmax,
+    int block_size,
+    int numel,
+    cudaStream_t stream) {
+  CallkDequantizeBlockwise<T>(quant_map, output, quant_data, absmax, block_size, numel, stream);
 
   return Status::OK();
 }
@@ -119,10 +126,35 @@ template Status DequantizeBnb4<half>(
     const half* quant_map,
     half* output,
     const uint8_t* quant_data,
-    const half *absmax,
+    const half* absmax,
     int block_size,
     int numel,
     cudaStream_t stream);
+
+template <>
+Status DequantizeBnb4<BFloat16>(
+    const BFloat16* quant_map,
+    BFloat16* output,
+    const uint8_t* quant_data,
+    const BFloat16* absmax,
+    int block_size,
+    int numel,
+    cudaStream_t stream) {
+  #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
+    CallkDequantizeBlockwise<nv_bfloat16>(
+        reinterpret_cast<const nv_bfloat16*>(quant_map),
+        reinterpret_cast<nv_bfloat16*>(output),
+        quant_data,
+        reinterpret_cast<const nv_bfloat16*>(absmax),
+        block_size,
+        numel,
+        stream);
+  #else
+    CallkDequantizeBlockwise<BFloat16>(quant_map, output, quant_data, absmax, block_size, numel, stream);
+  #endif
+
+  return Status::OK();
+}
 
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cu
@@ -3,7 +3,7 @@
 
 #include <cub/cub.cuh>
 #include <cuda_fp16.h>
-#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cu_inc/common.cuh"
 #include "contrib_ops/cpu/quantization/blockwise_quant_block_bnb4.h"
 #include "dequantize_blockwise_bnb4.cuh"
 
@@ -71,8 +71,8 @@ __global__ void kDequantizeBlockwise(
 
     #pragma unroll NUM_PER_TH
     for (int j = 0; j < NUM_PER_TH; j++) {
-      vals[j * 2] = ScalarMul(quant_map[qvals[j] >> 4], local_abs_max);
-      vals[j * 2 + 1] = ScalarMul(quant_map[qvals[j] & 0x0F], local_abs_max);
+      vals[j * 2] = quant_map[qvals[j] >> 4] * local_abs_max;
+      vals[j * 2 + 1] = quant_map[qvals[j] & 0x0F] * local_abs_max;
     }
 
     __syncthreads();

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh
@@ -11,6 +11,38 @@ namespace cuda {
 template <class T>
 Status SetBnbQuantMap(int quant_type, T* quant_map_buffer, cudaStream_t stream);
 
+// templated scalar multiply function
+template <class T>
+__device__ inline T ScalarMul(T a, T b);
+
+template <>
+__device__ inline float ScalarMul(float a, float b) {
+  return a * b;
+}
+
+template <>
+__device__ inline half ScalarMul(half a, half b) {
+  #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530
+    return a * b;
+  #else
+    // half multiplication not supported
+    return static_cast<half>(static_cast<float>(a) * static_cast<float>(b));
+  #endif
+}
+
+template <>
+__device__ inline BFloat16 ScalarMul(BFloat16 a, BFloat16 b) {
+  return a * b;
+}
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+// will use the native bfloat16 multiply instruction on sm_80+
+template <>
+__device__ inline nv_bfloat16 ScalarMul(nv_bfloat16 a, nv_bfloat16 b) {
+  return a * b;
+}
+#endif
+
 template <class T>
 Status DequantizeBnb4(
     const T* quant_map,

--- a/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh
@@ -11,38 +11,6 @@ namespace cuda {
 template <class T>
 Status SetBnbQuantMap(int quant_type, T* quant_map_buffer, cudaStream_t stream);
 
-// templated scalar multiply function
-template <class T>
-__device__ inline T ScalarMul(T a, T b);
-
-template <>
-__device__ inline float ScalarMul(float a, float b) {
-  return a * b;
-}
-
-template <>
-__device__ inline half ScalarMul(half a, half b) {
-  #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530
-    return a * b;
-  #else
-    // half multiplication not supported
-    return static_cast<half>(static_cast<float>(a) * static_cast<float>(b));
-  #endif
-}
-
-template <>
-__device__ inline BFloat16 ScalarMul(BFloat16 a, BFloat16 b) {
-  return a * b;
-}
-
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-// will use the native bfloat16 multiply instruction on sm_80+
-template <>
-__device__ inline nv_bfloat16 ScalarMul(nv_bfloat16 a, nv_bfloat16 b) {
-  return a * b;
-}
-#endif
-
 template <class T>
 Status DequantizeBnb4(
     const T* quant_map,

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cc
@@ -145,6 +145,17 @@ ONNX_OPERATOR_TYPED_KERNEL_EX(
         .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>()),
     MatMulBnb4<MLFloat16>);
 
+ONNX_OPERATOR_TYPED_KERNEL_EX(
+    MatMulBnb4,
+    kMSDomain,
+    1,
+    BFloat16,
+    kCudaExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<BFloat16>())
+        .TypeConstraint("T2", DataTypeImpl::GetTensorType<uint8_t>()),
+    MatMulBnb4<BFloat16>);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cu
@@ -6,8 +6,8 @@
 #include <cub/cub.cuh>
 #include <cublas_v2.h>
 #include <cuda_fp16.h>
+#include "contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh"
 #include "matmul_bnb4.cuh"
-#include "dequantize_blockwise_bnb4.cuh"
 
 namespace onnxruntime {
 namespace contrib {

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_bnb4.cu
@@ -6,43 +6,12 @@
 #include <cub/cub.cuh>
 #include <cublas_v2.h>
 #include <cuda_fp16.h>
-#include "contrib_ops/cuda/quantization/dequantize_blockwise_bnb4.cuh"
+#include "core/providers/cuda/cu_inc/common.cuh"
 #include "matmul_bnb4.cuh"
 
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
-
-template <class T>
-__device__ inline float ScalarMulFloatOut(T a, T b);
-
-template <>
-__device__ inline float ScalarMulFloatOut(float a, float b) {
-  return a * b;
-}
-
-template <>
-__device__ inline float ScalarMulFloatOut(half a, half b) {
-  #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530
-    return static_cast<float>(a * b);
-  #else
-    // half multiplication not supported
-    return static_cast<float>(a) * static_cast<float>(b);
-  #endif
-}
-
-template <>
-__device__ inline float ScalarMulFloatOut(BFloat16 a, BFloat16 b) {
-  return a * b;
-}
-
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
-// will use the native bfloat16 multiply instruction on sm_80+
-template <>
-__device__ inline float ScalarMulFloatOut(nv_bfloat16 a, nv_bfloat16 b) {
-  return static_cast<float>(a * b);
-}
-#endif
 
 #define num_values_4bit 32
 template <class T, int THREADS, int BITS>
@@ -110,8 +79,8 @@ __global__ void kgemm_4bit_inference_naive(
     for (int i = 0; i < 4; i++) {
       #pragma unroll
       for (int k = 0; k < num_values_8bit / 4; k++) {
-        local_B[k * 2] = ScalarMul(quant_map[local_B_4bit[(i * num_values_8bit / 4) + k] >> 4], local_absmax);
-        local_B[k * 2 + 1] = ScalarMul(quant_map[local_B_4bit[(i * num_values_8bit / 4) + k] & 0x0F], local_absmax);
+        local_B[k * 2] = quant_map[local_B_4bit[(i * num_values_8bit / 4) + k] >> 4] * local_absmax;
+        local_B[k * 2 + 1] = quant_map[local_B_4bit[(i * num_values_8bit / 4) + k] & 0x0F] * local_absmax;
       }
 
       if (inner_idx + (num_values_4bit / 4) + (i * num_values_4bit / 4) < K) {
@@ -138,7 +107,7 @@ __global__ void kgemm_4bit_inference_naive(
       // accumulate in float; small performance hit for Ampere, but lower error for outputs
       #pragma unroll
       for (int k = 0; k < num_values_4bit / 4; k++) {
-        local_C += ScalarMulFloatOut(local_A[k], local_B[k]);
+        local_C += static_cast<float>(local_A[k] * local_B[k]);
       }
     }
   }

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -3431,7 +3431,7 @@ MatMulBnb4 is a MatMul with weight quantized with 4 bits using either FP4 or NF4
       .Input(1, "B", "1-dimensional quantized data for weight", "T2")
       .Input(2, "absmax", "quantization constants", "T1")
       .Output(0, "Y", "tensor. The output tensor has the same rank as the input. ", "T1")
-      .TypeConstraint("T1", {"tensor(float)", "tensor(float16)"}, "Constrain input and output types to float/half_float tensors.")
+      .TypeConstraint("T1", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output types to float/half_float/brain_float tensors.")
       .TypeConstraint("T2", {"tensor(uint8)"}, "Constrain quantized weight types to uint8.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         // Type inference

--- a/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
+++ b/orttraining/orttraining/python/training/ortmodule/_custom_autograd_function_exporter.py
@@ -412,14 +412,24 @@ def _matmul4bit_export(g, n, *args, **kwargs):
         return None
 
     quant_state = args[4]
-    absmax, shape, dtype, blocksize, compressed_stats, quant_type, data_type = quant_state
+    if isinstance(quant_state, list):
+        # version <= 0.41.1
+        absmax, shape, dtype, blocksize, compressed_stats, quant_type, data_type = quant_state
+        nested = compressed_stats is not None
+    else:
+        # version > 0.41.1
+        absmax = quant_state.absmax
+        shape = quant_state.shape
+        blocksize = quant_state.blocksize
+        nested = quant_state.nested
+        quant_type = quant_state.quant_type
 
     # MatMulBnb4's blocksize needs to be a power of 2 and not smaller than 16
     if blocksize < 16 or blocksize & (blocksize - 1) != 0:
         return None
 
     # MatMulBnb4 does not support double de-quantization (e.g. absmax is int, needs to be dequantized too)
-    if compressed_stats is not None:
+    if nested:
         return None
 
     # The PyTorch linear weight shape is [out_feature, in_feature]


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add bfloat16 support for `MatMulBnb4` contrib op. This is useful for QLoRA fine-tuning. 
- On GPUs with SM80+ (A100, etc), it uses the native cuda bfloat16 dtype, `nv_bfloat16`. On other GPUs, it uses the onnxruntime `BFloat16` type which uses float for compute. 
- I have validated the op in a llama2-7b training scenario. The losses match pytorch training and the training throughput is better.
- Cannot add a bfloat16 case in the op unit test since casting BFloat16 to and from float multiple times during the test causes the required tolerances to be unachievable.

The custom autograd function exporter in onnxruntime-training is updated to support the latest version of bitsandbytes. They changed how the `quant_state` is stored. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable QLoRA fine-tuning with bfloat16.
