### PR TITLE
[js/webgpu] Fix shader errors in indicesGet/Set when rank > 4

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/common.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/common.ts
@@ -425,7 +425,11 @@ const createIndicesHelper =
         if (rank < 2) {
           return `${varIndices}`;
         } else {
-          return `${varIndices}[${idx}]`;
+          if (varIndices.startsWith('uniforms.')) {
+            return `${getUniformElementAt(varIndices, idx, rank)}`;
+          } else {
+            return `${varIndices}[${idx}]`;
+          }
         }
       };
 
@@ -433,7 +437,11 @@ const createIndicesHelper =
         if (rank < 2) {
           return `${varIndices}=${value};`;
         } else {
-          return `${varIndices}[${idx}]=${value};`;
+          if (varIndices.startsWith('uniforms.')) {
+            return `${getUniformElementAt(varIndices, idx, rank)}=${value};`;
+          } else {
+            return `${varIndices}[${idx}]=${value};`;
+          }
         }
       };
 


### PR DESCRIPTION
### Description
This PR fixes below errors:
```
error(s) generated while compiling the shader:
:5:44 error: index 4 out of bounds [0..1]
             return uniforms.input_strides[4] * (outputIndices[4] % uniforms.input_shape[4])+uniforms.input_strides[3] * (outputIndices[3] % uniforms.input_shape[3])+uniforms.input_strides[2] * (outputIndices[2] % uniforms.input_shape[2])+uniforms.input_strides[1] * (outputIndices[1] % uniforms.input_shape[1])+uniforms.input_strides[0] * (outputIndices[0] % uniforms.input_shape[0]);
                                           ^
FAILED #OpTest# - expand.jsonc [webgpu]Expand - Expand 5D - float32 Expand 5 - float32
FAILED #OpTest# - expand.jsonc [webgpu]Expand - Expand 5D - float32 Expand 5 - shape < input.size()


