### PR TITLE
Fix warning C4003 in ORT python binding code

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_module.cc
+++ b/onnxruntime/python/onnxruntime_pybind_module.cc
@@ -16,11 +16,13 @@ static constexpr bool HAS_COLLECTIVE_OPS = true;
 static constexpr bool HAS_COLLECTIVE_OPS = false;
 #endif
 
-void CreateInferencePybindStateModule(py::module& m);
+bool CreateInferencePybindStateModule(py::module& m);
 void CreateQuantPybindModule(py::module& m);
 
 PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
-  CreateInferencePybindStateModule(m);
+  if (!CreateInferencePybindStateModule(m)) {
+    throw pybind11::import_error();
+  }
   // move it out of shared method since training build has a little different behavior.
   m.def(
       "get_available_providers", []() -> const std::vector<std::string>& { return GetAvailableExecutionProviderNames(); },

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -49,15 +49,11 @@ namespace onnxruntime {
 }  // namespace onnxruntime
 
 #if defined(_MSC_VER)
-#pragma warning(disable : 4267 4996 4503 4003)
+#pragma warning(disable : 4267 4996 4503)
 #endif  // _MSC_VER
 
 #include <iterator>
 #include <algorithm>
-
-#if defined(_MSC_VER)
-#pragma warning(disable : 4267 4996 4503 4003)
-#endif  // _MSC_VER
 
 namespace onnxruntime {
 namespace python {
@@ -2059,15 +2055,11 @@ including arg name, arg type (contains both type and shape).)pbdoc")
       .export_values();
 }
 
-void CreateInferencePybindStateModule(py::module& m) {
+bool CreateInferencePybindStateModule(py::module& m) {
   m.doc() = "pybind11 stateful interface to ONNX runtime";
   RegisterExceptions(m);
 
-  // Initialization of the module
-  ([]() -> void {
-    // import_array1() forces a void return value.
-    import_array1();
-  })();
+  import_array1(false);
 
   auto env = GetEnv();
 
@@ -2087,13 +2079,7 @@ void CreateInferencePybindStateModule(py::module& m) {
   addGlobalSchemaFunctions(m);
   addOpSchemaSubmodule(m);
   addOpKernelSubmodule(m);
-}
-
-void InitArray() {
-  ([]() -> void {
-    // import_array1() forces a void return value.
-    import_array1();
-  })();
+  return true;
 }
 
 namespace {
@@ -2136,8 +2122,6 @@ class EnvInitializer {
 
  private:
   EnvInitializer() {
-    // Initialization of the module
-    InitArray();
     std::unique_ptr<Environment> env_ptr;
     Env::Default().GetTelemetryProvider().SetLanguageProjection(OrtLanguageProjection::ORT_PROJECTION_PYTHON);
     OrtPybindThrowIfError(Environment::Create(std::make_unique<LoggingManager>(

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -2082,6 +2082,12 @@ bool CreateInferencePybindStateModule(py::module& m) {
   return true;
 }
 
+// This function is only used by orttraining module
+bool InitArray() {
+  import_array1(false);
+  return true;
+}
+
 namespace {
 // This class provides a static shell for on-demand and thread-safe construction
 // of Environment object for both Inference and Training python layers.

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define PY_ARRAY_UNIQUE_SYMBOL onnxruntime_python_ARRAY_API
 #include <numpy/arrayobject.h>
 
 #include "orttraining/python/orttraining_pybind_common.h"

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -347,6 +347,7 @@ static bool CreateTrainingPybindStateModule(py::module& m) {
 #ifdef ENABLE_LAZY_TENSOR
   addObjectMethodsForLazyTensor(m);
 #endif
+  return true;
 }
 PYBIND11_MODULE(onnxruntime_pybind11_state, m) {
   if (!CreateTrainingPybindStateModule(m)) {

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
 #include "orttraining/python/orttraining_pybind_common.h"

--- a/orttraining/orttraining/python/orttraining_python_module.cc
+++ b/orttraining/orttraining/python/orttraining_python_module.cc
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define PY_ARRAY_UNIQUE_SYMBOL onnxruntime_python_ARRAY_API
+#include <numpy/arrayobject.h>
+
 #include "orttraining/python/orttraining_pybind_common.h"
 #include "python/onnxruntime_pybind_mlvalue.h"
 


### PR DESCRIPTION
### Description
Fix warning C4003 in ORT python binding code.

I have tested, in the case when "import_array1() " failed, it generates a warning like:

![image](https://github.com/microsoft/onnxruntime/assets/856316/b8e865f4-1970-410b-859b-66065c216b2e)

### Motivation and Context
It's better to fix the warning instead of suppressing it. 
