### PR TITLE
Throw for scalar input to Shape.

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/shape_op.h
+++ b/onnxruntime/core/providers/cpu/tensor/shape_op.h
@@ -36,6 +36,8 @@ class Shape final : public OpKernel {
     const TensorShape& input_shape = input->Shape();
 
     int64_t rank = gsl::narrow_cast<int64_t>(input_shape.NumDimensions());
+    // ONNX shape inferencing doesn't work with a scalar. Spec does not say it's unsupported.
+    ORT_ENFORCE(rank != 0, "Shape of a scalar is not supported");
 
     if (!needs_slicing_) {  // vanilla use of Shape (no slicing)
       Tensor* output = context->Output(0, {rank});


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Shape returns an empty tensor with shape {0} for a scalar, which is incorrect as there is a single data element. Throwing will at least make the cause of the failure clear.

Expected might be for it to return a shape of `{}`, but ONNX shape inferencing doesn't support scalar either as it calls add_dim on the output_shape at the start so result will always be rank 1 or higher.

https://github.com/onnx/onnx/blob/b60f69412abb5393ab819b936b473f83867f6c87/onnx/defs/tensor/defs.cc#L496

The ONNX spec doesn't say scalars aren't supported. @gramalingam should scalar input to Shape return an empty shape?


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Model failed downstream due to nullptr in output from Shape when called with a scalar.

