### PR TITLE
deleted the unused random_device variables because they caused a warning that was treated like an error.

### DIFF
--- a/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
+++ b/orttraining/orttraining/test/gradient/optimizer_ops_test.cc
@@ -1542,7 +1542,6 @@ TEST(OptimizerTest, LambOptimizerTestLarge) {
     std::vector<float> m(size);
     std::vector<float> v(size);
 
-    std::random_device random_device;
     std::mt19937 random_engine(0);
     std::uniform_real_distribution<float> dist(0.1f, 1.0f);
     for (int i = 0; i < size; ++i) {
@@ -1581,7 +1580,6 @@ TEST(OptimizerTest, LambOptimizerTestLarge) {
 
 TEST(OptimizerTest, LambOptimizerMultiTensorRatio) {
   constexpr int group_count = 127;
-  std::random_device random_device;
   std::mt19937 random_engine(0);
   std::uniform_real_distribution<float> dist(0.1f, 1.0f);
   std::uniform_int_distribution<int64_t> dist_int(1, 1228);

--- a/orttraining/orttraining/test/training_ops/cpu/reduction/reduction_ops_test.cc
+++ b/orttraining/orttraining/test/training_ops/cpu/reduction/reduction_ops_test.cc
@@ -275,7 +275,6 @@ void TestMultiTensorReduce(
   test.SetDeterminism(use_determinism);
 
   // Set up random number generator.
-  std::random_device random_device;
   std::mt19937 random_engine(0);
   std::uniform_real_distribution<float> dist(min, max);
   std::uniform_int_distribution<int64_t> dist_int(min_tensor_size, max_tensor_size);


### PR DESCRIPTION
deleted the unused random_device variables because they caused a warning that was treated like an error. 

**_Please check if the declaration is required for the random number generation. if so, there need to be a dummy reference to the variable or turning off the warning as error behavior._**

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


