### PR TITLE
Update TryConvertTensorToBroadcastScalar to exit early if constExpTen…

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -862,7 +862,7 @@ namespace Dml
         {
             return;
         }
-        else if (constExpTensor->IsDataInterface())
+        else if (!IsCpuData())
         {
             return;
         }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperator.cpp
@@ -862,7 +862,11 @@ namespace Dml
         {
             return;
         }
-        
+        else if (constExpTensor->IsDataInterface())
+        {
+            return;
+        }
+
         uint32_t totalKernelInputElementCount = constExpTensor->GetTotalElementCount();
         if (totalKernelInputElementCount <= 1)
         {


### PR DESCRIPTION
Update TryConvertTensorToBroadcastScalar  to fail gracefully if not CPU tensor

### Description
Added early exit for in TryConvertTensorToBroadcastScalar if there is no CpuData to prevent failure caused by constExpTensor->GetByteData() throwing.

### Motivation and Context
DmlPrototype branch was failing in QLinearConv when there was no CpuData

