### PR TITLE
[js/web] fix ESLint by excluding generated .js from tsconfig.json

### DIFF
--- a/js/web/tsconfig.json
+++ b/js/web/tsconfig.json
@@ -6,5 +6,5 @@
     "typeRoots": ["./node_modules/@webgpu/types", "./node_modules/@types", "../node_modules/@types"]
   },
   "include": ["lib", "test"],
-  "exclude": ["lib/wasm/proxy-worker"]
+  "exclude": ["lib/wasm/proxy-worker", "test/ort.test.js", "test/ort.test.min.js"]
 }


### PR DESCRIPTION
### Description
ESLint will went into error sometimes.

The root cause is because some large generated JavaScript file in the tsconfig's include path will cause TypeScript parser fail in a line of `string.match()` with a regex on a huge string (~8MB), causing the following error:
```
RangeError: Maximum call stack size exceeded
```

The solution is to remove the large files from the tsconfig's include path. Previously I excluded the `web/dist/` folder and this PR excludes `web/test/ort.test[.min].js`.