### PR TITLE
Update Llama benchmark scripts for ROCm compatibility

### DIFF
--- a/cmake/onnxruntime_rocm_hipify.cmake
+++ b/cmake/onnxruntime_rocm_hipify.cmake
@@ -100,6 +100,8 @@ set(contrib_ops_excluded_files
   "bert/group_query_attention.cc"
   "bert/group_query_attention_impl.h"
   "bert/group_query_attention_impl.cu"
+  "collective/sharding*"
+  "collective/distributed_*"
 )
 
 if (NOT onnxruntime_ENABLE_ATEN)

--- a/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/rocm/rocm_contrib_kernels.cc
@@ -89,6 +89,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ParametricSoftplus);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ParametricSoftplus);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ParametricSoftplus);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, RotaryEmbedding);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, RotaryEmbedding);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, Sampling);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ScaledTanh);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ScaledTanh);
@@ -241,6 +243,8 @@ Status RegisterRocmContribKernels(KernelRegistry& kernel_registry) {
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ParametricSoftplus)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ParametricSoftplus)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, MLFloat16, ParametricSoftplus)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, float, RotaryEmbedding)>,
+    BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, MLFloat16, RotaryEmbedding)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kRocmExecutionProvider, kMSDomain, 1, Sampling)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, float, ScaledTanh)>,
     BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kRocmExecutionProvider, kOnnxDomain, 1, double, ScaledTanh)>,

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -32,6 +32,7 @@ class MatMul final : public CudaKernel {
   const bool trans_batch_b_;
 };
 
+#ifndef USE_ROCM
 template <typename T>
 Status FuncMatMul(
     // Use OpKernel and do a pointer cast to unify functional calls with other eps.
@@ -48,6 +49,7 @@ Status FuncMatMul(
     bool trans_batch_A,
     bool trans_batch_B,
     Tensor* Y);
+#endif
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/tensor/concat_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/concat_impl.cu
@@ -24,11 +24,11 @@ template <typename T, typename InputDataArray>
 __global__ void _ConcatKernelSameConcatDim(const fast_divmod block_size_including_axis_dim_div,
                                            const fast_divmod block_size_inside_axis_dim_div,
                                            const fast_divmod concat_dim_size, T* output_data, InputDataArray input_data,
-                                           const CUDA_LONG N) {
-  CUDA_LONG start = kNumElementsPerThread * kNumThreadsPerBlock * blockIdx.x + threadIdx.x;
+                                           const int64_t N) {
+  int64_t start = kNumElementsPerThread * kNumThreadsPerBlock * blockIdx.x + threadIdx.x;
   T value[kNumElementsPerThread];
 
-  CUDA_LONG id = start;
+  int64_t id = start;
 #pragma unroll
   for (int i = 0; i < kNumElementsPerThread; ++i) {
     if (id < N) {
@@ -36,7 +36,7 @@ __global__ void _ConcatKernelSameConcatDim(const fast_divmod block_size_includin
       block_size_including_axis_dim_div.divmod(id, outer_block_index, offset);
       block_size_inside_axis_dim_div.divmod(offset, block_index, offset);
       concat_dim_size.divmod(block_index, input_index, block_offset);
-      CUDA_LONG input_pos =
+      int64_t input_pos =
           (outer_block_index * concat_dim_size.d_ + block_offset) * block_size_inside_axis_dim_div.d_ + offset;
       value[i] = reinterpret_cast<const T*>(input_data[input_index])[input_pos];
       id += kNumThreadsPerBlock;
@@ -57,7 +57,7 @@ template <typename InputDataArray>
 Status ConcatSameConcatDimImpl(cudaStream_t stream, const size_t element_bytes, const int block_size_including_axis_dim,
                                const int block_size_inside_axis_dim, const int64_t concat_size, void* output_data,
                                const InputDataArray input_data, const size_t output_size) {
-  CUDA_LONG N = static_cast<CUDA_LONG>(output_size);
+  int64_t N = static_cast<int64_t>(output_size);
   int blocksPerGrid = CeilDiv(N, kNumElementsPerThread * kNumThreadsPerBlock);
   fast_divmod block_size_including_axis_dim_div = fast_divmod(block_size_including_axis_dim);
   fast_divmod block_size_inside_axis_dim_div = fast_divmod(block_size_inside_axis_dim);

--- a/onnxruntime/core/providers/rocm/tunable/gemm_hipblaslt.h
+++ b/onnxruntime/core/providers/rocm/tunable/gemm_hipblaslt.h
@@ -26,6 +26,10 @@ using onnxruntime::contrib::rocm::blas::GemmFastGeluParams;
 
 #ifdef USE_HIPBLASLT
 
+// For large K and small M/N, K dim will be split to multiple workgroups and buffers,
+// which will require additional workspace. Here we set the max workspace size to 32MB.
+constexpr const size_t kHipBlasLtMaxWorkSpaceSizeInBytes = 32 * 1024 * 1024;
+
 enum ActivationType {
   NONE = 0,
   RELU = 1,
@@ -225,6 +229,9 @@ auto GetHipBlasLtTypeStringAndOps(ActivationType activation_type = ActivationTyp
 
       IAllocatorUniquePtr<void> workspace_buffer;
       if (workspace_size > 0) {
+        TUNABLE_OP_RETURN_UNSUPPORTED_ARGUMENT_IF(workspace_size > kHipBlasLtMaxWorkSpaceSizeInBytes,
+                                                  "Workspace size exceeds limit (32M): ", workspace_size);
+        workspace_size = kHipBlasLtMaxWorkSpaceSizeInBytes;
         workspace_buffer = params->tuning_ctx->GetScratchBuffer(workspace_size, params->stream);
       }
 

--- a/onnxruntime/python/tools/transformers/models/llama/benchmark.py
+++ b/onnxruntime/python/tools/transformers/models/llama/benchmark.py
@@ -619,7 +619,10 @@ def get_args(rank=0):
         if args.execution_provider == "CUDAExecutionProvider":
             args.execution_provider = (args.execution_provider, {"device_id": rank})
         elif args.execution_provider == "ROCMExecutionProvider":
-            args.execution_provider = (args.execution_provider, {"device_id": rank})
+            args.execution_provider = (
+                args.execution_provider,
+                {"device_id": rank, "tunable_op_enable": True, "tunable_op_tuning_enable": True},
+            )
             args.device = "cuda"
 
     # Check that paths have been specified for any benchmarking with ORT

--- a/onnxruntime/python/tools/transformers/models/llama/dist_settings.py
+++ b/onnxruntime/python/tools/transformers/models/llama/dist_settings.py
@@ -5,13 +5,11 @@ import torch.distributed as dist
 
 def init_dist():
     if "LOCAL_RANK" in os.environ:
-        int(os.environ["LOCAL_RANK"])
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
 
         dist.init_process_group("nccl", init_method="tcp://127.0.0.1:7645", world_size=world_size, rank=rank)
     elif "OMPI_COMM_WORLD_LOCAL_RANK" in os.environ:
-        int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", 0))
         rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
         world_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", 1))
 


### PR DESCRIPTION
### Description
* exclude some collective-related function definitions unavailable in ROCm
* enable RoPE in ROCm
* update Llama benchmark scripts.
   * (workaround to be updated) on ROCm, `--use-gqa` should not be used
   * (workaround to be updated) `--disable_attn` should be used for 70B, ROCm


