### PR TITLE
Tiny change to trigger the update of DORT's CI image

### DIFF
--- a/orttraining/orttraining/test/python/orttraining_test_dort.py
+++ b/orttraining/orttraining/test/python/orttraining_test_dort.py
@@ -19,6 +19,7 @@ class TestTorchDynamoOrt(unittest.TestCase):
     def setUp(self):
         # Make computation deterministic.
         torch.manual_seed(42)
+        print(f"TestTorchDynamoOrt uses PyTorch version {torch.__version__}")
 
     def test_elementwise_model(self):
         torch._dynamo.reset()

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps_lort.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_deps_lort.sh
@@ -19,7 +19,9 @@ fi
 export ONNX_ML=1
 export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=OFF -DONNX_WERROR=OFF"
 
+# This may install PyTorch, which will be overrided by the PyTorch local build below.
 /opt/python/cp39-cp39/bin/python3.9 -m pip install transformers
+
 # beartype is installed here so that onnxscript installation step won't
 # install a version PyTorch doesn't like. Once beartype fixes this problem.
 # We can remove this line.


### PR DESCRIPTION
Recent PyTorch breaks DORT CI and [a patch](https://github.com/pytorch/pytorch/pull/113697) has been merged into PyTorch main. In order to update DORT's CI, we made dummy change in this PR.