### PR TITLE
[js/web] use Chrome in CI for npm tests

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-web-ci.yml
@@ -96,6 +96,18 @@ jobs:
       flattenFolders: true
     displayName: 'Binplace js files'
   - script: |
+      npm i -g puppeteer
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Use puppeteer to prepare Chrome for tests'
+  - script: |
+      FOR /F "tokens=* USEBACKQ" %%F IN (`where /r %HOMEDRIVE%%HOMEPATH%\.cache\puppeteer chrome.exe`) DO (
+        SET var=%%F
+        ECHO found chrome.exe: %%F
+      )
+      ECHO ##vso[task.setvariable variable=CHROME_BIN;]%var%
+    workingDirectory: '$(Build.SourcesDirectory)'
+    displayName: 'Set CHROME_BIN'
+  - script: |
      npm ci
     workingDirectory: '$(Build.SourcesDirectory)\js'
     displayName: 'npm ci /js/'
@@ -156,85 +168,37 @@ jobs:
       workingDirectory: $(Build.BinariesDirectory)
       errorActionPreference: stop
     displayName: 'Pack NPM packages'
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Dump active Edge processes (before tests 0)'
   - script: |
-     npm test -- -e=edge -b=webgl,wasm,xnnpack
+     npm test -- -e=chrome -b=webgl,wasm,xnnpack
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (wasm,webgl,xnnpack backend)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'false')
   - script: |
-     npm test -- -e=edge -b=webgl,wasm,xnnpack,webgpu $(webgpuCommandlineExtraFlags)
+     npm test -- -e=chrome -b=webgl,wasm,xnnpack,webgpu $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (ALL backends)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Dump active Edge processes (before tests 1)'
   - script: |
-     npm test -- suite1 -e=edge -b=webgpu --io-binding=gpu-tensor $(webgpuCommandlineExtraFlags)
+     npm test -- suite1 -e=chrome -b=webgpu --io-binding=gpu-tensor $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (Suite1, webgpu, IO-binding=gpu-tensor)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-    # temporarily allow this test to fail, so that people are not blocked.
-    # investigation is ongoing for the root cause of the random failure (Edge crash).
-    # TODO: remove this line once the root cause is found and fixed.
-    continueOnError: true
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-    displayName: 'Dump active Edge processes (before tests 2)'
   - script: |
-     npm test -- suite1 -e=edge -b=webgpu --io-binding=gpu-location $(webgpuCommandlineExtraFlags)
+     npm test -- suite1 -e=chrome -b=webgpu --io-binding=gpu-location $(webgpuCommandlineExtraFlags)
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests (Suite1, webgpu, IO-binding=gpu-location)'
     condition: eq('${{ parameters.RunWebGpuTests }}', 'true')
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Dump active Edge processes (before tests 3)'
   - script: |
-     npm test -- --webgl-texture-pack-mode -b=webgl -e=edge
+     npm test -- --webgl-texture-pack-mode -b=webgl -e=chrome
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - WebGL: packed mode'
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Dump active Edge processes (before tests 4)'
   - script: |
-     npm test -- --wasm-enable-proxy -b=wasm -e=edge
+     npm test -- --wasm-enable-proxy -b=wasm -e=chrome
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'Run ort-web tests - WebAssembly: proxy'
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: Get-WmiObject Win32_Process -Filter "name = 'msedge.exe'" | Select-Object CommandLine | Format-List
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-    displayName: 'Dump active Edge processes (before E2E tests)'
-  - task: PowerShell@2
-    inputs:
-      targetType: 'inline'
-      script: dir -r $(Build.SourcesDirectory)\build\js\e2e
-      workingDirectory: '$(Build.SourcesDirectory)\js\web'
-      errorActionPreference: continue
-    displayName: 'Dump E2E test folder (before E2E tests)'
   - script: |
-      npm run test:e2e -- --browser=Edge_default
+      npm run test:e2e -- --browser=Chrome_default
     workingDirectory: '$(Build.SourcesDirectory)\js\web'
     displayName: 'E2E package consuming test'
     condition: and(succeeded(), eq('${{ parameters.BuildConfig }}', 'Release'))


### PR DESCRIPTION
### Description
use Chrome in CI for npm tests. Previously we use Edge, however it sometimes crashes with reasons not yet identified.