### PR TITLE
Handle non-default DequantizeLinear axis in DuplicateDQForOutputEdge

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/ensure_unique_dq_for_node_unit.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/ensure_unique_dq_for_node_unit.cc
@@ -53,7 +53,7 @@ Status DuplicateDQForOutputEdge(const graph_utils::GraphEdge& original_dq_output
                                     MakeString("Added by ", kTransformerName),
                                     dq_inputs,
                                     {&new_dq_output_nodearg},
-                                    nullptr,  // attributes
+                                    &original_dq_node.GetAttributes(),
                                     original_dq_node.Domain());
 
   // set up edges


### PR DESCRIPTION
### Description
This ensures that DequantizeLinear nodes introduced in DuplicateDQForOutputEdge during QDQ processing contain the axis attribute of the original node in case it was not equal to the default axis (1).

### Motivation and Context
This addresses an error encountered in a model which occured unless QDQ processing is disabled through session options.
