### PR TITLE
Fix --use_xcode documentation

### DIFF
--- a/docs/build/inferencing.md
+++ b/docs/build/inferencing.md
@@ -84,7 +84,7 @@ When building on x86 Windows without  "--arm" or "--arm64" or "--arm64ec" args, 
 By default, ONNX Runtime is configured to be built for a minimum target macOS version of 10.12.
 The shared library in the release Nuget(s) and the Python wheel may be installed on macOS versions of 10.12+.
 
-If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, please add the --user_xcode argument in the command line.
+If you would like to use [Xcode](https://developer.apple.com/xcode/) to build the onnxruntime for x86_64 macOS, please add the `--use_xcode` argument in the command line.
 
 Without this flag, the cmake build generator will be Unix makefile by default.
 


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->

The docs say the argument name is `--user_xcode`, but it is actually `--use_xcode`:

https://github.com/microsoft/onnxruntime/blob/247ce218595acad95a5beeb004cf4c8e74d367d3/tools/ci_build/build.py#L387



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix documentation
