### PR TITLE
[Quantization] Fix scale/zero-point for 16-bit QDQ Softmax

### DIFF
--- a/onnxruntime/python/tools/quantization/operators/softmax.py
+++ b/onnxruntime/python/tools/quantization/operators/softmax.py
@@ -91,6 +91,5 @@ class QDQSoftmax(QDQOperatorBase):
         rmin, rmax = 0.0, 1.0
         qmin, qmax = get_qmin_qmax_for_qType(self.quantizer.activation_qType, symmetric=symmetric)
         out_zero_point, out_scale = compute_scale_zp(rmin, rmax, qmin, qmax, symmetric=symmetric)
-        print(f"Softmax zp: {out_zero_point}, scale: {out_scale}\n")
 
         self.quantizer.set_quant_scale_zp(self.node.output[0], (out_scale, out_zero_point))

--- a/onnxruntime/python/tools/quantization/operators/softmax.py
+++ b/onnxruntime/python/tools/quantization/operators/softmax.py
@@ -1,6 +1,14 @@
 import onnx
 
-from ..quant_utils import TENSOR_NAME_QUANT_SUFFIX, QuantizedValue, QuantizedValueType, attribute_to_kwarg, ms_domain
+from ..quant_utils import (
+    TENSOR_NAME_QUANT_SUFFIX,
+    QuantizedValue,
+    QuantizedValueType,
+    attribute_to_kwarg,
+    compute_scale_zp,
+    get_qmin_qmax_for_qType,
+    ms_domain,
+)
 from .base_operator import QuantOperatorBase
 from .qdq_base_operator import QDQOperatorBase
 
@@ -77,15 +85,12 @@ class QLinearSoftmax(QuantOperatorBase):
 class QDQSoftmax(QDQOperatorBase):
     def quantize(self):
         super().quantize()
-        if self.quantizer.activation_qType == onnx.onnx_pb.TensorProto.UINT8:
-            out_scale = 1 / 256.0
-            out_zero_point = 0
-        elif self.quantizer.is_activation_symmetric:
-            # results are all greater or equal to 0, so we can only use
-            # half of the range
-            out_scale = 1 / 127.0
-            out_zero_point = 0
-        else:
-            out_scale = 1 / 256.0
-            out_zero_point = -128
+        symmetric = self.quantizer.is_activation_symmetric
+
+        # Enforce Softmax range: 0.0 to 1.0
+        rmin, rmax = 0.0, 1.0
+        qmin, qmax = get_qmin_qmax_for_qType(self.quantizer.activation_qType, symmetric=symmetric)
+        out_zero_point, out_scale = compute_scale_zp(rmin, rmax, qmin, qmax, symmetric=symmetric)
+        print(f"Softmax zp: {out_zero_point}, scale: {out_scale}\n")
+
         self.quantizer.set_quant_scale_zp(self.node.output[0], (out_scale, out_zero_point))

--- a/onnxruntime/test/python/quantization/op_test_utils.py
+++ b/onnxruntime/test/python/quantization/op_test_utils.py
@@ -398,12 +398,15 @@ def check_qtype_by_node_type(testcase, model_to_check, check_list):
     value_infos.update({ot.name: ot for ot in model.graph.output})
     value_infos.update({it.name: it for it in model.graph.input})
     initializers = {init.name: init for init in model.graph.initializer}
+    print(value_infos)
+    print(initializers)
 
     for node in model.graph.node:
         if node.op_type in check_list:
             input_output_check_list = check_list[node.op_type]
             for check_item in input_output_check_list:
                 tensor_name = node.input[check_item[1]] if check_item[0] == "i" else node.output[check_item[1]]
+                print(f"IS {check_item[0]} TENSOR IN GRAPH? {tensor_name}: {(tensor_name in value_infos) or (tensor_name in initializers)}")
                 testcase.assertTrue((tensor_name in value_infos) or (tensor_name in initializers))
                 if tensor_name in value_infos:
                     vi = value_infos[tensor_name]


### PR DESCRIPTION
### Description
Sets the appropriate scale and zero-point values for 16-bit QDQ Softmax. Previously, the scale/zp were set to fixed values that were specific to 8-bit quantization.



### Motivation and Context
Generate more accurate 16-bit QDQ models that contain Softmax.


