### PR TITLE
Update NDK version to 26.1.10909125

### DIFF
--- a/tools/android_custom_build/Dockerfile
+++ b/tools/android_custom_build/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /workspace
 
 # install Android SDK and tools
 ENV ANDROID_HOME=~/android-sdk
-ENV NDK_VERSION=26.0.10792818
+ENV NDK_VERSION=26.1.10909125
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${NDK_VERSION}
 
 RUN aria2c -q -d /tmp -o cmdline-tools.zip \

--- a/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-android-ndk.yml
@@ -3,7 +3,7 @@
   parameters:
   - name: AndroidNdkVersion
     type: string
-    default: "26.0.10792818"  # LTS version
+    default: "26.1.10909125"  # LTS version
 
   steps:
   - bash: |


### PR DESCRIPTION
### Description
Similar to #17852


### Motivation and Context
To avoid downloading NDK

