### PR TITLE
Eliminate intermediate string conversion buffer.

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -271,7 +271,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             unsafe
             {
-                return new string((sbyte*)bufferPtr.ToPointer(), 0, (int)bytesLen, Encoding.UTF8);
+                return Encoding.UTF8.GetString((byte*)bufferPtr.ToPointer(), (int)bytesLen);
             }
         }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/OrtValue.shared.cs
@@ -263,12 +263,16 @@ namespace Microsoft.ML.OnnxRuntime
         /// <returns>UTF-16 string instance</returns>
         public string GetStringElement(int index)
         {
-            var chars = GetStringTensorElementChars(index);
-            if (chars.Length == 0)
+            GetStringTensorElementBuffer((UIntPtr)index, out uint bytesLen, out IntPtr bufferPtr);
+            if (bytesLen == 0)
             {
                 return string.Empty;
             }
-            return new string(chars);
+
+            unsafe
+            {
+                return new string((sbyte*)bufferPtr.ToPointer(), 0, (int)bytesLen, Encoding.UTF8);
+            }
         }
 
 


### PR DESCRIPTION
### Description
  Make use of unsafe string constructor that is able to convert native
  UTF-8 string straight into the string instance buffer.

### Motivation and Context
Reduce garbage,

